### PR TITLE
Add headless prompt mode and source-generated tool schemas

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,10 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
+  <!-- Source generators -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+  </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />

--- a/Netclaw.slnx
+++ b/Netclaw.slnx
@@ -10,5 +10,7 @@
     <Project Path="src/Netclaw.Actors/Netclaw.Actors.csproj" />
     <Project Path="src/Netclaw.App/Netclaw.App.csproj" />
     <Project Path="src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj" />
+    <Project Path="src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />
+    <Project Path="src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj" />
   </Folder>
 </Solution>

--- a/docs/adr/ADR-001-own-tool-schemas.md
+++ b/docs/adr/ADR-001-own-tool-schemas.md
@@ -1,0 +1,154 @@
+# ADR-001: Own Tool Schemas via Compile-Time Source Generation
+
+**Date:** 2026-02-22
+**Status:** Accepted
+**Context:** First-party tool integration (shell, file read, file write)
+
+## Decision
+
+Netclaw owns its tool schema pipeline via a Roslyn incremental source generator.
+Tool authors declare a typed parameter record and an `ExecuteAsync` method; the
+generator emits JSON schema and a typed argument deserializer at compile time.
+
+At the `ChatOptions.Tools` boundary, schemas are wrapped in
+`AIFunctionFactory.CreateDeclaration()` to produce `AITool` objects that any
+`IChatClient` implementation can consume.
+
+## Context
+
+When we first wired tools to a real LLM (Ollama/qwen3:30b via OllamaSharp), two
+bugs surfaced immediately:
+
+1. **Nullable schema incompatibility.** `AIFunctionFactory` reflected over
+   `string? working_directory = null` and emitted `"type": ["string", "null"]`
+   in the JSON Schema. OllamaSharp's `AbstractionMapper` expected `"type"` to be
+   a plain string and threw a `JsonException`.
+
+2. **Argument type mismatch.** `FunctionCallContent.Arguments` is typed as
+   `IDictionary<string, object?>`, but the actual values inside depend on the
+   provider. OllamaSharp puts `JsonElement` values; other providers may put
+   native strings or ints. Our tools did `cmdObj is not string` and failed on
+   every call.
+
+Both bugs exist in the seam between schema generation (framework-owned) and
+argument extraction (our code).
+
+### Why M.E.AI's Approach Fails Structurally
+
+**M.E.AI generates the schema but doesn't own the consumption.** It reflects
+over your method, emits valid JSON Schema (`["string", "null"]`), then hands it
+to the provider SDK. The provider SDK re-parses that schema to convert it to the
+LLM's native tool format. If the provider's parser doesn't handle all JSON
+Schema patterns that M.E.AI emits, you get a runtime error. Nobody owns the full
+path — M.E.AI generates, the provider consumes, and they disagree on which
+subset of JSON Schema is valid.
+
+**M.E.AI doesn't normalize arguments on the return trip.** The `Arguments` dict
+is `IDictionary<string, object?>` where the `object?` is whatever the provider
+SDK puts there. If you let M.E.AI invoke the function end-to-end, it handles
+binding internally. But the moment you dispatch manually — because you need
+injected dependencies, audit logging, policy checks — you're on your own for
+type coercion.
+
+**M.E.AI is an abstraction layer, not an implementation layer.** It defines
+`IChatClient` and `AITool` but doesn't own the behavior behind them. When two
+implementations disagree across provider boundaries, there's no single owner to
+fix it.
+
+### Agent SDK Landscape
+
+| Approach | Schema | Invocation | Who |
+|----------|--------|------------|-----|
+| Own the pipeline | Hand-written JSON or generated | Parse arguments yourself | Oinker, IronClaw, most Go/Rust agents |
+| Framework does everything | Reflected from methods | Framework binds typed args | Semantic Kernel, LangChain |
+| Split responsibilities | Framework generates schema | Manual dispatch with raw dict | Where Netclaw started |
+
+Approach 3 is unstable: the framework generates schemas you don't control, and
+providers deserialize arguments in ways the framework doesn't normalize.
+
+Hand-written JSON schemas (Approach 1) fix the control problem but create a DX
+problem: schemas and extraction logic are separate, error-prone, and tedious.
+
+## Rationale
+
+**Build to the problem, not to the tool.**
+
+A Roslyn incremental source generator gives the DX of Approach 2 (declare a
+real function, everything else derived) with the control of Approach 1 (we own
+every mapping rule):
+
+- **Schema generation** happens at compile time from typed parameter records.
+  We control the rules: `string?` emits `"type": "string"` (not
+  `["string", "null"]`), nullability is expressed via the `"required"` list.
+- **Argument deserialization** is generated per-tool. Handles `JsonElement` and
+  native CLR types from any provider, producing a typed params object.
+- **Single owner.** We own both ends of the pipeline. The provider SDK is a
+  black box in the middle, but we defensively handle whatever it produces on
+  both sides.
+- **Same DX as AIFunctionFactory** — tool authors write typed parameters and an
+  execute method. No hand-written JSON, no phantom `Describe` methods, no
+  runtime reflection.
+- **Source generator is replaceable.** If M.E.AI fixes these issues upstream, we
+  can swap the generator internals without changing any tool author code.
+
+### Tool Author DX
+
+```csharp
+[NetclawTool("shell_execute",
+    "Execute a shell command and return stdout/stderr with exit code",
+    Grant = "shell")]
+public partial class ShellTool : NetclawTool<ShellTool.Params>
+{
+    public record Params(
+        [Description("The shell command to execute")] string Command,
+        [Description("Working directory (optional)")] string? WorkingDirectory = null);
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        // args.Command — typed, non-null
+        // args.WorkingDirectory — typed, nullable
+    }
+}
+```
+
+Registration: `registry.Register(new ShellTool(config))`.
+
+### What the Generator Emits
+
+For each `NetclawTool<TParams>` subclass:
+
+1. Static `JsonElement` field with the JSON schema
+2. `Parse(IDictionary<string, object?>)` method for typed deserialization
+3. `INetclawTool` interface implementation (Name, Description, ParameterSchema,
+   GrantCategory, untyped ExecuteAsync dispatch)
+
+## Consequences
+
+- Tool definition is single-source: the parameter record is the schema. Adding
+  a parameter means adding a constructor parameter — one place, not two.
+- `IChatClient` remains the LLM transport abstraction. `AITool` objects are
+  produced at the boundary via `CreateDeclaration`.
+- Runtime reflection for tool schemas is eliminated. Schema is a compiled
+  literal.
+- The source generator project is an additional build dependency. Incremental
+  generation ensures it doesn't impact build times significantly.
+- Tests using `AIFunctionFactory.Create(() => "result", name)` for fakes
+  continue to work alongside real tools.
+
+## Alternatives Considered
+
+**Hand-written JSON schemas.** Fixes control but bad DX — schema and extraction
+are separate, must be kept in sync manually. Acceptable as a stepping stone,
+not as the final state.
+
+**Runtime reflection in a base class.** Same DX as the source generator but
+at runtime. Works, but reintroduces the same category of problem we're solving
+(reflection producing unexpected output). Also adds startup cost.
+
+**Let M.E.AI invoke tools directly (Approach 2).** Requires restructuring tools
+to capture dependencies in closures. Still depends on framework schema
+generation. Trades one framework dependency for another.
+
+**Abandon `AITool` entirely.** Requires custom tool types and per-provider
+serialization. Rejected because `ChatOptions.Tools` expects `AITool` and
+replacing that means replacing `IChatClient`.

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class DispatchingToolExecutorTests
+{
+    private readonly DispatchingToolExecutor _executor;
+
+    public DispatchingToolExecutorTests()
+    {
+        var registry = new ToolRegistry();
+        registry.WithFirstPartyTools(new ToolConfig());
+        _executor = new DispatchingToolExecutor(registry);
+    }
+
+    [Fact]
+    public async Task Routes_shell_execute()
+    {
+        var toolCall = new FunctionCallContent(
+            "call-1", "shell_execute",
+            new Dictionary<string, object?> { ["Command"] = "echo routed" });
+
+        var result = await _executor.ExecuteAsync(toolCall);
+
+        Assert.Contains("routed", result);
+        Assert.Contains("Exit code: 0", result);
+    }
+
+    [Fact]
+    public async Task Routes_file_read_missing_file()
+    {
+        var toolCall = new FunctionCallContent(
+            "call-2", "file_read",
+            new Dictionary<string, object?> { ["Path"] = "/nonexistent/file.txt" });
+
+        var result = await _executor.ExecuteAsync(toolCall);
+
+        Assert.Contains("File not found", result);
+    }
+
+    [Fact]
+    public async Task Routes_file_write()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"netclaw-dispatch-{Guid.NewGuid():N}.txt");
+        try
+        {
+            var toolCall = new FunctionCallContent(
+                "call-3", "file_write",
+                new Dictionary<string, object?>
+                {
+                    ["Path"] = filePath,
+                    ["Content"] = "dispatch test"
+                });
+
+            var result = await _executor.ExecuteAsync(toolCall);
+
+            Assert.Contains("Successfully wrote", result);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task Unknown_tool_returns_error_string()
+    {
+        var toolCall = new FunctionCallContent(
+            "call-4", "unknown_tool",
+            new Dictionary<string, object?> { ["arg"] = "value" });
+
+        var result = await _executor.ExecuteAsync(toolCall);
+
+        Assert.Equal("Unknown tool: unknown_tool", result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -1,0 +1,97 @@
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class FileReadToolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileReadTool _tool = new(new ToolConfig());
+
+    public FileReadToolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Read_existing_file_returns_content()
+    {
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        await File.WriteAllTextAsync(filePath, "hello world");
+
+        var args = new Dictionary<string, object?> { ["Path"] = filePath };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
+    public async Task Read_missing_file_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "nonexistent.txt");
+        var args = new Dictionary<string, object?> { ["Path"] = filePath };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("File not found", result);
+    }
+
+    [Fact]
+    public async Task Read_with_offset_and_limit()
+    {
+        var filePath = Path.Combine(_tempDir, "lines.txt");
+        var lines = Enumerable.Range(1, 10).Select(i => $"Line {i}");
+        await File.WriteAllLinesAsync(filePath, lines);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["Offset"] = 3,
+            ["Limit"] = 2
+        };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Line 3", result);
+        Assert.Contains("Line 4", result);
+        Assert.DoesNotContain("Line 2", result);
+        Assert.DoesNotContain("Line 5", result);
+    }
+
+    [Fact]
+    public async Task Large_file_is_truncated()
+    {
+        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 100 });
+        var filePath = Path.Combine(_tempDir, "large.txt");
+        await File.WriteAllTextAsync(filePath, new string('x', 500));
+
+        var args = new Dictionary<string, object?> { ["Path"] = filePath };
+        var result = await tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("[output truncated]", result);
+    }
+
+    [Fact]
+    public async Task Missing_path_returns_error()
+    {
+        var args = new Dictionary<string, object?>();
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Path", result);
+        Assert.Contains("missing", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Null_arguments_returns_error()
+    {
+        var result = await _tool.ExecuteAsync(null, CancellationToken.None);
+        Assert.Contains("No arguments provided", result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileWriteToolTests.cs
@@ -1,0 +1,100 @@
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class FileWriteToolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileWriteTool _tool = new();
+
+    public FileWriteToolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Write_new_file_creates_it()
+    {
+        var filePath = Path.Combine(_tempDir, "new.txt");
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["Content"] = "hello world"
+        };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Contains("bytes", result);
+        Assert.Equal("hello world", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Overwrite_existing_file()
+    {
+        var filePath = Path.Combine(_tempDir, "existing.txt");
+        await File.WriteAllTextAsync(filePath, "old content");
+
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["Content"] = "new content"
+        };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Equal("new content", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Creates_parent_directories()
+    {
+        var filePath = Path.Combine(_tempDir, "sub", "dir", "deep.txt");
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["Content"] = "deep content"
+        };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Successfully wrote", result);
+        Assert.Equal("deep content", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Missing_path_returns_error()
+    {
+        var args = new Dictionary<string, object?> { ["Content"] = "hello" };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Path", result);
+        Assert.Contains("missing", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Missing_content_returns_error()
+    {
+        var args = new Dictionary<string, object?> { ["Path"] = "/tmp/test.txt" };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Content", result);
+        Assert.Contains("missing", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Null_arguments_returns_error()
+    {
+        var result = await _tool.ExecuteAsync(null, CancellationToken.None);
+        Assert.Contains("No arguments provided", result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -51,8 +51,11 @@ public class ShellToolTests
     public async Task Output_truncation_applies()
     {
         var tool = new ShellTool(new ToolConfig { MaxOutputChars = 50 });
-        // Generate output longer than 50 chars
-        var args = new Dictionary<string, object?> { ["Command"] = "printf 'x%.0s' {1..200}" };
+        // Generate output longer than 50 chars — use cross-platform command
+        var command = OperatingSystem.IsWindows()
+            ? "python -c \"print('x' * 200)\""
+            : "printf 'x%.0s' {1..200}";
+        var args = new Dictionary<string, object?> { ["Command"] = command };
 
         var result = await tool.ExecuteAsync(args, CancellationToken.None);
 
@@ -63,18 +66,20 @@ public class ShellToolTests
     public async Task Working_directory_is_respected()
     {
         var tmpDir = Path.GetTempPath();
+        // Use platform-appropriate command to print working directory
+        var command = OperatingSystem.IsWindows() ? "cd" : "pwd";
         var args = new Dictionary<string, object?>
         {
-            ["Command"] = "pwd",
+            ["Command"] = command,
             ["WorkingDirectory"] = tmpDir
         };
 
         var result = await _tool.ExecuteAsync(args, CancellationToken.None);
 
-        // Resolve symlinks — /tmp may be a symlink to /private/tmp on macOS
-        var resolvedTmpDir = Path.GetFullPath(tmpDir).TrimEnd('/');
+        // Normalize paths for comparison: resolve symlinks, trim trailing separators
+        var resolvedTmpDir = Path.GetFullPath(tmpDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         Assert.Contains("Exit code: 0", result);
-        Assert.Contains(resolvedTmpDir, result);
+        Assert.Contains(resolvedTmpDir, result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -1,0 +1,113 @@
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class ShellToolTests
+{
+    private readonly ShellTool _tool = new(new ToolConfig());
+
+    [Fact]
+    public async Task Execute_echo_returns_output()
+    {
+        var args = new Dictionary<string, object?> { ["Command"] = "echo hello" };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("hello", result);
+        Assert.Contains("Exit code: 0", result);
+    }
+
+    [Fact]
+    public async Task Execute_captures_stderr()
+    {
+        var args = new Dictionary<string, object?> { ["Command"] = "echo error >&2" };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("error", result);
+        Assert.Contains("Exit code: 0", result);
+    }
+
+    [Fact]
+    public async Task Execute_returns_nonzero_exit_code()
+    {
+        var args = new Dictionary<string, object?> { ["Command"] = "exit 42" };
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Exit code: 42", result);
+    }
+
+    [Fact]
+    public async Task Timeout_kills_long_running_process()
+    {
+        var tool = new ShellTool(new ToolConfig { ShellTimeoutSeconds = 1 });
+        var args = new Dictionary<string, object?> { ["Command"] = "sleep 100" };
+
+        var result = await tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("timed out", result);
+    }
+
+    [Fact]
+    public async Task Output_truncation_applies()
+    {
+        var tool = new ShellTool(new ToolConfig { MaxOutputChars = 50 });
+        // Generate output longer than 50 chars
+        var args = new Dictionary<string, object?> { ["Command"] = "printf 'x%.0s' {1..200}" };
+
+        var result = await tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("[output truncated]", result);
+    }
+
+    [Fact]
+    public async Task Working_directory_is_respected()
+    {
+        var tmpDir = Path.GetTempPath();
+        var args = new Dictionary<string, object?>
+        {
+            ["Command"] = "pwd",
+            ["WorkingDirectory"] = tmpDir
+        };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        // Resolve symlinks — /tmp may be a symlink to /private/tmp on macOS
+        var resolvedTmpDir = Path.GetFullPath(tmpDir).TrimEnd('/');
+        Assert.Contains("Exit code: 0", result);
+        Assert.Contains(resolvedTmpDir, result);
+    }
+
+    [Fact]
+    public async Task Missing_command_returns_error()
+    {
+        var args = new Dictionary<string, object?>();
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("Command", result);
+        Assert.Contains("missing", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Null_arguments_returns_error()
+    {
+        var result = await _tool.ExecuteAsync(null, CancellationToken.None);
+        Assert.Contains("No arguments provided", result);
+    }
+
+    [Fact]
+    public void TruncateOutput_no_truncation_when_under_limit()
+    {
+        var input = "short output";
+        Assert.Equal(input, ShellTool.TruncateOutput(input, 100));
+    }
+
+    [Fact]
+    public void TruncateOutput_truncates_and_appends_indicator()
+    {
+        var input = new string('x', 200);
+        var result = ShellTool.TruncateOutput(input, 50);
+
+        Assert.StartsWith(new string('x', 50), result);
+        Assert.EndsWith("[output truncated]", result);
+    }
+}

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -7,11 +7,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Akka.Cluster.Sharding" />
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Aaron.Akka.Reminders" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="protobuf-net" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Netclaw.Tools.Abstractions\Netclaw.Tools.Abstractions.csproj" />
+    <ProjectReference Include="..\Netclaw.Tools.Generators\Netclaw.Tools.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Routes <see cref="FunctionCallContent"/> to the correct tool by name via the <see cref="ToolRegistry"/>.
+/// </summary>
+public sealed class DispatchingToolExecutor : IToolExecutor
+{
+    private readonly ToolRegistry _registry;
+
+    public DispatchingToolExecutor(ToolRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    public Task<string> ExecuteAsync(FunctionCallContent toolCall, CancellationToken ct = default)
+    {
+        var tool = _registry.GetByName(toolCall.Name);
+        if (tool is null)
+            return Task.FromResult($"Unknown tool: {toolCall.Name}");
+
+        return tool.ExecuteAsync(toolCall.Arguments, ct);
+    }
+}

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using System.Text;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Reads file contents as UTF-8 text with optional line offset/limit.
+/// </summary>
+[NetclawTool("file_read",
+    "Read the contents of a file as text",
+    Grant = "file")]
+public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
+{
+    private readonly ToolConfig _config;
+
+    public record Params(
+        [property: Description("Absolute path to the file to read")] string Path,
+        [property: Description("Line number to start reading from (1-based, optional)")] int? Offset = null,
+        [property: Description("Maximum number of lines to read (optional)")] int? Limit = null);
+
+    public FileReadTool(ToolConfig config)
+    {
+        _config = config;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Path))
+            return "Error: 'path' parameter is required.";
+
+        if (!File.Exists(args.Path))
+            return $"Error: File not found: {args.Path}";
+
+        // Treat 0 or negative as "not specified"
+        int? offset = args.Offset > 0 ? args.Offset : null;
+        int? limit = args.Limit > 0 ? args.Limit : null;
+
+        try
+        {
+            if (offset.HasValue || limit.HasValue)
+            {
+                return await ReadLinesAsync(args.Path, offset ?? 1, limit, _config.MaxOutputChars, ct);
+            }
+
+            var content = await File.ReadAllTextAsync(args.Path, Encoding.UTF8, ct);
+            return ShellTool.TruncateOutput(content, _config.MaxOutputChars);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return $"Error: Permission denied: {args.Path}";
+        }
+        catch (IOException ex)
+        {
+            return $"Error reading file: {ex.Message}";
+        }
+    }
+
+    private static async Task<string> ReadLinesAsync(
+        string path, int startLine, int? maxLines, int maxChars, CancellationToken ct)
+    {
+        var sb = new StringBuilder();
+        var lineNumber = 0;
+        var linesRead = 0;
+
+        using var reader = new StreamReader(path, Encoding.UTF8);
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            lineNumber++;
+            if (lineNumber < startLine)
+                continue;
+
+            if (maxLines.HasValue && linesRead >= maxLines.Value)
+                break;
+
+            if (sb.Length > 0)
+                sb.AppendLine();
+            sb.Append($"{lineNumber,6}\t{line}");
+            linesRead++;
+
+            if (sb.Length >= maxChars)
+            {
+                return ShellTool.TruncateOutput(sb.ToString(), maxChars);
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Netclaw.Actors/Tools/FileWriteTool.cs
+++ b/src/Netclaw.Actors/Tools/FileWriteTool.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using System.Text;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Writes content to a file as UTF-8, creating parent directories if needed.
+/// </summary>
+[NetclawTool("file_write",
+    "Write content to a file, creating parent directories if needed",
+    Grant = "file")]
+public sealed partial class FileWriteTool : NetclawTool<FileWriteTool.Params>
+{
+    public record Params(
+        [property: Description("Absolute path to the file to write")] string Path,
+        [property: Description("Content to write to the file")] string Content);
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Path))
+            return "Error: 'path' parameter is required.";
+
+        try
+        {
+            var directory = System.IO.Path.GetDirectoryName(args.Path);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var bytes = Encoding.UTF8.GetBytes(args.Content);
+            await File.WriteAllBytesAsync(args.Path, bytes, ct);
+
+            return $"Successfully wrote {bytes.Length} bytes to {args.Path}";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return $"Error: Permission denied: {args.Path}";
+        }
+        catch (IOException ex)
+        {
+            return $"Error writing file: {ex.Message}";
+        }
+    }
+}

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Executes shell commands via /bin/bash (Linux) or cmd.exe (Windows).
+/// Captures stdout+stderr, enforces timeout, closes stdin immediately.
+/// </summary>
+[NetclawTool("shell_execute",
+    "Execute a shell command and return stdout/stderr output with exit code",
+    Grant = "shell")]
+public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
+{
+    private readonly ToolConfig _config;
+
+    public record Params(
+        [property: Description("The shell command to execute")] string Command,
+        [property: Description("Working directory to run the command in (optional)")] string? WorkingDirectory = null);
+
+    public ShellTool(ToolConfig config)
+    {
+        _config = config;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Command))
+            return "Error: 'command' parameter is required.";
+
+        var isWindows = OperatingSystem.IsWindows();
+        var psi = new ProcessStartInfo
+        {
+            FileName = isWindows ? "cmd.exe" : "/bin/bash",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (isWindows)
+        {
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(args.Command);
+        }
+        else
+        {
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add(args.Command);
+        }
+
+        if (!string.IsNullOrWhiteSpace(args.WorkingDirectory))
+            psi.WorkingDirectory = args.WorkingDirectory;
+
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_config.ShellTimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+        Process process;
+        try
+        {
+            process = Process.Start(psi)!;
+        }
+        catch (Exception ex)
+        {
+            return $"Error starting process: {ex.Message}";
+        }
+
+        using (process)
+        {
+            process.StandardInput.Close();
+
+            var outputBuilder = new StringBuilder();
+            var errorBuilder = new StringBuilder();
+
+            try
+            {
+                var stdoutTask = process.StandardOutput.ReadToEndAsync(linkedCts.Token);
+                var stderrTask = process.StandardError.ReadToEndAsync(linkedCts.Token);
+
+                outputBuilder.Append(await stdoutTask);
+                errorBuilder.Append(await stderrTask);
+
+                await process.WaitForExitAsync(linkedCts.Token);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                return $"Error: Command timed out after {_config.ShellTimeoutSeconds} seconds.";
+            }
+
+            var result = new StringBuilder();
+            if (outputBuilder.Length > 0)
+                result.Append(outputBuilder);
+            if (errorBuilder.Length > 0)
+            {
+                if (result.Length > 0)
+                    result.AppendLine();
+                result.Append(errorBuilder);
+            }
+
+            var output = TruncateOutput(result.ToString(), _config.MaxOutputChars);
+            return $"Exit code: {process.ExitCode}{Environment.NewLine}{output}";
+        }
+    }
+
+    internal static string TruncateOutput(string output, int maxChars)
+    {
+        if (output.Length <= maxChars)
+            return output;
+
+        return string.Concat(output.AsSpan(0, maxChars), $"{Environment.NewLine}... [output truncated]");
+    }
+}

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -87,7 +87,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
             {
-                try { process.Kill(entireProcessTree: true); } catch { }
+                try { process.Kill(entireProcessTree: true); } catch (InvalidOperationException) { /* process already exited */ }
                 return $"Error: Command timed out after {_config.ShellTimeoutSeconds} seconds.";
             }
 

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -87,7 +87,15 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
             {
-                try { process.Kill(entireProcessTree: true); } catch (InvalidOperationException) { /* process already exited */ }
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited between timeout detection and kill — expected TOCTOU race
+                    System.Diagnostics.Debug.WriteLine("Process already exited during timeout cleanup");
+                }
                 return $"Error: Command timed out after {_config.ShellTimeoutSeconds} seconds.";
             }
 

--- a/src/Netclaw.Actors/Tools/ToolConfig.cs
+++ b/src/Netclaw.Actors/Tools/ToolConfig.cs
@@ -1,0 +1,10 @@
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Shared configuration for first-party tool execution.
+/// </summary>
+public sealed class ToolConfig
+{
+    public int ShellTimeoutSeconds { get; init; } = 60;
+    public int MaxOutputChars { get; init; } = 32_000;
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -1,0 +1,17 @@
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Registers all first-party tool definitions with the <see cref="ToolRegistry"/>.
+/// Tools are source-generated from <see cref="Netclaw.Tools.NetclawToolAttribute"/> — see ADR-001.
+/// </summary>
+public static class ToolRegistrationExtensions
+{
+    public static ToolRegistry WithFirstPartyTools(this ToolRegistry registry, ToolConfig config)
+    {
+        registry.Register(new ShellTool(config));
+        registry.Register(new FileReadTool(config));
+        registry.Register(new FileWriteTool());
+
+        return registry;
+    }
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -1,33 +1,72 @@
 using Microsoft.Extensions.AI;
+using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
 /// Registration entry pairing a tool with its ACL grant category.
 /// </summary>
-public sealed record ToolRegistration(AITool Tool, string GrantCategory);
+public sealed record ToolRegistration(INetclawTool Tool, string GrantCategory);
 
 /// <summary>
-/// Registers <see cref="AITool"/> definitions with grant categories for policy filtering.
+/// Registers <see cref="INetclawTool"/> definitions with grant categories for policy filtering.
 /// Sessions receive only tools whose grant category is in the session's allowed set.
 /// </summary>
 public sealed class ToolRegistry
 {
     private readonly List<ToolRegistration> _tools = new();
 
-    public void Register(AITool tool, string grantCategory)
+    public void Register(INetclawTool tool)
     {
-        _tools.Add(new ToolRegistration(tool, grantCategory));
+        _tools.Add(new ToolRegistration(tool, tool.GrantCategory));
     }
 
-    /// <summary>All registered tools regardless of grants.</summary>
+    /// <summary>
+    /// Register an <see cref="AITool"/> directly (for test fakes that don't implement INetclawTool).
+    /// </summary>
+    public void Register(AITool tool, string grantCategory)
+    {
+        _tools.Add(new ToolRegistration(new AIToolAdapter(tool, grantCategory), grantCategory));
+    }
+
+    /// <summary>All registered tools as AITool for ChatOptions.Tools.</summary>
     public IReadOnlyList<AITool> GetAllTools() =>
-        _tools.Select(t => t.Tool).ToList();
+        _tools.Select(t => t.Tool.ToAITool()).ToList();
 
     /// <summary>Only tools whose grant category is in the allowed set.</summary>
     public IReadOnlyList<AITool> GetToolsForGrants(IReadOnlySet<string> grantedCategories) =>
         _tools
             .Where(t => grantedCategories.Contains(t.GrantCategory))
-            .Select(t => t.Tool)
+            .Select(t => t.Tool.ToAITool())
             .ToList();
+
+    /// <summary>Find a tool by name for dispatch.</summary>
+    public INetclawTool? GetByName(string name) =>
+        _tools.FirstOrDefault(t => t.Tool.Name == name)?.Tool;
+
+    /// <summary>
+    /// Adapter to wrap bare <see cref="AITool"/> instances (e.g. test fakes) as <see cref="INetclawTool"/>.
+    /// </summary>
+    private sealed class AIToolAdapter : INetclawTool
+    {
+        private readonly AITool _tool;
+
+        public AIToolAdapter(AITool tool, string grantCategory)
+        {
+            _tool = tool;
+            GrantCategory = grantCategory;
+            Name = tool.GetType().Name;
+            Description = "";
+            ParameterSchema = default;
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+        public string GrantCategory { get; }
+        public System.Text.Json.JsonElement ParameterSchema { get; }
+        public AITool ToAITool() => _tool;
+
+        public Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
+            => Task.FromResult("Not supported via adapter");
+    }
 }

--- a/src/Netclaw.App/HeadlessAdapter.cs
+++ b/src/Netclaw.App/HeadlessAdapter.cs
@@ -1,0 +1,197 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Configuration;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.App;
+
+/// <summary>
+/// Hosted service that sends a single prompt to the LLM session and streams
+/// all output (tool calls, results, text, usage) to stdout, then exits.
+///
+/// This is the <c>-p</c> / <c>--prompt</c> headless mode — same UX concept
+/// as <c>claude -p</c>. Useful for smoke-testing tool discovery and invocation
+/// against different models without a human in the loop.
+/// </summary>
+public sealed class HeadlessAdapter : IHostedService
+{
+    private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
+    private readonly ActorSystem _actorSystem;
+    private readonly NetclawPaths _paths;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly HeadlessOptions _options;
+    private readonly ILogger<HeadlessAdapter> _logger;
+
+    private CancellationTokenRegistration _shutdownRegistration;
+
+    public HeadlessAdapter(
+        IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
+        ActorSystem actorSystem,
+        NetclawPaths paths,
+        IHostApplicationLifetime lifetime,
+        HeadlessOptions options,
+        ILogger<HeadlessAdapter> logger)
+    {
+        _sessionManagerProvider = sessionManagerProvider;
+        _actorSystem = actorSystem;
+        _paths = paths;
+        _lifetime = lifetime;
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _shutdownRegistration = _lifetime.ApplicationStarted.Register(() =>
+        {
+            _ = Task.Run(() => RunHeadlessAsync(_lifetime.ApplicationStopping), CancellationToken.None);
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _shutdownRegistration.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task RunHeadlessAsync(CancellationToken stopping)
+    {
+        try
+        {
+            var sessionManager = await _sessionManagerProvider.GetAsync(stopping);
+            var sessionId = new SessionId($"headless/{Guid.NewGuid():N}");
+
+            // Set up session log file
+            _paths.EnsureDirectoriesExist();
+            var logFileName = $"{sessionId.Value.Replace("/", "-")}.log";
+            var logPath = Path.Combine(_paths.LogsDirectory, logFileName);
+            var logWriter = new StreamWriter(logPath, append: false) { AutoFlush = true };
+
+            logWriter.WriteLine($"[{DateTimeOffset.UtcNow:o}] Headless session started: {sessionId}");
+            logWriter.WriteLine($"[{DateTimeOffset.UtcNow:o}] PROMPT: {_options.Prompt}");
+
+            // Create subscriber actor that writes session output to stdout + log
+            var subscriber = _actorSystem.ActorOf(
+                Props.Create(() => new HeadlessSubscriberActor(logWriter, _lifetime)),
+                $"headless-subscriber-{sessionId.Value.Replace("/", "-")}");
+
+            // Join the session with full output (tool calls, thinking, usage)
+            sessionManager.Tell(new JoinSession
+            {
+                SessionId = sessionId,
+                Subscriber = subscriber,
+                Filter = OutputFilter.Full
+            });
+
+            // Send the single prompt
+            sessionManager.Tell(new SendUserMessage
+            {
+                SessionId = sessionId,
+                Content = _options.Prompt
+            });
+
+            _logger.LogInformation("Headless session started: {SessionId} (log: {LogPath})", sessionId, logPath);
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogDebug(ex, "Headless adapter cancelled (shutdown)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Headless adapter failed");
+            _lifetime.StopApplication();
+        }
+    }
+}
+
+/// <summary>
+/// Subscriber actor for headless mode. Streams all session output to stdout
+/// in a human-readable format and shuts down the application on <see cref="TurnCompleted"/>.
+/// </summary>
+public sealed class HeadlessSubscriberActor : ReceiveActor
+{
+    private readonly StreamWriter _log;
+    private readonly IHostApplicationLifetime _lifetime;
+
+    public HeadlessSubscriberActor(StreamWriter logWriter, IHostApplicationLifetime lifetime)
+    {
+        _log = logWriter;
+        _lifetime = lifetime;
+
+        Receive<SessionJoined>(msg =>
+        {
+            Log($"SESSION_JOINED turn_count={msg.TurnCount} title={msg.Title ?? "(none)"}");
+        });
+
+        Receive<TextOutput>(msg =>
+        {
+            Console.WriteLine(msg.Text);
+            Log($"ASSISTANT: {msg.Text}");
+        });
+
+        Receive<ThinkingOutput>(msg =>
+        {
+            Console.WriteLine($"[thinking] {msg.Text}");
+            Log($"THINKING: {msg.Text}");
+        });
+
+        Receive<ToolCallOutput>(msg =>
+        {
+            Console.WriteLine($"[tool:call] {msg.ToolName}({msg.ArgumentsJson ?? ""})");
+            Log($"TOOL_CALL: {msg.ToolName} call_id={msg.CallId} args={msg.ArgumentsJson ?? "{}"}");
+        });
+
+        Receive<ToolResultOutput>(msg =>
+        {
+            Console.WriteLine($"[tool:result] {msg.ToolName} \u2192 {msg.Result}");
+            Log($"TOOL_RESULT: {msg.ToolName} call_id={msg.CallId} result={msg.Result}");
+        });
+
+        Receive<UsageOutput>(msg =>
+        {
+            Console.WriteLine($"[usage] in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens}");
+            Log($"USAGE: in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens} cached={msg.CachedInputTokens} reasoning={msg.ReasoningTokens} context_window={msg.ContextWindowTokens}");
+        });
+
+        Receive<ErrorOutput>(msg =>
+        {
+            Console.Error.WriteLine($"[error] {msg.Message}");
+            Log($"ERROR: {msg.Message}");
+            if (msg.Cause is not null)
+                Log($"EXCEPTION: {msg.Cause}");
+        });
+
+        Receive<TurnCompleted>(msg =>
+        {
+            Log($"TURN_COMPLETED: turn={msg.TurnNumber}");
+            _lifetime.StopApplication();
+        });
+
+        Receive<CompactionOutput>(msg =>
+        {
+            Console.WriteLine($"[compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages");
+            Log($"COMPACTION: before={msg.MessagesBefore} after={msg.MessagesAfter} tool_results_cleared={msg.ToolResultsCleared} summarized={msg.Summarized}");
+        });
+
+        Receive<SessionTitleOutput>(_ =>
+        {
+            // Ignored in headless mode — no UI to update
+        });
+    }
+
+    private void Log(string message)
+    {
+        _log.WriteLine($"[{DateTimeOffset.UtcNow:o}] {message}");
+    }
+
+    protected override void PostStop()
+    {
+        Log("SESSION_ENDED");
+        _log.Dispose();
+        base.PostStop();
+    }
+}

--- a/src/Netclaw.App/HeadlessOptions.cs
+++ b/src/Netclaw.App/HeadlessOptions.cs
@@ -1,0 +1,6 @@
+namespace Netclaw.App;
+
+public sealed class HeadlessOptions
+{
+    public required string Prompt { get; init; }
+}

--- a/src/Netclaw.App/Program.cs
+++ b/src/Netclaw.App/Program.cs
@@ -8,7 +8,20 @@ using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tools;
+using Netclaw.App;
 using OllamaSharp;
+
+// -- CLI mode selection --
+string? headlessPrompt = null;
+for (var i = 0; i < args.Length; i++)
+{
+    if (args[i] is "-p" or "--prompt" && i + 1 < args.Length)
+    {
+        headlessPrompt = args[i + 1];
+        break;
+    }
+}
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -45,6 +58,15 @@ builder.Services.AddSingleton<ISystemPromptProvider>(
     new StaticSystemPromptProvider(
         "You are Netclaw, a helpful homelab operations assistant. Be concise and direct."));
 
+// -- Tools --
+var toolConfig = new ToolConfig();
+builder.Services.AddSingleton(toolConfig);
+
+var toolRegistry = new ToolRegistry();
+toolRegistry.WithFirstPartyTools(toolConfig);
+builder.Services.AddSingleton(toolRegistry);
+builder.Services.AddSingleton<IToolExecutor>(new DispatchingToolExecutor(toolRegistry));
+
 // -- Akka.NET actor system --
 builder.Services.AddAkka("netclaw", (akkaBuilder, sp) =>
 {
@@ -60,7 +82,15 @@ builder.Services.AddAkka("netclaw", (akkaBuilder, sp) =>
         .WithNetclawActors();
 });
 
-// -- Console adapter (TUI proof-of-concept) --
-builder.Services.AddHostedService<ConsoleAdapter>();
+// -- Adapter selection --
+if (headlessPrompt is not null)
+{
+    builder.Services.AddSingleton(new HeadlessOptions { Prompt = headlessPrompt });
+    builder.Services.AddHostedService<HeadlessAdapter>();
+}
+else
+{
+    builder.Services.AddHostedService<ConsoleAdapter>();
+}
 
 await builder.Build().RunAsync();

--- a/src/Netclaw.Tools.Abstractions/INetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/INetclawTool.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Tools;
+
+/// <summary>
+/// A self-contained tool definition: schema, metadata, and execution in one type.
+/// </summary>
+public interface INetclawTool
+{
+    /// <summary>Tool name as seen by the LLM.</summary>
+    string Name { get; }
+
+    /// <summary>Human-readable description included in the tool schema.</summary>
+    string Description { get; }
+
+    /// <summary>ACL grant category for policy filtering.</summary>
+    string GrantCategory { get; }
+
+    /// <summary>JSON Schema describing the tool's parameters.</summary>
+    JsonElement ParameterSchema { get; }
+
+    /// <summary>
+    /// Produce an <see cref="AITool"/> for the <c>ChatOptions.Tools</c> boundary.
+    /// </summary>
+    AITool ToAITool();
+
+    /// <summary>
+    /// Execute the tool with raw arguments from the LLM provider.
+    /// </summary>
+    Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default);
+}

--- a/src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj
+++ b/src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Base class for source-generated tools. The generator implements
+/// <see cref="INetclawTool"/> members and a typed <c>ParseArguments</c> method.
+/// Tool authors override <see cref="ExecuteAsync(TParams, CancellationToken)"/>.
+/// </summary>
+/// <typeparam name="TParams">
+/// A record type whose constructor parameters define the tool's schema.
+/// The source generator reads these parameters to emit JSON schema and parsing logic.
+/// </typeparam>
+public abstract partial class NetclawTool<TParams> : INetclawTool where TParams : class
+{
+    private AITool? _aiTool;
+
+    // These are implemented by the source generator in the partial class:
+    //   public string Name { get; }
+    //   public string Description { get; }
+    //   public string GrantCategory { get; }
+    //   public JsonElement ParameterSchema { get; }
+    //   public TParams ParseArguments(IDictionary<string, object?> arguments)
+
+    /// <inheritdoc />
+    public AITool ToAITool()
+    {
+        return _aiTool ??= AIFunctionFactory.CreateDeclaration(Name, Description, ParameterSchema);
+    }
+
+    /// <summary>
+    /// Execute the tool with typed, deserialized arguments.
+    /// </summary>
+    protected abstract Task<string> ExecuteAsync(TParams args, CancellationToken ct);
+
+    /// <inheritdoc />
+    public async Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
+    {
+        if (arguments is null)
+            return $"Error: No arguments provided for tool '{Name}'.";
+
+        TParams args;
+        try
+        {
+            args = ParseArguments(arguments);
+        }
+        catch (Exception ex)
+        {
+            return $"Error parsing arguments for tool '{Name}': {ex.Message}";
+        }
+
+        return await ExecuteAsync(args, ct);
+    }
+
+    // Partial method — implemented by the source generator
+    public abstract string Name { get; }
+    public abstract string Description { get; }
+    public abstract string GrantCategory { get; }
+    public abstract JsonElement ParameterSchema { get; }
+
+    /// <summary>
+    /// Deserialize raw LLM arguments into the typed params record.
+    /// Implemented by the source generator to handle JsonElement and native CLR types.
+    /// </summary>
+    public abstract TParams ParseArguments(IDictionary<string, object?> arguments);
+}

--- a/src/Netclaw.Tools.Abstractions/NetclawToolAttribute.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawToolAttribute.cs
@@ -1,0 +1,25 @@
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Marks a class as a Netclaw tool for source generation.
+/// The generator emits JSON schema, argument parsing, and
+/// <see cref="INetclawTool"/> implementation glue at compile time.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class NetclawToolAttribute : Attribute
+{
+    public NetclawToolAttribute(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
+
+    /// <summary>Tool name as seen by the LLM (e.g. "shell_execute").</summary>
+    public string Name { get; }
+
+    /// <summary>Human-readable description included in the tool schema.</summary>
+    public string Description { get; }
+
+    /// <summary>ACL grant category for policy filtering (e.g. "shell", "file").</summary>
+    public string Grant { get; set; } = "default";
+}

--- a/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Runtime helpers for extracting typed values from tool argument dictionaries.
+/// Called by source-generated <c>ParseArguments</c> methods. Handles both
+/// <see cref="JsonElement"/> values (OllamaSharp) and native CLR types (OpenAI, etc.).
+/// </summary>
+public static class ToolArgumentHelper
+{
+    public static string? GetString(IDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            JsonElement je => je.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    public static int? GetNullableInt(IDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        return value switch
+        {
+            int i => i,
+            long l => (int)l,
+            double d => (int)d,
+            JsonElement { ValueKind: JsonValueKind.Number } je => je.GetInt32(),
+            string s when int.TryParse(s, out var parsed) => parsed,
+            JsonElement { ValueKind: JsonValueKind.String } je when int.TryParse(je.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    public static double? GetNullableDouble(IDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        return value switch
+        {
+            double d => d,
+            float f => f,
+            int i => i,
+            long l => l,
+            JsonElement { ValueKind: JsonValueKind.Number } je => je.GetDouble(),
+            string s when double.TryParse(s, out var parsed) => parsed,
+            JsonElement { ValueKind: JsonValueKind.String } je when double.TryParse(je.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    public static bool? GetNullableBool(IDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        return value switch
+        {
+            bool b => b,
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            string s when bool.TryParse(s, out var parsed) => parsed,
+            JsonElement { ValueKind: JsonValueKind.String } je when bool.TryParse(je.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+}

--- a/src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj
+++ b/src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj
@@ -8,6 +8,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <!-- Generators should not be published as regular libraries -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj
+++ b/src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <!-- Generators should not be published as regular libraries -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
+++ b/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
@@ -1,0 +1,322 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Netclaw.Tools.Generators;
+
+[Generator]
+public sealed class NetclawToolGenerator : IIncrementalGenerator
+{
+    private const string AttributeFullName = "Netclaw.Tools.NetclawToolAttribute";
+    private const string BaseClassPrefix = "Netclaw.Tools.NetclawTool<";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var toolClasses = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                AttributeFullName,
+                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                transform: static (ctx, ct) => ExtractToolModel(ctx, ct))
+            .Where(static m => m is not null)
+            .Select(static (m, _) => m!);
+
+        context.RegisterSourceOutput(toolClasses, static (spc, model) => GenerateSource(spc, model));
+    }
+
+    private static ToolModel? ExtractToolModel(GeneratorAttributeSyntaxContext ctx, System.Threading.CancellationToken ct)
+    {
+        var classSymbol = (INamedTypeSymbol)ctx.TargetSymbol;
+        var attr = ctx.Attributes[0];
+
+        // Read attribute values
+        var name = attr.ConstructorArguments[0].Value as string;
+        var description = attr.ConstructorArguments[1].Value as string;
+        if (name is null || description is null)
+            return null;
+
+        var grant = "default";
+        foreach (var namedArg in attr.NamedArguments)
+        {
+            if (namedArg.Key == "Grant" && namedArg.Value.Value is string g)
+                grant = g;
+        }
+
+        // Find the TParams type from the base class
+        INamedTypeSymbol? paramsType = null;
+        var baseType = classSymbol.BaseType;
+        while (baseType is not null)
+        {
+            if (baseType.IsGenericType &&
+                baseType.OriginalDefinition.ToDisplayString().StartsWith("Netclaw.Tools.NetclawTool<"))
+            {
+                paramsType = baseType.TypeArguments[0] as INamedTypeSymbol;
+                break;
+            }
+            baseType = baseType.BaseType;
+        }
+
+        if (paramsType is null)
+            return null;
+
+        // Extract constructor parameters from the params record
+        var primaryCtor = paramsType.InstanceConstructors
+            .FirstOrDefault(c => c.Parameters.Length > 0 && !c.IsImplicitlyDeclared)
+            ?? paramsType.InstanceConstructors
+            .FirstOrDefault(c => c.Parameters.Length > 0);
+
+        if (primaryCtor is null)
+            return null;
+
+        var parameters = new List<ToolParameter>();
+        foreach (var param in primaryCtor.Parameters)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var paramDescription = "";
+            foreach (var paramAttr in param.GetAttributes())
+            {
+                if (paramAttr.AttributeClass?.Name == "DescriptionAttribute" &&
+                    paramAttr.ConstructorArguments.Length > 0 &&
+                    paramAttr.ConstructorArguments[0].Value is string desc)
+                {
+                    paramDescription = desc;
+                    break;
+                }
+            }
+
+            var isNullable = param.Type.NullableAnnotation == NullableAnnotation.Annotated;
+            var hasDefault = param.HasExplicitDefaultValue;
+            var isRequired = !isNullable && !hasDefault;
+
+            var jsonType = GetJsonType(param.Type);
+
+            parameters.Add(new ToolParameter(
+                param.Name,
+                paramDescription,
+                jsonType,
+                isRequired,
+                isNullable,
+                param.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+        }
+
+        var classNamespace = classSymbol.ContainingNamespace.IsGlobalNamespace
+            ? null
+            : classSymbol.ContainingNamespace.ToDisplayString();
+
+        return new ToolModel(
+            classNamespace,
+            classSymbol.Name,
+            name,
+            description,
+            grant,
+            paramsType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            parameters.ToImmutableArray());
+    }
+
+    private static string GetJsonType(ITypeSymbol type)
+    {
+        // Unwrap Nullable<T>
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable)
+            type = nullable.TypeArguments[0];
+
+        // Unwrap nullable reference annotation
+        if (type.NullableAnnotation == NullableAnnotation.Annotated && type.OriginalDefinition is INamedTypeSymbol)
+            type = type.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        return type.SpecialType switch
+        {
+            SpecialType.System_String => "string",
+            SpecialType.System_Int32 => "integer",
+            SpecialType.System_Int64 => "integer",
+            SpecialType.System_Single => "number",
+            SpecialType.System_Double => "number",
+            SpecialType.System_Boolean => "boolean",
+            _ => type.Name switch
+            {
+                "Int16" => "integer",
+                "UInt16" => "integer",
+                "UInt32" => "integer",
+                "UInt64" => "integer",
+                _ => "string" // fallback
+            }
+        };
+    }
+
+    private static void GenerateSource(SourceProductionContext spc, ToolModel model)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System.Text.Json;");
+        sb.AppendLine("using Microsoft.Extensions.AI;");
+        sb.AppendLine();
+
+        if (model.Namespace is not null)
+        {
+            sb.AppendLine($"namespace {model.Namespace};");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine($"partial class {model.ClassName}");
+        sb.AppendLine("{");
+
+        // -- Static schema field --
+        sb.AppendLine("    private static readonly JsonElement _generatedSchema =");
+        sb.AppendLine("        JsonDocument.Parse(\"\"\"");
+        sb.AppendLine("        {");
+        sb.AppendLine("            \"type\": \"object\",");
+        sb.AppendLine("            \"properties\": {");
+
+        for (var i = 0; i < model.Parameters.Length; i++)
+        {
+            var p = model.Parameters[i];
+            var comma = i < model.Parameters.Length - 1 ? "," : "";
+            sb.AppendLine($"                \"{p.Name}\": {{");
+            sb.AppendLine($"                    \"type\": \"{p.JsonType}\",");
+            sb.AppendLine($"                    \"description\": \"{EscapeJson(p.Description)}\"");
+            sb.AppendLine($"                }}{comma}");
+        }
+
+        sb.AppendLine("            },");
+
+        // Required array
+        var required = model.Parameters.Where(p => p.IsRequired).ToArray();
+        sb.Append("            \"required\": [");
+        sb.Append(string.Join(", ", required.Select(p => $"\"{p.Name}\"")));
+        sb.AppendLine("]");
+
+        sb.AppendLine("        }");
+        sb.AppendLine("        \"\"\").RootElement.Clone();");
+        sb.AppendLine();
+
+        // -- INetclawTool properties --
+        sb.AppendLine($"    public override string Name => \"{EscapeJson(model.ToolName)}\";");
+        sb.AppendLine($"    public override string Description => \"{EscapeJson(model.ToolDescription)}\";");
+        sb.AppendLine($"    public override string GrantCategory => \"{EscapeJson(model.Grant)}\";");
+        sb.AppendLine("    public override JsonElement ParameterSchema => _generatedSchema;");
+        sb.AppendLine();
+
+        // -- ParseArguments --
+        sb.AppendLine($"    public override {model.ParamsTypeName} ParseArguments(System.Collections.Generic.IDictionary<string, object?> arguments)");
+        sb.AppendLine("    {");
+
+        foreach (var p in model.Parameters)
+        {
+            if (p.JsonType == "string")
+            {
+                sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetString(arguments, \"{p.Name}\");");
+                if (p.IsRequired)
+                {
+                    sb.AppendLine($"        if (string.IsNullOrWhiteSpace(__{p.Name}))");
+                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing or empty.\");");
+                }
+            }
+            else if (p.JsonType == "integer")
+            {
+                if (p.IsNullable)
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableInt(arguments, \"{p.Name}\");");
+                else if (p.IsRequired)
+                {
+                    sb.AppendLine($"        var __{p.Name}_raw = Netclaw.Tools.ToolArgumentHelper.GetNullableInt(arguments, \"{p.Name}\");");
+                    sb.AppendLine($"        if (__{p.Name}_raw is null)");
+                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing.\");");
+                    sb.AppendLine($"        var __{p.Name} = __{p.Name}_raw.Value;");
+                }
+                else
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableInt(arguments, \"{p.Name}\") ?? 0;");
+            }
+            else if (p.JsonType == "number")
+            {
+                if (p.IsNullable)
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableDouble(arguments, \"{p.Name}\");");
+                else if (p.IsRequired)
+                {
+                    sb.AppendLine($"        var __{p.Name}_raw = Netclaw.Tools.ToolArgumentHelper.GetNullableDouble(arguments, \"{p.Name}\");");
+                    sb.AppendLine($"        if (__{p.Name}_raw is null)");
+                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing.\");");
+                    sb.AppendLine($"        var __{p.Name} = __{p.Name}_raw.Value;");
+                }
+                else
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableDouble(arguments, \"{p.Name}\") ?? 0.0;");
+            }
+            else if (p.JsonType == "boolean")
+            {
+                if (p.IsNullable)
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableBool(arguments, \"{p.Name}\");");
+                else if (p.IsRequired)
+                {
+                    sb.AppendLine($"        var __{p.Name}_raw = Netclaw.Tools.ToolArgumentHelper.GetNullableBool(arguments, \"{p.Name}\");");
+                    sb.AppendLine($"        if (__{p.Name}_raw is null)");
+                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing.\");");
+                    sb.AppendLine($"        var __{p.Name} = __{p.Name}_raw.Value;");
+                }
+                else
+                    sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetNullableBool(arguments, \"{p.Name}\") ?? false;");
+            }
+        }
+
+        sb.AppendLine();
+        sb.Append($"        return new {model.ParamsTypeName}(");
+        sb.Append(string.Join(", ", model.Parameters.Select(p => $"__{p.Name}")));
+        sb.AppendLine(");");
+        sb.AppendLine("    }");
+
+        sb.AppendLine("}");
+
+        spc.AddSource($"{model.ClassName}.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+    }
+
+    private static string EscapeJson(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}
+
+internal sealed class ToolModel
+{
+    public ToolModel(string? ns, string className, string toolName, string toolDescription,
+        string grant, string paramsTypeName, ImmutableArray<ToolParameter> parameters)
+    {
+        Namespace = ns;
+        ClassName = className;
+        ToolName = toolName;
+        ToolDescription = toolDescription;
+        Grant = grant;
+        ParamsTypeName = paramsTypeName;
+        Parameters = parameters;
+    }
+
+    public string? Namespace { get; }
+    public string ClassName { get; }
+    public string ToolName { get; }
+    public string ToolDescription { get; }
+    public string Grant { get; }
+    public string ParamsTypeName { get; }
+    public ImmutableArray<ToolParameter> Parameters { get; }
+}
+
+internal sealed class ToolParameter
+{
+    public ToolParameter(string name, string description, string jsonType,
+        bool isRequired, bool isNullable, string clrTypeName)
+    {
+        Name = name;
+        Description = description;
+        JsonType = jsonType;
+        IsRequired = isRequired;
+        IsNullable = isNullable;
+        ClrTypeName = clrTypeName;
+    }
+
+    public string Name { get; }
+    public string Description { get; }
+    public string JsonType { get; }
+    public bool IsRequired { get; }
+    public bool IsNullable { get; }
+    public string ClrTypeName { get; }
+}


### PR DESCRIPTION
## Summary

- Add `-p`/`--prompt` CLI flag for single-shot headless execution that streams tool calls, results, and assistant responses to stdout then exits — enables smoke-testing tool invocation against real LLMs without interactive TUI
- Replace M.E.AI's AIFunctionFactory reflection-based tool schema generation with a Roslyn incremental source generator that produces JSON schemas at compile time, giving full control over schema format and argument normalization across providers
- New `Netclaw.Tools.Abstractions` project: `INetclawTool` interface, `NetclawTool<T>` base class, `[NetclawTool]` attribute, `ToolArgumentHelper`
- New `Netclaw.Tools.Generators` project: Roslyn incremental source generator emitting `ParseArguments` and JSON schemas from typed `Params` records
- Migrate ShellTool, FileReadTool, FileWriteTool to the new `[NetclawTool]` pattern
- Refactor ToolRegistry and DispatchingToolExecutor to use `INetclawTool`
- Add ADR-001 documenting rationale for owning tool schemas

## Test plan

- [x] `dotnet build Netclaw.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Netclaw.slnx` — 110/110 tests passing
- [x] Headless smoke test: `dotnet run --project src/Netclaw.App -- -p "list the files in /tmp"` — LLM correctly called tools with PascalCase params from generated schema, tool executed, model responded