### PR TITLE
Add doctor semantic checks and status JSON mode

### DIFF
--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -28,10 +28,40 @@ public sealed class DoctorFixService(NetclawPaths paths)
         if (obj is null)
             return Task.FromResult(new DoctorFixPlan(fixes));
 
+        var changed = false;
+
         if (obj["configVersion"] is null)
         {
             obj["configVersion"] = 1;
+            changed = true;
+        }
 
+        if (obj["Slack"] is JsonObject slack && ReadBool(slack, "Enabled"))
+        {
+            var hasAllowedChannels = slack["AllowedChannelIds"] is JsonArray { Count: > 0 };
+            var hasDefaultChannel = !string.IsNullOrWhiteSpace(slack["DefaultChannelId"]?.GetValue<string>())
+                                    || !string.IsNullOrWhiteSpace(slack["DefaultChannelName"]?.GetValue<string>());
+
+            if (!hasAllowedChannels && !hasDefaultChannel)
+            {
+                slack["AllowedChannelIds"] = new JsonArray();
+                changed = true;
+            }
+        }
+
+        if (obj["Telemetry"] is JsonObject telemetry && ReadBool(telemetry, "Enabled"))
+        {
+            telemetry["Otlp"] ??= new JsonObject();
+            if (telemetry["Otlp"] is JsonObject otlp
+                && string.IsNullOrWhiteSpace(otlp["Endpoint"]?.GetValue<string>()))
+            {
+                otlp["Endpoint"] = "http://127.0.0.1:4317";
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
             var normalized = obj.ToJsonString(new JsonSerializerOptions
             {
                 WriteIndented = true
@@ -43,7 +73,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
             fixes.Add(new DoctorFileFix(
                 FilePath: paths.NetclawConfigPath,
-                Description: "Add missing configVersion with schema version 1.",
+                Description: "Apply safe configuration autofixes (schema version, ACL defaults, telemetry endpoint).",
                 OriginalText: original,
                 UpdatedText: replacement));
         }
@@ -56,6 +86,9 @@ public sealed class DoctorFixService(NetclawPaths paths)
         foreach (var fix in plan.Fixes)
             await File.WriteAllTextAsync(fix.FilePath, fix.UpdatedText, cancellationToken);
     }
+
+    private static bool ReadBool(JsonObject obj, string property)
+        => obj[property] is JsonValue v && v.TryGetValue<bool>(out var b) && b;
 }
 
 public sealed record DoctorFixPlan(IReadOnlyList<DoctorFileFix> Fixes)

--- a/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+internal static class DoctorJsonConfigReader
+{
+    public static (JsonObject? Root, DoctorCheckResult? Error) TryReadConfig(NetclawPaths paths)
+    {
+        if (!File.Exists(paths.NetclawConfigPath))
+        {
+            return (null, DoctorCheckResult.Warning(
+                "Config File",
+                $"Config file not found at {paths.NetclawConfigPath}.",
+                "Run `netclaw init` to scaffold a baseline config."));
+        }
+
+        try
+        {
+            var root = JsonNode.Parse(File.ReadAllText(paths.NetclawConfigPath)) as JsonObject;
+            if (root is null)
+            {
+                return (null, DoctorCheckResult.Error(
+                    "Config File",
+                    "netclaw.json root must be a JSON object.",
+                    "Wrap config in a top-level JSON object."));
+            }
+
+            return (root, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, DoctorCheckResult.Error(
+                "Config File",
+                $"Failed parsing {paths.NetclawConfigPath}: {ex.Message}",
+                "Fix malformed JSON in netclaw.json."));
+        }
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -9,6 +9,8 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<DoctorRunner>();
         services.AddSingleton<DoctorFixService>();
         services.AddSingleton<IDoctorCheck, ConfigSchemaDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, SlackAclDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, TelemetryDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
     }
 }

--- a/src/Netclaw.Cli/Doctor/SlackAclDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SlackAclDoctorCheck.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class SlackAclDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, readError) = DoctorJsonConfigReader.TryReadConfig(paths);
+        if (readError is not null)
+            return Task.FromResult(DoctorCheckResult.Pass("Slack ACL", "Skipped (base config is missing or invalid)."));
+
+        if (root!["Slack"] is not JsonObject slack || !ReadBool(slack, "Enabled"))
+            return Task.FromResult(DoctorCheckResult.Pass("Slack ACL", "Slack connector disabled or not configured."));
+
+        var hasAllowedChannels = ReadStringArray(slack, "AllowedChannelIds").Count > 0;
+        var hasDefaultChannel = !string.IsNullOrWhiteSpace(slack["DefaultChannelId"]?.GetValue<string>())
+                                || !string.IsNullOrWhiteSpace(slack["DefaultChannelName"]?.GetValue<string>());
+
+        if (!hasAllowedChannels && !hasDefaultChannel)
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Slack ACL",
+                "Slack is enabled with no channel allow-list/default channel; channel traffic will be denied.",
+                "Set `Slack:AllowedChannelIds` or `Slack:DefaultChannelId`/`Slack:DefaultChannelName`."));
+        }
+
+        return Task.FromResult(DoctorCheckResult.Pass("Slack ACL", "Slack channel policy has explicit channel scope."));
+    }
+
+    private static bool ReadBool(JsonObject obj, string property)
+        => obj[property] is JsonValue v && v.TryGetValue<bool>(out var b) && b;
+
+    private static List<string> ReadStringArray(JsonObject obj, string property)
+    {
+        if (obj[property] is not JsonArray arr)
+            return [];
+
+        return arr.Select(v => v?.GetValue<string>()).Where(s => !string.IsNullOrWhiteSpace(s)).Cast<string>().ToList();
+    }
+}

--- a/src/Netclaw.Cli/Doctor/TelemetryDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/TelemetryDoctorCheck.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class TelemetryDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, readError) = DoctorJsonConfigReader.TryReadConfig(paths);
+        if (readError is not null)
+            return Task.FromResult(DoctorCheckResult.Pass("Telemetry", "Skipped (base config is missing or invalid)."));
+
+        if (root!["Telemetry"] is not JsonObject telemetry || !ReadBool(telemetry, "Enabled"))
+            return Task.FromResult(DoctorCheckResult.Pass("Telemetry", "Telemetry disabled or not configured."));
+
+        var endpoint = telemetry["Otlp"]?["Endpoint"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Telemetry",
+                "Telemetry is enabled without Telemetry:Otlp:Endpoint; default endpoint will be used.",
+                "Set `Telemetry:Otlp:Endpoint` (e.g. http://127.0.0.1:4317)."));
+        }
+
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out _))
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Telemetry",
+                "Telemetry:Otlp:Endpoint must be an absolute URI.",
+                "Set `Telemetry:Otlp:Endpoint` to a valid absolute URI."));
+        }
+
+        return Task.FromResult(DoctorCheckResult.Pass("Telemetry", "Telemetry endpoint is valid."));
+    }
+
+    private static bool ReadBool(JsonObject obj, string property)
+        => obj[property] is JsonValue v && v.TryGetValue<bool>(out var b) && b;
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -121,6 +121,61 @@ static async Task RunAsync(string[] args)
             return;
         }
 
+        var statusAsJson = false;
+        for (var i = 1; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (arg is "--json")
+            {
+                statusAsJson = true;
+                continue;
+            }
+
+            if (arg is "--format")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    Console.WriteLine("[FAIL] status options: Missing value after --format. Expected text or json.");
+                    WriteStatusHelp();
+                    Environment.ExitCode = 1;
+                    return;
+                }
+
+                i++;
+                var format = args[i];
+                statusAsJson = string.Equals(format, "json", StringComparison.OrdinalIgnoreCase);
+                if (!statusAsJson && !string.Equals(format, "text", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"[FAIL] status options: Unsupported format '{format}'. Expected text or json.");
+                    WriteStatusHelp();
+                    Environment.ExitCode = 1;
+                    return;
+                }
+
+                continue;
+            }
+
+            if (arg.StartsWith("--format=", StringComparison.Ordinal))
+            {
+                var format = arg.Substring("--format=".Length);
+                statusAsJson = string.Equals(format, "json", StringComparison.OrdinalIgnoreCase);
+                if (!statusAsJson && !string.Equals(format, "text", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"[FAIL] status options: Unsupported format '{format}'. Expected text or json.");
+                    WriteStatusHelp();
+                    Environment.ExitCode = 1;
+                    return;
+                }
+
+                continue;
+            }
+
+            Console.WriteLine($"[FAIL] status options: Unknown option '{arg}'.");
+            WriteStatusHelp();
+            Environment.ExitCode = 1;
+            return;
+        }
+
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
         builder.Services.AddHttpClient();
@@ -130,7 +185,7 @@ static async Task RunAsync(string[] args)
 
         using var host = builder.Build();
         using var scope = host.Services.CreateScope();
-        var exitCode = await RunStatusAsync(scope.ServiceProvider, builder.Configuration);
+        var exitCode = await RunStatusAsync(scope.ServiceProvider, builder.Configuration, statusAsJson);
         Environment.ExitCode = exitCode;
         return;
     }
@@ -326,6 +381,10 @@ static void WriteStatusHelp()
     Console.WriteLine("  - daemon process uptime");
     Console.WriteLine("  - connector health (including disabled connectors)");
     Console.WriteLine("  - persistence and telemetry summary");
+    Console.WriteLine();
+    Console.WriteLine("Options:");
+    Console.WriteLine("  --json                 Alias for --format json");
+    Console.WriteLine("  --format <text|json>   Output format (default: text)");
 }
 
 static void WriteDoctorResult(DoctorRunResult result)
@@ -432,7 +491,7 @@ static void WriteSimpleDiff(string original, string updated)
     }
 }
 
-static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration configuration)
+static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration configuration, bool jsonOutput)
 {
     var endpoint = configuration["Daemon:Endpoint"]
         ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
@@ -466,7 +525,17 @@ static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration 
             return 1;
         }
 
-        WriteStatusResult(status, endpoint);
+        if (jsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(status, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            }));
+        }
+        else
+        {
+            WriteStatusResult(status, endpoint);
+        }
 
         return status.Overall.ToLowerInvariant() switch
         {

--- a/src/Netclaw.Cli/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Cli/Schemas/netclaw-config.v1.schema.json
@@ -27,10 +27,29 @@
           "items": { "type": "string" }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "Logging": {
       "type": "object",
+      "properties": {
+        "LogLevel": {
+          "type": "object",
+          "properties": {
+            "Default": {
+              "type": "string",
+              "enum": ["Trace", "Debug", "Information", "Warning", "Error", "Critical", "None"]
+            }
+          },
+          "additionalProperties": true
+        },
+        "Console": {
+          "type": "object",
+          "properties": {
+            "Enabled": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
       "additionalProperties": true
     },
     "Telemetry": {
@@ -40,12 +59,12 @@
         "Otlp": {
           "type": "object",
           "properties": {
-            "Endpoint": { "type": "string" }
+            "Endpoint": { "type": "string", "format": "uri" }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "Persistence": {
       "type": "object",


### PR DESCRIPTION
## Summary
- add semantic doctor checks for Slack ACL posture and telemetry endpoint validity
- expand doctor autofix planning to include safe defaults for Slack ACL and telemetry endpoint when enabled
- tighten `netclaw-config.v1` schema coverage for Logging/Telemetry/Slack sections and add JSON output mode support for status command formatting

## Validation
- dotnet build Netclaw.slnx
- dotnet test Netclaw.slnx
- dotnet slopwatch analyze