### PR TITLE
Harden smoke logs and add CI image caching

### DIFF
--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       PROJECT_NAME: netclaw-smoke-${{ github.run_id }}-${{ github.run_attempt }}
       SMOKE_OLLAMA_MODEL: qwen2:0.5b
+      SMOKE_BUILD: 0
       INIT_TIMEOUT_SECONDS: 1200
       START_TIMEOUT_SECONDS: 180
       STEP_TIMEOUT_SECONDS: 120
@@ -40,11 +41,27 @@ jobs:
         with:
           global-json-file: ./global.json
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build smoke sandbox image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/smoke/Dockerfile
+          tags: netclaw-smoke:local
+          load: true
+          cache-from: type=gha,scope=netclaw-smoke
+          cache-to: type=gha,mode=max,scope=netclaw-smoke
+
       - name: Start smoke sandbox
         run: bash scripts/smoke/up.sh
 
       - name: Run smoke checks
-        run: bash scripts/smoke/check.sh
+        run: |
+          mkdir -p smoke-logs
+          set -o pipefail
+          bash scripts/smoke/check.sh 2>&1 | tee smoke-logs/check.log
 
       - name: Collect smoke logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ command yet).
 # Start sandbox (build local image + start Ollama + pull tiny model)
 scripts/smoke/up.sh
 
+# Start without rebuilding image (useful after pre-building or in CI)
+SMOKE_BUILD=0 scripts/smoke/up.sh
+
 # Run smoke checks (daemon start/status/health/stop)
 scripts/smoke/check.sh
 
@@ -74,9 +77,10 @@ STEP_TIMEOUT_SECONDS=120 scripts/smoke/check.sh
 `smoke_sandbox` is available in GitHub Actions:
 
 - Runs manually via `workflow_dispatch`.
-- Runs on PRs labeled `smoke`.
-- Always uploads `smoke-logs-*` artifact (container logs, compose status,
-  daemon log, PID snapshot) for debugging.
+- Runs on every pull request update.
+- Uses Docker Buildx + GitHub Actions cache for smoke image layers.
+- Always uploads `smoke-logs-*` artifact (including `check.log`, container
+  logs, compose status, daemon log, PID snapshot) for debugging.
 
 ## CLI Reference
 

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -7,24 +7,13 @@ services:
 
   ollama-init:
     image: curlimages/curl:8.13.0
-    entrypoint: ["/bin/sh", "-c"]
+    entrypoint: ["/bin/sh", "/usr/local/bin/ollama-init.sh"]
     environment:
       SMOKE_OLLAMA_MODEL: ${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}
     depends_on:
       - ollama
-    command: >
-      set -eu;
-      echo "Waiting for Ollama API to become available...";
-      for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
-        if curl -fsS http://ollama:11434/api/tags >/dev/null; then
-          break;
-        fi;
-        echo "Ollama not ready yet (attempt $$i/12).";
-        sleep 5;
-      done;
-      echo "Pulling smoke model: $${SMOKE_OLLAMA_MODEL}";
-      curl -fsS -X POST http://ollama:11434/api/pull -d "{\"name\":\"$${SMOKE_OLLAMA_MODEL}\"}" >/dev/null;
-      echo "Model pull request completed.";
+    volumes:
+      - ./scripts/smoke/ollama-init.sh:/usr/local/bin/ollama-init.sh:ro
 
   netclaw-sandbox:
     image: netclaw-smoke:local

--- a/scripts/smoke/collect-logs.sh
+++ b/scripts/smoke/collect-logs.sh
@@ -36,4 +36,8 @@ run_timed "$STEP_TIMEOUT_SECONDS" docker compose -p "$PROJECT_NAME" -f "$COMPOSE
   'if [ -f /root/.netclaw/netclaw.pid ]; then cat /root/.netclaw/netclaw.pid; fi' \
   >"$LOG_DIR/netclaw.pid" || true
 
+run_timed "$STEP_TIMEOUT_SECONDS" docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox sh -lc \
+  'ls -la /root/.netclaw || true' \
+  >"$LOG_DIR/netclaw-home-ls.txt" || true
+
 echo "Smoke logs collected at: $LOG_DIR"

--- a/scripts/smoke/ollama-init.sh
+++ b/scripts/smoke/ollama-init.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+
+echo "Waiting for Ollama API to become available..."
+for i in $(seq 1 24); do
+  if curl -fsS http://ollama:11434/api/tags >/dev/null; then
+    echo "Ollama is ready."
+    break
+  fi
+
+  echo "Ollama not ready yet (attempt $i/24)."
+  sleep 5
+done
+
+echo "Pulling smoke model: $MODEL"
+curl -fsS -X POST http://ollama:11434/api/pull -d "{\"name\":\"$MODEL\"}"
+
+echo "Verifying model is available: $MODEL"
+curl -fsS http://ollama:11434/api/tags
+
+echo "Model init completed."

--- a/scripts/smoke/up.sh
+++ b/scripts/smoke/up.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.smoke.yml}"
 PROJECT_NAME="${PROJECT_NAME:-netclaw-smoke}"
+SMOKE_BUILD="${SMOKE_BUILD:-1}"
 
-docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d --build
+if [[ "$SMOKE_BUILD" == "1" ]]; then
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d --build
+else
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d
+fi
 
 cat <<EOF
 Smoke sandbox is starting.


### PR DESCRIPTION
## Summary
- make `ollama-init` output explicit and deterministic by moving bootstrap logic into a dedicated script mounted into the init container
- improve smoke diagnostics by teeing `scripts/smoke/check.sh` output into `smoke-logs/check.log` and collecting additional netclaw home snapshots
- add Docker Buildx + GitHub Actions cache-backed smoke image prebuild, then run compose startup with `SMOKE_BUILD=0`

## Validation
- `bash -n scripts/smoke/up.sh`
- `bash -n scripts/smoke/check.sh`
- `bash -n scripts/smoke/down.sh`
- `bash -n scripts/smoke/collect-logs.sh`
- `docker compose -f docker-compose.smoke.yml config`
- `scripts/smoke/up.sh`
- `scripts/smoke/check.sh`
- `scripts/smoke/collect-logs.sh /tmp/netclaw-smoke-logs-improved`
- `scripts/smoke/down.sh`