### PR TITLE
Add doctor autofix workflow and split test assemblies by domain

### DIFF
--- a/Netclaw.slnx
+++ b/Netclaw.slnx
@@ -10,7 +10,9 @@
     <Project Path="src/Netclaw.Actors/Netclaw.Actors.csproj" />
     <Project Path="src/Netclaw.Channels/Netclaw.Channels.csproj" />
     <Project Path="src/Netclaw.Configuration/Netclaw.Configuration.csproj" />
+    <Project Path="src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj" />
     <Project Path="src/Netclaw.Daemon/Netclaw.Daemon.csproj" />
+    <Project Path="src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj" />
     <Project Path="src/Netclaw.Cli/Netclaw.Cli.csproj" />
     <Project Path="src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj" />
     <Project Path="src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Akka.Hosting.TestKit"/>
     <PackageReference Include="Akka.Persistence.Hosting"/>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
@@ -19,9 +18,8 @@
 
   <ItemGroup>
     <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj"/>
-    <ProjectReference Include="../Netclaw.Cli/Netclaw.Cli.csproj" />
+    <ProjectReference Include="../Netclaw.Channels/Netclaw.Channels.csproj" />
     <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj"/>
-    <ProjectReference Include="../Netclaw.Daemon/Netclaw.Daemon.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -2,7 +2,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Cli.Daemon;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Cli;
+namespace Netclaw.Cli.Tests.Cli;
 
 public sealed class DaemonClientMappingTests
 {

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -12,7 +12,7 @@ using Netclaw.Cli.Daemon;
 using Netclaw.Daemon.Gateway;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Cli;
+namespace Netclaw.Cli.Tests.Cli;
 
 public sealed class DaemonClientReconnectIntegrationTests
 {

--- a/src/Netclaw.Cli.Tests/Cli/DaemonManagerCommandLineTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonManagerCommandLineTests.cs
@@ -1,7 +1,7 @@
 using Netclaw.Cli.Daemon;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Cli;
+namespace Netclaw.Cli.Tests.Cli;
 
 public sealed class DaemonManagerCommandLineTests
 {

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -2,7 +2,7 @@ using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Doctor;
+namespace Netclaw.Cli.Tests.Doctor;
 
 public sealed class ConfigSchemaDoctorCheckTests
 {

--- a/src/Netclaw.Cli.Tests/Doctor/DoctorCommandOptionsTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DoctorCommandOptionsTests.cs
@@ -1,0 +1,26 @@
+using Netclaw.Cli.Doctor;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class DoctorCommandOptionsTests
+{
+    [Fact]
+    public void ParsesFixAndDryRunOptions()
+    {
+        var options = DoctorCommandOptions.Parse(["doctor", "--fix", "--dry-run", "--format", "json"]);
+
+        Assert.True(options.Fix);
+        Assert.True(options.DryRun);
+        Assert.Equal(DoctorOutputFormat.Json, options.Format);
+    }
+
+    [Fact]
+    public void DryRunImpliesFix()
+    {
+        var options = DoctorCommandOptions.Parse(["doctor", "--dry-run"]);
+
+        Assert.True(options.Fix);
+        Assert.True(options.DryRun);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
@@ -1,0 +1,64 @@
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class DoctorFixServiceTests
+{
+    [Fact]
+    public async Task PlansConfigVersionFix_WhenMissing()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "Slack": {
+                "Enabled": true
+              }
+            }
+            """);
+
+        var service = new DoctorFixService(paths);
+        var plan = await service.BuildPlanAsync();
+
+        Assert.True(plan.HasChanges);
+        Assert.Single(plan.Fixes);
+        Assert.Contains("configVersion", plan.Fixes[0].UpdatedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AppliesFixPlanToDisk()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "Slack": {
+                "Enabled": true
+              }
+            }
+            """);
+
+        var service = new DoctorFixService(paths);
+        var plan = await service.BuildPlanAsync();
+
+        await service.ApplyAsync(plan);
+
+        var updated = await File.ReadAllTextAsync(paths.NetclawConfigPath);
+        Assert.Contains("\"configVersion\": 1", updated, StringComparison.Ordinal);
+    }
+
+    private static string CreateTempBasePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
+++ b/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj" />
+    <ProjectReference Include="../Netclaw.Cli/Netclaw.Cli.csproj" />
+    <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj" />
+    <ProjectReference Include="../Netclaw.Daemon/Netclaw.Daemon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Cli/Doctor/DoctorCommandOptions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorCommandOptions.cs
@@ -1,0 +1,70 @@
+namespace Netclaw.Cli.Doctor;
+
+public enum DoctorOutputFormat
+{
+    Text,
+    Json
+}
+
+public sealed record DoctorCommandOptions(
+    DoctorOutputFormat Format,
+    bool Fix,
+    bool DryRun,
+    bool Yes)
+{
+    public static DoctorCommandOptions Parse(string[] args)
+    {
+        var format = DoctorOutputFormat.Text;
+        var fix = false;
+        var dryRun = false;
+        var yes = false;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--fix":
+                    fix = true;
+                    break;
+                case "--dry-run":
+                    dryRun = true;
+                    break;
+                case "--yes":
+                case "-y":
+                    yes = true;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length)
+                        throw new InvalidOperationException("Missing value after --format. Expected text or json.");
+                    i++;
+                    format = ParseFormat(args[i]);
+                    break;
+                default:
+                    if (arg.StartsWith("--format=", StringComparison.Ordinal))
+                    {
+                        var value = arg.Substring("--format=".Length);
+                        format = ParseFormat(value);
+                        break;
+                    }
+
+                    throw new InvalidOperationException($"Unknown doctor option: {arg}");
+            }
+        }
+
+        if (dryRun)
+            fix = true;
+
+        return new DoctorCommandOptions(format, fix, dryRun, yes);
+    }
+
+    private static DoctorOutputFormat ParseFormat(string value)
+    {
+        return value.ToLowerInvariant() switch
+        {
+            "text" => DoctorOutputFormat.Text,
+            "json" => DoctorOutputFormat.Json,
+            _ => throw new InvalidOperationException($"Unsupported format '{value}'. Expected text or json.")
+        };
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class DoctorFixService(NetclawPaths paths)
+{
+    public Task<DoctorFixPlan> BuildPlanAsync(CancellationToken cancellationToken = default)
+    {
+        var fixes = new List<DoctorFileFix>();
+
+        if (!File.Exists(paths.NetclawConfigPath))
+            return Task.FromResult(new DoctorFixPlan(fixes));
+
+        string original;
+        JsonObject? obj;
+        try
+        {
+            original = File.ReadAllText(paths.NetclawConfigPath);
+            obj = JsonNode.Parse(original) as JsonObject;
+        }
+        catch
+        {
+            return Task.FromResult(new DoctorFixPlan(fixes));
+        }
+
+        if (obj is null)
+            return Task.FromResult(new DoctorFixPlan(fixes));
+
+        if (obj["configVersion"] is null)
+        {
+            obj["configVersion"] = 1;
+
+            var normalized = obj.ToJsonString(new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            var replacement = normalized.EndsWith(Environment.NewLine, StringComparison.Ordinal)
+                ? normalized
+                : normalized + Environment.NewLine;
+
+            fixes.Add(new DoctorFileFix(
+                FilePath: paths.NetclawConfigPath,
+                Description: "Add missing configVersion with schema version 1.",
+                OriginalText: original,
+                UpdatedText: replacement));
+        }
+
+        return Task.FromResult(new DoctorFixPlan(fixes));
+    }
+
+    public async Task ApplyAsync(DoctorFixPlan plan, CancellationToken cancellationToken = default)
+    {
+        foreach (var fix in plan.Fixes)
+            await File.WriteAllTextAsync(fix.FilePath, fix.UpdatedText, cancellationToken);
+    }
+}
+
+public sealed record DoctorFixPlan(IReadOnlyList<DoctorFileFix> Fixes)
+{
+    public bool HasChanges => Fixes.Count > 0;
+}
+
+public sealed record DoctorFileFix(
+    string FilePath,
+    string Description,
+    string OriginalText,
+    string UpdatedText);

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -7,6 +7,7 @@ public static class DoctorRegistrationExtensions
     public static void AddDoctorChecks(this IServiceCollection services)
     {
         services.AddSingleton<DoctorRunner>();
+        services.AddSingleton<DoctorFixService>();
         services.AddSingleton<IDoctorCheck, ConfigSchemaDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
     }

--- a/src/Netclaw.Cli/Netclaw.Cli.csproj
+++ b/src/Netclaw.Cli/Netclaw.Cli.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="JsonSchema.Net" />
     <PackageReference Include="Termina" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -50,6 +50,22 @@ static async Task RunAsync(string[] args)
             return;
         }
 
+        DoctorCommandOptions? doctorOptions = null;
+        if (mode is "doctor")
+        {
+            try
+            {
+                doctorOptions = DoctorCommandOptions.Parse(args);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.WriteLine($"[FAIL] doctor options: {ex.Message}");
+                WriteDoctorHelp();
+                Environment.ExitCode = 1;
+                return;
+            }
+        }
+
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
         if (mode is "doctor")
@@ -69,9 +85,30 @@ static async Task RunAsync(string[] args)
         using var host = builder.Build();
         using var scope = host.Services.CreateScope();
         var runner = scope.ServiceProvider.GetRequiredService<DoctorRunner>();
+        var fixService = scope.ServiceProvider.GetRequiredService<DoctorFixService>();
+
+        DoctorFixPlan? fixPlan = null;
+        if (doctorOptions!.Fix)
+        {
+            fixPlan = await fixService.BuildPlanAsync();
+            if (doctorOptions.Format is DoctorOutputFormat.Text)
+                WriteDoctorFixPlan(fixPlan, doctorOptions.DryRun);
+
+            if (fixPlan.HasChanges && !doctorOptions.DryRun)
+            {
+                var shouldApply = doctorOptions.Yes || PromptForDoctorFixApply();
+                if (shouldApply)
+                    await fixService.ApplyAsync(fixPlan);
+            }
+        }
+
         var result = await runner.RunAsync();
 
-        WriteDoctorResult(result);
+        if (doctorOptions.Format is DoctorOutputFormat.Json)
+            WriteDoctorJsonResult(result, fixPlan, doctorOptions);
+        else
+            WriteDoctorResult(result);
+
         Environment.ExitCode = result.ExitCode;
         return;
     }
@@ -268,6 +305,12 @@ static void WriteDoctorHelp()
     Console.WriteLine("  - netclaw.json schema validation (versioned by configVersion)");
     Console.WriteLine("  - secrets.json syntax validation");
     Console.WriteLine();
+    Console.WriteLine("Options:");
+    Console.WriteLine("  --format <text|json>   Output format (default: text)");
+    Console.WriteLine("  --fix                  Apply safe automatic fixes");
+    Console.WriteLine("  --dry-run              Show fixes without writing files (implies --fix)");
+    Console.WriteLine("  --yes, -y              Apply fixes without confirmation prompt");
+    Console.WriteLine();
     Console.WriteLine("Exit codes:");
     Console.WriteLine("  0  all checks passed");
     Console.WriteLine("  1  one or more checks failed");
@@ -304,6 +347,89 @@ static void WriteDoctorResult(DoctorRunResult result)
 
     Console.WriteLine();
     Console.WriteLine($"doctor exit code: {result.ExitCode}");
+}
+
+static void WriteDoctorJsonResult(DoctorRunResult result, DoctorFixPlan? fixPlan, DoctorCommandOptions options)
+{
+    var payload = new
+    {
+        exitCode = result.ExitCode,
+        checks = result.Results.Select(r => new
+        {
+            name = r.Name,
+            severity = r.Severity.ToString().ToLowerInvariant(),
+            message = r.Message,
+            remediation = r.Remediation
+        }),
+        fix = new
+        {
+            requested = options.Fix,
+            dryRun = options.DryRun,
+            changedFiles = fixPlan?.Fixes.Count ?? 0,
+            files = (fixPlan?.Fixes ?? []).Select(f => new
+            {
+                path = f.FilePath,
+                description = f.Description
+            })
+        }
+    };
+
+    Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+    {
+        WriteIndented = true
+    }));
+}
+
+static void WriteDoctorFixPlan(DoctorFixPlan plan, bool dryRun)
+{
+    if (!plan.HasChanges)
+    {
+        Console.WriteLine("No safe autofixes available.");
+        return;
+    }
+
+    Console.WriteLine(dryRun
+        ? "Planned fixes (dry-run):"
+        : "Planned fixes:");
+
+    foreach (var fix in plan.Fixes)
+    {
+        Console.WriteLine($"- {fix.FilePath}");
+        Console.WriteLine($"  {fix.Description}");
+        WriteSimpleDiff(fix.OriginalText, fix.UpdatedText);
+    }
+}
+
+static bool PromptForDoctorFixApply()
+{
+    Console.Write("Apply these fixes? [y/N]: ");
+    var response = Console.ReadLine();
+    return string.Equals(response, "y", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(response, "yes", StringComparison.OrdinalIgnoreCase);
+}
+
+static void WriteSimpleDiff(string original, string updated)
+{
+    var oldLines = original.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+    var newLines = updated.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+    Console.WriteLine("  --- before");
+    Console.WriteLine("  +++ after");
+
+    var max = Math.Max(oldLines.Length, newLines.Length);
+    for (var i = 0; i < max; i++)
+    {
+        var oldLine = i < oldLines.Length ? oldLines[i] : null;
+        var newLine = i < newLines.Length ? newLines[i] : null;
+
+        if (string.Equals(oldLine, newLine, StringComparison.Ordinal))
+            continue;
+
+        if (oldLine is not null)
+            Console.WriteLine($"  - {oldLine}");
+        if (newLine is not null)
+            Console.WriteLine($"  + {newLine}");
+    }
 }
 
 static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration configuration)

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -5,7 +5,7 @@ using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Gateway;
+namespace Netclaw.Daemon.Tests.Gateway;
 
 public sealed class DaemonRuntimeStatusServiceTests
 {

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionConnectionMapTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionConnectionMapTests.cs
@@ -2,7 +2,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Daemon.Gateway;
 using Xunit;
 
-namespace Netclaw.Actors.Tests.Gateway;
+namespace Netclaw.Daemon.Tests.Gateway;
 
 public sealed class SessionConnectionMapTests
 {

--- a/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
+++ b/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj" />
+    <ProjectReference Include="../Netclaw.Channels/Netclaw.Channels.csproj" />
+    <ProjectReference Include="../Netclaw.Daemon/Netclaw.Daemon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Daemon.Tests" />
+    <InternalsVisibleTo Include="Netclaw.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Akka.Hosting" />
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />


### PR DESCRIPTION
## Summary
- implement `netclaw doctor --format json` and `netclaw doctor --fix` with dry-run support and diff previews for safe, transparent config remediation
- add doctor option parsing and fix planning/apply services while keeping doctor focused on configuration concerns
- split tests by domain concern into `Netclaw.Cli.Tests` and `Netclaw.Daemon.Tests`, moving CLI/daemon tests out of actor-focused test assembly

## Validation
- `dotnet build Netclaw.slnx`
- `dotnet test Netclaw.slnx`
- `dotnet slopwatch analyze`