### PR TITLE
Add OTLP logs and metrics with typed telemetry configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <AkkaHostingVersion>1.5.60</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.60.1</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.4.0</AkkaRemindersVersion>
+    <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
@@ -20,6 +21,9 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ STEP_TIMEOUT_SECONDS=120 scripts/smoke/check.sh
 ## Operations Runbooks
 
 - Daemon upgrade and rollback planning: `docs/runbooks/daemon-upgrade.md`
+- Behavior debugging and telemetry triage: `docs/runbooks/behavior-debugging.md`
 
 ## Integrations
 

--- a/docs/runbooks/behavior-debugging.md
+++ b/docs/runbooks/behavior-debugging.md
@@ -80,21 +80,67 @@ If steps 1-4 appear but step 5 does not, inspect Slack outbound posting path.
 3. Confirm the bot user ID and mention parsing are correct.
 4. Confirm session key is stable: `{channelId}/{threadTs}`.
 
-## Optional OTEL Workstream (Recommended)
+## OTLP Telemetry (logs + metrics)
 
-If debugging latency/routing frequently, add OpenTelemetry instrumentation:
+Enable OpenTelemetry export from daemon:
 
-- activity source spans for:
-  - Slack ingress event receive
-  - conversation routing decision
-  - session enqueue
-  - model/tool turn completion
-  - Slack reply post
-- span attributes:
-  - `session.id`
-  - `slack.channel_id`
-  - `slack.thread_ts`
-  - `slack.event_id`
-- OTLP export to local collector (e.g. LocalTelemetry)
+```json
+{
+  "Telemetry": {
+    "Enabled": true,
+    "Otlp": {
+      "Endpoint": "http://127.0.0.1:4317"
+    }
+  }
+}
+```
+
+Current instrumentation emits:
+
+- metrics for:
+  - events received, dropped, routed
+  - messages enqueued
+  - replies posted/failed and reply latency histogram
+
+Export target can be LocalTelemetry (or any OTLP collector).
 
 This gives per-turn causality and timing without heavy log spelunking.
+
+## OTLP Query Cheat Sheet
+
+Use these metric names in your local telemetry UI (or PromQL-compatible query layer):
+
+- `netclaw.slack.events.received`
+  - event ingress count
+  - attributes: `kind`
+- `netclaw.slack.events.dropped`
+  - policy/guard drops (duplicates, ACL, loop prevention, etc.)
+  - attributes: `reason`
+- `netclaw.slack.events.routed`
+  - events that reached conversation routing
+  - attributes: `kind`
+- `netclaw.slack.messages.enqueued`
+  - messages accepted into session input queue
+- `netclaw.slack.replies.posted`
+  - successful Slack thread replies
+- `netclaw.slack.replies.failed`
+  - failed Slack reply attempts
+- `netclaw.slack.reply.duration.ms`
+  - histogram of reply post call duration (ms)
+
+Suggested quick checks:
+
+1. **No reply symptom**
+   - `events.received > 0` and `messages.enqueued > 0` but `replies.posted = 0`
+   - likely outbound post failure or output mapping issue.
+
+2. **Loop symptom**
+   - high `events.dropped{reason="bot_message"}` and high `events.received`
+   - indicates self-echo events are arriving and being correctly filtered.
+
+3. **Policy mismatch symptom**
+   - spikes in `events.dropped{reason="channel_not_allowed"}` or `user_not_allowed`
+   - check Slack ACL config (`AllowedChannelIds`, `AllowedUserIds`, DM settings).
+
+Tracing spans are intentionally disabled for now to avoid disconnected
+cross-actor telemetry noise.

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -199,6 +199,26 @@ Akka.NET logger integration.
 | `LogLevel:Default` | string | `Warning` | Minimum log level (`Debug`, `Information`, `Warning`, `Error`, etc.) shared by MEL and Akka.NET. |
 | `Console:Enabled` | bool | `false` | Enables console logger provider output for daemon debugging. |
 
+### Telemetry
+
+Optional OpenTelemetry export for logs and metrics.
+
+```json
+{
+  "Telemetry": {
+    "Enabled": true,
+    "Otlp": {
+      "Endpoint": "http://127.0.0.1:4317"
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Enabled` | bool | `false` | Enables OTLP export pipeline in daemon. |
+| `Otlp:Endpoint` | string | `http://127.0.0.1:4317` | OTLP collector endpoint (gRPC). |
+
 ## Secrets
 
 API keys and tokens should be stored in `secrets.json` using the same key
@@ -237,6 +257,10 @@ export NETCLAW_Providers__openrouter__ApiKey="sk-or-v1-..."
 # Set Slack tokens
 export NETCLAW_Slack__BotToken="xoxb-..."
 export NETCLAW_Slack__AppToken="xapp-..."
+
+# Enable OTLP telemetry
+export NETCLAW_Telemetry__Enabled="true"
+export NETCLAW_Telemetry__Otlp__Endpoint="http://127.0.0.1:4317"
 
 # Override session settings
 export NETCLAW_Session__MaxToolIterationsPerTurn="5"

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -1,6 +1,7 @@
 using Akka.Actor;
 using Akka.Event;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
 
 namespace Netclaw.Channels.Slack;
 
@@ -23,18 +24,21 @@ public sealed class SlackConversationActor : ReceiveActor
             if (!IsAllowedConversation(message))
             {
                 _log.Debug("Ignoring Slack event {0}: channel not allowed", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("channel_not_allowed");
                 return;
             }
 
             if (IsBotMessage(message))
             {
                 _log.Debug("Ignoring Slack event {0}: bot/self message", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("bot_message");
                 return;
             }
 
             if (!IsAllowedUser(message))
             {
                 _log.Debug("Ignoring Slack event {0}: user not allowed", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("user_not_allowed");
                 return;
             }
 
@@ -54,12 +58,14 @@ public sealed class SlackConversationActor : ReceiveActor
             if (decision is SlackRoutingDecision.Ignore)
             {
                 _log.Debug("Ignoring Slack event {0}: routing policy decision ignore", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("routing_policy_ignore");
                 return;
             }
 
             if (decision is SlackRoutingDecision.ContinueOnly && !threadExists)
             {
                 _log.Debug("Ignoring Slack event {0}: thread continuation requested but no thread actor exists", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("thread_not_initialized");
                 return;
             }
 
@@ -71,6 +77,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (string.IsNullOrWhiteSpace(normalized))
             {
                 _log.Debug("Ignoring Slack event {0}: normalized text is empty", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("empty_text");
                 return;
             }
 

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -2,6 +2,7 @@ using Akka.Actor;
 using Akka.Event;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
 
 namespace Netclaw.Channels.Slack;
 
@@ -21,9 +22,12 @@ public sealed class SlackGatewayActor : ReceiveActor
 
         Receive<SlackInboundMessage>(message =>
         {
+            ChannelTelemetry.RecordSlackEventReceived(message.Kind.ToString());
+
             if (!TryMarkEventProcessed(message.EventId))
             {
                 _log.Debug("Dropping duplicate Slack event {0}", message.EventId);
+                ChannelTelemetry.RecordSlackEventDropped("duplicate_event");
                 return;
             }
 
@@ -36,6 +40,7 @@ public sealed class SlackGatewayActor : ReceiveActor
                     actorName));
 
             _log.Debug("Routing Slack event {0} to conversation {1}", message.EventId, message.ChannelId);
+            ChannelTelemetry.RecordSlackEventRouted(message.Kind.ToString());
             conversation.Forward(message);
         });
     }

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -6,6 +6,7 @@ using Akka.Streams.Dsl;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Telemetry;
 
 namespace Netclaw.Channels.Slack;
 
@@ -78,7 +79,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         }
 
         if (result is QueueOfferResult.Enqueued)
+        {
             _log.Debug("Accepted inbound Slack message for session queue");
+            ChannelTelemetry.RecordSlackMessageEnqueued();
+        }
 
         if (result is QueueOfferResult.Failure failure)
             _log.Error(failure.Cause, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
@@ -159,6 +163,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
     private async Task SafePostAsync(string text)
     {
+        var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
         {
             await _dependencies.ReplyClient.PostThreadReplyAsync(new SlackPostMessage(
@@ -167,10 +172,12 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
                 Text: text));
 
             _log.Info("Posted Slack reply message");
+            ChannelTelemetry.RecordSlackReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
         }
     }
 

--- a/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.Metrics;
+
+namespace Netclaw.Channels.Telemetry;
+
+public static class ChannelTelemetry
+{
+    public const string MeterName = "Netclaw.Channels";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> SlackEventsReceived =
+        Meter.CreateCounter<long>("netclaw.slack.events.received");
+
+    private static readonly Counter<long> SlackEventsDropped =
+        Meter.CreateCounter<long>("netclaw.slack.events.dropped");
+
+    private static readonly Counter<long> SlackEventsRouted =
+        Meter.CreateCounter<long>("netclaw.slack.events.routed");
+
+    private static readonly Counter<long> SlackMessagesEnqueued =
+        Meter.CreateCounter<long>("netclaw.slack.messages.enqueued");
+
+    private static readonly Counter<long> SlackRepliesPosted =
+        Meter.CreateCounter<long>("netclaw.slack.replies.posted");
+
+    private static readonly Counter<long> SlackRepliesFailed =
+        Meter.CreateCounter<long>("netclaw.slack.replies.failed");
+
+    private static readonly Histogram<double> SlackReplyDurationMs =
+        Meter.CreateHistogram<double>("netclaw.slack.reply.duration.ms", unit: "ms");
+
+    public static void RecordSlackEventReceived(string kind)
+        => SlackEventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
+
+    public static void RecordSlackEventDropped(string reason)
+        => SlackEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    public static void RecordSlackEventRouted(string kind)
+        => SlackEventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
+
+    public static void RecordSlackMessageEnqueued()
+        => SlackMessagesEnqueued.Add(1);
+
+    public static void RecordSlackReplyPosted(double durationMs)
+    {
+        SlackRepliesPosted.Add(1);
+        SlackReplyDurationMs.Record(durationMs);
+    }
+
+    public static void RecordSlackReplyFailed(double durationMs)
+    {
+        SlackRepliesFailed.Add(1);
+        SlackReplyDurationMs.Record(durationMs);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/LoggingRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingRegistrationExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+
+namespace Netclaw.Daemon.Configuration;
+
+public static class LoggingRegistrationExtensions
+{
+    public static LogLevel ConfigureNetclawLogging(this WebApplicationBuilder builder)
+    {
+        var level = ResolveLogLevel(builder.Configuration);
+        var consoleEnabled = builder.Configuration.GetValue("Logging:Console:Enabled", false);
+
+        builder.Logging.ClearProviders();
+        if (consoleEnabled)
+            builder.Logging.AddSimpleConsole(options => options.SingleLine = true);
+
+        builder.Logging.SetMinimumLevel(level);
+        return level;
+    }
+
+    private static LogLevel ResolveLogLevel(IConfiguration configuration)
+    {
+        var configured = configuration["Logging:LogLevel:Default"];
+        if (Enum.TryParse<LogLevel>(configured, ignoreCase: true, out var level))
+            return level;
+
+        return LogLevel.Warning;
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -1,0 +1,45 @@
+using Netclaw.Channels;
+using Netclaw.Channels.Slack;
+using SlackNet.Events;
+using SlackNet.Extensions.DependencyInjection;
+
+namespace Netclaw.Daemon.Configuration;
+
+public static class SlackChannelRegistrationExtensions
+{
+    private const string SlackChannelKey = "slack";
+
+    public static void AddSlackChannelIntegration(this IServiceCollection services, IConfiguration configuration)
+    {
+        var slackOptions = configuration.GetSection("Slack").Get<SlackChannelOptions>() ?? new SlackChannelOptions();
+        services.AddSingleton(slackOptions);
+
+        if (!slackOptions.Enabled)
+            return;
+
+        if (string.IsNullOrWhiteSpace(slackOptions.BotToken))
+            throw new InvalidOperationException("Slack is enabled but Slack:BotToken is not configured.");
+
+        if (slackOptions.SocketMode && string.IsNullOrWhiteSpace(slackOptions.AppToken))
+            throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
+
+        services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
+        services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
+        services.AddSingleton<SlackChannel>(sp =>
+            (SlackChannel)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
+
+        services.AddSlackNet(c =>
+        {
+            c.UseApiToken(slackOptions.BotToken!);
+
+            if (slackOptions.SocketMode)
+                c.UseAppLevelToken(slackOptions.AppToken!);
+
+            c.RegisterEventHandler<MessageEvent, SlackChannel>();
+            c.RegisterEventHandler<AppMention, SlackChannel>();
+        });
+
+        services.AddSingleton<IHostedService>(sp =>
+            (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/TelemetryOptions.cs
+++ b/src/Netclaw.Daemon/Configuration/TelemetryOptions.cs
@@ -1,0 +1,15 @@
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class TelemetryOptions
+{
+    public const string SectionName = "Telemetry";
+
+    public bool Enabled { get; init; }
+
+    public TelemetryOtlpOptions Otlp { get; init; } = new();
+}
+
+public sealed class TelemetryOtlpOptions
+{
+    public string Endpoint { get; init; } = "http://127.0.0.1:4317";
+}

--- a/src/Netclaw.Daemon/Configuration/TelemetryOptionsValidator.cs
+++ b/src/Netclaw.Daemon/Configuration/TelemetryOptionsValidator.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Options;
+
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class TelemetryOptionsValidator : IValidateOptions<TelemetryOptions>
+{
+    public ValidateOptionsResult Validate(string? name, TelemetryOptions options)
+    {
+        if (!Uri.TryCreate(options.Otlp.Endpoint, UriKind.Absolute, out _))
+        {
+            return ValidateOptionsResult.Fail(
+                "Telemetry:Otlp:Endpoint must be an absolute URI.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/TelemetryRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/TelemetryRegistrationExtensions.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Options;
+using Netclaw.Channels.Telemetry;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+
+namespace Netclaw.Daemon.Configuration;
+
+public static class TelemetryRegistrationExtensions
+{
+    public static void AddNetclawTelemetry(this WebApplicationBuilder builder)
+    {
+        builder.Services
+            .AddOptions<TelemetryOptions>()
+            .Bind(builder.Configuration.GetSection(TelemetryOptions.SectionName))
+            .ValidateOnStart();
+        builder.Services.AddSingleton<IValidateOptions<TelemetryOptions>, TelemetryOptionsValidator>();
+
+        var telemetry = builder.Configuration
+            .GetSection(TelemetryOptions.SectionName)
+            .Get<TelemetryOptions>() ?? new TelemetryOptions();
+
+        if (!telemetry.Enabled)
+            return;
+
+        var endpoint = new Uri(telemetry.Otlp.Endpoint);
+
+        builder.Logging.AddOpenTelemetry(options =>
+        {
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+            options.ParseStateValues = true;
+            options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("netclawd"));
+            options.AddOtlpExporter(otlp => otlp.Endpoint = endpoint);
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService("netclawd"))
+            .WithMetrics(metrics =>
+            {
+                metrics.AddMeter(ChannelTelemetry.MeterName);
+                metrics.AddOtlpExporter(otlp => otlp.Endpoint = endpoint);
+            });
+    }
+}

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OllamaSharp" />
     <PackageReference Include="SlackNet.Extensions.DependencyInjection" />
   </ItemGroup>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -10,15 +10,9 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
-using Netclaw.Channels;
-using Netclaw.Channels.Slack;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Services;
-using SlackNet.Events;
-using SlackNet.Extensions.DependencyInjection;
-
-const string SlackChannelKey = "slack";
 
 try
 {
@@ -38,15 +32,9 @@ static async Task RunAsync(string[] args)
     builder.WebHost.UseUrls("http://127.0.0.1:5199");
 
     var paths = ConfigureConfigServices(builder.Services, builder.Configuration);
-    var daemonLogLevel = ResolveDaemonLogLevel(builder.Configuration);
-    var consoleLoggingEnabled = ResolveConsoleLoggingEnabled(builder.Configuration);
+    var daemonLogLevel = builder.ConfigureNetclawLogging();
+    builder.AddNetclawTelemetry();
     ConfigureDaemonServices(builder.Services, builder.Configuration, paths, daemonLogLevel);
-
-    // Suppress framework console logging — session logs go to disk
-    builder.Logging.ClearProviders();
-    if (consoleLoggingEnabled)
-        builder.Logging.AddSimpleConsole(options => options.SingleLine = true);
-    builder.Logging.SetMinimumLevel(daemonLogLevel);
 
     // SignalR for remote clients (CLI thin client, Blazor ops console)
     builder.Services.AddSignalR();
@@ -139,7 +127,6 @@ static void ConfigureDaemonServices(
         .Bind(configuration.GetSection("Persistence"))
         .ValidateOnStart();
     services.AddSingleton<IValidateOptions<DaemonPersistenceOptions>, DaemonPersistenceOptionsValidator>();
-
     var persistence = configuration.GetSection("Persistence")
         .Get<DaemonPersistenceOptions>() ?? new DaemonPersistenceOptions();
     services.AddSingleton(persistence);
@@ -223,7 +210,7 @@ static void ConfigureDaemonServices(
     // Session pipeline (stream API for channels)
     services.AddSingleton<SessionPipeline>();
 
-    ConfigureSlackChannel(services, configuration);
+    services.AddSlackChannelIntegration(configuration);
 
     // Config hot-reload watcher
     services.AddSingleton<ConfigWatcherService>();
@@ -236,20 +223,6 @@ static void ConfigureDaemonServices(
     // Active session cleanup during host shutdown
     services.AddSingleton<SessionRegistryShutdownService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionRegistryShutdownService>());
-}
-
-static LogLevel ResolveDaemonLogLevel(IConfiguration configuration)
-{
-    var configured = configuration["Logging:LogLevel:Default"];
-    if (Enum.TryParse<LogLevel>(configured, ignoreCase: true, out var level))
-        return level;
-
-    return LogLevel.Warning;
-}
-
-static bool ResolveConsoleLoggingEnabled(IConfiguration configuration)
-{
-    return configuration.GetValue("Logging:Console:Enabled", false);
 }
 
 static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)
@@ -265,38 +238,4 @@ static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)
         LogLevel.None => Akka.Event.LogLevel.ErrorLevel,
         _ => Akka.Event.LogLevel.WarningLevel
     };
-}
-
-static void ConfigureSlackChannel(IServiceCollection services, IConfiguration configuration)
-{
-    var slackOptions = configuration.GetSection("Slack").Get<SlackChannelOptions>() ?? new SlackChannelOptions();
-    services.AddSingleton(slackOptions);
-
-    if (!slackOptions.Enabled)
-        return;
-
-    if (string.IsNullOrWhiteSpace(slackOptions.BotToken))
-        throw new InvalidOperationException("Slack is enabled but Slack:BotToken is not configured.");
-
-    if (slackOptions.SocketMode && string.IsNullOrWhiteSpace(slackOptions.AppToken))
-        throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
-
-    services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
-    services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
-    services.AddSingleton<SlackChannel>(sp =>
-        (SlackChannel)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
-
-    services.AddSlackNet(c =>
-    {
-        c.UseApiToken(slackOptions.BotToken!);
-
-        if (slackOptions.SocketMode)
-            c.UseAppLevelToken(slackOptions.AppToken!);
-
-        c.RegisterEventHandler<MessageEvent, SlackChannel>();
-        c.RegisterEventHandler<AppMention, SlackChannel>();
-    });
-
-    services.AddSingleton<IHostedService>(sp =>
-        (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
 }


### PR DESCRIPTION
## Summary
- add OpenTelemetry OTLP export for daemon logs and metrics, with tracing intentionally disabled to avoid disconnected actor-span noise
- introduce strongly typed `Telemetry` options with `IValidateOptions`, and move daemon wiring into DI extension methods instead of inlining in `Program.cs`
- add Slack channel metrics for ingress/routing/drop/enqueue/reply outcomes and update runbook/config docs with LocalTelemetry troubleshooting guidance

## Validation
- dotnet build Netclaw.slnx
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
- dotnet slopwatch analyze