### PR TITLE
Add slopwatch integration for reward hacking detection

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "docfx"
       ],
       "rollForward": false
+    },
+    "slopwatch.cmd": {
+      "version": "0.3.3",
+      "commands": [
+        "slopwatch"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -48,7 +48,10 @@ jobs:
 
       - name: "dotnet test"
         shell: bash
-        run: dotnet test -c Release 
+        run: dotnet test -c Release
+
+      - name: "slopwatch analyze"
+        run: dotnet slopwatch analyze
 
       - name: "dotnet pack"
         run: dotnet pack -c Release -o ./bin/nuget

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -50,8 +50,26 @@ jobs:
         shell: bash
         run: dotnet test -c Release
 
-      - name: "slopwatch analyze"
-        run: dotnet slopwatch analyze
-
       - name: "dotnet pack"
         run: dotnet pack -c Release -o ./bin/nuget
+
+  slopwatch:
+    name: Slopwatch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: "Install .NET SDK"
+        uses: actions/setup-dotnet@v5.1.0
+        with:
+          global-json-file: "./global.json"
+
+      - name: "Restore .NET tools"
+        run: dotnet tool restore
+
+      - name: "slopwatch analyze"
+        run: dotnet slopwatch analyze

--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "createdAt": "2026-02-21T18:55:14.1378608+00:00",
+  "updatedAt": "2026-02-21T18:55:14.1452473+00:00",
+  "description": "Initial baseline created by 'slopwatch init' on 2026-02-21 18:55:14 UTC",
+  "entries": [
+    {
+      "hash": "9d4a53dc5193e639",
+      "ruleId": "SW005",
+      "filePath": "Directory.Build.props",
+      "lineNumber": 6,
+      "codeSnippet": "<NoWarn>$(NoWarn);CS1591</NoWarn>",
+      "message": "Adding warnings to NoWarn: CS1591",
+      "baselinedAt": "2026-02-21T18:55:14.1452032+00:00"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,20 @@ If discovery artifacts conflict with each other, update them before implementing
 - no north-star/deferred features in MVP without explicit PRD update
 - actor boundaries remain transport-agnostic (pub/sub over direct transport asks)
 - persistence types remain framework-owned and serialization-safe
+- no new Slopwatch violations: run `/dotnet-skills:slopwatch` after code changes
+
+## Post-Code Quality Check
+
+After any code changes, run:
+
+```bash
+dotnet slopwatch analyze     # Detect reward hacking (new violations fail CI)
+```
+
+Slopwatch detects: disabled/skipped tests, suppressed warnings, empty catch
+blocks, hardcoded values, TODO-as-done comments. Baseline is in
+`.slopwatch/baseline.json` — existing entries are accepted, new violations
+must be fixed or explicitly baselined with justification.
 
 ## Definition of Done
 
@@ -109,6 +123,7 @@ Done means all of the following are true:
 
 - behavior aligns with PRD + spec
 - acceptance criteria are testable and verified
+- `dotnet slopwatch analyze` passes (no new violations)
 - operational impact is documented (runbooks or CLI help)
 - OpenSpec artifacts are updated or archived appropriately
 


### PR DESCRIPTION
## Summary

- Add slopwatch.cmd v0.3.3 as a local dotnet tool
- Initialize baseline with 1 existing entry (CS1591 suppression in Directory.Build.props)
- Add `dotnet slopwatch analyze` step to PR validation CI workflow (runs after tests, before pack)
- Add slopwatch to AGENTS.md quality bar, definition of done, and post-code quality check section

## Test plan

- [x] `dotnet slopwatch analyze` passes locally (0 new issues)
- [ ] CI workflow runs slopwatch step successfully on PR