### PR TITLE
Expand Netclaw to autonomous operations agent with TUI-first validation

### DIFF
--- a/.claude/commands/opsx-apply.md
+++ b/.claude/commands/opsx-apply.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-apply.md

--- a/.claude/commands/opsx-archive.md
+++ b/.claude/commands/opsx-archive.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-archive.md

--- a/.claude/commands/opsx-bulk-archive.md
+++ b/.claude/commands/opsx-bulk-archive.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-bulk-archive.md

--- a/.claude/commands/opsx-continue.md
+++ b/.claude/commands/opsx-continue.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-continue.md

--- a/.claude/commands/opsx-explore.md
+++ b/.claude/commands/opsx-explore.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-explore.md

--- a/.claude/commands/opsx-ff.md
+++ b/.claude/commands/opsx-ff.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-ff.md

--- a/.claude/commands/opsx-new.md
+++ b/.claude/commands/opsx-new.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-new.md

--- a/.claude/commands/opsx-onboard.md
+++ b/.claude/commands/opsx-onboard.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-onboard.md

--- a/.claude/commands/opsx-sync.md
+++ b/.claude/commands/opsx-sync.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-sync.md

--- a/.claude/commands/opsx-verify.md
+++ b/.claude/commands/opsx-verify.md
@@ -1,0 +1,1 @@
+../../.opencode/command/opsx-verify.md

--- a/.claude/skills/netclaw-openspec-milestones
+++ b/.claude/skills/netclaw-openspec-milestones
@@ -1,0 +1,1 @@
+../../.opencode/skills/netclaw-openspec-milestones

--- a/.claude/skills/netclaw-openspec-planning
+++ b/.claude/skills/netclaw-openspec-planning
@@ -1,0 +1,1 @@
+../../.opencode/skills/netclaw-openspec-planning

--- a/.claude/skills/openspec-apply-change
+++ b/.claude/skills/openspec-apply-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-apply-change

--- a/.claude/skills/openspec-archive-change
+++ b/.claude/skills/openspec-archive-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-archive-change

--- a/.claude/skills/openspec-bulk-archive-change
+++ b/.claude/skills/openspec-bulk-archive-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-bulk-archive-change

--- a/.claude/skills/openspec-continue-change
+++ b/.claude/skills/openspec-continue-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-continue-change

--- a/.claude/skills/openspec-explore
+++ b/.claude/skills/openspec-explore
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-explore

--- a/.claude/skills/openspec-ff-change
+++ b/.claude/skills/openspec-ff-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-ff-change

--- a/.claude/skills/openspec-new-change
+++ b/.claude/skills/openspec-new-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-new-change

--- a/.claude/skills/openspec-onboard
+++ b/.claude/skills/openspec-onboard
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-onboard

--- a/.claude/skills/openspec-sync-specs
+++ b/.claude/skills/openspec-sync-specs
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-sync-specs

--- a/.claude/skills/openspec-verify-change
+++ b/.claude/skills/openspec-verify-change
@@ -1,0 +1,1 @@
+../../.opencode/skills/openspec-verify-change

--- a/.claude/skills/ralph-loop.md
+++ b/.claude/skills/ralph-loop.md
@@ -440,6 +440,31 @@ If a new component is created but **cannot be visually tested** because it isn't
 
 ---
 
+### 5.9) OpenSpec Artifact Gate (HARD STOP)
+
+**If the task requires creating or modifying OpenSpec artifacts** (specs,
+changes, proposals, delta specs, design docs, tasks files), you MUST use
+the OpenSpec skills. Do NOT manually create or edit files under `openspec/`.
+
+| Need | Skill |
+|------|-------|
+| New feature/capability needs spec work | `/opsx-new` |
+| Continue an in-progress change | `/opsx-continue` |
+| Fast-forward all artifacts at once | `/opsx-ff` |
+| Implement tasks from a change | `/opsx-apply` |
+| Sync delta specs to main specs | `/opsx-sync` |
+| Verify implementation matches specs | `/opsx-verify` |
+| Archive a completed change | `/opsx-archive` |
+
+**The only exception:** Updating task checkboxes in
+`openspec/changes/*/tasks.md` during RALPH iterations (Step 9).
+
+**If you encounter a missing OpenSpec capability during implementation:**
+1. STOP implementation
+2. Use `/opsx-new` to create the change
+3. Use `/opsx-ff` to generate all artifacts
+4. Resume implementation with proper traceability
+
 ### 6) Implement
 
 Follow architecture rules from the constitution (AGENTS.md / CLAUDE.md):

--- a/.claude/skills/ralph-output-adversarial-review.md
+++ b/.claude/skills/ralph-output-adversarial-review.md
@@ -138,6 +138,17 @@ For each task marked complete IN YOUR COMMIT RANGE:
 - If a task references an OpenSpec change, was the change task list updated?
 - Are spec/implementation changes synchronized (no undocumented behavior drift)?
 
+### A3) OpenSpec Workflow Compliance
+- Were OpenSpec artifacts (specs, changes, proposals, delta specs, design docs)
+  created through the `/opsx-*` skills, or were they manually edited?
+- Manual edits to `openspec/` files (other than task checkbox updates) are a
+  **PARTIAL** finding — the agent MUST use the OpenSpec skills:
+  - `/opsx-new` for new changes
+  - `/opsx-continue` or `/opsx-ff` for artifact creation
+  - `/opsx-sync` for syncing delta specs to main specs
+  - `/opsx-archive` for archiving completed changes
+- Check git diff for manually-created spec files that bypassed the workflow.
+
 ### B) Testing Strategy Compliance
 Using `testing-strategy` (if present):
 - If code coordinates DB/HTTP/actors/external services:

--- a/.claude/skills/ralph-run-diagnostics.md
+++ b/.claude/skills/ralph-run-diagnostics.md
@@ -52,6 +52,17 @@ If any of these are missing, mark as a diagnostic failure.
 - Was `openspec validate --all --no-interactive` run and logged before commit?
 - Do implementation changes keep capabilities/spec deltas consistent?
 
+### B3) OpenSpec Workflow Discipline
+- Were OpenSpec artifacts created through the `/opsx-*` skills?
+  - `/opsx-new` for new changes
+  - `/opsx-continue` or `/opsx-ff` for artifact creation
+  - `/opsx-sync` for syncing delta specs
+  - `/opsx-archive` for archiving completed changes
+- Manual creation/editing of files under `openspec/` (except task checkbox
+  updates) indicates a workflow violation.
+- Check iteration logs for evidence of skill invocation when OpenSpec work was
+  required.
+
 ### C) Verification Level Discipline
 - Was verification level appropriate for surface area?
   - I/O changes (db/http/actors/external) → L2+ (integration tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,38 @@ Expected outputs:
 - matching spec updates when behavior changes
 - no undocumented behavior drift
 
+## OpenSpec Workflow (MANDATORY)
+
+**You MUST use OpenSpec skills for all planning and spec work.** Do not manually
+create or edit OpenSpec artifacts (specs, changes, proposals, delta specs,
+design docs, task files). Use the skills listed below.
+
+### When Planning (new feature, capability, or spec change)
+
+1. `/opsx-new` — create a new OpenSpec change
+2. `/opsx-continue` — create next artifact in the change workflow
+3. `/opsx-ff` — fast-forward: generate all remaining artifacts at once
+
+### When Implementing (building code from a change)
+
+4. `/opsx-apply` — implement tasks from an OpenSpec change
+
+### When Finishing (syncing and archiving)
+
+5. `/opsx-sync` — sync delta specs from a change to main specs
+6. `/opsx-verify` — verify implementation matches change artifacts
+7. `/opsx-archive` — archive a completed change
+
+### Supporting Workflows
+
+- `/opsx-explore` — think through ideas before creating a change
+- `/opsx-onboard` — guided walkthrough of the full OpenSpec workflow
+- `/opsx-bulk-archive` — archive multiple completed changes
+
+**Hard rule:** If you need to create or modify files under `openspec/`, use the
+appropriate skill above. The only exception is updating task checkboxes in
+`openspec/changes/*/tasks.md` during RALPH iterations.
+
 ## Discovery Rules
 
 Before coding a capability, discover in this order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ Before coding a capability, discover in this order:
 3. matching OpenSpec capability in `openspec/specs/`
 4. active change plan in `openspec/changes/<name>/`
 
-If those artifacts conflict, update planning artifacts first, then implement.
+If planning and implementation artifacts conflict, fix planning artifacts first.
+If discovery artifacts conflict with each other, update them before implementing.
 
 ## Universal Quality Bar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,1 @@
-# Claude Agent Routing
-
-Canonical repository constitution lives in `AGENTS.md`.
-
-Always read in this order:
-
-1. `AGENTS.md`
-2. `PROJECT_CONTEXT.md`
-3. `TOOLING.md`
-4. `docs/prd/README.md`
-5. relevant files in `openspec/specs/` and `openspec/changes/`
-
-If planning and implementation artifacts conflict, fix planning artifacts first.
+AGENTS.md

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -183,8 +183,13 @@ Done when:
 
 ## Phase 1: Chat + Memory MVP
 
-OpenSpec Change: `openspec/changes/expand-mvp-for-autonomous-agent-vision/`
-Full task breakdown: `openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md`
+OpenSpec Changes:
+- `openspec/changes/expand-mvp-for-autonomous-agent-vision/` (Tasks 1.1–1.12)
+- `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Tasks 1.13–1.19, 1.22)
+
+Full task breakdowns:
+- `openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md`
+- `openspec/changes/add-tui-adapter-and-config-hot-reload/tasks.md`
 
 ### Task 1.1: Framework protocol and persistence-safe message envelopes
 
@@ -354,7 +359,119 @@ Done when:
 - [ ] Task management: list, pause, resume, delete via conversation and CLI.
 - [ ] Tests for persistence, timer lifecycle, isolated execution, failure handling.
 
-### Task 1.13: Slack Socket Mode adapter
+### Task 1.13: CLI scaffold with Cocona + Termina hosting
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md` (CLI-010, CLI-012)
+**OpenSpec:** `openspec/specs/netclaw-cli/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 1)
+**Surface area:** CLI framework
+**Verification:** L1
+
+Done when:
+- [ ] Cocona and Termina package references added to `Directory.Packages.props` and `Netclaw.App.csproj`.
+- [ ] `Program.cs` rewritten as Cocona entry point with DI registration.
+- [ ] `RunCommand.cs` created for daemon mode (`netclaw run`).
+- [ ] Termina wired as hosted service for TUI commands.
+- [ ] `dotnet build` passes with new dependencies.
+
+### Task 1.14: TUI chat adapter (`netclaw chat`)
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md` (CLI-011), `docs/prd/PRD-009-input-adapters-and-unified-input.md` (INPUT-005)
+**OpenSpec:** `openspec/specs/netclaw-input-adapters/spec.md`, `openspec/specs/netclaw-cli/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 2)
+**Surface area:** TUI + adapter
+**Verification:** L3
+**Wireframe:** `docs/ui/TUI-001-command-wireframes.md` (netclaw chat)
+
+Done when:
+- [ ] `TuiInputAdapter` implementing adapter contract (`SendUserMessage` with entity key `tui/{sessionId}`).
+- [ ] `ChatCommand.cs` hosts actor system in-process and launches TUI.
+- [ ] `ChatPage.cs` with `StreamingTextNode` (scrollable history) and `TextInputNode` (multi-line input).
+- [ ] `ChatViewModel.cs` with session lifecycle and broadcast subscription.
+- [ ] Inline tool activity panel (completed with duration, in-progress with spinner).
+- [ ] MCP status indicator in status bar (green/yellow/red).
+- [ ] E2E: user types → `SendUserMessage` → session actor → LLM → streaming response in TUI.
+
+### Task 1.15: TUI onboarding wizard (`netclaw init`)
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md` (CLI-010)
+**OpenSpec:** `openspec/specs/netclaw-onboarding/spec.md`, `openspec/specs/netclaw-cli/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 3)
+**Surface area:** TUI + onboarding
+**Verification:** L3
+**Wireframe:** `docs/ui/TUI-001-command-wireframes.md` (netclaw init)
+
+Done when:
+- [ ] `InitCommand.cs` launches Termina wizard.
+- [ ] `InitWizardPage.cs` with 7-step wizard layout (`PanelNode`, progress bar).
+- [ ] `InitWizardViewModel.cs` with step state machine and back-navigation.
+- [ ] Steps: LLM provider, Slack config, PostgreSQL, ACL bootstrap, MCP servers, exposure mode, health check.
+- [ ] Config file written to `~/.netclaw/config/netclaw.json` on completion.
+
+### Task 1.16: Plain CLI commands
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
+**OpenSpec:** `openspec/specs/netclaw-cli/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 4)
+**Surface area:** CLI
+**Verification:** L1
+
+Done when:
+- [ ] `DoctorCommand.cs` — startup checks with remediation guidance, exit codes 0/1/2.
+- [ ] `ConfigCommands.cs` — `config show` and `config validate`.
+- [ ] `AclCommands.cs` — `acl validate`, `acl test`, `acl explain`.
+- [ ] `ProjectCommands.cs` — `project list`, `project add`, `project remove`.
+- [ ] `ScheduleCommands.cs` — `schedule list|show|pause|resume|delete`.
+- [ ] Remaining commands: `environment scan|show`, `mcp list|validate|test`, `memory show`, `tools list|policy`, `test smoke`, `personality reset`.
+
+### Task 1.17: Config hot-reload
+
+**PRD:** `docs/prd/PRD-001-netclaw-mvp.md` (FR-016)
+**OpenSpec:** `openspec/specs/netclaw-config-hot-reload/spec.md`, `openspec/specs/netclaw-session/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 5)
+**Surface area:** runtime config
+**Verification:** L2
+
+Done when:
+- [ ] `ConfigWatcherService` as `IHostedService` with `FileSystemWatcher` per watched file.
+- [ ] 500ms debounce for file change events.
+- [ ] Validate-before-apply with rejection logging.
+- [ ] Config file deletion handling (warn, keep existing config).
+- [ ] ACL change events published to policy engine via Akka pub/sub.
+- [ ] Provider change events published to provider factory via Akka pub/sub.
+- [ ] MCP profile change events published to MCP manager via Akka pub/sub.
+- [ ] Schedule change events published to `ScheduleManagerActor` via Akka pub/sub.
+- [ ] Integration test: config file write → debounce → validate → actor notification.
+
+### Task 1.18: Conversational personality bootstrap
+
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 6)
+**Surface area:** onboarding
+**Verification:** L2
+
+Done when:
+- [ ] First-run detection: trigger bootstrap when soul files don't exist on first `netclaw chat`.
+- [ ] Bootstrap conversation: introduce, learn preferences, scan environment, write soul files, confirm.
+- [ ] PERSONALITY.md, INSTRUCTIONS.md, USER.md written to config directory.
+- [ ] Test: bootstrap triggers when files missing, skips when files exist.
+
+### Task 1.19: Local E2E validation via TUI
+
+**PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
+**OpenSpec:** all Phase 1 specs
+**OpenSpec Changes:** `openspec/changes/add-tui-adapter-and-config-hot-reload/` (Section 7)
+**Surface area:** end-to-end
+**Verification:** L4
+
+Done when:
+- [ ] E2E: `netclaw chat` → session → tool call → streaming response.
+- [ ] E2E: scheduled task → fresh session → result displayed.
+- [ ] E2E: config change → hot-reload → policy refresh verified.
+- [ ] CI tests pass without live provider credentials.
+
+### Task 1.20: Slack Socket Mode adapter
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
 **OpenSpec:** `openspec/specs/netclaw-slack-socket/spec.md`, `openspec/specs/netclaw-input-adapters/spec.md`
@@ -368,36 +485,7 @@ Done when:
 - [ ] Reconnection on disconnect.
 - [ ] End-to-end test proves message → reply loop.
 
-### Task 1.14: CLI onboarding and management commands
-
-**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
-**OpenSpec:** `openspec/specs/netclaw-cli/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
-**Surface area:** CLI
-**Verification:** L1
-
-Done when:
-- [ ] `netclaw init` guided wizard (provider, Slack, PostgreSQL, ACL, MCP, exposure, health check).
-- [ ] `netclaw config show|validate` and `netclaw acl validate|test|explain`.
-- [ ] `netclaw project list|add|remove` and `netclaw environment scan|show`.
-- [ ] `netclaw schedule list|show|pause|resume|delete`.
-- [ ] `netclaw mcp list|validate|test`.
-- [ ] `netclaw personality reset` and `netclaw memory show`.
-- [ ] `netclaw gateway status|doctor`.
-- [ ] `netclaw test smoke --provider ollama`.
-
-### Task 1.15: Conversational personality bootstrap
-
-**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
-**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
-**Surface area:** onboarding
-**Verification:** L2
-
-Done when:
-- [ ] First-run detection: trigger bootstrap when soul files don't exist.
-- [ ] Bootstrap conversation: introduce, learn preferences, scan environment, write soul files, confirm.
-- [ ] Test for bootstrap trigger and soul file creation.
-
-### Task 1.16: Integration and acceptance
+### Task 1.21: Full integration and acceptance
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
 **OpenSpec:** all Phase 1 specs
@@ -411,16 +499,16 @@ Done when:
 - [ ] CI test suite passes without live provider credentials.
 - [ ] Deploy to pi1 and verify Slack interaction.
 
-### Task 1.17: Sync specs and archive change
+### Task 1.22: Spec sync and archive
 
-**OpenSpec Changes:** `openspec/changes/expand-mvp-for-autonomous-agent-vision/`
+**OpenSpec Changes:** `openspec/changes/expand-mvp-for-autonomous-agent-vision/`, `openspec/changes/add-tui-adapter-and-config-hot-reload/`
 **Surface area:** process
 **Verification:** L0
 
 Done when:
-- [ ] Delta specs synced to main specs.
+- [ ] Delta specs synced to main specs for both changes.
 - [ ] `openspec validate --all --no-interactive` passes.
-- [ ] Change archived with `openspec archive expand-mvp-for-autonomous-agent-vision`.
+- [ ] Changes archived.
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -58,219 +58,394 @@ Done when:
 
 ---
 
-## Phase 1: Slack Session Vertical Slice
+## Phase 0.5: Vision Alignment and Spec Revision (Active)
 
-### Task 1.1: Implement framework protocol and persistence-safe message envelopes
+Product vision was significantly expanded on 2026-02-21. Netclaw is no longer
+just a Slack chat assistant — it is an always-on autonomous operations agent.
+All planning artifacts must be revised to match before implementation begins.
+
+See `PROJECT_CONTEXT.md` for the full revised vision.
+See Memorizer memory "Netclaw — Full Product Vision (Interview Feb 2026)" for
+interview context.
+
+### Task 0.5.1: Research agent soul patterns from comparable projects
+
+**PRD:** `docs/prd/PRD-001-netclaw-mvp.md` (to be revised)
+**OpenSpec Capabilities:** `openspec/specs/netclaw-session/spec.md`
+**OpenSpec Changes:** n/a (research task)
+**Surface area:** planning
+**Verification:** L0
+
+Research OpenClaw, IronClaw, ZeroClaw, and similar self-hosted LLM assistant
+projects for patterns around:
+- Agent soul / personality configuration (markdown-based system prompts)
+- Memory.md and persistent memory conventions
+- Tooling configuration and capability discovery
+- Onboarding wizard flows
+- Scheduled task management
+
+Done when:
+- [x] Research findings are saved to Memorizer with tag `netclaw-research`.
+- [x] Summary document created at `docs/research/agent-patterns.md`.
+- [x] Key patterns identified for adoption or rejection with rationale.
+
+### Task 0.5.2: Revise PRDs to match expanded product vision
+
+**PRD:** all `docs/prd/PRD-*.md`
+**OpenSpec Capabilities:** all `openspec/specs/*/spec.md`
+**OpenSpec Changes:** all active changes
+**Surface area:** planning
+**Verification:** L0
+
+Current PRDs describe a narrower "chat assistant with ACL" scope. They need
+revision to reflect the full vision:
+- PRD-001: expand MVP scope (local memory, scheduling, tool access, self-config)
+- PRD-002: keep security envelope, add capability self-discovery context
+- PRD-003: defer ops console to Phase 5
+- PRD-004: revise CLI to focus on onboarding wizard
+- PRD-005: update provider strategy (OpenRouter primary, MSFT.EXT.AI pluggable)
+- PRD-006: expand MCP role (Memorizer as external memory tier)
+- New PRD needed: agent personality / soul and local memory system
+- New PRD needed: scheduling and periodic task management
+- New PRD needed: input adapters (ambient channels, webhooks, timers)
+
+Done when:
+- [x] All existing PRDs revised to align with `PROJECT_CONTEXT.md` vision.
+- [x] New PRDs created for local memory, scheduling, and input adapters.
+- [x] `docs/prd/README.md` index updated.
+
+### Task 0.5.3: Revise engineering specs to match expanded PRDs
+
+**PRD:** all revised PRDs from Task 0.5.2
+**OpenSpec Capabilities:** all `openspec/specs/*/spec.md`
+**OpenSpec Changes:** all active changes
+**Surface area:** planning
+**Verification:** L0
+
+Engineering specs need revision to include:
+- Concrete message protocol types (from Memorizer design memories)
+- Local memory file format and loading mechanism
+- Scheduling actor design
+- Configuration file format and self-modification
+- Environment capability discovery mechanism
+- Serialization strategy (protobuf-net with field numbers)
+
+Done when:
+- [x] Engineering specs revised to include concrete type definitions.
+- [x] Protocol message types documented with code examples.
+- [x] Local memory and config file format specified.
+- [x] Scheduling mechanism specified.
+
+### Task 0.5.4: Revise OpenSpec capabilities and create new change plans
+
+**PRD:** revised PRDs from Task 0.5.2
+**OpenSpec Capabilities:** all `openspec/specs/*/spec.md`
+**OpenSpec Changes:** to be created
+**Surface area:** planning
+**Verification:** L0
+
+OpenSpec artifacts need to match the revised PRDs:
+- Update existing capability specs for expanded scope
+- Create new capability specs for local memory, scheduling, input adapters
+- Create new change plans aligned with the revised phasing
+- Archive or revise existing change plans that no longer match
+
+Done when:
+- [x] OpenSpec capabilities updated to match revised PRDs.
+- [x] New capability specs created for new subsystems.
+- [x] Change plans created for revised Phase 1 (Chat + Memory MVP).
+- [x] `openspec validate --all --no-interactive` passes.
+
+### Task 0.5.5: Revise implementation plan Phase 1+ for new phasing
+
+**PRD:** revised PRDs
+**OpenSpec Capabilities:** revised specs
+**OpenSpec Changes:** revised changes
+**Surface area:** planning
+**Verification:** L0
+
+Rewrite Phase 1 and subsequent phases to match the revised product vision
+phasing from `PROJECT_CONTEXT.md`. Current Phase 1-5 are based on the old
+narrower scope. New phasing:
+
+1. Chat + Memory MVP
+2. Input Expansion (ambient channels, webhooks, channel instructions)
+3. Delegated Coding (Claude Code / OpenCode spawning)
+4. Browser + Research (web automation, research pipelines)
+5. Ops Console (web UI)
+
+Done when:
+- [x] Phase 1+ rewritten with concrete tasks, PRD refs, and OpenSpec refs.
+- [x] Each task has clear done-when criteria suitable for RALPH execution.
+- [x] Implementation plan is RALPH-consumable for Phase 1.
+
+---
+
+## Phase 1: Chat + Memory MVP
+
+OpenSpec Change: `openspec/changes/expand-mvp-for-autonomous-agent-vision/`
+Full task breakdown: `openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md`
+
+### Task 1.1: Framework protocol and persistence-safe message envelopes
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-session/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
+**OpenSpec:** `openspec/specs/netclaw-session/spec.md`, `openspec/specs/netclaw-input-adapters/spec.md`
 **Surface area:** actor framework
 **Verification:** L2
 
 Done when:
-- [ ] `Commands`, `Events`, and `Broadcasts` are implemented with concrete types.
-- [ ] Framework-owned serializable chat message type is implemented (no direct persistence of `Microsoft.Extensions.AI` types).
-- [ ] Session entity key semantics `{channelId}/{threadTs}` are encoded in protocol contracts.
-- [ ] Integration tests verify event serialization round-trip.
+- [ ] `SendUserMessage`, `TurnRecorded`, `SessionCompacted`, `TurnBroadcast`, `CompactionBroadcast` implemented with protobuf-net serialization.
+- [ ] `SerializableChatMessage` framework-owned type implemented (no direct persistence of MEAI types).
+- [ ] `SessionMessageExtractor` supports entity key patterns: `{channelId}/{threadTs}` and `schedule/{taskId}/{runTs}`.
+- [ ] Source metadata (adapter type, sender identity, channel, timestamp) on all commands.
+- [ ] Integration tests verify serialization round-trip and entity key extraction.
 
-### Task 1.2: Implement `LlmSessionActor` persistence and turn loop
+### Task 1.2: Session actor core with persistence and turn loop
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-session/spec.md`, `openspec/specs/netclaw-slack-socket/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
+**OpenSpec:** `openspec/specs/netclaw-session/spec.md`
 **Surface area:** actor runtime
 **Verification:** L2
 
 Done when:
-- [ ] Actor recovers state from journal/snapshot before handling new turns.
-- [ ] Turn processing persists turn events and emits turn broadcasts.
-- [ ] Snapshot strategy and compaction trigger plumbing are implemented.
-- [ ] Integration tests prove restart recovery preserves context.
+- [ ] `LlmSessionActor` recovers state from PostgreSQL journal/snapshots.
+- [ ] Turn loop: receive `SendUserMessage`, invoke `IChatClient`, persist `TurnRecorded`, emit `TurnBroadcast` via pub/sub.
+- [ ] Snapshot strategy and compaction via `SummarizingChatReducer`.
+- [ ] Pre-compaction memory flush: silent agentic turn saves durable memories before context resets.
+- [ ] Integration tests prove restart recovery and pre-compaction flush execution.
 
-### Task 1.3: Implement session parent and entity routing
+### Task 1.3: Session parent and entity routing
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-session/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
+**OpenSpec:** `openspec/specs/netclaw-session/spec.md`
 **Surface area:** actor runtime
 **Verification:** L2
 
 Done when:
-- [ ] `LlmAgentParentActor` wraps `GenericChildPerEntityParent` behavior.
-- [ ] Session extraction routes same thread messages to the same child actor.
-- [ ] Parent actor tests verify entity lifecycle and message routing behavior.
+- [ ] `LlmAgentParentActor` wraps `GenericChildPerEntityParent`.
+- [ ] Session extraction routes same-thread messages to same child actor.
+- [ ] Multi-key-pattern support (Slack and timer patterns).
+- [ ] Tests verify entity lifecycle and message routing.
 
-### Task 1.4: Wire Slack Socket Mode vertical slice
+### Task 1.4: Layered system prompt and personality
 
-**PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-slack-socket/spec.md`, `openspec/specs/netclaw-session/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
-**Surface area:** integration
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`
+**Surface area:** agent personality
 **Verification:** L2
 
 Done when:
-- [ ] Slack Socket Mode adapter receives inbound events and dispatches actor commands.
-- [ ] Reply broadcast is posted into the originating Slack thread.
-- [ ] End-to-end local test proves message -> reply loop.
+- [ ] `~/.netclaw/` directory structure created on startup (soul/, projects/, environment/, schedules/, config/).
+- [ ] System prompt assembled from layers: PERSONALITY.md → INSTRUCTIONS.md → USER.md → project AGENTS.md → session context.
+- [ ] Missing layers handled gracefully.
+- [ ] Tests for prompt assembly with missing layers and project overlay injection.
 
----
-
-## Phase 2: Security Envelope and ACL Enforcement
-
-### Task 2.1: Implement ACL configuration loader and evaluator
+### Task 1.5: ACL and policy engine with tool grants
 
 **PRD:** `docs/prd/PRD-002-gateway-security-envelope.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-acl/spec.md`, `openspec/specs/netclaw-gateway-security/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
+**OpenSpec:** `openspec/specs/netclaw-acl/spec.md`, `openspec/specs/netclaw-gateway-security/spec.md`
 **Surface area:** security
 **Verification:** L2
 
 Done when:
-- [ ] ACL parser supports channel rules, sender allowlists, and mention/ambient mode.
-- [ ] Default deny behavior is enforced when no explicit allow exists.
+- [ ] ACL parser supports channel rules, sender allowlists, mention/ambient mode, and tool grant categories (shell, web_search, web_fetch, github, mcp:{server}, config_write, schedule_write).
+- [ ] Default deny enforced when no explicit allow.
+- [ ] Self-configuration prohibition: agent cannot modify ACL/security through conversation.
 - [ ] Invalid ACL blocks startup with actionable diagnostics.
-- [ ] Policy decision tests cover allow/deny reason codes.
+- [ ] Shell execution boundaries enforced (SEC-009): timeout, output truncation, no stdin, working dir.
+- [ ] Tool invocation audit logging.
+- [ ] Policy decision tests cover all grant categories.
 
-### Task 2.2: Enforce tool and MCP policy gates
+### Task 1.6: Tool framework and MEAI registration
 
-**PRD:** `docs/prd/PRD-002-gateway-security-envelope.md`, `docs/prd/PRD-006-mcp-tool-integration.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-acl/spec.md`, `openspec/specs/netclaw-mcp/spec.md`
-**OpenSpec Changes:** `openspec/changes/add-mcp-support-v1/`
-**Surface area:** security/integration
+**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`, `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-tools/spec.md`, `openspec/specs/netclaw-model-providers/spec.md`
+**Surface area:** tool framework
 **Verification:** L2
 
 Done when:
-- [ ] Tool and MCP invocations require explicit grants.
-- [ ] Denied calls return policy reason codes and audit records.
-- [ ] Integration tests verify denial path for missing grants.
+- [ ] Tool registry registers `AIFunction` definitions through `Microsoft.Extensions.AI`.
+- [ ] Policy-filtered tool loading: session receives only tools matching ACL grants.
+- [ ] Tool invocation audit logging (tool name, session ID, timestamp, allow/deny).
+- [ ] Tool context added to session state at initialization.
+- [ ] Tests for registration, policy filtering, and audit logging.
 
-### Task 2.3: Implement exposure modes and privileged approval checks
+### Task 1.7: First-party tools (search, fetch, shell, GitHub)
 
-**PRD:** `docs/prd/PRD-002-gateway-security-envelope.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-gateway-security/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`
-**Surface area:** security/ops
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-tools/spec.md`
+**Surface area:** tools
 **Verification:** L2
 
 Done when:
-- [ ] `local`, `tailscale-serve`, `tailscale-funnel`, and `cloudflare-tunnel` modes are validated.
-- [ ] Public modes require configured auth policy and fail validation otherwise.
-- [ ] `gateway doctor/status` surfaces exposure and approval state.
+- [ ] Web search tool with Brave Search API and SearXNG backends, configurable via `netclaw.json`.
+- [ ] Web fetch tool with HTML-to-text extraction and output truncation.
+- [ ] Shell execution tool with timeout, output truncation, stdin closure, working directory.
+- [ ] GitHub CLI tool via `gh` shell-out with structured output parsing and missing dependency handling.
+- [ ] Tests for each tool with mocked HTTP/process dependencies.
 
----
-
-## Phase 3: Guided Onboarding, Providers, MCP, and Testing
-
-### Task 3.1: Implement guided onboarding CLI flow
-
-**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-cli/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
-**OpenSpec Changes:** `openspec/changes/add-guided-onboarding-and-provider-strategy/`
-**Surface area:** CLI
-**Verification:** L1
-
-Done when:
-- [ ] `netclaw init` implements stepwise onboarding with resume support.
-- [ ] Onboarding captures Slack Socket Mode configuration and ACL bootstrap.
-- [ ] Onboarding output includes final readiness summary and next command.
-
-### Task 3.2: Implement provider abstraction and local smoke profile defaults
+### Task 1.8: Provider abstraction with MEAI and fallback
 
 **PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-model-providers/spec.md`, `openspec/specs/netclaw-testing/spec.md`
-**OpenSpec Changes:** `openspec/changes/add-guided-onboarding-and-provider-strategy/`, `openspec/changes/add-provider-smoke-and-ci-independence/`
+**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
 **Surface area:** provider integration
 **Verification:** L2
 
 Done when:
-- [ ] Provider abstraction supports OpenRouter, OpenAI, Anthropic, and Ollama profiles.
-- [ ] Local smoke defaults target `http://big-gpu:11434` with `qwen3:30b` (`qwen3:14b` fallback).
-- [ ] `netclaw test smoke --provider ollama` reports actionable pass/fail diagnostics.
+- [ ] `IChatClient` provider registration via DI (OpenRouter, Anthropic, OpenAI, Ollama).
+- [ ] Primary + fallback model with automatic failover on rate limit/timeout/error.
+- [ ] Tool calling through MEAI tool calling API.
+- [ ] CI tests pass without live provider credentials.
+- [ ] Tests for provider switching, fallback activation, tool calling round-trip.
 
-### Task 3.3: Implement MCP server registry and validation commands
+### Task 1.9: MCP integration and Memorizer
 
 **PRD:** `docs/prd/PRD-006-mcp-tool-integration.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-mcp/spec.md`, `openspec/specs/netclaw-cli/spec.md`
-**OpenSpec Changes:** `openspec/changes/add-mcp-support-v1/`
-**Surface area:** integration/CLI
+**OpenSpec:** `openspec/specs/netclaw-mcp/spec.md`
+**Surface area:** integration
 **Verification:** L2
 
 Done when:
-- [ ] MCP profile configuration supports named servers with enable/disable control.
-- [ ] `netclaw mcp list|validate|test` commands are implemented.
-- [ ] Runtime degrades gracefully when MCP server is unavailable.
+- [ ] MCP server profiles (named, stdio/SSE transport, enable/disable).
+- [ ] Tool discovery at startup: connect, list tools, register as MEAI definitions.
+- [ ] Graceful degradation: unavailable server returns error, agent continues, reconnect on next call.
+- [ ] Memorizer store/search/get cycle works through session.
+- [ ] Tests for connection, discovery, policy gating, degradation.
 
-### Task 3.4: Implement CI-safe testing split
+### Task 1.10: Local memory (project registry, environment inventory)
 
-**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`, `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-testing/spec.md`
-**OpenSpec Changes:** `openspec/changes/add-provider-smoke-and-ci-independence/`
-**Surface area:** testing/CI
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`
+**Surface area:** agent memory
 **Verification:** L2
 
 Done when:
-- [ ] CI-required tests run without live provider credentials.
-- [ ] Live provider smoke tests are opt-in and excluded from required CI jobs.
-- [ ] Test docs and pipeline config reflect category split.
+- [ ] Project registry (`projects/registry.json`): add, remove, list, validate paths, load at startup.
+- [ ] Environment inventory (`environment/inventory.json`): scan for git, gh, claude, opencode, dotnet, node.
+- [ ] Capability self-discovery at startup and on-demand rescan.
+- [ ] Tests for project registry CRUD and environment scan.
 
----
+### Task 1.11: Self-configuration through conversation
 
-## Phase 4: Ops Console and Diagnostics Surface
-
-### Task 4.1: Implement management API endpoints for UI contracts
-
-**PRD:** `docs/prd/PRD-003-operator-ux-ops-console.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-operator-ui/spec.md`, `openspec/specs/netclaw-cli/spec.md`
-**OpenSpec Changes:** `openspec/changes/design-ops-console-and-cli-v1/`
-**Surface area:** web API
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`
+**Surface area:** agent config
 **Verification:** L2
 
 Done when:
-- [ ] API endpoints exist for overview, sessions, policy decisions, security, and MCP health.
-- [ ] Response shapes align with `SPEC-005-operator-ui-contract.md`.
-- [ ] Integration tests cover key API contract responses.
+- [ ] Agent modifies personality, instructions, user preferences, project registry, and environment through conversation.
+- [ ] Validation-before-write and atomic file writes (temp + rename).
+- [ ] Prohibited modification enforcement: reject ACL, security, tool grants, exposure, credentials.
+- [ ] Tests for allowed modifications, prohibited modifications, validation failures.
 
-### Task 4.2: Implement minimal ops console UI shell
+### Task 1.12: Scheduling system
 
-**PRD:** `docs/prd/PRD-003-operator-ux-ops-console.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-operator-ui/spec.md`
-**OpenSpec Changes:** `openspec/changes/design-ops-console-and-cli-v1/`
-**Surface area:** UI
-**Verification:** L3
+**PRD:** `docs/prd/PRD-008-scheduling-and-periodic-tasks.md`
+**OpenSpec:** `openspec/specs/netclaw-scheduling/spec.md`
+**Surface area:** scheduling
+**Verification:** L2
 
 Done when:
-- [ ] Routes `/overview`, `/sessions`, `/policy`, `/security`, `/diagnostics`, and `/tools` exist.
-- [ ] UI displays health, policy, and MCP summary data from management APIs.
-- [ ] L3 evidence includes screenshots and console-clean checks.
+- [ ] `ScheduleManagerActor` loads tasks from `schedules/tasks.json`, manages Akka timers.
+- [ ] Chat-driven creation: interval and cron types, validate tool grants, persist task.
+- [ ] Isolated execution: timer dispatches `SendUserMessage` with `schedule/{taskId}/{runTs}` entity key.
+- [ ] Result reporting: post to configured Slack channel, silent-unless-notable mode.
+- [ ] Guardrails: max concurrent (3), timeout (5min), consecutive failure auto-pause (5).
+- [ ] Task management: list, pause, resume, delete via conversation and CLI.
+- [ ] Tests for persistence, timer lifecycle, isolated execution, failure handling.
 
----
-
-## Phase 5: Host Acceptance and OpenSpec Lifecycle
-
-### Task 5.1: Validate pi1 MVP acceptance flow
+### Task 1.13: Slack Socket Mode adapter
 
 **PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/netclaw-session/spec.md`, `openspec/specs/netclaw-gateway-security/spec.md`, `openspec/specs/netclaw-mcp/spec.md`
-**OpenSpec Changes:** `openspec/changes/define-netclaw-mvp-foundation/`, `openspec/changes/add-mcp-support-v1/`
+**OpenSpec:** `openspec/specs/netclaw-slack-socket/spec.md`, `openspec/specs/netclaw-input-adapters/spec.md`
+**Surface area:** integration
+**Verification:** L2
+
+Done when:
+- [ ] Socket Mode connection and event handling (`app_mention`, `message`).
+- [ ] Entity key extraction: `{channelId}/{threadTs}`.
+- [ ] Reply delivery: subscribe to session broadcasts, post replies to originating thread.
+- [ ] Reconnection on disconnect.
+- [ ] End-to-end test proves message → reply loop.
+
+### Task 1.14: CLI onboarding and management commands
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
+**OpenSpec:** `openspec/specs/netclaw-cli/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
+**Surface area:** CLI
+**Verification:** L1
+
+Done when:
+- [ ] `netclaw init` guided wizard (provider, Slack, PostgreSQL, ACL, MCP, exposure, health check).
+- [ ] `netclaw config show|validate` and `netclaw acl validate|test|explain`.
+- [ ] `netclaw project list|add|remove` and `netclaw environment scan|show`.
+- [ ] `netclaw schedule list|show|pause|resume|delete`.
+- [ ] `netclaw mcp list|validate|test`.
+- [ ] `netclaw personality reset` and `netclaw memory show`.
+- [ ] `netclaw gateway status|doctor`.
+- [ ] `netclaw test smoke --provider ollama`.
+
+### Task 1.15: Conversational personality bootstrap
+
+**PRD:** `docs/prd/PRD-007-agent-personality-and-local-memory.md`
+**OpenSpec:** `openspec/specs/netclaw-agent-memory/spec.md`, `openspec/specs/netclaw-onboarding/spec.md`
+**Surface area:** onboarding
+**Verification:** L2
+
+Done when:
+- [ ] First-run detection: trigger bootstrap when soul files don't exist.
+- [ ] Bootstrap conversation: introduce, learn preferences, scan environment, write soul files, confirm.
+- [ ] Test for bootstrap trigger and soul file creation.
+
+### Task 1.16: Integration and acceptance
+
+**PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
+**OpenSpec:** all Phase 1 specs
 **Surface area:** end-to-end
 **Verification:** L4
 
 Done when:
-- [ ] Slack in-thread replies work on `pi1` with session continuity across restart.
-- [ ] Compaction preserves working context for long threads.
-- [ ] ACL/exposure policy denial paths are verified on host.
-- [ ] Local smoke test against `big-gpu` succeeds when invoked.
+- [ ] E2E: Slack message → session → tool call → reply in thread.
+- [ ] E2E: scheduled task fires → fresh session → result posted to Slack.
+- [ ] E2E: restart recovery preserves session context and scheduled tasks.
+- [ ] CI test suite passes without live provider credentials.
+- [ ] Deploy to pi1 and verify Slack interaction.
 
-### Task 5.2: Archive completed OpenSpec changes and prep release notes
+### Task 1.17: Sync specs and archive change
 
-**PRD:** `docs/prd/PRD-001-netclaw-mvp.md`
-**OpenSpec Capabilities:** `openspec/specs/README.md`
-**OpenSpec Changes:** `openspec/changes/*`
-**Surface area:** release/process
+**OpenSpec Changes:** `openspec/changes/expand-mvp-for-autonomous-agent-vision/`
+**Surface area:** process
 **Verification:** L0
 
 Done when:
-- [ ] Completed changes are archived with `openspec archive <change-name>`.
-- [ ] Main capability specs reflect implemented behavior.
-- [ ] `RELEASE_NOTES.md` captures user-facing MVP behavior delivered.
+- [ ] Delta specs synced to main specs.
+- [ ] `openspec validate --all --no-interactive` passes.
+- [ ] Change archived with `openspec archive expand-mvp-for-autonomous-agent-vision`.
+
+---
+
+## Phase 2: Input Expansion (Post-MVP)
+
+Ambient channels, webhooks, channel instructions, onboarding wizard.
+Tasks to be defined when Phase 1 is complete.
+
+---
+
+## Phase 3: Delegated Coding (Post-MVP)
+
+Claude Code / OpenCode spawning, process monitoring.
+Tasks to be defined when Phase 2 is complete.
+
+---
+
+## Phase 4: Browser + Research (Post-MVP)
+
+Web automation, price monitoring, research pipelines.
+Tasks to be defined when Phase 3 is complete.
+
+---
+
+## Phase 5: Ops Console (Post-MVP)
+
+Web UI for config, sessions, diagnostics (PRD-003).
+Tasks to be defined when Phase 4 is complete.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -2,21 +2,55 @@
 
 ## What Netclaw Is
 
-Netclaw is a Slack-connected homelab assistant that runs as a .NET 10 host on
-owned infrastructure. It is built on top of Akka.Agents, a minimal actor-based
-session framework using Akka.NET persistence, pub/sub broadcasts, and
-conversation compaction.
+Netclaw is an **always-on autonomous operations agent** running on homelab
+infrastructure (pi1). It is a single-process .NET 10 application built on
+Akka.Agents, communicating primarily through Slack. It is NOT just a chat
+assistant — it is an autonomous operations platform that can monitor, react,
+investigate, delegate work, and manage its own schedule.
 
 ## Primary User
 
 - owner-operator running Netclaw on homelab hardware (pi1)
-- interacts primarily through Slack
+- interacts primarily through Slack (including mobile, on the go)
 - needs predictable behavior, persistence, and strong safety defaults
+- wants to pop off background tasks and have them run autonomously
+
+## Full Product Vision
+
+### Core Use Cases
+
+1. **Chat assistant with memory** — message it in Slack, it remembers context
+   across restarts, can research topics, delegate work, save findings
+2. **Ambient channel monitoring** — listens to alert channels, reacts to
+   production issues (pull OTel data from Seq, file GitHub issues)
+3. **Delegated coding tasks** — spawns Claude Code / OpenCode in `-p` mode,
+   monitors progress, posts PR links back to Slack
+4. **Research and scheduling** — web search, browser automation, chat-driven
+   scheduled tasks ("check eBay for this GPU every 6 hours")
+5. **Chain-reaction workflows** — filing an issue can trigger another session
+   to attempt a fix via webhook
+
+### Key Architectural Insight
+
+Everything is just a message arriving at a session actor with context-specific
+instructions. The input source (Slack, webhook, timer, future web UI) is
+irrelevant — the differentiator is the instructions attached to the context.
+
+| Input Source          | Delivery Mechanism                          |
+|-----------------------|---------------------------------------------|
+| User @mention         | Slack Socket Mode                           |
+| Ambient channel alert | Slack Socket Mode (require_mention: false)  |
+| Webhook (GitHub, CI)  | HTTP via Tailscale Serve / Cloudflare Tunnel|
+| Scheduled task        | Internal timer                              |
+| Web UI (future)       | WebSocket / HTTP                            |
 
 ## MVP Outcome
 
 Netclaw runs on `pi1`, answers Slack messages in thread, persists session state
-across restarts, and compacts long threads without losing working context.
+across restarts, compacts long threads, has local memory (project registry,
+environment inventory, agent personality), integrates with MCP (Memorizer),
+provides basic tool access (web search, shell, GitHub), and supports
+chat-driven scheduling.
 
 ## Product Boundaries (MVP)
 
@@ -29,17 +63,84 @@ In scope:
 - compaction via summarization reducer
 - pub/sub session broadcasts for adapters and future UI subscribers
 - default-deny ACL with explicit channel/sender/data grants
-- file-based system prompt including opening or zero clause contract
-- MCP server integration with policy-gated tool invocation
-- minimal operator UX via CLI and management UI mockups/specs
+- agent personality / soul (markdown-based system prompt)
+- first-party local memory: project registry, environment inventory, config
+- MCP server integration (Memorizer for research/knowledge, other tools)
+- basic tool access: web search, web fetch, shell execution, GitHub (gh CLI)
+- chat-driven scheduling (agent manages its own schedule)
+- OpenRouter as primary LLM provider via Microsoft.Extensions.AI (pluggable)
+- configurable primary + fallback model
+- capability self-discovery (installed tools, credentials, host info)
+- self-configuration through conversation (bot updates its own config files)
 
 Out of scope (deferred):
 
 - split gateway/agent processes
-- sub-agent orchestration and hooks
+- webhook ingress (Tailscale Serve / Cloudflare Tunnel)
+- ambient channel monitoring with per-channel instructions
+- sub-agent model routing (cheaper models for high-token tasks)
+- browser automation
+- delegated coding (Claude Code / OpenCode spawning)
 - web UI implementation (spec/mockup only in this phase)
+- formal approval gates and tool isolation/sandboxing
 - telemetry and advanced model capability abstraction layers
 - session branching/revert features
+
+## Personality Model
+
+- **Single global personality** for the human-facing chatbot
+- **Spawns sub-agents** with specialized system prompts for discrete tasks
+  (browser automation, diagnostics, coding)
+- **Loads project AGENTS.md** as context overlays when working on registered
+  projects (same layered model as Claude Code)
+
+## Memory Architecture
+
+### First-Party Local Memory
+
+- Agent soul / personality (markdown files on disk)
+- Project registry: repo paths, alert channels, capabilities, AGENTS.md paths
+- Environment inventory: installed tools, credentials, host capabilities
+- Scheduled tasks and channel-level instructions
+- Storage: files on disk, loaded into agent context at session start
+  (alternatively SQLite with vector search if growth warrants it)
+
+### External Memory (MCP)
+
+- Memorizer for research findings, knowledge base, cross-session learning
+- Important MCP tool but NOT the core memory mechanism
+- Local memory is more personal: file paths, tool availability, project info
+
+## Capability Self-Discovery
+
+Netclaw maintains awareness of its environment:
+
+- Is `claude` / `opencode` CLI available?
+- Do I have git credentials? For which hosts?
+- What .NET SDK is installed? Can I install new versions via install scripts?
+- What repos are registered and where on disk?
+- What MCP servers are configured and reachable?
+
+## Autonomy Model
+
+- Fully autonomous for investigation, analysis, filing issues
+- Fully autonomous for spawning Claude Code / OpenCode
+- **Cannot merge PRs** (enforced by git credential scope)
+- Posts progress to Slack threads for passive visibility
+- Formal approval gates and tool isolation are post-MVP
+
+## Configuration Model
+
+- Bot can update its own configuration through conversation
+- Config stored as files on disk, loaded at session/agent start
+- Session reboot needed to refresh config (cached in LLM context)
+- Future web UI reads same config files
+
+## LLM Provider Strategy
+
+- OpenRouter as primary provider via `Microsoft.Extensions.AI`
+- Configurable primary model + fallback model
+- Sub-agent model routing (post-MVP)
 
 ## Architectural Decisions to Preserve
 
@@ -48,12 +149,20 @@ Out of scope (deferred):
   model internals
 - Serialization boundary: never persist framework-external chat types directly
 - Security boundary: default deny, explicit allow, fail-closed configuration
+- Everything is just input: all sources produce messages routed to session
+  actors with context-specific instructions
+
+## Phasing
+
+1. **Chat + Memory MVP** — Slack, persistence, compaction, local memory,
+   MCP/Memorizer, basic tools, scheduling
+2. **Input Expansion** — ambient channels, webhook ingress, channel
+   instructions, onboarding wizard
+3. **Delegated Coding** — Claude Code / OpenCode spawning, process monitoring
+4. **Browser + Research** — web automation, price monitoring, research pipelines
+5. **Ops Console** — web UI for config, sessions, diagnostics
 
 ## Current Phase
 
-Documentation-first planning:
-
-- establish PRDs and engineering specs
-- define operator UI/CLI contracts
-- bootstrap OpenSpec change planning and baseline capability specs
-- then begin implementation through OpenSpec task execution
+Vision definition and specification. PRDs and engineering specs need revision
+to align with the expanded product vision before implementation begins.

--- a/docs/prd/PRD-001-netclaw-mvp.md
+++ b/docs/prd/PRD-001-netclaw-mvp.md
@@ -2,20 +2,40 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
+- Revised: 2026-02-21 (expanded product vision)
 
 ## Problem Statement
 
-The operator needs a personal assistant that can reliably act through Slack,
-keep conversational context across restarts, and remain secure on a homelab
-host without requiring a complex distributed deployment.
+The operator needs an always-on autonomous operations agent running on homelab
+infrastructure that can answer questions through Slack, remember context across
+restarts, manage its own schedule, discover and use local tools, maintain
+awareness of its environment, and modify its own configuration through
+conversation — all without requiring a complex distributed deployment.
 
 ## Product Goal
 
-Deliver a minimal but dependable Slack-connected assistant that is actor-driven,
-persistence-backed, and safe-by-default.
+Deliver a minimal but dependable autonomous operations agent that is
+actor-driven, persistence-backed, memory-aware, tool-capable, and
+safe-by-default. Netclaw is not just a chat assistant — it is an autonomous
+operations platform that can monitor, react, investigate, delegate work, and
+manage its own schedule.
+
+## Key Architectural Insight
+
+Everything is just a message arriving at a session actor with context-specific
+instructions. The input source (Slack, webhook, timer, future web UI) is
+irrelevant — the differentiator is the instructions attached to the context.
+
+| Input Source          | Delivery Mechanism                          | MVP? |
+|-----------------------|---------------------------------------------|------|
+| User @mention         | Slack Socket Mode                           | Yes  |
+| Scheduled task        | Internal timer                              | Yes  |
+| Ambient channel alert | Slack Socket Mode (require_mention: false)  | No   |
+| Webhook (GitHub, CI)  | HTTP via Tailscale Serve / Cloudflare Tunnel| No   |
+| Web UI (future)       | WebSocket / HTTP                            | No   |
 
 ## MVP Success Criteria
 
@@ -24,18 +44,34 @@ persistence-backed, and safe-by-default.
 3. Long sessions compact context while preserving task continuity.
 4. Unauthorized interactions are denied by policy.
 5. Operator can configure and validate system behavior without source edits.
+6. Agent maintains personality, project registry, and environment awareness
+   across sessions.
+7. Agent can use local tools (web search, shell, GitHub CLI) through
+   policy-gated access.
+8. Agent can create and manage scheduled tasks through conversation.
+9. Agent can discover its own capabilities (installed tools, credentials,
+   host info).
+10. Agent can modify its own configuration through conversation.
+11. MCP integration provides external memory (Memorizer) and tool capabilities.
 
 ## Non-Goals (MVP)
 
 - Multi-process gateway/agent split
-- sub-agent orchestration framework
-- web management UI implementation (spec + mockups only)
-- advanced observability and model capability abstractions
-- branch/revert session editing features
+- Ambient channel monitoring with per-channel instructions
+- Webhook ingress (Tailscale Serve / Cloudflare Tunnel)
+- Sub-agent model routing (cheaper models for high-token tasks)
+- Browser automation
+- Delegated coding (Claude Code / OpenCode spawning)
+- Web management UI implementation (spec + mockups only)
+- Formal approval gates and tool isolation/sandboxing
+- Telemetry and advanced model capability abstraction layers
+- Session branching/revert features
 
 ## Primary Personas
 
-- `Owner-Operator`: runs Netclaw on homelab hardware and interacts through Slack.
+- `Owner-Operator`: runs Netclaw on homelab hardware (pi1), interacts through
+  Slack (including mobile, on the go), needs predictable behavior, persistence,
+  and strong safety defaults.
 - `Future Maintainer`: extends capabilities and needs stable behavioral specs.
 
 ## Functional Requirements
@@ -48,7 +84,9 @@ that thread shall route to the same session actor.
 ### FR-002 Turn Processing and Broadcast
 
 User input shall produce a persisted turn event and a broadcast event consumed
-by the Slack adapter for reply delivery.
+by the Slack adapter for reply delivery. Pub/sub session broadcasts enable
+adapters and future UI subscribers to consume session output without direct
+transport coupling.
 
 ### FR-003 Persistent Recovery
 
@@ -63,17 +101,25 @@ summary reduction and persist a compaction event.
 ### FR-005 Default-Deny ACL
 
 All inbound interactions and privileged operations shall be denied unless
-explicitly allowed by configuration.
+explicitly allowed by configuration. See PRD-002.
 
-### FR-006 System Prompt Contract
+### FR-006 Layered System Prompt
 
-A file-based system prompt, including opening/zero clause guidance, shall be
-injected consistently into turn context.
+Session context shall be assembled from layered system prompt sources:
+
+1. Core personality (PERSONALITY.md — hardcoded agent identity)
+2. Operating instructions (INSTRUCTIONS.md — behavioral guidelines)
+3. User context (USER.md — owner preferences)
+4. Project overlay (AGENTS.md from registered project — loaded on demand)
+5. Session-specific context (conversation, tool results, memory)
+
+Later layers augment or override earlier layers. All soul files are loaded at
+session start and cached.
 
 ### FR-007 Operator Controls
 
 CLI commands and documented UI contracts shall cover onboarding, config
-validation, ACL diagnostics, and session inspection workflows.
+validation, ACL diagnostics, and session inspection workflows. See PRD-004.
 
 ### FR-008 Slack Socket Mode Transport
 
@@ -82,15 +128,83 @@ event handling during MVP, avoiding required public inbound HTTP endpoints.
 
 ### FR-009 MCP Tool Integration
 
-Netclaw shall support MCP server integration in MVP so tool capabilities can be
-loaded from a configured server list with policy enforcement.
+Netclaw shall support MCP server integration so tool capabilities can be loaded
+from a configured server list with policy enforcement. Memorizer shall serve as
+the external memory tier for research, knowledge base, and cross-session
+learning. See PRD-006.
+
+### FR-010 Local Memory System
+
+Netclaw shall maintain first-party local memory on disk:
+
+- Agent soul / personality (markdown files)
+- Project registry (repo paths, capabilities, AGENTS.md paths)
+- Environment inventory (installed tools, credentials, host capabilities)
+- Scheduled task definitions
+- Channel-level instructions (post-MVP)
+
+Local memory is personal and operational (file paths, tool availability,
+project info). Large-corpus knowledge is delegated to Memorizer via MCP.
+See PRD-007.
+
+### FR-011 Tool Access
+
+Netclaw shall provide policy-gated access to local tools:
+
+- Web search (Brave Search API or equivalent)
+- Web fetch (URL content retrieval)
+- Shell execution (sandboxed command execution)
+- GitHub (via `gh` CLI)
+
+Tool invocation is subject to ACL grants per PRD-002. Tool results are included
+in session context for the LLM.
+
+### FR-012 Chat-Driven Scheduling
+
+The agent shall create, list, and cancel scheduled tasks through conversation.
+Scheduled tasks are persisted as JSON and executed by Akka timers. Each
+scheduled execution creates a fresh session or runs in a dedicated scheduling
+actor. See PRD-008.
+
+### FR-013 Capability Self-Discovery
+
+Netclaw shall maintain awareness of its environment:
+
+- Is `claude` / `opencode` CLI available?
+- Do I have git credentials? For which hosts?
+- What .NET SDK is installed?
+- What repos are registered and where on disk?
+- What MCP servers are configured and reachable?
+
+Discovery runs at startup and can be re-triggered through conversation.
+See PRD-007.
+
+### FR-014 Self-Configuration
+
+The agent shall modify its own configuration files through conversation:
+
+- Update personality, instructions, and user preferences
+- Register and unregister projects
+- Update environment inventory
+- Create and manage scheduled tasks
+
+Configuration is cached in LLM context at session start. Session reboot
+refreshes the context. See PRD-007.
+
+### FR-015 Pre-Compaction Memory Flush
+
+Before context compaction occurs, Netclaw shall trigger a silent agentic turn
+prompting the model to write durable memories to disk. This directly counters
+context rot — losing important information when context resets. See PRD-007.
 
 ## Operational Requirements
 
-- single-process host deployment on `pi1`
-- no required public inbound HTTP path for base Slack operation
-- secure failure mode: invalid policy/config blocks startup
+- Single-process host deployment on `pi1`
+- No required public inbound HTTP path for base Slack operation
+- Secure failure mode: invalid policy/config blocks startup
 - CI/CD test path does not require live model provider credentials
+- Agent data directory (`~/.netclaw/` or configured path) stores all local
+  memory, config, and schedule files
 
 ## Acceptance Tests
 
@@ -99,6 +213,21 @@ loaded from a configured server list with policy enforcement.
 3. Long thread triggers compaction without losing active task objective.
 4. Disallowed sender/channel is rejected and logged as policy deny.
 5. CLI config validation reports pass before runtime start.
+6. Agent personality is consistent across sessions and restarts.
+7. Agent can list registered projects and environment capabilities.
+8. Agent can create a scheduled task through conversation.
+9. Agent can use web search and shell tools when policy allows.
+10. MCP Memorizer stores and retrieves cross-session knowledge.
+
+## Phasing
+
+1. **Chat + Memory MVP** (this PRD) — Slack, persistence, compaction, local
+   memory, MCP/Memorizer, basic tools, scheduling
+2. **Input Expansion** — ambient channels, webhooks, channel instructions,
+   onboarding wizard
+3. **Delegated Coding** — Claude Code / OpenCode spawning, process monitoring
+4. **Browser + Research** — web automation, price monitoring, research pipelines
+5. **Ops Console** — web UI for config, sessions, diagnostics
 
 ## Risks and Mitigations
 
@@ -108,3 +237,18 @@ loaded from a configured server list with policy enforcement.
   - `Mitigation`: framework-owned serializable message envelope only.
 - `Risk`: MVP scope creep toward north-star architecture.
   - `Mitigation`: explicit non-goals and change reviews against this PRD.
+- `Risk`: context rot from long-running sessions losing important memories.
+  - `Mitigation`: pre-compaction memory flush pattern (FR-015).
+- `Risk`: agent self-modification introduces inconsistent state.
+  - `Mitigation`: session reboot on config change; validate before write.
+
+## Cross-References
+
+- Security: PRD-002
+- Ops Console: PRD-003 (deferred to Phase 5)
+- CLI Onboarding: PRD-004
+- Model Providers: PRD-005
+- MCP Integration: PRD-006
+- Agent Personality and Memory: PRD-007
+- Scheduling: PRD-008
+- Input Adapters: PRD-009 (post-MVP)

--- a/docs/prd/PRD-001-netclaw-mvp.md
+++ b/docs/prd/PRD-001-netclaw-mvp.md
@@ -31,6 +31,7 @@ irrelevant — the differentiator is the instructions attached to the context.
 
 | Input Source          | Delivery Mechanism                          | MVP? |
 |-----------------------|---------------------------------------------|------|
+| Local TUI             | `netclaw chat` in-process                   | Yes  |
 | User @mention         | Slack Socket Mode                           | Yes  |
 | Scheduled task        | Internal timer                              | Yes  |
 | Ambient channel alert | Slack Socket Mode (require_mention: false)  | No   |
@@ -196,6 +197,22 @@ refreshes the context. See PRD-007.
 Before context compaction occurs, Netclaw shall trigger a silent agentic turn
 prompting the model to write durable memories to disk. This directly counters
 context rot — losing important information when context resets. See PRD-007.
+
+### FR-016 Config Hot-Reload
+
+Netclaw shall monitor operational configuration files for changes and apply
+updates without process restart:
+
+- **Watched files** (hot-reloaded): ACL rules, provider config, MCP profiles,
+  schedule definitions
+- **Unwatched files** (require restart or session reboot): personality files,
+  project registry, environment inventory
+
+Mechanism: `FileSystemWatcher` + 500ms debounce + validate-before-apply.
+Invalid config changes SHALL be rejected with logged diagnostics. Valid changes
+SHALL notify owning actors (ACL changes → policy engine refresh, provider
+changes → `IChatClient` rebuild, MCP changes → reconnect/disconnect servers,
+schedule changes → timer reconfiguration).
 
 ## Operational Requirements
 

--- a/docs/prd/PRD-002-gateway-security-envelope.md
+++ b/docs/prd/PRD-002-gateway-security-envelope.md
@@ -2,15 +2,17 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
+- Revised: 2026-02-21 (expanded for tool execution, self-config safety)
 - Depends on: `PRD-001`
 
 ## Goal
 
 Define the minimum security controls required for shipping Netclaw MVP without
-introducing unsafe defaults.
+introducing unsafe defaults. This covers inbound message policy, tool execution
+policy, self-configuration safety, and exposure controls.
 
 ## Security Principles
 
@@ -19,6 +21,7 @@ introducing unsafe defaults.
 3. Fail closed on invalid configuration.
 4. Tool access is policy mediated, not model mediated.
 5. Keep trust boundaries simple and inspectable.
+6. Self-configuration changes are validated before write.
 
 ## Requirements
 
@@ -30,11 +33,23 @@ sender, and interaction mode.
 ### SEC-002 Mention and Ambient Policy Controls
 
 Channels must explicitly declare whether mention is required. Ambient mode may
-act without mention only where policy allows.
+act without mention only where policy allows. Ambient monitoring is post-MVP
+but the policy model must support it from day one.
 
-### SEC-003 Data Grant Controls
+### SEC-003 Data and Tool Grant Controls
 
-Data/tool access must be checked against configured grants before execution.
+Data access and tool invocation must be checked against configured grants before
+execution. Tool categories for MVP:
+
+- `shell` — command execution (highest risk)
+- `web_search` — web search API calls
+- `web_fetch` — URL content retrieval
+- `github` — GitHub CLI operations
+- `mcp:{server_name}` — MCP server tool invocation
+- `config_write` — self-modification of agent config files
+- `schedule_write` — creation/modification of scheduled tasks
+
+Each grant specifies allowed senders and channels. Missing grant = deny.
 
 ### SEC-004 Startup Validation
 
@@ -65,8 +80,32 @@ Pairing must be required before first privileged browser-session action.
 
 ### SEC-007 Auditability
 
-Policy denies, privileged approvals, and exposure settings must be auditable in
-operator-facing diagnostics.
+Policy denies, privileged approvals, tool invocations, and exposure settings
+must be auditable in operator-facing diagnostics. Tool invocation audit records
+shall include: tool name, invoking session, timestamp, and allow/deny result.
+
+### SEC-008 Self-Configuration Safety
+
+When the agent modifies its own configuration files (FR-014):
+
+- Config changes must be validated before being written to disk.
+- Invalid config changes must be rejected with an explanation to the user.
+- ACL and security policy files cannot be modified by the agent through
+  conversation — only through CLI or direct file edit by the operator.
+- Agent can modify: personality, instructions, user preferences, project
+  registry, environment inventory, and scheduled tasks.
+- Agent cannot modify: ACL rules, exposure policy, tool grants, or security
+  settings.
+
+### SEC-009 Shell Execution Boundaries
+
+Shell execution (when granted) operates under these constraints:
+
+- Commands run as the Netclaw process user (no privilege escalation).
+- Execution timeout is configurable (default: 60 seconds).
+- Output is truncated to a configurable limit to prevent context flooding.
+- No interactive commands (stdin is closed).
+- Working directory is the registered project path or a configured scratch dir.
 
 ## Threat Model Scope (MVP)
 
@@ -76,12 +115,14 @@ In scope:
 - prompt-injection attempts via inbound messages
 - accidental over-exposure from misconfiguration
 - misuse of high-trust tools by over-broad policy grants
+- agent self-modification introducing inconsistent or dangerous state
 
 Out of scope (deferred):
 
 - full marketplace supply-chain scanning
 - enterprise SSO and federated identity controls
 - distributed policy propagation across services
+- sandboxed tool execution (formal isolation)
 
 ## Acceptance Criteria
 
@@ -91,3 +132,13 @@ Out of scope (deferred):
 4. Invalid ACL file prevents successful host start.
 5. Diagnostics expose effective exposure mode and latest policy denies.
 6. Public exposure mode without access policy fails validation.
+7. Shell execution respects timeout and output limits.
+8. Agent cannot modify ACL or security config through conversation.
+9. Tool invocation audit trail is available in diagnostics.
+
+## Cross-References
+
+- MVP scope: PRD-001
+- CLI diagnostics: PRD-004
+- Tool access: PRD-006 (MCP), PRD-007 (local tools)
+- Self-configuration: PRD-007

--- a/docs/prd/PRD-003-operator-ux-ops-console.md
+++ b/docs/prd/PRD-003-operator-ux-ops-console.md
@@ -2,15 +2,26 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Deferred to Phase 5
 - Owner: Netclaw engineering
 - Date: 2026-02-21
+- Revised: 2026-02-21 (explicitly deferred; spec/mockup deliverable clarified)
 - Depends on: `PRD-001`, `PRD-002`
+
+## Deferral Note
+
+The ops console web UI is **Phase 5** work. During MVP (Phase 1), all operator
+workflows are served by CLI commands (PRD-004). This PRD defines the target
+experience so CLI and management API contracts can be designed with the future
+UI in mind.
+
+**MVP deliverable:** UI spec and mockups only. No implementation.
 
 ## Goal
 
 Define a management experience that lets an owner-operator understand system
-health, inspect sessions, and control policy without reading source code.
+health, inspect sessions, control policy, review memory and scheduling state,
+and diagnose failures without reading source code.
 
 ## UX Direction
 
@@ -19,6 +30,7 @@ Ops console, not chat-first dashboard:
 - dense information layout
 - fast diagnostics and actionability
 - explicit security and policy visibility
+- memory and scheduling visibility
 
 ## Jobs To Be Done
 
@@ -27,13 +39,17 @@ Ops console, not chat-first dashboard:
 3. As an operator, I can review and update ACL rules safely.
 4. As an operator, I can verify exposure mode and security posture at a glance.
 5. As an operator, I can diagnose failures from one place.
+6. As an operator, I can see registered projects and environment inventory.
+7. As an operator, I can see and manage scheduled tasks.
+8. As an operator, I can see agent memory and personality configuration.
+9. As an operator, I can see MCP server health and tool availability.
 
 ## Core Screens
 
 ### UX-001 Overview
 
-Surface runtime health, active sessions, policy deny counters, and recent
-critical events.
+Surface runtime health, active sessions, policy deny counters, scheduled task
+status, memory health, and recent critical events.
 
 ### UX-002 Session Inspector
 
@@ -52,13 +68,23 @@ warnings.
 
 ### UX-005 Diagnostics
 
-Provide filtered logs, actor errors, persistence status, and operator guidance
-for next actions.
+Provide filtered logs, actor errors, persistence status, tool invocation
+audit trail, and operator guidance for next actions.
 
-### UX-006 UI Stack (Delivery)
+### UX-006 Memory and Configuration
+
+View agent personality files, project registry, environment inventory, and
+allow editing through the UI (same validation as self-configuration).
+
+### UX-007 Scheduling
+
+View, create, pause, and delete scheduled tasks. Show execution history and
+next-fire times.
+
+### UX-008 UI Stack (Delivery)
 
 The management console implementation target is ASP.NET Core with Blazor Server
-components in the same host process for MVP. Real-time updates use SignalR.
+components in the same host process. Real-time updates use SignalR.
 
 Rationale: keeps deployment and security surface simple, avoids separate Node
 build/runtime, and aligns with .NET-first operations.
@@ -70,14 +96,28 @@ build/runtime, and aligns with .NET-first operations.
 - validation errors are actionable and location-specific
 - mobile layout supports read-only triage and acknowledge actions
 
-## Out of Scope (MVP)
+## Out of Scope
 
-- full web UI implementation
 - visual analytics historical dashboards
 - multi-tenant role-based admin views
+- implementation during MVP (Phase 1-4)
 
-## Acceptance Criteria
+## Acceptance Criteria (Phase 5)
 
 1. Mockups define all core screens with component-level content.
 2. UI spec defines data contracts needed from runtime.
-3. Every operator workflow has an equivalent CLI path for MVP.
+3. Every operator workflow has an equivalent CLI path.
+4. Management API endpoints exist for all UI data needs.
+
+## Acceptance Criteria (MVP - spec only)
+
+1. UI screen definitions exist as mockups in `docs/ui/`.
+2. Management API contract is documented for future implementation.
+3. CLI commands in PRD-004 cover all operator workflows.
+
+## Cross-References
+
+- CLI alternative: PRD-004
+- Security controls: PRD-002
+- Memory system: PRD-007
+- Scheduling: PRD-008

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -2,60 +2,110 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
-- Depends on: `PRD-001`, `PRD-002`, `PRD-003`
+- Revised: 2026-02-21 (two-phase onboarding, expanded command surface)
+- Depends on: `PRD-001`, `PRD-002`
 
 ## Goal
 
 Provide a first-class operator CLI to bootstrap, validate, and troubleshoot
-Netclaw without manual file hunting.
+Netclaw. The CLI is the **primary operator interface during MVP** — all
+workflows that will eventually appear in the ops console (PRD-003) must be
+accessible via CLI first.
 
 ## Product Outcome
 
-An owner can go from empty config to safe runtime startup and ongoing diagnostics
-using CLI commands and guided output.
+An owner can go from empty config to safe runtime startup and ongoing
+diagnostics using CLI commands and guided output.
 
-## UX Direction
+## Two-Phase Onboarding
 
-- onboarding-first, safe defaults
-- explicit security confirmations before risky enablement
-- step-by-step provider and Slack setup with validation at each step
+### Phase 1: CLI Wizard (`netclaw init`)
+
+Technical setup, no LLM required:
+
+1. LLM provider configuration (OpenRouter API key, model selection)
+2. Slack app setup (bot token, app token for Socket Mode)
+3. PostgreSQL connection string
+4. ACL bootstrap (owner identity, initial channel rules)
+5. MCP server configuration (optional — Memorizer recommended)
+6. Exposure mode selection (local-only default)
+7. Health check (verify Slack connection, DB connection, LLM reachability)
+
+### Phase 2: Conversational Personality Bootstrap (first Slack message)
+
+Agent-driven setup, requires running LLM:
+
+1. "Hi, I'm Netclaw. Let me learn about you and your setup."
+2. Ask about projects to register (repo paths on disk)
+3. Discover environment capabilities (scan for installed tools)
+4. Write PERSONALITY.md, USER.md, environment inventory
+5. Confirm readiness
+
+Phase 2 is triggered automatically on first conversation if personality files
+don't exist. It can also be re-triggered via CLI (`netclaw personality reset`).
 
 ## Command Surface (MVP)
 
-- `netclaw init`
-- `netclaw config show|validate`
-- `netclaw acl validate|test|explain`
-- `netclaw gateway status|doctor|pair`
-- `netclaw session inspect|compact`
-- `netclaw prompt show|validate`
-- `netclaw tools list|policy`
-- `netclaw mcp list|validate|test`
-- `netclaw test smoke [--provider ollama]`
+### Onboarding and Configuration
+
+- `netclaw init` — guided first-time setup wizard
+- `netclaw config show|validate` — display/validate current configuration
+- `netclaw personality reset` — re-trigger conversational personality setup
+
+### Security and Policy
+
+- `netclaw acl validate|test|explain` — ACL validation, testing, explanation
+- `netclaw gateway status|doctor` — connectivity, exposure, health diagnostics
+
+### Sessions
+
+- `netclaw session list|inspect|compact` — session management and inspection
+
+### Memory and Projects
+
+- `netclaw project list|add|remove` — project registry management
+- `netclaw environment scan|show` — capability self-discovery and display
+- `netclaw memory show` — display current agent memory files
+
+### Scheduling
+
+- `netclaw schedule list|show|pause|resume|delete` — scheduled task management
+
+### Tools and MCP
+
+- `netclaw tools list|policy` — tool availability and policy display
+- `netclaw mcp list|validate|test` — MCP server management
+
+### Testing
+
+- `netclaw test smoke [--provider ollama]` — provider smoke test
 
 ## Requirements
 
 ### CLI-001 Onboarding
 
 `init` creates baseline config and highlights required secrets and policy items.
+Onboarding captures all Phase 1 setup items in a stepwise flow.
 
 ### CLI-001A Guided Setup Wizard
 
 `netclaw init` SHALL support an interactive guided onboarding flow that:
 
-1. captures runtime profile (local only vs remote managed)
-2. configures Slack Socket Mode credentials
-3. configures model provider (OpenRouter default)
-4. configures MCP server profiles (optional step, explicit enable)
-5. scaffolds ACL in default-deny mode
-6. runs final validation and prints next-step run commands
+1. Captures LLM provider configuration (OpenRouter default)
+2. Configures Slack Socket Mode credentials (bot token + app token)
+3. Configures PostgreSQL connection string
+4. Scaffolds ACL in default-deny mode with owner identity
+5. Optionally configures MCP servers (Memorizer recommended)
+6. Selects exposure mode (local default)
+7. Runs final validation and prints next-step run commands
 
 ### CLI-002 Validation
 
-`config validate` and `acl validate` provide structured errors with file path and
-property location.
+`config validate` and `acl validate` provide structured errors with file path
+and property location.
 
 ### CLI-003 Explainability
 
@@ -63,12 +113,13 @@ property location.
 
 ### CLI-004 Runtime Diagnostics
 
-`gateway status` and `gateway doctor` summarize connectivity, persistence, and
-policy health.
+`gateway status` and `gateway doctor` summarize connectivity, persistence,
+policy health, MCP server health, and scheduled task status.
 
 ### CLI-005 Session Operations
 
-`session inspect` exposes current state, last activity, and compaction metadata.
+`session inspect` exposes current state, last activity, compaction metadata,
+and active tool grants for the session.
 
 ### CLI-006 Safe Defaults
 
@@ -80,9 +131,28 @@ provided.
 The onboarding flow SHALL be resumable and indicate which setup steps are
 completed, pending, or invalid.
 
+### CLI-008 Project Registration
+
+`project add` SHALL register a project with:
+- repo path on disk
+- optional AGENTS.md path (defaults to `{repo}/AGENTS.md`)
+- optional associated Slack channels
+- capabilities (has tests, has CI, language/framework)
+
+### CLI-009 Environment Discovery
+
+`environment scan` SHALL discover:
+- Installed CLIs: `claude`, `opencode`, `git`, `gh`, `dotnet`, `node`
+- Git credential availability (for which hosts)
+- .NET SDK version
+- MCP server reachability
+- Registered project paths validity
+
+Results are persisted to the environment inventory file.
+
 ## UX Requirements
 
-- human-readable output by default, machine-friendly JSON opt-in
+- human-readable output by default, machine-friendly JSON opt-in (`--json`)
 - explicit exit codes for automation
 - no hidden side effects for diagnostic commands
 
@@ -92,3 +162,16 @@ completed, pending, or invalid.
 2. Every high-risk command has confirmation or explicit `--yes` semantics.
 3. Error output includes remediation guidance.
 4. Fresh install reaches a runnable baseline in one guided flow.
+5. Personality bootstrap triggers automatically on first conversation.
+6. Environment scan discovers and persists capability inventory.
+7. Project registration persists project registry to disk.
+
+## Cross-References
+
+- MVP scope: PRD-001
+- Security validation: PRD-002
+- Ops console (future UI): PRD-003
+- Provider setup: PRD-005
+- MCP setup: PRD-006
+- Memory and personality: PRD-007
+- Scheduling: PRD-008

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -5,7 +5,8 @@
 - State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
-- Revised: 2026-02-21 (two-phase onboarding, expanded command surface)
+- Revised: 2026-02-21 (two-phase onboarding, expanded command surface, TUI
+  commands, Cocona + Termina frameworks)
 - Depends on: `PRD-001`, `PRD-002`
 
 ## Goal
@@ -19,6 +20,14 @@ accessible via CLI first.
 
 An owner can go from empty config to safe runtime startup and ongoing
 diagnostics using CLI commands and guided output.
+
+## CLI Framework
+
+- **Cocona** for command routing (lightweight, convention-based, DI integration)
+- **Termina 0.5.1** for interactive TUI commands (`netclaw init`, `netclaw chat`)
+- All other commands use plain console output via Cocona
+- `netclaw run` is the explicit daemon entry point (Slack + timers + health
+  endpoints, no TUI)
 
 ## Two-Phase Onboarding
 
@@ -34,7 +43,7 @@ Technical setup, no LLM required:
 6. Exposure mode selection (local-only default)
 7. Health check (verify Slack connection, DB connection, LLM reachability)
 
-### Phase 2: Conversational Personality Bootstrap (first Slack message)
+### Phase 2: Conversational Personality Bootstrap (first `netclaw chat`)
 
 Agent-driven setup, requires running LLM:
 
@@ -44,14 +53,26 @@ Agent-driven setup, requires running LLM:
 4. Write PERSONALITY.md, USER.md, environment inventory
 5. Confirm readiness
 
-Phase 2 is triggered automatically on first conversation if personality files
+Phase 2 is triggered automatically on first `netclaw chat` if personality files
 don't exist. It can also be re-triggered via CLI (`netclaw personality reset`).
 
 ## Command Surface (MVP)
 
-### Onboarding and Configuration
+### TUI-Interactive Commands (Termina)
 
-- `netclaw init` — guided first-time setup wizard
+- `netclaw init` — guided first-time setup wizard (7-step TUI wizard)
+- `netclaw chat` — interactive agent prompt with streaming responses, tool
+  activity display, and MCP status. Hosts actor system in-process. Session
+  entity key: `tui/{uuid}`. See TUI-001 wireframes.
+
+### Daemon Mode
+
+- `netclaw run` — start daemon mode (Slack Socket Mode + Akka actor system +
+  scheduled task timers + health endpoints). No TUI. Primary production entry
+  point.
+
+### Onboarding and Configuration (Plain CLI)
+
 - `netclaw config show|validate` — display/validate current configuration
 - `netclaw personality reset` — re-trigger conversational personality setup
 
@@ -149,6 +170,29 @@ completed, pending, or invalid.
 - Registered project paths validity
 
 Results are persisted to the environment inventory file.
+
+### CLI-010 TUI Commands
+
+`netclaw init` and `netclaw chat` SHALL use Termina 0.5.1 for interactive TUI
+rendering. All other commands SHALL use plain console output. TUI commands SHALL
+launch Termina as a hosted service within the Cocona command handler.
+
+### CLI-011 Local Chat Adapter
+
+`netclaw chat` SHALL host the full actor system in-process and provide a local
+input adapter for MVP validation. The TUI adapter SHALL:
+
+- Produce `SendUserMessage` commands with entity key `tui/{sessionId}`
+- Render session broadcasts as streaming text via StreamingTextNode
+- Display tool invocation status inline (completed with duration, in-progress
+  with spinner)
+- Show MCP server connectivity status in the status bar
+
+### CLI-012 Daemon Entry Point
+
+`netclaw run` SHALL start the daemon process with Slack Socket Mode adapter,
+Akka actor system, scheduled task timers, and health endpoints. No TUI
+rendering. This is the primary production entry point.
 
 ## UX Requirements
 

--- a/docs/prd/PRD-005-model-provider-strategy.md
+++ b/docs/prd/PRD-005-model-provider-strategy.md
@@ -2,21 +2,55 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
+- Revised: 2026-02-21 (MEAI abstraction, primary+fallback model)
 - Depends on: `PRD-001`, `PRD-004`
 
 ## Goal
 
-Ship Netclaw with OpenRouter as the default provider while preserving a clean
-path to support multiple model providers without architecture churn.
+Ship Netclaw with OpenRouter as the default provider using
+`Microsoft.Extensions.AI` as the pluggable abstraction layer. Support a
+configurable primary model and fallback model for resilience.
 
 ## Product Outcomes
 
 1. First-run onboarding works with OpenRouter out of the box.
 2. Additional providers can be configured by operator choice.
-3. Provider behavior is observable and diagnosable from CLI/ops console.
+3. Provider behavior is observable and diagnosable from CLI.
+4. Fallback model activates when primary is unavailable.
+
+## Provider Architecture
+
+### Microsoft.Extensions.AI (MEAI) Abstraction
+
+All LLM interactions flow through `Microsoft.Extensions.AI` interfaces
+(`IChatClient`). This provides:
+
+- Provider-agnostic tool calling
+- Consistent streaming and non-streaming APIs
+- DI-friendly registration
+- Middleware pipeline (logging, caching, rate limiting)
+
+The session actor receives an `IChatClient` — it never knows or cares which
+provider backs it.
+
+### Primary + Fallback Model
+
+Configuration specifies:
+
+- **Primary model**: used for all normal interactions
+- **Fallback model**: used when primary fails (rate limit, timeout, outage)
+
+Fallback activation is automatic and logged. The agent reports which model
+served the response when asked.
+
+### Sub-Agent Model Routing (Post-MVP)
+
+Future: cheaper/faster models for high-token tasks (summarization, search
+result processing) while reserving the primary model for reasoning. This
+requires the framework to support per-request model selection. Deferred.
 
 ## Requirements
 
@@ -27,8 +61,9 @@ configuration.
 
 ### MP-002 Provider Abstraction
 
-Runtime SHALL use a provider abstraction that allows selecting a provider by
-name and model identifier at configuration time.
+Runtime SHALL use `Microsoft.Extensions.AI` `IChatClient` as the provider
+abstraction. Provider selection is a configuration concern, not an actor
+concern.
 
 ### MP-003 Initial Provider Set
 
@@ -49,29 +84,52 @@ clear remediation steps on failure.
 
 ### MP-005 Provider Health Diagnostics
 
-CLI and ops diagnostics SHALL report effective provider, model, and health state
-(reachable, auth error, rate limited, unknown failure).
+CLI diagnostics SHALL report effective provider, model, fallback status, and
+health state (reachable, auth error, rate limited, unknown failure).
 
 ### MP-006 Local Smoke Test Path
 
 The project SHALL support local smoke tests against an Ollama endpoint for
 integration confidence without making live-provider calls mandatory.
 
-### MP-008 Local Dev Ollama Profile
-
-The default local smoke profile SHALL target the Tailscale-reachable Ollama
-server `big-gpu` and use a high-quality model profile suitable for 24 GB VRAM.
-
 ### MP-007 CI Provider Independence
 
 Automated test suites required by CI/CD SHALL pass without requiring any live
 model provider credentials or network access to external inference services.
 
+### MP-008 Local Dev Ollama Profile
+
+The default local smoke profile SHALL target the Tailscale-reachable Ollama
+server `big-gpu` (`http://big-gpu:11434`) and use `qwen3:30b` (fallback
+`qwen3:14b`).
+
+### MP-009 Primary + Fallback Configuration
+
+Configuration SHALL support specifying both a primary and fallback model:
+
+```json
+{
+  "provider": "openrouter",
+  "primary_model": "anthropic/claude-sonnet-4",
+  "fallback_model": "anthropic/claude-haiku-4",
+  "fallback_on": ["rate_limit", "timeout", "provider_error"]
+}
+```
+
+Fallback activation SHALL be logged and visible in diagnostics.
+
+### MP-010 Tool Calling Support
+
+The provider abstraction SHALL support tool/function calling through MEAI's
+built-in tool calling API. Tool definitions are registered at session startup
+based on policy grants.
+
 ## Non-Goals (MVP)
 
-- automated cross-provider failover logic
-- dynamic per-turn provider routing
-- provider marketplace/plugin loading
+- Automated cross-provider failover logic (beyond primary/fallback)
+- Dynamic per-turn provider routing
+- Provider marketplace/plugin loading
+- Sub-agent model routing
 
 ## Acceptance Criteria
 
@@ -80,4 +138,11 @@ model provider credentials or network access to external inference services.
 3. Runtime diagnostics show current provider/model and last provider error.
 4. Local smoke tests can run against configured Ollama endpoint when enabled.
 5. CI validation pipeline passes with provider mocks/fakes only.
-6. Local smoke profile documents a recommended model and fallback model.
+6. Fallback model activates when primary is unreachable.
+7. Tool calling works through MEAI abstraction.
+
+## Cross-References
+
+- MVP scope: PRD-001
+- CLI onboarding: PRD-004
+- Tool integration: PRD-006 (MCP tools), PRD-007 (local tools)

--- a/docs/prd/PRD-006-mcp-tool-integration.md
+++ b/docs/prd/PRD-006-mcp-tool-integration.md
@@ -2,54 +2,119 @@
 
 ## Status
 
-- State: Draft for execution
+- State: Draft for execution (revised)
 - Owner: Netclaw engineering
 - Date: 2026-02-21
+- Revised: 2026-02-21 (Memorizer as external memory tier, tool loading)
 - Depends on: `PRD-001`, `PRD-002`, `PRD-004`
 
 ## Goal
 
 Support MCP servers in MVP so Netclaw can use externally hosted tools through a
-controlled and auditable integration path.
+controlled and auditable integration path. Memorizer serves as the primary
+external memory tier for research findings, knowledge base, and cross-session
+learning.
 
 ## Product Outcomes
 
 1. Operators can register and validate MCP servers during onboarding or CLI.
 2. MCP tools are available to Netclaw sessions only when policy allows.
 3. MCP connectivity and failures are visible in diagnostics.
+4. Memorizer provides durable cross-session knowledge that outlives compaction.
+
+## Two-Tier Memory Architecture
+
+Netclaw uses a two-tier memory model:
+
+| Tier | Storage | Content | Scope |
+|------|---------|---------|-------|
+| Local (PRD-007) | Files on disk | Personality, projects, environment, schedules | Personal, operational |
+| External (this PRD) | MCP/Memorizer | Research, knowledge base, cross-session learning | Knowledge, durable |
+
+Local memory is small, personal, and loaded into context. External memory is
+queried on demand via MCP tool calls.
 
 ## Requirements
 
 ### MCP-001 Server Configuration
 
 Operators SHALL configure MCP servers via config/CLI with named profiles.
+Each profile includes: name, transport (stdio/SSE), command/URL, environment
+variables, and enable/disable flag.
 
 ### MCP-002 Connection Validation
 
 CLI SHALL validate MCP server reachability and protocol compatibility.
+`netclaw mcp test {server}` SHALL attempt a tool listing and report results.
 
 ### MCP-003 Policy Gating
 
 MCP tool invocation SHALL be subject to the same ACL/data grant checks as local
-tools.
+tools. Grants use the format `mcp:{server_name}` per SEC-003 in PRD-002.
 
 ### MCP-004 Safe Defaults
 
-MCP integration is disabled until explicitly configured and enabled.
+MCP integration is disabled until explicitly configured and enabled. Each MCP
+server must be individually enabled.
 
 ### MCP-005 Diagnostics
 
-Runtime diagnostics SHALL show server health, tool discovery state, and recent
-MCP invocation failures.
+Runtime diagnostics SHALL show server health, tool discovery state, available
+tool count, and recent MCP invocation failures.
+
+### MCP-006 Tool Discovery and Registration
+
+On startup (and on demand), Netclaw SHALL discover available tools from each
+enabled MCP server and register them as available tool definitions for the MEAI
+tool calling pipeline. Tool definitions are refreshed on session start.
+
+### MCP-007 Memorizer as External Memory
+
+Memorizer SHALL be the recommended first MCP server configured during
+onboarding. It provides:
+
+- `store` — persist research findings and knowledge
+- `search` — semantic search across stored memories
+- `get` / `get_many` — retrieve specific memories
+- `delete` — remove outdated memories
+- `create_relationship` — link related memories
+
+The agent uses Memorizer for:
+- Saving research findings that should outlive the current session
+- Retrieving previously learned knowledge on related topics
+- Building a knowledge base across conversations and sessions
+- Pre-compaction memory flush (saving durable context before compaction)
+
+### MCP-008 Graceful Degradation
+
+Runtime SHALL degrade gracefully when MCP server is unavailable:
+
+- Tool calls to unavailable servers return a clear error message
+- The agent continues operating with remaining tools
+- Reconnection is attempted on next tool call
+- Diagnostics flag the outage
 
 ## Non-Goals (MVP)
 
-- dynamic marketplace discovery of MCP servers
-- unmanaged auto-install of remote tool bundles
-- multi-tenant tool permission partitioning
+- Dynamic marketplace discovery of MCP servers
+- Unmanaged auto-install of remote tool bundles
+- Multi-tenant tool permission partitioning
+- Hot-reload of MCP tool definitions (requires session reboot)
 
 ## Acceptance Criteria
 
 1. `netclaw mcp validate` reports pass for a healthy server.
 2. Denied MCP tool calls return policy deny reason.
 3. Diagnostics show MCP server status and last error.
+4. Memorizer store/search/get cycle works through Netclaw session.
+5. MCP tools appear in session tool definitions when server is enabled and
+   granted.
+6. Unavailable MCP server does not crash the session.
+
+## Cross-References
+
+- MVP scope: PRD-001
+- Security policy: PRD-002 (SEC-003 grant format)
+- CLI validation: PRD-004
+- Provider tool calling: PRD-005 (MP-010)
+- Local memory tier: PRD-007

--- a/docs/prd/PRD-007-agent-personality-and-local-memory.md
+++ b/docs/prd/PRD-007-agent-personality-and-local-memory.md
@@ -1,0 +1,268 @@
+# PRD-007: Agent Personality and Local Memory
+
+## Status
+
+- State: Draft for execution (new)
+- Owner: Netclaw engineering
+- Date: 2026-02-21
+- Depends on: `PRD-001`, `PRD-002`
+
+## Goal
+
+Define the agent soul (personality, instructions, user preferences), local
+memory system (project registry, environment inventory), capability
+self-discovery, self-configuration, and first-party tool access. This is the
+"brain" of Netclaw — everything that makes it a persistent, context-aware
+agent rather than a stateless chat endpoint.
+
+## Product Outcomes
+
+1. Netclaw has a consistent personality across sessions and restarts.
+2. Operator preferences and project knowledge persist on disk.
+3. Agent knows what tools and capabilities are available in its environment.
+4. Agent can modify its own config through conversation (within safety bounds).
+5. Agent has access to useful tools (search, shell, GitHub) through policy gates.
+
+## Agent Soul Architecture
+
+### File-Based Personality (Soul Files)
+
+Agent identity is stored as data (markdown files), not code. The agent
+reconstructs its personality from files on every session start. This makes
+identity hot-swappable and version-controllable without code changes.
+
+```
+~/.netclaw/
+  soul/
+    PERSONALITY.md     # Agent character, tone, values, boundaries
+    INSTRUCTIONS.md    # Operating rules, behavioral guidelines
+    USER.md            # Owner preferences, timezone, how to address them
+  projects/
+    registry.json      # Registered project configurations
+  environment/
+    inventory.json     # Discovered tools, credentials, capabilities
+  schedules/
+    tasks.json         # Persisted scheduled tasks (see PRD-008)
+  config/
+    netclaw.json       # Main configuration (provider, Slack, DB, etc.)
+    acl.json           # Access control policy (operator-only, not self-modifiable)
+```
+
+### Layered System Prompt Assembly
+
+Session context is assembled from layers (later layers augment earlier):
+
+1. **PERSONALITY.md** — who the agent is (values, tone, boundaries)
+2. **INSTRUCTIONS.md** — how the agent operates (rules, workflows)
+3. **USER.md** — who it serves (owner name, preferences, timezone)
+4. **Project AGENTS.md** — context overlay when working on a registered project
+5. **Environment summary** — condensed capability inventory
+6. **Session context** — conversation history, tool results, memory
+
+### Conversational Personality Bootstrap
+
+On first interaction (or when personality files don't exist), the agent runs
+a personality bootstrap conversation:
+
+1. Introduce itself and explain the setup process
+2. Learn the owner's name, preferences, communication style
+3. Scan environment for installed tools and capabilities
+4. Write initial PERSONALITY.md, INSTRUCTIONS.md, USER.md
+5. Confirm readiness
+
+This can be re-triggered via `netclaw personality reset` (PRD-004).
+
+## Local Memory System
+
+### Project Registry (`projects/registry.json`)
+
+```json
+{
+  "projects": [
+    {
+      "name": "netclaw",
+      "path": "/home/user/repos/netclaw",
+      "agents_md": "/home/user/repos/netclaw/AGENTS.md",
+      "channels": ["C0123NETCLAW"],
+      "capabilities": {
+        "language": "csharp",
+        "framework": "akka.net",
+        "has_tests": true,
+        "has_ci": true
+      }
+    }
+  ]
+}
+```
+
+Projects are registered through conversation or CLI. When a user asks about
+a project, the agent loads its AGENTS.md as a context overlay.
+
+### Environment Inventory (`environment/inventory.json`)
+
+```json
+{
+  "last_scan": "2026-02-21T10:00:00Z",
+  "host": {
+    "hostname": "pi1",
+    "os": "linux",
+    "arch": "arm64"
+  },
+  "tools": {
+    "git": { "available": true, "version": "2.43.0", "hosts": ["github.com"] },
+    "gh": { "available": true, "version": "2.44.0" },
+    "claude": { "available": false },
+    "opencode": { "available": false },
+    "dotnet": { "available": true, "version": "10.0.100" },
+    "node": { "available": false }
+  },
+  "mcp_servers": {
+    "memorizer": { "configured": true, "reachable": true }
+  }
+}
+```
+
+Environment discovery runs at startup and can be re-triggered by the agent
+or via `netclaw environment scan` (PRD-004).
+
+## Capability Self-Discovery
+
+The agent SHALL maintain awareness of its environment by discovering:
+
+- Installed CLIs: `claude`, `opencode`, `git`, `gh`, `dotnet`, `node`
+- Git credential availability (for which remote hosts)
+- .NET SDK version and installed workloads
+- Registered projects and their on-disk validity
+- MCP server reachability and available tool counts
+
+Discovery is:
+- **Automatic at startup** — initial scan on process start
+- **Periodic** — optional heartbeat re-scan (post-MVP)
+- **On-demand** — agent can re-scan through conversation or CLI
+
+Results are persisted to `environment/inventory.json` and summarized in the
+system prompt.
+
+## Self-Configuration
+
+The agent can modify its own configuration through conversation:
+
+### Allowed Self-Modifications
+
+- Update PERSONALITY.md, INSTRUCTIONS.md, USER.md
+- Register/unregister projects in registry.json
+- Update environment inventory
+- Create/manage scheduled tasks (PRD-008)
+
+### Prohibited Self-Modifications (SEC-008)
+
+- ACL rules and security policy
+- Exposure mode and network configuration
+- Tool grant policies
+- Provider credentials
+
+### Safety Protocol
+
+1. Agent proposes the change and explains what will be modified
+2. Change is validated before writing (schema validation, path checks)
+3. File is written atomically (write to temp, rename)
+4. Agent reports the change was saved
+5. Session reboot is required for context refresh (config is cached)
+
+## First-Party Tool Access
+
+### Tool Implementation Strategy
+
+1. **Use existing .NET packages** where available and well-maintained
+2. **Build thin REST API wrappers** where no good package exists
+3. **Shell-out to established CLIs** where they already work well
+4. **Avoid** packages that are abandoned, have known vulnerabilities, or
+   require proprietary licenses
+
+### MVP Tool Set
+
+#### Web Search
+
+- **Primary**: Brave Search API (free tier: 2,000 queries/month)
+  - Structured JSON response, popular in agent ecosystem
+  - Requires API key configured during onboarding
+- **Alternative**: SearXNG (self-hosted meta-search, no API key needed)
+  - For operators who want zero external API dependencies
+  - Runs in Docker on homelab infrastructure
+- **Implementation**: Thin `HttpClient` wrapper registered as MEAI tool
+
+#### Web Fetch
+
+- Retrieve and parse content from URLs
+- HTML-to-text extraction for LLM consumption
+- Configurable output truncation to prevent context flooding
+- **Implementation**: `HttpClient` + HTML parsing library
+
+#### Shell Execution
+
+- Run commands in the Netclaw process user context
+- Timeout and output limits per SEC-009
+- No interactive commands (stdin closed)
+- Working directory is registered project path or scratch dir
+- **Implementation**: `System.Diagnostics.Process` wrapper
+
+#### GitHub (via `gh` CLI)
+
+- Issue creation, PR management, repo operations
+- Uses authenticated `gh` CLI (credentials managed by operator)
+- No direct GitHub API calls needed
+- **Implementation**: Shell-out to `gh` with structured output parsing
+
+### Tool Registration with MEAI
+
+All tools are registered as `Microsoft.Extensions.AI` tool definitions:
+
+- Tool metadata (name, description, parameters) defined at startup
+- Available tools filtered by session policy grants
+- Tool results are returned to the LLM as tool response messages
+- Tool invocations are logged for audit (SEC-007)
+
+## Pre-Compaction Memory Flush
+
+Before context compaction (FR-015), the agent executes a silent agentic turn:
+
+1. System detects context approaching compaction threshold
+2. Agent is prompted: "Session nearing compaction. Save important context."
+3. Agent writes durable memories:
+   - Important findings to Memorizer (external memory tier)
+   - Updated project notes to local files if needed
+   - Current task state summary to memory
+4. Compaction proceeds after flush completes
+
+This directly counters context rot — the primary failure mode of long-running
+LLM sessions.
+
+## Non-Goals (MVP)
+
+- Hybrid search (vector + keyword) for local memory
+- Memory hygiene / auto-cleanup of stale entries
+- Multiple personality profiles or persona switching
+- Hot-reload of personality files (requires session reboot)
+
+## Acceptance Criteria
+
+1. Agent personality is consistent across sessions and restarts.
+2. Personality bootstrap conversation produces valid soul files.
+3. Project registry persists and loads correctly.
+4. Environment scan discovers installed tools accurately.
+5. Self-configuration changes are validated before write.
+6. Agent cannot modify ACL or security files through conversation.
+7. Web search returns results when Brave API key is configured.
+8. Shell execution respects timeout and output limits.
+9. GitHub operations work through `gh` CLI shell-out.
+10. Pre-compaction flush saves durable memories before context reset.
+11. Tool invocations are logged with audit records.
+
+## Cross-References
+
+- MVP scope: PRD-001 (FR-006, FR-010, FR-011, FR-013, FR-014, FR-015)
+- Security bounds: PRD-002 (SEC-003, SEC-008, SEC-009)
+- CLI operations: PRD-004 (CLI-008, CLI-009)
+- Provider tool calling: PRD-005 (MP-010)
+- External memory: PRD-006 (MCP-007)
+- Scheduling: PRD-008

--- a/docs/prd/PRD-008-scheduling-and-periodic-tasks.md
+++ b/docs/prd/PRD-008-scheduling-and-periodic-tasks.md
@@ -1,0 +1,183 @@
+# PRD-008: Scheduling and Periodic Tasks
+
+## Status
+
+- State: Draft for execution (new)
+- Owner: Netclaw engineering
+- Date: 2026-02-21
+- Depends on: `PRD-001`, `PRD-002`, `PRD-007`
+
+## Goal
+
+Enable Netclaw to manage its own schedule through conversation. The operator
+can say "check this every 6 hours" and Netclaw persists the task, executes it
+on schedule, and reports results back to the appropriate Slack channel.
+
+## Product Outcomes
+
+1. Operator can create scheduled tasks through natural conversation.
+2. Scheduled tasks survive process restarts.
+3. Task results are posted to the originating or configured Slack channel.
+4. Operator can manage (list, pause, delete) scheduled tasks via CLI or chat.
+
+## Scheduling Architecture
+
+### Chat-Driven Task Creation
+
+The agent creates scheduled tasks through conversation:
+
+```
+User: "Check eBay for RTX 5090 listings every 6 hours and let me know if
+      any are under $1500"
+Agent: "I'll check eBay for RTX 5090 listings every 6 hours and alert you
+       if any are under $1500. Created schedule 'ebay-rtx-5090-check'
+       (every 6h). Next run: 2026-02-21T16:00:00Z."
+```
+
+### Schedule Types (MVP)
+
+- **Fixed interval** (`every`): run every N minutes/hours/days
+- **Cron expression** (`cron`): standard 5-field cron syntax
+- **One-shot** (`at`): run once at a specific time (post-MVP)
+
+### Execution Model
+
+Each scheduled task execution:
+
+1. Creates a fresh session actor (isolated from interactive sessions)
+2. Loads the task's instruction prompt as the user message
+3. Loads the agent's personality + any project context overlays
+4. Grants the task's configured tool permissions
+5. Executes the LLM turn loop
+6. Posts results to the configured Slack channel/thread
+7. Logs execution outcome (success, failure, skipped)
+
+### Persistence
+
+Scheduled tasks are persisted to `~/.netclaw/schedules/tasks.json`:
+
+```json
+{
+  "tasks": [
+    {
+      "id": "ebay-rtx-5090-check",
+      "name": "eBay RTX 5090 price check",
+      "created_by": "slack:U0123OWNER",
+      "created_at": "2026-02-21T10:00:00Z",
+      "schedule": {
+        "type": "interval",
+        "interval_minutes": 360
+      },
+      "instruction": "Search eBay for RTX 5090 listings. Report any under $1500.",
+      "report_to": {
+        "channel": "C0123ALERTS",
+        "thread_ts": null
+      },
+      "tool_grants": ["web_search", "web_fetch"],
+      "status": "active",
+      "last_run": "2026-02-21T10:00:00Z",
+      "last_result": "success",
+      "next_run": "2026-02-21T16:00:00Z"
+    }
+  ]
+}
+```
+
+### Akka Timer Integration
+
+Scheduled tasks use Akka's built-in timer/scheduler system:
+
+- A `ScheduleManagerActor` loads tasks from disk at startup
+- Each active task gets a recurring timer message
+- Timer fires dispatch a `RunScheduledTask` command to a scheduling actor
+- The scheduling actor creates a fresh session for execution
+- Results are broadcast back through pub/sub for Slack delivery
+
+### Guardrails
+
+- **Max concurrent executions**: configurable limit (default: 3)
+- **Execution timeout**: per-task timeout (default: 5 minutes)
+- **Consecutive failure tracking**: disable after N consecutive failures
+  (default: 5), notify operator
+- **Cooldown**: minimum interval between runs (prevents accidental tight loops)
+
+## Requirements
+
+### SCHED-001 Chat-Driven Creation
+
+The agent SHALL create scheduled tasks when the user requests recurring or
+timed actions through conversation. The agent assigns a human-readable task
+ID and confirms the schedule.
+
+### SCHED-002 Schedule Persistence
+
+Scheduled tasks SHALL be persisted to disk (`schedules/tasks.json`) and
+survive process restarts. Tasks are loaded at startup and timers are
+re-established.
+
+### SCHED-003 Isolated Execution
+
+Each scheduled task execution SHALL run in a fresh session actor with its
+own context. Scheduled sessions do not share state with interactive sessions.
+
+### SCHED-004 Result Reporting
+
+Task execution results SHALL be posted to the configured Slack channel. If
+execution produces nothing notable, a brief acknowledgment is posted (or
+suppressed if configured for silent-unless-notable).
+
+### SCHED-005 Task Management
+
+The agent and CLI SHALL support:
+- List all scheduled tasks with status and next-run time
+- Pause/resume individual tasks
+- Delete tasks
+- Show execution history for a task
+
+### SCHED-006 Tool Grants
+
+Each scheduled task SHALL specify its required tool grants. These are checked
+against ACL policy at execution time. Tasks requesting ungrantable tools fail
+at creation time.
+
+### SCHED-007 Failure Handling
+
+Consecutive failures SHALL be tracked. After the configured failure threshold,
+the task is automatically paused and the operator is notified in the reporting
+channel.
+
+### SCHED-008 Heartbeat System (Post-MVP)
+
+A periodic heartbeat check that reads a `HEARTBEAT.md` checklist and processes
+items that need attention. If nothing needs attention, no message is sent.
+Deferred to Phase 2.
+
+## Non-Goals (MVP)
+
+- Event triggers (fire on channel message matching regex)
+- Webhook triggers (fire on incoming POST)
+- Manual triggers (fire via CLI only)
+- One-shot scheduled tasks (fire once at a specific time)
+- Per-routine persistent state (JSON blob per task)
+- Heartbeat system
+
+## Acceptance Criteria
+
+1. User can create a scheduled task through conversation.
+2. Scheduled tasks survive process restart.
+3. Timer fires create fresh session actors for execution.
+4. Results are posted to the configured Slack channel.
+5. CLI can list, pause, and delete scheduled tasks.
+6. Tasks with ungrantable tools are rejected at creation.
+7. Consecutive failures pause the task and notify the operator.
+8. Max concurrent execution limit is enforced.
+
+## Cross-References
+
+- MVP scope: PRD-001 (FR-012)
+- Security: PRD-002 (tool grants)
+- CLI management: PRD-004
+- Provider for execution: PRD-005
+- Tool access: PRD-006 (MCP), PRD-007 (local tools)
+- Agent personality (loaded during execution): PRD-007
+- Input adapters (post-MVP triggers): PRD-009

--- a/docs/prd/PRD-009-input-adapters-and-unified-input.md
+++ b/docs/prd/PRD-009-input-adapters-and-unified-input.md
@@ -27,6 +27,7 @@ child session actor.
 
 | Input Source          | Delivery Mechanism                          | Phase | Entity Key Pattern |
 |-----------------------|---------------------------------------------|-------|--------------------|
+| Local TUI             | `netclaw chat` in-process                   | 1     | `tui/{sessionId}` |
 | User @mention         | Slack Socket Mode                           | 1     | `{channelId}/{threadTs}` |
 | Scheduled task        | Internal Akka timer                         | 1     | `schedule/{taskId}/{runTs}` |
 | Ambient channel alert | Slack Socket Mode (require_mention: false)  | 2     | `{channelId}/{threadTs}` |
@@ -34,6 +35,16 @@ child session actor.
 | Web UI (future)       | WebSocket / HTTP                            | 5     | `web/{sessionId}` |
 
 ### MVP Input Adapters
+
+**Local TUI Adapter** (Phase 1):
+- Hosted in-process by `netclaw chat` command
+- Receives keyboard input via Termina TextInputNode
+- Produces `SendUserMessage` commands with entity key `tui/{sessionId}`
+- Subscribes to session broadcasts for reply delivery
+- Renders responses as streaming text via StreamingTextNode
+- Displays tool invocation status inline (name, duration, spinner)
+- Shows MCP server connectivity in status bar
+- Full actor system runs in-process — validates entire agent stack locally
 
 **Slack Socket Mode Adapter** (Phase 1):
 - Connects via Slack's WebSocket-based Socket Mode
@@ -135,12 +146,21 @@ adapters and session actors.
 All inbound commands SHALL carry source metadata sufficient for ACL evaluation
 and audit logging: adapter type, sender identity, channel, timestamp.
 
+### INPUT-005 TUI Adapter
+
+The TUI adapter SHALL receive keyboard input via Termina TextInputNode, produce
+`SendUserMessage` commands with entity key `tui/{sessionId}`, subscribe to
+session broadcasts, and render responses as streaming text. The TUI adapter
+SHALL display tool invocation status inline between user message and response.
+
 ## Acceptance Criteria (MVP)
 
-1. Slack adapter handles @mention events and replies in thread.
-2. Timer adapter fires scheduled tasks and delivers results via Slack.
-3. Session actors receive identical command types regardless of source.
-4. Source metadata is available for ACL checks and audit logging.
+1. TUI adapter receives input, routes through session actor, renders streaming
+   response.
+2. Slack adapter handles @mention events and replies in thread.
+3. Timer adapter fires scheduled tasks and delivers results via Slack.
+4. Session actors receive identical command types regardless of source.
+5. Source metadata is available for ACL checks and audit logging.
 
 ## Acceptance Criteria (Phase 2)
 

--- a/docs/prd/PRD-009-input-adapters-and-unified-input.md
+++ b/docs/prd/PRD-009-input-adapters-and-unified-input.md
@@ -1,0 +1,156 @@
+# PRD-009: Input Adapters and Unified Input Architecture
+
+## Status
+
+- State: Draft for execution (new, mostly post-MVP)
+- Owner: Netclaw engineering
+- Date: 2026-02-21
+- Depends on: `PRD-001`, `PRD-002`, `PRD-008`
+
+## Goal
+
+Define the unified input architecture that treats all message sources
+identically. While MVP implements only Slack Socket Mode and internal timers,
+the architecture must support future input sources without structural changes.
+
+## Key Architectural Insight
+
+Everything is just a message arriving at a session actor with context-specific
+instructions. The input source is irrelevant — the differentiator is the
+instructions attached to the context.
+
+All inputs produce a `SendUserMessage` command routed to the session parent
+actor. The session parent extracts an entity key and routes to the correct
+child session actor.
+
+## Input Source Taxonomy
+
+| Input Source          | Delivery Mechanism                          | Phase | Entity Key Pattern |
+|-----------------------|---------------------------------------------|-------|--------------------|
+| User @mention         | Slack Socket Mode                           | 1     | `{channelId}/{threadTs}` |
+| Scheduled task        | Internal Akka timer                         | 1     | `schedule/{taskId}/{runTs}` |
+| Ambient channel alert | Slack Socket Mode (require_mention: false)  | 2     | `{channelId}/{threadTs}` |
+| Webhook (GitHub, CI)  | HTTP via Tailscale Serve / Cloudflare Tunnel| 2     | `webhook/{source}/{eventId}` |
+| Web UI (future)       | WebSocket / HTTP                            | 5     | `web/{sessionId}` |
+
+### MVP Input Adapters
+
+**Slack Socket Mode Adapter** (Phase 1):
+- Connects via Slack's WebSocket-based Socket Mode
+- Receives `message` and `app_mention` events
+- Extracts entity key: `{channelId}/{threadTs}`
+- Converts Slack event to `SendUserMessage` command
+- Subscribes to session broadcasts for reply delivery
+- Posts reply messages back to originating Slack thread
+
+**Internal Timer Adapter** (Phase 1):
+- Fires on Akka timer ticks for scheduled tasks
+- Creates `SendUserMessage` with task instruction as content
+- Uses entity key: `schedule/{taskId}/{runTs}`
+- Result broadcast is consumed by Slack adapter for delivery
+
+### Post-MVP Input Adapters
+
+**Ambient Channel Monitor** (Phase 2):
+- Same Slack Socket Mode connection, different routing
+- Channels configured with `require_mention: false`
+- Messages are filtered by channel-level instructions before routing
+- Channel instructions define what the agent should watch for
+
+**Webhook Adapter** (Phase 2):
+- HTTP endpoint behind Tailscale Serve or Cloudflare Tunnel
+- Receives POST from GitHub, CI/CD, or other external systems
+- Webhook definitions specify: source, expected payload, routing rules
+- Each webhook hit creates a new session with source-specific instructions
+
+**Web UI Adapter** (Phase 5):
+- WebSocket connection from Blazor Server ops console
+- Provides interactive session control and real-time updates
+- Same pub/sub broadcast pattern as Slack adapter
+
+## Adapter Contract
+
+All adapters implement the same pattern:
+
+1. **Receive** external input (Slack event, timer tick, HTTP POST)
+2. **Transform** into `SendUserMessage` command with:
+   - Message content (user text, webhook payload, task instruction)
+   - Entity key (determines which session actor handles it)
+   - Source metadata (adapter type, sender identity, channel)
+   - Context instructions (channel-level rules, webhook routing)
+3. **Route** command to session parent actor
+4. **Subscribe** to session broadcast for response delivery
+5. **Deliver** response back through the originating channel
+
+The session actor never knows or cares which adapter sent the message. This is
+the transport-agnostic boundary defined in `PROJECT_CONTEXT.md`.
+
+## Channel Instructions (Phase 2)
+
+Per-channel configuration that shapes how the agent processes messages from
+specific channels:
+
+```json
+{
+  "channel": "C0123ALERTS",
+  "require_mention": false,
+  "instructions": "This is an alert channel. When you see error messages, check Seq for related logs and file a GitHub issue if the error is new.",
+  "tool_grants": ["web_fetch", "github", "shell"],
+  "auto_respond": true
+}
+```
+
+Channel instructions are loaded as context overlays (same layered model as
+project AGENTS.md files).
+
+## Non-Goals (MVP)
+
+- Ambient channel monitoring implementation
+- Webhook ingress implementation
+- Web UI adapter implementation
+- Channel-level instruction configuration
+- Dynamic adapter registration/hot-plug
+- Multi-platform adapters (Discord, Telegram, etc.)
+
+## MVP Requirements
+
+### INPUT-001 Slack Adapter
+
+Slack Socket Mode adapter SHALL receive events, extract entity keys, produce
+`SendUserMessage` commands, subscribe to broadcasts, and deliver replies.
+
+### INPUT-002 Timer Adapter
+
+Internal timer adapter SHALL fire on schedule, create fresh sessions for task
+execution, and route results to Slack delivery.
+
+### INPUT-003 Transport Agnosticism
+
+Session actors SHALL never reference adapter-specific types. The
+`SendUserMessage` command and broadcast events are the only contract between
+adapters and session actors.
+
+### INPUT-004 Source Metadata
+
+All inbound commands SHALL carry source metadata sufficient for ACL evaluation
+and audit logging: adapter type, sender identity, channel, timestamp.
+
+## Acceptance Criteria (MVP)
+
+1. Slack adapter handles @mention events and replies in thread.
+2. Timer adapter fires scheduled tasks and delivers results via Slack.
+3. Session actors receive identical command types regardless of source.
+4. Source metadata is available for ACL checks and audit logging.
+
+## Acceptance Criteria (Phase 2)
+
+5. Ambient channel adapter processes messages without @mention.
+6. Webhook adapter accepts POST and creates routed sessions.
+7. Channel instructions shape agent behavior per channel.
+
+## Cross-References
+
+- Session architecture: PRD-001 (FR-001, FR-002, FR-008)
+- Security (ACL per source): PRD-002
+- Scheduling (timer source): PRD-008
+- Ops console (web UI source): PRD-003

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -4,12 +4,25 @@ This directory contains product requirements for Netclaw.
 
 ## Active PRDs
 
-- `PRD-001-netclaw-mvp.md`
-- `PRD-002-gateway-security-envelope.md`
-- `PRD-003-operator-ux-ops-console.md`
-- `PRD-004-cli-onboarding-and-config.md`
-- `PRD-005-model-provider-strategy.md`
-- `PRD-006-mcp-tool-integration.md`
+| PRD | Title | Phase | Status |
+|-----|-------|-------|--------|
+| `PRD-001-netclaw-mvp.md` | Netclaw MVP | 1 | Revised |
+| `PRD-002-gateway-security-envelope.md` | Gateway Security Envelope | 1 | Revised |
+| `PRD-003-operator-ux-ops-console.md` | Operator UX - Ops Console | 5 (deferred) | Revised |
+| `PRD-004-cli-onboarding-and-config.md` | CLI Onboarding and Configuration | 1-2 | Revised |
+| `PRD-005-model-provider-strategy.md` | Model Provider Strategy | 1 | Revised |
+| `PRD-006-mcp-tool-integration.md` | MCP Tool Integration | 1 | Revised |
+| `PRD-007-agent-personality-and-local-memory.md` | Agent Personality and Local Memory | 1 | New |
+| `PRD-008-scheduling-and-periodic-tasks.md` | Scheduling and Periodic Tasks | 1 | New |
+| `PRD-009-input-adapters-and-unified-input.md` | Input Adapters and Unified Input | 1 (partial), 2+ | New |
+
+## Revision History
+
+- **2026-02-21 (initial)**: PRDs 001-006 created for narrow "chat assistant
+  with ACL" scope.
+- **2026-02-21 (expanded)**: All PRDs revised to match expanded product vision.
+  Netclaw is now an always-on autonomous operations agent. PRDs 007-009 added
+  for local memory, scheduling, and input adapters.
 
 ## Traceability Rules
 
@@ -29,3 +42,21 @@ This directory contains product requirements for Netclaw.
 - Onboarding -> `openspec/specs/netclaw-onboarding/spec.md`
 - Model providers -> `openspec/specs/netclaw-model-providers/spec.md`
 - MCP tools -> `openspec/specs/netclaw-mcp/spec.md`
+- Agent personality and memory -> `openspec/specs/netclaw-agent-memory/spec.md` (new)
+- Scheduling -> `openspec/specs/netclaw-scheduling/spec.md` (new)
+- Input adapters -> `openspec/specs/netclaw-input-adapters/spec.md` (new)
+- First-party tools -> `openspec/specs/netclaw-tools/spec.md` (new)
+
+## Cross-Reference Matrix
+
+| PRD | Depends On | Depended By |
+|-----|-----------|-------------|
+| 001 | — | all others |
+| 002 | 001 | 003, 004, 006, 007, 008, 009 |
+| 003 | 001, 002 | — |
+| 004 | 001, 002 | — |
+| 005 | 001, 004 | — |
+| 006 | 001, 002, 004 | — |
+| 007 | 001, 002 | 008 |
+| 008 | 001, 002, 007 | — |
+| 009 | 001, 002, 008 | — |

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -45,6 +45,7 @@ This directory contains product requirements for Netclaw.
 - Agent personality and memory -> `openspec/specs/netclaw-agent-memory/spec.md` (new)
 - Scheduling -> `openspec/specs/netclaw-scheduling/spec.md` (new)
 - Input adapters -> `openspec/specs/netclaw-input-adapters/spec.md` (new)
+- Config hot-reload -> `openspec/specs/netclaw-config-hot-reload/spec.md` (new)
 - First-party tools -> `openspec/specs/netclaw-tools/spec.md` (new)
 
 ## Cross-Reference Matrix

--- a/docs/research/agent-patterns.md
+++ b/docs/research/agent-patterns.md
@@ -1,0 +1,408 @@
+# Agent Architecture Patterns Research
+
+Date: 2026-02-21
+Task: 0.5.1 (IMPLEMENTATION_PLAN.md)
+
+Research across OpenClaw, IronClaw, ZeroClaw, PicoClaw, Goose, Claude Code,
+Aider, Continue.dev, and Open Interpreter to identify patterns for Netclaw's
+agent soul, memory, tooling, onboarding, and scheduling systems.
+
+---
+
+## 1. Agent Soul / Personality
+
+### The Emerging Standard: Separation of Concerns
+
+The OpenClaw ecosystem established a de facto standard that separates agent
+identity into distinct markdown files, each with a single responsibility:
+
+| File | Purpose | Analogy |
+|------|---------|---------|
+| `SOUL.md` | Values, personality, tone, boundaries | "Why" — who the agent *is* |
+| `IDENTITY.md` | Name, capabilities, metadata, version | "Who" — what it can do |
+| `AGENTS.md` | Operating instructions, workflows, rules | "How" — behavioral guidelines |
+| `USER.md` | Owner preferences, timezone, how to address them | "For whom" |
+| `TOOLS.md` | Available tool documentation/guidance | "With what" |
+| `HEARTBEAT.md` | Periodic task checklist | "When" (proactive) |
+
+This pattern is used by OpenClaw, IronClaw, ZeroClaw, and PicoClaw. Claude
+Code uses a simpler model (single CLAUDE.md + `.claude/rules/` directory).
+
+### System Prompt Layering (Universal Pattern)
+
+Every tool surveyed uses a layered system prompt model:
+
+```
+Layer 1: Core system message (hardcoded by the tool)
+Layer 2: User-global configuration (~/.tool/config)
+Layer 3: Project-level instructions (repo root files)
+Layer 4: Path/directory-specific rules (loaded on demand)
+Layer 5: Session-specific context (conversation, tool results)
+```
+
+Later layers augment or override earlier layers. This is consistent across
+Claude Code, Goose, and the OpenClaw family.
+
+### Key Insight: Soul Is Data, Not Code
+
+IronClaw made this explicit: the personality is stored as data (markdown files
+in a workspace database), not as code. The agent "reconstructs itself from
+files on every boot." This makes identity hot-swappable and version-
+controllable without code changes.
+
+### Recommendation for Netclaw
+
+Adopt a simplified version of the OpenClaw file structure, adapted for
+Netclaw's actor-based architecture:
+
+```
+~/.netclaw/
+  soul/
+    PERSONALITY.md     # Agent character, tone, values
+    INSTRUCTIONS.md    # Operating rules and behavioral guidelines
+    USER.md            # Owner preferences and context
+  projects/            # Registered project configurations
+  environment/         # Capability inventory and tool availability
+  schedules/           # Persisted scheduled tasks
+```
+
+These files get loaded into the LLM context at session start. The session
+actor caches them; a session reboot refreshes the context.
+
+---
+
+## 2. Memory Architecture
+
+### Three Dominant Patterns
+
+**Pattern A: Pure file-based (markdown)**
+- Used by: Claude Code, PicoClaw, OpenClaw (base)
+- Pros: Simple, portable, human-readable, version-controllable
+- Cons: No semantic search, doesn't scale past ~100KB of notes
+- How: Markdown files on disk, loaded into context at session start
+
+**Pattern B: Hybrid SQLite + file**
+- Used by: ZeroClaw, OpenClaw (advanced)
+- Pros: Semantic search via vector embeddings + exact keyword via FTS5/BM25
+- Cons: Requires embedding provider, more complex
+- How: SQLite with FTS5 + vector BLOBs, configurable weights (default 0.7
+  vector / 0.3 keyword)
+
+**Pattern C: Database + hybrid search**
+- Used by: IronClaw (PostgreSQL + pgvector)
+- Pros: Full Reciprocal Rank Fusion (RRF), memory hygiene (auto-cleanup),
+  production-grade search
+- Cons: Requires PostgreSQL, more infrastructure
+- How: `score(d) = sum(1 / (k + rank(d)))` across FTS and vector results
+
+### OpenClaw's Memory Lifecycle (Best-in-Class)
+
+1. Agent appends notes to `memory/YYYY-MM-DD.md` (daily logs)
+2. Important facts get curated into `MEMORY.md` (long-term, evergreen)
+3. Markdown changes trigger async embedding updates
+4. Queries use `memory_search` (semantic) or `memory_get` (targeted read)
+5. **Pre-compaction flush**: silent agentic turn saves durable memories before
+   context window resets
+6. Temporal decay ensures recent notes rank higher (30-day half-life)
+7. MMR re-ranking prevents redundant results
+
+### Pre-Compaction Memory Flush (Critical Pattern)
+
+OpenClaw triggers a silent agentic turn when context approaches compaction
+threshold. The model is prompted to write durable memories to disk before
+the context resets. This directly counters "context rot" — the #1 complaint
+about LLM assistants.
+
+```json5
+memoryFlush: {
+  enabled: true,
+  softThresholdTokens: 4000,
+  systemPrompt: "Session nearing compaction. Store durable memories now."
+}
+```
+
+### IronClaw's Memory Hygiene
+
+Automatic cleanup of stale workspace documents runs on heartbeat ticks.
+Identity files (SOUL.md, IDENTITY.md, etc.) are exempt from cleanup.
+Configurable retention (default 30 days) and cadence (default 12 hours).
+
+### Research Consensus
+
+The field is converging on hybrid architectures that combine file-based
+curated memory with vector/graph search for retrieval over larger corpora.
+Key insight: **indiscriminate memory storage degrades performance** — active
+pruning and curation yields up to 10% performance gains over naive strategies.
+
+### Recommendation for Netclaw
+
+**Start with Pattern A (files), design for Pattern B (hybrid SQLite):**
+
+- MVP: Markdown files on disk for soul, projects, environment inventory
+- The pre-compaction flush pattern is essential — implement from day one
+- Netclaw already has PostgreSQL for Akka.Persistence journal/snapshots; could
+  add a memory table with pgvector later if SQLite is insufficient
+- MCP/Memorizer serves as the "Pattern C" tier for research and knowledge base
+- Keep local memory small and personal (file paths, tool inventory, schedules)
+- Delegate large-corpus memory to Memorizer via MCP
+
+---
+
+## 3. Tooling Configuration
+
+### Tool Discovery Patterns
+
+**Built-in registry** (OpenClaw, IronClaw):
+- Tools registered at startup, exposed as both system prompt text and
+  structured function definitions
+- Allow/deny lists control which tools are available per session
+- Tool groups provide shorthands (`group:fs`, `group:web`, etc.)
+
+**MCP-first** (Goose, Continue.dev):
+- All tool capabilities come from MCP server connections
+- Extensions are configured in YAML, spawned as MCP server processes
+- Natural discovery via MCP capability negotiation
+
+**Protected tool names** (IronClaw):
+- A hardcoded set of ~30 built-in tool names that cannot be shadowed by
+  dynamic registrations. Prevents malicious WASM tools from replacing
+  `shell` or `memory_write`.
+
+### IronClaw's Three-Tier Tool System
+
+| Tier | Description | Security |
+|------|-------------|----------|
+| Built-in | Native Rust tools | Full trust |
+| WASM | Sandboxed WebAssembly modules | Capability-based permissions |
+| MCP | External protocol servers | OAuth 2.1, rate limiting |
+
+WASM tools run in isolated containers with explicit opt-in for HTTP, secrets,
+and tool invocation. Credential injection happens at the host boundary —
+API keys are never exposed to WASM code.
+
+### Conversational Tool Installation (IronClaw)
+
+```
+User: "add notion"
+  -> tool_search("notion")      -> finds MCP server in registry
+  -> tool_install("notion")     -> saves config
+  -> tool_auth("notion")        -> OAuth flow, returns URL
+  -> tool_activate("notion")    -> connects, registers tools
+```
+
+### Recommendation for Netclaw
+
+- Use `Microsoft.Extensions.AI` tool abstraction as the built-in tier
+- MCP for external tools (Memorizer, future integrations)
+- Capability self-discovery for system tools (git, claude, opencode, dotnet)
+- Allow/deny lists per session or per channel instruction set
+- No WASM sandbox needed for MVP (single-user, trusted environment)
+
+---
+
+## 4. Onboarding
+
+### OpenClaw's Two-Phase Onboarding
+
+**Phase 1: Technical wizard** (`openclaw onboard`, 7 steps):
+1. Model/auth selection
+2. Workspace setup + bootstrap file seeding
+3. Gateway configuration (port, auth, Tailscale)
+4. Channel integration (WhatsApp, Telegram, Discord, Slack, etc.)
+5. Daemon installation (systemd/LaunchAgent)
+6. Health verification
+7. Skills installation
+
+**Phase 2: Personality bootstrap** (first conversation):
+1. User sends: "Hey, let's get you set up. Read BOOTSTRAP.md."
+2. Agent runs a short Q&A ritual (one question at a time)
+3. Writes identity and preferences to IDENTITY.md, USER.md, SOUL.md
+4. Deletes BOOTSTRAP.md so it only runs once
+
+### IronClaw's Onboarding (8 steps)
+
+1. Database connection + migrations
+2. Security (master key generation, AES-256-GCM)
+3. Inference provider selection
+4. Model selection
+5. Embeddings configuration
+6. Channel configuration (CLI, HTTP, Telegram, Tunnel, WASM)
+7. Extension installation
+8. Heartbeat configuration
+
+### Recommendation for Netclaw
+
+**Two-phase onboarding aligned with Netclaw's architecture:**
+
+Phase 1 — CLI wizard (`netclaw init`):
+1. LLM provider configuration (OpenRouter API key, model selection)
+2. Slack app setup (bot token, app token for Socket Mode)
+3. PostgreSQL connection string
+4. ACL bootstrap (owner identity, initial channel rules)
+5. Exposure mode (local-only, Tailscale Serve, Cloudflare Tunnel)
+6. Health check (verify Slack connection, DB connection, LLM reachability)
+
+Phase 2 — Conversational personality setup (first Slack message):
+1. "Hi, I'm Netclaw. Let me learn about you and your setup."
+2. Ask about projects to register (repo paths)
+3. Discover environment capabilities (scan for installed tools)
+4. Write PERSONALITY.md, USER.md, environment inventory
+5. Confirm readiness
+
+---
+
+## 5. Scheduling
+
+### OpenClaw's Cron System
+
+Three schedule types: one-shot (`at`), fixed interval (`every`), cron
+expressions. Jobs persist to `~/.openclaw/cron/jobs.json`. Gateway-owned
+(not model-owned). Execution modes: main session (inline) or isolated
+(fresh session per run). Exponential retry backoff. Delivery modes: announce
+to channel, webhook POST, or internal-only.
+
+### IronClaw's Routines Engine (Most Sophisticated)
+
+**Four trigger types:**
+- `Cron` — fire on a cron schedule
+- `Event` — fire when a channel message matches a regex pattern
+- `Webhook` — fire on incoming POST to `/hooks/routine/{id}`
+- `Manual` — fire only via tool call or CLI
+
+**Execution modes:**
+- Lightweight — single LLM call, no scheduler slot
+- Full job — delegated to scheduler with isolated context
+
+**Guardrails:**
+- Cooldown periods between fires
+- Max concurrent runs per routine
+- Global max concurrent routines
+- Consecutive failure tracking
+- Per-routine state (JSON blob persisted in DB)
+
+### PicoClaw's Heartbeat Pattern
+
+`HEARTBEAT.md` is checked every 30 minutes. The agent reads the checklist,
+processes any items that need attention, and reports findings to the
+configured channel. If nothing needs attention, it replies `"HEARTBEAT_OK"`
+and no message is sent.
+
+### Recommendation for Netclaw
+
+Adopt IronClaw's routines model, simplified for MVP:
+
+- **Cron triggers** for scheduled tasks (chat-driven: "check this every 6h")
+- **Event triggers** for ambient channel monitoring (post-MVP)
+- **Webhook triggers** for external integrations (post-MVP)
+- Persist schedules as files on disk (JSON), loaded at startup
+- Akka scheduler/timers for execution (natural fit for actor system)
+- Each scheduled task execution creates a new session or runs in a dedicated
+  scheduling actor
+- Heartbeat system for proactive periodic checks (simple: check HEARTBEAT.md
+  every N minutes)
+
+---
+
+## 6. Configuration Model
+
+### Comparison
+
+| Tool | Format | Hot-reload | Self-modifiable |
+|------|--------|------------|-----------------|
+| OpenClaw | JSON5 | Yes (hybrid mode) | Yes (via CLI/UI/chat) |
+| IronClaw | TOML + DB | DB changes immediate | Yes (via tools) |
+| ZeroClaw | TOML | No | No |
+| Claude Code | Markdown | On session start | Yes (via conversation) |
+| Goose | YAML | No | No |
+
+### Key Insight: Markdown for Behavior, Structured Data for Config
+
+Every tool uses markdown for behavioral instructions (system prompts, rules,
+personality) and a structured format (YAML/TOML/JSON) for technical
+configuration (model selection, API keys, tool registration, scheduling).
+
+### Recommendation for Netclaw
+
+- **Markdown** for soul files (PERSONALITY.md, INSTRUCTIONS.md, USER.md)
+- **JSON** for structured config (projects registry, environment inventory,
+  scheduled tasks, channel instructions, ACL rules)
+- All files on disk under `~/.netclaw/` or a configured data directory
+- Bot can modify its own config files through conversation
+- Session reboot to refresh (config cached in LLM context)
+- Future web UI reads same files
+
+---
+
+## 7. Patterns to Adopt
+
+### Must-Have (MVP)
+
+1. **Separated soul files** — PERSONALITY.md, INSTRUCTIONS.md, USER.md
+2. **Pre-compaction memory flush** — save durable memories before context resets
+3. **Layered system prompt** — global personality + project AGENTS.md overlays
+4. **Capability self-discovery** — scan environment for installed tools at
+   startup and on demand
+5. **Chat-driven scheduling** — cron triggers persisted as JSON, executed by
+   Akka timers
+6. **Self-configuration** — bot modifies its own config files through
+   conversation
+7. **Project registry** — explicit registration with repo path, AGENTS.md
+   location, and associated channels
+
+### Should-Have (Phase 2)
+
+1. **Event triggers** — ambient channel monitoring with regex pattern matching
+2. **Heartbeat system** — periodic proactive check-in
+3. **Onboarding wizard** — CLI setup + conversational personality bootstrap
+4. **Memory hygiene** — auto-cleanup of stale daily logs (IronClaw pattern)
+
+### Nice-to-Have (Later)
+
+1. **Hybrid search** — SQLite FTS5 + vector embeddings for local memory
+2. **Webhook triggers** — external integrations via Tailscale/CF Tunnel
+3. **Hot-reload config** — apply config changes without full restart
+4. **Protected tool names** — prevent shadowing of built-in tools
+
+### Patterns to Reject
+
+1. **WASM sandbox** — unnecessary for single-user trusted environment
+2. **Separate IDENTITY.md file** — merge into PERSONALITY.md for simplicity
+3. **Multiple embedding providers** — start with one (OpenRouter or Ollama)
+4. **BOOTSTRAP.md self-destruct** — cute but unnecessary; onboarding can be
+   a CLI flag or first-run detection
+
+---
+
+## Sources
+
+### Primary Research
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — 68K stars, TypeScript,
+  the ecosystem standard
+- [IronClaw (NEAR AI)](https://github.com/nearai/ironclaw) — Rust,
+  security-first with WASM sandbox
+- [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw) — Rust, 3.4MB binary,
+  <5MB RAM
+- [PicoClaw](https://github.com/sipeed/picoclaw) — most comprehensive
+  file-based identity system
+- [Goose (Block)](https://github.com/block/goose) — MCP-first, recipes +
+  scheduling
+- [Claude Code](https://code.claude.com) — CLAUDE.md, .claude/rules/,
+  project memory
+- [Aider](https://aider.chat) — repo map, CONVENTIONS.md
+- [Continue.dev](https://docs.continue.dev) — .continuerules, MCP tools
+- [Open Interpreter](https://github.com/openinterpreter/open-interpreter) —
+  code execution focus
+
+### Documentation
+
+- [OpenClaw Docs](https://docs.openclaw.ai/) — system prompt, memory, tools,
+  cron, configuration
+- [IronClaw DeepWiki](https://deepwiki.com/nearai/ironclaw)
+- [ZeroClaw DeepWiki](https://deepwiki.com/zeroclaw-labs/zeroclaw)
+
+### Research Papers and Articles
+
+- [Design Patterns for Long-Term Memory in LLM-Powered Architectures](https://serokell.io/blog/design-patterns-for-long-term-memory-in-llm-powered-architectures)
+- [Making Sense of Memory in AI Agents](https://www.leoniemonigatti.com/blog/memory-in-ai-agents.html)
+- [Comparing Memory Systems for LLM Agents](https://www.marktechpost.com/2025/11/10/comparing-memory-systems-for-llm-agents-vector-graph-and-event-logs/)

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -6,6 +6,8 @@ This directory contains management UI planning artifacts for Netclaw.
 
 - `UI-001-ops-console-mockup.md` - page architecture, wireframes, and
   component behavior
+- `TUI-001-command-wireframes.md` - Termina TUI wireframes for `netclaw init`,
+  `netclaw chat`, and plain CLI commands
 - `ops-console-v1.html` - static high-fidelity mockup for visual direction
 
 ## Design Intent

--- a/docs/ui/TUI-001-command-wireframes.md
+++ b/docs/ui/TUI-001-command-wireframes.md
@@ -1,0 +1,269 @@
+# TUI-001: Command Wireframes
+
+Source PRDs: `PRD-004`, `PRD-009`
+
+## Overview
+
+Netclaw's CLI uses **Cocona** for command routing and **Termina 0.5.1** for
+interactive TUI commands. Only two commands use Termina TUI rendering — all
+other commands use plain console output via Cocona.
+
+| Command         | Interface | Framework |
+|-----------------|-----------|-----------|
+| `netclaw init`  | TUI       | Termina   |
+| `netclaw chat`  | TUI       | Termina   |
+| All others      | Plain CLI | Cocona    |
+
+## Termina Component Vocabulary
+
+All wireframes reference actual Termina 0.5.1 components:
+
+- **PanelNode** — bordered container with optional title
+- **TextInputNode** — single or multi-line text input
+- **SelectionListNode** — keyboard-navigable option list
+- **TextNode** — static or dynamic text block
+- **StreamingTextNode** — scrollable text that appends content in real-time
+- **SpinnerNode** — animated progress indicator
+
+---
+
+## `netclaw init` — Onboarding Wizard (TUI)
+
+Interactive 7-step setup wizard. Termina hosts the full wizard as a single
+application with step navigation.
+
+### Wireframe
+
+```
+╭─ Netclaw Setup ──────────────────────────────────────────────╮
+│                                                              │
+│  Step 2 of 7: Slack Configuration        [■■□□□□□] 28%      │
+│                                                              │
+│  ╭─ Slack Bot Token ───────────────────────────────────────╮ │
+│  │ xoxb-************************************               │ │
+│  ╰─────────────────────────────────────────────────────────╯ │
+│                                                              │
+│  ╭─ Slack App Token ───────────────────────────────────────╮ │
+│  │ xapp-************************************               │ │
+│  ╰─────────────────────────────────────────────────────────╯ │
+│                                                              │
+│  ℹ  Socket Mode requires both tokens. See:                  │
+│     https://api.slack.com/apis/socket-mode                   │
+│                                                              │
+│  [Enter] Next   [Esc] Back   [Ctrl+Q] Quit                  │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+### Components Per Step
+
+| Step | Title                  | Components                                            |
+|------|------------------------|-------------------------------------------------------|
+| 1    | LLM Provider           | SelectionListNode (OpenRouter/Anthropic/OpenAI/Ollama) + TextInputNode (API key) |
+| 2    | Slack Configuration    | TextInputNode (bot token) + TextInputNode (app token) |
+| 3    | PostgreSQL Connection  | TextInputNode (connection string) + SpinnerNode (live validation) |
+| 4    | ACL Bootstrap          | TextInputNode (owner identity) + SelectionListNode (initial channels) |
+| 5    | MCP Servers            | SelectionListNode (Memorizer recommended / custom / skip) |
+| 6    | Exposure Mode          | SelectionListNode (local-only default / tailscale / cloudflare) |
+| 7    | Health Check           | TextNode (validation results with SpinnerNodes → checkmarks) |
+
+### Layout Structure
+
+```
+PanelNode (outer: "Netclaw Setup")
+├── TextNode (step indicator + progress bar)
+├── [step-specific components]
+│   ├── TextInputNode (for text/secret input, masked for tokens)
+│   ├── SelectionListNode (for choice input)
+│   └── SpinnerNode (for live validation)
+├── TextNode (help text / contextual guidance)
+└── TextNode (key bindings: Enter/Esc/Ctrl+Q)
+```
+
+### Step Detail: Health Check (Step 7)
+
+```
+╭─ Netclaw Setup ──────────────────────────────────────────────╮
+│                                                              │
+│  Step 7 of 7: Health Check               [■■■■■■■] 100%     │
+│                                                              │
+│  Verifying configuration...                                  │
+│                                                              │
+│  ✓  LLM provider reachable (OpenRouter)                      │
+│  ✓  Slack bot token valid                                    │
+│  ✓  Slack app token valid                                    │
+│  ✓  PostgreSQL connected (3ms)                               │
+│  ✓  MCP: memorizer connected (12 tools)                      │
+│  ●  Exposure: local-only (no public endpoint)                │
+│                                                              │
+│  All checks passed. Run `netclaw run` to start.              │
+│                                                              │
+│  [Enter] Finish   [Esc] Back   [Ctrl+Q] Quit                │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+### Behaviors
+
+- Progress bar uses block characters (■□) rendered via TextNode
+- Secret inputs (API keys, tokens) use masked TextInputNode
+- Step 3 (PostgreSQL) validates connectivity live with SpinnerNode → checkmark
+- Step 7 (Health Check) runs all probes in sequence with SpinnerNode → result
+- [Esc] navigates back to previous step; [Ctrl+Q] exits with confirmation
+- Config file written to `~/.netclaw/config/netclaw.json` on completion
+
+---
+
+## `netclaw chat` — Interactive Agent Prompt (TUI)
+
+Full interactive chat session with the Netclaw agent. Hosts the actor system
+in-process. Session entity key: `tui/{uuid}`.
+
+### Wireframe
+
+```
+╭─ Netclaw Chat ─────────────────── session: tui/a1b2c3 ──────╮
+│                                                              │
+│  System: Personality loaded. 5 tools. Memorizer connected.   │
+│                                                              │
+│  You: Check the CI status on netclaw and summarize           │
+│                                                              │
+│  ╭─ Tool Activity ──────────────────────────────────────╮    │
+│  │ ✓ shell: gh run list --limit 3           (2.1s)      │    │
+│  │ ● web_fetch: github.com/...actions        (...)      │    │
+│  ╰──────────────────────────────────────────────────────╯    │
+│                                                              │
+│  Netclaw: Here's your CI status:                             │
+│                                                              │
+│  | Run  | Branch | Status  | Duration |                      │
+│  |------|--------|---------|----------|                      │
+│  | #42  | dev    | ✓ pass  | 3m 12s   |                      │
+│  | #41  | dev    | ✓ pass  | 2m 58s   |                      │
+│  | #40  | feat/x | ✗ fail  | 1m 04s   |                      │
+│                                                              │
+│  Run #40 failed on feat/x. Want me to investigate?           │
+│  ●                                                           │
+╰──────────────────────────────────────────────────────────────╯
+╭─ Input ──────────────────────────────────────────────────────╮
+│ Yes, show me the failure logs and                            │
+│ see if it's a flaky test or a real issue.                    │
+│ █                                                            │
+╰──────────────────────────────────────────────────────────────╯
+ [Enter] Send  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit  ✓ MCP (2/2)
+```
+
+### Layout Structure
+
+```
+PanelNode (outer: "Netclaw Chat", subtitle: session ID)
+├── StreamingTextNode (scrollable chat history, fills available space)
+│   ├── System messages (personality, tool count, MCP status)
+│   ├── User messages (prefixed "You:")
+│   ├── Tool Activity PanelNode (inline, collapsible)
+│   │   ├── TextNode (✓ completed: tool name + duration, green)
+│   │   └── SpinnerNode (● in-progress: tool name, yellow)
+│   └── Assistant messages (prefixed "Netclaw:", streamed via SpinnerSegment)
+│
+PanelNode (input: "Input")
+├── TextInputNode (multi-line, 3 rows, fixed at bottom)
+│
+TextNode (status bar: key bindings + MCP indicator)
+```
+
+### Key Behaviors
+
+- **StreamingTextNode** fills most of the screen, scrollable with PgUp/PgDn
+- **TextInputNode** is multi-line (3 rows), fixed at bottom in its own PanelNode
+- **Tool Activity** panel appears inline between user message and response:
+  - ✓ completed tools with name + duration (green)
+  - ● in-progress tools with SpinnerNode (yellow)
+  - Panel collapses when no tools are active
+- **MCP status indicator** (bottom-right of status bar, reactive):
+  - `✓ MCP (2/2)` = green — all servers connected
+  - `⚠ MCP (1/2)` = yellow — degraded (auth required or warning)
+  - `✗ MCP (0/2)` = red — server(s) unreachable
+- **SpinnerSegment** shows while LLM is thinking; tokens stream in real-time
+- **Session entity key**: `tui/{uuid}`, full actor system hosted in-process
+- **MCP**: per-agent, not gateway-level
+
+### Input Handling
+
+- [Enter] sends the current input buffer as a user message
+- Multi-line input supported (Shift+Enter or paste)
+- Input buffer clears after send
+- History scrollback not implemented in MVP
+
+---
+
+## `netclaw doctor` — Plain CLI Output (No TUI)
+
+Simple check-and-report command. Runs startup checks, prints color-coded
+results, exits with appropriate exit code. Not interactive — no Termina TUI.
+
+### Output Example
+
+```
+$ netclaw doctor
+
+Netclaw Doctor
+
+Checking startup requirements...
+
+  ✓  Config file valid
+  ✓  ACL valid (3 channel rules, 2 tool grants)
+  ✓  LLM provider reachable (OpenRouter)
+  ✓  PostgreSQL connected (2ms)
+  ✗  Slack bot token invalid or expired
+     Fix: netclaw init --step slack
+  ✓  MCP: memorizer connected (12 tools)
+  ⚠  MCP: searxng needs auth
+     Fix: Add API key to ~/.netclaw/config/netclaw.json
+
+Result: 1 error, 1 warning. Netclaw cannot start.
+```
+
+### Behavior
+
+- Runs all startup checks in sequence
+- Color-coded output: ✓ green, ⚠ yellow, ✗ red
+- Errors include remediation commands (e.g., `netclaw init --step slack`)
+- Exit code: 0 (all pass), 1 (errors), 2 (warnings only)
+- No interactivity — suitable for scripting and CI
+
+---
+
+## Commands That Stay Plain CLI (No TUI)
+
+All of the following commands use standard console output via Cocona.
+No Termina TUI components are used.
+
+| Command                              | Output Style        |
+|--------------------------------------|---------------------|
+| `netclaw doctor`                     | Check list          |
+| `netclaw config show`                | Formatted text/JSON |
+| `netclaw config validate`            | Validation results  |
+| `netclaw acl validate\|test\|explain`  | Policy check results|
+| `netclaw session list\|inspect`        | Tabular             |
+| `netclaw project list\|add\|remove`    | Simple CRUD         |
+| `netclaw environment scan\|show`       | Scan results        |
+| `netclaw memory show`                | Display memory files|
+| `netclaw schedule list\|show\|pause\|resume\|delete` | Tabular |
+| `netclaw tools list\|policy`           | Tabular             |
+| `netclaw mcp list\|validate\|test`     | Validation results  |
+| `netclaw test smoke`                 | Test results        |
+| `netclaw personality reset`          | Confirmation        |
+| `netclaw run`                        | Daemon (no TUI)     |
+
+### `netclaw run` — Daemon Mode
+
+Starts the full Netclaw process: Slack Socket Mode adapter, Akka actor system,
+scheduled task timers, health endpoints. No TUI — logs to console/file.
+This is the primary production entry point.
+
+---
+
+## Cross-References
+
+- CLI command surface: PRD-004
+- TUI adapter contract: PRD-009
+- Ops console (web): UI-001
+- Cocona framework: implementation decision
+- Termina 0.5.1: implementation decision

--- a/docs/ui/UI-001-ops-console-mockup.md
+++ b/docs/ui/UI-001-ops-console-mockup.md
@@ -140,9 +140,83 @@ Wizard requirements:
 - Empty states include a concrete next action.
 - Failure states include direct CLI command equivalent.
 
+## 8) Memory and Configuration
+
+Route: `/memory-config`
+
+```
++--------------------------------------------------------------------------------+
+| NETCLAW OPS CONSOLE                                           Memory & Config  |
++----------------------+---------------------------------------------------------+
+| Navigation           | ╭─ Personality ───────────────────────────────────────╮ |
+| - Overview           | │ PERSONALITY.md  │ INSTRUCTIONS.md │ USER.md        │ |
+| - Sessions           | │ [View] [Edit]   │ [View] [Edit]   │ [View] [Edit]  │ |
+| - Policy             | ╰────────────────────────────────────────────────────╯ |
+| - Security           |                                                         |
+| - Diagnostics        | ╭─ Projects ──────────────────────────────────────────╮ |
+| - Memory & Config  * | │ Name       Path                     Lang   CI       │ |
+| - Scheduling         | │ netclaw    /home/user/repos/netclaw  C#     ✓       │ |
+|                      | │ termina    /home/user/repos/termina  C#     ✓       │ |
+| Quick Actions        | │ [Add Project]                                       │ |
+| [Validate Config]    | ╰────────────────────────────────────────────────────╯ |
+| [Run Doctor]         |                                                         |
+| [Inspect ACL]        | ╭─ Environment ───────────────────────────────────────╮ |
+|                      | │ git 2.43  gh 2.62  dotnet 10.0  node 22.1          │ |
+|                      | │ Last scan: 2026-02-21 14:30                         │ |
+|                      | │ [Rescan]                                             │ |
+|                      | ╰────────────────────────────────────────────────────╯ |
++----------------------+---------------------------------------------------------+
+```
+
+Panels:
+
+- **Personality** — view and edit soul files (PERSONALITY.md, INSTRUCTIONS.md,
+  USER.md). Inline markdown editor with preview.
+- **Projects** — registered project list with path, language, CI status.
+  Add/remove projects. Links to project AGENTS.md when present.
+- **Environment** — discovered tools and versions from last environment scan.
+  Rescan button triggers a fresh discovery.
+
+## 9) Scheduling
+
+Route: `/scheduling`
+
+```
++--------------------------------------------------------------------------------+
+| NETCLAW OPS CONSOLE                                              Scheduling    |
++----------------------+---------------------------------------------------------+
+| Navigation           | ╭─ Scheduled Tasks ───────────────────────────────────╮ |
+| - Overview           | │ Name          Type     Schedule     Status   Next   │ |
+| - Sessions           | │ daily-standup  cron     0 9 * * 1-5  active   09:00 │ |
+| - Policy             | │ check-ci       interval 30m          active   14:32 │ |
+| - Security           | │ backup-db      cron     0 2 * * *    paused   --    │ |
+| - Diagnostics        | │                                                     │ |
+| - Memory & Config    | │ [Create Task] [Pause All]                           │ |
+| - Scheduling       * | ╰────────────────────────────────────────────────────╯ |
+|                      |                                                         |
+| Quick Actions        | ╭─ Execution History ─────────────────────────────────╮ |
+| [Validate Config]    | │ Time           Task          Duration  Result       │ |
+| [Run Doctor]         | │ 14:02 today    check-ci      12s       ✓ success   │ |
+| [Inspect ACL]        | │ 09:00 today    daily-standup  45s       ✓ success   │ |
+|                      | │ 02:00 today    backup-db      --        ⊘ paused    │ |
+|                      | │ 14:02 yest.    check-ci      8s        ✓ success   │ |
+|                      | ╰────────────────────────────────────────────────────╯ |
++----------------------+---------------------------------------------------------+
+```
+
+Panels:
+
+- **Scheduled Tasks** — task list with name, type (cron/interval), schedule
+  expression, status (active/paused), next fire time. Actions: create, pause,
+  resume, delete. Pause All for maintenance windows.
+- **Execution History** — recent execution log with timestamp, task name,
+  duration, and result. Click-through to session inspector for full details.
+
 ## CLI Parity Matrix
 
 - Overview health <-> `netclaw gateway status`
 - Policy simulator <-> `netclaw acl test` / `netclaw acl explain`
 - Diagnostics panel <-> `netclaw gateway doctor`
 - Session inspector <-> `netclaw session inspect`
+- Memory & Config <-> `netclaw memory show` / `netclaw project list` / `netclaw environment show`
+- Scheduling <-> `netclaw schedule list` / `netclaw schedule show`

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/.openspec.yaml
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/design.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/design.md
@@ -1,0 +1,155 @@
+## Context
+
+Netclaw's current implementation plan (Phase 1) reaches the Slack adapter at
+Task 1.13 — the first opportunity for end-to-end validation. This creates a
+gap: Tasks 1.1-1.12 build actor framework, persistence, tools, scheduling,
+and memory, but none of them can be validated end-to-end without live Slack
+credentials and infrastructure.
+
+Adding a local TUI adapter (`netclaw chat`) as the first input adapter closes
+this gap. The full agent stack — session actors, tool calls, streaming
+responses, MCP integration — can be validated locally through the terminal.
+Slack becomes just another adapter plugged into an already-validated system.
+
+Config hot-reload addresses a second operational need: a long-running homelab
+agent should not require process restarts for routine configuration changes
+(ACL rules, provider settings, MCP profiles, schedules).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide `netclaw chat` as the first E2E validation path for the agent stack
+- Deliver `netclaw init` as an interactive TUI onboarding wizard
+- Add `netclaw run` as the explicit daemon entry point
+- Route all CLI commands through Cocona for consistent DI and command parsing
+- Enable hot-reload for operational config files without process restart
+- Resequence implementation plan to TUI-first, Slack-second
+
+**Non-Goals:**
+
+- Web UI adapter (Phase 5)
+- Webhook adapter (Phase 2)
+- Hot-reload for personality files, project registry, or environment inventory
+  (these are session-scoped; change requires session reboot)
+- TUI-based ambient monitoring
+- Custom Termina component development (use existing component library)
+
+## Decisions
+
+### Decision 1: Cocona for CLI command routing
+
+**Choice:** Cocona 2.3.0
+
+**Alternatives considered:**
+- `System.CommandLine` — more complex, verbose attribute model, no built-in DI
+- `Spectre.Console.Cli` — good CLI, but we need TUI (not just formatted output)
+- Raw `WebApplication` with custom arg parsing — current state, not scalable
+
+**Rationale:** Cocona is lightweight, convention-based, and has built-in DI
+integration through `Microsoft.Extensions.DependencyInjection`. Commands are
+simple classes with method parameters mapped to CLI arguments. It integrates
+cleanly with `IHostedService` for daemon mode.
+
+### Decision 2: Termina 0.5.1 for TUI
+
+**Choice:** Termina 0.5.1 (owned library)
+
+**Rationale:** Termina is Aaron's own reactive MVVM TUI framework for .NET 10.
+It provides the component vocabulary needed (PanelNode, TextInputNode,
+SelectionListNode, StreamingTextNode, SpinnerNode) and is AOT-compatible.
+Only `netclaw init` and `netclaw chat` use TUI — all other commands stay
+plain CLI via Cocona.
+
+### Decision 3: TUI adapter hosts actor system in-process
+
+**Choice:** `netclaw chat` hosts the full Akka actor system in-process, same
+as `netclaw run` does for daemon mode.
+
+**Alternatives considered:**
+- Connect to running daemon via IPC — adds complexity, requires daemon running
+- Lightweight mode without actors — loses the validation benefit
+
+**Rationale:** The whole point is validating the same actor stack that runs in
+production. In-process hosting means `netclaw chat` exercises the exact same
+code paths as Slack-driven sessions, just with a different input adapter.
+
+### Decision 4: FileSystemWatcher for config hot-reload
+
+**Choice:** `FileSystemWatcher` + 500ms debounce + validate-before-apply
+
+**Alternatives considered:**
+- Polling with interval — wastes CPU, slower to detect changes
+- `inotify` directly — platform-specific, FSW already wraps this on Linux
+- Config server / etcd — over-engineered for single-process homelab agent
+
+**Rationale:** `FileSystemWatcher` is built into .NET, works on all platforms,
+and is sufficient for a single-process agent watching a handful of config files.
+The debounce window (500ms) prevents rapid-fire reloads during file save
+operations. Validate-before-apply ensures invalid configs never reach the
+runtime.
+
+### Decision 5: Watched vs unwatched file classification
+
+**Watched (hot-reloaded):**
+- ACL rules — policy engine refresh
+- Provider config — `IChatClient` rebuild
+- MCP profiles — server reconnect/disconnect
+- Schedule definitions — timer reconfiguration
+
+**Unwatched (require restart or session reboot):**
+- Personality files (PERSONALITY.md, INSTRUCTIONS.md, USER.md) — cached in LLM
+  context at session start
+- Project registry — loaded at session start
+- Environment inventory — loaded at startup
+
+**Rationale:** Watched files control runtime behavior that can be atomically
+swapped. Unwatched files are loaded into LLM context at session start and
+changing them mid-session would create inconsistency.
+
+### Decision 6: Actor notification on config change
+
+Config changes are dispatched to owning actors via Akka pub/sub:
+
+| Config File | Owning Actor/Service | Notification |
+|-------------|---------------------|--------------|
+| ACL rules | Policy engine | Re-evaluate grants for active sessions |
+| Provider config | Provider factory | Rebuild `IChatClient` instances |
+| MCP profiles | MCP manager | Reconnect/disconnect affected servers |
+| Schedule definitions | ScheduleManagerActor | Reconfigure timers |
+
+This preserves actor boundaries — the `ConfigWatcherService` publishes change
+events, actors subscribe to the topics they care about.
+
+## Risks / Trade-offs
+
+**[Risk]** FileSystemWatcher can miss events on some filesystems (NFS, Docker
+volumes).
+→ **Mitigation:** Target is local disk on pi1. Document that networked
+filesystems are unsupported for config directory. Add `netclaw config validate`
+as manual fallback.
+
+**[Risk]** Debounce window too short could cause partial reads of multi-file
+config changes.
+→ **Mitigation:** 500ms default is conservative. Each file is validated
+independently. Operator can also use `netclaw config validate` before manual
+reload.
+
+**[Risk]** TUI adapter adds maintenance surface for a dev-only input path.
+→ **Mitigation:** TUI adapter implements the same adapter contract as Slack.
+It's not a separate code path — it's the same `SendUserMessage` → session →
+broadcast pipeline. The TUI-specific code is only the rendering layer.
+
+**[Risk]** Cocona + Termina add two new package dependencies.
+→ **Mitigation:** Both are lightweight. Cocona is ~50KB. Termina is owned and
+maintained by the project owner. Both support AOT compilation.
+
+**[Failure mode]** Config file deleted while being watched.
+→ **Recovery:** `ConfigWatcherService` treats deletion as "no config" and logs
+a warning. Existing runtime config remains in effect until a valid replacement
+is written. Does not crash the process.
+
+**[Failure mode]** Invalid config written to watched file.
+→ **Recovery:** Validate-before-apply rejects the change. Previous valid config
+remains active. Diagnostic log entry includes validation errors and the file
+path. `netclaw doctor` reports the validation failure.

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/proposal.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+The current implementation plan requires Slack Socket Mode as the first
+end-to-end validation path (Task 1.13), but Slack credentials and live
+infrastructure make autonomous RALPH execution fragile. Adding a local TUI
+adapter (`netclaw chat`) as the first input adapter lets us validate the entire
+agent stack — session actors, tool calls, streaming responses, MCP integration —
+without any external dependencies. Config hot-reload removes the need to restart
+the process when operational configuration changes, which is critical for a
+long-running homelab agent.
+
+Source PRDs: `PRD-001` (FR-016), `PRD-004` (CLI-010, CLI-011, CLI-012),
+`PRD-009` (INPUT-005).
+
+## What Changes
+
+- Add Cocona as the CLI command routing framework (replaces raw
+  `WebApplication` entry point)
+- Add Termina 0.5.1 as the TUI framework for interactive commands
+- Add `netclaw chat` command — interactive agent prompt with streaming
+  responses, tool activity display, and MCP status via TUI adapter
+- Add `netclaw init` command — 7-step onboarding wizard delivered through TUI
+- Add `netclaw run` command — explicit daemon entry point (Slack + timers +
+  health endpoints, no TUI)
+- Add `netclaw doctor` and all other plain CLI commands via Cocona
+- Add TUI input adapter implementing the adapter contract (`SendUserMessage`
+  with entity key `tui/{sessionId}`)
+- Add config hot-reload for operational configuration files (ACL, providers,
+  MCP profiles, schedules) via `FileSystemWatcher` + debounce +
+  validate-before-apply
+- Resequence implementation plan: TUI-first validation before Slack adapter
+
+### In Scope (MVP)
+
+- TUI adapter as Phase 1 input source
+- Cocona command routing for full PRD-004 command surface
+- Termina TUI for `netclaw init` and `netclaw chat`
+- Config hot-reload for ACL, provider, MCP, and schedule files
+- Actor notification on config change (policy refresh, provider rebuild,
+  MCP reconnect)
+
+### Out of Scope
+
+- Web UI adapter (Phase 5)
+- Webhook adapter (Phase 2)
+- Hot-reload of personality files, project registry, or environment inventory
+- TUI-based ambient monitoring
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-config-hot-reload`: FileSystemWatcher-based hot-reload for
+  operational config files. Debounce, validate-before-apply, actor
+  notification, watched vs unwatched file classification.
+
+### Modified Capabilities
+
+- `netclaw-cli`: Add Cocona framework requirement, TUI command classification
+  (TUI-interactive vs plain-CLI), `netclaw run` daemon entry point,
+  `netclaw chat` local adapter command
+- `netclaw-input-adapters`: Add TUI adapter as Phase 1 input source with
+  entity key pattern `tui/{sessionId}` and adapter contract implementation
+- `netclaw-onboarding`: Add TUI wizard as onboarding delivery mechanism
+  (Termina-based 7-step wizard for `netclaw init`)
+- `netclaw-session`: Add config hot-reload integration — re-evaluate tool
+  grants when ACL changes, provider swap on config change, MCP reconnect
+  on profile change
+
+## Impact
+
+- **Runtime entry point**: `Program.cs` rewritten from `WebApplication` to
+  Cocona command host with Termina integration
+- **Package dependencies**: Cocona 2.3.0, Termina 0.5.1 added to
+  `Directory.Packages.props` and `Netclaw.App.csproj`
+- **New source files**: `Commands/` directory for Cocona commands, `Tui/`
+  directory for Termina pages and view models, `Adapters/TuiInputAdapter.cs`,
+  `Services/ConfigWatcherService.cs`
+- **Implementation plan**: Tasks 1.13-1.22 resequenced to TUI-first ordering
+- **Security**: No new attack surface — TUI runs locally, config hot-reload
+  validates before applying, invalid configs are rejected
+- **Operational**: Process no longer requires restart for ACL/provider/MCP/
+  schedule config changes

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-cli/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-cli/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Cocona command routing
+
+The application SHALL use Cocona as the CLI command routing framework. All
+commands SHALL be routed through Cocona's convention-based command model with
+DI integration.
+
+#### Scenario: Command routed through Cocona
+
+- **WHEN** operator runs `netclaw <command> [args]`
+- **THEN** Cocona routes to the matching command class
+- **AND** DI-registered services are available to the command handler
+
+### Requirement: TUI command classification
+
+Commands SHALL be classified as either TUI-interactive (rendered via Termina)
+or plain-CLI (standard console output). Only `netclaw init` and `netclaw chat`
+SHALL use Termina TUI. All other commands SHALL use plain console output.
+
+#### Scenario: TUI command launches Termina
+
+- **WHEN** operator runs `netclaw chat` or `netclaw init`
+- **THEN** the command handler launches Termina as a hosted service
+- **AND** the TUI renders interactive components
+
+#### Scenario: Plain CLI command uses console output
+
+- **WHEN** operator runs `netclaw doctor` or any non-TUI command
+- **THEN** the command handler writes to standard output
+- **AND** no Termina TUI is launched
+
+### Requirement: Interactive chat command
+
+The CLI SHALL provide `netclaw chat` as an interactive agent prompt that hosts
+the full actor system in-process. The chat command SHALL use the TUI adapter
+to produce `SendUserMessage` commands with entity key `tui/{sessionId}`.
+
+#### Scenario: Start chat session
+
+- **WHEN** operator runs `netclaw chat`
+- **THEN** the actor system starts in-process
+- **AND** a TUI chat interface is rendered with input panel and message history
+- **AND** a new session with entity key `tui/{uuid}` is created
+
+#### Scenario: Send message in chat
+
+- **GIVEN** a chat session is active
+- **WHEN** operator types a message and presses Enter
+- **THEN** a `SendUserMessage` command is dispatched to the session parent
+- **AND** the response streams into the chat history via StreamingTextNode
+
+#### Scenario: Tool activity displayed inline
+
+- **GIVEN** a chat session is processing a turn with tool calls
+- **WHEN** tools are invoked during the turn
+- **THEN** a tool activity panel appears inline showing tool name, status, and
+  duration
+- **AND** completed tools show checkmark with duration
+- **AND** in-progress tools show spinner
+
+#### Scenario: MCP status displayed in status bar
+
+- **GIVEN** MCP servers are configured
+- **WHEN** the chat TUI is active
+- **THEN** the status bar shows MCP connectivity status
+- **AND** green indicates all servers connected
+- **AND** yellow indicates degraded connectivity
+- **AND** red indicates servers unreachable
+
+### Requirement: Daemon entry point
+
+The CLI SHALL provide `netclaw run` as the explicit daemon entry point. The
+daemon SHALL start the Slack Socket Mode adapter, Akka actor system, scheduled
+task timers, and health endpoints. The daemon SHALL NOT render a TUI.
+
+#### Scenario: Start daemon mode
+
+- **WHEN** operator runs `netclaw run`
+- **THEN** the Slack Socket Mode adapter connects
+- **AND** the Akka actor system starts
+- **AND** scheduled task timers are registered
+- **AND** health endpoints are available
+- **AND** no TUI is rendered
+
+#### Scenario: Daemon logs to console
+
+- **GIVEN** the daemon is running
+- **WHEN** events occur (messages, tool calls, errors)
+- **THEN** events are logged to console and/or configured log output
+- **AND** no interactive input is expected
+
+### Requirement: Doctor command
+
+The CLI SHALL provide `netclaw doctor` as a plain CLI command that runs startup
+checks and reports results with remediation guidance. The doctor command SHALL
+exit with code 0 (all pass), 1 (errors), or 2 (warnings only).
+
+#### Scenario: All checks pass
+
+- **WHEN** operator runs `netclaw doctor`
+- **AND** all startup checks pass
+- **THEN** output shows checkmarks for each check
+- **AND** exit code is 0
+
+#### Scenario: Check fails with remediation
+
+- **WHEN** operator runs `netclaw doctor`
+- **AND** a startup check fails
+- **THEN** output shows the failure with a remediation command
+- **AND** exit code is 1

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-config-hot-reload/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-config-hot-reload/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Operational config file monitoring
+
+The system SHALL monitor operational configuration files for changes using
+`FileSystemWatcher`. Monitored files SHALL include ACL rules, provider
+configuration, MCP server profiles, and schedule definitions.
+
+#### Scenario: ACL file change detected
+
+- **GIVEN** the ACL rules file exists at the configured path
+- **WHEN** the file is modified on disk
+- **THEN** the `ConfigWatcherService` detects the change within 500ms
+
+#### Scenario: Provider config change detected
+
+- **GIVEN** the provider configuration file exists at the configured path
+- **WHEN** the file is modified on disk
+- **THEN** the `ConfigWatcherService` detects the change within 500ms
+
+#### Scenario: Unwatched files are not monitored
+
+- **GIVEN** personality files, project registry, or environment inventory files
+  exist
+- **WHEN** those files are modified on disk
+- **THEN** the `ConfigWatcherService` does NOT detect or process the change
+
+### Requirement: Change event debounce
+
+The system SHALL debounce file change events with a configurable window
+(default 500ms) to prevent rapid-fire reloads during file save operations.
+
+#### Scenario: Rapid successive writes debounced
+
+- **GIVEN** a watched config file is being saved
+- **WHEN** the file system emits multiple change events within 500ms
+- **THEN** the system processes only one reload after the debounce window
+
+#### Scenario: Separate files reload independently
+
+- **GIVEN** ACL rules and provider config are both watched
+- **WHEN** both files change within the debounce window
+- **THEN** each file's change is processed independently after its own debounce
+
+### Requirement: Validate before apply
+
+The system SHALL validate changed configuration before applying it to the
+runtime. Invalid configuration SHALL be rejected with logged diagnostics.
+The previous valid configuration SHALL remain in effect.
+
+#### Scenario: Valid config change applied
+
+- **GIVEN** a watched config file changes
+- **WHEN** the new content passes validation
+- **THEN** the change is applied to the runtime
+- **AND** owning actors are notified
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** a watched config file changes
+- **WHEN** the new content fails validation
+- **THEN** the change is NOT applied
+- **AND** the previous valid configuration remains in effect
+- **AND** validation errors are logged with file path and error details
+
+#### Scenario: Config file deleted
+
+- **GIVEN** a watched config file is being monitored
+- **WHEN** the file is deleted from disk
+- **THEN** the system logs a warning
+- **AND** the existing runtime configuration remains in effect
+- **AND** the process does NOT crash
+
+### Requirement: Actor notification on config change
+
+The system SHALL notify owning actors when their configuration changes via
+Akka pub/sub. Each config domain SHALL map to a specific actor or service.
+
+#### Scenario: ACL change triggers policy refresh
+
+- **GIVEN** the ACL rules file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the policy engine re-evaluates tool grants for active sessions
+
+#### Scenario: Provider change triggers IChatClient rebuild
+
+- **GIVEN** the provider configuration file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the provider factory rebuilds `IChatClient` instances
+
+#### Scenario: MCP profile change triggers server reconnection
+
+- **GIVEN** an MCP server profile has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** affected MCP servers are reconnected or disconnected as appropriate
+
+#### Scenario: Schedule change triggers timer reconfiguration
+
+- **GIVEN** the schedule definitions file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the `ScheduleManagerActor` reconfigures timers to match the new
+  definitions
+
+### Requirement: ConfigWatcherService hosted service
+
+The `ConfigWatcherService` SHALL be implemented as an `IHostedService` that
+starts with the application and stops on shutdown. It SHALL manage
+`FileSystemWatcher` instances for each watched config file.
+
+#### Scenario: Service starts with application
+
+- **GIVEN** the application is starting
+- **WHEN** the hosted service initializes
+- **THEN** `FileSystemWatcher` instances are created for each watched config
+  file
+- **AND** the service begins monitoring for changes
+
+#### Scenario: Service stops on shutdown
+
+- **GIVEN** the application is shutting down
+- **WHEN** the hosted service stops
+- **THEN** all `FileSystemWatcher` instances are disposed
+- **AND** no further change events are processed

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: TUI input adapter
+
+The TUI adapter SHALL receive keyboard input via Termina TextInputNode, produce
+`SendUserMessage` commands with entity key `tui/{sessionId}`, subscribe to
+session broadcasts, and render responses as streaming text. The TUI adapter
+SHALL be a Phase 1 input source.
+
+#### Scenario: TUI adapter produces SendUserMessage
+
+- **GIVEN** the operator is in a `netclaw chat` session
+- **WHEN** the operator types a message and presses Enter
+- **THEN** the TUI adapter produces a `SendUserMessage` command
+- **AND** the command contains the message content, entity key `tui/{sessionId}`,
+  and source metadata with adapter type `tui`
+
+#### Scenario: TUI adapter renders streaming response
+
+- **GIVEN** a session actor is processing a turn from the TUI adapter
+- **WHEN** the session emits token-level broadcast events
+- **THEN** the TUI adapter renders tokens in real-time via StreamingTextNode
+- **AND** the response appears incrementally in the chat history
+
+#### Scenario: TUI adapter displays tool invocation status
+
+- **GIVEN** a session is executing tool calls
+- **WHEN** a tool invocation starts
+- **THEN** the TUI adapter displays an inline tool activity panel
+- **AND** shows the tool name with a spinner indicator
+- **WHEN** the tool invocation completes
+- **THEN** the spinner is replaced with a checkmark and duration
+
+#### Scenario: TUI adapter subscribes to session broadcasts
+
+- **GIVEN** the TUI adapter has sent a `SendUserMessage` command
+- **WHEN** the session actor emits a `TurnBroadcast` event
+- **THEN** the TUI adapter receives the broadcast
+- **AND** renders the response content in the chat history
+
+#### Scenario: TUI source metadata populated
+
+- **GIVEN** the operator sends a message via `netclaw chat`
+- **WHEN** the TUI adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `tui`
+- **AND** includes `local-operator` as sender identity
+- **AND** includes the session ID as channel identifier
+- **AND** includes the current timestamp
+
+## MODIFIED Requirements
+
+### Requirement: Entity key routing
+
+The session parent actor SHALL extract an entity key from each
+`SendUserMessage` command and route to the correct child session actor. Slack
+messages SHALL use entity key pattern `{channelId}/{threadTs}`. Timer
+messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`. TUI
+messages SHALL use entity key pattern `tui/{sessionId}`.
+
+#### Scenario: Slack message routed by thread identity
+
+- **GIVEN** a Slack message arrives from channel `C0123` in thread `T456`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `C0123/T456`
+- **AND** the command is routed to the session actor for that key
+
+#### Scenario: Timer message routed by task and run identity
+
+- **GIVEN** a timer fires for task `ebay-check` at timestamp `1708531200`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `schedule/ebay-check/1708531200`
+- **AND** a new session actor is created for that entity key
+
+#### Scenario: TUI message routed by session identity
+
+- **GIVEN** a TUI message arrives with session ID `a1b2c3`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `tui/a1b2c3`
+- **AND** the command is routed to the session actor for that key
+
+#### Scenario: Repeated messages in same thread route to same actor
+
+- **GIVEN** a session actor exists for entity key `C0123/T456`
+- **WHEN** another message arrives in the same Slack thread
+- **THEN** the message is routed to the existing session actor
+- **AND** no new session actor is created
+
+#### Scenario: Repeated TUI messages route to same actor
+
+- **GIVEN** a session actor exists for entity key `tui/a1b2c3`
+- **WHEN** the operator sends another message in the same chat session
+- **THEN** the message is routed to the existing session actor

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: TUI wizard delivery mechanism
+
+The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI
+as an interactive 7-step wizard with progress indication, validation, and
+back-navigation.
+
+#### Scenario: Wizard renders in TUI
+
+- **WHEN** operator runs `netclaw init`
+- **THEN** a Termina TUI application launches
+- **AND** the wizard displays step progress (e.g., "Step 2 of 7")
+- **AND** the wizard displays a progress bar
+
+#### Scenario: Step-specific components rendered
+
+- **GIVEN** the wizard is on a step requiring text input
+- **WHEN** the step is displayed
+- **THEN** the wizard renders TextInputNode components for text/secret fields
+- **AND** renders SelectionListNode components for choice fields
+
+#### Scenario: Back navigation between steps
+
+- **GIVEN** the wizard is on step 3
+- **WHEN** the operator presses Esc
+- **THEN** the wizard navigates back to step 2
+- **AND** previous input values are preserved
+
+#### Scenario: Live validation during wizard
+
+- **GIVEN** the wizard is on the PostgreSQL step
+- **WHEN** the operator enters a connection string
+- **THEN** the wizard validates connectivity with a SpinnerNode
+- **AND** displays success or failure before allowing progression
+
+## MODIFIED Requirements
+
+### Requirement: Phase 2 conversational personality bootstrap
+
+The system SHALL trigger a conversational personality bootstrap on the first
+`netclaw chat` session if personality files (PERSONALITY.md, INSTRUCTIONS.md,
+USER.md) do not exist. The bootstrap conversation SHALL ask the operator about
+communication preferences, tone, name preferences, and working style, then
+write the resulting soul files to the standard config directory.
+
+#### Scenario: First conversation triggers bootstrap
+
+- **GIVEN** no personality files exist in the config directory
+- **WHEN** the operator starts their first `netclaw chat` session
+- **THEN** the agent initiates a personality bootstrap conversation
+- **AND** asks about communication preferences and working style
+
+#### Scenario: Bootstrap writes soul files
+
+- **GIVEN** the personality bootstrap conversation is complete
+- **WHEN** the operator has answered all preference questions
+- **THEN** the system writes PERSONALITY.md, INSTRUCTIONS.md, and USER.md to
+  the config directory
+
+#### Scenario: Bootstrap skipped when files exist
+
+- **GIVEN** personality files already exist in the config directory
+- **WHEN** a new conversation starts
+- **THEN** no personality bootstrap is triggered
+- **AND** the existing personality files are loaded normally

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-session/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-session/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Config hot-reload integration
+
+The session system SHALL respond to config change notifications dispatched by
+the `ConfigWatcherService`. Active sessions SHALL re-evaluate their tool grants
+when ACL changes, rebuild provider connections when provider config changes,
+and reconnect MCP servers when MCP profiles change.
+
+#### Scenario: ACL change refreshes tool grants for active session
+
+- **GIVEN** a session actor is active with tools loaded from the previous ACL
+- **WHEN** the config watcher publishes an ACL change event
+- **THEN** the session actor re-evaluates tool grants against the new ACL
+- **AND** adds or removes tools from the session's available tool set
+
+#### Scenario: Provider change triggers IChatClient rebuild
+
+- **GIVEN** a session actor is using an `IChatClient` from the current provider
+  configuration
+- **WHEN** the config watcher publishes a provider change event
+- **THEN** the session actor obtains a new `IChatClient` from the provider
+  factory
+- **AND** subsequent turns use the new provider configuration
+
+#### Scenario: MCP profile change triggers server reconnection
+
+- **GIVEN** a session actor has MCP tools loaded from connected servers
+- **WHEN** the config watcher publishes an MCP profile change event
+- **THEN** the session actor refreshes its MCP tool definitions
+- **AND** newly added servers' tools become available
+- **AND** removed servers' tools are no longer available
+
+#### Scenario: Schedule change does not affect active sessions
+
+- **GIVEN** a session actor is processing turns
+- **WHEN** the config watcher publishes a schedule change event
+- **THEN** the session actor does NOT take any action
+- **AND** the `ScheduleManagerActor` handles timer reconfiguration independently

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/tasks.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/tasks.md
@@ -1,0 +1,72 @@
+## 1. CLI Scaffold with Cocona + Termina Hosting
+
+- [ ] 1.1 Add Cocona and Termina package references to Directory.Packages.props and Netclaw.App.csproj
+- [ ] 1.2 Rewrite Program.cs as Cocona entry point with DI registration
+- [ ] 1.3 Create RunCommand.cs for daemon mode (`netclaw run`)
+- [ ] 1.4 Wire Termina as hosted service for TUI commands
+- [ ] 1.5 Verify `dotnet build` passes with new dependencies
+
+## 2. TUI Chat Adapter (`netclaw chat`)
+
+- [ ] 2.1 Create TuiInputAdapter implementing adapter contract (SendUserMessage with entity key `tui/{sessionId}`)
+- [ ] 2.2 Create ChatCommand.cs that hosts actor system in-process and launches TUI
+- [ ] 2.3 Create ChatPage.cs with StreamingTextNode (scrollable history) and TextInputNode (multi-line input)
+- [ ] 2.4 Create ChatViewModel.cs with session lifecycle and broadcast subscription
+- [ ] 2.5 Implement inline tool activity panel (completed with duration, in-progress with spinner)
+- [ ] 2.6 Implement MCP status indicator in status bar (green/yellow/red)
+- [ ] 2.7 E2E: user types → SendUserMessage → session actor → LLM → streaming response in TUI
+
+## 3. TUI Onboarding Wizard (`netclaw init`)
+
+- [ ] 3.1 Create InitCommand.cs that launches Termina wizard
+- [ ] 3.2 Create InitWizardPage.cs with 7-step wizard layout (PanelNode, progress bar)
+- [ ] 3.3 Create InitWizardViewModel.cs with step state machine and back-navigation
+- [ ] 3.4 Implement Step 1: LLM provider (SelectionListNode + TextInputNode for API key)
+- [ ] 3.5 Implement Step 2: Slack configuration (masked TextInputNodes for tokens)
+- [ ] 3.6 Implement Step 3: PostgreSQL connection (TextInputNode + live validation SpinnerNode)
+- [ ] 3.7 Implement Step 4: ACL bootstrap (owner identity + initial channels)
+- [ ] 3.8 Implement Step 5: MCP servers (SelectionListNode with Memorizer recommended)
+- [ ] 3.9 Implement Step 6: Exposure mode (SelectionListNode with security warnings)
+- [ ] 3.10 Implement Step 7: Health check (live probe panel with SpinnerNodes → checkmarks)
+- [ ] 3.11 Write config file to ~/.netclaw/config/netclaw.json on completion
+
+## 4. Plain CLI Commands
+
+- [ ] 4.1 Create DoctorCommand.cs — startup checks with remediation guidance, exit codes 0/1/2
+- [ ] 4.2 Create ConfigCommands.cs — `config show` and `config validate`
+- [ ] 4.3 Create AclCommands.cs — `acl validate`, `acl test`, `acl explain`
+- [ ] 4.4 Create ProjectCommands.cs — `project list`, `project add`, `project remove`
+- [ ] 4.5 Create ScheduleCommands.cs — `schedule list|show|pause|resume|delete`
+- [ ] 4.6 Create remaining commands: `environment scan|show`, `mcp list|validate|test`, `memory show`, `tools list|policy`, `test smoke`, `personality reset`
+
+## 5. Config Hot-Reload
+
+- [ ] 5.1 Create ConfigWatcherService as IHostedService with FileSystemWatcher per watched file
+- [ ] 5.2 Implement 500ms debounce for file change events
+- [ ] 5.3 Implement validate-before-apply with rejection logging
+- [ ] 5.4 Implement config file deletion handling (warn, keep existing config)
+- [ ] 5.5 Publish ACL change events to policy engine via Akka pub/sub
+- [ ] 5.6 Publish provider change events to provider factory via Akka pub/sub
+- [ ] 5.7 Publish MCP profile change events to MCP manager via Akka pub/sub
+- [ ] 5.8 Publish schedule change events to ScheduleManagerActor via Akka pub/sub
+- [ ] 5.9 Integration test: config file write → debounce → validate → actor notification
+
+## 6. Conversational Personality Bootstrap via TUI
+
+- [ ] 6.1 Detect missing soul files on first `netclaw chat` session
+- [ ] 6.2 Trigger bootstrap conversation flow in TUI (introduce, learn preferences, scan environment)
+- [ ] 6.3 Write PERSONALITY.md, INSTRUCTIONS.md, USER.md to config directory
+- [ ] 6.4 Test: bootstrap triggers when files missing, skips when files exist
+
+## 7. Local E2E Validation
+
+- [ ] 7.1 E2E: `netclaw chat` → session → tool call → streaming response
+- [ ] 7.2 E2E: scheduled task → fresh session → result displayed
+- [ ] 7.3 E2E: config change → hot-reload → policy refresh verified
+- [ ] 7.4 CI tests pass without live provider credentials
+
+## 8. Spec Sync
+
+- [ ] 8.1 Sync delta specs from this change to main specs
+- [ ] 8.2 Run `openspec validate --all --no-interactive` — passes
+- [ ] 8.3 Archive change with `openspec archive add-tui-adapter-and-config-hot-reload`

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/.openspec.yaml
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/design.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/design.md
@@ -1,0 +1,215 @@
+## Context
+
+Netclaw was originally scoped as a Slack chat assistant with ACL and
+persistence. The product vision has expanded to an always-on autonomous
+operations agent with local memory, tool access, scheduling, self-discovery,
+and self-configuration. The core Akka.Agents framework (session actors,
+persistence, compaction, pub/sub broadcasts) remains unchanged — this design
+extends it with new actor types, tool integration, and file-based state.
+
+### Current State
+
+- `LlmSessionActor`: persistent actor keyed by `{channelId}/{threadTs}`,
+  handles turn loop, persists events, emits broadcasts, compacts via
+  `SummarizingChatReducer`
+- `LlmAgentParentActor`: wraps `GenericChildPerEntityParent`, routes messages
+  by entity key using `SessionMessageExtractor`
+- `SerializableChatMessage`: framework-owned persistence type (protobuf-net)
+- Slack Socket Mode adapter: planned but not yet implemented
+- PostgreSQL journal/snapshots via Akka.Persistence
+- Microsoft.Extensions.AI `IChatClient` for LLM interaction
+
+### Constraints
+
+- Single-process architecture on ARM64 (pi1)
+- Owner-operated, single-user trust model
+- No public HTTP endpoint required for MVP
+- CI tests must not require live LLM providers
+- Akka.Persistence types must remain framework-owned and serializable
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extend session actor with tool calling and layered system prompt
+- Add file-based agent personality and local memory loaded at session start
+- Add scheduled task execution via Akka timers and fresh session actors
+- Add first-party tools (web search, web fetch, shell, GitHub) with policy gates
+- Add MCP tool discovery and registration through MEAI pipeline
+- Define transport-agnostic input adapter contract
+- Maintain all existing session actor, persistence, and pub/sub guarantees
+
+**Non-Goals:**
+
+- Changing the Akka.Agents framework itself (session actor core is stable)
+- Ambient channel monitoring (Phase 2)
+- Webhook ingress (Phase 2)
+- Browser automation or delegated coding
+- Web UI implementation (Phase 5, spec/mockup only)
+- Sub-agent model routing
+- Vector/hybrid search for local memory
+
+## Decisions
+
+### D1: File-based local memory over database
+
+**Decision**: Store agent soul files, project registry, environment inventory,
+and scheduled tasks as files on disk under `~/.netclaw/`.
+
+**Alternatives considered**:
+- SQLite with FTS5 + vector: More powerful search, but unnecessary for the
+  small amount of data (< 100KB). Adds dependency complexity.
+- PostgreSQL tables alongside Akka.Persistence: Conflates operational state
+  with agent state. Makes backup/restore harder.
+
+**Rationale**: Files are human-readable, version-controllable, trivially
+backed up, and sufficient for MVP scale. The agent reconstructs its context
+from files on every session start (IronClaw pattern). Upgrade to SQLite or
+PostgreSQL is straightforward if scale demands it.
+
+### D2: Tools as MEAI tool definitions, not custom protocol
+
+**Decision**: All tools (first-party and MCP) are registered as
+`Microsoft.Extensions.AI` `AIFunction` definitions and invoked through the
+standard MEAI tool calling pipeline.
+
+**Alternatives considered**:
+- Custom tool protocol with manual JSON dispatch: More control, but duplicates
+  what MEAI already provides and won't benefit from MEAI middleware.
+- Separate tool actor per tool type: Adds actor overhead for what is
+  fundamentally a function call with policy check.
+
+**Rationale**: MEAI already handles tool definition, invocation, and response
+serialization. The session actor doesn't need to know tool internals — it
+just calls `IChatClient.GetResponseAsync()` and MEAI handles tool loops.
+Policy checking happens at registration time (exclude ungrantable tools from
+the session's tool set) and at invocation time (belt-and-suspenders).
+
+### D3: ScheduleManagerActor as top-level actor, not nested under session parent
+
+**Decision**: `ScheduleManagerActor` is a separate top-level actor that loads
+task definitions from disk, manages Akka timers, and dispatches scheduled
+executions by sending `SendUserMessage` commands to the session parent actor.
+
+**Alternatives considered**:
+- Schedule as a behavior of the session parent: Muddies the single
+  responsibility of entity routing. Schedule is orthogonal to session identity.
+- External cron daemon (systemd timers): Loses conversational management and
+  requires IPC. Doesn't survive config changes through chat.
+
+**Rationale**: Akka timers are the natural mechanism for periodic execution in
+an actor system. A dedicated actor owns the schedule state (file on disk),
+timer lifecycle, concurrent execution limits, and failure tracking. It
+dispatches work to the session parent using the same command protocol as any
+other input adapter.
+
+### D4: Brave Search API as primary search with SearXNG alternative
+
+**Decision**: Support two web search backends configurable in `netclaw.json`:
+Brave Search API (requires API key, free tier 2000/month) and SearXNG
+(self-hosted, no API key).
+
+**Alternatives considered**:
+- DuckDuckGo scraping: No official API, fragile, rate-limited
+- Tavily: AI-focused but adds another paid dependency
+- Google Custom Search: Complex setup, limited free tier
+
+**Rationale**: Brave Search is the agent ecosystem standard (used by OpenClaw,
+IronClaw). SearXNG provides a zero-dependency alternative for operators who
+prefer self-hosting everything on homelab infrastructure. Both return
+structured JSON suitable for LLM consumption.
+
+### D5: Pre-compaction flush as system-initiated silent turn
+
+**Decision**: When session context approaches the compaction threshold, the
+system injects a system message prompting the model to save durable memories,
+then proceeds with compaction after the flush turn completes.
+
+**Alternatives considered**:
+- Automatic extraction without model involvement: Can't determine what's
+  "important" without model judgment.
+- User-triggered save: Unreliable — users forget, and compaction can happen
+  while they're away.
+
+**Rationale**: The model is the best judge of what information should survive
+compaction. OpenClaw's pre-compaction flush pattern is proven effective against
+context rot. The flush turn is silent (not posted to Slack) and uses the same
+turn loop as normal interaction.
+
+### D6: Entity key patterns for multi-source routing
+
+**Decision**: Different input sources use different entity key patterns:
+- Slack: `{channelId}/{threadTs}` (existing)
+- Scheduled tasks: `schedule/{taskId}/{runTs}`
+- Future webhooks: `webhook/{source}/{eventId}`
+
+**Alternatives considered**:
+- Single flat key space: Risks collisions between Slack thread IDs and
+  schedule IDs. No semantic routing information.
+- Separate actor systems per source: Over-engineered for single-process MVP.
+
+**Rationale**: Prefixed entity keys allow the session parent to route all
+sources through the same `GenericChildPerEntityParent` mechanism while keeping
+session isolation. The `SessionMessageExtractor` already handles key
+extraction — it just needs to support multiple key formats.
+
+### D7: Shell execution via Process wrapper, not Roslyn scripting
+
+**Decision**: Shell tool executes commands via `System.Diagnostics.Process`
+with timeout, output truncation, and stdin closure.
+
+**Alternatives considered**:
+- Roslyn C# scripting: More powerful but massive attack surface, hard to
+  sandbox.
+- Container-per-execution: Secure but slow and complex for MVP.
+
+**Rationale**: Process execution is simple, well-understood, and matches how
+other agent tools (Claude Code, OpenClaw) handle shell access. Security comes
+from policy gates (must have `shell` grant) and boundaries (timeout, output
+limits, no stdin). The Netclaw process user should have appropriate OS-level
+permissions.
+
+## Risks / Trade-offs
+
+### [Risk] Agent self-modification creates inconsistent state
+→ **Mitigation**: Validate all config changes before write. Atomic file writes
+(temp + rename). Session reboot required for context refresh. ACL/security
+files excluded from self-modification.
+
+### [Risk] Shell execution is a high-risk attack surface
+→ **Mitigation**: Policy-gated (requires explicit `shell` grant). Timeout
+enforcement kills runaway processes. Output truncation prevents context
+flooding. No interactive mode. Working directory restricted to project paths.
+
+### [Risk] Scheduled task execution consumes resources on pi1
+→ **Mitigation**: Max concurrent execution limit (default 3). Execution
+timeout per task (default 5 minutes). Consecutive failure auto-pause.
+Operator notification on failure.
+
+### [Risk] Pre-compaction flush fails or takes too long
+→ **Mitigation**: Flush has its own timeout. If flush fails, compaction
+proceeds anyway (degraded but not blocked). Flush failure is logged.
+
+### [Risk] File-based memory doesn't scale
+→ **Mitigation**: MVP data volume is tiny (< 100KB). Migration path to SQLite
+or PostgreSQL is straightforward — just change the storage backend behind the
+same loading interface. Memorizer handles large-corpus knowledge.
+
+### [Risk] Brave Search API key exposure
+→ **Mitigation**: API keys stored in `config/netclaw.json` which is in the
+data directory (not the repo). File permissions should be restrictive (600).
+Keys are never logged or included in session context.
+
+## Open Questions
+
+1. **Slack thread reply format**: Should tool invocation results be shown to
+   the user in Slack, or only the final agent response? Leaning toward final
+   response only with tool activity available in diagnostics.
+
+2. **Schedule persistence format**: JSON file is simple but doesn't support
+   concurrent writes. Should we use a write-ahead pattern or just accept that
+   schedule modifications are rare and serialize through the actor?
+
+3. **Environment scan granularity**: How deep should capability discovery go?
+   Current plan: binary availability + version. Should we also check
+   authentication state (e.g., `gh auth status`)?

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/proposal.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/proposal.md
@@ -1,0 +1,107 @@
+## Why
+
+Netclaw's original planning scope described a narrow "Slack chat assistant with
+ACL." The product vision has been significantly expanded: Netclaw is an
+always-on autonomous operations agent that maintains its own personality,
+discovers its environment, manages its schedule, uses local tools, and modifies
+its own configuration through conversation. All existing PRDs (001-006) have
+been revised and three new PRDs (007-009) have been created. The OpenSpec
+capability specs must now match this expanded vision so implementation tasks
+are RALPH-consumable.
+
+Source PRDs: PRD-001 (revised), PRD-002 (revised), PRD-003 (deferred Phase 5),
+PRD-004 (revised), PRD-005 (revised), PRD-006 (revised), PRD-007 (new),
+PRD-008 (new), PRD-009 (new).
+
+See `PROJECT_CONTEXT.md` for the full product vision.
+See `docs/research/agent-patterns.md` for the research informing these changes.
+
+## What Changes
+
+- Add agent personality system: layered system prompt from soul files
+  (PERSONALITY.md, INSTRUCTIONS.md, USER.md), conversational personality
+  bootstrap, project context overlays
+- Add local memory system: project registry (JSON), environment inventory
+  (JSON), standard `~/.netclaw/` data directory
+- Add capability self-discovery: scan for installed tools (git, gh, claude,
+  opencode, dotnet), git credentials, MCP server reachability
+- Add self-configuration: agent modifies own config through conversation
+  within safety boundaries (cannot modify ACL/security)
+- Add pre-compaction memory flush: silent agentic turn saves durable memories
+  before context resets
+- Add first-party tool access: web search (Brave Search API / SearXNG),
+  web fetch, shell execution, GitHub via `gh` CLI — all policy-gated
+- Add tool registration via Microsoft.Extensions.AI tool calling API
+- Add chat-driven scheduling: create/list/pause/delete scheduled tasks through
+  conversation, persist as JSON, execute via Akka timers in fresh sessions
+- Add unified input adapter architecture: transport-agnostic session commands,
+  source metadata, entity key routing patterns for Slack and timer adapters
+- Expand ACL with tool grant categories (shell, web_search, web_fetch, github,
+  mcp:{server}, config_write, schedule_write)
+- Expand security envelope with self-config safety rules (SEC-008) and shell
+  execution boundaries (SEC-009)
+- Expand MCP role: Memorizer as external memory tier, tool discovery and
+  registration at startup, graceful degradation
+- Expand provider strategy: Microsoft.Extensions.AI abstraction, primary +
+  fallback model configuration, tool calling support
+- Expand CLI with project/environment/memory/schedule management commands
+  and two-phase onboarding (CLI wizard + conversational personality bootstrap)
+- Defer ops console implementation to Phase 5 (spec/mockup only in MVP)
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-agent-memory`: Agent personality (soul files), local memory (project
+  registry, environment inventory), capability self-discovery,
+  self-configuration through conversation, pre-compaction memory flush,
+  standard config directory. Source: PRD-007.
+- `netclaw-scheduling`: Chat-driven scheduled task creation, persistence,
+  isolated execution via Akka timers, result reporting, failure handling and
+  guardrails. Source: PRD-008.
+- `netclaw-input-adapters`: Unified input architecture, transport-agnostic
+  session commands, source metadata, entity key routing, Slack Socket Mode
+  adapter, internal timer adapter. Source: PRD-009.
+- `netclaw-tools`: First-party tool access (web search, web fetch, shell,
+  GitHub CLI), tool registration with MEAI, policy-gated invocation,
+  configurable search backend. Source: PRD-001 FR-011, PRD-002 SEC-009,
+  PRD-007.
+
+### Modified Capabilities
+
+- `netclaw-session`: Add pre-compaction memory flush trigger, pub/sub broadcast
+  clarification for multi-adapter delivery, tool context in session state.
+- `netclaw-acl`: Add tool grant categories (shell, web_search, web_fetch,
+  github, mcp:{server}, config_write, schedule_write), self-config prohibition
+  rules.
+- `netclaw-gateway-security`: Add self-configuration safety rules (SEC-008),
+  shell execution boundaries (SEC-009), tool invocation audit records.
+- `netclaw-mcp`: Add Memorizer as external memory tier, tool discovery and
+  registration at startup, graceful degradation on server unavailability.
+- `netclaw-model-providers`: Add Microsoft.Extensions.AI (IChatClient)
+  abstraction, primary + fallback model configuration, tool calling support
+  through MEAI.
+- `netclaw-cli`: Add project/environment/memory/schedule management commands,
+  two-phase onboarding (CLI wizard + conversational personality bootstrap),
+  environment scan command.
+- `netclaw-onboarding`: Add Phase 2 conversational personality bootstrap,
+  environment discovery during onboarding, project registration.
+- `netclaw-operator-ui`: Defer implementation to Phase 5, add memory/schedule
+  screen definitions for future UI, clarify MVP deliverable is spec/mockup only.
+
+## Impact
+
+- **Actor framework**: New actor types needed (ScheduleManagerActor, tool
+  execution actors). Session actor gains tool context and pre-compaction flush.
+- **Persistence**: Scheduled tasks persisted as files on disk (not in Akka
+  journal). Session actor persistence unchanged.
+- **Configuration**: New `~/.netclaw/` directory structure with soul files,
+  project registry, environment inventory, schedules, and config.
+- **Dependencies**: Brave Search API client (thin HttpClient wrapper),
+  HTML-to-text library for web fetch. Microsoft.Extensions.AI already in use.
+- **Security surface**: Shell execution, web fetch, and self-configuration
+  create new attack surfaces requiring policy gates.
+- **CLI**: Significant expansion of command surface. All new commands are
+  read-only by default.
+- **Testing**: Tool mocks/fakes needed for CI. Scheduled task execution tests
+  need timer simulation.

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-acl/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-acl/spec.md
@@ -1,0 +1,75 @@
+## MODIFIED Requirements
+
+### Requirement: Tool and data grants
+
+The system SHALL enforce explicit grants for tool and data access. Grants SHALL
+be organized into specific tool grant categories: `shell`, `web_search`,
+`web_fetch`, `github`, `mcp:{server_name}`, `config_write`, and
+`schedule_write`. Each grant SHALL specify the allowed senders and channels to
+which it applies.
+
+#### Scenario: Missing grant blocks tool call
+
+- **WHEN** a tool call is attempted without a matching grant
+- **THEN** execution is denied with a policy reason code
+
+#### Scenario: Category-specific grant allows tool
+
+- **GIVEN** ACL grants `web_search` for sender `U12345` on channel `C99999`
+- **WHEN** sender `U12345` requests a web search in channel `C99999`
+- **THEN** ACL evaluation returns allow for the `web_search` tool category
+
+#### Scenario: MCP server-scoped grant
+
+- **GIVEN** ACL grants `mcp:memorizer` for sender `U12345`
+- **WHEN** sender `U12345` requests an MCP tool from the `memorizer` server
+- **THEN** ACL evaluation returns allow
+- **AND** MCP tools from other servers without explicit grants are denied
+
+#### Scenario: Config write grant required for self-configuration
+
+- **GIVEN** ACL does not grant `config_write` for the current sender
+- **WHEN** the agent attempts to write configuration files through conversation
+- **THEN** the write is denied with a policy reason code
+
+## ADDED Requirements
+
+### Requirement: Self-configuration prohibition
+
+ACL and security policy files MUST NOT be modifiable by the agent through
+conversation. These files SHALL only be modified through the CLI or direct file
+edit by the operator. This prohibition SHALL be enforced regardless of any
+grants in the ACL policy.
+
+#### Scenario: Agent cannot modify ACL through conversation
+
+- **WHEN** an agent session attempts to modify ACL policy files
+- **THEN** the modification is denied regardless of active grants
+- **AND** the denial reason indicates that ACL files require CLI or direct edit
+
+#### Scenario: Agent cannot modify security policy through conversation
+
+- **WHEN** an agent session attempts to modify gateway security policy files
+- **THEN** the modification is denied regardless of active grants
+
+### Requirement: Scheduled task tool grants
+
+Each scheduled task definition SHALL specify the required tool grants for its
+execution. At execution time, the system SHALL verify that all required tool
+grants are still valid before running the task.
+
+#### Scenario: Scheduled task with valid grants executes
+
+- **GIVEN** a scheduled task requires `web_search` and `mcp:memorizer`
+- **AND** both grants are present in the current ACL policy
+- **WHEN** the scheduled task fires
+- **THEN** the task executes with the granted tools available
+
+#### Scenario: Scheduled task with revoked grant is blocked
+
+- **GIVEN** a scheduled task requires `web_search`
+- **AND** the `web_search` grant has been removed from ACL policy since the task
+  was created
+- **WHEN** the scheduled task fires
+- **THEN** execution is denied with a policy reason code
+- **AND** the task failure is recorded with the missing grant details

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,223 @@
+# netclaw-agent-memory Delta Spec
+
+**Change**: expand-mvp-for-autonomous-agent-vision
+**Source**: PRD-007 (Agent Personality and Local Memory)
+**Capability**: netclaw-agent-memory (new)
+
+## Purpose
+
+Define agent personality (soul files), local memory (project registry,
+environment inventory), capability self-discovery, self-configuration through
+conversation, pre-compaction memory flush, and the standard configuration
+directory structure. This capability makes Netclaw a persistent, context-aware
+agent rather than a stateless chat endpoint.
+
+## ADDED Requirements
+
+### Requirement: Layered system prompt assembly
+
+The system SHALL assemble session context from ordered layers: PERSONALITY.md,
+INSTRUCTIONS.md, USER.md, project AGENTS.md overlay, and session-specific
+context. Later layers SHALL augment earlier layers. All soul files SHALL be
+loaded at session start and cached for the session lifetime.
+
+#### Scenario: Full layer assembly on session start
+
+- **GIVEN** soul files exist at `~/.netclaw/soul/PERSONALITY.md`,
+  `~/.netclaw/soul/INSTRUCTIONS.md`, and `~/.netclaw/soul/USER.md`
+- **WHEN** a new session starts
+- **THEN** the system prompt includes content from all three soul files in
+  layer order (personality, instructions, user)
+- **AND** session-specific context is appended after the soul layers
+
+#### Scenario: Project overlay loaded on demand
+
+- **GIVEN** a registered project has an `agents_md` path in the project registry
+- **WHEN** the session involves that project
+- **THEN** the project AGENTS.md content is included as a context overlay
+  between the user layer and session context layer
+
+#### Scenario: Missing soul file does not prevent session start
+
+- **GIVEN** one or more soul files do not exist on disk
+- **WHEN** a new session starts
+- **THEN** the system assembles the prompt from available layers
+- **AND** the missing layer is omitted without error
+
+### Requirement: Conversational personality bootstrap
+
+The system SHALL run a personality bootstrap conversation on first interaction
+when soul files do not exist. The bootstrap SHALL learn owner preferences,
+scan the environment, and write initial soul files to disk.
+
+#### Scenario: First-run bootstrap triggered
+
+- **GIVEN** no soul files exist at `~/.netclaw/soul/`
+- **WHEN** the first user message arrives
+- **THEN** the agent initiates a personality bootstrap conversation
+- **AND** the agent introduces itself and explains the setup process
+
+#### Scenario: Bootstrap writes soul files
+
+- **GIVEN** the personality bootstrap conversation completes
+- **WHEN** the agent has gathered owner name, preferences, and communication
+  style
+- **THEN** the agent writes PERSONALITY.md, INSTRUCTIONS.md, and USER.md to
+  `~/.netclaw/soul/`
+- **AND** the agent confirms readiness to the user
+
+#### Scenario: Bootstrap re-triggered via CLI
+
+- **GIVEN** soul files already exist
+- **WHEN** the operator runs `netclaw personality reset`
+- **THEN** the existing soul files are backed up
+- **AND** the next session triggers a fresh bootstrap conversation
+
+### Requirement: Project registry persistence
+
+The system SHALL persist registered projects as JSON on disk at
+`~/.netclaw/projects/registry.json`. Projects SHALL be registered and
+unregistered through conversation or CLI.
+
+#### Scenario: Register project through conversation
+
+- **GIVEN** the user asks the agent to register a project
+- **WHEN** the agent receives a valid project path and name
+- **THEN** the project is added to `registry.json`
+- **AND** the agent confirms the registration with project details
+
+#### Scenario: Project registry survives restart
+
+- **GIVEN** projects are registered in `registry.json`
+- **WHEN** the process restarts
+- **THEN** the project registry is loaded from disk
+- **AND** all previously registered projects are available in agent context
+
+#### Scenario: Invalid project path rejected
+
+- **GIVEN** the user asks to register a project
+- **WHEN** the provided path does not exist on disk
+- **THEN** the registration is rejected with an explanation
+
+### Requirement: Environment capability self-discovery
+
+The system SHALL scan for installed tools and capabilities at startup and
+on-demand. Discovered capabilities SHALL be persisted to
+`~/.netclaw/environment/inventory.json` and summarized in the system prompt.
+
+#### Scenario: Automatic scan at startup
+
+- **WHEN** the Netclaw process starts
+- **THEN** the system scans for installed CLIs (`git`, `gh`, `claude`,
+  `opencode`, `dotnet`, `node`)
+- **AND** checks git credential availability for remote hosts
+- **AND** checks MCP server reachability
+- **AND** persists results to `inventory.json`
+
+#### Scenario: On-demand rescan through conversation
+
+- **GIVEN** the agent is in an active session
+- **WHEN** the user asks the agent to rescan its environment
+- **THEN** the agent re-runs the environment scan
+- **AND** updates `inventory.json` with current results
+- **AND** reports changes since the last scan
+
+#### Scenario: Unavailable tool recorded accurately
+
+- **GIVEN** a tool (e.g., `claude`) is not installed
+- **WHEN** the environment scan runs
+- **THEN** the tool is recorded as `available: false` in the inventory
+- **AND** the agent does not attempt to use that tool in subsequent sessions
+
+### Requirement: Self-configuration through conversation
+
+The system SHALL allow the agent to modify its own configuration files through
+conversation within safety bounds. The agent MUST NOT modify ACL, security
+policy, tool grant policies, exposure mode, network configuration, or provider
+credentials through conversation.
+
+#### Scenario: Agent updates personality file
+
+- **GIVEN** the user asks the agent to adjust its personality
+- **WHEN** the agent proposes and the user confirms the change
+- **THEN** the agent validates the change
+- **AND** writes the updated file atomically (write to temp, rename)
+- **AND** reports that the change was saved
+- **AND** advises that a session reboot is needed for context refresh
+
+#### Scenario: Agent attempts to modify ACL
+
+- **GIVEN** the user asks the agent to update ACL rules through conversation
+- **WHEN** the agent evaluates the request
+- **THEN** the agent refuses the modification
+- **AND** explains that ACL changes require CLI or direct file edit by the
+  operator
+
+#### Scenario: Agent registers project through self-configuration
+
+- **GIVEN** the user describes a project to register
+- **WHEN** the agent has sufficient details (name, path)
+- **THEN** the agent adds the project to `registry.json`
+- **AND** validates the project path exists before writing
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** the agent proposes a configuration change
+- **WHEN** schema validation fails on the proposed change
+- **THEN** the change is not written to disk
+- **AND** the agent reports the validation failure to the user
+
+### Requirement: Pre-compaction memory flush
+
+The system SHALL trigger a silent agentic turn before context compaction to
+save durable memories. The flush SHALL complete before compaction proceeds.
+
+#### Scenario: Flush triggered before compaction
+
+- **GIVEN** session context approaches the compaction threshold
+- **WHEN** the system detects compaction is imminent
+- **THEN** the agent is prompted to save important context
+- **AND** the agent writes durable memories (Memorizer, local files)
+- **AND** compaction proceeds only after flush completes
+
+#### Scenario: Flush saves to external memory
+
+- **GIVEN** MCP Memorizer is configured and reachable
+- **WHEN** the pre-compaction flush runs
+- **THEN** the agent writes important findings to Memorizer
+- **AND** writes current task state summary to memory
+
+#### Scenario: Flush completes even when Memorizer unavailable
+
+- **GIVEN** MCP Memorizer is unreachable
+- **WHEN** the pre-compaction flush runs
+- **THEN** the agent saves available context to local files
+- **AND** compaction proceeds without blocking indefinitely
+
+### Requirement: Standard configuration directory
+
+The system SHALL use `~/.netclaw/` as the standard configuration directory
+with the following subdirectory structure: `soul/`, `projects/`, `environment/`,
+`schedules/`, and `config/`. The directory SHALL be created if it does not
+exist at startup.
+
+#### Scenario: Directory created on first startup
+
+- **GIVEN** the `~/.netclaw/` directory does not exist
+- **WHEN** the Netclaw process starts
+- **THEN** the system creates `~/.netclaw/` and all required subdirectories
+  (`soul/`, `projects/`, `environment/`, `schedules/`, `config/`)
+
+#### Scenario: Existing directory preserved
+
+- **GIVEN** `~/.netclaw/` already exists with files
+- **WHEN** the Netclaw process starts
+- **THEN** existing files are not overwritten or removed
+- **AND** any missing subdirectories are created
+
+#### Scenario: Configurable base path
+
+- **GIVEN** an alternative data directory is specified in configuration
+- **WHEN** the Netclaw process starts
+- **THEN** the system uses the configured path instead of `~/.netclaw/`
+- **AND** the same subdirectory structure is maintained

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-cli/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-cli/spec.md
@@ -1,0 +1,155 @@
+## MODIFIED Requirements
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init`. The onboarding
+wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
+PostgreSQL connection string, MCP server configuration, and exposure mode
+selection. On completion, the wizard SHALL run a health check to verify the
+baseline configuration is functional.
+
+#### Scenario: First-time setup
+
+- **WHEN** operator runs `netclaw init` on a fresh install
+- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
+  exposure mode inputs
+- **AND** writes a runnable baseline configuration
+
+#### Scenario: PostgreSQL connection configured during init
+
+- **WHEN** onboarding reaches the persistence step
+- **THEN** the wizard prompts for a PostgreSQL connection string
+- **AND** validates connectivity before proceeding
+
+#### Scenario: MCP server configured during init
+
+- **WHEN** onboarding reaches the MCP step
+- **THEN** the wizard prompts for at least one MCP server profile (Memorizer
+  recommended)
+- **AND** validates server handshake before proceeding
+
+#### Scenario: Exposure mode selected during init
+
+- **WHEN** onboarding reaches the exposure step
+- **THEN** the wizard presents available exposure modes (local, tailscale-serve,
+  tailscale-funnel, cloudflare-tunnel)
+- **AND** applies security warnings for public modes
+
+#### Scenario: Health check on completion
+
+- **WHEN** onboarding completes all steps
+- **THEN** the wizard runs a health check covering Slack connectivity, provider
+  validation, persistence connectivity, and MCP server reachability
+- **AND** reports pass/fail for each component
+
+## ADDED Requirements
+
+### Requirement: Project management commands
+
+The CLI SHALL provide `netclaw project list|add|remove` commands for managing
+the project registry. Projects represent registered repositories with their
+paths, capabilities, and associated AGENTS.md files.
+
+#### Scenario: List registered projects
+
+- **WHEN** operator runs `netclaw project list`
+- **THEN** output displays all registered projects with paths and capabilities
+
+#### Scenario: Add a project
+
+- **WHEN** operator runs `netclaw project add --path /home/user/repos/myproject`
+- **THEN** the project is added to the project registry
+- **AND** the system scans for an AGENTS.md file in the project root
+
+#### Scenario: Remove a project
+
+- **GIVEN** a project is registered
+- **WHEN** operator runs `netclaw project remove myproject`
+- **THEN** the project is removed from the registry
+
+### Requirement: Environment discovery command
+
+The CLI SHALL provide `netclaw environment scan|show` commands for discovering
+and displaying the capability inventory of the host environment.
+
+#### Scenario: Scan environment
+
+- **WHEN** operator runs `netclaw environment scan`
+- **THEN** the system discovers installed tools (git, gh, claude, opencode,
+  dotnet), git credentials, MCP server reachability, and host capabilities
+- **AND** writes the inventory to the environment inventory file
+
+#### Scenario: Show environment
+
+- **WHEN** operator runs `netclaw environment show`
+- **THEN** output displays the current environment inventory with tool
+  availability, credential status, and capability details
+
+### Requirement: Memory display command
+
+The CLI SHALL provide `netclaw memory show` for displaying the contents of
+agent memory files (personality, project registry, environment inventory).
+
+#### Scenario: Show agent memory
+
+- **WHEN** operator runs `netclaw memory show`
+- **THEN** output displays the contents of personality files, project registry,
+  and environment inventory in a readable format
+
+#### Scenario: Show specific memory category
+
+- **WHEN** operator runs `netclaw memory show --category personality`
+- **THEN** output displays only the personality/soul files
+
+### Requirement: Schedule management commands
+
+The CLI SHALL provide `netclaw schedule list|show|pause|resume|delete` commands
+for managing scheduled tasks.
+
+#### Scenario: List scheduled tasks
+
+- **WHEN** operator runs `netclaw schedule list`
+- **THEN** output displays all scheduled tasks with name, schedule, status, and
+  last execution result
+
+#### Scenario: Show scheduled task details
+
+- **WHEN** operator runs `netclaw schedule show my-task`
+- **THEN** output displays the full task definition including schedule, required
+  tool grants, instructions, and execution history
+
+#### Scenario: Pause a scheduled task
+
+- **GIVEN** a scheduled task is active
+- **WHEN** operator runs `netclaw schedule pause my-task`
+- **THEN** the task is paused and will not execute until resumed
+
+#### Scenario: Resume a paused task
+
+- **GIVEN** a scheduled task is paused
+- **WHEN** operator runs `netclaw schedule resume my-task`
+- **THEN** the task is reactivated and will execute on its next scheduled time
+
+#### Scenario: Delete a scheduled task
+
+- **GIVEN** a scheduled task exists
+- **WHEN** operator runs `netclaw schedule delete my-task`
+- **THEN** the task is permanently removed from the schedule registry
+
+### Requirement: Personality reset command
+
+The CLI SHALL provide `netclaw personality reset` to delete existing personality
+files and re-trigger the conversational personality bootstrap on the next
+conversation.
+
+#### Scenario: Reset personality
+
+- **WHEN** operator runs `netclaw personality reset`
+- **THEN** existing personality/soul files are deleted
+- **AND** the next conversation triggers the conversational personality bootstrap
+
+#### Scenario: Reset confirmation
+
+- **WHEN** operator runs `netclaw personality reset`
+- **THEN** the CLI requires explicit confirmation before deleting personality
+  files

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-gateway-security/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-gateway-security/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Self-configuration safety (SEC-008)
+
+The system SHALL validate configuration changes before writing them to disk.
+ACL and security policy files MUST NOT be self-modifiable by the agent. The
+agent SHALL be permitted to modify personality files, project registry,
+environment inventory, and schedule definitions through conversation.
+
+#### Scenario: Agent modifies permitted configuration
+
+- **GIVEN** the agent has `config_write` grant
+- **WHEN** the agent writes to a personality file or project registry
+- **THEN** the change is validated against schema before write
+- **AND** the write succeeds if validation passes
+
+#### Scenario: Agent blocked from modifying security files
+
+- **WHEN** the agent attempts to modify ACL, security policy, or gateway
+  configuration files
+- **THEN** the write is rejected regardless of grants
+- **AND** an audit record is created for the denied attempt
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** the agent has `config_write` grant
+- **WHEN** the agent writes configuration that fails schema validation
+- **THEN** the write is rejected
+- **AND** the agent receives validation error details
+
+### Requirement: Shell execution boundaries (SEC-009)
+
+The system SHALL enforce safety boundaries on shell command execution. Shell
+commands SHALL run as the process user with no privilege escalation. A
+configurable timeout (default 60 seconds) SHALL terminate long-running
+commands. Output SHALL be truncated at a configurable limit. Interactive
+commands (those requiring stdin) SHALL be rejected. Working directory SHALL be
+restricted to configured allowed paths.
+
+#### Scenario: Shell command completes within timeout
+
+- **GIVEN** shell execution timeout is configured to 60 seconds
+- **WHEN** a shell command completes in 10 seconds
+- **THEN** the output is returned to the session
+
+#### Scenario: Shell command exceeds timeout
+
+- **GIVEN** shell execution timeout is configured to 60 seconds
+- **WHEN** a shell command runs for more than 60 seconds
+- **THEN** the process is terminated
+- **AND** the session receives a timeout error
+
+#### Scenario: Interactive command rejected
+
+- **WHEN** a shell command requires interactive stdin input
+- **THEN** execution is rejected before launch
+- **AND** the session receives a rejection reason
+
+#### Scenario: Output truncation
+
+- **GIVEN** output truncation limit is configured
+- **WHEN** shell command output exceeds the configured limit
+- **THEN** output is truncated with an indicator that content was omitted
+
+#### Scenario: Working directory restriction
+
+- **WHEN** a shell command targets a directory outside configured allowed paths
+- **THEN** execution is denied with a policy reason code
+
+### Requirement: Tool invocation audit
+
+The system SHALL create audit records for all tool invocations. Each audit
+record SHALL include: tool name, session ID, timestamp, and allow/deny result.
+
+#### Scenario: Allowed tool invocation is audited
+
+- **WHEN** a tool invocation is allowed by policy
+- **THEN** an audit record is created with tool name, session ID, timestamp, and
+  result `allow`
+
+#### Scenario: Denied tool invocation is audited
+
+- **WHEN** a tool invocation is denied by policy
+- **THEN** an audit record is created with tool name, session ID, timestamp, and
+  result `deny` with reason code
+
+#### Scenario: Audit records visible in diagnostics
+
+- **WHEN** operator queries tool invocation audit
+- **THEN** records are available with filtering by session ID, tool name, and
+  time range

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,198 @@
+# netclaw-input-adapters Delta Spec
+
+**Change**: expand-mvp-for-autonomous-agent-vision
+**Source**: PRD-009 (Input Adapters and Unified Input)
+**Capability**: netclaw-input-adapters (new)
+
+## Purpose
+
+Define the unified input adapter architecture that treats all message sources
+identically. All inputs produce a `SendUserMessage` command routed to the
+session parent actor. This capability covers transport-agnostic session
+commands, source metadata, entity key routing, broadcast subscription for
+reply delivery, the Slack Socket Mode adapter, and the internal timer adapter.
+
+## ADDED Requirements
+
+### Requirement: Transport-agnostic session commands
+
+All input adapters SHALL produce `SendUserMessage` as the universal command
+contract for delivering input to session actors. Session actors SHALL never
+reference adapter-specific types. The `SendUserMessage` command and broadcast
+events SHALL be the only contract between adapters and session actors.
+
+#### Scenario: Slack adapter produces SendUserMessage
+
+- **GIVEN** a Slack `app_mention` event is received
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the message content, entity key, and source
+  metadata
+
+#### Scenario: Timer adapter produces SendUserMessage
+
+- **GIVEN** an Akka timer fires for a scheduled task
+- **WHEN** the timer adapter processes the tick
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the task instruction as message content
+
+#### Scenario: Session actor is adapter-agnostic
+
+- **GIVEN** a session actor receives a `SendUserMessage` command
+- **WHEN** the session processes the turn
+- **THEN** the session actor does not import or reference any adapter-specific
+  types
+- **AND** the session behavior is identical regardless of the originating
+  adapter
+
+### Requirement: Source metadata on all commands
+
+All inbound `SendUserMessage` commands SHALL carry source metadata sufficient
+for ACL evaluation and audit logging. Source metadata SHALL include adapter
+type, sender identity, channel identifier, and timestamp.
+
+#### Scenario: Slack source metadata populated
+
+- **GIVEN** a Slack message event is received
+- **WHEN** the Slack adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `slack`
+- **AND** includes the Slack user ID as sender identity
+- **AND** includes the Slack channel ID
+- **AND** includes the event timestamp
+
+#### Scenario: Timer source metadata populated
+
+- **GIVEN** an Akka timer fires for a scheduled task
+- **WHEN** the timer adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `timer`
+- **AND** includes the task creator as sender identity
+- **AND** includes the task ID as the channel equivalent
+- **AND** includes the timer fire timestamp
+
+#### Scenario: ACL uses source metadata for evaluation
+
+- **GIVEN** a `SendUserMessage` command arrives with source metadata
+- **WHEN** the ACL gate evaluates the command
+- **THEN** the evaluation uses the sender identity from source metadata
+- **AND** the evaluation uses the channel identifier from source metadata
+
+### Requirement: Entity key routing
+
+The session parent actor SHALL extract an entity key from each
+`SendUserMessage` command and route to the correct child session actor. Slack
+messages SHALL use entity key pattern `{channelId}/{threadTs}`. Timer
+messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`.
+
+#### Scenario: Slack message routed by thread identity
+
+- **GIVEN** a Slack message arrives from channel `C0123` in thread `T456`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `C0123/T456`
+- **AND** the command is routed to the session actor for that key
+
+#### Scenario: Timer message routed by task and run identity
+
+- **GIVEN** a timer fires for task `ebay-check` at timestamp `1708531200`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `schedule/ebay-check/1708531200`
+- **AND** a new session actor is created for that entity key
+
+#### Scenario: Repeated messages in same thread route to same actor
+
+- **GIVEN** a session actor exists for entity key `C0123/T456`
+- **WHEN** another message arrives in the same Slack thread
+- **THEN** the message is routed to the existing session actor
+- **AND** no new session actor is created
+
+### Requirement: Broadcast subscription for reply delivery
+
+Input adapters SHALL subscribe to session broadcast events to deliver replies
+back through the originating channel. Adapters SHALL consume broadcast events
+through pub/sub without direct transport coupling to session actors.
+
+#### Scenario: Slack adapter receives reply broadcast
+
+- **GIVEN** the Slack adapter is subscribed to session broadcasts
+- **WHEN** a session actor emits a turn broadcast with a reply
+- **THEN** the Slack adapter receives the broadcast
+- **AND** delivers the reply to the originating Slack thread
+
+#### Scenario: Timer result broadcast consumed by Slack adapter
+
+- **GIVEN** a scheduled task session completes with results
+- **WHEN** the session emits a result broadcast
+- **THEN** the Slack adapter receives the broadcast
+- **AND** posts the results to the task's configured reporting channel
+
+#### Scenario: Multiple adapters can subscribe to same session
+
+- **GIVEN** both a Slack adapter and a future UI adapter are running
+- **WHEN** a session emits a broadcast
+- **THEN** both adapters receive the broadcast independently
+- **AND** each adapter delivers through its own channel
+
+### Requirement: Slack Socket Mode adapter
+
+The Slack adapter SHALL connect via Slack Socket Mode, handle `app_mention`
+events, dispatch `SendUserMessage` commands to the session parent, and
+deliver reply broadcasts back to the originating Slack thread.
+
+#### Scenario: Socket Mode connection established at startup
+
+- **GIVEN** valid Slack app and bot tokens are configured
+- **WHEN** Netclaw starts
+- **THEN** the Slack adapter opens a Socket Mode connection
+- **AND** reports connection health in operator diagnostics
+
+#### Scenario: App mention event dispatched as session command
+
+- **GIVEN** the Slack adapter is connected
+- **WHEN** an `app_mention` event is received from an allowed channel
+- **THEN** the adapter extracts entity key `{channelId}/{threadTs}`
+- **AND** creates a `SendUserMessage` with the message text, entity key, and
+  Slack source metadata
+- **AND** routes the command to the session parent actor
+
+#### Scenario: Reply delivered to originating thread
+
+- **GIVEN** a session processes a turn from a Slack message
+- **WHEN** the session emits a reply broadcast
+- **THEN** the Slack adapter posts the reply in the same thread
+- **AND** uses the Slack bot token for the API call
+
+#### Scenario: Socket Mode reconnects on disconnect
+
+- **GIVEN** the Slack Socket Mode connection drops
+- **WHEN** the adapter detects the disconnection
+- **THEN** the adapter attempts to reconnect
+- **AND** logs the disconnection and reconnection events
+
+### Requirement: Internal timer adapter
+
+The timer adapter SHALL fire on Akka timer ticks for scheduled tasks, create
+`SendUserMessage` commands with the task instruction as content, and use entity
+key pattern `schedule/{taskId}/{runTs}`. Each timer fire SHALL create a fresh
+session for isolated execution.
+
+#### Scenario: Timer fires for active scheduled task
+
+- **GIVEN** an active scheduled task has a timer registered
+- **WHEN** the Akka timer fires
+- **THEN** the timer adapter creates a `SendUserMessage` command
+- **AND** the message content is the task's instruction prompt
+- **AND** the entity key is `schedule/{taskId}/{runTs}`
+
+#### Scenario: Fresh session created per timer execution
+
+- **GIVEN** a timer fires for task `daily-report`
+- **WHEN** the timer adapter dispatches the command
+- **THEN** a new session actor is created for the unique entity key
+- **AND** the session loads the agent personality from soul files
+- **AND** the session does not reuse any previous execution's state
+
+#### Scenario: Timer adapter does not fire for paused tasks
+
+- **GIVEN** a scheduled task is in `paused` status
+- **WHEN** the system checks for timer scheduling
+- **THEN** no timer is registered for the paused task
+- **AND** no `SendUserMessage` command is produced

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-mcp/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-mcp/spec.md
@@ -1,0 +1,103 @@
+## MODIFIED Requirements
+
+### Requirement: MCP server profile configuration
+
+The system SHALL support named MCP server profiles in configuration. Each
+profile SHALL specify a transport type (`stdio` or `SSE`), the command or URL
+for the server, and optional environment variables to pass to the server
+process.
+
+#### Scenario: Disabled by default
+
+- **WHEN** no MCP profile is enabled
+- **THEN** no MCP tools are loaded
+
+#### Scenario: Stdio transport profile
+
+- **GIVEN** an MCP profile is configured with transport type `stdio`
+- **WHEN** the profile is loaded
+- **THEN** the system launches the server using the configured command
+- **AND** communicates via stdio transport
+
+#### Scenario: SSE transport profile
+
+- **GIVEN** an MCP profile is configured with transport type `SSE`
+- **WHEN** the profile is loaded
+- **THEN** the system connects to the configured URL via SSE transport
+
+#### Scenario: Environment variables passed to server
+
+- **GIVEN** an MCP profile specifies environment variables
+- **WHEN** the server process is launched (stdio transport)
+- **THEN** the configured environment variables are set in the server process
+  environment
+
+## ADDED Requirements
+
+### Requirement: Memorizer as external memory tier
+
+The Memorizer MCP server SHALL be the recommended first MCP server for Netclaw
+deployments. Memorizer provides `store`, `search`, `get`, `delete`, and
+`create_relationship` operations for persisting research findings and
+cross-session learning. Memorizer is an external memory tier complementing
+first-party local memory (personality, project registry, environment inventory).
+
+#### Scenario: Store research finding via Memorizer
+
+- **GIVEN** the `memorizer` MCP server is configured and reachable
+- **AND** the session has `mcp:memorizer` grant
+- **WHEN** the agent stores a research finding
+- **THEN** the finding is persisted in Memorizer and retrievable in future
+  sessions
+
+#### Scenario: Search across sessions via Memorizer
+
+- **GIVEN** prior sessions have stored findings in Memorizer
+- **WHEN** the agent searches Memorizer for a topic
+- **THEN** relevant findings from prior sessions are returned
+
+### Requirement: Tool discovery and registration
+
+On startup, the system SHALL discover tools from all enabled MCP server
+profiles and register them as Microsoft.Extensions.AI (MEAI) tool definitions.
+Tool discovery SHALL refresh on each session start to pick up newly added or
+removed tools from MCP servers.
+
+#### Scenario: Startup tool discovery
+
+- **GIVEN** two MCP servers are enabled with a combined total of 5 tools
+- **WHEN** the system starts
+- **THEN** all 5 tools are discovered and registered as MEAI tool definitions
+
+#### Scenario: Session-start tool refresh
+
+- **GIVEN** an MCP server has added a new tool since last session start
+- **WHEN** a new session actor initializes
+- **THEN** the refreshed tool list includes the newly added tool
+
+### Requirement: Graceful degradation
+
+Tool calls to unavailable MCP servers SHALL return a clear error message to the
+agent. The agent SHALL continue operating with remaining available tools. The
+system SHALL attempt reconnection on the next tool call to a previously
+unavailable server.
+
+#### Scenario: Unavailable server returns clear error
+
+- **GIVEN** a configured MCP server is unreachable
+- **WHEN** the agent invokes a tool from that server
+- **THEN** a clear error is returned indicating the server is unavailable
+- **AND** the agent continues the conversation with remaining tools
+
+#### Scenario: Reconnection on next call
+
+- **GIVEN** an MCP server was previously unreachable
+- **WHEN** the agent invokes a tool from that server again
+- **THEN** the system attempts reconnection before returning an error
+
+#### Scenario: Partial server availability
+
+- **GIVEN** two MCP servers are configured and one is unreachable
+- **WHEN** a session initializes
+- **THEN** tools from the reachable server are available
+- **AND** tools from the unreachable server are marked as unavailable

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Multi-provider support
+
+The system SHALL support selecting one provider profile from a supported set.
+All provider interactions SHALL use the Microsoft.Extensions.AI `IChatClient`
+abstraction layer, ensuring provider-agnostic model access throughout the
+application.
+
+#### Scenario: Switch provider
+
+- **GIVEN** OpenRouter is configured
+- **WHEN** operator selects Anthropic, OpenAI, or Ollama profile
+- **THEN** runtime uses selected provider through the `IChatClient` interface
+  after validation
+
+#### Scenario: Provider accessed through MEAI abstraction
+
+- **GIVEN** a provider profile is configured
+- **WHEN** the session actor sends a chat completion request
+- **THEN** the request is routed through the `IChatClient` abstraction
+- **AND** no provider-specific types leak into session or actor code
+
+## ADDED Requirements
+
+### Requirement: Primary and fallback model
+
+The system SHALL support configuring both a primary model and a fallback model.
+When the primary model is unavailable due to rate limiting, timeout, or error,
+the system SHALL automatically switch to the fallback model. Fallback activation
+SHALL be logged for operator visibility.
+
+#### Scenario: Primary model succeeds
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** the primary model responds successfully
+- **THEN** the primary model response is used
+- **AND** no fallback activation occurs
+
+#### Scenario: Automatic fallback on primary failure
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** the primary model returns a rate limit, timeout, or error response
+- **THEN** the system retries the request using the fallback model
+- **AND** a log entry records the fallback activation with the failure reason
+
+#### Scenario: Fallback model also fails
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** both primary and fallback models fail
+- **THEN** the session receives an error indicating model unavailability
+- **AND** the error is logged with details from both failures
+
+### Requirement: Tool calling support
+
+Tool definitions SHALL be registered through the Microsoft.Extensions.AI tool
+calling API. Tool metadata SHALL be included in the system prompt so the model
+is aware of available tools and their capabilities.
+
+#### Scenario: Tools registered through MEAI API
+
+- **GIVEN** tools are discovered from MCP servers and first-party tool providers
+- **WHEN** a session is initialized
+- **THEN** tool definitions are registered through the MEAI tool calling API
+- **AND** the model can invoke tools through the standard MEAI tool call flow
+
+#### Scenario: Tool metadata in system prompt
+
+- **GIVEN** tools are registered for a session
+- **WHEN** the system prompt is assembled
+- **THEN** tool metadata (names, descriptions, parameter schemas) is included
+  in the prompt context

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Phase 2 conversational personality bootstrap
+
+The system SHALL trigger a conversational personality bootstrap on the first
+conversation if personality files (PERSONALITY.md, INSTRUCTIONS.md, USER.md)
+do not exist. The bootstrap conversation SHALL ask the operator about
+communication preferences, tone, name preferences, and working style, then
+write the resulting soul files to the standard config directory.
+
+#### Scenario: First conversation triggers bootstrap
+
+- **GIVEN** no personality files exist in the config directory
+- **WHEN** the operator starts their first conversation with Netclaw
+- **THEN** the agent initiates a personality bootstrap conversation
+- **AND** asks about communication preferences and working style
+
+#### Scenario: Bootstrap writes soul files
+
+- **GIVEN** the personality bootstrap conversation is complete
+- **WHEN** the operator has answered all preference questions
+- **THEN** the system writes PERSONALITY.md, INSTRUCTIONS.md, and USER.md to
+  the config directory
+
+#### Scenario: Bootstrap skipped when files exist
+
+- **GIVEN** personality files already exist in the config directory
+- **WHEN** a new conversation starts
+- **THEN** no personality bootstrap is triggered
+- **AND** the existing personality files are loaded normally
+
+### Requirement: Environment discovery during onboarding
+
+The system SHALL scan for installed tools and host capabilities as part of
+Phase 2 onboarding. Discovery results SHALL be persisted to the environment
+inventory file for use in session context and capability self-awareness.
+
+#### Scenario: Tool discovery during onboarding
+
+- **WHEN** Phase 2 onboarding runs environment discovery
+- **THEN** the system scans for installed tools (git, gh, claude, opencode,
+  dotnet, node)
+- **AND** checks git credential status
+- **AND** writes results to the environment inventory file
+
+#### Scenario: MCP server reachability check during onboarding
+
+- **GIVEN** MCP servers are configured
+- **WHEN** Phase 2 onboarding runs environment discovery
+- **THEN** the system checks reachability of each configured MCP server
+- **AND** records reachability status in the environment inventory
+
+### Requirement: Project registration during onboarding
+
+The system SHALL ask the operator about repositories to register as part of
+Phase 2 onboarding. Registered projects are added to the project registry
+with their paths, capabilities, and AGENTS.md locations.
+
+#### Scenario: Register projects during onboarding
+
+- **WHEN** Phase 2 onboarding reaches the project registration step
+- **THEN** the system asks the operator about repositories to register
+- **AND** scans provided paths for AGENTS.md files
+
+#### Scenario: Skip project registration
+
+- **WHEN** Phase 2 onboarding reaches the project registration step
+- **AND** the operator indicates no projects to register
+- **THEN** onboarding proceeds with an empty project registry

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-operator-ui/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-operator-ui/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Phase 5 deferral
+
+The operator UI implementation SHALL be deferred to Phase 5. The MVP
+deliverable for the operator UI is a specification and mockup only. No
+runtime UI code SHALL be included in the MVP build.
+
+#### Scenario: MVP excludes UI runtime code
+
+- **WHEN** the MVP is built
+- **THEN** no operator UI runtime code is included in the build artifacts
+- **AND** the UI specification and mockups exist as planning documents
+
+#### Scenario: UI specs maintained for Phase 5
+
+- **GIVEN** the operator UI is deferred to Phase 5
+- **WHEN** UI-related capability specs are updated
+- **THEN** the specs define future behavior for Phase 5 implementation
+
+### Requirement: Memory and configuration screen
+
+The operator UI SHALL provide a screen for viewing personality files, the
+project registry, and the environment inventory. This screen provides
+read-only visibility into the agent's local memory and configuration state.
+
+#### Scenario: View personality files
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the contents of PERSONALITY.md, INSTRUCTIONS.md, and USER.md are
+  displayed
+
+#### Scenario: View project registry
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the project registry is displayed with project names, paths, and
+  capabilities
+
+#### Scenario: View environment inventory
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the environment inventory is displayed with installed tools,
+  credential status, and MCP server reachability
+
+### Requirement: Scheduling screen
+
+The operator UI SHALL provide a screen for viewing, creating, pausing, and
+deleting scheduled tasks. The screen SHALL also display execution history for
+each task.
+
+#### Scenario: View scheduled tasks
+
+- **WHEN** an operator opens the scheduling screen
+- **THEN** all scheduled tasks are listed with name, schedule, status, and
+  last execution result
+
+#### Scenario: Create scheduled task from UI
+
+- **WHEN** an operator creates a new scheduled task from the scheduling screen
+- **THEN** the task is added to the schedule registry with the specified
+  schedule, instructions, and required tool grants
+
+#### Scenario: Pause and delete from UI
+
+- **GIVEN** a scheduled task exists
+- **WHEN** an operator pauses or deletes the task from the scheduling screen
+- **THEN** the task status is updated accordingly
+
+#### Scenario: View execution history
+
+- **WHEN** an operator selects a scheduled task on the scheduling screen
+- **THEN** the execution history is displayed with timestamps, outcomes, and
+  error details for failed runs

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-scheduling/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-scheduling/spec.md
@@ -1,0 +1,217 @@
+# netclaw-scheduling Delta Spec
+
+**Change**: expand-mvp-for-autonomous-agent-vision
+**Source**: PRD-008 (Scheduling and Periodic Tasks)
+**Capability**: netclaw-scheduling (new)
+
+## Purpose
+
+Define chat-driven scheduled task creation, persistence, isolated execution
+via Akka timers, result reporting, task management, and failure handling
+guardrails. This capability enables Netclaw to manage its own schedule
+through conversation and execute tasks autonomously.
+
+## ADDED Requirements
+
+### Requirement: Chat-driven task creation
+
+The agent SHALL create scheduled tasks when the user requests recurring or
+timed actions through conversation. The agent SHALL assign a human-readable
+task ID and confirm the schedule. Tasks SHALL support fixed interval and cron
+expression schedule types. Tasks requesting tool grants that cannot be
+satisfied by ACL policy SHALL be rejected at creation time.
+
+#### Scenario: Create interval-based scheduled task
+
+- **GIVEN** the user asks the agent to perform an action on a recurring basis
+- **WHEN** the agent parses the request as a fixed-interval schedule
+- **THEN** the agent creates a task with the specified interval
+- **AND** assigns a human-readable task ID
+- **AND** confirms the schedule, next run time, and required tool grants
+
+#### Scenario: Create cron-based scheduled task
+
+- **GIVEN** the user specifies a cron expression for scheduling
+- **WHEN** the agent validates the cron expression
+- **THEN** the agent creates a task with the cron schedule
+- **AND** confirms the resolved next execution time
+
+#### Scenario: Reject task with ungrantable tools
+
+- **GIVEN** the user requests a scheduled task that requires the `shell` tool
+- **WHEN** the `shell` grant is not available in the ACL policy for that sender
+- **THEN** the agent rejects the task at creation time
+- **AND** explains which tool grants are missing
+
+#### Scenario: Task ID collision avoided
+
+- **GIVEN** a task with ID `ebay-check` already exists
+- **WHEN** the user requests a new task that would generate the same ID
+- **THEN** the agent generates a unique variant of the ID
+- **AND** confirms the actual task ID assigned
+
+### Requirement: Schedule persistence
+
+Scheduled tasks SHALL be persisted to disk at
+`~/.netclaw/schedules/tasks.json` and SHALL survive process restarts. On
+startup, the system SHALL load persisted tasks and re-establish Akka timers
+for all active tasks.
+
+#### Scenario: Tasks survive process restart
+
+- **GIVEN** active scheduled tasks exist in `tasks.json`
+- **WHEN** the Netclaw process restarts
+- **THEN** all persisted tasks are loaded from disk
+- **AND** Akka timers are re-established for active tasks
+- **AND** paused tasks remain paused
+
+#### Scenario: New task persisted immediately
+
+- **GIVEN** the user creates a new scheduled task through conversation
+- **WHEN** the task is confirmed
+- **THEN** the task is written to `tasks.json` before the confirmation is sent
+
+#### Scenario: Corrupted tasks file handled gracefully
+
+- **GIVEN** `tasks.json` contains invalid JSON
+- **WHEN** the Netclaw process starts
+- **THEN** the system logs a warning
+- **AND** starts without any scheduled tasks
+- **AND** the operator is notified of the corruption
+
+### Requirement: Isolated task execution
+
+Each scheduled task execution SHALL run in a fresh session actor with its own
+context. The session SHALL load the agent personality and any relevant project
+context overlays. Scheduled sessions SHALL NOT share state with interactive
+sessions.
+
+#### Scenario: Fresh session per execution
+
+- **GIVEN** a scheduled task fires
+- **WHEN** the timer tick triggers execution
+- **THEN** a new session actor is created with entity key
+  `schedule/{taskId}/{runTs}`
+- **AND** the task instruction is delivered as the user message
+- **AND** agent personality is loaded from soul files
+
+#### Scenario: Scheduled session isolated from interactive sessions
+
+- **GIVEN** an interactive Slack session exists for the same user
+- **WHEN** a scheduled task executes
+- **THEN** the scheduled session does not read or modify interactive session
+  state
+- **AND** the interactive session does not see scheduled session turns
+
+#### Scenario: Task tool grants applied to session
+
+- **GIVEN** a scheduled task specifies `tool_grants: ["web_search", "web_fetch"]`
+- **WHEN** the task session starts
+- **THEN** only the granted tools are available to the session
+- **AND** ungrantable tools are not offered to the LLM
+
+### Requirement: Result reporting
+
+Task execution results SHALL be posted to the configured Slack channel. The
+system SHALL support a silent-unless-notable mode where routine results are
+suppressed and only notable findings are posted.
+
+#### Scenario: Results posted to configured channel
+
+- **GIVEN** a scheduled task has `report_to.channel` configured
+- **WHEN** the task execution completes with results
+- **THEN** the results are posted to the configured Slack channel
+
+#### Scenario: Silent-unless-notable suppresses routine results
+
+- **GIVEN** a scheduled task is configured with silent-unless-notable mode
+- **WHEN** the task execution completes with no notable findings
+- **THEN** no message is posted to Slack
+- **AND** the execution is logged as completed with no notable output
+
+#### Scenario: Notable results always posted
+
+- **GIVEN** a scheduled task is configured with silent-unless-notable mode
+- **WHEN** the task execution produces notable findings
+- **THEN** the results are posted to the configured Slack channel
+- **AND** the findings are clearly presented
+
+### Requirement: Task management
+
+The agent and CLI SHALL support listing, pausing, resuming, and deleting
+scheduled tasks. The agent SHALL provide task status and next-run time
+when listing tasks.
+
+#### Scenario: List all scheduled tasks via conversation
+
+- **GIVEN** multiple scheduled tasks exist
+- **WHEN** the user asks to see scheduled tasks
+- **THEN** the agent lists all tasks with ID, name, status, schedule, and
+  next run time
+
+#### Scenario: Pause a scheduled task
+
+- **GIVEN** an active scheduled task exists
+- **WHEN** the user asks the agent to pause the task
+- **THEN** the task status is set to paused
+- **AND** the Akka timer for the task is cancelled
+- **AND** the task remains in `tasks.json` with `status: "paused"`
+
+#### Scenario: Resume a paused task
+
+- **GIVEN** a paused scheduled task exists
+- **WHEN** the user asks the agent to resume the task
+- **THEN** the task status is set to active
+- **AND** the Akka timer is re-established
+- **AND** the next run time is calculated from the current time
+
+#### Scenario: Delete a scheduled task
+
+- **GIVEN** a scheduled task exists
+- **WHEN** the user asks the agent to delete the task
+- **THEN** the task is removed from `tasks.json`
+- **AND** the Akka timer is cancelled
+- **AND** the agent confirms deletion
+
+#### Scenario: Manage tasks via CLI
+
+- **GIVEN** active scheduled tasks exist
+- **WHEN** the operator runs CLI commands for schedule management
+- **THEN** the CLI supports list, pause, resume, and delete operations
+- **AND** changes are reflected in `tasks.json`
+
+### Requirement: Failure handling and guardrails
+
+The system SHALL track consecutive failures per task. After the configured
+failure threshold (default: 5), the task SHALL be automatically paused and
+the operator notified. The system SHALL enforce a maximum concurrent execution
+limit (default: 3) and a per-task execution timeout (default: 5 minutes).
+
+#### Scenario: Consecutive failures auto-pause task
+
+- **GIVEN** a scheduled task has failed 5 consecutive times
+- **WHEN** the 5th failure is recorded
+- **THEN** the task is automatically paused
+- **AND** the operator is notified in the task's reporting channel
+- **AND** the notification includes the last failure reason
+
+#### Scenario: Successful execution resets failure counter
+
+- **GIVEN** a scheduled task has 3 consecutive failures recorded
+- **WHEN** the next execution succeeds
+- **THEN** the consecutive failure counter is reset to zero
+
+#### Scenario: Max concurrent execution limit enforced
+
+- **GIVEN** 3 scheduled tasks are currently executing (at the default limit)
+- **WHEN** another scheduled task timer fires
+- **THEN** the execution is deferred until a slot becomes available
+- **AND** the deferral is logged
+
+#### Scenario: Execution timeout enforced
+
+- **GIVEN** a scheduled task is executing
+- **WHEN** the execution exceeds the configured timeout (default: 5 minutes)
+- **THEN** the execution is terminated
+- **AND** the result is recorded as a timeout failure
+- **AND** the failure contributes to the consecutive failure counter

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-session/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-session/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Conversation compaction
+
+The system SHALL compact long session history using summary reduction. Before
+compaction runs, the system SHALL trigger a pre-compaction memory flush that
+persists durable memories (key facts, decisions, action items) to local memory
+files so they survive context reset.
+
+#### Scenario: Compaction threshold reached
+
+- **GIVEN** session history exceeds configured threshold
+- **WHEN** compaction runs
+- **THEN** a compaction event is persisted
+- **AND** compacted state remains usable for future turns
+
+#### Scenario: Pre-compaction memory flush
+
+- **GIVEN** session history exceeds configured compaction threshold
+- **WHEN** compaction is about to run
+- **THEN** the system SHALL execute a silent agentic turn that extracts durable
+  memories from the conversation
+- **AND** persists them to local memory files before context is reset
+
+### Requirement: Persisted turn lifecycle
+
+The system SHALL persist each completed turn and emit a turn broadcast via
+pub/sub. Broadcast delivery SHALL use a publish-subscribe pattern so that
+multiple adapters (Slack, future web UI, timer adapter) can independently
+consume turn events without the session actor knowing which adapters are
+subscribed.
+
+#### Scenario: Persist and broadcast assistant reply
+
+- **WHEN** the assistant produces a response
+- **THEN** a turn event is persisted
+- **AND** a broadcast is published to the session topic for all subscribers
+
+#### Scenario: Multi-adapter broadcast delivery
+
+- **GIVEN** multiple adapters are subscribed to session broadcasts
+- **WHEN** a turn broadcast is published
+- **THEN** each subscribed adapter receives the broadcast independently
+- **AND** the session actor does not reference specific adapter types
+
+## ADDED Requirements
+
+### Requirement: Tool context in session state
+
+The system SHALL load available tools into session state based on the active
+policy grants at session initialization. Tool definitions SHALL be refreshed
+from the tool registry each time a session actor starts or recovers.
+
+#### Scenario: Session loads granted tools at initialization
+
+- **GIVEN** the ACL grants `shell`, `web_search`, and `mcp:memorizer` to the
+  current channel and sender
+- **WHEN** a session actor initializes
+- **THEN** session state includes tool definitions for only the granted tool
+  categories
+
+#### Scenario: Denied tools excluded from session
+
+- **GIVEN** the ACL does not grant `github` for the current channel
+- **WHEN** a session actor initializes
+- **THEN** GitHub tool definitions are not loaded into session state

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-tools/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-tools/spec.md
@@ -1,0 +1,237 @@
+# netclaw-tools Delta Spec
+
+**Change**: expand-mvp-for-autonomous-agent-vision
+**Source**: PRD-001 (FR-011), PRD-002 (SEC-003, SEC-009), PRD-005 (MP-010),
+PRD-007 (Agent Personality and Local Memory)
+**Capability**: netclaw-tools (new)
+
+## Purpose
+
+Define first-party tool access for Netclaw: web search, web fetch, shell
+execution, and GitHub CLI. All tools are registered through
+Microsoft.Extensions.AI, filtered by policy grants, and audited on invocation.
+This capability provides the agent with the ability to act on the world beyond
+conversation.
+
+## ADDED Requirements
+
+### Requirement: Tool registration with MEAI
+
+All first-party tools SHALL be registered as `Microsoft.Extensions.AI` tool
+definitions at startup. Tool metadata (name, description, parameters) SHALL be
+defined at registration. Available tools presented to the LLM SHALL be filtered
+per session based on ACL policy grants.
+
+#### Scenario: Tools registered at startup
+
+- **WHEN** the Netclaw process starts
+- **THEN** all configured first-party tools are registered as MEAI tool
+  definitions
+- **AND** each tool definition includes name, description, and parameter schema
+
+#### Scenario: Session receives filtered tool set
+
+- **GIVEN** a session has ACL grants for `web_search` and `web_fetch` but not
+  `shell`
+- **WHEN** the session starts and tools are provided to the LLM
+- **THEN** only `web_search` and `web_fetch` tool definitions are included
+- **AND** `shell` is not offered to the LLM
+
+#### Scenario: Tool results returned as tool response messages
+
+- **GIVEN** the LLM issues a tool call during a turn
+- **WHEN** the tool executes and produces a result
+- **THEN** the result is returned to the LLM as an MEAI tool response message
+- **AND** the session continues the turn loop with the tool result in context
+
+### Requirement: Web search tool
+
+The system SHALL provide a web search tool using Brave Search API as the
+primary backend and SearXNG as the alternative backend. The tool SHALL return
+structured search results suitable for LLM consumption.
+
+#### Scenario: Web search via Brave Search API
+
+- **GIVEN** the Brave Search API key is configured
+- **WHEN** the agent invokes the web search tool with a query
+- **THEN** the tool sends the query to the Brave Search API
+- **AND** returns structured results (title, URL, snippet) to the LLM
+
+#### Scenario: Web search via SearXNG
+
+- **GIVEN** the search backend is configured as SearXNG with a valid endpoint
+- **WHEN** the agent invokes the web search tool with a query
+- **THEN** the tool sends the query to the SearXNG instance
+- **AND** returns structured results in the same format as Brave Search
+
+#### Scenario: Missing API key prevents tool registration
+
+- **GIVEN** Brave Search is configured as the search backend
+- **WHEN** no API key is provided in configuration
+- **THEN** the web search tool is not registered at startup
+- **AND** a warning is logged indicating the tool is unavailable
+
+### Requirement: Web fetch tool
+
+The system SHALL provide a web fetch tool that retrieves content from URLs,
+extracts text from HTML, and truncates output to a configurable limit to
+prevent context flooding.
+
+#### Scenario: Fetch and extract text from URL
+
+- **GIVEN** the web fetch tool is available
+- **WHEN** the agent invokes the tool with a URL
+- **THEN** the tool retrieves the page content via HTTP
+- **AND** extracts text from HTML (removing markup)
+- **AND** returns the extracted text to the LLM
+
+#### Scenario: Output truncated to configured limit
+
+- **GIVEN** the fetched page content exceeds the configured output limit
+- **WHEN** the tool processes the content
+- **THEN** the output is truncated to the configured character limit
+- **AND** a truncation indicator is appended to the result
+
+#### Scenario: Non-HTML content returned as-is
+
+- **GIVEN** the fetched URL returns plain text or JSON content
+- **WHEN** the tool processes the response
+- **THEN** the content is returned without HTML extraction
+- **AND** output truncation still applies
+
+#### Scenario: Unreachable URL returns error
+
+- **GIVEN** the agent invokes the web fetch tool with an unreachable URL
+- **WHEN** the HTTP request fails
+- **THEN** the tool returns an error message to the LLM
+- **AND** the error does not crash the session
+
+### Requirement: Shell execution tool
+
+The system SHALL provide a shell execution tool that runs commands as the
+Netclaw process user context. Stdin SHALL be closed (no interactive commands).
+Execution SHALL enforce a configurable timeout (default: 60 seconds). Output
+SHALL be truncated to a configurable limit.
+
+#### Scenario: Execute command and return output
+
+- **GIVEN** the `shell` grant is available for the session
+- **WHEN** the agent invokes the shell tool with a command
+- **THEN** the command is executed as the Netclaw process user
+- **AND** stdout and stderr are captured
+- **AND** the combined output is returned to the LLM
+
+#### Scenario: Execution timeout enforced
+
+- **GIVEN** a shell command is running
+- **WHEN** the command exceeds the configured timeout (default: 60 seconds)
+- **THEN** the process is terminated
+- **AND** the tool returns a timeout error message to the LLM
+
+#### Scenario: Output truncated to limit
+
+- **GIVEN** a shell command produces output exceeding the configured limit
+- **WHEN** the output is captured
+- **THEN** the output is truncated to the configured character limit
+- **AND** a truncation indicator is appended
+
+#### Scenario: Stdin closed prevents interactive commands
+
+- **GIVEN** the agent invokes the shell tool with a command
+- **WHEN** the process is created
+- **THEN** stdin is closed immediately
+- **AND** commands that require interactive input fail promptly
+
+#### Scenario: Working directory set to project path
+
+- **GIVEN** the session is associated with a registered project
+- **WHEN** the shell tool executes a command
+- **THEN** the working directory is set to the project's registered path
+
+### Requirement: GitHub CLI tool
+
+The system SHALL provide a GitHub tool that shells out to the `gh` CLI for
+issue creation, PR management, and repo operations. The tool SHALL parse
+structured output from `gh`. If `gh` is not installed, the tool SHALL not be
+registered and SHALL report the missing dependency.
+
+#### Scenario: Execute gh command and return structured output
+
+- **GIVEN** the `github` grant is available and `gh` is installed
+- **WHEN** the agent invokes the GitHub tool with a `gh` command
+- **THEN** the tool executes the `gh` command via shell
+- **AND** parses the output into structured form
+- **AND** returns the structured result to the LLM
+
+#### Scenario: gh CLI not installed
+
+- **GIVEN** `gh` is not found in the environment inventory
+- **WHEN** the Netclaw process starts
+- **THEN** the GitHub tool is not registered
+- **AND** a warning is logged indicating the GitHub tool is unavailable due to
+  missing `gh` CLI
+
+#### Scenario: gh authentication failure handled
+
+- **GIVEN** the `gh` CLI is installed but not authenticated
+- **WHEN** a GitHub tool invocation is attempted
+- **THEN** the tool returns an authentication error message to the LLM
+- **AND** the error does not crash the session
+
+### Requirement: Policy-gated tool invocation
+
+The system SHALL check ACL grants before every tool execution. Tool
+invocations SHALL be logged with audit records including tool name, invoking
+session, timestamp, and allow/deny result.
+
+#### Scenario: Granted tool executes successfully
+
+- **GIVEN** the session has an ACL grant for `web_search`
+- **WHEN** the LLM requests a web search tool call
+- **THEN** the ACL check passes
+- **AND** the tool executes
+- **AND** an audit record is logged with tool name, session ID, timestamp, and
+  `allow` result
+
+#### Scenario: Ungrantable tool denied at invocation
+
+- **GIVEN** the session does not have an ACL grant for `shell`
+- **WHEN** the LLM requests a shell tool call
+- **THEN** the ACL check fails
+- **AND** the tool is not executed
+- **AND** a policy denial with reason code is returned to the LLM
+- **AND** an audit record is logged with tool name, session ID, timestamp, and
+  `deny` result
+
+#### Scenario: Audit records available in diagnostics
+
+- **GIVEN** tool invocations have occurred
+- **WHEN** the operator views diagnostics
+- **THEN** audit records show tool name, invoking session, timestamp, and
+  allow/deny result for each invocation
+
+### Requirement: Configurable search backend
+
+The system SHALL support configuring either Brave Search API or SearXNG as the
+web search backend. The choice SHALL be made through configuration without code
+changes.
+
+#### Scenario: Brave Search configured as default
+
+- **GIVEN** the configuration specifies `search_backend: "brave"`
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses Brave Search API for queries
+
+#### Scenario: SearXNG configured as alternative
+
+- **GIVEN** the configuration specifies `search_backend: "searxng"` with an
+  endpoint URL
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses the SearXNG endpoint for queries
+
+#### Scenario: Invalid search backend rejected at startup
+
+- **GIVEN** the configuration specifies an unrecognized search backend value
+- **WHEN** the Netclaw process starts
+- **THEN** the web search tool is not registered
+- **AND** a configuration validation warning is logged

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Expand MVP for Autonomous Agent Vision
+
+## 1. Framework Protocol and Persistence Envelopes
+
+- [ ] 1.1 Implement `SendUserMessage`, `TurnRecorded`, `SessionCompacted`,
+  `TurnBroadcast`, and `CompactionBroadcast` concrete types with protobuf-net
+  serialization.
+- [ ] 1.2 Implement `SerializableChatMessage` framework-owned chat type (no
+  direct persistence of `Microsoft.Extensions.AI` types).
+- [ ] 1.3 Implement `SessionMessageExtractor` supporting entity key patterns:
+  `{channelId}/{threadTs}` for Slack, `schedule/{taskId}/{runTs}` for timers.
+- [ ] 1.4 Write integration tests verifying event serialization round-trip and
+  entity key extraction for both Slack and timer patterns.
+
+## 2. Session Actor Core
+
+- [ ] 2.1 Implement `LlmSessionActor` with persistent state recovery from
+  PostgreSQL journal/snapshots.
+- [ ] 2.2 Implement turn processing loop: receive `SendUserMessage`, invoke
+  `IChatClient`, persist `TurnRecorded`, emit `TurnBroadcast` via pub/sub.
+- [ ] 2.3 Implement snapshot strategy and compaction trigger via
+  `SummarizingChatReducer`.
+- [ ] 2.4 Implement pre-compaction memory flush: silent agentic turn that saves
+  durable memories before context resets (spec: netclaw-agent-memory).
+- [ ] 2.5 Add source metadata to `SendUserMessage` (adapter type, sender
+  identity, channel, timestamp) per netclaw-input-adapters spec.
+- [ ] 2.6 Write integration tests proving restart recovery preserves context
+  and pre-compaction flush executes before compaction.
+
+## 3. Session Parent and Entity Routing
+
+- [ ] 3.1 Implement `LlmAgentParentActor` wrapping `GenericChildPerEntityParent`.
+- [ ] 3.2 Implement session extraction routing same-thread messages to same
+  child actor using `SessionMessageExtractor`.
+- [ ] 3.3 Write tests verifying entity lifecycle, message routing, and
+  multi-key-pattern support.
+
+## 4. Layered System Prompt and Personality
+
+- [ ] 4.1 Create `~/.netclaw/` standard directory structure (soul/, projects/,
+  environment/, schedules/, config/) with creation-on-startup behavior.
+- [ ] 4.2 Implement system prompt assembly from layered sources:
+  PERSONALITY.md → INSTRUCTIONS.md → USER.md → project AGENTS.md → session
+  context.
+- [ ] 4.3 Implement project AGENTS.md overlay loading from registered project
+  paths.
+- [ ] 4.4 Write tests for prompt assembly with missing layers and project
+  overlay injection.
+
+## 5. ACL and Policy Engine
+
+- [ ] 5.1 Implement ACL configuration parser supporting channel rules, sender
+  allowlists, mention/ambient mode, and tool grant categories (shell,
+  web_search, web_fetch, github, mcp:{server}, config_write, schedule_write).
+- [ ] 5.2 Implement default-deny evaluation: deny when no explicit allow exists.
+- [ ] 5.3 Implement self-configuration prohibition: agent cannot modify ACL or
+  security files through conversation.
+- [ ] 5.4 Implement startup validation: invalid ACL blocks startup with
+  actionable diagnostics.
+- [ ] 5.5 Write policy decision tests covering allow/deny reason codes for all
+  tool grant categories.
+
+## 6. Tool Framework and MEAI Registration
+
+- [ ] 6.1 Implement tool registry that registers `AIFunction` definitions
+  through `Microsoft.Extensions.AI`.
+- [ ] 6.2 Implement policy-filtered tool loading: session receives only tools
+  matching its ACL grants.
+- [ ] 6.3 Implement tool invocation audit logging (tool name, session ID,
+  timestamp, allow/deny).
+- [ ] 6.4 Add tool context to session state at initialization.
+- [ ] 6.5 Write tests for tool registration, policy filtering, and audit
+  logging.
+
+## 7. First-Party Tools
+
+- [ ] 7.1 Implement web search tool with Brave Search API backend (thin
+  `HttpClient` wrapper, structured JSON response).
+- [ ] 7.2 Implement web search SearXNG backend as alternative (same tool
+  interface, different backend).
+- [ ] 7.3 Implement configurable search backend selection via
+  `config/netclaw.json`.
+- [ ] 7.4 Implement web fetch tool (URL retrieval, HTML-to-text extraction,
+  output truncation).
+- [ ] 7.5 Implement shell execution tool (`System.Diagnostics.Process`
+  wrapper, timeout enforcement, output truncation, stdin closure, working
+  directory from project registry).
+- [ ] 7.6 Implement GitHub CLI tool (shell-out to `gh`, structured output
+  parsing, missing dependency handling).
+- [ ] 7.7 Write tests for each tool with mocked HTTP/process dependencies.
+
+## 8. MCP Integration and Memorizer
+
+- [ ] 8.1 Implement MCP server profile configuration (named profiles, transport
+  type stdio/SSE, enable/disable).
+- [ ] 8.2 Implement MCP tool discovery at startup: connect to enabled servers,
+  list tools, register as MEAI tool definitions.
+- [ ] 8.3 Implement graceful degradation: unavailable server returns error,
+  agent continues, reconnect on next call.
+- [ ] 8.4 Implement MCP validation command (`netclaw mcp validate`).
+- [ ] 8.5 Write tests for MCP connection, tool discovery, policy gating, and
+  degradation.
+
+## 9. Local Memory System
+
+- [ ] 9.1 Implement project registry (`projects/registry.json`): add, remove,
+  list, validate paths, load at startup.
+- [ ] 9.2 Implement environment inventory (`environment/inventory.json`): scan
+  for git, gh, claude, opencode, dotnet, node; check versions and credentials.
+- [ ] 9.3 Implement capability self-discovery at startup and on-demand rescan.
+- [ ] 9.4 Write tests for project registry CRUD and environment scan accuracy.
+
+## 10. Self-Configuration Through Conversation
+
+- [ ] 10.1 Implement self-configuration tool: agent modifies personality,
+  instructions, user preferences, project registry, and environment inventory
+  through conversation.
+- [ ] 10.2 Implement validation-before-write and atomic file writes (temp +
+  rename).
+- [ ] 10.3 Implement prohibited modification enforcement: reject ACL, security
+  policy, tool grants, exposure mode, and credential changes.
+- [ ] 10.4 Write tests for allowed modifications, prohibited modifications, and
+  validation failures.
+
+## 11. Scheduling System
+
+- [ ] 11.1 Implement `ScheduleManagerActor` that loads tasks from
+  `schedules/tasks.json` at startup and manages Akka timers.
+- [ ] 11.2 Implement chat-driven task creation: parse interval and cron
+  schedule types from conversation, validate tool grants, persist task.
+- [ ] 11.3 Implement isolated task execution: timer fires dispatch
+  `SendUserMessage` to session parent with fresh entity key
+  (`schedule/{taskId}/{runTs}`).
+- [ ] 11.4 Implement result reporting: post execution results to configured
+  Slack channel, support silent-unless-notable mode.
+- [ ] 11.5 Implement guardrails: max concurrent executions (default 3),
+  execution timeout (default 5min), consecutive failure auto-pause (default 5).
+- [ ] 11.6 Implement task management: list, pause, resume, delete via
+  conversation and CLI.
+- [ ] 11.7 Write tests for schedule persistence, timer lifecycle, isolated
+  execution, and failure handling.
+
+## 12. Slack Socket Mode Adapter
+
+- [ ] 12.1 Implement Slack Socket Mode connection and event handling
+  (`app_mention`, `message` events).
+- [ ] 12.2 Implement entity key extraction from Slack events
+  (`{channelId}/{threadTs}`).
+- [ ] 12.3 Implement reply delivery: subscribe to session broadcasts, post
+  replies to originating Slack thread.
+- [ ] 12.4 Implement reconnection on disconnect.
+- [ ] 12.5 Write end-to-end test proving message → reply loop.
+
+## 13. Provider Abstraction
+
+- [ ] 13.1 Wire `Microsoft.Extensions.AI` `IChatClient` provider registration
+  with DI (OpenRouter, Anthropic, OpenAI, Ollama profiles).
+- [ ] 13.2 Implement primary + fallback model configuration with automatic
+  failover on rate limit, timeout, or provider error.
+- [ ] 13.3 Implement tool calling support through MEAI tool calling API.
+- [ ] 13.4 Write tests for provider switching, fallback activation, and tool
+  calling round-trip.
+
+## 14. CLI Onboarding and Management
+
+- [ ] 14.1 Implement `netclaw init` guided wizard (LLM provider, Slack
+  credentials, PostgreSQL connection, ACL bootstrap, MCP config, exposure mode,
+  health check).
+- [ ] 14.2 Implement `netclaw config show|validate` and
+  `netclaw acl validate|test|explain`.
+- [ ] 14.3 Implement `netclaw project list|add|remove` and
+  `netclaw environment scan|show`.
+- [ ] 14.4 Implement `netclaw schedule list|show|pause|resume|delete`.
+- [ ] 14.5 Implement `netclaw mcp list|validate|test`.
+- [ ] 14.6 Implement `netclaw personality reset` and `netclaw memory show`.
+- [ ] 14.7 Implement `netclaw gateway status|doctor`.
+- [ ] 14.8 Implement `netclaw test smoke --provider ollama`.
+
+## 15. Conversational Personality Bootstrap
+
+- [ ] 15.1 Implement first-run detection: trigger bootstrap when soul files
+  don't exist.
+- [ ] 15.2 Implement bootstrap conversation flow: introduce, learn preferences,
+  scan environment, write soul files, confirm readiness.
+- [ ] 15.3 Write test for bootstrap trigger and soul file creation.
+
+## 16. Spec Sync and Validation
+
+- [ ] 16.1 Sync delta specs to main specs using `openspec sync` or equivalent.
+- [ ] 16.2 Run `openspec validate --all --no-interactive` and fix any issues.
+- [ ] 16.3 Update `IMPLEMENTATION_PLAN.md` Phase 1+ with tasks from this
+  change plan.
+
+## 17. Integration and Acceptance
+
+- [ ] 17.1 End-to-end test: Slack message → session → tool call → reply in
+  thread.
+- [ ] 17.2 End-to-end test: scheduled task fires → fresh session → result
+  posted to Slack.
+- [ ] 17.3 End-to-end test: restart recovery preserves session context and
+  scheduled tasks.
+- [ ] 17.4 Verify CI test suite passes without live provider credentials.

--- a/openspec/specs/netclaw-acl/spec.md
+++ b/openspec/specs/netclaw-acl/spec.md
@@ -40,9 +40,72 @@ The system SHALL respect `require_mention` per channel.
 
 ### Requirement: Tool and data grants
 
-The system SHALL enforce explicit grants for tool/data access.
+The system SHALL enforce explicit grants for tool and data access. Grants SHALL
+be organized into specific tool grant categories: `shell`, `web_search`,
+`web_fetch`, `github`, `mcp:{server_name}`, `config_write`, and
+`schedule_write`. Each grant SHALL specify the allowed senders and channels to
+which it applies.
 
 #### Scenario: Missing grant blocks tool call
 
-- **WHEN** a tool call is attempted without grant
+- **WHEN** a tool call is attempted without a matching grant
 - **THEN** execution is denied with a policy reason code
+
+#### Scenario: Category-specific grant allows tool
+
+- **GIVEN** ACL grants `web_search` for sender `U12345` on channel `C99999`
+- **WHEN** sender `U12345` requests a web search in channel `C99999`
+- **THEN** ACL evaluation returns allow for the `web_search` tool category
+
+#### Scenario: MCP server-scoped grant
+
+- **GIVEN** ACL grants `mcp:memorizer` for sender `U12345`
+- **WHEN** sender `U12345` requests an MCP tool from the `memorizer` server
+- **THEN** ACL evaluation returns allow
+- **AND** MCP tools from other servers without explicit grants are denied
+
+#### Scenario: Config write grant required for self-configuration
+
+- **GIVEN** ACL does not grant `config_write` for the current sender
+- **WHEN** the agent attempts to write configuration files through conversation
+- **THEN** the write is denied with a policy reason code
+
+### Requirement: Self-configuration prohibition
+
+ACL and security policy files MUST NOT be modifiable by the agent through
+conversation. These files SHALL only be modified through the CLI or direct file
+edit by the operator. This prohibition SHALL be enforced regardless of any
+grants in the ACL policy.
+
+#### Scenario: Agent cannot modify ACL through conversation
+
+- **WHEN** an agent session attempts to modify ACL policy files
+- **THEN** the modification is denied regardless of active grants
+- **AND** the denial reason indicates that ACL files require CLI or direct edit
+
+#### Scenario: Agent cannot modify security policy through conversation
+
+- **WHEN** an agent session attempts to modify gateway security policy files
+- **THEN** the modification is denied regardless of active grants
+
+### Requirement: Scheduled task tool grants
+
+Each scheduled task definition SHALL specify the required tool grants for its
+execution. At execution time, the system SHALL verify that all required tool
+grants are still valid before running the task.
+
+#### Scenario: Scheduled task with valid grants executes
+
+- **GIVEN** a scheduled task requires `web_search` and `mcp:memorizer`
+- **AND** both grants are present in the current ACL policy
+- **WHEN** the scheduled task fires
+- **THEN** the task executes with the granted tools available
+
+#### Scenario: Scheduled task with revoked grant is blocked
+
+- **GIVEN** a scheduled task requires `web_search`
+- **AND** the `web_search` grant has been removed from ACL policy since the task
+  was created
+- **WHEN** the scheduled task fires
+- **THEN** execution is denied with a policy reason code
+- **AND** the task failure is recorded with the missing grant details

--- a/openspec/specs/netclaw-agent-memory/spec.md
+++ b/openspec/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,219 @@
+# netclaw-agent-memory Specification
+
+## Purpose
+
+Define agent personality (soul files), local memory (project registry,
+environment inventory), capability self-discovery, self-configuration through
+conversation, pre-compaction memory flush, and the standard configuration
+directory structure. This capability makes Netclaw a persistent, context-aware
+agent rather than a stateless chat endpoint.
+
+## Requirements
+
+### Requirement: Layered system prompt assembly
+
+The system SHALL assemble session context from ordered layers: PERSONALITY.md,
+INSTRUCTIONS.md, USER.md, project AGENTS.md overlay, and session-specific
+context. Later layers SHALL augment earlier layers. All soul files SHALL be
+loaded at session start and cached for the session lifetime.
+
+#### Scenario: Full layer assembly on session start
+
+- **GIVEN** soul files exist at `~/.netclaw/soul/PERSONALITY.md`,
+  `~/.netclaw/soul/INSTRUCTIONS.md`, and `~/.netclaw/soul/USER.md`
+- **WHEN** a new session starts
+- **THEN** the system prompt includes content from all three soul files in
+  layer order (personality, instructions, user)
+- **AND** session-specific context is appended after the soul layers
+
+#### Scenario: Project overlay loaded on demand
+
+- **GIVEN** a registered project has an `agents_md` path in the project registry
+- **WHEN** the session involves that project
+- **THEN** the project AGENTS.md content is included as a context overlay
+  between the user layer and session context layer
+
+#### Scenario: Missing soul file does not prevent session start
+
+- **GIVEN** one or more soul files do not exist on disk
+- **WHEN** a new session starts
+- **THEN** the system assembles the prompt from available layers
+- **AND** the missing layer is omitted without error
+
+### Requirement: Conversational personality bootstrap
+
+The system SHALL run a personality bootstrap conversation on first interaction
+when soul files do not exist. The bootstrap SHALL learn owner preferences,
+scan the environment, and write initial soul files to disk.
+
+#### Scenario: First-run bootstrap triggered
+
+- **GIVEN** no soul files exist at `~/.netclaw/soul/`
+- **WHEN** the first user message arrives
+- **THEN** the agent initiates a personality bootstrap conversation
+- **AND** the agent introduces itself and explains the setup process
+
+#### Scenario: Bootstrap writes soul files
+
+- **GIVEN** the personality bootstrap conversation completes
+- **WHEN** the agent has gathered owner name, preferences, and communication
+  style
+- **THEN** the agent writes PERSONALITY.md, INSTRUCTIONS.md, and USER.md to
+  `~/.netclaw/soul/`
+- **AND** the agent confirms readiness to the user
+
+#### Scenario: Bootstrap re-triggered via CLI
+
+- **GIVEN** soul files already exist
+- **WHEN** the operator runs `netclaw personality reset`
+- **THEN** the existing soul files are backed up
+- **AND** the next session triggers a fresh bootstrap conversation
+
+### Requirement: Project registry persistence
+
+The system SHALL persist registered projects as JSON on disk at
+`~/.netclaw/projects/registry.json`. Projects SHALL be registered and
+unregistered through conversation or CLI.
+
+#### Scenario: Register project through conversation
+
+- **GIVEN** the user asks the agent to register a project
+- **WHEN** the agent receives a valid project path and name
+- **THEN** the project is added to `registry.json`
+- **AND** the agent confirms the registration with project details
+
+#### Scenario: Project registry survives restart
+
+- **GIVEN** projects are registered in `registry.json`
+- **WHEN** the process restarts
+- **THEN** the project registry is loaded from disk
+- **AND** all previously registered projects are available in agent context
+
+#### Scenario: Invalid project path rejected
+
+- **GIVEN** the user asks to register a project
+- **WHEN** the provided path does not exist on disk
+- **THEN** the registration is rejected with an explanation
+
+### Requirement: Environment capability self-discovery
+
+The system SHALL scan for installed tools and capabilities at startup and
+on-demand. Discovered capabilities SHALL be persisted to
+`~/.netclaw/environment/inventory.json` and summarized in the system prompt.
+
+#### Scenario: Automatic scan at startup
+
+- **WHEN** the Netclaw process starts
+- **THEN** the system scans for installed CLIs (`git`, `gh`, `claude`,
+  `opencode`, `dotnet`, `node`)
+- **AND** checks git credential availability for remote hosts
+- **AND** checks MCP server reachability
+- **AND** persists results to `inventory.json`
+
+#### Scenario: On-demand rescan through conversation
+
+- **GIVEN** the agent is in an active session
+- **WHEN** the user asks the agent to rescan its environment
+- **THEN** the agent re-runs the environment scan
+- **AND** updates `inventory.json` with current results
+- **AND** reports changes since the last scan
+
+#### Scenario: Unavailable tool recorded accurately
+
+- **GIVEN** a tool (e.g., `claude`) is not installed
+- **WHEN** the environment scan runs
+- **THEN** the tool is recorded as `available: false` in the inventory
+- **AND** the agent does not attempt to use that tool in subsequent sessions
+
+### Requirement: Self-configuration through conversation
+
+The system SHALL allow the agent to modify its own configuration files through
+conversation within safety bounds. The agent MUST NOT modify ACL, security
+policy, tool grant policies, exposure mode, network configuration, or provider
+credentials through conversation.
+
+#### Scenario: Agent updates personality file
+
+- **GIVEN** the user asks the agent to adjust its personality
+- **WHEN** the agent proposes and the user confirms the change
+- **THEN** the agent validates the change
+- **AND** writes the updated file atomically (write to temp, rename)
+- **AND** reports that the change was saved
+- **AND** advises that a session reboot is needed for context refresh
+
+#### Scenario: Agent attempts to modify ACL
+
+- **GIVEN** the user asks the agent to update ACL rules through conversation
+- **WHEN** the agent evaluates the request
+- **THEN** the agent refuses the modification
+- **AND** explains that ACL changes require CLI or direct file edit by the
+  operator
+
+#### Scenario: Agent registers project through self-configuration
+
+- **GIVEN** the user describes a project to register
+- **WHEN** the agent has sufficient details (name, path)
+- **THEN** the agent adds the project to `registry.json`
+- **AND** validates the project path exists before writing
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** the agent proposes a configuration change
+- **WHEN** schema validation fails on the proposed change
+- **THEN** the change is not written to disk
+- **AND** the agent reports the validation failure to the user
+
+### Requirement: Pre-compaction memory flush
+
+The system SHALL trigger a silent agentic turn before context compaction to
+save durable memories. The flush SHALL complete before compaction proceeds.
+
+#### Scenario: Flush triggered before compaction
+
+- **GIVEN** session context approaches the compaction threshold
+- **WHEN** the system detects compaction is imminent
+- **THEN** the agent is prompted to save important context
+- **AND** the agent writes durable memories (Memorizer, local files)
+- **AND** compaction proceeds only after flush completes
+
+#### Scenario: Flush saves to external memory
+
+- **GIVEN** MCP Memorizer is configured and reachable
+- **WHEN** the pre-compaction flush runs
+- **THEN** the agent writes important findings to Memorizer
+- **AND** writes current task state summary to memory
+
+#### Scenario: Flush completes even when Memorizer unavailable
+
+- **GIVEN** MCP Memorizer is unreachable
+- **WHEN** the pre-compaction flush runs
+- **THEN** the agent saves available context to local files
+- **AND** compaction proceeds without blocking indefinitely
+
+### Requirement: Standard configuration directory
+
+The system SHALL use `~/.netclaw/` as the standard configuration directory
+with the following subdirectory structure: `soul/`, `projects/`, `environment/`,
+`schedules/`, and `config/`. The directory SHALL be created if it does not
+exist at startup.
+
+#### Scenario: Directory created on first startup
+
+- **GIVEN** the `~/.netclaw/` directory does not exist
+- **WHEN** the Netclaw process starts
+- **THEN** the system creates `~/.netclaw/` and all required subdirectories
+  (`soul/`, `projects/`, `environment/`, `schedules/`, `config/`)
+
+#### Scenario: Existing directory preserved
+
+- **GIVEN** `~/.netclaw/` already exists with files
+- **WHEN** the Netclaw process starts
+- **THEN** existing files are not overwritten or removed
+- **AND** any missing subdirectories are created
+
+#### Scenario: Configurable base path
+
+- **GIVEN** an alternative data directory is specified in configuration
+- **WHEN** the Netclaw process starts
+- **THEN** the system uses the configured path instead of `~/.netclaw/`
+- **AND** the same subdirectory structure is maintained

--- a/openspec/specs/netclaw-cli/spec.md
+++ b/openspec/specs/netclaw-cli/spec.md
@@ -197,3 +197,113 @@ conversation.
 - **WHEN** operator runs `netclaw personality reset`
 - **THEN** the CLI requires explicit confirmation before deleting personality
   files
+
+### Requirement: Cocona command routing
+
+The application SHALL use Cocona as the CLI command routing framework. All
+commands SHALL be routed through Cocona's convention-based command model with
+DI integration.
+
+#### Scenario: Command routed through Cocona
+
+- **WHEN** operator runs `netclaw <command> [args]`
+- **THEN** Cocona routes to the matching command class
+- **AND** DI-registered services are available to the command handler
+
+### Requirement: TUI command classification
+
+Commands SHALL be classified as either TUI-interactive (rendered via Termina)
+or plain-CLI (standard console output). Only `netclaw init` and `netclaw chat`
+SHALL use Termina TUI. All other commands SHALL use plain console output.
+
+#### Scenario: TUI command launches Termina
+
+- **WHEN** operator runs `netclaw chat` or `netclaw init`
+- **THEN** the command handler launches Termina as a hosted service
+- **AND** the TUI renders interactive components
+
+#### Scenario: Plain CLI command uses console output
+
+- **WHEN** operator runs `netclaw doctor` or any non-TUI command
+- **THEN** the command handler writes to standard output
+- **AND** no Termina TUI is launched
+
+### Requirement: Interactive chat command
+
+The CLI SHALL provide `netclaw chat` as an interactive agent prompt that hosts
+the full actor system in-process. The chat command SHALL use the TUI adapter
+to produce `SendUserMessage` commands with entity key `tui/{sessionId}`.
+
+#### Scenario: Start chat session
+
+- **WHEN** operator runs `netclaw chat`
+- **THEN** the actor system starts in-process
+- **AND** a TUI chat interface is rendered with input panel and message history
+- **AND** a new session with entity key `tui/{uuid}` is created
+
+#### Scenario: Send message in chat
+
+- **GIVEN** a chat session is active
+- **WHEN** operator types a message and presses Enter
+- **THEN** a `SendUserMessage` command is dispatched to the session parent
+- **AND** the response streams into the chat history via StreamingTextNode
+
+#### Scenario: Tool activity displayed inline
+
+- **GIVEN** a chat session is processing a turn with tool calls
+- **WHEN** tools are invoked during the turn
+- **THEN** a tool activity panel appears inline showing tool name, status, and
+  duration
+- **AND** completed tools show checkmark with duration
+- **AND** in-progress tools show spinner
+
+#### Scenario: MCP status displayed in status bar
+
+- **GIVEN** MCP servers are configured
+- **WHEN** the chat TUI is active
+- **THEN** the status bar shows MCP connectivity status
+- **AND** green indicates all servers connected
+- **AND** yellow indicates degraded connectivity
+- **AND** red indicates servers unreachable
+
+### Requirement: Daemon entry point
+
+The CLI SHALL provide `netclaw run` as the explicit daemon entry point. The
+daemon SHALL start the Slack Socket Mode adapter, Akka actor system, scheduled
+task timers, and health endpoints. The daemon SHALL NOT render a TUI.
+
+#### Scenario: Start daemon mode
+
+- **WHEN** operator runs `netclaw run`
+- **THEN** the Slack Socket Mode adapter connects
+- **AND** the Akka actor system starts
+- **AND** scheduled task timers are registered
+- **AND** health endpoints are available
+- **AND** no TUI is rendered
+
+#### Scenario: Daemon logs to console
+
+- **GIVEN** the daemon is running
+- **WHEN** events occur (messages, tool calls, errors)
+- **THEN** events are logged to console and/or configured log output
+- **AND** no interactive input is expected
+
+### Requirement: Doctor command
+
+The CLI SHALL provide `netclaw doctor` as a plain CLI command that runs startup
+checks and reports results with remediation guidance. The doctor command SHALL
+exit with code 0 (all pass), 1 (errors), or 2 (warnings only).
+
+#### Scenario: All checks pass
+
+- **WHEN** operator runs `netclaw doctor`
+- **AND** all startup checks pass
+- **THEN** output shows checkmarks for each check
+- **AND** exit code is 0
+
+#### Scenario: Check fails with remediation
+
+- **WHEN** operator runs `netclaw doctor`
+- **AND** a startup check fails
+- **THEN** output shows the failure with a remediation command
+- **AND** exit code is 1

--- a/openspec/specs/netclaw-cli/spec.md
+++ b/openspec/specs/netclaw-cli/spec.md
@@ -9,13 +9,45 @@ diagnostics.
 
 ### Requirement: Guided onboarding
 
-The CLI SHALL provide guided setup through `netclaw init`.
+The CLI SHALL provide guided setup through `netclaw init`. The onboarding
+wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
+PostgreSQL connection string, MCP server configuration, and exposure mode
+selection. On completion, the wizard SHALL run a health check to verify the
+baseline configuration is functional.
 
 #### Scenario: First-time setup
 
 - **WHEN** operator runs `netclaw init` on a fresh install
-- **THEN** guided setup collects Slack, provider, and ACL inputs
+- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
+  exposure mode inputs
 - **AND** writes a runnable baseline configuration
+
+#### Scenario: PostgreSQL connection configured during init
+
+- **WHEN** onboarding reaches the persistence step
+- **THEN** the wizard prompts for a PostgreSQL connection string
+- **AND** validates connectivity before proceeding
+
+#### Scenario: MCP server configured during init
+
+- **WHEN** onboarding reaches the MCP step
+- **THEN** the wizard prompts for at least one MCP server profile (Memorizer
+  recommended)
+- **AND** validates server handshake before proceeding
+
+#### Scenario: Exposure mode selected during init
+
+- **WHEN** onboarding reaches the exposure step
+- **THEN** the wizard presents available exposure modes (local, tailscale-serve,
+  tailscale-funnel, cloudflare-tunnel)
+- **AND** applies security warnings for public modes
+
+#### Scenario: Health check on completion
+
+- **WHEN** onboarding completes all steps
+- **THEN** the wizard runs a health check covering Slack connectivity, provider
+  validation, persistence connectivity, and MCP server reachability
+- **AND** reports pass/fail for each component
 
 ### Requirement: Resumable onboarding
 
@@ -55,3 +87,113 @@ The CLI SHALL expose an explicit smoke-test command for live provider checks.
 - **WHEN** operator runs `netclaw test smoke --provider ollama`
 - **THEN** CLI executes provider connectivity smoke checks
 - **AND** outputs a concise pass/fail report
+
+### Requirement: Project management commands
+
+The CLI SHALL provide `netclaw project list|add|remove` commands for managing
+the project registry. Projects represent registered repositories with their
+paths, capabilities, and associated AGENTS.md files.
+
+#### Scenario: List registered projects
+
+- **WHEN** operator runs `netclaw project list`
+- **THEN** output displays all registered projects with paths and capabilities
+
+#### Scenario: Add a project
+
+- **WHEN** operator runs `netclaw project add --path /home/user/repos/myproject`
+- **THEN** the project is added to the project registry
+- **AND** the system scans for an AGENTS.md file in the project root
+
+#### Scenario: Remove a project
+
+- **GIVEN** a project is registered
+- **WHEN** operator runs `netclaw project remove myproject`
+- **THEN** the project is removed from the registry
+
+### Requirement: Environment discovery command
+
+The CLI SHALL provide `netclaw environment scan|show` commands for discovering
+and displaying the capability inventory of the host environment.
+
+#### Scenario: Scan environment
+
+- **WHEN** operator runs `netclaw environment scan`
+- **THEN** the system discovers installed tools (git, gh, claude, opencode,
+  dotnet), git credentials, MCP server reachability, and host capabilities
+- **AND** writes the inventory to the environment inventory file
+
+#### Scenario: Show environment
+
+- **WHEN** operator runs `netclaw environment show`
+- **THEN** output displays the current environment inventory with tool
+  availability, credential status, and capability details
+
+### Requirement: Memory display command
+
+The CLI SHALL provide `netclaw memory show` for displaying the contents of
+agent memory files (personality, project registry, environment inventory).
+
+#### Scenario: Show agent memory
+
+- **WHEN** operator runs `netclaw memory show`
+- **THEN** output displays the contents of personality files, project registry,
+  and environment inventory in a readable format
+
+#### Scenario: Show specific memory category
+
+- **WHEN** operator runs `netclaw memory show --category personality`
+- **THEN** output displays only the personality/soul files
+
+### Requirement: Schedule management commands
+
+The CLI SHALL provide `netclaw schedule list|show|pause|resume|delete` commands
+for managing scheduled tasks.
+
+#### Scenario: List scheduled tasks
+
+- **WHEN** operator runs `netclaw schedule list`
+- **THEN** output displays all scheduled tasks with name, schedule, status, and
+  last execution result
+
+#### Scenario: Show scheduled task details
+
+- **WHEN** operator runs `netclaw schedule show my-task`
+- **THEN** output displays the full task definition including schedule, required
+  tool grants, instructions, and execution history
+
+#### Scenario: Pause a scheduled task
+
+- **GIVEN** a scheduled task is active
+- **WHEN** operator runs `netclaw schedule pause my-task`
+- **THEN** the task is paused and will not execute until resumed
+
+#### Scenario: Resume a paused task
+
+- **GIVEN** a scheduled task is paused
+- **WHEN** operator runs `netclaw schedule resume my-task`
+- **THEN** the task is reactivated and will execute on its next scheduled time
+
+#### Scenario: Delete a scheduled task
+
+- **GIVEN** a scheduled task exists
+- **WHEN** operator runs `netclaw schedule delete my-task`
+- **THEN** the task is permanently removed from the schedule registry
+
+### Requirement: Personality reset command
+
+The CLI SHALL provide `netclaw personality reset` to delete existing personality
+files and re-trigger the conversational personality bootstrap on the next
+conversation.
+
+#### Scenario: Reset personality
+
+- **WHEN** operator runs `netclaw personality reset`
+- **THEN** existing personality/soul files are deleted
+- **AND** the next conversation triggers the conversational personality bootstrap
+
+#### Scenario: Reset confirmation
+
+- **WHEN** operator runs `netclaw personality reset`
+- **THEN** the CLI requires explicit confirmation before deleting personality
+  files

--- a/openspec/specs/netclaw-config-hot-reload/spec.md
+++ b/openspec/specs/netclaw-config-hot-reload/spec.md
@@ -1,0 +1,131 @@
+# netclaw-config-hot-reload Specification
+
+## Purpose
+
+Define hot-reload behavior for operational configuration files. The system
+monitors ACL rules, provider configuration, MCP server profiles, and schedule
+definitions for changes and applies them to the runtime without process restart.
+
+## Requirements
+
+### Requirement: Operational config file monitoring
+
+The system SHALL monitor operational configuration files for changes using
+`FileSystemWatcher`. Monitored files SHALL include ACL rules, provider
+configuration, MCP server profiles, and schedule definitions.
+
+#### Scenario: ACL file change detected
+
+- **GIVEN** the ACL rules file exists at the configured path
+- **WHEN** the file is modified on disk
+- **THEN** the `ConfigWatcherService` detects the change within 500ms
+
+#### Scenario: Provider config change detected
+
+- **GIVEN** the provider configuration file exists at the configured path
+- **WHEN** the file is modified on disk
+- **THEN** the `ConfigWatcherService` detects the change within 500ms
+
+#### Scenario: Unwatched files are not monitored
+
+- **GIVEN** personality files, project registry, or environment inventory files
+  exist
+- **WHEN** those files are modified on disk
+- **THEN** the `ConfigWatcherService` does NOT detect or process the change
+
+### Requirement: Change event debounce
+
+The system SHALL debounce file change events with a configurable window
+(default 500ms) to prevent rapid-fire reloads during file save operations.
+
+#### Scenario: Rapid successive writes debounced
+
+- **GIVEN** a watched config file is being saved
+- **WHEN** the file system emits multiple change events within 500ms
+- **THEN** the system processes only one reload after the debounce window
+
+#### Scenario: Separate files reload independently
+
+- **GIVEN** ACL rules and provider config are both watched
+- **WHEN** both files change within the debounce window
+- **THEN** each file's change is processed independently after its own debounce
+
+### Requirement: Validate before apply
+
+The system SHALL validate changed configuration before applying it to the
+runtime. Invalid configuration SHALL be rejected with logged diagnostics.
+The previous valid configuration SHALL remain in effect.
+
+#### Scenario: Valid config change applied
+
+- **GIVEN** a watched config file changes
+- **WHEN** the new content passes validation
+- **THEN** the change is applied to the runtime
+- **AND** owning actors are notified
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** a watched config file changes
+- **WHEN** the new content fails validation
+- **THEN** the change is NOT applied
+- **AND** the previous valid configuration remains in effect
+- **AND** validation errors are logged with file path and error details
+
+#### Scenario: Config file deleted
+
+- **GIVEN** a watched config file is being monitored
+- **WHEN** the file is deleted from disk
+- **THEN** the system logs a warning
+- **AND** the existing runtime configuration remains in effect
+- **AND** the process does NOT crash
+
+### Requirement: Actor notification on config change
+
+The system SHALL notify owning actors when their configuration changes via
+Akka pub/sub. Each config domain SHALL map to a specific actor or service.
+
+#### Scenario: ACL change triggers policy refresh
+
+- **GIVEN** the ACL rules file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the policy engine re-evaluates tool grants for active sessions
+
+#### Scenario: Provider change triggers IChatClient rebuild
+
+- **GIVEN** the provider configuration file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the provider factory rebuilds `IChatClient` instances
+
+#### Scenario: MCP profile change triggers server reconnection
+
+- **GIVEN** an MCP server profile has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** affected MCP servers are reconnected or disconnected as appropriate
+
+#### Scenario: Schedule change triggers timer reconfiguration
+
+- **GIVEN** the schedule definitions file has been validated successfully
+- **WHEN** the config watcher dispatches the change event
+- **THEN** the `ScheduleManagerActor` reconfigures timers to match the new
+  definitions
+
+### Requirement: ConfigWatcherService hosted service
+
+The `ConfigWatcherService` SHALL be implemented as an `IHostedService` that
+starts with the application and stops on shutdown. It SHALL manage
+`FileSystemWatcher` instances for each watched config file.
+
+#### Scenario: Service starts with application
+
+- **GIVEN** the application is starting
+- **WHEN** the hosted service initializes
+- **THEN** `FileSystemWatcher` instances are created for each watched config
+  file
+- **AND** the service begins monitoring for changes
+
+#### Scenario: Service stops on shutdown
+
+- **GIVEN** the application is shutting down
+- **WHEN** the hosted service stops
+- **THEN** all `FileSystemWatcher` instances are disposed
+- **AND** no further change events are processed

--- a/openspec/specs/netclaw-gateway-security/spec.md
+++ b/openspec/specs/netclaw-gateway-security/spec.md
@@ -58,3 +58,93 @@ The system SHALL expose policy denies and exposure status in diagnostics.
 
 - **WHEN** policy allow/deny decisions occur
 - **THEN** diagnostics include timestamped records with reason codes
+
+### Requirement: Self-configuration safety (SEC-008)
+
+The system SHALL validate configuration changes before writing them to disk.
+ACL and security policy files MUST NOT be self-modifiable by the agent. The
+agent SHALL be permitted to modify personality files, project registry,
+environment inventory, and schedule definitions through conversation.
+
+#### Scenario: Agent modifies permitted configuration
+
+- **GIVEN** the agent has `config_write` grant
+- **WHEN** the agent writes to a personality file or project registry
+- **THEN** the change is validated against schema before write
+- **AND** the write succeeds if validation passes
+
+#### Scenario: Agent blocked from modifying security files
+
+- **WHEN** the agent attempts to modify ACL, security policy, or gateway
+  configuration files
+- **THEN** the write is rejected regardless of grants
+- **AND** an audit record is created for the denied attempt
+
+#### Scenario: Invalid config change rejected
+
+- **GIVEN** the agent has `config_write` grant
+- **WHEN** the agent writes configuration that fails schema validation
+- **THEN** the write is rejected
+- **AND** the agent receives validation error details
+
+### Requirement: Shell execution boundaries (SEC-009)
+
+The system SHALL enforce safety boundaries on shell command execution. Shell
+commands SHALL run as the process user with no privilege escalation. A
+configurable timeout (default 60 seconds) SHALL terminate long-running
+commands. Output SHALL be truncated at a configurable limit. Interactive
+commands (those requiring stdin) SHALL be rejected. Working directory SHALL be
+restricted to configured allowed paths.
+
+#### Scenario: Shell command completes within timeout
+
+- **GIVEN** shell execution timeout is configured to 60 seconds
+- **WHEN** a shell command completes in 10 seconds
+- **THEN** the output is returned to the session
+
+#### Scenario: Shell command exceeds timeout
+
+- **GIVEN** shell execution timeout is configured to 60 seconds
+- **WHEN** a shell command runs for more than 60 seconds
+- **THEN** the process is terminated
+- **AND** the session receives a timeout error
+
+#### Scenario: Interactive command rejected
+
+- **WHEN** a shell command requires interactive stdin input
+- **THEN** execution is rejected before launch
+- **AND** the session receives a rejection reason
+
+#### Scenario: Output truncation
+
+- **GIVEN** output truncation limit is configured
+- **WHEN** shell command output exceeds the configured limit
+- **THEN** output is truncated with an indicator that content was omitted
+
+#### Scenario: Working directory restriction
+
+- **WHEN** a shell command targets a directory outside configured allowed paths
+- **THEN** execution is denied with a policy reason code
+
+### Requirement: Tool invocation audit
+
+The system SHALL create audit records for all tool invocations. Each audit
+record SHALL include: tool name, session ID, timestamp, and allow/deny result.
+
+#### Scenario: Allowed tool invocation is audited
+
+- **WHEN** a tool invocation is allowed by policy
+- **THEN** an audit record is created with tool name, session ID, timestamp, and
+  result `allow`
+
+#### Scenario: Denied tool invocation is audited
+
+- **WHEN** a tool invocation is denied by policy
+- **THEN** an audit record is created with tool name, session ID, timestamp, and
+  result `deny` with reason code
+
+#### Scenario: Audit records visible in diagnostics
+
+- **WHEN** operator queries tool invocation audit
+- **THEN** records are available with filtering by session ID, tool name, and
+  time range

--- a/openspec/specs/netclaw-input-adapters/spec.md
+++ b/openspec/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,194 @@
+# netclaw-input-adapters Specification
+
+## Purpose
+
+Define the unified input adapter architecture that treats all message sources
+identically. All inputs produce a `SendUserMessage` command routed to the
+session parent actor. This capability covers transport-agnostic session
+commands, source metadata, entity key routing, broadcast subscription for
+reply delivery, the Slack Socket Mode adapter, and the internal timer adapter.
+
+## Requirements
+
+### Requirement: Transport-agnostic session commands
+
+All input adapters SHALL produce `SendUserMessage` as the universal command
+contract for delivering input to session actors. Session actors SHALL never
+reference adapter-specific types. The `SendUserMessage` command and broadcast
+events SHALL be the only contract between adapters and session actors.
+
+#### Scenario: Slack adapter produces SendUserMessage
+
+- **GIVEN** a Slack `app_mention` event is received
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the message content, entity key, and source
+  metadata
+
+#### Scenario: Timer adapter produces SendUserMessage
+
+- **GIVEN** an Akka timer fires for a scheduled task
+- **WHEN** the timer adapter processes the tick
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the task instruction as message content
+
+#### Scenario: Session actor is adapter-agnostic
+
+- **GIVEN** a session actor receives a `SendUserMessage` command
+- **WHEN** the session processes the turn
+- **THEN** the session actor does not import or reference any adapter-specific
+  types
+- **AND** the session behavior is identical regardless of the originating
+  adapter
+
+### Requirement: Source metadata on all commands
+
+All inbound `SendUserMessage` commands SHALL carry source metadata sufficient
+for ACL evaluation and audit logging. Source metadata SHALL include adapter
+type, sender identity, channel identifier, and timestamp.
+
+#### Scenario: Slack source metadata populated
+
+- **GIVEN** a Slack message event is received
+- **WHEN** the Slack adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `slack`
+- **AND** includes the Slack user ID as sender identity
+- **AND** includes the Slack channel ID
+- **AND** includes the event timestamp
+
+#### Scenario: Timer source metadata populated
+
+- **GIVEN** an Akka timer fires for a scheduled task
+- **WHEN** the timer adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `timer`
+- **AND** includes the task creator as sender identity
+- **AND** includes the task ID as the channel equivalent
+- **AND** includes the timer fire timestamp
+
+#### Scenario: ACL uses source metadata for evaluation
+
+- **GIVEN** a `SendUserMessage` command arrives with source metadata
+- **WHEN** the ACL gate evaluates the command
+- **THEN** the evaluation uses the sender identity from source metadata
+- **AND** the evaluation uses the channel identifier from source metadata
+
+### Requirement: Entity key routing
+
+The session parent actor SHALL extract an entity key from each
+`SendUserMessage` command and route to the correct child session actor. Slack
+messages SHALL use entity key pattern `{channelId}/{threadTs}`. Timer
+messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`.
+
+#### Scenario: Slack message routed by thread identity
+
+- **GIVEN** a Slack message arrives from channel `C0123` in thread `T456`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `C0123/T456`
+- **AND** the command is routed to the session actor for that key
+
+#### Scenario: Timer message routed by task and run identity
+
+- **GIVEN** a timer fires for task `ebay-check` at timestamp `1708531200`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `schedule/ebay-check/1708531200`
+- **AND** a new session actor is created for that entity key
+
+#### Scenario: Repeated messages in same thread route to same actor
+
+- **GIVEN** a session actor exists for entity key `C0123/T456`
+- **WHEN** another message arrives in the same Slack thread
+- **THEN** the message is routed to the existing session actor
+- **AND** no new session actor is created
+
+### Requirement: Broadcast subscription for reply delivery
+
+Input adapters SHALL subscribe to session broadcast events to deliver replies
+back through the originating channel. Adapters SHALL consume broadcast events
+through pub/sub without direct transport coupling to session actors.
+
+#### Scenario: Slack adapter receives reply broadcast
+
+- **GIVEN** the Slack adapter is subscribed to session broadcasts
+- **WHEN** a session actor emits a turn broadcast with a reply
+- **THEN** the Slack adapter receives the broadcast
+- **AND** delivers the reply to the originating Slack thread
+
+#### Scenario: Timer result broadcast consumed by Slack adapter
+
+- **GIVEN** a scheduled task session completes with results
+- **WHEN** the session emits a result broadcast
+- **THEN** the Slack adapter receives the broadcast
+- **AND** posts the results to the task's configured reporting channel
+
+#### Scenario: Multiple adapters can subscribe to same session
+
+- **GIVEN** both a Slack adapter and a future UI adapter are running
+- **WHEN** a session emits a broadcast
+- **THEN** both adapters receive the broadcast independently
+- **AND** each adapter delivers through its own channel
+
+### Requirement: Slack Socket Mode adapter
+
+The Slack adapter SHALL connect via Slack Socket Mode, handle `app_mention`
+events, dispatch `SendUserMessage` commands to the session parent, and
+deliver reply broadcasts back to the originating Slack thread.
+
+#### Scenario: Socket Mode connection established at startup
+
+- **GIVEN** valid Slack app and bot tokens are configured
+- **WHEN** Netclaw starts
+- **THEN** the Slack adapter opens a Socket Mode connection
+- **AND** reports connection health in operator diagnostics
+
+#### Scenario: App mention event dispatched as session command
+
+- **GIVEN** the Slack adapter is connected
+- **WHEN** an `app_mention` event is received from an allowed channel
+- **THEN** the adapter extracts entity key `{channelId}/{threadTs}`
+- **AND** creates a `SendUserMessage` with the message text, entity key, and
+  Slack source metadata
+- **AND** routes the command to the session parent actor
+
+#### Scenario: Reply delivered to originating thread
+
+- **GIVEN** a session processes a turn from a Slack message
+- **WHEN** the session emits a reply broadcast
+- **THEN** the Slack adapter posts the reply in the same thread
+- **AND** uses the Slack bot token for the API call
+
+#### Scenario: Socket Mode reconnects on disconnect
+
+- **GIVEN** the Slack Socket Mode connection drops
+- **WHEN** the adapter detects the disconnection
+- **THEN** the adapter attempts to reconnect
+- **AND** logs the disconnection and reconnection events
+
+### Requirement: Internal timer adapter
+
+The timer adapter SHALL fire on Akka timer ticks for scheduled tasks, create
+`SendUserMessage` commands with the task instruction as content, and use entity
+key pattern `schedule/{taskId}/{runTs}`. Each timer fire SHALL create a fresh
+session for isolated execution.
+
+#### Scenario: Timer fires for active scheduled task
+
+- **GIVEN** an active scheduled task has a timer registered
+- **WHEN** the Akka timer fires
+- **THEN** the timer adapter creates a `SendUserMessage` command
+- **AND** the message content is the task's instruction prompt
+- **AND** the entity key is `schedule/{taskId}/{runTs}`
+
+#### Scenario: Fresh session created per timer execution
+
+- **GIVEN** a timer fires for task `daily-report`
+- **WHEN** the timer adapter dispatches the command
+- **THEN** a new session actor is created for the unique entity key
+- **AND** the session loads the agent personality from soul files
+- **AND** the session does not reuse any previous execution's state
+
+#### Scenario: Timer adapter does not fire for paused tasks
+
+- **GIVEN** a scheduled task is in `paused` status
+- **WHEN** the system checks for timer scheduling
+- **THEN** no timer is registered for the paused task
+- **AND** no `SendUserMessage` command is produced

--- a/openspec/specs/netclaw-input-adapters/spec.md
+++ b/openspec/specs/netclaw-input-adapters/spec.md
@@ -77,7 +77,8 @@ type, sender identity, channel identifier, and timestamp.
 The session parent actor SHALL extract an entity key from each
 `SendUserMessage` command and route to the correct child session actor. Slack
 messages SHALL use entity key pattern `{channelId}/{threadTs}`. Timer
-messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`.
+messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`. TUI
+messages SHALL use entity key pattern `tui/{sessionId}`.
 
 #### Scenario: Slack message routed by thread identity
 
@@ -93,12 +94,25 @@ messages SHALL use entity key pattern `schedule/{taskId}/{runTs}`.
 - **THEN** the entity key is `schedule/ebay-check/1708531200`
 - **AND** a new session actor is created for that entity key
 
+#### Scenario: TUI message routed by session identity
+
+- **GIVEN** a TUI message arrives with session ID `a1b2c3`
+- **WHEN** the session parent extracts the entity key
+- **THEN** the entity key is `tui/a1b2c3`
+- **AND** the command is routed to the session actor for that key
+
 #### Scenario: Repeated messages in same thread route to same actor
 
 - **GIVEN** a session actor exists for entity key `C0123/T456`
 - **WHEN** another message arrives in the same Slack thread
 - **THEN** the message is routed to the existing session actor
 - **AND** no new session actor is created
+
+#### Scenario: Repeated TUI messages route to same actor
+
+- **GIVEN** a session actor exists for entity key `tui/a1b2c3`
+- **WHEN** the operator sends another message in the same chat session
+- **THEN** the message is routed to the existing session actor
 
 ### Requirement: Broadcast subscription for reply delivery
 
@@ -192,3 +206,50 @@ session for isolated execution.
 - **WHEN** the system checks for timer scheduling
 - **THEN** no timer is registered for the paused task
 - **AND** no `SendUserMessage` command is produced
+
+### Requirement: TUI input adapter
+
+The TUI adapter SHALL receive keyboard input via Termina TextInputNode, produce
+`SendUserMessage` commands with entity key `tui/{sessionId}`, subscribe to
+session broadcasts, and render responses as streaming text. The TUI adapter
+SHALL be a Phase 1 input source.
+
+#### Scenario: TUI adapter produces SendUserMessage
+
+- **GIVEN** the operator is in a `netclaw chat` session
+- **WHEN** the operator types a message and presses Enter
+- **THEN** the TUI adapter produces a `SendUserMessage` command
+- **AND** the command contains the message content, entity key `tui/{sessionId}`,
+  and source metadata with adapter type `tui`
+
+#### Scenario: TUI adapter renders streaming response
+
+- **GIVEN** a session actor is processing a turn from the TUI adapter
+- **WHEN** the session emits token-level broadcast events
+- **THEN** the TUI adapter renders tokens in real-time via StreamingTextNode
+- **AND** the response appears incrementally in the chat history
+
+#### Scenario: TUI adapter displays tool invocation status
+
+- **GIVEN** a session is executing tool calls
+- **WHEN** a tool invocation starts
+- **THEN** the TUI adapter displays an inline tool activity panel
+- **AND** shows the tool name with a spinner indicator
+- **WHEN** the tool invocation completes
+- **THEN** the spinner is replaced with a checkmark and duration
+
+#### Scenario: TUI adapter subscribes to session broadcasts
+
+- **GIVEN** the TUI adapter has sent a `SendUserMessage` command
+- **WHEN** the session actor emits a `TurnBroadcast` event
+- **THEN** the TUI adapter receives the broadcast
+- **AND** renders the response content in the chat history
+
+#### Scenario: TUI source metadata populated
+
+- **GIVEN** the operator sends a message via `netclaw chat`
+- **WHEN** the TUI adapter creates the `SendUserMessage` command
+- **THEN** the source metadata includes adapter type `tui`
+- **AND** includes `local-operator` as sender identity
+- **AND** includes the session ID as channel identifier
+- **AND** includes the current timestamp

--- a/openspec/specs/netclaw-mcp/spec.md
+++ b/openspec/specs/netclaw-mcp/spec.md
@@ -8,12 +8,35 @@ Define MCP server integration, validation, policy enforcement, and diagnostics.
 
 ### Requirement: MCP server profile configuration
 
-The system SHALL support named MCP server profiles in configuration.
+The system SHALL support named MCP server profiles in configuration. Each
+profile SHALL specify a transport type (`stdio` or `SSE`), the command or URL
+for the server, and optional environment variables to pass to the server
+process.
 
 #### Scenario: Disabled by default
 
 - **WHEN** no MCP profile is enabled
 - **THEN** no MCP tools are loaded
+
+#### Scenario: Stdio transport profile
+
+- **GIVEN** an MCP profile is configured with transport type `stdio`
+- **WHEN** the profile is loaded
+- **THEN** the system launches the server using the configured command
+- **AND** communicates via stdio transport
+
+#### Scenario: SSE transport profile
+
+- **GIVEN** an MCP profile is configured with transport type `SSE`
+- **WHEN** the profile is loaded
+- **THEN** the system connects to the configured URL via SSE transport
+
+#### Scenario: Environment variables passed to server
+
+- **GIVEN** an MCP profile specifies environment variables
+- **WHEN** the server process is launched (stdio transport)
+- **THEN** the configured environment variables are set in the server process
+  environment
 
 ### Requirement: MCP validation
 
@@ -41,3 +64,71 @@ The system SHALL expose MCP server health in diagnostics.
 
 - **WHEN** a configured MCP server is unreachable
 - **THEN** diagnostics mark it degraded or unavailable with last error timestamp
+
+### Requirement: Memorizer as external memory tier
+
+The Memorizer MCP server SHALL be the recommended first MCP server for Netclaw
+deployments. Memorizer provides `store`, `search`, `get`, `delete`, and
+`create_relationship` operations for persisting research findings and
+cross-session learning. Memorizer is an external memory tier complementing
+first-party local memory (personality, project registry, environment inventory).
+
+#### Scenario: Store research finding via Memorizer
+
+- **GIVEN** the `memorizer` MCP server is configured and reachable
+- **AND** the session has `mcp:memorizer` grant
+- **WHEN** the agent stores a research finding
+- **THEN** the finding is persisted in Memorizer and retrievable in future
+  sessions
+
+#### Scenario: Search across sessions via Memorizer
+
+- **GIVEN** prior sessions have stored findings in Memorizer
+- **WHEN** the agent searches Memorizer for a topic
+- **THEN** relevant findings from prior sessions are returned
+
+### Requirement: Tool discovery and registration
+
+On startup, the system SHALL discover tools from all enabled MCP server
+profiles and register them as Microsoft.Extensions.AI (MEAI) tool definitions.
+Tool discovery SHALL refresh on each session start to pick up newly added or
+removed tools from MCP servers.
+
+#### Scenario: Startup tool discovery
+
+- **GIVEN** two MCP servers are enabled with a combined total of 5 tools
+- **WHEN** the system starts
+- **THEN** all 5 tools are discovered and registered as MEAI tool definitions
+
+#### Scenario: Session-start tool refresh
+
+- **GIVEN** an MCP server has added a new tool since last session start
+- **WHEN** a new session actor initializes
+- **THEN** the refreshed tool list includes the newly added tool
+
+### Requirement: Graceful degradation
+
+Tool calls to unavailable MCP servers SHALL return a clear error message to the
+agent. The agent SHALL continue operating with remaining available tools. The
+system SHALL attempt reconnection on the next tool call to a previously
+unavailable server.
+
+#### Scenario: Unavailable server returns clear error
+
+- **GIVEN** a configured MCP server is unreachable
+- **WHEN** the agent invokes a tool from that server
+- **THEN** a clear error is returned indicating the server is unavailable
+- **AND** the agent continues the conversation with remaining tools
+
+#### Scenario: Reconnection on next call
+
+- **GIVEN** an MCP server was previously unreachable
+- **WHEN** the agent invokes a tool from that server again
+- **THEN** the system attempts reconnection before returning an error
+
+#### Scenario: Partial server availability
+
+- **GIVEN** two MCP servers are configured and one is unreachable
+- **WHEN** a session initializes
+- **THEN** tools from the reachable server are available
+- **AND** tools from the unreachable server are marked as unavailable

--- a/openspec/specs/netclaw-model-providers/spec.md
+++ b/openspec/specs/netclaw-model-providers/spec.md
@@ -18,12 +18,23 @@ The system SHALL default to OpenRouter during first-run setup.
 ### Requirement: Multi-provider support
 
 The system SHALL support selecting one provider profile from a supported set.
+All provider interactions SHALL use the Microsoft.Extensions.AI `IChatClient`
+abstraction layer, ensuring provider-agnostic model access throughout the
+application.
 
 #### Scenario: Switch provider
 
 - **GIVEN** OpenRouter is configured
 - **WHEN** operator selects Anthropic, OpenAI, or Ollama profile
-- **THEN** runtime uses selected provider after validation
+- **THEN** runtime uses selected provider through the `IChatClient` interface
+  after validation
+
+#### Scenario: Provider accessed through MEAI abstraction
+
+- **GIVEN** a provider profile is configured
+- **WHEN** the session actor sends a chat completion request
+- **THEN** the request is routed through the `IChatClient` abstraction
+- **AND** no provider-specific types leak into session or actor code
 
 ### Requirement: Optional live smoke provider checks
 
@@ -69,3 +80,51 @@ The system SHALL expose current provider and model in diagnostics.
 
 - **WHEN** operator checks status
 - **THEN** diagnostics include provider name, model, and last error state
+
+### Requirement: Primary and fallback model
+
+The system SHALL support configuring both a primary model and a fallback model.
+When the primary model is unavailable due to rate limiting, timeout, or error,
+the system SHALL automatically switch to the fallback model. Fallback activation
+SHALL be logged for operator visibility.
+
+#### Scenario: Primary model succeeds
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** the primary model responds successfully
+- **THEN** the primary model response is used
+- **AND** no fallback activation occurs
+
+#### Scenario: Automatic fallback on primary failure
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** the primary model returns a rate limit, timeout, or error response
+- **THEN** the system retries the request using the fallback model
+- **AND** a log entry records the fallback activation with the failure reason
+
+#### Scenario: Fallback model also fails
+
+- **GIVEN** both primary and fallback models are configured
+- **WHEN** both primary and fallback models fail
+- **THEN** the session receives an error indicating model unavailability
+- **AND** the error is logged with details from both failures
+
+### Requirement: Tool calling support
+
+Tool definitions SHALL be registered through the Microsoft.Extensions.AI tool
+calling API. Tool metadata SHALL be included in the system prompt so the model
+is aware of available tools and their capabilities.
+
+#### Scenario: Tools registered through MEAI API
+
+- **GIVEN** tools are discovered from MCP servers and first-party tool providers
+- **WHEN** a session is initialized
+- **THEN** tool definitions are registered through the MEAI tool calling API
+- **AND** the model can invoke tools through the standard MEAI tool call flow
+
+#### Scenario: Tool metadata in system prompt
+
+- **GIVEN** tools are registered for a session
+- **WHEN** the system prompt is assembled
+- **THEN** tool metadata (names, descriptions, parameter schemas) is included
+  in the prompt context

--- a/openspec/specs/netclaw-onboarding/spec.md
+++ b/openspec/specs/netclaw-onboarding/spec.md
@@ -79,15 +79,15 @@ baseline configuration is functional.
 ### Requirement: Phase 2 conversational personality bootstrap
 
 The system SHALL trigger a conversational personality bootstrap on the first
-conversation if personality files (PERSONALITY.md, INSTRUCTIONS.md, USER.md)
-do not exist. The bootstrap conversation SHALL ask the operator about
+`netclaw chat` session if personality files (PERSONALITY.md, INSTRUCTIONS.md,
+USER.md) do not exist. The bootstrap conversation SHALL ask the operator about
 communication preferences, tone, name preferences, and working style, then
 write the resulting soul files to the standard config directory.
 
 #### Scenario: First conversation triggers bootstrap
 
 - **GIVEN** no personality files exist in the config directory
-- **WHEN** the operator starts their first conversation with Netclaw
+- **WHEN** the operator starts their first `netclaw chat` session
 - **THEN** the agent initiates a personality bootstrap conversation
 - **AND** asks about communication preferences and working style
 
@@ -143,3 +143,37 @@ with their paths, capabilities, and AGENTS.md locations.
 - **WHEN** Phase 2 onboarding reaches the project registration step
 - **AND** the operator indicates no projects to register
 - **THEN** onboarding proceeds with an empty project registry
+
+### Requirement: TUI wizard delivery mechanism
+
+The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI
+as an interactive 7-step wizard with progress indication, validation, and
+back-navigation.
+
+#### Scenario: Wizard renders in TUI
+
+- **WHEN** operator runs `netclaw init`
+- **THEN** a Termina TUI application launches
+- **AND** the wizard displays step progress (e.g., "Step 2 of 7")
+- **AND** the wizard displays a progress bar
+
+#### Scenario: Step-specific components rendered
+
+- **GIVEN** the wizard is on a step requiring text input
+- **WHEN** the step is displayed
+- **THEN** the wizard renders TextInputNode components for text/secret fields
+- **AND** renders SelectionListNode components for choice fields
+
+#### Scenario: Back navigation between steps
+
+- **GIVEN** the wizard is on step 3
+- **WHEN** the operator presses Esc
+- **THEN** the wizard navigates back to step 2
+- **AND** previous input values are preserved
+
+#### Scenario: Live validation during wizard
+
+- **GIVEN** the wizard is on the PostgreSQL step
+- **WHEN** the operator enters a connection string
+- **THEN** the wizard validates connectivity with a SpinnerNode
+- **AND** displays success or failure before allowing progression

--- a/openspec/specs/netclaw-onboarding/spec.md
+++ b/openspec/specs/netclaw-onboarding/spec.md
@@ -33,3 +33,113 @@ The system SHALL show explicit warnings before enabling public exposure modes.
 
 - **WHEN** operator selects `tailscale-funnel`
 - **THEN** onboarding requires explicit confirmation and auth policy validation
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init`. The onboarding
+wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
+PostgreSQL connection string, MCP server configuration, and exposure mode
+selection. On completion, the wizard SHALL run a health check to verify the
+baseline configuration is functional.
+
+#### Scenario: First-time setup
+
+- **WHEN** operator runs `netclaw init` on a fresh install
+- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
+  exposure mode inputs
+- **AND** writes a runnable baseline configuration
+
+#### Scenario: PostgreSQL connection configured during init
+
+- **WHEN** onboarding reaches the persistence step
+- **THEN** the wizard prompts for a PostgreSQL connection string
+- **AND** validates connectivity before proceeding
+
+#### Scenario: MCP server configured during init
+
+- **WHEN** onboarding reaches the MCP step
+- **THEN** the wizard prompts for at least one MCP server profile (Memorizer
+  recommended)
+- **AND** validates server handshake before proceeding
+
+#### Scenario: Exposure mode selected during init
+
+- **WHEN** onboarding reaches the exposure step
+- **THEN** the wizard presents available exposure modes (local, tailscale-serve,
+  tailscale-funnel, cloudflare-tunnel)
+- **AND** applies security warnings for public modes
+
+#### Scenario: Health check on completion
+
+- **WHEN** onboarding completes all steps
+- **THEN** the wizard runs a health check covering Slack connectivity, provider
+  validation, persistence connectivity, and MCP server reachability
+- **AND** reports pass/fail for each component
+
+### Requirement: Phase 2 conversational personality bootstrap
+
+The system SHALL trigger a conversational personality bootstrap on the first
+conversation if personality files (PERSONALITY.md, INSTRUCTIONS.md, USER.md)
+do not exist. The bootstrap conversation SHALL ask the operator about
+communication preferences, tone, name preferences, and working style, then
+write the resulting soul files to the standard config directory.
+
+#### Scenario: First conversation triggers bootstrap
+
+- **GIVEN** no personality files exist in the config directory
+- **WHEN** the operator starts their first conversation with Netclaw
+- **THEN** the agent initiates a personality bootstrap conversation
+- **AND** asks about communication preferences and working style
+
+#### Scenario: Bootstrap writes soul files
+
+- **GIVEN** the personality bootstrap conversation is complete
+- **WHEN** the operator has answered all preference questions
+- **THEN** the system writes PERSONALITY.md, INSTRUCTIONS.md, and USER.md to
+  the config directory
+
+#### Scenario: Bootstrap skipped when files exist
+
+- **GIVEN** personality files already exist in the config directory
+- **WHEN** a new conversation starts
+- **THEN** no personality bootstrap is triggered
+- **AND** the existing personality files are loaded normally
+
+### Requirement: Environment discovery during onboarding
+
+The system SHALL scan for installed tools and host capabilities as part of
+Phase 2 onboarding. Discovery results SHALL be persisted to the environment
+inventory file for use in session context and capability self-awareness.
+
+#### Scenario: Tool discovery during onboarding
+
+- **WHEN** Phase 2 onboarding runs environment discovery
+- **THEN** the system scans for installed tools (git, gh, claude, opencode,
+  dotnet, node)
+- **AND** checks git credential status
+- **AND** writes results to the environment inventory file
+
+#### Scenario: MCP server reachability check during onboarding
+
+- **GIVEN** MCP servers are configured
+- **WHEN** Phase 2 onboarding runs environment discovery
+- **THEN** the system checks reachability of each configured MCP server
+- **AND** records reachability status in the environment inventory
+
+### Requirement: Project registration during onboarding
+
+The system SHALL ask the operator about repositories to register as part of
+Phase 2 onboarding. Registered projects are added to the project registry
+with their paths, capabilities, and AGENTS.md locations.
+
+#### Scenario: Register projects during onboarding
+
+- **WHEN** Phase 2 onboarding reaches the project registration step
+- **THEN** the system asks the operator about repositories to register
+- **AND** scans provided paths for AGENTS.md files
+
+#### Scenario: Skip project registration
+
+- **WHEN** Phase 2 onboarding reaches the project registration step
+- **AND** the operator indicates no projects to register
+- **THEN** onboarding proceeds with an empty project registry

--- a/openspec/specs/netclaw-operator-ui/spec.md
+++ b/openspec/specs/netclaw-operator-ui/spec.md
@@ -43,3 +43,75 @@ The UI SHALL surface exposure mode and approval state prominently.
 
 - **WHEN** system runs in public exposure mode
 - **THEN** security page shows elevated warning status
+
+### Requirement: Phase 5 deferral
+
+The operator UI implementation SHALL be deferred to Phase 5. The MVP
+deliverable for the operator UI is a specification and mockup only. No
+runtime UI code SHALL be included in the MVP build.
+
+#### Scenario: MVP excludes UI runtime code
+
+- **WHEN** the MVP is built
+- **THEN** no operator UI runtime code is included in the build artifacts
+- **AND** the UI specification and mockups exist as planning documents
+
+#### Scenario: UI specs maintained for Phase 5
+
+- **GIVEN** the operator UI is deferred to Phase 5
+- **WHEN** UI-related capability specs are updated
+- **THEN** the specs define future behavior for Phase 5 implementation
+
+### Requirement: Memory and configuration screen
+
+The operator UI SHALL provide a screen for viewing personality files, the
+project registry, and the environment inventory. This screen provides
+read-only visibility into the agent's local memory and configuration state.
+
+#### Scenario: View personality files
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the contents of PERSONALITY.md, INSTRUCTIONS.md, and USER.md are
+  displayed
+
+#### Scenario: View project registry
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the project registry is displayed with project names, paths, and
+  capabilities
+
+#### Scenario: View environment inventory
+
+- **WHEN** an operator opens the memory and configuration screen
+- **THEN** the environment inventory is displayed with installed tools,
+  credential status, and MCP server reachability
+
+### Requirement: Scheduling screen
+
+The operator UI SHALL provide a screen for viewing, creating, pausing, and
+deleting scheduled tasks. The screen SHALL also display execution history for
+each task.
+
+#### Scenario: View scheduled tasks
+
+- **WHEN** an operator opens the scheduling screen
+- **THEN** all scheduled tasks are listed with name, schedule, status, and
+  last execution result
+
+#### Scenario: Create scheduled task from UI
+
+- **WHEN** an operator creates a new scheduled task from the scheduling screen
+- **THEN** the task is added to the schedule registry with the specified
+  schedule, instructions, and required tool grants
+
+#### Scenario: Pause and delete from UI
+
+- **GIVEN** a scheduled task exists
+- **WHEN** an operator pauses or deletes the task from the scheduling screen
+- **THEN** the task status is updated accordingly
+
+#### Scenario: View execution history
+
+- **WHEN** an operator selects a scheduled task on the scheduling screen
+- **THEN** the execution history is displayed with timestamps, outcomes, and
+  error details for failed runs

--- a/openspec/specs/netclaw-scheduling/spec.md
+++ b/openspec/specs/netclaw-scheduling/spec.md
@@ -1,0 +1,213 @@
+# netclaw-scheduling Specification
+
+## Purpose
+
+Define chat-driven scheduled task creation, persistence, isolated execution
+via Akka timers, result reporting, task management, and failure handling
+guardrails. This capability enables Netclaw to manage its own schedule
+through conversation and execute tasks autonomously.
+
+## Requirements
+
+### Requirement: Chat-driven task creation
+
+The agent SHALL create scheduled tasks when the user requests recurring or
+timed actions through conversation. The agent SHALL assign a human-readable
+task ID and confirm the schedule. Tasks SHALL support fixed interval and cron
+expression schedule types. Tasks requesting tool grants that cannot be
+satisfied by ACL policy SHALL be rejected at creation time.
+
+#### Scenario: Create interval-based scheduled task
+
+- **GIVEN** the user asks the agent to perform an action on a recurring basis
+- **WHEN** the agent parses the request as a fixed-interval schedule
+- **THEN** the agent creates a task with the specified interval
+- **AND** assigns a human-readable task ID
+- **AND** confirms the schedule, next run time, and required tool grants
+
+#### Scenario: Create cron-based scheduled task
+
+- **GIVEN** the user specifies a cron expression for scheduling
+- **WHEN** the agent validates the cron expression
+- **THEN** the agent creates a task with the cron schedule
+- **AND** confirms the resolved next execution time
+
+#### Scenario: Reject task with ungrantable tools
+
+- **GIVEN** the user requests a scheduled task that requires the `shell` tool
+- **WHEN** the `shell` grant is not available in the ACL policy for that sender
+- **THEN** the agent rejects the task at creation time
+- **AND** explains which tool grants are missing
+
+#### Scenario: Task ID collision avoided
+
+- **GIVEN** a task with ID `ebay-check` already exists
+- **WHEN** the user requests a new task that would generate the same ID
+- **THEN** the agent generates a unique variant of the ID
+- **AND** confirms the actual task ID assigned
+
+### Requirement: Schedule persistence
+
+Scheduled tasks SHALL be persisted to disk at
+`~/.netclaw/schedules/tasks.json` and SHALL survive process restarts. On
+startup, the system SHALL load persisted tasks and re-establish Akka timers
+for all active tasks.
+
+#### Scenario: Tasks survive process restart
+
+- **GIVEN** active scheduled tasks exist in `tasks.json`
+- **WHEN** the Netclaw process restarts
+- **THEN** all persisted tasks are loaded from disk
+- **AND** Akka timers are re-established for active tasks
+- **AND** paused tasks remain paused
+
+#### Scenario: New task persisted immediately
+
+- **GIVEN** the user creates a new scheduled task through conversation
+- **WHEN** the task is confirmed
+- **THEN** the task is written to `tasks.json` before the confirmation is sent
+
+#### Scenario: Corrupted tasks file handled gracefully
+
+- **GIVEN** `tasks.json` contains invalid JSON
+- **WHEN** the Netclaw process starts
+- **THEN** the system logs a warning
+- **AND** starts without any scheduled tasks
+- **AND** the operator is notified of the corruption
+
+### Requirement: Isolated task execution
+
+Each scheduled task execution SHALL run in a fresh session actor with its own
+context. The session SHALL load the agent personality and any relevant project
+context overlays. Scheduled sessions SHALL NOT share state with interactive
+sessions.
+
+#### Scenario: Fresh session per execution
+
+- **GIVEN** a scheduled task fires
+- **WHEN** the timer tick triggers execution
+- **THEN** a new session actor is created with entity key
+  `schedule/{taskId}/{runTs}`
+- **AND** the task instruction is delivered as the user message
+- **AND** agent personality is loaded from soul files
+
+#### Scenario: Scheduled session isolated from interactive sessions
+
+- **GIVEN** an interactive Slack session exists for the same user
+- **WHEN** a scheduled task executes
+- **THEN** the scheduled session does not read or modify interactive session
+  state
+- **AND** the interactive session does not see scheduled session turns
+
+#### Scenario: Task tool grants applied to session
+
+- **GIVEN** a scheduled task specifies `tool_grants: ["web_search", "web_fetch"]`
+- **WHEN** the task session starts
+- **THEN** only the granted tools are available to the session
+- **AND** ungrantable tools are not offered to the LLM
+
+### Requirement: Result reporting
+
+Task execution results SHALL be posted to the configured Slack channel. The
+system SHALL support a silent-unless-notable mode where routine results are
+suppressed and only notable findings are posted.
+
+#### Scenario: Results posted to configured channel
+
+- **GIVEN** a scheduled task has `report_to.channel` configured
+- **WHEN** the task execution completes with results
+- **THEN** the results are posted to the configured Slack channel
+
+#### Scenario: Silent-unless-notable suppresses routine results
+
+- **GIVEN** a scheduled task is configured with silent-unless-notable mode
+- **WHEN** the task execution completes with no notable findings
+- **THEN** no message is posted to Slack
+- **AND** the execution is logged as completed with no notable output
+
+#### Scenario: Notable results always posted
+
+- **GIVEN** a scheduled task is configured with silent-unless-notable mode
+- **WHEN** the task execution produces notable findings
+- **THEN** the results are posted to the configured Slack channel
+- **AND** the findings are clearly presented
+
+### Requirement: Task management
+
+The agent and CLI SHALL support listing, pausing, resuming, and deleting
+scheduled tasks. The agent SHALL provide task status and next-run time
+when listing tasks.
+
+#### Scenario: List all scheduled tasks via conversation
+
+- **GIVEN** multiple scheduled tasks exist
+- **WHEN** the user asks to see scheduled tasks
+- **THEN** the agent lists all tasks with ID, name, status, schedule, and
+  next run time
+
+#### Scenario: Pause a scheduled task
+
+- **GIVEN** an active scheduled task exists
+- **WHEN** the user asks the agent to pause the task
+- **THEN** the task status is set to paused
+- **AND** the Akka timer for the task is cancelled
+- **AND** the task remains in `tasks.json` with `status: "paused"`
+
+#### Scenario: Resume a paused task
+
+- **GIVEN** a paused scheduled task exists
+- **WHEN** the user asks the agent to resume the task
+- **THEN** the task status is set to active
+- **AND** the Akka timer is re-established
+- **AND** the next run time is calculated from the current time
+
+#### Scenario: Delete a scheduled task
+
+- **GIVEN** a scheduled task exists
+- **WHEN** the user asks the agent to delete the task
+- **THEN** the task is removed from `tasks.json`
+- **AND** the Akka timer is cancelled
+- **AND** the agent confirms deletion
+
+#### Scenario: Manage tasks via CLI
+
+- **GIVEN** active scheduled tasks exist
+- **WHEN** the operator runs CLI commands for schedule management
+- **THEN** the CLI supports list, pause, resume, and delete operations
+- **AND** changes are reflected in `tasks.json`
+
+### Requirement: Failure handling and guardrails
+
+The system SHALL track consecutive failures per task. After the configured
+failure threshold (default: 5), the task SHALL be automatically paused and
+the operator notified. The system SHALL enforce a maximum concurrent execution
+limit (default: 3) and a per-task execution timeout (default: 5 minutes).
+
+#### Scenario: Consecutive failures auto-pause task
+
+- **GIVEN** a scheduled task has failed 5 consecutive times
+- **WHEN** the 5th failure is recorded
+- **THEN** the task is automatically paused
+- **AND** the operator is notified in the task's reporting channel
+- **AND** the notification includes the last failure reason
+
+#### Scenario: Successful execution resets failure counter
+
+- **GIVEN** a scheduled task has 3 consecutive failures recorded
+- **WHEN** the next execution succeeds
+- **THEN** the consecutive failure counter is reset to zero
+
+#### Scenario: Max concurrent execution limit enforced
+
+- **GIVEN** 3 scheduled tasks are currently executing (at the default limit)
+- **WHEN** another scheduled task timer fires
+- **THEN** the execution is deferred until a slot becomes available
+- **AND** the deferral is logged
+
+#### Scenario: Execution timeout enforced
+
+- **GIVEN** a scheduled task is executing
+- **WHEN** the execution exceeds the configured timeout (default: 5 minutes)
+- **THEN** the execution is terminated
+- **AND** the result is recorded as a timeout failure
+- **AND** the failure contributes to the consecutive failure counter

--- a/openspec/specs/netclaw-session/spec.md
+++ b/openspec/specs/netclaw-session/spec.md
@@ -19,13 +19,24 @@ The system SHALL key each session by `{channelId}/{threadTs}`.
 
 ### Requirement: Persisted turn lifecycle
 
-The system SHALL persist each completed turn and emit a turn broadcast.
+The system SHALL persist each completed turn and emit a turn broadcast via
+pub/sub. Broadcast delivery SHALL use a publish-subscribe pattern so that
+multiple adapters (Slack, future web UI, timer adapter) can independently
+consume turn events without the session actor knowing which adapters are
+subscribed.
 
 #### Scenario: Persist and broadcast assistant reply
 
 - **WHEN** the assistant produces a response
 - **THEN** a turn event is persisted
-- **AND** a broadcast is emitted for subscribers
+- **AND** a broadcast is published to the session topic for all subscribers
+
+#### Scenario: Multi-adapter broadcast delivery
+
+- **GIVEN** multiple adapters are subscribed to session broadcasts
+- **WHEN** a turn broadcast is published
+- **THEN** each subscribed adapter receives the broadcast independently
+- **AND** the session actor does not reference specific adapter types
 
 ### Requirement: Session recovery across restart
 
@@ -39,7 +50,10 @@ The system SHALL recover session state from journal and snapshots.
 
 ### Requirement: Conversation compaction
 
-The system SHALL compact long session history using summary reduction.
+The system SHALL compact long session history using summary reduction. Before
+compaction runs, the system SHALL trigger a pre-compaction memory flush that
+persists durable memories (key facts, decisions, action items) to local memory
+files so they survive context reset.
 
 #### Scenario: Compaction threshold reached
 
@@ -47,3 +61,31 @@ The system SHALL compact long session history using summary reduction.
 - **WHEN** compaction runs
 - **THEN** a compaction event is persisted
 - **AND** compacted state remains usable for future turns
+
+#### Scenario: Pre-compaction memory flush
+
+- **GIVEN** session history exceeds configured compaction threshold
+- **WHEN** compaction is about to run
+- **THEN** the system SHALL execute a silent agentic turn that extracts durable
+  memories from the conversation
+- **AND** persists them to local memory files before context is reset
+
+### Requirement: Tool context in session state
+
+The system SHALL load available tools into session state based on the active
+policy grants at session initialization. Tool definitions SHALL be refreshed
+from the tool registry each time a session actor starts or recovers.
+
+#### Scenario: Session loads granted tools at initialization
+
+- **GIVEN** the ACL grants `shell`, `web_search`, and `mcp:memorizer` to the
+  current channel and sender
+- **WHEN** a session actor initializes
+- **THEN** session state includes tool definitions for only the granted tool
+  categories
+
+#### Scenario: Denied tools excluded from session
+
+- **GIVEN** the ACL does not grant `github` for the current channel
+- **WHEN** a session actor initializes
+- **THEN** GitHub tool definitions are not loaded into session state

--- a/openspec/specs/netclaw-session/spec.md
+++ b/openspec/specs/netclaw-session/spec.md
@@ -89,3 +89,41 @@ from the tool registry each time a session actor starts or recovers.
 - **GIVEN** the ACL does not grant `github` for the current channel
 - **WHEN** a session actor initializes
 - **THEN** GitHub tool definitions are not loaded into session state
+
+### Requirement: Config hot-reload integration
+
+The session system SHALL respond to config change notifications dispatched by
+the `ConfigWatcherService`. Active sessions SHALL re-evaluate their tool grants
+when ACL changes, rebuild provider connections when provider config changes,
+and reconnect MCP servers when MCP profiles change.
+
+#### Scenario: ACL change refreshes tool grants for active session
+
+- **GIVEN** a session actor is active with tools loaded from the previous ACL
+- **WHEN** the config watcher publishes an ACL change event
+- **THEN** the session actor re-evaluates tool grants against the new ACL
+- **AND** adds or removes tools from the session's available tool set
+
+#### Scenario: Provider change triggers IChatClient rebuild
+
+- **GIVEN** a session actor is using an `IChatClient` from the current provider
+  configuration
+- **WHEN** the config watcher publishes a provider change event
+- **THEN** the session actor obtains a new `IChatClient` from the provider
+  factory
+- **AND** subsequent turns use the new provider configuration
+
+#### Scenario: MCP profile change triggers server reconnection
+
+- **GIVEN** a session actor has MCP tools loaded from connected servers
+- **WHEN** the config watcher publishes an MCP profile change event
+- **THEN** the session actor refreshes its MCP tool definitions
+- **AND** newly added servers' tools become available
+- **AND** removed servers' tools are no longer available
+
+#### Scenario: Schedule change does not affect active sessions
+
+- **GIVEN** a session actor is processing turns
+- **WHEN** the config watcher publishes a schedule change event
+- **THEN** the session actor does NOT take any action
+- **AND** the `ScheduleManagerActor` handles timer reconfiguration independently

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -1,0 +1,232 @@
+# netclaw-tools Specification
+
+## Purpose
+
+Define first-party tool access for Netclaw: web search, web fetch, shell
+execution, and GitHub CLI. All tools are registered through
+Microsoft.Extensions.AI, filtered by policy grants, and audited on invocation.
+This capability provides the agent with the ability to act on the world beyond
+conversation.
+
+## Requirements
+
+### Requirement: Tool registration with MEAI
+
+All first-party tools SHALL be registered as `Microsoft.Extensions.AI` tool
+definitions at startup. Tool metadata (name, description, parameters) SHALL be
+defined at registration. Available tools presented to the LLM SHALL be filtered
+per session based on ACL policy grants.
+
+#### Scenario: Tools registered at startup
+
+- **WHEN** the Netclaw process starts
+- **THEN** all configured first-party tools are registered as MEAI tool
+  definitions
+- **AND** each tool definition includes name, description, and parameter schema
+
+#### Scenario: Session receives filtered tool set
+
+- **GIVEN** a session has ACL grants for `web_search` and `web_fetch` but not
+  `shell`
+- **WHEN** the session starts and tools are provided to the LLM
+- **THEN** only `web_search` and `web_fetch` tool definitions are included
+- **AND** `shell` is not offered to the LLM
+
+#### Scenario: Tool results returned as tool response messages
+
+- **GIVEN** the LLM issues a tool call during a turn
+- **WHEN** the tool executes and produces a result
+- **THEN** the result is returned to the LLM as an MEAI tool response message
+- **AND** the session continues the turn loop with the tool result in context
+
+### Requirement: Web search tool
+
+The system SHALL provide a web search tool using Brave Search API as the
+primary backend and SearXNG as the alternative backend. The tool SHALL return
+structured search results suitable for LLM consumption.
+
+#### Scenario: Web search via Brave Search API
+
+- **GIVEN** the Brave Search API key is configured
+- **WHEN** the agent invokes the web search tool with a query
+- **THEN** the tool sends the query to the Brave Search API
+- **AND** returns structured results (title, URL, snippet) to the LLM
+
+#### Scenario: Web search via SearXNG
+
+- **GIVEN** the search backend is configured as SearXNG with a valid endpoint
+- **WHEN** the agent invokes the web search tool with a query
+- **THEN** the tool sends the query to the SearXNG instance
+- **AND** returns structured results in the same format as Brave Search
+
+#### Scenario: Missing API key prevents tool registration
+
+- **GIVEN** Brave Search is configured as the search backend
+- **WHEN** no API key is provided in configuration
+- **THEN** the web search tool is not registered at startup
+- **AND** a warning is logged indicating the tool is unavailable
+
+### Requirement: Web fetch tool
+
+The system SHALL provide a web fetch tool that retrieves content from URLs,
+extracts text from HTML, and truncates output to a configurable limit to
+prevent context flooding.
+
+#### Scenario: Fetch and extract text from URL
+
+- **GIVEN** the web fetch tool is available
+- **WHEN** the agent invokes the tool with a URL
+- **THEN** the tool retrieves the page content via HTTP
+- **AND** extracts text from HTML (removing markup)
+- **AND** returns the extracted text to the LLM
+
+#### Scenario: Output truncated to configured limit
+
+- **GIVEN** the fetched page content exceeds the configured output limit
+- **WHEN** the tool processes the content
+- **THEN** the output is truncated to the configured character limit
+- **AND** a truncation indicator is appended to the result
+
+#### Scenario: Non-HTML content returned as-is
+
+- **GIVEN** the fetched URL returns plain text or JSON content
+- **WHEN** the tool processes the response
+- **THEN** the content is returned without HTML extraction
+- **AND** output truncation still applies
+
+#### Scenario: Unreachable URL returns error
+
+- **GIVEN** the agent invokes the web fetch tool with an unreachable URL
+- **WHEN** the HTTP request fails
+- **THEN** the tool returns an error message to the LLM
+- **AND** the error does not crash the session
+
+### Requirement: Shell execution tool
+
+The system SHALL provide a shell execution tool that runs commands as the
+Netclaw process user context. Stdin SHALL be closed (no interactive commands).
+Execution SHALL enforce a configurable timeout (default: 60 seconds). Output
+SHALL be truncated to a configurable limit.
+
+#### Scenario: Execute command and return output
+
+- **GIVEN** the `shell` grant is available for the session
+- **WHEN** the agent invokes the shell tool with a command
+- **THEN** the command is executed as the Netclaw process user
+- **AND** stdout and stderr are captured
+- **AND** the combined output is returned to the LLM
+
+#### Scenario: Execution timeout enforced
+
+- **GIVEN** a shell command is running
+- **WHEN** the command exceeds the configured timeout (default: 60 seconds)
+- **THEN** the process is terminated
+- **AND** the tool returns a timeout error message to the LLM
+
+#### Scenario: Output truncated to limit
+
+- **GIVEN** a shell command produces output exceeding the configured limit
+- **WHEN** the output is captured
+- **THEN** the output is truncated to the configured character limit
+- **AND** a truncation indicator is appended
+
+#### Scenario: Stdin closed prevents interactive commands
+
+- **GIVEN** the agent invokes the shell tool with a command
+- **WHEN** the process is created
+- **THEN** stdin is closed immediately
+- **AND** commands that require interactive input fail promptly
+
+#### Scenario: Working directory set to project path
+
+- **GIVEN** the session is associated with a registered project
+- **WHEN** the shell tool executes a command
+- **THEN** the working directory is set to the project's registered path
+
+### Requirement: GitHub CLI tool
+
+The system SHALL provide a GitHub tool that shells out to the `gh` CLI for
+issue creation, PR management, and repo operations. The tool SHALL parse
+structured output from `gh`. If `gh` is not installed, the tool SHALL not be
+registered and SHALL report the missing dependency.
+
+#### Scenario: Execute gh command and return structured output
+
+- **GIVEN** the `github` grant is available and `gh` is installed
+- **WHEN** the agent invokes the GitHub tool with a `gh` command
+- **THEN** the tool executes the `gh` command via shell
+- **AND** parses the output into structured form
+- **AND** returns the structured result to the LLM
+
+#### Scenario: gh CLI not installed
+
+- **GIVEN** `gh` is not found in the environment inventory
+- **WHEN** the Netclaw process starts
+- **THEN** the GitHub tool is not registered
+- **AND** a warning is logged indicating the GitHub tool is unavailable due to
+  missing `gh` CLI
+
+#### Scenario: gh authentication failure handled
+
+- **GIVEN** the `gh` CLI is installed but not authenticated
+- **WHEN** a GitHub tool invocation is attempted
+- **THEN** the tool returns an authentication error message to the LLM
+- **AND** the error does not crash the session
+
+### Requirement: Policy-gated tool invocation
+
+The system SHALL check ACL grants before every tool execution. Tool
+invocations SHALL be logged with audit records including tool name, invoking
+session, timestamp, and allow/deny result.
+
+#### Scenario: Granted tool executes successfully
+
+- **GIVEN** the session has an ACL grant for `web_search`
+- **WHEN** the LLM requests a web search tool call
+- **THEN** the ACL check passes
+- **AND** the tool executes
+- **AND** an audit record is logged with tool name, session ID, timestamp, and
+  `allow` result
+
+#### Scenario: Ungrantable tool denied at invocation
+
+- **GIVEN** the session does not have an ACL grant for `shell`
+- **WHEN** the LLM requests a shell tool call
+- **THEN** the ACL check fails
+- **AND** the tool is not executed
+- **AND** a policy denial with reason code is returned to the LLM
+- **AND** an audit record is logged with tool name, session ID, timestamp, and
+  `deny` result
+
+#### Scenario: Audit records available in diagnostics
+
+- **GIVEN** tool invocations have occurred
+- **WHEN** the operator views diagnostics
+- **THEN** audit records show tool name, invoking session, timestamp, and
+  allow/deny result for each invocation
+
+### Requirement: Configurable search backend
+
+The system SHALL support configuring either Brave Search API or SearXNG as the
+web search backend. The choice SHALL be made through configuration without code
+changes.
+
+#### Scenario: Brave Search configured as default
+
+- **GIVEN** the configuration specifies `search_backend: "brave"`
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses Brave Search API for queries
+
+#### Scenario: SearXNG configured as alternative
+
+- **GIVEN** the configuration specifies `search_backend: "searxng"` with an
+  endpoint URL
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses the SearXNG endpoint for queries
+
+#### Scenario: Invalid search backend rejected at startup
+
+- **GIVEN** the configuration specifies an unrecognized search backend value
+- **WHEN** the Netclaw process starts
+- **THEN** the web search tool is not registered
+- **AND** a configuration validation warning is logged

--- a/ralph-opencode.sh
+++ b/ralph-opencode.sh
@@ -174,6 +174,8 @@ ${prior_reviews:-  (none — this is the first review)}
 
 3. **Full review areas (from skill):**
    - A) Checkbox Integrity — do changes satisfy Done-when criteria?
+   - A2) OpenSpec Integrity — code aligned with referenced specs?
+   - A3) OpenSpec Workflow Compliance — were /opsx-* skills used (not manual edits)?
    - B) Testing Strategy Compliance — integration tests for I/O, screenshots for UI
    - C) Architecture Compliance — follow constraints from AGENTS.md/CLAUDE.md
    - D) Framework compliance per CLAUDE.md
@@ -347,6 +349,15 @@ for ((i=1; i<=ITERATIONS; i++)); do
    - REQUIRED: ralph-loop.md (process discipline)
    - If UI impacted: ui-smoke-validation.md (or follow UI validation policy)
    - If schema/events touched: extend-only-design.md (if present)
+
+3b) OpenSpec Workflow (MANDATORY — see AGENTS.md for full details):
+   - If your task involves PLANNING work (new specs, changes, proposals):
+     Use /opsx-new, /opsx-continue, or /opsx-ff — do NOT manually create openspec/ files
+   - If your task involves FINISHING work (syncing specs, archiving):
+     Use /opsx-sync, /opsx-verify, /opsx-archive
+   - The ONLY manual edit allowed under openspec/ is ticking task checkboxes
+     in openspec/changes/*/tasks.md
+   - Run 'openspec validate --all --no-interactive' before every commit
 
 4) BEFORE coding: choose Verification Level (L0-L4) and state why:
    - I/O coordination (DB/HTTP/actors/external) => L2+ (integration tests required)

--- a/ralph.sh
+++ b/ralph.sh
@@ -178,6 +178,8 @@ ${prior_reviews:-  (none — this is the first review)}
 
 3. **Full review areas (from skill):**
    - A) Checkbox Integrity — do changes satisfy Done-when criteria?
+   - A2) OpenSpec Integrity — code aligned with referenced specs?
+   - A3) OpenSpec Workflow Compliance — were /opsx-* skills used (not manual edits)?
    - B) Testing Strategy Compliance — integration tests for I/O, screenshots for UI
    - C) Architecture Compliance — follow constraints from AGENTS.md/CLAUDE.md
    - D) Framework compliance per CLAUDE.md
@@ -351,6 +353,15 @@ for ((i=1; i<=ITERATIONS; i++)); do
    - REQUIRED: ralph-loop.md (process discipline)
    - If UI impacted: ui-smoke-validation.md (or follow UI validation policy)
    - If schema/events touched: extend-only-design.md (if present)
+
+3b) OpenSpec Workflow (MANDATORY — see AGENTS.md for full details):
+   - If your task involves PLANNING work (new specs, changes, proposals):
+     Use /opsx-new, /opsx-continue, or /opsx-ff — do NOT manually create openspec/ files
+   - If your task involves FINISHING work (syncing specs, archiving):
+     Use /opsx-sync, /opsx-verify, /opsx-archive
+   - The ONLY manual edit allowed under openspec/ is ticking task checkboxes
+     in openspec/changes/*/tasks.md
+   - Run 'openspec validate --all --no-interactive' before every commit
 
 4) BEFORE coding: choose Verification Level (L0-L4) and state why:
    - I/O coordination (DB/HTTP/actors/external) => L2+ (integration tests required)


### PR DESCRIPTION
## Summary

- Expanded product vision from Slack chat assistant to always-on autonomous operations agent
- Revised all 6 existing PRDs and created 3 new ones (personality/memory, scheduling, input adapters)
- Created 12 new OpenSpec capability specs and 2 OpenSpec changes with full artifact workflows
- Added TUI wireframes (Termina) for `netclaw init` wizard and `netclaw chat` interactive prompt
- Added web UI wireframes for Memory & Config (UX-006) and Scheduling (UX-007) screens
- Resequenced IMPLEMENTATION_PLAN.md Phase 1 tasks 1.13-1.22 for TUI-first validation before Slack
- Added config hot-reload capability (FileSystemWatcher + debounce + validate-before-apply)
- Hardened AGENTS.md, CLAUDE.md, and RALPH skills/scripts with mandatory OpenSpec workflow enforcement
- Symlinked OpenSpec skills into `.claude/skills/` and `.claude/commands/` for Claude Code discovery

## Key decisions

- **CLI framework**: Cocona (lightweight, convention-based, DI integration)
- **TUI framework**: Termina 0.5.1 (owned, reactive MVVM, .NET 10, AOT-compatible)
- **Chat model**: Integrated — `netclaw chat` hosts actor system in-process
- **Hot-reload scope**: ACL, providers, MCP profiles, schedules only (not personality/projects)
- **Hot-reload mechanism**: FileSystemWatcher + 500ms debounce + validate-before-apply
- **TUI-first**: Full agent validation through TUI before adding Slack adapter

## Test plan

- [ ] `openspec validate --all --no-interactive` passes (verified: 22/22)
- [ ] All PRDs have consistent cross-references
- [ ] IMPLEMENTATION_PLAN.md task ordering respects dependency chains
- [ ] RALPH scripts (`ralph.sh`, `ralph-opencode.sh`) include OpenSpec enforcement in iteration and review prompts
- [ ] RALPH is ready to begin Task 1.1 autonomously