### PR TITLE
Add SQLite daemon migrations and reentrant session test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
     <AkkaHostingVersion>1.5.60</AkkaHostingVersion>
+    <AkkaPersistenceSqlHostingVersion>1.5.60.1</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.4.0</AkkaRemindersVersion>
   </PropertyGroup>
   <!-- App dependencies -->
@@ -11,10 +12,12 @@
     <PackageVersion Include="Akka.Cluster.Sharding" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Akka.Persistence.Sql.Hosting" Version="$(AkkaPersistenceSqlHostingVersion)" />
     <PackageVersion Include="Aaron.Akka.Reminders" Version="$(AkkaRemindersVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ STEP_TIMEOUT_SECONDS=120 scripts/smoke/check.sh
 - Always uploads `smoke-logs-*` artifact (including `check.log`, container
   logs, compose status, daemon log, PID snapshot) for debugging.
 
+## Operations Runbooks
+
+- Daemon upgrade and rollback planning: `docs/runbooks/daemon-upgrade.md`
+
 ## CLI Reference
 
 ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ STEP_TIMEOUT_SECONDS=120 scripts/smoke/check.sh
 
 - Daemon upgrade and rollback planning: `docs/runbooks/daemon-upgrade.md`
 
+## Persistence Config
+
+Daemon persistence config belongs in `~/.netclaw/config/netclaw.json` (not
+`secrets.json`). SQLite path is local file state, not a secret.
+
+```json
+{
+  "Persistence": {
+    "Provider": "Sqlite",
+    "Sqlite": {
+      "Path": "/home/your-user/.netclaw/netclaw.db",
+      "AutoMigrate": true
+    }
+  }
+}
+```
+
 ## CLI Reference
 
 ```

--- a/docs/runbooks/daemon-upgrade.md
+++ b/docs/runbooks/daemon-upgrade.md
@@ -1,0 +1,58 @@
+# Daemon Upgrade Runbook
+
+This runbook describes how to upgrade `netclawd` safely while preserving local
+state under `~/.netclaw`.
+
+## Goals
+
+- keep user/session state across upgrades
+- apply schema migrations at daemon startup
+- provide a clear rollback path
+
+## Data and Binary Separation
+
+- **Binaries**: `netclawd` / `netclaw` executable artifacts
+- **Persistent data**: `~/.netclaw` (including `netclaw.db`, config, logs)
+
+Upgrade reliability depends on replacing binaries while retaining persistent
+data.
+
+## Docker Upgrade
+
+1. Stop old container.
+2. Keep the existing persistent volume mounted at the same data path.
+3. Start new image version.
+4. Wait for startup migration + readiness:
+   - `/api/health/ready`
+   - `netclaw daemon status` (if CLI available)
+
+## Direct Host Upgrade
+
+1. Stop daemon:
+   - `netclaw daemon stop`
+   - or `systemctl --user stop netclaw`
+2. Optional backup:
+   - `cp ~/.netclaw/netclaw.db ~/.netclaw/netclaw.db.bak.$(date +%s)`
+3. Replace binaries with new version.
+4. Start daemon:
+   - `netclaw daemon start`
+   - or `systemctl --user start netclaw`
+5. Verify health:
+   - `netclaw daemon status`
+   - `curl http://127.0.0.1:5199/api/health/ready`
+
+## Rollback Notes
+
+- Rollback is binary rollback plus, if needed, restoring a DB backup.
+- Schema migrations should be treated as forward-only unless explicitly
+  documented otherwise.
+- For releases with incompatible schema changes, publish a release note entry
+  with explicit rollback guidance.
+
+## Release Checklist (Pre-Distribution)
+
+- migration scripts are idempotent and versioned
+- startup migration tested on existing DB from previous release
+- upgrade and rollback steps validated on:
+  - Docker deployment path
+  - direct host/systemd path

--- a/src/Netclaw.Actors.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -17,6 +17,65 @@ namespace Netclaw.Actors.Tests.Cli;
 public sealed class DaemonClientReconnectIntegrationTests
 {
     [Fact]
+    public async Task EnsureSession_reattaches_same_session_after_transport_disconnect()
+    {
+        var port = GetFreeTcpPort();
+        using var host = await StartFakeHubAsync(port);
+
+        await using var client = new DaemonClient($"http://127.0.0.1:{port}");
+
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconnectedOutput = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var connectionSub = client.ConnectionEvents.Subscribe(evt =>
+        {
+            if (evt.State is DaemonConnectionState.Disconnected)
+                disconnected.TrySetResult();
+
+            if (evt.State is DaemonConnectionState.Connected && disconnected.Task.IsCompleted)
+                reconnected.TrySetResult();
+        });
+
+        using var outputSub = client.SessionOutput.Subscribe(output =>
+        {
+            if (output is TextOutput { Text: "echo:after" })
+                reconnectedOutput.TrySetResult();
+        });
+
+        var sessionId = await client.CreateSessionAsync("tui");
+
+        try
+        {
+            await client.SendAsync(new ChannelInput
+            {
+                SenderId = "test",
+                Contents = [new TextContent("drop")],
+                ReceivedAt = DateTimeOffset.UtcNow
+            });
+        }
+        catch (Exception ex)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(ex.Message));
+        }
+
+        await WaitFor(disconnected.Task, TimeSpan.FromSeconds(5));
+        await WaitFor(reconnected.Task, TimeSpan.FromSeconds(10));
+
+        var ensured = await client.EnsureSessionAsync("tui");
+        Assert.Equal(sessionId, ensured);
+
+        await client.SendAsync(new ChannelInput
+        {
+            SenderId = "test",
+            Contents = [new TextContent("after")],
+            ReceivedAt = DateTimeOffset.UtcNow
+        });
+
+        await WaitFor(reconnectedOutput.Task, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task EnsureSession_recreates_session_after_server_restart()
     {
         var port = GetFreeTcpPort();
@@ -148,6 +207,12 @@ public sealed class DaemonClientReconnectIntegrationTests
         {
             if (!_state.IsAttached(Context.ConnectionId, sessionId))
                 throw new HubException("session not attached");
+
+            if (string.Equals(text, "drop", StringComparison.Ordinal))
+            {
+                Context.Abort();
+                return;
+            }
 
             await Clients.Caller.ReceiveOutput(new SessionOutputDto
             {

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -22,6 +22,7 @@ public sealed class NetclawPaths
     public string LogsDirectory => Path.Combine(BasePath, "logs");
     public string DaemonLogPath => Path.Combine(LogsDirectory, "daemon.log");
     public string PidFilePath => Path.Combine(BasePath, "netclaw.pid");
+    public string SqliteDbPath => Path.Combine(BasePath, "netclaw.db");
 
     public NetclawPaths(string? basePath = null)
     {

--- a/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptions.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptions.cs
@@ -1,8 +1,14 @@
 namespace Netclaw.Daemon.Configuration;
 
+public enum PersistenceProvider
+{
+    Sqlite,
+    InMemory
+}
+
 public sealed class DaemonPersistenceOptions
 {
-    public string Provider { get; init; } = "Sqlite";
+    public PersistenceProvider Provider { get; init; } = PersistenceProvider.Sqlite;
 
     public SqlitePersistenceOptions Sqlite { get; init; } = new();
 }

--- a/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptions.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptions.cs
@@ -1,0 +1,15 @@
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class DaemonPersistenceOptions
+{
+    public string Provider { get; init; } = "Sqlite";
+
+    public SqlitePersistenceOptions Sqlite { get; init; } = new();
+}
+
+public sealed class SqlitePersistenceOptions
+{
+    public string? Path { get; init; }
+
+    public bool AutoMigrate { get; init; } = true;
+}

--- a/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptionsValidator.cs
+++ b/src/Netclaw.Daemon/Configuration/DaemonPersistenceOptionsValidator.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Options;
+
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class DaemonPersistenceOptionsValidator : IValidateOptions<DaemonPersistenceOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DaemonPersistenceOptions options)
+    {
+        if (options.Provider == PersistenceProvider.Sqlite
+            && options.Sqlite.Path is not null
+            && string.IsNullOrWhiteSpace(options.Sqlite.Path))
+        {
+            return ValidateOptionsResult.Fail(
+                "Persistence:Sqlite:Path cannot be empty when provided.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -11,7 +11,15 @@
   <ItemGroup>
     <PackageReference Include="Akka.Hosting" />
     <PackageReference Include="Akka.Persistence.Hosting" />
+    <PackageReference Include="Akka.Persistence.Sql.Hosting" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="OllamaSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="migrations\sqlite\**\*.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Tools;
@@ -119,6 +120,12 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
 
 static void ConfigureDaemonServices(IServiceCollection services, IConfigurationManager configuration, NetclawPaths paths)
 {
+    services
+        .AddOptions<DaemonPersistenceOptions>()
+        .Bind(configuration.GetSection("Persistence"))
+        .ValidateOnStart();
+    services.AddSingleton<IValidateOptions<DaemonPersistenceOptions>, DaemonPersistenceOptionsValidator>();
+
     var persistence = configuration.GetSection("Persistence")
         .Get<DaemonPersistenceOptions>() ?? new DaemonPersistenceOptions();
     services.AddSingleton(persistence);
@@ -182,7 +189,7 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
             setup.LogLevel = Akka.Event.LogLevel.WarningLevel;
         });
 
-        if (string.Equals(persistence.Provider, "Sqlite", StringComparison.OrdinalIgnoreCase))
+        if (persistence.Provider is PersistenceProvider.Sqlite)
         {
             var connectionString = $"Data Source={sqlitePath}";
             akkaBuilder = akkaBuilder.WithSqlPersistence(

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1,5 +1,6 @@
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using Akka.Persistence.Sql.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -118,6 +119,10 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
 
 static void ConfigureDaemonServices(IServiceCollection services, IConfigurationManager configuration, NetclawPaths paths)
 {
+    var persistence = configuration.GetSection("Persistence")
+        .Get<DaemonPersistenceOptions>() ?? new DaemonPersistenceOptions();
+    services.AddSingleton(persistence);
+
     services.Configure<HostOptions>(options =>
     {
         options.ShutdownTimeout = TimeSpan.FromSeconds(10);
@@ -158,19 +163,40 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
     services.AddSingleton<ISystemPromptProvider>(
         new FileSystemPromptProvider(paths));
 
+    var sqlitePath = string.IsNullOrWhiteSpace(persistence.Sqlite.Path)
+        ? paths.SqliteDbPath
+        : persistence.Sqlite.Path!;
+
+    // Schema migration for SQLite persistence
+    services.AddSingleton<SchemaMigrator>();
+    services.AddSingleton<SchemaMigrationHostedService>();
+    services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SchemaMigrationHostedService>());
+
     // Akka.NET actor system
     services.AddAkka("netclaw", (akkaBuilder, sp) =>
     {
-        akkaBuilder
-            .ConfigureLoggers(setup =>
-            {
-                setup.ClearLoggers();
-                setup.AddLoggerFactory();
-                setup.LogLevel = Akka.Event.LogLevel.WarningLevel;
-            })
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
+        akkaBuilder = akkaBuilder.ConfigureLoggers(setup =>
+        {
+            setup.ClearLoggers();
+            setup.AddLoggerFactory();
+            setup.LogLevel = Akka.Event.LogLevel.WarningLevel;
+        });
+
+        if (string.Equals(persistence.Provider, "Sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            var connectionString = $"Data Source={sqlitePath}";
+            akkaBuilder = akkaBuilder.WithSqlPersistence(
+                connectionString: connectionString,
+                providerName: "SQLite.MS");
+        }
+        else
+        {
+            akkaBuilder = akkaBuilder
+                .WithInMemoryJournal()
+                .WithInMemorySnapshotStore();
+        }
+
+        akkaBuilder.WithNetclawActors();
     });
 
     // Session pipeline (stream API for channels)

--- a/src/Netclaw.Daemon/Services/SchemaMigrationHostedService.cs
+++ b/src/Netclaw.Daemon/Services/SchemaMigrationHostedService.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+public sealed class SchemaMigrationHostedService : IHostedService
+{
+    private readonly DaemonPersistenceOptions _options;
+    private readonly NetclawPaths _paths;
+    private readonly SchemaMigrator _migrator;
+    private readonly ILogger<SchemaMigrationHostedService> _logger;
+
+    public SchemaMigrationHostedService(
+        DaemonPersistenceOptions options,
+        NetclawPaths paths,
+        SchemaMigrator migrator,
+        ILogger<SchemaMigrationHostedService> logger)
+    {
+        _options = options;
+        _paths = paths;
+        _migrator = migrator;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!string.Equals(_options.Provider, "Sqlite", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (!_options.Sqlite.AutoMigrate)
+            return;
+
+        var sqlitePath = ResolveSqlitePath();
+        _logger.LogInformation("Running SQLite schema migrations at {Path}", sqlitePath);
+        await _migrator.MigrateAsync(sqlitePath, cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private string ResolveSqlitePath()
+        => string.IsNullOrWhiteSpace(_options.Sqlite.Path)
+            ? _paths.SqliteDbPath
+            : _options.Sqlite.Path!;
+}

--- a/src/Netclaw.Daemon/Services/SchemaMigrationHostedService.cs
+++ b/src/Netclaw.Daemon/Services/SchemaMigrationHostedService.cs
@@ -26,7 +26,7 @@ public sealed class SchemaMigrationHostedService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        if (!string.Equals(_options.Provider, "Sqlite", StringComparison.OrdinalIgnoreCase))
+        if (_options.Provider is not PersistenceProvider.Sqlite)
             return;
 
         if (!_options.Sqlite.AutoMigrate)

--- a/src/Netclaw.Daemon/Services/SchemaMigrator.cs
+++ b/src/Netclaw.Daemon/Services/SchemaMigrator.cs
@@ -1,0 +1,122 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+public sealed class SchemaMigrator
+{
+    private readonly NetclawPaths _paths;
+    private readonly ILogger<SchemaMigrator> _logger;
+
+    public SchemaMigrator(NetclawPaths paths, ILogger<SchemaMigrator> logger)
+    {
+        _paths = paths;
+        _logger = logger;
+    }
+
+    public async Task MigrateAsync(string sqlitePath, CancellationToken cancellationToken)
+    {
+        _paths.EnsureDirectoriesExist();
+        Directory.CreateDirectory(Path.GetDirectoryName(sqlitePath) ?? _paths.BasePath);
+
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = sqlitePath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+
+        await using var conn = new SqliteConnection(connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await EnsureSchemaVersionTableAsync(conn, cancellationToken);
+
+        var applied = await ReadAppliedVersionsAsync(conn, cancellationToken);
+        var migrations = DiscoverMigrations();
+
+        foreach (var migration in migrations)
+        {
+            if (applied.Contains(migration.Version))
+                continue;
+
+            _logger.LogInformation("Applying SQLite migration {Version}: {Name}", migration.Version, migration.Name);
+
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(cancellationToken);
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = migration.Sql;
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = "INSERT INTO schema_version(version, name, applied_at) VALUES ($v, $n, unixepoch())";
+                cmd.Parameters.AddWithValue("$v", migration.Version);
+                cmd.Parameters.AddWithValue("$n", migration.Name);
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await tx.CommitAsync(cancellationToken);
+        }
+
+        _logger.LogInformation("SQLite schema migration complete ({Count} migration files discovered)", migrations.Count);
+    }
+
+    private static async Task EnsureSchemaVersionTableAsync(SqliteConnection conn, CancellationToken cancellationToken)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            """
+            CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at INTEGER NOT NULL
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task<HashSet<int>> ReadAppliedVersionsAsync(SqliteConnection conn, CancellationToken cancellationToken)
+    {
+        var versions = new HashSet<int>();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT version FROM schema_version";
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            versions.Add(reader.GetInt32(0));
+        }
+
+        return versions;
+    }
+
+    private static List<SqlMigration> DiscoverMigrations()
+    {
+        var migrationRoot = Path.Combine(AppContext.BaseDirectory, "migrations", "sqlite");
+        if (!Directory.Exists(migrationRoot))
+            return [];
+
+        return Directory.GetFiles(migrationRoot, "*.sql", SearchOption.TopDirectoryOnly)
+            .Select(path => new
+            {
+                Path = path,
+                Name = Path.GetFileName(path),
+                Version = ParseVersion(Path.GetFileName(path))
+            })
+            .Where(x => x.Version is not null)
+            .OrderBy(x => x.Version)
+            .Select(x => new SqlMigration(x.Version!.Value, x.Name, File.ReadAllText(x.Path)))
+            .ToList();
+    }
+
+    private static int? ParseVersion(string fileName)
+    {
+        var first = fileName.Split('_', 2)[0];
+        return int.TryParse(first, out var v) ? v : null;
+    }
+
+    private sealed record SqlMigration(int Version, string Name, string Sql);
+}

--- a/src/Netclaw.Daemon/migrations/sqlite/001_akka_persistence_tables.sql
+++ b/src/Netclaw.Daemon/migrations/sqlite/001_akka_persistence_tables.sql
@@ -1,0 +1,50 @@
+-- Netclaw SQLite migration 001
+-- Initializes Akka.Persistence.Sql default SQLite tables.
+
+CREATE TABLE IF NOT EXISTS journal (
+    ordering INTEGER PRIMARY KEY AUTOINCREMENT,
+    deleted INTEGER NOT NULL DEFAULT 0,
+    persistence_id TEXT NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    created INTEGER NOT NULL,
+    tags TEXT,
+    message BLOB NOT NULL,
+    identifier INTEGER,
+    manifest TEXT,
+    writer_uuid TEXT,
+    UNIQUE (persistence_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS journal_ordering_idx ON journal (ordering);
+CREATE INDEX IF NOT EXISTS journal_created_idx ON journal (created);
+CREATE INDEX IF NOT EXISTS journal_persistence_id_idx ON journal (persistence_id);
+
+CREATE TABLE IF NOT EXISTS snapshot (
+    persistence_id TEXT NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    created INTEGER NOT NULL,
+    snapshot BLOB,
+    manifest TEXT,
+    serializer_id INTEGER,
+    PRIMARY KEY (persistence_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS snapshot_sequence_number_idx ON snapshot (sequence_number);
+CREATE INDEX IF NOT EXISTS snapshot_created_idx ON snapshot (created);
+
+CREATE TABLE IF NOT EXISTS journal_metadata (
+    persistence_id TEXT NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    PRIMARY KEY (persistence_id, sequence_number)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+    ordering_id INTEGER NOT NULL,
+    tag TEXT NOT NULL,
+    sequence_nr INTEGER NOT NULL,
+    persistence_id TEXT NOT NULL,
+    PRIMARY KEY (ordering_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS tags_persistence_id_sequence_nr_idx ON tags (persistence_id, sequence_nr);
+CREATE INDEX IF NOT EXISTS tags_tag_idx ON tags (tag);

--- a/src/Netclaw.Daemon/migrations/sqlite/002_data_migrations_tracking.sql
+++ b/src/Netclaw.Daemon/migrations/sqlite/002_data_migrations_tracking.sql
@@ -1,0 +1,11 @@
+-- Netclaw SQLite migration 002
+-- Tracks one-time data migrations.
+
+CREATE TABLE IF NOT EXISTS data_migrations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    executed_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS data_migrations_name_idx ON data_migrations(name);


### PR DESCRIPTION
## Summary
- add daemon-side SQLite persistence configuration with startup schema migration support and versioned SQL scripts for Akka persistence tables plus data migration tracking
- add `~/.netclaw/netclaw.db` path support and document host/docker upgrade workflow in a new daemon upgrade runbook
- add an integration test that verifies reattaching an existing session after transport disconnect using in-memory state

## Validation
- `dotnet build Netclaw.slnx`
- `dotnet test Netclaw.slnx`
- `dotnet slopwatch analyze`
- daemon start/stop manual check with SQLite migration creation