### PR TITLE
Refactor Slack channel actor hierarchy and harden reply flow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
+    <PackageVersion Include="SlackNet" Version="0.17.9" />
+    <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
     <PackageVersion Include="Termina" Version="0.6.0" />
   </ItemGroup>
   <!-- Serialization -->

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ STEP_TIMEOUT_SECONDS=120 scripts/smoke/check.sh
 
 - Daemon upgrade and rollback planning: `docs/runbooks/daemon-upgrade.md`
 
+## Integrations
+
+- Integration docs index: `docs/integrations/README.md`
+- Slack Socket Mode setup: `docs/integrations/slack-socket-mode.md`
+- Slack ACL policy model: `docs/integrations/slack-acl-policy.md`
+
 ## Persistence Config
 
 Daemon persistence config belongs in `~/.netclaw/config/netclaw.json` (not

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,6 @@
+# Integrations
+
+Runtime integrations that connect Netclaw to external systems.
+
+- `slack-socket-mode.md` - Slack Socket Mode setup, configuration, and behavior
+- `slack-acl-policy.md` - Slack channel ACL policy and room controls

--- a/docs/integrations/slack-acl-policy.md
+++ b/docs/integrations/slack-acl-policy.md
@@ -1,0 +1,43 @@
+# Slack ACL Policy
+
+Slack ACL policy controls where Netclaw is allowed to engage and who can invoke it.
+
+## Defaults
+
+- Channel conversations require `@mention` to start a thread.
+- Once a thread is started, follow-up thread replies are accepted without mention.
+- Direct messages are allowed by default.
+
+## Policy settings
+
+Configure in `~/.netclaw/config/netclaw.json`:
+
+```json
+{
+  "Slack": {
+    "MentionOnly": true,
+    "AllowDirectMessages": true,
+    "AllowedChannelIds": ["C0AGM484P0Q"],
+    "AllowedUserIds": ["U12345678", "U87654321"]
+  }
+}
+```
+
+- `MentionOnly`: requires mention to start non-DM sessions.
+- `AllowDirectMessages`: enables DM conversations without mention.
+- `AllowedChannelIds`: optional allow-list of channels.
+- `AllowedUserIds`: optional allow-list of Slack users.
+
+If `AllowedChannelIds` or `AllowedUserIds` is omitted, Netclaw does not enforce
+that specific allow-list.
+
+## Actor enforcement model
+
+Slack policy is enforced by Slack channel actors:
+
+- `SlackGatewayActor`: global event ingress and de-duplication
+- `SlackConversationActor`: room/DM ACL and mention/thread policy
+- `SlackThreadBindingActor`: thread-to-session binding (`{channelId}/{threadTs}`)
+
+This keeps Slack-specific policy state inside actor boundaries rather than
+in process-local adapter dictionaries.

--- a/docs/integrations/slack-socket-mode.md
+++ b/docs/integrations/slack-socket-mode.md
@@ -1,0 +1,80 @@
+# Slack Socket Mode Integration
+
+This document describes how to configure and run the Netclaw Slack channel.
+
+## Overview
+
+The Slack channel runs inside `netclawd` using Slack Socket Mode.
+
+- Inbound events: `app_mention`, `message`
+- Session identity: `{channelId}/{threadTs}`
+- Reply behavior: assistant replies are posted back to the same thread
+- Thread behavior: mention starts thread, thread replies continue without mention
+
+No public webhook endpoint is required.
+
+## Prerequisites
+
+Create a Slack app with:
+
+- Socket Mode enabled
+- Bot token (`xoxb-...`)
+- App-level token (`xapp-...`)
+- Bot scopes at minimum:
+  - `app_mentions:read`
+  - `channels:history`
+  - `chat:write`
+  - `groups:history` (if private channels are used)
+  - `channels:read` and `groups:read` (if resolving by channel name)
+
+Install the app to your workspace.
+
+## Configuration
+
+Put non-secret behavior in `~/.netclaw/config/netclaw.json`:
+
+```json
+{
+  "Slack": {
+    "Enabled": true,
+    "SocketMode": true,
+    "MentionOnly": true,
+    "DefaultChannelName": "openclaw"
+  }
+}
+```
+
+Put tokens in `~/.netclaw/config/secrets.json`:
+
+```json
+{
+  "Slack": {
+    "BotToken": "xoxb-your-bot-token",
+    "AppToken": "xapp-your-app-token"
+  }
+}
+```
+
+Supported Slack settings:
+
+- `Enabled` - toggles Slack channel startup
+- `SocketMode` - currently must be `true`
+- `BotToken` - Slack bot token for Web API and auth
+- `AppToken` - Slack app-level token for Socket Mode
+- `DefaultChannelId` - optional hard filter to one channel ID
+- `DefaultChannelName` - optional channel name resolved at startup
+- `MentionOnly` - if `true`, plain `message` events require bot mention
+- `AllowDirectMessages` - if `true`, direct messages do not require mention
+- `AllowedChannelIds` - optional channel allow-list
+- `AllowedUserIds` - optional user allow-list
+
+## Runtime behavior
+
+- When Slack is disabled, daemon starts normally and Slack channel stays inactive.
+- If Slack is enabled but required tokens are missing, daemon startup fails fast.
+- Socket Mode disconnects are handled by SlackNet reconnecting client behavior.
+
+## Security note
+
+Treat Slack tokens as secrets. If a token is ever posted in chat, shell history, logs,
+or commits, rotate it immediately in Slack and update `secrets.json`.

--- a/docs/runbooks/behavior-debugging.md
+++ b/docs/runbooks/behavior-debugging.md
@@ -1,0 +1,100 @@
+# Behavior Debugging Runbook
+
+Use this when Netclaw behavior is confusing (missing replies, duplicate replies,
+message loops, dropped sessions, or unexpected policy decisions).
+
+## Quick Triage
+
+1. Confirm daemon status:
+
+   ```bash
+   netclaw daemon status
+   ```
+
+2. Confirm Slack session activity is being persisted:
+
+   ```bash
+   sqlite3 "$HOME/.netclaw/netclaw.db" \
+     "select persistence_id, max(created), max(sequence_number) from journal group by persistence_id order by max(created) desc limit 10;"
+   ```
+
+3. If session rows are created but Slack has no reply, focus on outbound adapter
+   path (Slack thread binding actor and Slack post client).
+
+## Enable Debug Logging
+
+Set these in `~/.netclaw/config/netclaw.json`:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    },
+    "Console": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+Notes:
+
+- `LogLevel:Default` is shared by MEL and Akka.NET logger integration.
+- `Console:Enabled` prints logs to stdout/stderr for Rider/terminal debugging.
+
+## What Healthy Slack Flow Looks Like
+
+Expected sequence (same `SessionId` / `SlackThreadTs`):
+
+1. `Routing Slack event ... to conversation ...`
+2. `Routing Slack event ... to session thread actor`
+3. `Accepted inbound Slack message for session queue`
+4. Session actor logs `Received user message`
+5. `Posted Slack reply message`
+
+If steps 1-4 appear but step 5 does not, inspect Slack outbound posting path.
+
+## Known Failure Signatures
+
+- `Ignoring Slack event ... channel not allowed`
+  - Channel ACL filter blocked event.
+  - DM may be blocked by channel filtering if policy precedence is incorrect.
+
+- repeated assistant replies / loops
+  - Bot messages are being re-consumed as inbound events.
+  - Ensure bot/self messages are ignored at conversation policy layer.
+
+- `ThreadOutput ... unhandled` on `Flow-...-unknown-operation`
+  - Stream callback captured wrong actor context.
+  - Use captured `self` actor ref for stream-to-actor bridging.
+
+- `CommandAck` dead letters
+  - Stream fire-and-forget path without ack consumer.
+  - Route commands through relay actor that no-ops `CommandAck`.
+
+## Slack-Specific Checks
+
+1. Verify bot can post to thread using direct API call.
+2. Compare channel history vs thread replies to detect thread mismatches.
+3. Confirm the bot user ID and mention parsing are correct.
+4. Confirm session key is stable: `{channelId}/{threadTs}`.
+
+## Optional OTEL Workstream (Recommended)
+
+If debugging latency/routing frequently, add OpenTelemetry instrumentation:
+
+- activity source spans for:
+  - Slack ingress event receive
+  - conversation routing decision
+  - session enqueue
+  - model/tool turn completion
+  - Slack reply post
+- span attributes:
+  - `session.id`
+  - `slack.channel_id`
+  - `slack.thread_ts`
+  - `slack.event_id`
+- OTLP export to local collector (e.g. LocalTelemetry)
+
+This gives per-turn causality and timing without heavy log spelunking.

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -176,6 +176,29 @@ Slack Socket Mode channel configuration.
 | `AllowedChannelIds` | string[]? | `null` | Optional allow-list of Slack channel IDs. |
 | `AllowedUserIds` | string[]? | `null` | Optional allow-list of Slack user IDs. |
 
+### Logging
+
+Unified daemon logging settings used by both Microsoft.Extensions.Logging and
+Akka.NET logger integration.
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    },
+    "Console": {
+      "Enabled": true
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `LogLevel:Default` | string | `Warning` | Minimum log level (`Debug`, `Information`, `Warning`, `Error`, etc.) shared by MEL and Akka.NET. |
+| `Console:Enabled` | bool | `false` | Enables console logger provider output for daemon debugging. |
+
 ## Secrets
 
 API keys and tokens should be stored in `secrets.json` using the same key

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -148,6 +148,34 @@ Configuration for first-party tool execution.
 | `ShellTimeoutSeconds` | int | `60` | Timeout for shell command execution. |
 | `MaxOutputChars` | int | `32000` | Maximum characters captured from tool output. |
 
+### Slack
+
+Slack Socket Mode channel configuration.
+
+```json
+{
+  "Slack": {
+    "Enabled": true,
+    "SocketMode": true,
+    "MentionOnly": true,
+    "DefaultChannelName": "openclaw"
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Enabled` | bool | `false` | Enables Slack channel startup in the daemon. |
+| `SocketMode` | bool | `true` | Slack transport mode. MVP supports Socket Mode only. |
+| `BotToken` | string? | `null` | Slack bot token (`xoxb-...`). Store in `secrets.json`. |
+| `AppToken` | string? | `null` | Slack app-level token (`xapp-...`). Required for Socket Mode. Store in `secrets.json`. |
+| `DefaultChannelId` | string? | `null` | Optional fixed channel ID filter. |
+| `DefaultChannelName` | string? | `null` | Optional channel name resolved to channel ID at startup. |
+| `MentionOnly` | bool | `true` | If true, plain `message` events are ignored unless the bot is mentioned. |
+| `AllowDirectMessages` | bool | `true` | If true, DM messages do not require mention. |
+| `AllowedChannelIds` | string[]? | `null` | Optional allow-list of Slack channel IDs. |
+| `AllowedUserIds` | string[]? | `null` | Optional allow-list of Slack user IDs. |
+
 ## Secrets
 
 API keys and tokens should be stored in `secrets.json` using the same key
@@ -155,6 +183,10 @@ paths as `netclaw.json`. The configuration system merges them automatically.
 
 ```json
 {
+  "Slack": {
+    "BotToken": "xoxb-your-bot-token",
+    "AppToken": "xapp-your-app-token"
+  },
   "Providers": {
     "openrouter": {
       "ApiKey": "sk-or-v1-your-key-here"
@@ -178,6 +210,10 @@ export NETCLAW_Models__Main__ModelId="anthropic/claude-sonnet-4"
 
 # Set a provider API key
 export NETCLAW_Providers__openrouter__ApiKey="sk-or-v1-..."
+
+# Set Slack tokens
+export NETCLAW_Slack__BotToken="xoxb-..."
+export NETCLAW_Slack__AppToken="xapp-..."
 
 # Override session settings
 export NETCLAW_Session__MaxToolIterationsPerTurn="5"

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
@@ -143,13 +143,13 @@
 
 ## 12. Slack Socket Mode Adapter
 
-- [ ] 12.1 Implement Slack Socket Mode connection and event handling
+- [x] 12.1 Implement Slack Socket Mode connection and event handling
   (`app_mention`, `message` events).
-- [ ] 12.2 Implement entity key extraction from Slack events
+- [x] 12.2 Implement entity key extraction from Slack events
   (`{channelId}/{threadTs}`).
-- [ ] 12.3 Implement reply delivery: subscribe to session broadcasts, post
+- [x] 12.3 Implement reply delivery: subscribe to session broadcasts, post
   replies to originating Slack thread.
-- [ ] 12.4 Implement reconnection on disconnect.
+- [x] 12.4 Implement reconnection on disconnect.
 - [ ] 12.5 Write end-to-end test proving message → reply loop.
 
 ## 13. Provider Abstraction

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -1,0 +1,171 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Slack;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void Gateway_deduplicates_same_event_id()
+    {
+        var sink = CreateTestProbe("gateway-sink");
+        var deps = CreateDependencies(
+            conversationPropsFactory: (_, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gateway-test-1");
+        var message = CreateMessage(eventId: "C1:100", channelId: "C1", eventTs: "100.1");
+
+        gateway.Tell(message);
+        gateway.Tell(message);
+
+        sink.ExpectMsg<SlackInboundMessage>();
+        sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public void Conversation_requires_mention_to_start_and_allows_thread_followups()
+    {
+        var sink = CreateTestProbe("conversation-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-1");
+
+        conversation.Tell(CreateMessage(
+            eventId: "C1:200",
+            channelId: "C1",
+            eventTs: "200.1",
+            text: "no mention",
+            threadTs: null));
+
+        sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+
+        conversation.Tell(CreateAppMention(
+            eventId: "C1:201",
+            channelId: "C1",
+            eventTs: "201.1",
+            text: "<@UBOT> start"));
+
+        var first = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal("C1/201.1", first.SessionId.Value);
+        Assert.Equal("start", first.Text);
+
+        conversation.Tell(CreateMessage(
+            eventId: "C1:202",
+            channelId: "C1",
+            eventTs: "202.1",
+            text: "follow up",
+            threadTs: "201.1"));
+
+        var second = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal("C1/201.1", second.SessionId.Value);
+        Assert.Equal("follow up", second.Text);
+    }
+
+    [Fact]
+    public void Conversation_allows_dm_without_mention_when_enabled()
+    {
+        var sink = CreateTestProbe("dm-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("D1", deps), "slack-conversation-test-2");
+
+        conversation.Tell(CreateMessage(
+            eventId: "D1:300",
+            channelId: "D1",
+            eventTs: "300.1",
+            text: "hello from dm",
+            isDirectMessage: true,
+            threadTs: null));
+
+        var inbound = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal("D1/300.1", inbound.SessionId.Value);
+        Assert.Equal("hello from dm", inbound.Text);
+    }
+
+    private static SlackGatewayDependencies CreateDependencies(
+        Func<string, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
+        Func<SessionId, string, string, SlackGatewayDependencies, Props>? threadPropsFactory = null)
+    {
+        return new SlackGatewayDependencies(
+            Pipeline: null!,
+            ActorSystem: null!,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                MentionOnly = true,
+                AllowDirectMessages = true
+            },
+            BotUserId: "UBOT",
+            DefaultChannelId: null,
+            PostMessageAsync: _ => Task.CompletedTask,
+            ConversationPropsFactory: conversationPropsFactory,
+            ThreadPropsFactory: threadPropsFactory);
+    }
+
+    private static SlackInboundMessage CreateMessage(
+        string eventId,
+        string channelId,
+        string eventTs,
+        string text = "hello",
+        string? threadTs = null,
+        bool isDirectMessage = false)
+    {
+        return new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: eventId,
+            ChannelId: channelId,
+            ThreadTs: threadTs,
+            EventTs: eventTs,
+            UserId: "U1",
+            BotId: null,
+            Text: text,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: isDirectMessage);
+    }
+
+    private static SlackInboundMessage CreateAppMention(
+        string eventId,
+        string channelId,
+        string eventTs,
+        string text)
+    {
+        return new SlackInboundMessage(
+            Kind: SlackInboundKind.AppMention,
+            EventId: eventId,
+            ChannelId: channelId,
+            ThreadTs: null,
+            EventTs: eventTs,
+            UserId: "U1",
+            BotId: null,
+            Text: text,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: false);
+    }
+
+    private sealed class ForwardActor : ReceiveActor
+    {
+        public ForwardActor(IActorRef target)
+        {
+            ReceiveAny(msg => target.Tell(msg));
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -99,6 +99,31 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         Assert.Equal("hello from dm", inbound.Text);
     }
 
+    [Fact]
+    public void Conversation_ignores_bot_messages_to_prevent_feedback_loop()
+    {
+        var sink = CreateTestProbe("bot-loop-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-3");
+
+        conversation.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: "C1:400",
+            ChannelId: "C1",
+            ThreadTs: "400.1",
+            EventTs: "400.2",
+            UserId: "UBOT",
+            BotId: "B1",
+            Text: "bot output",
+            Subtype: "bot_message",
+            Hidden: false,
+            IsDirectMessage: false));
+
+        sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+    }
+
     private static SlackGatewayDependencies CreateDependencies(
         Func<string, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
         Func<SessionId, string, string, SlackGatewayDependencies, Props>? threadPropsFactory = null)

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -114,7 +114,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
             },
             BotUserId: "UBOT",
             DefaultChannelId: null,
-            PostMessageAsync: _ => Task.CompletedTask,
+            ReplyClient: new NoopReplyClient(),
             ConversationPropsFactory: conversationPropsFactory,
             ThreadPropsFactory: threadPropsFactory);
     }
@@ -167,5 +167,11 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         {
             ReceiveAny(msg => target.Tell(msg));
         }
+    }
+
+    private sealed class NoopReplyClient : ISlackReplyClient
+    {
+        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
@@ -1,0 +1,114 @@
+using Netclaw.Channels.Slack;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public class SlackRoutingPolicyTests
+{
+    [Fact]
+    public void MessageWithoutMention_DoesNotStartThread_WhenMentionOnly()
+    {
+        var message = CreateMessage(text: "hello", threadTs: null, isDirectMessage: false);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: false,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.Ignore, decision);
+    }
+
+    [Fact]
+    public void AppMention_StartsThread_WhenMentionOnly()
+    {
+        var message = CreateAppMention(text: "<@U1> hello", threadTs: null);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: false,
+            containsBotMention: true);
+
+        Assert.Equal(SlackRoutingDecision.StartOrContinue, decision);
+    }
+
+    [Fact]
+    public void ExistingThreadReply_ContinuesWithoutMention()
+    {
+        var message = CreateMessage(text: "follow up", threadTs: "1740468105.120900", isDirectMessage: false);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: true,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.ContinueOnly, decision);
+    }
+
+    [Fact]
+    public void DirectMessage_ProcessesWithoutMention_WhenEnabled()
+    {
+        var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: false,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.StartOrContinue, decision);
+    }
+
+    [Fact]
+    public void DirectMessage_Ignored_WhenDisabled()
+    {
+        var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: false,
+            threadExists: false,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.Ignore, decision);
+    }
+
+    private static SlackInboundMessage CreateMessage(string text, string? threadTs, bool isDirectMessage)
+    {
+        return new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: "C0:1",
+            ChannelId: isDirectMessage ? "D0" : "C0",
+            ThreadTs: threadTs,
+            EventTs: "1740468000.000001",
+            UserId: "U123",
+            BotId: null,
+            Text: text,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: isDirectMessage);
+    }
+
+    private static SlackInboundMessage CreateAppMention(string text, string? threadTs)
+    {
+        return new SlackInboundMessage(
+            Kind: SlackInboundKind.AppMention,
+            EventId: "C0:2",
+            ChannelId: "C0",
+            ThreadTs: threadTs,
+            EventTs: "1740468000.000002",
+            UserId: "U123",
+            BotId: null,
+            Text: text,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: false);
+    }
+}

--- a/src/Netclaw.Actors/Channels/ChannelInput.cs
+++ b/src/Netclaw.Actors/Channels/ChannelInput.cs
@@ -15,6 +15,11 @@ public sealed record ChannelInput
     public required string SenderId { get; init; }
 
     /// <summary>
+    /// Optional channel-specific identifier (e.g. Slack channel ID).
+    /// </summary>
+    public string? ChannelId { get; init; }
+
+    /// <summary>
     /// Optional message ID for correlation and deduplication.
     /// </summary>
     public string? MessageId { get; init; }

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -1,5 +1,6 @@
 using Akka;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Hosting;
 using Akka.Streams;
 using Akka.Streams.Dsl;
@@ -34,15 +35,18 @@ public sealed record SessionPipelineOptions
 public sealed class MaterializedSession : IAsyncDisposable
 {
     private readonly SharedKillSwitch _killSwitch;
+    private readonly Action? _onDispose;
 
     internal MaterializedSession(
         Sink<ChannelInput, NotUsed> input,
         Source<SessionOutput, NotUsed> output,
-        SharedKillSwitch killSwitch)
+        SharedKillSwitch killSwitch,
+        Action? onDispose = null)
     {
         Input = input;
         Output = output;
         _killSwitch = killSwitch;
+        _onDispose = onDispose;
     }
 
     /// <summary>
@@ -75,6 +79,7 @@ public sealed class MaterializedSession : IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         _killSwitch.Shutdown();
+        _onDispose?.Invoke();
         return ValueTask.CompletedTask;
     }
 }
@@ -118,6 +123,9 @@ public sealed class SessionPipeline
     {
         var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
         var killSwitch = KillSwitches.Shared($"session-{sessionId.Value}");
+        var commandRelay = _system.ActorOf(
+            SessionCommandRelayActor.CreateProps(sessionManager, sessionId),
+            $"session-command-relay-{Uri.EscapeDataString(sessionId.Value)}-{Guid.NewGuid():N}");
 
         // Pre-materialize subscriber to capture IActorRef before building streams
         var (subscriber, responseSource) = Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
@@ -127,7 +135,7 @@ public sealed class SessionPipeline
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options))
             .Via(killSwitch.Flow<SendUserMessage>())
-            .To(Sink.ActorRef<SendUserMessage>(sessionManager, Done.Instance,
+            .To(Sink.ActorRef<SendUserMessage>(commandRelay, Done.Instance,
                 ex => new Status.Failure(ex)));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source
@@ -142,7 +150,11 @@ public sealed class SessionPipeline
             Filter = options.Filter
         });
 
-        return new MaterializedSession(inputSink, outputSource, killSwitch);
+        return new MaterializedSession(
+            inputSink,
+            outputSource,
+            killSwitch,
+            onDispose: () => _system.Stop(commandRelay));
     }
 
     private SendUserMessage MapToCommand(
@@ -165,4 +177,26 @@ public sealed class SessionPipeline
             }
         };
     }
+}
+
+internal sealed class SessionCommandRelayActor : ReceiveActor
+{
+    private readonly IActorRef _sessionManager;
+    private readonly SessionId _sessionId;
+    private readonly ILoggingAdapter _log;
+
+    public SessionCommandRelayActor(IActorRef sessionManager, SessionId sessionId)
+    {
+        _sessionManager = sessionManager;
+        _sessionId = sessionId;
+        _log = Context.GetLogger().WithContext("SessionId", sessionId.Value);
+
+        Receive<SendUserMessage>(cmd => _sessionManager.Tell(cmd, Self));
+        Receive<CommandAck>(_ => { });
+        Receive<CommandNack>(nack =>
+            _log.Warning("Session command rejected: {0}", nack.Reason));
+    }
+
+    public static Props CreateProps(IActorRef sessionManager, SessionId sessionId) =>
+        Props.Create(() => new SessionCommandRelayActor(sessionManager, sessionId));
 }

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -160,6 +160,7 @@ public sealed class SessionPipeline
             {
                 ChannelType = options.ChannelType,
                 SenderId = input.SenderId,
+                ChannelId = input.ChannelId,
                 ReceivedAt = input.ReceivedAt
             }
         };

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -137,7 +137,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
             _toolIterationCount = 0;
             _state = _state.AddUserMessage(cmd.Content);
-            Sender.Tell(CommandAck.For(_sessionId));
+            TryReplyAck();
             FireLlmCall();
             Become(Processing);
         });
@@ -152,7 +152,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         {
             _log.Info("Buffering user message (LLM call in progress)");
             _buffer.Add(cmd);
-            Sender.Tell(CommandAck.For(_sessionId));
+            TryReplyAck();
         });
 
         Command<LlmResponseReceived>(msg =>
@@ -276,7 +276,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         {
             _log.Info("Buffering user message (compaction in progress)");
             _buffer.Add(cmd);
-            Sender.Tell(CommandAck.For(_sessionId));
+            TryReplyAck();
         });
 
         Command<CompactionTriggered>(msg =>
@@ -931,6 +931,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 subscriber.Tell(output);
             }
         }
+    }
+
+    private void TryReplyAck()
+    {
+        if (Sender.IsNobody() || Equals(Sender, Context.System.DeadLetters))
+            return;
+
+        Sender.Tell(CommandAck.For(_sessionId));
     }
 
     internal void SetTitle(string title)

--- a/src/Netclaw.Channels/IChannel.cs
+++ b/src/Netclaw.Channels/IChannel.cs
@@ -12,7 +12,7 @@ public interface IChannel : IHostedService
 
     string DisplayName { get; }
 
-    ChannelHealth GetHealth();
+    ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default);
 }
 
 public enum ChannelHealthStatus

--- a/src/Netclaw.Channels/Netclaw.Channels.csproj
+++ b/src/Netclaw.Channels/Netclaw.Channels.csproj
@@ -7,11 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="SlackNet" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
+    <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
@@ -1,0 +1,6 @@
+namespace Netclaw.Channels.Slack;
+
+public interface ISlackReplyClient
+{
+    Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default);
+}

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -1,0 +1,200 @@
+using Akka.Actor;
+using Akka.Pattern;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Channels;
+using SlackNet;
+using SlackNet.Events;
+using SlackNet.WebApi;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEventHandler<AppMention>, IHostedService
+{
+    private readonly SessionPipeline _pipeline;
+    private readonly ActorSystem _system;
+    private readonly ISlackApiClient _slack;
+    private readonly ISlackSocketModeClient _socketModeClient;
+    private readonly TimeProvider _timeProvider;
+    private readonly SlackChannelOptions _options;
+    private readonly ILogger<SlackChannel> _logger;
+
+    private IActorRef? _gateway;
+    private string? _botUserId;
+    private string? _defaultChannelId;
+    private volatile bool _connected;
+
+    public SlackChannel(
+        SessionPipeline pipeline,
+        ActorSystem system,
+        ISlackApiClient slack,
+        ISlackSocketModeClient socketModeClient,
+        TimeProvider timeProvider,
+        SlackChannelOptions options,
+        ILogger<SlackChannel> logger)
+    {
+        _pipeline = pipeline;
+        _system = system;
+        _slack = slack;
+        _socketModeClient = socketModeClient;
+        _timeProvider = timeProvider;
+        _options = options;
+        _logger = logger;
+    }
+
+    public string ChannelType => "slack";
+
+    public string DisplayName => "Slack";
+
+    public ChannelHealth GetHealth()
+    {
+        if (!_options.Enabled)
+            return new ChannelHealth(ChannelHealthStatus.Degraded, "Slack channel disabled.");
+
+        if (_connected)
+            return new ChannelHealth(ChannelHealthStatus.Healthy);
+
+        return new ChannelHealth(ChannelHealthStatus.Disconnected, "Slack socket mode disconnected.");
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Slack channel disabled by configuration.");
+            return;
+        }
+
+        if (!_options.SocketMode)
+            throw new InvalidOperationException("Slack channel currently supports Socket Mode only.");
+
+        var auth = await _slack.Auth.Test(cancellationToken);
+        _botUserId = auth.UserId;
+        _defaultChannelId = await ResolveDefaultChannelIdAsync(cancellationToken);
+
+        _gateway = _system.ActorOf(
+            SlackGatewayActor.CreateProps(new SlackGatewayDependencies(
+                Pipeline: _pipeline,
+                ActorSystem: _system,
+                TimeProvider: _timeProvider,
+                Options: _options,
+                BotUserId: _botUserId,
+                DefaultChannelId: _defaultChannelId,
+                PostMessageAsync: PostReplyAsync)),
+            "slack-gateway");
+
+        await _socketModeClient.Connect(cancellationToken: cancellationToken);
+        _connected = true;
+
+        _logger.LogInformation("Slack channel connected as user {BotUserId}.", _botUserId);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _connected = false;
+        _socketModeClient.Disconnect();
+
+        if (_gateway is not null)
+        {
+            try
+            {
+                await _gateway.GracefulStop(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+                _system.Stop(_gateway);
+            }
+
+            _gateway = null;
+        }
+    }
+
+    public Task Handle(MessageEvent slackEvent)
+    {
+        _gateway?.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: BuildEventId(slackEvent.Channel, slackEvent.Ts),
+            ChannelId: slackEvent.Channel,
+            ThreadTs: slackEvent.ThreadTs,
+            EventTs: slackEvent.Ts,
+            UserId: slackEvent.User,
+            BotId: slackEvent.BotId,
+            Text: slackEvent.Text ?? string.Empty,
+            Subtype: slackEvent.Subtype,
+            Hidden: slackEvent.Hidden,
+            IsDirectMessage: IsDirectConversation(slackEvent.Channel)));
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(AppMention slackEvent)
+    {
+        _gateway?.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.AppMention,
+            EventId: BuildEventId(slackEvent.Channel, slackEvent.Ts),
+            ChannelId: slackEvent.Channel,
+            ThreadTs: slackEvent.ThreadTs,
+            EventTs: slackEvent.Ts,
+            UserId: slackEvent.User,
+            BotId: null,
+            Text: slackEvent.Text ?? string.Empty,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: IsDirectConversation(slackEvent.Channel)));
+
+        return Task.CompletedTask;
+    }
+
+    private Task PostReplyAsync(SlackPostMessage message)
+    {
+        return _slack.Chat.PostMessage(new Message
+        {
+            Channel = message.ChannelId,
+            ThreadTs = message.ThreadTs,
+            Text = message.Text
+        });
+    }
+
+    private static bool IsDirectConversation(string channelId)
+    {
+        if (string.IsNullOrWhiteSpace(channelId))
+            return false;
+
+        return channelId.StartsWith("D", StringComparison.Ordinal);
+    }
+
+    private static string BuildEventId(string channelId, string eventTs) =>
+        string.IsNullOrWhiteSpace(channelId) || string.IsNullOrWhiteSpace(eventTs)
+            ? Guid.NewGuid().ToString("N")
+            : $"{channelId}:{eventTs}";
+
+    private async Task<string?> ResolveDefaultChannelIdAsync(CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.DefaultChannelId))
+            return _options.DefaultChannelId;
+
+        if (string.IsNullOrWhiteSpace(_options.DefaultChannelName))
+            return null;
+
+        var cursor = default(string);
+        do
+        {
+            var page = await _slack.Conversations.List(
+                types: [ConversationType.PublicChannel, ConversationType.PrivateChannel],
+                cursor: cursor,
+                cancellationToken: cancellationToken);
+
+            var match = page.Channels.FirstOrDefault(c =>
+                string.Equals(c.Name, _options.DefaultChannelName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(c.NameNormalized, _options.DefaultChannelName, StringComparison.OrdinalIgnoreCase));
+
+            if (match is not null)
+                return match.Id;
+
+            cursor = page.ResponseMetadata?.NextCursor;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        _logger.LogWarning("Could not resolve Slack channel name '{ChannelName}'. Listening on all channels.", _options.DefaultChannelName);
+        return null;
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -9,12 +9,13 @@ using SlackNet.WebApi;
 
 namespace Netclaw.Channels.Slack;
 
-public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEventHandler<AppMention>, IHostedService
+public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEventHandler<AppMention>
 {
     private readonly SessionPipeline _pipeline;
     private readonly ActorSystem _system;
     private readonly ISlackApiClient _slack;
     private readonly ISlackSocketModeClient _socketModeClient;
+    private readonly ISlackReplyClient _replyClient;
     private readonly TimeProvider _timeProvider;
     private readonly SlackChannelOptions _options;
     private readonly ILogger<SlackChannel> _logger;
@@ -29,6 +30,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         ActorSystem system,
         ISlackApiClient slack,
         ISlackSocketModeClient socketModeClient,
+        ISlackReplyClient replyClient,
         TimeProvider timeProvider,
         SlackChannelOptions options,
         ILogger<SlackChannel> logger)
@@ -37,6 +39,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         _system = system;
         _slack = slack;
         _socketModeClient = socketModeClient;
+        _replyClient = replyClient;
         _timeProvider = timeProvider;
         _options = options;
         _logger = logger;
@@ -46,15 +49,15 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
 
     public string DisplayName => "Slack";
 
-    public ChannelHealth GetHealth()
+    public ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default)
     {
         if (!_options.Enabled)
-            return new ChannelHealth(ChannelHealthStatus.Degraded, "Slack channel disabled.");
+            return ValueTask.FromResult(new ChannelHealth(ChannelHealthStatus.Degraded, "Slack channel disabled."));
 
         if (_connected)
-            return new ChannelHealth(ChannelHealthStatus.Healthy);
+            return ValueTask.FromResult(new ChannelHealth(ChannelHealthStatus.Healthy));
 
-        return new ChannelHealth(ChannelHealthStatus.Disconnected, "Slack socket mode disconnected.");
+        return ValueTask.FromResult(new ChannelHealth(ChannelHealthStatus.Disconnected, "Slack socket mode disconnected."));
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -80,7 +83,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 Options: _options,
                 BotUserId: _botUserId,
                 DefaultChannelId: _defaultChannelId,
-                PostMessageAsync: PostReplyAsync)),
+                ReplyClient: _replyClient)),
             "slack-gateway");
 
         await _socketModeClient.Connect(cancellationToken: cancellationToken);
@@ -113,7 +116,12 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
-            EventId: BuildEventId(slackEvent.Channel, slackEvent.Ts),
+            EventId: BuildEventId(
+                channelId: slackEvent.Channel,
+                eventTs: slackEvent.Ts,
+                threadTs: slackEvent.ThreadTs,
+                userId: slackEvent.User,
+                text: slackEvent.Text),
             ChannelId: slackEvent.Channel,
             ThreadTs: slackEvent.ThreadTs,
             EventTs: slackEvent.Ts,
@@ -131,7 +139,12 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: BuildEventId(slackEvent.Channel, slackEvent.Ts),
+            EventId: BuildEventId(
+                channelId: slackEvent.Channel,
+                eventTs: slackEvent.Ts,
+                threadTs: slackEvent.ThreadTs,
+                userId: slackEvent.User,
+                text: slackEvent.Text),
             ChannelId: slackEvent.Channel,
             ThreadTs: slackEvent.ThreadTs,
             EventTs: slackEvent.Ts,
@@ -145,28 +158,34 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         return Task.CompletedTask;
     }
 
-    private Task PostReplyAsync(SlackPostMessage message)
-    {
-        return _slack.Chat.PostMessage(new Message
-        {
-            Channel = message.ChannelId,
-            ThreadTs = message.ThreadTs,
-            Text = message.Text
-        });
-    }
-
     private static bool IsDirectConversation(string channelId)
     {
         if (string.IsNullOrWhiteSpace(channelId))
             return false;
 
-        return channelId.StartsWith("D", StringComparison.Ordinal);
+        return channelId.StartsWith('D');
     }
 
-    private static string BuildEventId(string channelId, string eventTs) =>
-        string.IsNullOrWhiteSpace(channelId) || string.IsNullOrWhiteSpace(eventTs)
-            ? Guid.NewGuid().ToString("N")
-            : $"{channelId}:{eventTs}";
+    private static string BuildEventId(
+        string? channelId,
+        string? eventTs,
+        string? threadTs,
+        string? userId,
+        string? text)
+    {
+        if (!string.IsNullOrWhiteSpace(channelId) && !string.IsNullOrWhiteSpace(eventTs))
+            return $"{channelId}:{eventTs}";
+
+        var fallback = string.Join("|", [
+            channelId ?? string.Empty,
+            threadTs ?? string.Empty,
+            eventTs ?? string.Empty,
+            userId ?? string.Empty,
+            text ?? string.Empty
+        ]);
+
+        return fallback;
+    }
 
     private async Task<string?> ResolveDefaultChannelIdAsync(CancellationToken cancellationToken)
     {

--- a/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
@@ -1,0 +1,24 @@
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackChannelOptions
+{
+    public bool Enabled { get; init; }
+
+    public bool SocketMode { get; init; } = true;
+
+    public string? BotToken { get; init; }
+
+    public string? AppToken { get; init; }
+
+    public string? DefaultChannelId { get; init; }
+
+    public string? DefaultChannelName { get; init; }
+
+    public bool MentionOnly { get; init; } = true;
+
+    public bool AllowDirectMessages { get; init; } = true;
+
+    public string[]? AllowedChannelIds { get; init; }
+
+    public string[]? AllowedUserIds { get; init; }
+}

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -26,6 +26,12 @@ public sealed class SlackConversationActor : ReceiveActor
                 return;
             }
 
+            if (IsBotMessage(message))
+            {
+                _log.Debug("Ignoring Slack event {0}: bot/self message", message.EventId);
+                return;
+            }
+
             if (!IsAllowedUser(message))
             {
                 _log.Debug("Ignoring Slack event {0}: user not allowed", message.EventId);
@@ -90,6 +96,9 @@ public sealed class SlackConversationActor : ReceiveActor
 
     private bool IsAllowedConversation(SlackInboundMessage message)
     {
+        if (message.IsDirectMessage)
+            return _dependencies.Options.AllowDirectMessages;
+
         if (!string.IsNullOrWhiteSpace(_dependencies.DefaultChannelId)
             && !string.Equals(message.ChannelId, _dependencies.DefaultChannelId, StringComparison.Ordinal))
             return false;
@@ -99,6 +108,18 @@ public sealed class SlackConversationActor : ReceiveActor
             return false;
 
         return true;
+    }
+
+    private bool IsBotMessage(SlackInboundMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(message.BotId))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(_dependencies.BotUserId)
+            && string.Equals(message.UserId, _dependencies.BotUserId, StringComparison.Ordinal))
+            return true;
+
+        return false;
     }
 
     private bool IsAllowedUser(SlackInboundMessage message)

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -1,4 +1,5 @@
 using Akka.Actor;
+using Akka.Event;
 using Netclaw.Actors.Protocol;
 
 namespace Netclaw.Channels.Slack;
@@ -7,19 +8,29 @@ public sealed class SlackConversationActor : ReceiveActor
 {
     private readonly string _conversationId;
     private readonly SlackGatewayDependencies _dependencies;
+    private readonly ILoggingAdapter _log;
 
     public SlackConversationActor(string conversationId, SlackGatewayDependencies dependencies)
     {
         _conversationId = conversationId;
         _dependencies = dependencies;
+        _log = Context.GetLogger()
+            .WithContext("Adapter", "slack")
+            .WithContext("SlackChannelId", _conversationId);
 
         Receive<SlackInboundMessage>(message =>
         {
             if (!IsAllowedConversation(message))
+            {
+                _log.Debug("Ignoring Slack event {0}: channel not allowed", message.EventId);
                 return;
+            }
 
             if (!IsAllowedUser(message))
+            {
+                _log.Debug("Ignoring Slack event {0}: user not allowed", message.EventId);
                 return;
+            }
 
             var containsMention = ContainsBotMention(message.Text);
             var threadTs = string.IsNullOrWhiteSpace(message.ThreadTs) ? message.EventTs : message.ThreadTs!;
@@ -35,10 +46,16 @@ public sealed class SlackConversationActor : ReceiveActor
                 containsMention);
 
             if (decision is SlackRoutingDecision.Ignore)
+            {
+                _log.Debug("Ignoring Slack event {0}: routing policy decision ignore", message.EventId);
                 return;
+            }
 
             if (decision is SlackRoutingDecision.ContinueOnly && !threadExists)
+            {
+                _log.Debug("Ignoring Slack event {0}: thread continuation requested but no thread actor exists", message.EventId);
                 return;
+            }
 
             var thread = existingThread.IsNobody()
                 ? Context.ActorOf(CreateThreadProps(message.ChannelId, threadTs), threadActorName)
@@ -46,10 +63,20 @@ public sealed class SlackConversationActor : ReceiveActor
 
             var normalized = NormalizeInboundText(message.Text);
             if (string.IsNullOrWhiteSpace(normalized))
+            {
+                _log.Debug("Ignoring Slack event {0}: normalized text is empty", message.EventId);
                 return;
+            }
+
+            var sessionId = new SessionId($"{_conversationId}/{threadTs}");
+            var log = _log
+                .WithContext("SlackThreadTs", threadTs)
+                .WithContext("SessionId", sessionId.Value);
+
+            log.Debug("Routing Slack event {0} to session thread actor", message.EventId);
 
             thread.Forward(new SlackThreadInbound(
-                SessionId: new SessionId($"{_conversationId}/{threadTs}"),
+                SessionId: sessionId,
                 ChannelId: message.ChannelId,
                 ThreadTs: threadTs,
                 SenderId: message.UserId ?? "slack-user",

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -1,0 +1,118 @@
+using Akka.Actor;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackConversationActor : ReceiveActor
+{
+    private readonly string _conversationId;
+    private readonly SlackGatewayDependencies _dependencies;
+
+    public SlackConversationActor(string conversationId, SlackGatewayDependencies dependencies)
+    {
+        _conversationId = conversationId;
+        _dependencies = dependencies;
+
+        Receive<SlackInboundMessage>(message =>
+        {
+            if (!IsAllowedConversation(message))
+                return;
+
+            if (!IsAllowedUser(message))
+                return;
+
+            var containsMention = ContainsBotMention(message.Text);
+            var threadTs = string.IsNullOrWhiteSpace(message.ThreadTs) ? message.EventTs : message.ThreadTs!;
+            var threadActorName = Uri.EscapeDataString(threadTs);
+            var existingThread = Context.Child(threadActorName);
+            var threadExists = !existingThread.IsNobody();
+
+            var decision = SlackRoutingPolicy.Evaluate(
+                message,
+                _dependencies.Options.MentionOnly,
+                _dependencies.Options.AllowDirectMessages,
+                threadExists,
+                containsMention);
+
+            if (decision is SlackRoutingDecision.Ignore)
+                return;
+
+            if (decision is SlackRoutingDecision.ContinueOnly && !threadExists)
+                return;
+
+            var thread = existingThread.IsNobody()
+                ? Context.ActorOf(CreateThreadProps(message.ChannelId, threadTs), threadActorName)
+                : existingThread;
+
+            var normalized = NormalizeInboundText(message.Text);
+            if (string.IsNullOrWhiteSpace(normalized))
+                return;
+
+            thread.Forward(new SlackThreadInbound(
+                SessionId: new SessionId($"{_conversationId}/{threadTs}"),
+                ChannelId: message.ChannelId,
+                ThreadTs: threadTs,
+                SenderId: message.UserId ?? "slack-user",
+                Text: normalized,
+                ReceivedAt: _dependencies.TimeProvider.GetUtcNow()));
+        });
+    }
+
+    public static Props CreateProps(string conversationId, SlackGatewayDependencies dependencies) =>
+        Props.Create(() => new SlackConversationActor(conversationId, dependencies));
+
+    private bool IsAllowedConversation(SlackInboundMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(_dependencies.DefaultChannelId)
+            && !string.Equals(message.ChannelId, _dependencies.DefaultChannelId, StringComparison.Ordinal))
+            return false;
+
+        if (_dependencies.Options.AllowedChannelIds is { Length: > 0 }
+            && !_dependencies.Options.AllowedChannelIds.Contains(message.ChannelId, StringComparer.Ordinal))
+            return false;
+
+        return true;
+    }
+
+    private bool IsAllowedUser(SlackInboundMessage message)
+    {
+        if (_dependencies.Options.AllowedUserIds is not { Length: > 0 })
+            return true;
+
+        if (string.IsNullOrWhiteSpace(message.UserId))
+            return false;
+
+        return _dependencies.Options.AllowedUserIds.Contains(message.UserId, StringComparer.Ordinal);
+    }
+
+    private bool ContainsBotMention(string text)
+    {
+        if (string.IsNullOrWhiteSpace(_dependencies.BotUserId))
+            return false;
+
+        return text.Contains($"<@{_dependencies.BotUserId}>", StringComparison.Ordinal);
+    }
+
+    private string NormalizeInboundText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(_dependencies.BotUserId))
+            return text.Trim();
+
+        var mention = $"<@{_dependencies.BotUserId}>";
+        return text.Replace(mention, string.Empty, StringComparison.Ordinal).Trim();
+    }
+
+    private Props CreateThreadProps(string channelId, string threadTs)
+    {
+        var sessionId = new SessionId($"{_conversationId}/{threadTs}");
+
+        if (_dependencies.ThreadPropsFactory is not null)
+            return _dependencies.ThreadPropsFactory(sessionId, channelId, threadTs, _dependencies);
+
+        return SlackThreadBindingActor.CreateProps(
+            sessionId: sessionId,
+            channelId: channelId,
+            threadTs: threadTs,
+            dependencies: _dependencies);
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -1,0 +1,67 @@
+using Akka.Actor;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackGatewayActor : ReceiveActor
+{
+    private const int MaxProcessedEventIds = 4096;
+
+    private readonly SlackGatewayDependencies _dependencies;
+    private readonly Dictionary<string, byte> _processedEventIds = new(StringComparer.Ordinal);
+    private readonly Queue<string> _processedEventOrder = new();
+
+    public SlackGatewayActor(SlackGatewayDependencies dependencies)
+    {
+        _dependencies = dependencies;
+
+        Receive<SlackInboundMessage>(message =>
+        {
+            if (!TryMarkEventProcessed(message.EventId))
+                return;
+
+            var actorName = Uri.EscapeDataString(message.ChannelId);
+            var conversationProps = _dependencies.ConversationPropsFactory?.Invoke(message.ChannelId, _dependencies)
+                ?? SlackConversationActor.CreateProps(message.ChannelId, _dependencies);
+            var conversation = Context.Child(actorName)
+                .GetOrElse(() => Context.ActorOf(
+                    conversationProps,
+                    actorName));
+
+            conversation.Forward(message);
+        });
+    }
+
+    public static Props CreateProps(SlackGatewayDependencies dependencies) =>
+        Props.Create(() => new SlackGatewayActor(dependencies));
+
+    private bool TryMarkEventProcessed(string eventId)
+    {
+        if (string.IsNullOrWhiteSpace(eventId))
+            return true;
+
+        if (_processedEventIds.ContainsKey(eventId))
+            return false;
+
+        _processedEventIds[eventId] = 0;
+        _processedEventOrder.Enqueue(eventId);
+
+        while (_processedEventIds.Count > MaxProcessedEventIds
+               && _processedEventOrder.TryDequeue(out var oldestEventId))
+            _processedEventIds.Remove(oldestEventId);
+
+        return true;
+    }
+}
+
+public sealed record SlackGatewayDependencies(
+    SessionPipeline Pipeline,
+    ActorSystem ActorSystem,
+    TimeProvider TimeProvider,
+    SlackChannelOptions Options,
+    string? BotUserId,
+    string? DefaultChannelId,
+    Func<SlackPostMessage, Task> PostMessageAsync,
+    Func<string, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
+    Func<SessionId, string, string, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -1,4 +1,5 @@
 using Akka.Actor;
+using Akka.Event;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 
@@ -9,17 +10,22 @@ public sealed class SlackGatewayActor : ReceiveActor
     private const int MaxProcessedEventIds = 4096;
 
     private readonly SlackGatewayDependencies _dependencies;
+    private readonly ILoggingAdapter _log;
     private readonly Dictionary<string, byte> _processedEventIds = new(StringComparer.Ordinal);
     private readonly Queue<string> _processedEventOrder = new();
 
     public SlackGatewayActor(SlackGatewayDependencies dependencies)
     {
         _dependencies = dependencies;
+        _log = Context.GetLogger().WithContext("Adapter", "slack");
 
         Receive<SlackInboundMessage>(message =>
         {
             if (!TryMarkEventProcessed(message.EventId))
+            {
+                _log.Debug("Dropping duplicate Slack event {0}", message.EventId);
                 return;
+            }
 
             var actorName = Uri.EscapeDataString(message.ChannelId);
             var conversationProps = _dependencies.ConversationPropsFactory?.Invoke(message.ChannelId, _dependencies)
@@ -29,6 +35,7 @@ public sealed class SlackGatewayActor : ReceiveActor
                     conversationProps,
                     actorName));
 
+            _log.Debug("Routing Slack event {0} to conversation {1}", message.EventId, message.ChannelId);
             conversation.Forward(message);
         });
     }
@@ -62,6 +69,6 @@ public sealed record SlackGatewayDependencies(
     SlackChannelOptions Options,
     string? BotUserId,
     string? DefaultChannelId,
-    Func<SlackPostMessage, Task> PostMessageAsync,
+    ISlackReplyClient ReplyClient,
     Func<string, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
     Func<SessionId, string, string, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -1,0 +1,35 @@
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Channels.Slack;
+
+public enum SlackInboundKind
+{
+    Message,
+    AppMention
+}
+
+public sealed record SlackInboundMessage(
+    SlackInboundKind Kind,
+    string EventId,
+    string ChannelId,
+    string? ThreadTs,
+    string EventTs,
+    string? UserId,
+    string? BotId,
+    string Text,
+    string? Subtype,
+    bool Hidden,
+    bool IsDirectMessage);
+
+public sealed record SlackThreadInbound(
+    SessionId SessionId,
+    string ChannelId,
+    string ThreadTs,
+    string SenderId,
+    string Text,
+    DateTimeOffset ReceivedAt);
+
+public sealed record SlackPostMessage(
+    string ChannelId,
+    string ThreadTs,
+    string Text);

--- a/src/Netclaw.Channels/Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackReplyClient.cs
@@ -1,0 +1,17 @@
+using SlackNet;
+using SlackNet.WebApi;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackReplyClient
+{
+    public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+    {
+        return slackApiClient.Chat.PostMessage(new Message
+        {
+            Channel = message.ChannelId,
+            ThreadTs = message.ThreadTs,
+            Text = message.Text
+        });
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
+++ b/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
@@ -1,0 +1,42 @@
+namespace Netclaw.Channels.Slack;
+
+public static class SlackRoutingPolicy
+{
+    public static SlackRoutingDecision Evaluate(
+        SlackInboundMessage message,
+        bool mentionOnly,
+        bool allowDirectMessages,
+        bool threadExists,
+        bool containsBotMention)
+    {
+        if (string.IsNullOrWhiteSpace(message.Text))
+            return SlackRoutingDecision.Ignore;
+
+        if (message.Kind is SlackInboundKind.AppMention)
+            return SlackRoutingDecision.StartOrContinue;
+
+        if (message.Kind is not SlackInboundKind.Message)
+            return SlackRoutingDecision.Ignore;
+
+        if (message.Hidden || !string.IsNullOrWhiteSpace(message.Subtype))
+            return SlackRoutingDecision.Ignore;
+
+        if (message.IsDirectMessage)
+            return allowDirectMessages ? SlackRoutingDecision.StartOrContinue : SlackRoutingDecision.Ignore;
+
+        if (threadExists)
+            return SlackRoutingDecision.ContinueOnly;
+
+        if (!mentionOnly)
+            return SlackRoutingDecision.StartOrContinue;
+
+        return containsBotMention ? SlackRoutingDecision.StartOrContinue : SlackRoutingDecision.Ignore;
+    }
+}
+
+public enum SlackRoutingDecision
+{
+    Ignore,
+    ContinueOnly,
+    StartOrContinue
+}

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -1,0 +1,127 @@
+using System.Text;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Channels.Slack;
+
+internal sealed class SlackThreadBindingActor : ReceiveActor
+{
+    private readonly SessionId _sessionId;
+    private readonly string _channelId;
+    private readonly string _threadTs;
+    private readonly SlackGatewayDependencies _dependencies;
+
+    private readonly StringBuilder _buffer = new();
+
+    private MaterializedSession? _session;
+    private ISourceQueueWithComplete<ChannelInput>? _inputQueue;
+
+    public SlackThreadBindingActor(
+        SessionId sessionId,
+        string channelId,
+        string threadTs,
+        SlackGatewayDependencies dependencies)
+    {
+        _sessionId = sessionId;
+        _channelId = channelId;
+        _threadTs = threadTs;
+        _dependencies = dependencies;
+
+        ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
+        ReceiveAsync<ThreadOutput>(HandleOutputAsync);
+    }
+
+    public static Props CreateProps(
+        SessionId sessionId,
+        string channelId,
+        string threadTs,
+        SlackGatewayDependencies dependencies) =>
+        Props.Create(() => new SlackThreadBindingActor(sessionId, channelId, threadTs, dependencies));
+
+    protected override void PostStop()
+    {
+        _inputQueue?.Complete();
+        _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        base.PostStop();
+    }
+
+    private async Task HandleInboundAsync(SlackThreadInbound message)
+    {
+        await EnsureInitializedAsync();
+
+        var result = await _inputQueue!.OfferAsync(new ChannelInput
+        {
+            SenderId = message.SenderId,
+            ChannelId = _channelId,
+            Contents = [new TextContent(message.Text)],
+            ReceivedAt = message.ReceivedAt
+        });
+
+        if (result is QueueOfferResult.QueueClosed)
+            Context.Stop(Self);
+    }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_session is not null)
+            return;
+
+        var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
+        {
+            ChannelType = "slack",
+            Filter = OutputFilter.Full
+        });
+
+        var inputQueue = Source.Queue<ChannelInput>(32, OverflowStrategy.Backpressure)
+            .ToMaterialized(materialized.Input, Keep.Left)
+            .Run(_dependencies.ActorSystem);
+
+        materialized.Output
+            .To(Sink.ForEach<SessionOutput>(output => Self.Tell(new ThreadOutput(output))))
+            .Run(_dependencies.ActorSystem);
+
+        _session = materialized;
+        _inputQueue = inputQueue;
+    }
+
+    private async Task HandleOutputAsync(ThreadOutput threadOutput)
+    {
+        switch (threadOutput.Output)
+        {
+            case TextDeltaOutput delta:
+                _buffer.Append(delta.Delta);
+                break;
+
+            case TextOutput text when _buffer.Length == 0:
+                _buffer.Append(text.Text);
+                break;
+
+            case ErrorOutput err:
+                await _dependencies.PostMessageAsync(new SlackPostMessage(
+                    ChannelId: _channelId,
+                    ThreadTs: _threadTs,
+                    Text: $":warning: {err.Message}"));
+                _buffer.Clear();
+                break;
+
+            case TurnCompleted:
+                var reply = _buffer.ToString().Trim();
+                _buffer.Clear();
+                if (!string.IsNullOrWhiteSpace(reply))
+                {
+                    await _dependencies.PostMessageAsync(new SlackPostMessage(
+                        ChannelId: _channelId,
+                        ThreadTs: _threadTs,
+                        Text: reply));
+                }
+
+                break;
+        }
+    }
+
+    private sealed record ThreadOutput(SessionOutput Output);
+}

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Streams;
 using Akka.Streams.Dsl;
 using Microsoft.Extensions.AI;
@@ -14,8 +15,11 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
     private readonly string _channelId;
     private readonly string _threadTs;
     private readonly SlackGatewayDependencies _dependencies;
+    private readonly ILoggingAdapter _log;
 
     private readonly StringBuilder _buffer = new();
+    private bool _sawTextDelta;
+    private bool _postedThisTurn;
 
     private MaterializedSession? _session;
     private ISourceQueueWithComplete<ChannelInput>? _inputQueue;
@@ -30,6 +34,11 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         _channelId = channelId;
         _threadTs = threadTs;
         _dependencies = dependencies;
+        _log = Context.GetLogger()
+            .WithContext("Adapter", "slack")
+            .WithContext("SessionId", _sessionId.Value)
+            .WithContext("SlackChannelId", _channelId)
+            .WithContext("SlackThreadTs", _threadTs);
 
         ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
         ReceiveAsync<ThreadOutput>(HandleOutputAsync);
@@ -62,13 +71,25 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         });
 
         if (result is QueueOfferResult.QueueClosed)
+        {
+            _log.Warning("Slack thread queue closed for session {0}", _sessionId.Value);
             Context.Stop(Self);
+            return;
+        }
+
+        if (result is QueueOfferResult.Enqueued)
+            _log.Debug("Accepted inbound Slack message for session queue");
+
+        if (result is QueueOfferResult.Failure failure)
+            _log.Error(failure.Cause, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
     }
 
     private async Task EnsureInitializedAsync()
     {
         if (_session is not null)
             return;
+
+        _log.Info("Initializing Slack thread binding pipeline");
 
         var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
         {
@@ -86,6 +107,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
         _session = materialized;
         _inputQueue = inputQueue;
+
+        _log.Info("Slack thread binding pipeline initialized");
     }
 
     private async Task HandleOutputAsync(ThreadOutput threadOutput)
@@ -94,32 +117,59 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         {
             case TextDeltaOutput delta:
                 _buffer.Append(delta.Delta);
+                _sawTextDelta = true;
                 break;
 
-            case TextOutput text when _buffer.Length == 0:
-                _buffer.Append(text.Text);
+            case TextOutput text:
+                if (!_sawTextDelta && !_postedThisTurn)
+                {
+                    var fullText = text.Text?.Trim();
+                    if (!string.IsNullOrWhiteSpace(fullText))
+                    {
+                        await SafePostAsync(fullText);
+                        _postedThisTurn = true;
+                    }
+                }
+
                 break;
 
             case ErrorOutput err:
-                await _dependencies.PostMessageAsync(new SlackPostMessage(
-                    ChannelId: _channelId,
-                    ThreadTs: _threadTs,
-                    Text: $":warning: {err.Message}"));
+                await SafePostAsync($":warning: {err.Message}");
                 _buffer.Clear();
                 break;
 
             case TurnCompleted:
-                var reply = _buffer.ToString().Trim();
-                _buffer.Clear();
-                if (!string.IsNullOrWhiteSpace(reply))
+                if (_sawTextDelta && !_postedThisTurn)
                 {
-                    await _dependencies.PostMessageAsync(new SlackPostMessage(
-                        ChannelId: _channelId,
-                        ThreadTs: _threadTs,
-                        Text: reply));
+                    var reply = _buffer.ToString().Trim();
+                    if (!string.IsNullOrWhiteSpace(reply))
+                        await SafePostAsync(reply);
+                    else
+                        _log.Debug("Turn completed with no buffered reply text");
                 }
 
+                _buffer.Clear();
+                _sawTextDelta = false;
+                _postedThisTurn = false;
+
                 break;
+        }
+    }
+
+    private async Task SafePostAsync(string text)
+    {
+        try
+        {
+            await _dependencies.ReplyClient.PostThreadReplyAsync(new SlackPostMessage(
+                ChannelId: _channelId,
+                ThreadTs: _threadTs,
+                Text: text));
+
+            _log.Info("Posted Slack reply message");
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
         }
     }
 

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -90,6 +90,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
             return;
 
         _log.Info("Initializing Slack thread binding pipeline");
+        var self = Self;
 
         var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
         {
@@ -102,7 +103,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
             .Run(_dependencies.ActorSystem);
 
         materialized.Output
-            .To(Sink.ForEach<SessionOutput>(output => Self.Tell(new ThreadOutput(output))))
+            .To(Sink.ForEach<SessionOutput>(output => self.Tell(new ThreadOutput(output))))
             .Run(_dependencies.ActorSystem);
 
         _session = materialized;

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -29,9 +29,14 @@ public sealed class HeadlessChannel : IChannel
     public string ChannelType => "headless";
     public string DisplayName => "Headless Prompt";
 
-    public ChannelHealth GetHealth() => _isConnected
-        ? new ChannelHealth(ChannelHealthStatus.Healthy)
-        : new ChannelHealth(ChannelHealthStatus.Disconnected, "No active daemon connection");
+    public ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default)
+    {
+        var health = _isConnected
+            ? new ChannelHealth(ChannelHealthStatus.Healthy)
+            : new ChannelHealth(ChannelHealthStatus.Disconnected, "No active daemon connection");
+
+        return ValueTask.FromResult(health);
+    }
 
     public HeadlessChannel(
         DaemonClient daemonClient,

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="OllamaSharp" />
+    <PackageReference Include="SlackNet.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -18,6 +18,8 @@ using Netclaw.Daemon.Services;
 using SlackNet.Events;
 using SlackNet.Extensions.DependencyInjection;
 
+const string SlackChannelKey = "slack";
+
 try
 {
     await RunAsync(args);
@@ -242,7 +244,10 @@ static void ConfigureSlackChannel(IServiceCollection services, IConfiguration co
     if (slackOptions.SocketMode && string.IsNullOrWhiteSpace(slackOptions.AppToken))
         throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
 
-    services.AddSingleton<SlackChannel>();
+    services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
+    services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
+    services.AddSingleton<SlackChannel>(sp =>
+        (SlackChannel)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
 
     services.AddSlackNet(c =>
     {
@@ -255,6 +260,6 @@ static void ConfigureSlackChannel(IServiceCollection services, IConfiguration co
         c.RegisterEventHandler<AppMention, SlackChannel>();
     });
 
-    services.AddSingleton<IChannel>(sp => sp.GetRequiredService<SlackChannel>());
-    services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SlackChannel>());
+    services.AddSingleton<IHostedService>(sp =>
+        (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -38,11 +38,15 @@ static async Task RunAsync(string[] args)
     builder.WebHost.UseUrls("http://127.0.0.1:5199");
 
     var paths = ConfigureConfigServices(builder.Services, builder.Configuration);
-    ConfigureDaemonServices(builder.Services, builder.Configuration, paths);
+    var daemonLogLevel = ResolveDaemonLogLevel(builder.Configuration);
+    var consoleLoggingEnabled = ResolveConsoleLoggingEnabled(builder.Configuration);
+    ConfigureDaemonServices(builder.Services, builder.Configuration, paths, daemonLogLevel);
 
     // Suppress framework console logging — session logs go to disk
     builder.Logging.ClearProviders();
-    builder.Logging.SetMinimumLevel(LogLevel.Warning);
+    if (consoleLoggingEnabled)
+        builder.Logging.AddSimpleConsole(options => options.SingleLine = true);
+    builder.Logging.SetMinimumLevel(daemonLogLevel);
 
     // SignalR for remote clients (CLI thin client, Blazor ops console)
     builder.Services.AddSignalR();
@@ -124,7 +128,11 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
 // Daemon-only services (actor system, tools, persistence)
 // ═══════════════════════════════════════════════════════════════════════
 
-static void ConfigureDaemonServices(IServiceCollection services, IConfigurationManager configuration, NetclawPaths paths)
+static void ConfigureDaemonServices(
+    IServiceCollection services,
+    IConfigurationManager configuration,
+    NetclawPaths paths,
+    LogLevel daemonLogLevel)
 {
     services
         .AddOptions<DaemonPersistenceOptions>()
@@ -192,7 +200,7 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
         {
             setup.ClearLoggers();
             setup.AddLoggerFactory();
-            setup.LogLevel = Akka.Event.LogLevel.WarningLevel;
+            setup.LogLevel = ToAkkaLogLevel(daemonLogLevel);
         });
 
         if (persistence.Provider is PersistenceProvider.Sqlite)
@@ -228,6 +236,35 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
     // Active session cleanup during host shutdown
     services.AddSingleton<SessionRegistryShutdownService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionRegistryShutdownService>());
+}
+
+static LogLevel ResolveDaemonLogLevel(IConfiguration configuration)
+{
+    var configured = configuration["Logging:LogLevel:Default"];
+    if (Enum.TryParse<LogLevel>(configured, ignoreCase: true, out var level))
+        return level;
+
+    return LogLevel.Warning;
+}
+
+static bool ResolveConsoleLoggingEnabled(IConfiguration configuration)
+{
+    return configuration.GetValue("Logging:Console:Enabled", false);
+}
+
+static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)
+{
+    return logLevel switch
+    {
+        LogLevel.Trace => Akka.Event.LogLevel.DebugLevel,
+        LogLevel.Debug => Akka.Event.LogLevel.DebugLevel,
+        LogLevel.Information => Akka.Event.LogLevel.InfoLevel,
+        LogLevel.Warning => Akka.Event.LogLevel.WarningLevel,
+        LogLevel.Error => Akka.Event.LogLevel.ErrorLevel,
+        LogLevel.Critical => Akka.Event.LogLevel.ErrorLevel,
+        LogLevel.None => Akka.Event.LogLevel.ErrorLevel,
+        _ => Akka.Event.LogLevel.WarningLevel
+    };
 }
 
 static void ConfigureSlackChannel(IServiceCollection services, IConfiguration configuration)

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -10,9 +10,13 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Channels;
+using Netclaw.Channels.Slack;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Services;
+using SlackNet.Events;
+using SlackNet.Extensions.DependencyInjection;
 
 try
 {
@@ -209,6 +213,8 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
     // Session pipeline (stream API for channels)
     services.AddSingleton<SessionPipeline>();
 
+    ConfigureSlackChannel(services, configuration);
+
     // Config hot-reload watcher
     services.AddSingleton<ConfigWatcherService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<ConfigWatcherService>());
@@ -220,4 +226,35 @@ static void ConfigureDaemonServices(IServiceCollection services, IConfigurationM
     // Active session cleanup during host shutdown
     services.AddSingleton<SessionRegistryShutdownService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionRegistryShutdownService>());
+}
+
+static void ConfigureSlackChannel(IServiceCollection services, IConfiguration configuration)
+{
+    var slackOptions = configuration.GetSection("Slack").Get<SlackChannelOptions>() ?? new SlackChannelOptions();
+    services.AddSingleton(slackOptions);
+
+    if (!slackOptions.Enabled)
+        return;
+
+    if (string.IsNullOrWhiteSpace(slackOptions.BotToken))
+        throw new InvalidOperationException("Slack is enabled but Slack:BotToken is not configured.");
+
+    if (slackOptions.SocketMode && string.IsNullOrWhiteSpace(slackOptions.AppToken))
+        throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
+
+    services.AddSingleton<SlackChannel>();
+
+    services.AddSlackNet(c =>
+    {
+        c.UseApiToken(slackOptions.BotToken!);
+
+        if (slackOptions.SocketMode)
+            c.UseAppLevelToken(slackOptions.AppToken!);
+
+        c.RegisterEventHandler<MessageEvent, SlackChannel>();
+        c.RegisterEventHandler<AppMention, SlackChannel>();
+    });
+
+    services.AddSingleton<IChannel>(sp => sp.GetRequiredService<SlackChannel>());
+    services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SlackChannel>());
 }


### PR DESCRIPTION
## Summary
- Refactor Slack integration into an actor hierarchy (`SlackGatewayActor`, `SlackConversationActor`, `SlackThreadBindingActor`) with deterministic `{channelId}/{threadTs}` session binding and routing policy tests.
- Fix Slack runtime behavior issues: prevent bot self-echo loops, keep command ack noise out of dead letters via relay actor no-op handling, and stabilize stream-to-actor output forwarding.
- Improve operability: add async channel health contract, keyed Slack channel wiring, thin `ISlackReplyClient` abstraction, unified daemon/Akka debug log level config, and a behavior debugging runbook.

## Validation
- `dotnet build Netclaw.slnx`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj`
- `dotnet slopwatch analyze`