### PR TITLE
Add runtime status API and explicit CLI help commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ netclaw daemon stop           Gracefully stop the daemon (SIGTERM)
 netclaw daemon status         Show daemon PID and uptime
 netclaw daemon install        Install as systemd user service (Linux)
 netclaw daemon uninstall      Remove systemd user service (Linux)
+netclaw status                Runtime status from daemon health JSON endpoint
 netclaw config                Configuration management (planned)
 netclaw init                  First-run setup wizard (planned)
 netclaw doctor                Configuration diagnostics (schema + secrets syntax)

--- a/docs/runbooks/daemon-upgrade.md
+++ b/docs/runbooks/daemon-upgrade.md
@@ -24,6 +24,7 @@ data.
 3. Start new image version.
 4. Wait for startup migration + readiness:
    - `/api/health/ready`
+   - `/api/health/status`
    - `netclaw daemon status` (if CLI available)
 
 ## Direct Host Upgrade
@@ -38,8 +39,10 @@ data.
    - `netclaw daemon start`
    - or `systemctl --user start netclaw`
 5. Verify health:
-   - `netclaw daemon status`
-   - `curl http://127.0.0.1:5199/api/health/ready`
+    - `netclaw daemon status`
+    - `netclaw status`
+    - `curl http://127.0.0.1:5199/api/health/ready`
+    - `curl http://127.0.0.1:5199/api/health/status`
 
 ## Rollback Notes
 

--- a/docs/spec/SPEC-011-daemon-architecture.md
+++ b/docs/spec/SPEC-011-daemon-architecture.md
@@ -30,7 +30,8 @@ and channel management.
 Netclaw.Daemon Process
 ├── ASP.NET Host (WebApplication)
 │   ├── SignalR Hub (/hub/session)     ← primary client API
-│   └── Health Probe (/api/health/ready)
+│   ├── Readiness Probe (/api/health/ready)
+│   └── Runtime Status JSON (/api/health/status)
 │
 ├── SessionPipeline (Akka.Streams — typed Input/Output channels)
 │

--- a/src/Netclaw.Actors.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Actors.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Options;
+using Netclaw.Channels;
+using Netclaw.Channels.Slack;
+using Netclaw.Daemon.Configuration;
+using Netclaw.Daemon.Gateway;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Gateway;
+
+public sealed class DaemonRuntimeStatusServiceTests
+{
+    [Fact]
+    public async Task IncludesSlackConnectorAsDisabled_WhenNotEnabled()
+    {
+        var service = new DaemonRuntimeStatusService(
+            TimeProvider.System,
+            channels: Array.Empty<IChannel>(),
+            slackOptions: new SlackChannelOptions { Enabled = false },
+            persistenceOptions: new DaemonPersistenceOptions(),
+            telemetryOptions: Options.Create(new TelemetryOptions()));
+
+        var status = await service.GetStatusAsync();
+        var slack = status.Connectors.Single(c => c.Key == "slack");
+
+        Assert.False(slack.Enabled);
+        Assert.Equal("disabled", slack.Status);
+    }
+
+    [Fact]
+    public async Task ReportsSlackAsDisconnected_WhenEnabledButMissingRuntimeChannel()
+    {
+        var service = new DaemonRuntimeStatusService(
+            TimeProvider.System,
+            channels: Array.Empty<IChannel>(),
+            slackOptions: new SlackChannelOptions { Enabled = true, AllowedChannelIds = ["C1"] },
+            persistenceOptions: new DaemonPersistenceOptions(),
+            telemetryOptions: Options.Create(new TelemetryOptions()));
+
+        var status = await service.GetStatusAsync();
+        var slack = status.Connectors.Single(c => c.Key == "slack");
+
+        Assert.True(slack.Enabled);
+        Assert.Equal("disconnected", slack.Status);
+    }
+}

--- a/src/Netclaw.Cli/Daemon/DaemonRuntimeStatusDto.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonRuntimeStatusDto.cs
@@ -1,0 +1,48 @@
+namespace Netclaw.Cli.Daemon;
+
+public sealed class DaemonRuntimeStatusDto
+{
+    public string Overall { get; init; } = "unknown";
+
+    public required DaemonProcessStatusDto Process { get; init; }
+
+    public required List<DaemonConnectorStatusDto> Connectors { get; init; }
+
+    public required DaemonPersistenceStatusDto Persistence { get; init; }
+
+    public required DaemonTelemetryStatusDto Telemetry { get; init; }
+}
+
+public sealed class DaemonProcessStatusDto
+{
+    public int Pid { get; init; }
+
+    public DateTimeOffset StartedAtUtc { get; init; }
+
+    public long UptimeSeconds { get; init; }
+}
+
+public sealed class DaemonConnectorStatusDto
+{
+    public required string Key { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public bool Enabled { get; init; }
+
+    public required string Status { get; init; }
+
+    public string? Message { get; init; }
+}
+
+public sealed class DaemonPersistenceStatusDto
+{
+    public required string Provider { get; init; }
+}
+
+public sealed class DaemonTelemetryStatusDto
+{
+    public bool Enabled { get; init; }
+
+    public string? OtlpEndpoint { get; init; }
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 using Netclaw.Channels;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
@@ -26,6 +27,12 @@ static async Task RunAsync(string[] args)
     var mode = args.Length > 0 ? args[0] : "chat";
     string? headlessPrompt = null;
 
+    if (IsHelpToken(mode))
+    {
+        WriteGeneralHelp();
+        return;
+    }
+
     if (mode is "-p" or "--prompt")
     {
         headlessPrompt = args.Length > 1
@@ -37,6 +44,12 @@ static async Task RunAsync(string[] args)
     // ── Lightweight modes (no Akka, no persistence) ──
     if (mode is "init" or "doctor")
     {
+        if (args.Length > 1 && IsHelpToken(args[1]))
+        {
+            WriteDoctorHelp();
+            return;
+        }
+
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
         if (mode is "doctor")
@@ -63,10 +76,35 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    if (mode is "status")
+    {
+        if (args.Length > 1 && IsHelpToken(args[1]))
+        {
+            WriteStatusHelp();
+            return;
+        }
+
+        var builder = Host.CreateApplicationBuilder(args);
+        ConfigureConfigServices(builder.Services, builder.Configuration);
+        builder.Services.AddHttpClient();
+
+        builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var exitCode = await RunStatusAsync(scope.ServiceProvider, builder.Configuration);
+        Environment.ExitCode = exitCode;
+        return;
+    }
+
     // ── Daemon management ──
     if (mode is "daemon")
     {
         var subcommand = args.Length > 1 ? args[1] : "help";
+        if (IsHelpToken(subcommand))
+            subcommand = "help";
+
         var paths = new NetclawPaths();
         paths.EnsureDirectoriesExist();
         var manager = new DaemonManager(paths, TimeProvider.System);
@@ -86,6 +124,8 @@ static async Task RunAsync(string[] args)
             case "status":
                 var status = manager.GetStatus();
                 Console.WriteLine(status.Message);
+                if (status.IsRunning)
+                    Console.WriteLine("Tip: run `netclaw status` for detailed runtime connector and telemetry health.");
                 return;
 
             case "install":
@@ -99,7 +139,7 @@ static async Task RunAsync(string[] args)
                 return;
 
             default:
-                Console.WriteLine("Usage: netclaw daemon [start|stop|status|install|uninstall]");
+                WriteDaemonHelp();
                 Environment.ExitCode = 1;
                 return;
         }
@@ -187,6 +227,64 @@ static void WriteDaemonResult(DaemonResult result)
         Environment.ExitCode = 1;
 }
 
+static bool IsHelpToken(string token)
+{
+    return token is "help" or "-h" or "--help";
+}
+
+static void WriteGeneralHelp()
+{
+    Console.WriteLine("Usage: netclaw <command> [options]");
+    Console.WriteLine();
+    Console.WriteLine("Commands:");
+    Console.WriteLine("  chat                     Interactive TUI chat (default)");
+    Console.WriteLine("  -p, --prompt <text>      Headless single-prompt mode");
+    Console.WriteLine("  doctor                   Configuration diagnostics (offline)");
+    Console.WriteLine("  status                   Runtime status from daemon health JSON endpoint");
+    Console.WriteLine("  daemon <subcommand>      Manage daemon lifecycle");
+    Console.WriteLine("  init                     First-run setup wizard (planned)");
+    Console.WriteLine("  config                   Configuration management (planned)");
+    Console.WriteLine();
+    Console.WriteLine("Run `netclaw daemon --help`, `netclaw doctor --help`, or `netclaw status --help` for details.");
+}
+
+static void WriteDaemonHelp()
+{
+    Console.WriteLine("Usage: netclaw daemon <subcommand>");
+    Console.WriteLine();
+    Console.WriteLine("Subcommands:");
+    Console.WriteLine("  start       Start daemon as a background process");
+    Console.WriteLine("  stop        Stop daemon gracefully");
+    Console.WriteLine("  status      Show daemon process status");
+    Console.WriteLine("  install     Install systemd user service (Linux)");
+    Console.WriteLine("  uninstall   Remove systemd user service (Linux)");
+}
+
+static void WriteDoctorHelp()
+{
+    Console.WriteLine("Usage: netclaw doctor");
+    Console.WriteLine();
+    Console.WriteLine("Runs offline configuration diagnostics:");
+    Console.WriteLine("  - netclaw.json schema validation (versioned by configVersion)");
+    Console.WriteLine("  - secrets.json syntax validation");
+    Console.WriteLine();
+    Console.WriteLine("Exit codes:");
+    Console.WriteLine("  0  all checks passed");
+    Console.WriteLine("  1  one or more checks failed");
+    Console.WriteLine("  2  warnings only");
+}
+
+static void WriteStatusHelp()
+{
+    Console.WriteLine("Usage: netclaw status");
+    Console.WriteLine();
+    Console.WriteLine("Queries daemon runtime status from /api/health/status and prints:");
+    Console.WriteLine("  - overall health");
+    Console.WriteLine("  - daemon process uptime");
+    Console.WriteLine("  - connector health (including disabled connectors)");
+    Console.WriteLine("  - persistence and telemetry summary");
+}
+
 static void WriteDoctorResult(DoctorRunResult result)
 {
     foreach (var check in result.Results)
@@ -206,6 +304,89 @@ static void WriteDoctorResult(DoctorRunResult result)
 
     Console.WriteLine();
     Console.WriteLine($"doctor exit code: {result.ExitCode}");
+}
+
+static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration configuration)
+{
+    var endpoint = configuration["Daemon:Endpoint"]
+        ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
+        ?? "http://127.0.0.1:5199";
+
+    var url = $"{endpoint.TrimEnd('/')}/api/health/status";
+    var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+    var client = httpClientFactory.CreateClient();
+
+    try
+    {
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var response = await client.GetAsync(url, timeoutCts.Token);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"[FAIL] status: daemon returned {(int)response.StatusCode} from {url}");
+            Console.WriteLine("       fix: run `netclaw daemon status` and `netclaw daemon start`.");
+            return 1;
+        }
+
+        var payload = await response.Content.ReadAsStreamAsync(timeoutCts.Token);
+        var status = await JsonSerializer.DeserializeAsync<DaemonRuntimeStatusDto>(
+            payload,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web),
+            timeoutCts.Token);
+
+        if (status is null)
+        {
+            Console.WriteLine("[FAIL] status: daemon returned an empty status payload.");
+            return 1;
+        }
+
+        WriteStatusResult(status, endpoint);
+
+        return status.Overall.ToLowerInvariant() switch
+        {
+            "healthy" => 0,
+            "degraded" => 2,
+            _ => 1
+        };
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"[FAIL] status: unable to reach daemon at {url}: {ex.Message}");
+        Console.WriteLine("       fix: run `netclaw daemon start` and retry.");
+        return 1;
+    }
+}
+
+static void WriteStatusResult(DaemonRuntimeStatusDto status, string endpoint)
+{
+    Console.WriteLine($"overall: {status.Overall}");
+    Console.WriteLine($"daemon: PID {status.Process.Pid}, uptime {FormatUptime(status.Process.UptimeSeconds)}, endpoint {endpoint}");
+    Console.WriteLine($"persistence: {status.Persistence.Provider}");
+    Console.WriteLine($"telemetry: {(status.Telemetry.Enabled ? "enabled" : "disabled")}" +
+                      (status.Telemetry.Enabled && !string.IsNullOrWhiteSpace(status.Telemetry.OtlpEndpoint)
+                          ? $" ({status.Telemetry.OtlpEndpoint})"
+                          : string.Empty));
+
+    Console.WriteLine("connectors:");
+    foreach (var connector in status.Connectors.OrderBy(c => c.Key, StringComparer.OrdinalIgnoreCase))
+    {
+        var enabled = connector.Enabled ? "enabled" : "disabled";
+        Console.WriteLine($"- {connector.Key}: {connector.Status} ({enabled})");
+        if (!string.IsNullOrWhiteSpace(connector.Message))
+            Console.WriteLine($"    {connector.Message}");
+    }
+}
+
+static string FormatUptime(long uptimeSeconds)
+{
+    var uptime = TimeSpan.FromSeconds(Math.Max(0, uptimeSeconds));
+
+    if (uptime.TotalDays >= 1)
+        return $"{(int)uptime.TotalDays}d {uptime.Hours}h {uptime.Minutes}m";
+    if (uptime.TotalHours >= 1)
+        return $"{uptime.Hours}h {uptime.Minutes}m";
+
+    return $"{uptime.Minutes}m {uptime.Seconds}s";
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -25,6 +25,8 @@ public static class SlackChannelRegistrationExtensions
 
         services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
         services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
+        services.AddSingleton<IChannel>(sp =>
+            sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
         services.AddSingleton<SlackChannel>(sp =>
             (SlackChannel)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
 

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using Netclaw.Channels;
+using Netclaw.Channels.Slack;
+using Netclaw.Daemon.Configuration;
+
+namespace Netclaw.Daemon.Gateway;
+
+public sealed class DaemonRuntimeStatusService(
+    TimeProvider timeProvider,
+    IEnumerable<IChannel> channels,
+    SlackChannelOptions slackOptions,
+    DaemonPersistenceOptions persistenceOptions,
+    IOptions<TelemetryOptions> telemetryOptions)
+{
+    public async Task<DaemonRuntimeStatusResponse> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var process = Process.GetCurrentProcess();
+        var startedAt = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+        var now = timeProvider.GetUtcNow();
+        var uptime = now - startedAt;
+
+        var connectors = new List<ConnectorStatus>
+        {
+            await BuildSlackStatusAsync(cancellationToken)
+        };
+
+        var overall = ResolveOverallStatus(connectors);
+
+        return new DaemonRuntimeStatusResponse
+        {
+            Overall = overall,
+            Process = new ProcessStatus
+            {
+                Pid = process.Id,
+                StartedAtUtc = startedAt,
+                UptimeSeconds = (long)uptime.TotalSeconds
+            },
+            Connectors = connectors,
+            Persistence = new PersistenceStatus
+            {
+                Provider = persistenceOptions.Provider.ToString()
+            },
+            Telemetry = new TelemetryStatus
+            {
+                Enabled = telemetryOptions.Value.Enabled,
+                OtlpEndpoint = telemetryOptions.Value.Otlp.Endpoint
+            }
+        };
+    }
+
+    private async Task<ConnectorStatus> BuildSlackStatusAsync(CancellationToken cancellationToken)
+    {
+        if (!slackOptions.Enabled)
+        {
+            return new ConnectorStatus
+            {
+                Key = "slack",
+                DisplayName = "Slack",
+                Enabled = false,
+                Status = "disabled",
+                Message = "Slack connector is disabled in configuration."
+            };
+        }
+
+        var slackChannel = channels.FirstOrDefault(c =>
+            string.Equals(c.ChannelType, "slack", StringComparison.OrdinalIgnoreCase));
+
+        if (slackChannel is null)
+        {
+            return new ConnectorStatus
+            {
+                Key = "slack",
+                DisplayName = "Slack",
+                Enabled = true,
+                Status = "disconnected",
+                Message = "Slack connector is enabled but was not registered."
+            };
+        }
+
+        var health = await slackChannel.GetHealthAsync(cancellationToken);
+        return new ConnectorStatus
+        {
+            Key = "slack",
+            DisplayName = slackChannel.DisplayName,
+            Enabled = true,
+            Status = health.Status switch
+            {
+                ChannelHealthStatus.Healthy => "healthy",
+                ChannelHealthStatus.Degraded => "degraded",
+                ChannelHealthStatus.Disconnected => "disconnected",
+                _ => "unknown"
+            },
+            Message = health.Detail
+        };
+    }
+
+    private static string ResolveOverallStatus(IReadOnlyList<ConnectorStatus> connectors)
+    {
+        if (connectors.Any(c => c.Enabled && c.Status is "disconnected"))
+            return "degraded";
+
+        if (connectors.Any(c => c.Enabled && c.Status is "degraded"))
+            return "degraded";
+
+        return "healthy";
+    }
+}
+
+public sealed class DaemonRuntimeStatusResponse
+{
+    public string Overall { get; init; } = "unknown";
+
+    public required ProcessStatus Process { get; init; }
+
+    public required List<ConnectorStatus> Connectors { get; init; }
+
+    public required PersistenceStatus Persistence { get; init; }
+
+    public required TelemetryStatus Telemetry { get; init; }
+}
+
+public sealed class ProcessStatus
+{
+    public int Pid { get; init; }
+
+    public DateTimeOffset StartedAtUtc { get; init; }
+
+    public long UptimeSeconds { get; init; }
+}
+
+public sealed class ConnectorStatus
+{
+    public required string Key { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public bool Enabled { get; init; }
+
+    public required string Status { get; init; }
+
+    public string? Message { get; init; }
+}
+
+public sealed class PersistenceStatus
+{
+    public required string Provider { get; init; }
+}
+
+public sealed class TelemetryStatus
+{
+    public bool Enabled { get; init; }
+
+    public string? OtlpEndpoint { get; init; }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -39,12 +39,15 @@ static async Task RunAsync(string[] args)
     // SignalR for remote clients (CLI thin client, Blazor ops console)
     builder.Services.AddSignalR();
     builder.Services.AddSingleton<SessionRegistry>();
+    builder.Services.AddSingleton<DaemonRuntimeStatusService>();
 
     var app = builder.Build();
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");
     app.MapGet("/api/health/ready", () => Results.Ok("healthy"));
+    app.MapGet("/api/health/status", async (DaemonRuntimeStatusService statusService, CancellationToken cancellationToken) =>
+        Results.Ok(await statusService.GetStatusAsync(cancellationToken)));
 
     await app.RunAsync();
 }


### PR DESCRIPTION
## Summary
- add `/api/health/status` with connector-aware runtime JSON output (process, connectors, persistence, telemetry)
- wire `netclaw status` to consume runtime status JSON and keep `netclaw daemon status` focused on process lifecycle with a guidance hint
- add explicit CLI help handling for top-level and key subcommands (`--help`, `-h`, `help`) to avoid accidental chat/TUI startup

## Validation
- `dotnet build Netclaw.slnx`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj`
- `dotnet slopwatch analyze`