### PR TITLE
Add OAuth-first onboarding OpenSpec change

### DIFF
--- a/openspec/changes/oauth-first-provider-onboarding/.openspec.yaml
+++ b/openspec/changes/oauth-first-provider-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-26

--- a/openspec/changes/oauth-first-provider-onboarding/design.md
+++ b/openspec/changes/oauth-first-provider-onboarding/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`netclaw init` already provides a Termina-based wizard, but provider onboarding is currently optimized for static credential entry and not explicit about OAuth-first paths, model-catalog discovery degradation, or operator recovery after partial setup failures. This change spans onboarding UX (`netclaw-onboarding`), provider behavior contracts (`netclaw-model-providers`), and diagnostics/reporting (`netclaw-cli`) and must remain aligned with PRD-004 and PRD-005.
+
+Architecture constraints remain unchanged: the CLI is thin where possible, runs in .NET 10, and preserves security defaults (masked secrets, fail-closed validation, default-deny assumptions). Session actors and persistence remain transport-agnostic and are not coupled to onboarding-specific provider branch logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define explicit Termina decision-tree behavior for provider selection and auth-method branching during `netclaw init`.
+- Define deterministic OAuth device flow states and transitions, including timeout, deny, and retry/cancel outcomes.
+- Define model discovery fallback paths when provider catalog lookups fail or return incomplete data.
+- Define follow-up doctor checks that verify onboarding outcomes and provide remediation-first guidance.
+- Preserve existing secure input handling and keep OpenRouter as default where operator accepts defaults.
+
+**Non-Goals:**
+- Implement new provider SDK integrations beyond existing provider profile model.
+- Add browser-based OAuth authorization code flow in MVP.
+- Add runtime model auto-routing policies beyond existing primary/fallback semantics.
+- Change actor persistence schema for sessions, tools, or Slack message handling.
+
+## Decisions
+
+### Decision: Represent onboarding as explicit decision trees in Termina state machine
+
+The onboarding workflow will formalize provider setup as branching states rather than linear prompts.
+
+Rationale:
+- Makes reentrant behavior deterministic and auditable.
+- Allows provider- and auth-specific validation without ambiguous transitions.
+
+Alternatives considered:
+- Keep linear prompts with conditional skips. Rejected because hidden branch behavior is hard to debug and document.
+- Move provider onboarding to plain CLI mode. Rejected because PRD-004 anchors `netclaw init` as Termina TUI.
+
+### Decision: OAuth-first providers use device flow only in MVP
+
+For providers with OAuth support, onboarding will use device authorization flow with explicit states: `StartDeviceAuth`, `ShowUserCode`, `PollToken`, `TokenGranted`, `AuthDenied`, `AuthExpired`, `OperatorCancelled`.
+
+Rationale:
+- Works in local terminal environments without callback listeners.
+- Keeps secrets out of command-line history and avoids redirect URI complexity.
+
+Alternatives considered:
+- Authorization code + local callback server. Rejected for MVP complexity and host-network edge cases.
+- Manual token paste. Rejected due to high operator error rate and poor UX.
+
+### Decision: Model discovery uses tiered fallback path with explicit provenance
+
+Model selection will attempt, in order: (1) live provider catalog API, (2) cached last-known-good catalog, (3) curated provider defaults in config templates, (4) operator manual model entry with validation.
+
+Rationale:
+- Preserves onboarding momentum during transient provider outages.
+- Maintains operator awareness of confidence level for selected model source.
+
+Alternatives considered:
+- Fail onboarding if live catalog unavailable. Rejected due to poor first-run resilience.
+- Always require manual model entry. Rejected because it increases setup friction and support load.
+
+### Decision: Doctor includes onboarding follow-up checks tied to decision-tree outputs
+
+`netclaw doctor` will add checks that validate the resolved provider profile, effective auth method, token/API-key availability, model provenance, and fallback readiness.
+
+Rationale:
+- Connects first-run onboarding outcomes with post-onboarding troubleshooting.
+- Reduces ambiguity when onboarding succeeds with degraded model discovery.
+
+Alternatives considered:
+- Keep doctor generic and rely on `config validate`. Rejected because provider auth/model issues need richer runtime-oriented remediation.
+
+## Risks / Trade-offs
+
+- [OAuth polling variability across providers] -> Mitigation: normalize polling interval/backoff policy in provider profile metadata and surface wait state in Termina progress components.
+- [Catalog fallback picks outdated models] -> Mitigation: annotate model provenance in config and doctor output, warn when using cache/default/manual sources.
+- [Increased onboarding complexity] -> Mitigation: render branch context headers in Termina ("Provider: X | Auth: OAuth device flow") and allow back-navigation without data loss.
+- [Security regression from mixed credential modes] -> Mitigation: enforce masked input, redact logs, and fail closed when required auth artifacts are missing for selected branch.
+
+## Migration Plan
+
+1. Add spec deltas for onboarding, provider, and CLI capabilities.
+2. Implement provider onboarding state machine branch metadata and transition guards.
+3. Implement OAuth device flow handlers and persistence of resulting auth artifacts in existing secure config stores.
+4. Implement model discovery fallback sequence and provenance tagging.
+5. Extend doctor checks with provider onboarding follow-up diagnostics and remediation text.
+6. Rollout behind existing onboarding path without schema-breaking config changes.
+
+Rollback strategy:
+- Revert to pre-change onboarding branch behavior while retaining backward-compatible config fields.
+- Keep existing API-key path operational if OAuth-specific branches are disabled.
+
+## Open Questions
+
+- Which providers in MVP are marked OAuth-capable at launch versus API-key-only?
+- Should doctor hard-fail (exit 1) or warn (exit 2) when model provenance is fallback-derived but still usable?
+- Should onboarding cache model catalogs per provider profile or globally per provider name?

--- a/openspec/changes/oauth-first-provider-onboarding/proposal.md
+++ b/openspec/changes/oauth-first-provider-onboarding/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Netclaw onboarding currently treats provider setup as mostly static credential entry, which creates friction for OAuth-first providers and leaves operators guessing when model discovery or diagnostics fail. We need an explicit OAuth-first onboarding flow now to satisfy PRD-004 guided setup and PRD-005 multi-provider resilience with actionable recovery paths.
+
+## What Changes
+
+- Add explicit provider-selection decision trees in Termina onboarding, including OAuth-capable vs API-key-only provider branches.
+- Add OAuth device flow onboarding behavior with clear step states (start, code display, polling, success/failure, retry/cancel).
+- Add model discovery decision trees with deterministic fallback paths when provider catalogs are unavailable or incomplete.
+- Extend `netclaw doctor` follow-up checks to validate onboarding outputs (provider auth state, resolved model selection, fallback readiness).
+- Keep OpenRouter as default but support OAuth-first provider onboarding without weakening secret-safe handling or default-deny posture.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `netclaw-onboarding`: onboarding requirements gain explicit decision trees for provider selection, auth branching, OAuth device flow steps, and model discovery fallback handling.
+- `netclaw-model-providers`: provider requirements gain OAuth device authorization path semantics, model-catalog fallback behavior, and diagnostics visibility for degraded discovery/auth states.
+- `netclaw-cli`: CLI requirements gain doctor follow-up checks tied to onboarding/provider outcomes and remediation-first output for OAuth/model resolution failures.
+
+## Impact
+
+- **Code/Runtime**: onboarding workflow orchestration, provider auth abstractions, model discovery pipeline, and doctor check composition in CLI application layers.
+- **Security**: no clear-text credential leakage; OAuth tokens handled with the same secret-safe guarantees as API keys; fail-closed behavior when auth cannot be established.
+- **Operations**: improved first-run success and faster troubleshooting through explicit stateful diagnostics and remediation commands.
+- **Dependencies/APIs**: no new external runtime channel; provider integrations may require additional OAuth metadata endpoints or device-authorization settings per provider profile.
+- **Traceability**: maps directly to `PRD-004` (guided/reentrant onboarding + diagnostics) and `PRD-005` (provider strategy, validation, fallback, observability).

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-cli/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-cli/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init`. The onboarding
+wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
+PostgreSQL connection string, MCP server configuration, and exposure mode
+selection. Provider setup SHALL use explicit Termina decision trees for
+provider selection, auth method branching, OAuth device flow progression (when
+applicable), and model discovery fallback paths. On completion, the wizard
+SHALL run a health check to verify the baseline configuration is functional.
+
+#### Scenario: First-time setup with provider decision tree
+- **WHEN** operator runs `netclaw init` on a fresh install
+- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
+  exposure mode inputs
+- **AND** provider setup executes explicit branches for provider choice, auth
+  method, and model resolution path before writing config
+
+#### Scenario: OAuth device flow shown in onboarding
+- **GIVEN** selected provider branch uses `oauth-device`
+- **WHEN** onboarding reaches auth execution
+- **THEN** Termina shows verification URI and user code, then token polling
+  progress and final status
+- **AND** onboarding provides retry or branch-change actions when authorization
+  does not complete
+
+#### Scenario: Model discovery fallback shown in onboarding
+- **GIVEN** provider auth branch is completed
+- **WHEN** model catalog lookup fails
+- **THEN** onboarding follows fallback path (cache -> defaults -> manual)
+- **AND** selected fallback path is shown in completion summary
+
+### Requirement: Doctor command
+
+The CLI SHALL provide `netclaw doctor` as a plain CLI command that runs startup
+checks and reports results with remediation guidance. The doctor command SHALL
+include provider onboarding follow-up checks and SHALL exit with code 0 (all
+pass), 1 (errors), or 2 (warnings only).
+
+#### Scenario: Doctor provider follow-up checks
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** checks include effective provider profile, resolved auth method,
+  authorization artifact presence, primary/fallback model validity, and model
+  provenance status
+- **AND** output includes targeted remediation commands for each failed or
+  degraded check
+
+#### Scenario: Degraded onboarding outcome surfaces warning
+- **GIVEN** provider setup succeeded using non-live model fallback source
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** doctor reports warnings with model provenance details
+- **AND** exit code is 2 unless a required provider/auth check fails

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Multi-provider support
+
+The system SHALL support selecting one provider profile from a supported set.
+All provider interactions SHALL use the Microsoft.Extensions.AI `IChatClient`
+abstraction layer, and provider onboarding SHALL include explicit auth method
+branching per provider profile (`oauth-device` and/or `api-key`) where
+supported.
+
+#### Scenario: Switch provider with auth branch selection
+- **GIVEN** OpenRouter is configured
+- **WHEN** operator selects Anthropic, OpenAI, or Ollama profile
+- **THEN** runtime uses selected provider through the `IChatClient` interface
+  after branch-specific validation
+- **AND** selected auth branch is persisted with the provider profile
+
+#### Scenario: Provider accessed through MEAI abstraction
+- **GIVEN** a provider profile is configured
+- **WHEN** the session actor sends a chat completion request
+- **THEN** the request is routed through the `IChatClient` abstraction
+- **AND** no provider-specific types leak into session or actor code
+
+### Requirement: Provider diagnostics
+
+The system SHALL expose current provider and model in diagnostics, including
+resolved auth method, model source provenance, fallback configuration status,
+and last provider error state.
+
+#### Scenario: Provider status report includes onboarding outcomes
+- **WHEN** operator checks status
+- **THEN** diagnostics include provider name, auth method, primary model,
+  fallback model, model source provenance, and last error state
+- **AND** diagnostics mark degraded status when model source is not live catalog
+
+## ADDED Requirements
+
+### Requirement: OAuth device authorization support
+
+For providers marked OAuth-capable, the system SHALL support OAuth device
+authorization as a first-class provider onboarding method.
+
+#### Scenario: OAuth device authorization succeeds
+- **GIVEN** selected provider supports OAuth device flow
+- **WHEN** onboarding requests a device code and the operator completes
+  verification
+- **THEN** system exchanges the device code for provider tokens
+- **AND** provider profile is marked authorized for runtime use
+
+#### Scenario: OAuth device polling fails
+- **GIVEN** selected provider supports OAuth device flow
+- **WHEN** polling returns denied, expired, or timeout states
+- **THEN** onboarding reports provider-specific remediation guidance
+- **AND** authorization state remains incomplete until operator retries or
+  selects another auth path
+
+### Requirement: Model discovery fallback sequence
+
+Model selection SHALL use deterministic fallback when live model discovery is
+unavailable. The fallback order SHALL be: live provider catalog, cached
+last-known-good catalog, curated provider defaults, then manual model entry.
+
+#### Scenario: Live catalog unavailable
+- **GIVEN** provider profile and auth are configured
+- **WHEN** live model catalog request fails
+- **THEN** system attempts cached catalog and then curated defaults in order
+- **AND** onboarding prompts for manual entry only if prior fallback paths fail
+
+#### Scenario: Model provenance recorded
+- **GIVEN** model is selected through any discovery path
+- **WHEN** provider configuration is saved
+- **THEN** system records the model source as one of `live`, `cache`,
+  `defaults`, or `manual`
+- **AND** diagnostics expose this provenance to operators

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,78 @@
+## MODIFIED Requirements
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init` using explicit Termina
+decision trees for provider onboarding. The onboarding wizard SHALL collect
+Slack credentials, provider configuration, ACL inputs, PostgreSQL connection
+string, MCP server configuration, and exposure mode selection. Provider setup
+SHALL branch by selected provider and auth method, and SHALL include model
+discovery fallback behavior when live provider catalogs are unavailable. On
+completion, the wizard SHALL run a health check to verify the baseline
+configuration is functional.
+
+#### Scenario: Provider selection decision tree in Termina
+- **WHEN** onboarding reaches provider configuration
+- **THEN** Termina presents provider choices with OpenRouter as default
+- **AND** selecting a provider advances through an explicit branch path:
+  provider selection -> auth method branch -> model selection path -> validation
+
+#### Scenario: Auth method branch selection
+- **GIVEN** a selected provider supports multiple auth methods
+- **WHEN** onboarding reaches auth configuration for that provider
+- **THEN** Termina shows explicit auth branches (`oauth-device` or `api-key`)
+- **AND** the selected branch determines subsequent required inputs and
+  validation rules
+
+#### Scenario: Model discovery fallback branch
+- **GIVEN** provider and auth branch are selected
+- **WHEN** live model catalog discovery fails or returns no usable models
+- **THEN** onboarding executes fallback in order: cached catalog, curated
+  defaults, manual model entry
+- **AND** the selected model source provenance is recorded for diagnostics
+
+#### Scenario: Health check on completion
+- **WHEN** onboarding completes all steps
+- **THEN** the wizard runs a health check covering Slack connectivity, provider
+  validation, persistence connectivity, and MCP server reachability
+- **AND** reports pass/fail for each component
+
+### Requirement: TUI wizard delivery mechanism
+
+The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI as
+an interactive 7-step wizard with progress indication, validation,
+back-navigation, and branch-context display for provider onboarding decisions.
+
+#### Scenario: Wizard renders branch context in TUI
+- **WHEN** operator runs `netclaw init`
+- **THEN** Termina displays wizard progress and current branch context (provider,
+  auth method, model source)
+- **AND** context updates immediately when branch decisions change
+
+#### Scenario: Back navigation preserves branch state
+- **GIVEN** operator has selected provider and auth method branches
+- **WHEN** operator navigates backward and changes a prior branch decision
+- **THEN** downstream branch-dependent fields are recalculated
+- **AND** invalidated values are cleared before progression is allowed
+
+## ADDED Requirements
+
+### Requirement: OAuth device flow onboarding steps
+
+When the selected provider auth branch is `oauth-device`, onboarding SHALL
+execute an explicit device flow state sequence and SHALL expose each step in
+Termina so the operator can recover from partial or failed authorization.
+
+#### Scenario: OAuth device flow success path
+- **GIVEN** operator selected `oauth-device` auth
+- **WHEN** onboarding starts device authorization
+- **THEN** Termina executes and displays states in order: start request -> show
+  verification URI and user code -> poll token endpoint -> token received
+- **AND** onboarding stores resulting auth artifacts in secret-safe config
+
+#### Scenario: OAuth device flow denied or expired
+- **GIVEN** onboarding is polling for OAuth device authorization
+- **WHEN** provider returns `access_denied` or `expired_token`
+- **THEN** Termina shows the failure state with remediation
+- **AND** operator can choose retry, switch auth method, switch provider, or
+  cancel onboarding step

--- a/openspec/changes/oauth-first-provider-onboarding/tasks.md
+++ b/openspec/changes/oauth-first-provider-onboarding/tasks.md
@@ -1,0 +1,29 @@
+## 1. Onboarding Decision Tree Foundation
+
+- [ ] 1.1 Add provider onboarding branch state model for Termina wizard (provider selection, auth method, model discovery path)
+- [ ] 1.2 Implement branch transition guards so back-navigation recalculates and clears invalid downstream values
+- [ ] 1.3 Render branch context indicators in Termina (`provider`, `auth method`, `model source`) and verify updates on branch changes
+
+## 2. OAuth Device Flow Branch
+
+- [ ] 2.1 Add OAuth-capable provider profile metadata and auth-method resolver (`oauth-device` vs `api-key`)
+- [ ] 2.2 Implement OAuth device flow sequence (`start`, `show code`, `poll`, `success`, `denied/expired/cancel`) with retry and branch-switch actions
+- [ ] 2.3 Persist OAuth auth artifacts through existing secret-safe config pipeline and verify redaction in logs/output
+
+## 3. Model Discovery Fallback Paths
+
+- [ ] 3.1 Implement model discovery fallback order (live catalog -> cache -> curated defaults -> manual entry)
+- [ ] 3.2 Persist model provenance (`live`, `cache`, `defaults`, `manual`) with provider config
+- [ ] 3.3 Add onboarding completion summary details for selected model source and fallback/degraded state
+
+## 4. Doctor Follow-Up Checks
+
+- [ ] 4.1 Extend `netclaw doctor` checks for provider onboarding outcomes (auth method, auth artifact presence, primary/fallback validity, model provenance)
+- [ ] 4.2 Add remediation-first output text for each failure/degraded check and wire exit code behavior (0/1/2)
+- [ ] 4.3 Ensure degraded fallback-only model state returns warning exit code 2 unless required auth/provider checks fail
+
+## 5. Validation, Traceability, and Spec Hygiene
+
+- [ ] 5.1 Add/adjust tests for onboarding branch transitions, OAuth device flow failure recovery, and model fallback sequencing
+- [ ] 5.2 Add/adjust tests for doctor follow-up checks and exit-code semantics
+- [ ] 5.3 Update CLI/operator docs to reflect OAuth-first onboarding tree and doctor follow-up checks, with explicit references to PRD-004 and PRD-005


### PR DESCRIPTION
## Summary
- add a new OpenSpec change `oauth-first-provider-onboarding` aligned to PRD-004 and PRD-005
- define explicit Termina onboarding decision trees for provider selection, auth branching, OAuth device flow, and model discovery fallbacks
- add CLI doctor follow-up requirements for provider auth/model provenance diagnostics and remediation-first output

## Validation
- openspec validate --all --no-interactive