### PR TITLE
Secure Slack defaults and add config-focused doctor command

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -502,7 +502,9 @@ Done when:
 CLI commands that work without the daemon by reading local files.
 
 Done when:
-- [ ] `netclaw doctor` — validate config files, probe daemon reachability, test provider connectivity.
+- [ ] `netclaw doctor` — validate local configuration files only (schema + semantic checks), no daemon/runtime probes.
+- [ ] `netclaw doctor --fix` (future) — optional safe autofix mode for config-only issues (with `--dry-run` support).
+- [ ] `netclaw doctor --interactive` (future) — optional Termina remediation flow for guided config repair.
 - [ ] `netclaw config show|validate` — dump/validate merged config.
 - [ ] `netclaw project list|add|remove` — manage project registry (local JSON files).
 - [ ] `netclaw environment scan|show` — discover local system capabilities.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ netclaw daemon install        Install as systemd user service (Linux)
 netclaw daemon uninstall      Remove systemd user service (Linux)
 netclaw config                Configuration management (planned)
 netclaw init                  First-run setup wizard (planned)
-netclaw doctor                Health checks (planned)
+netclaw doctor                Configuration diagnostics (schema + secrets syntax)
 ```
 
 ### Daemon Binary Discovery

--- a/docs/integrations/slack-acl-policy.md
+++ b/docs/integrations/slack-acl-policy.md
@@ -6,7 +6,8 @@ Slack ACL policy controls where Netclaw is allowed to engage and who can invoke 
 
 - Channel conversations require `@mention` to start a thread.
 - Once a thread is started, follow-up thread replies are accepted without mention.
-- Direct messages are allowed by default.
+- Direct messages are denied by default.
+- No channels are allowed by default (`AllowedChannelIds` is empty).
 
 ## Policy settings
 
@@ -16,7 +17,7 @@ Configure in `~/.netclaw/config/netclaw.json`:
 {
   "Slack": {
     "MentionOnly": true,
-    "AllowDirectMessages": true,
+    "AllowDirectMessages": false,
     "AllowedChannelIds": ["C0AGM484P0Q"],
     "AllowedUserIds": ["U12345678", "U87654321"]
   }
@@ -25,11 +26,10 @@ Configure in `~/.netclaw/config/netclaw.json`:
 
 - `MentionOnly`: requires mention to start non-DM sessions.
 - `AllowDirectMessages`: enables DM conversations without mention.
-- `AllowedChannelIds`: optional allow-list of channels.
+- `AllowedChannelIds`: required allow-list of channels for non-DM traffic.
 - `AllowedUserIds`: optional allow-list of Slack users.
 
-If `AllowedChannelIds` or `AllowedUserIds` is omitted, Netclaw does not enforce
-that specific allow-list.
+If `AllowedChannelIds` is omitted, it defaults to `[]` and channel traffic is denied.
 
 ## Actor enforcement model
 

--- a/docs/integrations/slack-socket-mode.md
+++ b/docs/integrations/slack-socket-mode.md
@@ -64,9 +64,9 @@ Supported Slack settings:
 - `DefaultChannelId` - optional hard filter to one channel ID
 - `DefaultChannelName` - optional channel name resolved at startup
 - `MentionOnly` - if `true`, plain `message` events require bot mention
-- `AllowDirectMessages` - if `true`, direct messages do not require mention
-- `AllowedChannelIds` - optional channel allow-list
-- `AllowedUserIds` - optional user allow-list
+- `AllowDirectMessages` - defaults to `false` (secure by default)
+- `AllowedChannelIds` - defaults to empty array (`[]`), so no channels are allowed until explicitly configured
+- `AllowedUserIds` - defaults to empty array (`[]`), meaning no user filter is applied beyond channel/DM policy
 
 ## Runtime behavior
 

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -172,9 +172,9 @@ Slack Socket Mode channel configuration.
 | `DefaultChannelId` | string? | `null` | Optional fixed channel ID filter. |
 | `DefaultChannelName` | string? | `null` | Optional channel name resolved to channel ID at startup. |
 | `MentionOnly` | bool | `true` | If true, plain `message` events are ignored unless the bot is mentioned. |
-| `AllowDirectMessages` | bool | `true` | If true, DM messages do not require mention. |
-| `AllowedChannelIds` | string[]? | `null` | Optional allow-list of Slack channel IDs. |
-| `AllowedUserIds` | string[]? | `null` | Optional allow-list of Slack user IDs. |
+| `AllowDirectMessages` | bool | `false` | If true, DM messages do not require mention. |
+| `AllowedChannelIds` | string[] | `[]` | Allow-list of Slack channel IDs. Empty means no channels are allowed. |
+| `AllowedUserIds` | string[] | `[]` | Optional allow-list of Slack user IDs. Empty means all users in allowed channels/DM policy are accepted. |
 
 ### Logging
 

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -36,6 +36,20 @@ All configuration lives under `~/.netclaw/`:
 
 Directories are created automatically on first run.
 
+## Schema Versioning
+
+`netclaw doctor` validates `netclaw.json` against versioned JSON schema files.
+Set a root `configVersion` field in your config to opt into strict schema
+validation.
+
+Example:
+
+```json
+{
+  "configVersion": 1
+}
+```
+
 ## Configuration Sections
 
 ### Providers

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -135,7 +135,8 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
             Options: new SlackChannelOptions
             {
                 MentionOnly = true,
-                AllowDirectMessages = true
+                AllowDirectMessages = true,
+                AllowedChannelIds = ["C1"]
             },
             BotUserId: "UBOT",
             DefaultChannelId: null,

--- a/src/Netclaw.Actors.Tests/Configuration/SlackChannelOptionsDefaultsTests.cs
+++ b/src/Netclaw.Actors.Tests/Configuration/SlackChannelOptionsDefaultsTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Configuration;
+using Netclaw.Channels.Slack;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Configuration;
+
+public sealed class SlackChannelOptionsDefaultsTests
+{
+    [Fact]
+    public void BindsSecureDefaults_WhenSlackSectionMissing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+        var options = configuration.GetSection("Slack").Get<SlackChannelOptions>() ?? new SlackChannelOptions();
+
+        Assert.False(options.Enabled);
+        Assert.True(options.SocketMode);
+        Assert.True(options.MentionOnly);
+        Assert.False(options.AllowDirectMessages);
+        Assert.Empty(options.AllowedChannelIds);
+        Assert.Empty(options.AllowedUserIds);
+    }
+
+    [Fact]
+    public void KeepsSecureDefaults_WhenSlackSectionPartiallyConfigured()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["Slack:Enabled"] = "true",
+            ["Slack:DefaultChannelName"] = "openclaw"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var options = configuration.GetSection("Slack").Get<SlackChannelOptions>() ?? new SlackChannelOptions();
+
+        Assert.True(options.Enabled);
+        Assert.Equal("openclaw", options.DefaultChannelName);
+        Assert.True(options.MentionOnly);
+        Assert.False(options.AllowDirectMessages);
+        Assert.Empty(options.AllowedChannelIds);
+        Assert.Empty(options.AllowedUserIds);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Actors.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -1,0 +1,55 @@
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Doctor;
+
+public sealed class ConfigSchemaDoctorCheckTests
+{
+    [Fact]
+    public async Task ReturnsWarning_WhenConfigFileMissing()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("not found", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenConfigMatchesSchemaV1()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Slack": {
+                "Enabled": true,
+                "MentionOnly": true,
+                "AllowDirectMessages": false,
+                "AllowedChannelIds": ["C123"]
+              }
+            }
+            """);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    private static string CreateTempBasePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
@@ -16,9 +16,9 @@ public sealed class SlackChannelOptions
 
     public bool MentionOnly { get; init; } = true;
 
-    public bool AllowDirectMessages { get; init; } = true;
+    public bool AllowDirectMessages { get; init; }
 
-    public string[]? AllowedChannelIds { get; init; }
+    public string[] AllowedChannelIds { get; init; } = [];
 
-    public string[]? AllowedUserIds { get; init; }
+    public string[] AllowedUserIds { get; init; } = [];
 }

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -106,15 +106,13 @@ public sealed class SlackConversationActor : ReceiveActor
         if (message.IsDirectMessage)
             return _dependencies.Options.AllowDirectMessages;
 
-        if (!string.IsNullOrWhiteSpace(_dependencies.DefaultChannelId)
-            && !string.Equals(message.ChannelId, _dependencies.DefaultChannelId, StringComparison.Ordinal))
-            return false;
+        var matchesDefaultChannel = !string.IsNullOrWhiteSpace(_dependencies.DefaultChannelId)
+            && string.Equals(message.ChannelId, _dependencies.DefaultChannelId, StringComparison.Ordinal);
 
-        if (_dependencies.Options.AllowedChannelIds is { Length: > 0 }
-            && !_dependencies.Options.AllowedChannelIds.Contains(message.ChannelId, StringComparer.Ordinal))
-            return false;
+        var matchesAllowedChannel = _dependencies.Options.AllowedChannelIds
+            .Contains(message.ChannelId, StringComparer.Ordinal);
 
-        return true;
+        return matchesDefaultChannel || matchesAllowedChannel;
     }
 
     private bool IsBotMessage(SlackInboundMessage message)
@@ -131,7 +129,7 @@ public sealed class SlackConversationActor : ReceiveActor
 
     private bool IsAllowedUser(SlackInboundMessage message)
     {
-        if (_dependencies.Options.AllowedUserIds is not { Length: > 0 })
+        if (_dependencies.Options.AllowedUserIds.Length == 0)
             return true;
 
         if (string.IsNullOrWhiteSpace(message.UserId))

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(paths.NetclawConfigPath))
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Config Schema",
+                $"Config file not found at {paths.NetclawConfigPath}.",
+                "Run `netclaw init` to scaffold a baseline config."));
+        }
+
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(File.ReadAllText(paths.NetclawConfigPath));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                $"Failed parsing {paths.NetclawConfigPath}: {ex.Message}",
+                "Fix malformed JSON in netclaw.json."));
+        }
+
+        if (root is not JsonObject obj)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                "netclaw.json root must be a JSON object.",
+                "Wrap config in a top-level JSON object."));
+        }
+
+        var syntheticVersion = false;
+        int version;
+        if (obj["configVersion"] is JsonValue versionValue && versionValue.TryGetValue<int>(out var parsedVersion))
+        {
+            version = parsedVersion;
+        }
+        else if (obj["configVersion"] is null)
+        {
+            version = 1;
+            obj["configVersion"] = version;
+            syntheticVersion = true;
+        }
+        else
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                "configVersion must be an integer.",
+                "Set `configVersion` to a supported integer value, e.g. 1."));
+        }
+
+        var schemaPath = ResolveSchemaPath(version);
+        if (!File.Exists(schemaPath))
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                $"No schema found for configVersion {version}.",
+                $"Install/update Netclaw schema file: {schemaPath}"));
+        }
+
+        JsonSchema schema;
+        try
+        {
+            schema = JsonSchema.FromText(File.ReadAllText(schemaPath));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                $"Failed loading schema {schemaPath}: {ex.Message}"));
+        }
+
+        var evaluation = schema.Evaluate(obj, new EvaluationOptions
+        {
+            OutputFormat = OutputFormat.List
+        });
+
+        if (!evaluation.IsValid)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Config Schema",
+                "Config does not match schema.",
+                "Run `netclaw config validate` (planned) or check configVersion/schema fields in netclaw.json."));
+        }
+
+        if (syntheticVersion)
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Config Schema",
+                "Config validated against schema v1, but configVersion is missing.",
+                "Add `\"configVersion\": 1` to netclaw.json."));
+        }
+
+        return Task.FromResult(DoctorCheckResult.Pass(
+            "Config Schema",
+            $"Config matches schema v{version}."));
+    }
+
+    private static string ResolveSchemaPath(int version)
+    {
+        var fileName = $"netclaw-config.v{version}.schema.json";
+        var runtimePath = Path.Combine(AppContext.BaseDirectory, "Schemas", fileName);
+        if (File.Exists(runtimePath))
+            return runtimePath;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "Netclaw.Cli", "Schemas", fileName);
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        return runtimePath;
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorCheckResult.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorCheckResult.cs
@@ -1,0 +1,17 @@
+namespace Netclaw.Cli.Doctor;
+
+public sealed record DoctorCheckResult(
+    string Name,
+    DoctorSeverity Severity,
+    string Message,
+    string? Remediation = null)
+{
+    public static DoctorCheckResult Pass(string name, string message) =>
+        new(name, DoctorSeverity.Pass, message);
+
+    public static DoctorCheckResult Warning(string name, string message, string? remediation = null) =>
+        new(name, DoctorSeverity.Warning, message, remediation);
+
+    public static DoctorCheckResult Error(string name, string message, string? remediation = null) =>
+        new(name, DoctorSeverity.Error, message, remediation);
+}

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Netclaw.Cli.Doctor;
+
+public static class DoctorRegistrationExtensions
+{
+    public static void AddDoctorChecks(this IServiceCollection services)
+    {
+        services.AddSingleton<DoctorRunner>();
+        services.AddSingleton<IDoctorCheck, ConfigSchemaDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorRunner.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRunner.cs
@@ -1,0 +1,19 @@
+namespace Netclaw.Cli.Doctor;
+
+public sealed class DoctorRunner(IEnumerable<IDoctorCheck> checks)
+{
+    public async Task<DoctorRunResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var results = new List<DoctorCheckResult>();
+        foreach (var check in checks)
+            results.Add(await check.RunAsync(cancellationToken));
+
+        var hasErrors = results.Any(r => r.Severity == DoctorSeverity.Error);
+        var hasWarnings = results.Any(r => r.Severity == DoctorSeverity.Warning);
+
+        var exitCode = hasErrors ? 1 : hasWarnings ? 2 : 0;
+        return new DoctorRunResult(results, exitCode);
+    }
+}
+
+public sealed record DoctorRunResult(IReadOnlyList<DoctorCheckResult> Results, int ExitCode);

--- a/src/Netclaw.Cli/Doctor/DoctorSeverity.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorSeverity.cs
@@ -1,0 +1,8 @@
+namespace Netclaw.Cli.Doctor;
+
+public enum DoctorSeverity
+{
+    Pass,
+    Warning,
+    Error
+}

--- a/src/Netclaw.Cli/Doctor/IDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/IDoctorCheck.cs
@@ -1,0 +1,6 @@
+namespace Netclaw.Cli.Doctor;
+
+public interface IDoctorCheck
+{
+    Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Netclaw.Cli/Doctor/SecretsJsonDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SecretsJsonDoctorCheck.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class SecretsJsonDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(paths.SecretsPath))
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Secrets JSON",
+                $"Secrets file not found at {paths.SecretsPath}.",
+                "Create secrets.json if you need provider/slack credentials."));
+        }
+
+        try
+        {
+            using var _ = JsonDocument.Parse(File.ReadAllText(paths.SecretsPath));
+            return Task.FromResult(DoctorCheckResult.Pass("Secrets JSON", "secrets.json parses successfully."));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Secrets JSON",
+                $"Failed parsing {paths.SecretsPath}: {ex.Message}",
+                "Fix malformed JSON in secrets.json."));
+        }
+    }
+}

--- a/src/Netclaw.Cli/Netclaw.Cli.csproj
+++ b/src/Netclaw.Cli/Netclaw.Cli.csproj
@@ -11,8 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" />
     <PackageReference Include="Termina" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Schemas/**/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Netclaw.Channels;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Termina.Hosting;
@@ -38,16 +39,27 @@ static async Task RunAsync(string[] args)
     {
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
+        if (mode is "doctor")
+            builder.Services.AddDoctorChecks();
 
         // Suppress framework console logging
         builder.Logging.ClearProviders();
         builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
         // TODO: init → Termina TUI wizard (Task 1.22)
-        // TODO: doctor → health checks (Task 1.21)
-        Console.WriteLine($"netclaw {mode}: not yet implemented");
+        if (mode is "init")
+        {
+            Console.WriteLine("netclaw init: not yet implemented");
+            return;
+        }
 
-        await builder.Build().RunAsync();
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<DoctorRunner>();
+        var result = await runner.RunAsync();
+
+        WriteDoctorResult(result);
+        Environment.ExitCode = result.ExitCode;
         return;
     }
 
@@ -173,6 +185,27 @@ static void WriteDaemonResult(DaemonResult result)
     Console.WriteLine(result.Message);
     if (!result.Success)
         Environment.ExitCode = 1;
+}
+
+static void WriteDoctorResult(DoctorRunResult result)
+{
+    foreach (var check in result.Results)
+    {
+        var prefix = check.Severity switch
+        {
+            DoctorSeverity.Pass => "[PASS]",
+            DoctorSeverity.Warning => "[WARN]",
+            DoctorSeverity.Error => "[FAIL]",
+            _ => "[INFO]"
+        };
+
+        Console.WriteLine($"{prefix} {check.Name}: {check.Message}");
+        if (!string.IsNullOrWhiteSpace(check.Remediation))
+            Console.WriteLine($"       fix: {check.Remediation}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine($"doctor exit code: {result.ExitCode}");
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/Netclaw.Cli/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Cli/Schemas/netclaw-config.v1.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.netclaw.local/config/v1",
+  "title": "Netclaw Config v1",
+  "type": "object",
+  "required": ["configVersion"],
+  "properties": {
+    "configVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "Slack": {
+      "type": "object",
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "SocketMode": { "type": "boolean" },
+        "DefaultChannelId": { "type": ["string", "null"] },
+        "DefaultChannelName": { "type": ["string", "null"] },
+        "MentionOnly": { "type": "boolean" },
+        "AllowDirectMessages": { "type": "boolean" },
+        "AllowedChannelIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "AllowedUserIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "Logging": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Telemetry": {
+      "type": "object",
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "Otlp": {
+          "type": "object",
+          "properties": {
+            "Endpoint": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "Persistence": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Session": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Tools": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Providers": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Models": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- tighten Slack defaults to secure-by-default posture (DMs disabled by default, channel ingress deny-until-allowed) and add explicit default-binding tests to prevent accidental drift
- implement `netclaw doctor` as a configuration-only diagnostics command with clear exit codes and remediation output
- add versioned JSON schema support (`configVersion`, v1 schema) and secrets JSON syntax checks, and update docs/plan to keep runtime liveness under status commands

## Validation
- `dotnet build Netclaw.slnx`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj`
- `dotnet slopwatch analyze`