### PR TITLE
Improve chat reconnect UX and reentrant session behavior

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
-    <PackageVersion Include="Termina" Version="0.5.1" />
+    <PackageVersion Include="Termina" Version="0.6.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -35,11 +35,16 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
     private SegmentId _assistantSegmentId;
     private readonly StringBuilder _assistantBuffer = new();
 
+    // Prompt history navigation
+    private readonly List<string> _promptHistory = [];
+    private int _historyIndex = -1;
+    private string _historyDraft = string.Empty;
+
     protected override void OnBound()
     {
         base.OnBound();
 
-        _chatHistory = StreamingTextNode.Create();
+        _chatHistory = StreamingTextNode.Create().WithScrollbar();
         _promptInput = new TextInputNode()
             .WithPlaceholder("Type a message...");
 
@@ -55,6 +60,8 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 _promptInput.Clear();
 
                 var combined = string.Join("\n", batch);
+
+                RememberPrompt(combined);
 
                 // Render user message
                 _chatHistory.AppendLine("");
@@ -73,6 +80,16 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         // Route keyboard input
         ViewModel.Input.OfType<KeyPressed>()
             .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+
+        // Route bracketed paste events directly to the text input node
+        ViewModel.Input.OfType<PasteEvent>()
+            .Subscribe(paste => _promptInput.HandlePaste(paste))
+            .DisposeWith(Subscriptions);
+
+        // Route mouse wheel scrolling to chat history
+        ViewModel.Input.OfType<MouseScrollEvent>()
+            .Subscribe(HandleMouseScroll)
             .DisposeWith(Subscriptions);
     }
 
@@ -104,13 +121,14 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
     {
         return Observable.CombineLatest(
                 ViewModel.IsGeneratingChanged,
+                ViewModel.IsInputEnabledChanged,
                 ViewModel.StatusMessageChanged,
                 ViewModel.UsageDisplayChanged.StartWith((string?)null),
-                (isGenerating, status, usage) =>
+                (isGenerating, isInputEnabled, status, usage) =>
                 {
                     var keys = isGenerating
                         ? "[Ctrl+Q] Quit"
-                        : "[Enter] Send  [PgUp/PgDn] Scroll  [Ctrl+Q] Quit";
+                        : "[Enter] Send  [Ctrl+Shift+V] Paste  [PgUp/PgDn/Wheel] Scroll  [Ctrl+Q] Quit";
 
                     var usagePart = usage is not null ? $"  |  {usage}" : "";
                     var text = $" {keys}  |  {status}  |  {ViewModel.ModelId}{usagePart}";
@@ -165,7 +183,28 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             return;
 
         // Everything else goes to the text input
+        if (keyInfo.Key == ConsoleKey.UpArrow)
+        {
+            NavigateHistoryUp();
+            return;
+        }
+
+        if (keyInfo.Key == ConsoleKey.DownArrow)
+        {
+            NavigateHistoryDown();
+            return;
+        }
+
         _promptInput.HandleInput(keyInfo);
+    }
+
+    private void HandleMouseScroll(MouseScrollEvent evt)
+    {
+        // +1 = wheel up, -1 = wheel down
+        if (evt.Delta > 0)
+            _chatHistory.ScrollUp(3, 80);
+        else if (evt.Delta < 0)
+            _chatHistory.ScrollDown(3);
     }
 
     private void HandleOutput(SessionOutput output)
@@ -173,8 +212,9 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         switch (output)
         {
             case SessionJoined msg:
+                var sessionState = msg.TurnCount > 0 ? "Resumed session." : "New session.";
                 _chatHistory.AppendLine(
-                    $"System: Session started. {(msg.Title is not null ? $"Title: {msg.Title}" : "New session.")}",
+                    $"System: Session started. {(msg.Title is not null ? $"Title: {msg.Title}" : sessionState)}",
                     Color.BrightBlack);
                 _chatHistory.AppendLine("");
                 break;
@@ -322,5 +362,54 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         _assistantSegmentId = default;
         _assistantBuffer.Clear();
         _chatHistory.AppendLine("");
+    }
+
+    private void RememberPrompt(string prompt)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+            return;
+
+        if (_promptHistory.Count == 0 || !string.Equals(_promptHistory[^1], prompt, StringComparison.Ordinal))
+            _promptHistory.Add(prompt);
+
+        if (_promptHistory.Count > 100)
+            _promptHistory.RemoveAt(0);
+
+        _historyIndex = -1;
+        _historyDraft = string.Empty;
+    }
+
+    private void NavigateHistoryUp()
+    {
+        if (_promptHistory.Count == 0)
+            return;
+
+        if (_historyIndex < 0)
+        {
+            _historyDraft = _promptInput.Text;
+            _historyIndex = _promptHistory.Count - 1;
+        }
+        else if (_historyIndex > 0)
+        {
+            _historyIndex--;
+        }
+
+        _promptInput.Text = _promptHistory[_historyIndex];
+    }
+
+    private void NavigateHistoryDown()
+    {
+        if (_historyIndex < 0)
+            return;
+
+        if (_historyIndex < _promptHistory.Count - 1)
+        {
+            _historyIndex++;
+            _promptInput.Text = _promptHistory[_historyIndex];
+            return;
+        }
+
+        _historyIndex = -1;
+        _promptInput.Text = _historyDraft;
     }
 }

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -20,11 +20,15 @@ public partial class ChatViewModel : ReactiveViewModel
     private readonly SessionConfig _sessionConfig;
 
     private readonly Subject<SessionOutput> _outputSubject = new();
+    private readonly Queue<string> _pendingMessages = new();
     private IDisposable? _daemonOutputSubscription;
     private IDisposable? _daemonConnectionSubscription;
+    private bool _sessionReady;
+    private int _connectAttempts;
 
 #pragma warning disable CS0169, CS0414 // Backing fields used by [Reactive] source generator
     [Reactive] private bool _isGenerating;
+    [Reactive] private bool _isInputEnabled = true;
     [Reactive] private string _statusMessage = "Connecting...";
     [Reactive] private string? _sessionIdDisplay;
     [Reactive] private string? _usageDisplay;
@@ -59,56 +63,49 @@ public partial class ChatViewModel : ReactiveViewModel
         _ = InitializeSessionAsync();
     }
 
-    private async Task InitializeSessionAsync()
+    private Task InitializeSessionAsync()
     {
-        try
-        {
-            _daemonOutputSubscription = _daemonClient.SessionOutput
-                .Subscribe(output =>
+        _daemonOutputSubscription = _daemonClient.SessionOutput
+            .Subscribe(output =>
+            {
+                _outputSubject.OnNext(output);
+
+                switch (output)
                 {
-                    _outputSubject.OnNext(output);
+                    case TurnCompleted:
+                        IsGenerating = false;
+                        break;
+                    case ErrorOutput:
+                        IsGenerating = false;
+                        break;
+                }
 
-                    // Track turn lifecycle for generation state
-                    switch (output)
-                    {
-                        case TurnCompleted:
-                            IsGenerating = false;
-                            break;
-                        case ErrorOutput:
-                            IsGenerating = false;
-                            break;
-                    }
+                RequestRedraw();
+            });
 
-                    RequestRedraw();
-                });
-
-            _daemonConnectionSubscription = _daemonClient.ConnectionEvents
-                .Subscribe(evt =>
+        _daemonConnectionSubscription = _daemonClient.ConnectionEvents
+            .Subscribe(evt =>
+            {
+                if (evt.State is DaemonConnectionState.Disconnected or DaemonConnectionState.Reconnecting)
                 {
-                    if (IsGenerating && evt.State is DaemonConnectionState.Connected)
-                    {
-                        StatusMessage = "Generating...";
-                    }
-                    else
-                    {
-                        StatusMessage = evt.Message;
-                    }
+                    _sessionReady = false;
+                }
 
-                    RequestRedraw();
-                });
+                if (evt.State is DaemonConnectionState.Connected)
+                {
+                    _ = EnsureSessionAndFlushAsync();
+                }
 
-            await ConnectWithRetryAsync();
-            var sessionId = await _daemonClient.CreateSessionAsync("tui");
-            SessionIdDisplay = sessionId;
+                if (IsGenerating && evt.State is DaemonConnectionState.Connected)
+                    StatusMessage = "Generating...";
+                else
+                    StatusMessage = evt.Message;
 
-            StatusMessage = "Ready";
-            RequestRedraw();
-        }
-        catch (Exception ex)
-        {
-            StatusMessage = $"Connection failed: {ex.Message}";
-            RequestRedraw();
-        }
+                RequestRedraw();
+            });
+
+        _ = ConnectUntilReadyAsync();
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -118,6 +115,17 @@ public partial class ChatViewModel : ReactiveViewModel
     {
         if (string.IsNullOrWhiteSpace(text))
             return;
+
+        if (!_sessionReady || !_daemonClient.IsConnected)
+        {
+            _pendingMessages.Enqueue(text);
+            IsGenerating = false;
+            IsInputEnabled = true;
+            StatusMessage = $"Queued {_pendingMessages.Count} message(s). Reconnecting...";
+            RequestRedraw();
+            _ = ConnectUntilReadyAsync();
+            return;
+        }
 
         IsGenerating = true;
         StatusMessage = "Generating...";
@@ -136,8 +144,12 @@ public partial class ChatViewModel : ReactiveViewModel
         catch (Exception ex)
         {
             IsGenerating = false;
-            StatusMessage = $"Connection failed: {ex.Message}";
+            _sessionReady = false;
+            IsInputEnabled = true;
+            _pendingMessages.Enqueue(text);
+            StatusMessage = $"Send failed ({ex.Message}). Reconnecting...";
             RequestRedraw();
+            _ = ConnectUntilReadyAsync();
         }
     }
 
@@ -156,7 +168,7 @@ public partial class ChatViewModel : ReactiveViewModel
         base.Dispose();
     }
 
-    private async Task ConnectWithRetryAsync()
+    private async Task ConnectUntilReadyAsync()
     {
         var delays = new[]
         {
@@ -166,21 +178,47 @@ public partial class ChatViewModel : ReactiveViewModel
             TimeSpan.FromSeconds(10)
         };
 
-        for (var attempt = 0; attempt <= delays.Length; attempt++)
+        while (!_sessionReady)
         {
             try
             {
                 await _daemonClient.ConnectAsync();
+                await EnsureSessionAndFlushAsync();
                 return;
             }
-            catch when (attempt < delays.Length)
+            catch
             {
-                StatusMessage = $"Connecting... retry {attempt + 1}/{delays.Length}";
+                _connectAttempts++;
+                var idx = Math.Min(_connectAttempts - 1, delays.Length - 1);
+                StatusMessage = $"Connecting... retry {_connectAttempts} in {delays[idx].TotalSeconds:0}s";
                 RequestRedraw();
-                await Task.Delay(delays[attempt]);
+                await Task.Delay(delays[idx]);
             }
         }
+    }
 
-        throw new InvalidOperationException("Unable to connect to daemon after retries.");
+    private async Task EnsureSessionAndFlushAsync()
+    {
+        var sessionId = await _daemonClient.EnsureSessionAsync("tui");
+        SessionIdDisplay = sessionId;
+        _sessionReady = true;
+        IsInputEnabled = true;
+        _connectAttempts = 0;
+
+        while (_pendingMessages.Count > 0)
+        {
+            var pending = _pendingMessages.Dequeue();
+            await _daemonClient.SendAsync(new ChannelInput
+            {
+                SenderId = "local-user",
+                Contents = [new TextContent(pending)],
+                ReceivedAt = _timeProvider.GetUtcNow()
+            });
+        }
+
+        if (!IsGenerating)
+            StatusMessage = "Ready";
+
+        RequestRedraw();
     }
 }

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -53,6 +53,20 @@ public sealed class SessionRegistry
         var callerConnectionId = ParseConnectionId(connectionId);
         var sessionId = new SessionId($"signalr/{Guid.NewGuid():N}");
 
+        await MaterializeAndBindSessionAsync(sessionId, callerConnectionId, channelType);
+
+        return sessionId.Value;
+    }
+
+    private async Task MaterializeAndBindSessionAsync(
+        SessionId sessionId,
+        SignalRConnectionId callerConnectionId,
+        string channelType)
+    {
+        var existing = _sessions.TryGetValue(sessionId, out var existingSession)
+            ? existingSession
+            : null;
+
         var session = await _pipeline.CreateAsync(sessionId, new SessionPipelineOptions
         {
             ChannelType = channelType
@@ -74,12 +88,13 @@ public sealed class SessionRegistry
             await previous.Session.DisposeAsync();
         }
 
+        if (existing is not null)
+            await existing.Session.DisposeAsync();
+
         // Materialize output: stream → currently attached SignalR connection.
         session.Output
             .To(Sink.ForEach<SessionOutput>(output => PublishOutput(sessionId, output)))
             .Run(_system);
-
-        return sessionId.Value;
     }
 
     public async Task<SessionEnsureResultDto> EnsureSessionAsync(
@@ -101,6 +116,13 @@ public sealed class SessionRegistry
                     Created = false
                 };
             }
+
+            await MaterializeAndBindSessionAsync(requestedSessionId, callerConnectionId, channelType);
+            return new SessionEnsureResultDto
+            {
+                SessionId = requestedSessionId.Value,
+                Created = false
+            };
         }
 
         var createdSessionId = await CreateSessionAsync(connectionId, channelType);


### PR DESCRIPTION
## Summary
- upgrade CLI to Termina 0.6.0 and enable chat-window UX improvements: scrollbar, mouse wheel scroll, and explicit bracketed paste routing for large clipboard payloads
- add prompt history navigation in chat input (`Up` / `Down`) with draft restoration behavior
- harden reconnect behavior by queueing outbound prompts while disconnected and flushing them after session reattachment
- improve daemon session ensure behavior by rematerializing requested session IDs instead of always creating a fresh random session

## Validation
- `dotnet build src/Netclaw.Cli/Netclaw.Cli.csproj`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj`
- `dotnet slopwatch analyze`
- manual verification: large paste in chat, reconnect queue flush, session reentry behavior