### PR TITLE
Purge PostgreSQL refs, add provider design addendum, split M1 phases

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -121,9 +121,9 @@ Done when:
 
 Done when:
 - [ ] `InitCommand.cs` launches Termina wizard.
-- [ ] `InitWizardPage.cs` with 7-step wizard layout (`PanelNode`, progress bar).
+- [ ] `InitWizardPage.cs` with 6-step wizard layout (`PanelNode`, progress bar).
 - [ ] `InitWizardViewModel.cs` with step state machine and back-navigation.
-- [ ] Steps: LLM provider (with OAuth/API key branch from M1.1–M1.2), Slack config, PostgreSQL, ACL bootstrap, MCP servers, exposure mode, health check.
+- [ ] Steps: LLM provider (with OAuth/API key branch from M1.1–M1.2), Slack config, ACL bootstrap, MCP servers, exposure mode, health check.
 - [ ] Config file written to `~/.netclaw/config/netclaw.json` on completion.
 
 ### Task M1.5: Doctor follow-up checks for provider onboarding

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Netclaw Implementation Plan
 
-Last updated: 2026-02-25
+Last updated: 2026-02-26
 Mode: build
 
 This file is RALPH-consumable.
@@ -69,64 +69,88 @@ actor-LLM optimization patterns, gateway architecture analysis.
 - `openspec/changes/add-tui-adapter-and-config-hot-reload/` (wizard tasks)
 
 **Goal:** Connect to cloud inference providers (OpenRouter, Anthropic, OpenAI) via
-guided onboarding wizard with OAuth device flow and API key paths.
+guided onboarding wizard with OAuth device flow and API key paths. Multi-provider
+configuration from day one.
 
-### Task M1.1: Provider onboarding branch state model
+**Design reference:** `openspec/changes/oauth-first-provider-onboarding/design.md`
+(includes concrete type definitions, state machine, back-navigation clearing
+rules, provider capability matrix, and headless testing guidance).
 
-**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`, `docs/prd/PRD-005-model-provider-strategy.md`
-**OpenSpec:** `openspec/specs/netclaw-onboarding/spec.md`, `openspec/specs/netclaw-model-providers/spec.md`
-**OpenSpec Tasks:** oauth-first-provider-onboarding 1.1–1.3
-**Surface area:** onboarding wizard
-**Verification:** L2
+**Provider capability matrix:**
 
-Done when:
-- [ ] Provider onboarding branch state model added for Termina wizard (provider selection, auth method, model discovery path).
-- [ ] Branch transition guards so back-navigation recalculates and clears invalid downstream values.
-- [ ] Branch context indicators rendered in Termina (`provider`, `auth method`, `model source`) and verified on branch changes.
+| Provider    | Auth Methods               | Model Discovery | Notes                |
+|-------------|----------------------------|-----------------|----------------------|
+| Anthropic   | OAuth device flow, API key | Yes             | OAuth-first          |
+| OpenAI      | OAuth device flow, API key | Yes             | OAuth-first          |
+| OpenRouter  | API key only               | Yes             | No OAuth support     |
+| Ollama      | None (local)               | Yes             | No auth required     |
 
-### Task M1.2: OAuth device flow implementation
+### Phase A: Autonomous (RALPH-executable without operator credentials)
 
-**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
-**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
-**OpenSpec Tasks:** oauth-first-provider-onboarding 2.1–2.3
-**Surface area:** authentication
-**Verification:** L2
-
-Done when:
-- [ ] OAuth-capable provider profile metadata and auth-method resolver (`oauth-device` vs `api-key`).
-- [ ] OAuth device flow sequence (`start`, `show code`, `poll`, `success`, `denied/expired/cancel`) with retry and branch-switch actions.
-- [ ] OAuth auth artifacts persisted through secret-safe config pipeline, redacted in logs/output.
-
-### Task M1.3: Model discovery fallback pipeline
+#### Task M1.A1: Provider config types and capability registry
 
 **PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
 **OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
-**OpenSpec Tasks:** oauth-first-provider-onboarding 3.1–3.3
-**Surface area:** provider integration
+**OpenSpec Tasks:** oauth-first-provider-onboarding 1.1
+**Surface area:** `Netclaw.Configuration`
 **Verification:** L2
 
 Done when:
-- [ ] Model discovery fallback order implemented (live catalog → cache → curated defaults → manual entry).
-- [ ] Model provenance (`live`, `cache`, `defaults`, `manual`) persisted with provider config.
-- [ ] Onboarding completion summary shows selected model source and fallback/degraded state.
+- [ ] `AuthMethod` enum added (`None`, `ApiKey`, `OAuthDevice`).
+- [ ] `ModelDiscoverySource` enum added (`Live`, `Cache`, `Defaults`, `Manual`).
+- [ ] `ProviderEntry` extended with `AuthMethod` property (default `None`), OAuth token fields (`OAuthAccessToken`, `OAuthRefreshToken`, `OAuthTokenExpiry`).
+- [ ] `ModelReference` extended with `Provenance` property (`ModelDiscoverySource?`).
+- [ ] `ProviderCapabilities` static class mapping provider type → supported auth methods and model discovery support.
+- [ ] OAuth token fields bound from `secrets.json` overlay, not `netclaw.json`.
 
-### Task M1.4: Init wizard scaffold
+#### Task M1.A2: ChatClientFactory cloud provider cases
+
+**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
+**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
+**OpenSpec Tasks:** expand-mvp 13.1
+**Surface area:** `Netclaw.Daemon`
+**Verification:** L2
+
+Done when:
+- [ ] `ChatClientFactory.Create()` switch handles `openrouter`, `anthropic`, `openai` provider types.
+- [ ] Each provider creates appropriate `IChatClient` using MEAI-compatible SDK or HTTP client.
+- [ ] Tests with fake/mock HTTP backends verify client creation for each provider type.
+
+#### Task M1.A3: Init wizard scaffold (Termina)
 
 **PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md` (CLI-010)
 **OpenSpec:** `openspec/specs/netclaw-onboarding/spec.md`, `openspec/specs/netclaw-cli/spec.md`
-**OpenSpec Tasks:** add-tui-adapter 3.1–3.11
-**Surface area:** TUI + onboarding
+**OpenSpec Tasks:** add-tui-adapter 3.1–3.9
+**Surface area:** `Netclaw.Cli` TUI
 **Verification:** L3
 **Wireframe:** `docs/ui/TUI-001-command-wireframes.md` (netclaw init)
 
 Done when:
-- [ ] `InitCommand.cs` launches Termina wizard.
-- [ ] `InitWizardPage.cs` with 6-step wizard layout (`PanelNode`, progress bar).
-- [ ] `InitWizardViewModel.cs` with step state machine and back-navigation.
-- [ ] Steps: LLM provider (with OAuth/API key branch from M1.1–M1.2), Slack config, ACL bootstrap, MCP servers, exposure mode, health check.
-- [ ] Config file written to `~/.netclaw/config/netclaw.json` on completion.
+- [ ] `InitCommand.cs` launches Termina wizard (replaces stub).
+- [ ] `InitWizardPage.cs` with 6-step wizard layout (`PanelNode`, progress bar, step indicator).
+- [ ] `InitWizardViewModel.cs` with step state machine and back-navigation (Esc goes back, preserves prior input).
+- [ ] Step 1 (LLM provider) branches by provider type and auth method per design doc state machine.
+- [ ] Back-navigation clearing rules: provider change clears auth + model; auth method change clears artifacts.
+- [ ] Steps 2–5 (Slack, ACL, MCP, exposure) render with appropriate `TextInputNode`/`SelectionListNode` components.
+- [ ] Step 6 (health check) runs validation probes with `SpinnerNode` → result indicator.
+- [ ] Config written to `~/.netclaw/config/netclaw.json` and secrets to `~/.netclaw/config/secrets.json` on completion.
 
-### Task M1.5: Doctor follow-up checks for provider onboarding
+#### Task M1.A4: Headless wizard tests (VirtualTerminal)
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
+**OpenSpec:** `openspec/specs/netclaw-onboarding/spec.md`
+**Surface area:** testing
+**Verification:** L3
+
+Done when:
+- [ ] Tests use Termina `VirtualTerminal` + `VirtualInputSource` for headless wizard testing.
+- [ ] Test: full wizard flow with Ollama (no auth) produces valid config file.
+- [ ] Test: provider selection → back-navigation clears downstream state.
+- [ ] Test: API key entry with masked input produces correct secrets.json.
+- [ ] Test: health check step reports validation results.
+- [ ] All tests use fake/mock provider backends (no live API calls).
+
+#### Task M1.A5: Doctor config-shape checks
 
 **PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
 **OpenSpec:** `openspec/specs/netclaw-cli/spec.md`
@@ -135,11 +159,26 @@ Done when:
 **Verification:** L2
 
 Done when:
-- [ ] `netclaw doctor` checks extended for provider onboarding outcomes (auth method, auth artifact presence, primary/fallback validity, model provenance).
-- [ ] Remediation-first output text for each failure/degraded check with exit code behavior (0/1/2).
-- [ ] Degraded fallback-only model state returns warning exit code 2 unless required auth/provider checks fail.
+- [ ] `netclaw doctor` validates provider entry has required fields for its auth method (API key present for `ApiKey`, OAuth tokens for `OAuthDevice`).
+- [ ] Doctor checks model provenance and warns (exit 2) when model source is `Cache`, `Defaults`, or `Manual`.
+- [ ] Doctor checks primary model provider is reachable (ping endpoint, verify auth).
+- [ ] Remediation-first output for each failure with specific fix commands.
 
-### Task M1.6: Provider fallback model failover
+#### Task M1.A6: Model discovery fallback pipeline
+
+**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
+**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
+**OpenSpec Tasks:** oauth-first-provider-onboarding 3.1–3.3
+**Surface area:** provider integration
+**Verification:** L2
+
+Done when:
+- [ ] Model discovery fallback order implemented: live catalog → cache → curated defaults → manual entry.
+- [ ] Cached catalogs stored per provider type in `~/.netclaw/cache/models/`.
+- [ ] `ModelDiscoverySource` provenance persisted with `ModelReference` in config.
+- [ ] Tests with mocked discovery API verify fallback cascade and provenance tagging.
+
+#### Task M1.A7: Provider fallback model failover
 
 **PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
 **OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
@@ -149,9 +188,51 @@ Done when:
 
 Done when:
 - [ ] Primary + fallback model configuration with automatic failover on rate limit, timeout, or provider error.
-- [ ] Tests for provider switching and fallback activation.
+- [ ] Failover logic in `NetclawChatClientProvider` or `IChatClient` decorator.
+- [ ] Tests for provider switching and fallback activation with simulated failures.
 
-### Task M1.7: Milestone 1 validation and tests
+### Phase B: Interactive (needs operator for real credentials)
+
+#### Task M1.B1: OAuth device flow implementation
+
+**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
+**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
+**OpenSpec Tasks:** oauth-first-provider-onboarding 2.1–2.3
+**Surface area:** authentication
+**Verification:** L2
+
+Done when:
+- [ ] OAuth device flow client for Anthropic (`start` → `show code` → `poll` → `success`/`denied`/`expired`/`cancel`).
+- [ ] OAuth device flow client for OpenAI (same state machine, different endpoints).
+- [ ] OAuth tokens persisted to `secrets.json` via secure config pipeline, redacted in all logs/output.
+- [ ] Wizard Step 1b (OAuth) integrates device flow with Termina `SpinnerNode` for poll-wait state.
+
+#### Task M1.B2: Live provider validation
+
+**PRD:** `docs/prd/PRD-005-model-provider-strategy.md`
+**OpenSpec:** `openspec/specs/netclaw-model-providers/spec.md`
+**Surface area:** provider integration + onboarding
+**Verification:** L2
+
+Done when:
+- [ ] API key validation against live endpoints (OpenRouter, Anthropic, OpenAI) during wizard and doctor.
+- [ ] Live model catalog discovery from provider APIs populates `SelectionListNode` in wizard.
+- [ ] Doctor verifies live provider reachability and auth validity.
+
+#### Task M1.B3: Provider management CLI commands
+
+**PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
+**OpenSpec:** `openspec/specs/netclaw-cli/spec.md`
+**Surface area:** CLI
+**Verification:** L2
+
+Done when:
+- [ ] `netclaw provider add` — interactive: pick type, enter credentials, validate, save.
+- [ ] `netclaw provider list` — show all configured providers, active model assignments, auth status.
+- [ ] `netclaw provider switch` — change which provider is used for a model role (Main/Fallback/Compaction).
+- [ ] `netclaw provider remove` — remove a configured provider (warn if models still reference it).
+
+#### Task M1.B4: End-to-end onboarding smoke test
 
 **PRD:** all Milestone 1 PRDs
 **OpenSpec Tasks:** oauth-first-provider-onboarding 5.1–5.3
@@ -159,9 +240,9 @@ Done when:
 **Verification:** L2
 
 Done when:
-- [ ] Tests for onboarding branch transitions, OAuth device flow failure recovery, and model fallback sequencing.
-- [ ] Tests for doctor follow-up checks and exit-code semantics.
-- [ ] CLI/operator docs updated to reflect OAuth-first onboarding tree and doctor follow-up checks, with explicit references to PRD-004 and PRD-005.
+- [ ] End-to-end onboarding with real provider credentials verified manually.
+- [ ] Doctor follow-up checks pass after successful onboarding.
+- [ ] CLI/operator docs updated to reflect OAuth-first onboarding tree, provider management commands, and doctor follow-up checks.
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -219,18 +219,22 @@ Done when:
 - [ ] Live model catalog discovery from provider APIs populates `SelectionListNode` in wizard.
 - [ ] Doctor verifies live provider reachability and auth validity.
 
-#### Task M1.B3: Provider management CLI commands
+#### Task M1.B3: Provider and model management commands (dual-mode)
 
 **PRD:** `docs/prd/PRD-004-cli-onboarding-and-config.md`
 **OpenSpec:** `openspec/specs/netclaw-cli/spec.md`
-**Surface area:** CLI
-**Verification:** L2
+**Wireframe:** `docs/ui/TUI-001-command-wireframes.md` (netclaw provider, netclaw model)
+**Surface area:** CLI + TUI
+**Verification:** L3
 
 Done when:
-- [ ] `netclaw provider add` — interactive: pick type, enter credentials, validate, save.
-- [ ] `netclaw provider list` — show all configured providers, active model assignments, auth status.
-- [ ] `netclaw provider switch` — change which provider is used for a model role (Main/Fallback/Compaction).
-- [ ] `netclaw provider remove` — remove a configured provider (warn if models still reference it).
+- [ ] `netclaw provider` (bare) — Termina TUI guided setup reusing wizard Step 1 components (provider type, auth, credentials).
+- [ ] `netclaw provider add` — single-shot: add with explicit `--name`, `--type`, `--auth-method` args.
+- [ ] `netclaw provider list` — plain CLI: show configured providers, auth status.
+- [ ] `netclaw provider remove` — plain CLI: remove provider (warn if model roles reference it).
+- [ ] `netclaw model` (bare) — Termina TUI tree-based browser: providers → models, current role assignments, select to reassign.
+- [ ] `netclaw model --role --provider --model` — single-shot: assign model to role directly.
+- [ ] Model selector TUI component shared between `netclaw model` and `netclaw init` Step 1c.
 
 #### Task M1.B4: End-to-end onboarding smoke test
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -59,7 +59,7 @@ In scope:
 - single-process host (gateway + actors in same process)
 - Slack Socket Mode adapter
 - per-thread session actors keyed by `{channelId}/{threadTs}`
-- PostgreSQL journal and snapshot persistence
+- SQLite journal and snapshot persistence (in-memory for tests)
 - compaction via summarization reducer
 - pub/sub session broadcasts for adapters and future UI subscribers
 - default-deny ACL with explicit channel/sender/data grants

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -30,7 +30,7 @@
 - Slack Socket Mode
   - requires bot token and app token
   - no public inbound HTTP required for base interaction
-- PostgreSQL for Akka.Persistence journal and snapshots
+- SQLite for Akka.Persistence journal and snapshots (in-memory for tests)
 - MCP servers for external tool integration (MVP requirement)
 - local Ollama endpoint can be used for optional smoke tests
   - local dev host: `big-gpu` on Tailscale (`http://big-gpu:11434`)

--- a/docs/prd/PRD-001-netclaw-mvp.md
+++ b/docs/prd/PRD-001-netclaw-mvp.md
@@ -164,7 +164,7 @@ transport coupling.
 
 ### FR-003 Persistent Recovery
 
-Session state shall recover from PostgreSQL journal and snapshots after
+Session state shall recover from SQLite journal and snapshots after
 process restart.
 
 ### FR-004 Conversation Compaction

--- a/docs/prd/PRD-004-cli-onboarding-and-config.md
+++ b/docs/prd/PRD-004-cli-onboarding-and-config.md
@@ -60,14 +60,13 @@ all steps.
 
 Steps:
 
-1. LLM provider configuration (endpoint URL, API key, model selection,
-   connectivity test via direct HTTP to provider)
+1. LLM provider configuration (endpoint URL, API key or OAuth device flow,
+   model selection, connectivity test via direct HTTP to provider)
 2. Slack app setup (bot token, app token for Socket Mode)
-3. PostgreSQL connection string
-4. ACL bootstrap (owner identity, initial channel rules)
-5. MCP server configuration (optional — Memorizer recommended)
-6. Exposure mode selection (local-only default)
-7. Health check (verify Slack connection, DB connection, LLM reachability)
+3. ACL bootstrap (owner identity, initial channel rules)
+4. MCP server configuration (optional — Memorizer recommended)
+5. Exposure mode selection (local-only default)
+6. Health check (verify Slack connection, LLM reachability, MCP connectivity)
 
 ### Phase 2: Conversational Personality Bootstrap (first `netclaw chat`)
 
@@ -154,13 +153,12 @@ Onboarding captures all Phase 1 setup items in a stepwise flow.
 
 `netclaw init` SHALL support an interactive guided onboarding flow that:
 
-1. Captures LLM provider configuration (OpenRouter default)
+1. Captures LLM provider configuration (OpenRouter default, OAuth or API key)
 2. Configures Slack Socket Mode credentials (bot token + app token)
-3. Configures PostgreSQL connection string
-4. Scaffolds ACL in default-deny mode with owner identity
-5. Optionally configures MCP servers (Memorizer recommended)
-6. Selects exposure mode (local default)
-7. Runs final validation and prints next-step run commands
+3. Scaffolds ACL in default-deny mode with owner identity
+4. Optionally configures MCP servers (Memorizer recommended)
+5. Selects exposure mode (local default)
+6. Runs final validation and prints next-step run commands
 
 ### CLI-002 Validation
 

--- a/docs/ui/TUI-001-command-wireframes.md
+++ b/docs/ui/TUI-001-command-wireframes.md
@@ -5,14 +5,20 @@ Source PRDs: `PRD-004`, `PRD-009`
 ## Overview
 
 Netclaw's CLI uses **simple arg routing** in `Program.cs` for mode selection and
-**Termina 0.5.1** for interactive TUI commands. Only two commands use Termina
-TUI rendering — all other commands use plain console output.
+**Termina 0.5.1** for interactive TUI commands. Several commands use Termina TUI
+rendering — all other commands use plain console output.
 
-| Command         | Interface | Framework |
-|-----------------|-----------|-----------|
-| `netclaw init`  | TUI       | Termina (lightweight mode — no Akka) |
-| `netclaw chat`  | TUI       | Termina (daemon mode — full stack)   |
-| All others      | Plain CLI | Plain console output                 |
+**Dual-mode pattern:** Some commands are **dual-mode** — bare invocation (no args)
+launches Termina TUI for interactive discovery; with explicit args, they run as
+single-shot CLI commands suitable for scripting.
+
+| Command              | Interface    | Framework |
+|----------------------|--------------|-----------|
+| `netclaw init`       | TUI          | Termina (lightweight mode — no Akka) |
+| `netclaw chat`       | TUI          | Termina (daemon mode — full stack)   |
+| `netclaw provider`   | Dual-mode    | Termina (bare) / Plain CLI (with subcommand) |
+| `netclaw model`      | Dual-mode    | Termina (bare) / Plain CLI (with args) |
+| All others           | Plain CLI    | Plain console output                 |
 
 ## Termina Component Vocabulary
 
@@ -78,7 +84,7 @@ PanelNode (outer: "Netclaw Setup")
 └── TextNode (key bindings: Enter/Esc/Ctrl+Q)
 ```
 
-### Step Detail: Health Check (Step 7)
+### Step Detail: Health Check (Step 6)
 
 ```
 ╭─ Netclaw Setup ──────────────────────────────────────────────╮
@@ -190,6 +196,131 @@ TextNode (status bar: key bindings + MCP indicator)
 
 ---
 
+## `netclaw provider` — Dual-Mode Provider Management
+
+**Bare invocation** launches Termina TUI — a guided walk-through that reuses the
+wizard's Step 1 components (provider selection, auth method branching, OAuth
+device flow, credential entry, model selection). This is the "hold my hand" path.
+
+**With subcommands** (`add`, `list`, `remove`) runs as single-shot plain CLI.
+
+### Wireframe (TUI mode — bare `netclaw provider`)
+
+```
+╭─ Provider Setup ─────────────────────────────────────────────╮
+│                                                              │
+│  Configure a new LLM provider                               │
+│                                                              │
+│  Select provider type:                                       │
+│                                                              │
+│  ╭───────────────────────────────────────────────────────╮   │
+│  │  ● Anthropic          (OAuth + API key)               │   │
+│  │    OpenAI             (OAuth + API key)               │   │
+│  │    OpenRouter         (API key)                       │   │
+│  │    Ollama             (local, no auth)                │   │
+│  ╰───────────────────────────────────────────────────────╯   │
+│                                                              │
+│  [Enter] Select   [Esc] Cancel   [Ctrl+Q] Quit              │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+### Behaviors
+
+- Reuses the same provider setup components as `netclaw init` Step 1
+- After provider is configured, prompts for model role assignment
+- New provider is added to `~/.netclaw/config/netclaw.json`
+- Secrets written to `~/.netclaw/config/secrets.json`
+- OAuth device flow uses same Termina `SpinnerNode` poll-wait as wizard
+
+### Single-Shot Examples
+
+```
+$ netclaw provider add --name my-anthropic --type anthropic --auth-method api-key
+API key: ****
+Provider 'my-anthropic' configured.
+
+$ netclaw provider list
+Name            Type         Auth         Status
+my-anthropic    anthropic    API key      ✓ valid
+local-ollama    ollama       none         ✓ reachable
+my-openrouter   openrouter   API key      ✓ valid
+
+$ netclaw provider remove my-openrouter
+⚠ Model 'Compaction' references this provider. Reassign first.
+```
+
+---
+
+## `netclaw model` — Dual-Mode Model Selection
+
+**Bare invocation** launches Termina TUI — a tree-based model browser showing all
+configured providers, their available models (via live/cached discovery), and
+current role assignments. Operator selects a role, browses models, and assigns.
+
+**With args** (`--role`, `--provider`, `--model`) runs as single-shot assignment.
+
+### Wireframe (TUI mode — bare `netclaw model`)
+
+```
+╭─ Model Selection ────────────────────────────────────────────╮
+│                                                              │
+│  Current assignments:                                        │
+│    Main:       claude-sonnet-4-20250514 (my-anthropic)       │
+│    Fallback:   qwen3:30b (local-ollama)                      │
+│    Compaction: qwen3:8b (local-ollama)                       │
+│                                                              │
+│  Select role to change: [Main ▾]                             │
+│                                                              │
+│  Available models:                                           │
+│  ├── my-anthropic (OAuth ✓)                                  │
+│  │   ├── claude-sonnet-4-20250514 (128k) ← current          │
+│  │   ├── claude-haiku-4-5-20251001 (200k)                    │
+│  │   └── claude-opus-4-20250514 (200k)                       │
+│  ├── local-ollama                                            │
+│  │   ├── qwen3:30b (32k)                                    │
+│  │   └── qwen3:8b (32k)                                     │
+│  └── my-openrouter (API key ✓)                               │
+│      ├── google/gemini-2.5-pro                               │
+│      └── anthropic/claude-sonnet-4-20250514                  │
+│                                                              │
+│  [Enter] Select   [Esc] Cancel   [Ctrl+Q] Quit              │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+### Layout Structure
+
+```
+PanelNode (outer: "Model Selection")
+├── TextNode (current role assignments)
+├── SelectionListNode (role selector: Main/Fallback/Compaction)
+├── [tree view of providers and models]
+│   ├── TextNode (provider name + auth status)
+│   └── SelectionListNode (models under that provider)
+└── TextNode (key bindings)
+```
+
+### Behaviors
+
+- Tree populated via model discovery (live → cache → defaults) across all
+  configured providers
+- SpinnerNode shown while discovering models from each provider
+- Provider auth status shown inline (✓ valid / ⚠ expired / ✗ unreachable)
+- Current model for selected role marked with `← current`
+- On selection: updates `Models` section of `netclaw.json`, confirms change
+- Model selector component is shared with `netclaw init` Step 1c
+
+### Single-Shot Examples
+
+```
+$ netclaw model --role main --provider my-anthropic --model claude-sonnet-4-20250514
+Main model set to claude-sonnet-4-20250514 (my-anthropic).
+
+$ netclaw model --role fallback --provider local-ollama --model qwen3:30b
+Fallback model set to qwen3:30b (local-ollama).
+```
+
+---
+
 ## `netclaw doctor` — Plain CLI Output (No TUI)
 
 Simple check-and-report command. Runs startup checks, prints color-coded
@@ -236,6 +367,8 @@ No Termina TUI components are used.
 | `netclaw doctor`                     | Check list          |
 | `netclaw config show`                | Formatted text/JSON |
 | `netclaw config validate`            | Validation results  |
+| `netclaw provider add\|list\|remove`   | Simple CRUD         |
+| `netclaw model --role ... --model ...` | Single-shot assign |
 | `netclaw acl validate\|test\|explain`  | Policy check results|
 | `netclaw session list\|inspect`        | Tabular             |
 | `netclaw project list\|add\|remove`    | Simple CRUD         |
@@ -247,6 +380,9 @@ No Termina TUI components are used.
 | `netclaw test smoke`                 | Test results        |
 | `netclaw personality reset`          | Confirmation        |
 | `netclaw run`                        | Daemon (no TUI)     |
+
+Note: `netclaw provider` (bare) and `netclaw model` (bare) are dual-mode — they
+launch Termina TUI when invoked without subcommands or args. See wireframes above.
 
 ### `netclaw run` — Daemon Mode
 

--- a/docs/ui/TUI-001-command-wireframes.md
+++ b/docs/ui/TUI-001-command-wireframes.md
@@ -29,7 +29,7 @@ All wireframes reference actual Termina 0.5.1 components:
 
 ## `netclaw init` — Onboarding Wizard (TUI)
 
-Interactive 7-step setup wizard. Termina hosts the full wizard as a single
+Interactive 6-step setup wizard. Termina hosts the full wizard as a single
 application with step navigation.
 
 ### Wireframe
@@ -37,7 +37,7 @@ application with step navigation.
 ```
 ╭─ Netclaw Setup ──────────────────────────────────────────────╮
 │                                                              │
-│  Step 2 of 7: Slack Configuration        [■■□□□□□] 28%      │
+│  Step 2 of 6: Slack Configuration        [■■□□□□□] 33%      │
 │                                                              │
 │  ╭─ Slack Bot Token ───────────────────────────────────────╮ │
 │  │ xoxb-************************************               │ │
@@ -58,13 +58,12 @@ application with step navigation.
 
 | Step | Title                  | Components                                            |
 |------|------------------------|-------------------------------------------------------|
-| 1    | LLM Provider           | SelectionListNode (OpenRouter/Anthropic/OpenAI/Ollama) + TextInputNode (API key) |
+| 1    | LLM Provider           | SelectionListNode (OpenRouter/Anthropic/OpenAI/Ollama) + auth branch (API key or OAuth device flow) |
 | 2    | Slack Configuration    | TextInputNode (bot token) + TextInputNode (app token) |
-| 3    | PostgreSQL Connection  | TextInputNode (connection string) + SpinnerNode (live validation) |
-| 4    | ACL Bootstrap          | TextInputNode (owner identity) + SelectionListNode (initial channels) |
-| 5    | MCP Servers            | SelectionListNode (Memorizer recommended / custom / skip) |
-| 6    | Exposure Mode          | SelectionListNode (local-only default / tailscale / cloudflare) |
-| 7    | Health Check           | TextNode (validation results with SpinnerNodes → checkmarks) |
+| 3    | ACL Bootstrap          | TextInputNode (owner identity) + SelectionListNode (initial channels) |
+| 4    | MCP Servers            | SelectionListNode (Memorizer recommended / custom / skip) |
+| 5    | Exposure Mode          | SelectionListNode (local-only default / tailscale / cloudflare) |
+| 6    | Health Check           | TextNode (validation results with SpinnerNodes → checkmarks) |
 
 ### Layout Structure
 
@@ -84,14 +83,13 @@ PanelNode (outer: "Netclaw Setup")
 ```
 ╭─ Netclaw Setup ──────────────────────────────────────────────╮
 │                                                              │
-│  Step 7 of 7: Health Check               [■■■■■■■] 100%     │
+│  Step 6 of 6: Health Check               [■■■■■■■] 100%     │
 │                                                              │
 │  Verifying configuration...                                  │
 │                                                              │
 │  ✓  LLM provider reachable (OpenRouter)                      │
 │  ✓  Slack bot token valid                                    │
 │  ✓  Slack app token valid                                    │
-│  ✓  PostgreSQL connected (3ms)                               │
 │  ✓  MCP: memorizer connected (12 tools)                      │
 │  ●  Exposure: local-only (no public endpoint)                │
 │                                                              │
@@ -105,8 +103,7 @@ PanelNode (outer: "Netclaw Setup")
 
 - Progress bar uses block characters (■□) rendered via TextNode
 - Secret inputs (API keys, tokens) use masked TextInputNode
-- Step 3 (PostgreSQL) validates connectivity live with SpinnerNode → checkmark
-- Step 7 (Health Check) runs all probes in sequence with SpinnerNode → result
+- Step 6 (Health Check) runs all probes in sequence with SpinnerNode → result
 - [Esc] navigates back to previous step; [Ctrl+Q] exits with confirmation
 - Config file written to `~/.netclaw/config/netclaw.json` on completion
 
@@ -210,7 +207,6 @@ Checking startup requirements...
   ✓  Config file valid
   ✓  ACL valid (3 channel rules, 2 tool grants)
   ✓  LLM provider reachable (OpenRouter)
-  ✓  PostgreSQL connected (2ms)
   ✗  Slack bot token invalid or expired
      Fix: netclaw init --step slack
   ✓  MCP: memorizer connected (12 tools)

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/specs/netclaw-onboarding/spec.md
@@ -3,14 +3,14 @@
 ### Requirement: TUI wizard delivery mechanism
 
 The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI
-as an interactive 7-step wizard with progress indication, validation, and
+as an interactive 6-step wizard with progress indication, validation, and
 back-navigation.
 
 #### Scenario: Wizard renders in TUI
 
 - **WHEN** operator runs `netclaw init`
 - **THEN** a Termina TUI application launches
-- **AND** the wizard displays step progress (e.g., "Step 2 of 7")
+- **AND** the wizard displays step progress (e.g., "Step 2 of 6")
 - **AND** the wizard displays a progress bar
 
 #### Scenario: Step-specific components rendered
@@ -29,8 +29,8 @@ back-navigation.
 
 #### Scenario: Live validation during wizard
 
-- **GIVEN** the wizard is on the PostgreSQL step
-- **WHEN** the operator enters a connection string
+- **GIVEN** the wizard is on the MCP server step
+- **WHEN** the operator enters a server profile
 - **THEN** the wizard validates connectivity with a SpinnerNode
 - **AND** displays success or failure before allowing progression
 

--- a/openspec/changes/add-tui-adapter-and-config-hot-reload/tasks.md
+++ b/openspec/changes/add-tui-adapter-and-config-hot-reload/tasks.md
@@ -19,15 +19,14 @@
 ## 3. TUI Onboarding Wizard (`netclaw init`)
 
 - [ ] 3.1 Create InitCommand.cs that launches Termina wizard
-- [ ] 3.2 Create InitWizardPage.cs with 7-step wizard layout (PanelNode, progress bar)
+- [ ] 3.2 Create InitWizardPage.cs with 6-step wizard layout (PanelNode, progress bar)
 - [ ] 3.3 Create InitWizardViewModel.cs with step state machine and back-navigation
-- [ ] 3.4 Implement Step 1: LLM provider (SelectionListNode + TextInputNode for API key)
+- [ ] 3.4 Implement Step 1: LLM provider (SelectionListNode + TextInputNode for API key / OAuth branch)
 - [ ] 3.5 Implement Step 2: Slack configuration (masked TextInputNodes for tokens)
-- [ ] 3.6 Implement Step 3: PostgreSQL connection (TextInputNode + live validation SpinnerNode)
-- [ ] 3.7 Implement Step 4: ACL bootstrap (owner identity + initial channels)
-- [ ] 3.8 Implement Step 5: MCP servers (SelectionListNode with Memorizer recommended)
-- [ ] 3.9 Implement Step 6: Exposure mode (SelectionListNode with security warnings)
-- [ ] 3.10 Implement Step 7: Health check (live probe panel with SpinnerNodes → checkmarks)
+- [ ] 3.6 Implement Step 3: ACL bootstrap (owner identity + initial channels)
+- [ ] 3.7 Implement Step 4: MCP servers (SelectionListNode with Memorizer recommended)
+- [ ] 3.8 Implement Step 5: Exposure mode (SelectionListNode with security warnings)
+- [ ] 3.9 Implement Step 6: Health check (live probe panel with SpinnerNodes → checkmarks)
 - [ ] 3.11 Write config file to ~/.netclaw/config/netclaw.json on completion
 
 ## 4. Plain CLI Commands

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/design.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/design.md
@@ -16,7 +16,7 @@ extends it with new actor types, tool integration, and file-based state.
   by entity key using `SessionMessageExtractor`
 - `SerializableChatMessage`: framework-owned persistence type (protobuf-net)
 - Slack Socket Mode adapter: planned but not yet implemented
-- PostgreSQL journal/snapshots via Akka.Persistence
+- SQLite journal/snapshots via Akka.Persistence (in-memory for tests)
 - Microsoft.Extensions.AI `IChatClient` for LLM interaction
 
 ### Constraints

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-cli/spec.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/specs/netclaw-cli/spec.md
@@ -4,22 +4,16 @@
 
 The CLI SHALL provide guided setup through `netclaw init`. The onboarding
 wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
-PostgreSQL connection string, MCP server configuration, and exposure mode
-selection. On completion, the wizard SHALL run a health check to verify the
-baseline configuration is functional.
+MCP server configuration, and exposure mode selection. On completion, the
+wizard SHALL run a health check to verify the baseline configuration is
+functional.
 
 #### Scenario: First-time setup
 
 - **WHEN** operator runs `netclaw init` on a fresh install
-- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
-  exposure mode inputs
+- **THEN** guided setup collects provider, Slack, ACL, MCP, and exposure mode
+  inputs
 - **AND** writes a runnable baseline configuration
-
-#### Scenario: PostgreSQL connection configured during init
-
-- **WHEN** onboarding reaches the persistence step
-- **THEN** the wizard prompts for a PostgreSQL connection string
-- **AND** validates connectivity before proceeding
 
 #### Scenario: MCP server configured during init
 

--- a/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
+++ b/openspec/changes/expand-mvp-for-autonomous-agent-vision/tasks.md
@@ -15,7 +15,7 @@
 ## 2. Session Actor Core
 
 - [x] 2.1 Implement `LlmSessionActor` with persistent state recovery from
-  journal/snapshots (in-memory for MVP, PostgreSQL deferred).
+  journal/snapshots (SQLite for production, in-memory for tests).
 - [x] 2.2 Implement turn processing loop: receive `SendUserMessage`, invoke
   `IChatClient`, persist `TurnRecorded`, emit typed outputs to subscribers.
 - [x] 2.3 Implement snapshot strategy, tiered compaction (tool result clearing +
@@ -165,8 +165,7 @@
 ## 14. CLI Onboarding and Management
 
 - [ ] 14.1 Implement `netclaw init` guided wizard (LLM provider, Slack
-  credentials, PostgreSQL connection, ACL bootstrap, MCP config, exposure mode,
-  health check).
+  credentials, ACL bootstrap, MCP config, exposure mode, health check).
 - [ ] 14.2 Implement `netclaw config show|validate` and
   `netclaw acl validate|test|explain`.
 - [ ] 14.3 Implement `netclaw project list|add|remove` and

--- a/openspec/changes/oauth-first-provider-onboarding/design.md
+++ b/openspec/changes/oauth-first-provider-onboarding/design.md
@@ -88,8 +88,298 @@ Rollback strategy:
 - Revert to pre-change onboarding branch behavior while retaining backward-compatible config fields.
 - Keep existing API-key path operational if OAuth-specific branches are disabled.
 
-## Open Questions
+## Open Questions (Resolved)
 
-- Which providers in MVP are marked OAuth-capable at launch versus API-key-only?
-- Should doctor hard-fail (exit 1) or warn (exit 2) when model provenance is fallback-derived but still usable?
-- Should onboarding cache model catalogs per provider profile or globally per provider name?
+### Q: Which providers are OAuth-capable vs API-key-only?
+
+**Resolved.** Provider capability matrix for MVP:
+
+| Provider    | Auth Methods               | Model Discovery API         | Notes                          |
+|-------------|----------------------------|-----------------------------|--------------------------------|
+| Anthropic   | OAuth device flow, API key | `GET /v1/models`            | OAuth-first, API key fallback  |
+| OpenAI      | OAuth device flow, API key | `GET /v1/models`            | OAuth-first, API key fallback  |
+| OpenRouter   | API key only               | `GET /api/v1/models`        | No OAuth support               |
+| Ollama      | None (local)               | `GET /api/tags`             | No auth required               |
+
+Wizard presents OAuth as the recommended path for Anthropic and OpenAI. API key
+is always available as fallback. OpenRouter and Ollama skip the auth-method
+selection step entirely.
+
+### Q: Should doctor hard-fail or warn for fallback-derived model provenance?
+
+**Resolved.** Warning (exit 2). The provider is reachable and functional — the
+model selection just used a degraded source. Doctor output will include the
+provenance and a suggestion to re-run model discovery when the catalog is
+available again.
+
+### Q: Should onboarding cache model catalogs per profile or per provider name?
+
+**Resolved.** Per provider name. Multiple profiles pointing to the same provider
+type share cached catalog data. Cache location: `~/.netclaw/cache/models/`.
+
+---
+
+## Addendum: Concrete Type Definitions and Multi-Provider Design
+
+This section provides the concrete C# types, state model, and algorithms that
+RALPH needs to implement Milestone 1 without ambiguity.
+
+### Provider Capability Model
+
+Extend existing `ProviderEntry` with auth method metadata:
+
+```csharp
+// New enum — auth methods a provider supports
+public enum AuthMethod
+{
+    None,        // Ollama — no auth required
+    ApiKey,      // Static API key in secrets.json
+    OAuthDevice  // OAuth 2.0 device authorization grant
+}
+
+// New enum — how a model ID was resolved
+public enum ModelDiscoverySource
+{
+    Live,     // From provider's model listing API
+    Cache,    // From cached last-known-good catalog
+    Defaults, // From curated defaults in config templates
+    Manual    // Operator typed it in
+}
+```
+
+Extend `ProviderEntry` (existing type in `Netclaw.Configuration`):
+
+```csharp
+public sealed class ProviderEntry
+{
+    public string Type { get; set; } = "ollama";
+    public string Endpoint { get; set; } = "http://localhost:11434";
+    public string? ApiKey { get; set; }
+
+    // NEW: resolved auth method for this provider instance
+    public AuthMethod AuthMethod { get; set; } = AuthMethod.None;
+
+    // NEW: OAuth artifacts (populated after successful device flow)
+    public string? OAuthAccessToken { get; set; }
+    public string? OAuthRefreshToken { get; set; }
+    public DateTimeOffset? OAuthTokenExpiry { get; set; }
+}
+```
+
+Extend `ModelReference` (existing type in `Netclaw.Configuration`):
+
+```csharp
+public sealed class ModelReference
+{
+    public string Provider { get; set; } = "local-ollama";
+    public string ModelId { get; set; } = "qwen3:30b";
+    public int? ContextWindow { get; set; }
+
+    // NEW: how this model ID was resolved during onboarding
+    public ModelDiscoverySource? Provenance { get; set; }
+}
+```
+
+**Important:** OAuth tokens go in `secrets.json`, NOT `netclaw.json`. The
+`ProviderEntry` class binds from layered config (netclaw.json + secrets.json),
+so the secrets overlay provides the token fields while netclaw.json has the
+non-secret fields (Type, Endpoint, AuthMethod).
+
+### Provider Capability Registry
+
+Static metadata about what each provider type supports. Not persisted — compiled
+into the application:
+
+```csharp
+public static class ProviderCapabilities
+{
+    public static IReadOnlyList<AuthMethod> GetSupportedAuthMethods(string providerType)
+        => providerType.ToLowerInvariant() switch
+        {
+            "anthropic" => [AuthMethod.OAuthDevice, AuthMethod.ApiKey],
+            "openai" => [AuthMethod.OAuthDevice, AuthMethod.ApiKey],
+            "openrouter" => [AuthMethod.ApiKey],
+            "ollama" => [AuthMethod.None],
+            _ => [AuthMethod.ApiKey] // unknown providers default to API key
+        };
+
+    public static bool SupportsModelDiscovery(string providerType)
+        => providerType.ToLowerInvariant() is
+            "ollama" or "openrouter" or "anthropic" or "openai";
+}
+```
+
+### Wizard State Machine
+
+The init wizard has 6 steps. Step 1 (LLM provider) branches based on provider
+type and auth method:
+
+```
+Step 1: Provider Selection
+├── SelectionListNode: [Anthropic, OpenAI, OpenRouter, Ollama]
+│
+├── IF provider supports multiple auth methods:
+│   └── Step 1a: Auth Method Selection
+│       ├── SelectionListNode: [OAuth Device Flow (recommended), API Key]
+│       │
+│       ├── IF OAuth Device Flow:
+│       │   └── Step 1b: OAuth Device Flow
+│       │       ├── TextNode: "Visit {verification_uri}"
+│       │       ├── TextNode: "Enter code: {user_code}"
+│       │       ├── SpinnerNode: "Waiting for authorization..."
+│       │       └── Outcomes: success → Step 1c | denied/expired → retry or back
+│       │
+│       └── IF API Key:
+│           └── Step 1b: API Key Entry
+│               └── TextInputNode (masked): "Enter API key"
+│
+├── IF provider is API-key-only (OpenRouter):
+│   └── Step 1b: API Key Entry
+│       └── TextInputNode (masked): "Enter API key"
+│
+├── IF provider is Ollama:
+│   └── Step 1b: Endpoint Configuration
+│       └── TextInputNode: "Ollama endpoint" (default: http://localhost:11434)
+│
+└── Step 1c: Model Selection
+    ├── Attempt live discovery → cache → defaults → manual
+    ├── SelectionListNode: [discovered models] or TextInputNode for manual
+    └── TextNode: "Source: {provenance}" (live/cache/defaults/manual)
+
+Step 2: Slack Configuration (unchanged from wireframe)
+Step 3: ACL Bootstrap (unchanged)
+Step 4: MCP Servers (unchanged)
+Step 5: Exposure Mode (unchanged)
+Step 6: Health Check (unchanged)
+```
+
+### Back-Navigation Clearing Rules
+
+When the operator presses Esc to go back, downstream state must be cleared if
+the changed step invalidates it:
+
+| Changed Step         | Clears                                              |
+|----------------------|-----------------------------------------------------|
+| Provider selection   | Auth method, auth artifacts, model selection, model provenance |
+| Auth method          | Auth artifacts (tokens/API key), model selection (if provider changed) |
+| Model selection      | Nothing downstream                                  |
+| Slack config         | Nothing downstream                                  |
+| ACL bootstrap        | Nothing downstream                                  |
+| MCP servers          | Nothing downstream                                  |
+| Exposure mode        | Nothing downstream                                  |
+
+Rule: provider change clears everything downstream within Step 1. Auth method
+change clears auth artifacts. Steps 2–5 are independent and never clear each
+other.
+
+### Multi-Provider Configuration
+
+The wizard configures the **first** provider. Post-wizard, operators use CLI
+commands to manage additional providers:
+
+```
+netclaw provider add       # interactive: pick type, enter credentials
+netclaw provider list      # show all configured providers and active models
+netclaw provider switch    # change which provider is used for a model role
+netclaw provider remove    # remove a configured provider
+```
+
+Config structure in `netclaw.json`:
+
+```json
+{
+  "Providers": {
+    "my-anthropic": {
+      "Type": "anthropic",
+      "Endpoint": "https://api.anthropic.com",
+      "AuthMethod": "OAuthDevice"
+    },
+    "my-openrouter": {
+      "Type": "openrouter",
+      "Endpoint": "https://openrouter.ai/api",
+      "AuthMethod": "ApiKey"
+    },
+    "local-ollama": {
+      "Type": "ollama",
+      "Endpoint": "http://localhost:11434",
+      "AuthMethod": "None"
+    }
+  },
+  "Models": {
+    "Main": { "Provider": "my-anthropic", "ModelId": "claude-sonnet-4-20250514" },
+    "Fallback": { "Provider": "local-ollama", "ModelId": "qwen3:30b" },
+    "Compaction": { "Provider": "local-ollama", "ModelId": "qwen3:8b" }
+  }
+}
+```
+
+Secrets in `secrets.json`:
+
+```json
+{
+  "Providers": {
+    "my-anthropic": {
+      "OAuthAccessToken": "sk-ant-...",
+      "OAuthRefreshToken": "rt-ant-...",
+      "OAuthTokenExpiry": "2026-03-25T00:00:00Z"
+    },
+    "my-openrouter": {
+      "ApiKey": "sk-or-..."
+    }
+  }
+}
+```
+
+### ChatClientFactory Extension Points
+
+The existing `ChatClientFactory` switch expression adds new cases:
+
+```csharp
+return provider.Type.ToLowerInvariant() switch
+{
+    "ollama" => new OllamaApiClient(...),
+    "openrouter" => CreateOpenRouterClient(provider, model),
+    "anthropic" => CreateAnthropicClient(provider, model),
+    "openai" => CreateOpenAIClient(provider, model),
+    _ => throw new InvalidOperationException(...)
+};
+```
+
+Each `Create*Client` method reads from the layered config (netclaw.json +
+secrets.json) to get both endpoint/type and auth credentials.
+
+### Headless TUI Testing
+
+Termina 0.6.0 ships `VirtualTerminal` and `VirtualInputSource` for headless
+testing. The wizard tests should:
+
+1. Create `VirtualTerminal` + `VirtualInputSource`
+2. Launch `InitWizardPage` headlessly
+3. Simulate keystrokes via `VirtualInputSource` to navigate wizard steps
+4. Assert on `VirtualTerminal` output state
+
+This allows RALPH to write comprehensive wizard tests without needing a real
+terminal or live provider credentials. Use fake/mock provider backends for
+credential validation steps.
+
+### RALPH Phase Split
+
+Milestone 1 is split into two phases to separate autonomous work from
+credential-dependent interactive work:
+
+**Phase A (autonomous — RALPH can execute alone):**
+- Config types: `AuthMethod`, `ModelDiscoverySource`, `ProviderEntry` extensions
+- `ProviderCapabilities` static registry
+- `ChatClientFactory` provider type cases (OpenRouter, Anthropic, OpenAI)
+- Init wizard scaffold with Termina (page, view model, step state machine)
+- Back-navigation clearing algorithm
+- Fake/mock provider backends for testing
+- Headless TUI tests via `VirtualTerminal`
+- Doctor config-shape checks (does provider entry have required fields?)
+
+**Phase B (interactive — needs operator for real credentials):**
+- Real OAuth device flow endpoints (Anthropic, OpenAI)
+- Real API key validation against live endpoints
+- Real model catalog discovery from live APIs
+- Provider `add`/`switch`/`remove` CLI commands with live validation
+- End-to-end onboarding smoke test with real provider

--- a/openspec/changes/oauth-first-provider-onboarding/design.md
+++ b/openspec/changes/oauth-first-provider-onboarding/design.md
@@ -272,17 +272,72 @@ Rule: provider change clears everything downstream within Step 1. Auth method
 change clears auth artifacts. Steps 2–5 are independent and never clear each
 other.
 
-### Multi-Provider Configuration
+### Multi-Provider Configuration and Dual-Mode CLI
 
-The wizard configures the **first** provider. Post-wizard, operators use CLI
-commands to manage additional providers:
+The wizard configures the **first** provider. Post-wizard, operators manage
+providers and models through dual-mode commands that follow a consistent
+pattern: **no args = Termina TUI discovery, args = single-shot scriptable.**
+
+#### `netclaw provider` — Provider credential management
 
 ```
-netclaw provider add       # interactive: pick type, enter credentials
-netclaw provider list      # show all configured providers and active models
-netclaw provider switch    # change which provider is used for a model role
-netclaw provider remove    # remove a configured provider
+netclaw provider              # TUI: guided walk-through (add provider, auth,
+                              # model selection — reuses wizard Step 1 components)
+netclaw provider add          # single-shot: add with explicit args
+  --name my-anthropic
+  --type anthropic
+  --auth-method oauth-device
+netclaw provider list         # plain CLI: show configured providers + auth status
+netclaw provider remove <name> # plain CLI: remove provider (warn if models reference it)
 ```
+
+Bare `netclaw provider` launches the same Termina components used in the wizard's
+Step 1 — provider selection, auth method branching, OAuth device flow, credential
+entry. This is the "hold my hand" path and also serves as the entry point for
+OAuth flows that require interactive browser authorization.
+
+#### `netclaw model` — Model selection and role assignment
+
+```
+netclaw model                 # TUI: tree-based browser showing all providers
+                              # and their available models, current role assignments
+netclaw model                 # single-shot: assign model to role directly
+  --role main
+  --provider my-anthropic
+  --model claude-sonnet-4-20250514
+```
+
+Bare `netclaw model` launches Termina with a tree-based model browser:
+
+```
+╭─ Model Selection ────────────────────────────────────────────╮
+│                                                              │
+│  Current assignments:                                        │
+│    Main:       claude-sonnet-4-20250514 (my-anthropic)       │
+│    Fallback:   qwen3:30b (local-ollama)                      │
+│    Compaction: qwen3:8b (local-ollama)                       │
+│                                                              │
+│  Select role to change: [Main ▾]                             │
+│                                                              │
+│  Available models:                                           │
+│  ├── my-anthropic (OAuth ✓)                                  │
+│  │   ├── claude-sonnet-4-20250514 (128k) ← current          │
+│  │   ├── claude-haiku-4-5-20251001 (200k)                    │
+│  │   └── claude-opus-4-20250514 (200k)                       │
+│  ├── local-ollama                                            │
+│  │   ├── qwen3:30b (32k)                                    │
+│  │   └── qwen3:8b (32k)                                     │
+│  └── my-openrouter (API key ✓)                               │
+│      ├── google/gemini-2.5-pro                               │
+│      └── anthropic/claude-sonnet-4-20250514                  │
+│                                                              │
+│  [Enter] Select   [Esc] Cancel   [Ctrl+Q] Quit              │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+The tree is populated from model discovery (live → cache → defaults) across all
+configured providers. The model selector component is shared with the wizard's
+Step 1c.
 
 Config structure in `netclaw.json`:
 
@@ -381,5 +436,6 @@ credential-dependent interactive work:
 - Real OAuth device flow endpoints (Anthropic, OpenAI)
 - Real API key validation against live endpoints
 - Real model catalog discovery from live APIs
-- Provider `add`/`switch`/`remove` CLI commands with live validation
+- `netclaw provider` TUI and `provider add/list/remove` single-shot commands
+- `netclaw model` TUI and single-shot model role assignment
 - End-to-end onboarding smoke test with real provider

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-cli/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-cli/spec.md
@@ -4,16 +4,16 @@
 
 The CLI SHALL provide guided setup through `netclaw init`. The onboarding
 wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
-PostgreSQL connection string, MCP server configuration, and exposure mode
-selection. Provider setup SHALL use explicit Termina decision trees for
+MCP server configuration, and exposure mode selection. Provider setup SHALL
+use explicit Termina decision trees for
 provider selection, auth method branching, OAuth device flow progression (when
 applicable), and model discovery fallback paths. On completion, the wizard
 SHALL run a health check to verify the baseline configuration is functional.
 
 #### Scenario: First-time setup with provider decision tree
 - **WHEN** operator runs `netclaw init` on a fresh install
-- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
-  exposure mode inputs
+- **THEN** guided setup collects provider, Slack, ACL, MCP, and exposure mode
+  inputs
 - **AND** provider setup executes explicit branches for provider choice, auth
   method, and model resolution path before writing config
 

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
@@ -4,8 +4,8 @@
 
 The CLI SHALL provide guided setup through `netclaw init` using explicit Termina
 decision trees for provider onboarding. The onboarding wizard SHALL collect
-Slack credentials, provider configuration, ACL inputs, PostgreSQL connection
-string, MCP server configuration, and exposure mode selection. Provider setup
+Slack credentials, provider configuration, ACL inputs, MCP server
+configuration, and exposure mode selection. Provider setup
 SHALL branch by selected provider and auth method, and SHALL include model
 discovery fallback behavior when live provider catalogs are unavailable. On
 completion, the wizard SHALL run a health check to verify the baseline
@@ -34,13 +34,13 @@ configuration is functional.
 #### Scenario: Health check on completion
 - **WHEN** onboarding completes all steps
 - **THEN** the wizard runs a health check covering Slack connectivity, provider
-  validation, persistence connectivity, and MCP server reachability
+  validation, and MCP server reachability
 - **AND** reports pass/fail for each component
 
 ### Requirement: TUI wizard delivery mechanism
 
 The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI as
-an interactive 7-step wizard with progress indication, validation,
+an interactive 6-step wizard with progress indication, validation,
 back-navigation, and branch-context display for provider onboarding decisions.
 
 #### Scenario: Wizard renders branch context in TUI

--- a/openspec/specs/netclaw-cli/spec.md
+++ b/openspec/specs/netclaw-cli/spec.md
@@ -11,22 +11,16 @@ diagnostics.
 
 The CLI SHALL provide guided setup through `netclaw init`. The onboarding
 wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
-PostgreSQL connection string, MCP server configuration, and exposure mode
-selection. On completion, the wizard SHALL run a health check to verify the
-baseline configuration is functional.
+MCP server configuration, and exposure mode selection. On completion, the
+wizard SHALL run a health check to verify the baseline configuration is
+functional.
 
 #### Scenario: First-time setup
 
 - **WHEN** operator runs `netclaw init` on a fresh install
-- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
-  exposure mode inputs
+- **THEN** guided setup collects provider, Slack, ACL, MCP, and exposure mode
+  inputs
 - **AND** writes a runnable baseline configuration
-
-#### Scenario: PostgreSQL connection configured during init
-
-- **WHEN** onboarding reaches the persistence step
-- **THEN** the wizard prompts for a PostgreSQL connection string
-- **AND** validates connectivity before proceeding
 
 #### Scenario: MCP server configured during init
 
@@ -46,7 +40,7 @@ baseline configuration is functional.
 
 - **WHEN** onboarding completes all steps
 - **THEN** the wizard runs a health check covering Slack connectivity, provider
-  validation, persistence connectivity, and MCP server reachability
+  validation, and MCP server reachability
 - **AND** reports pass/fail for each component
 
 ### Requirement: Resumable onboarding

--- a/openspec/specs/netclaw-onboarding/spec.md
+++ b/openspec/specs/netclaw-onboarding/spec.md
@@ -38,22 +38,16 @@ The system SHALL show explicit warnings before enabling public exposure modes.
 
 The CLI SHALL provide guided setup through `netclaw init`. The onboarding
 wizard SHALL collect Slack credentials, provider configuration, ACL inputs,
-PostgreSQL connection string, MCP server configuration, and exposure mode
-selection. On completion, the wizard SHALL run a health check to verify the
-baseline configuration is functional.
+MCP server configuration, and exposure mode selection. On completion, the
+wizard SHALL run a health check to verify the baseline configuration is
+functional.
 
 #### Scenario: First-time setup
 
 - **WHEN** operator runs `netclaw init` on a fresh install
-- **THEN** guided setup collects Slack, provider, ACL, PostgreSQL, MCP, and
-  exposure mode inputs
+- **THEN** guided setup collects provider, Slack, ACL, MCP, and exposure mode
+  inputs
 - **AND** writes a runnable baseline configuration
-
-#### Scenario: PostgreSQL connection configured during init
-
-- **WHEN** onboarding reaches the persistence step
-- **THEN** the wizard prompts for a PostgreSQL connection string
-- **AND** validates connectivity before proceeding
 
 #### Scenario: MCP server configured during init
 
@@ -73,7 +67,7 @@ baseline configuration is functional.
 
 - **WHEN** onboarding completes all steps
 - **THEN** the wizard runs a health check covering Slack connectivity, provider
-  validation, persistence connectivity, and MCP server reachability
+  validation, and MCP server reachability
 - **AND** reports pass/fail for each component
 
 ### Requirement: Phase 2 conversational personality bootstrap
@@ -147,14 +141,14 @@ with their paths, capabilities, and AGENTS.md locations.
 ### Requirement: TUI wizard delivery mechanism
 
 The `netclaw init` onboarding wizard SHALL be delivered through Termina TUI
-as an interactive 7-step wizard with progress indication, validation, and
+as an interactive 6-step wizard with progress indication, validation, and
 back-navigation.
 
 #### Scenario: Wizard renders in TUI
 
 - **WHEN** operator runs `netclaw init`
 - **THEN** a Termina TUI application launches
-- **AND** the wizard displays step progress (e.g., "Step 2 of 7")
+- **AND** the wizard displays step progress (e.g., "Step 2 of 6")
 - **AND** the wizard displays a progress bar
 
 #### Scenario: Step-specific components rendered
@@ -173,7 +167,7 @@ back-navigation.
 
 #### Scenario: Live validation during wizard
 
-- **GIVEN** the wizard is on the PostgreSQL step
-- **WHEN** the operator enters a connection string
+- **GIVEN** the wizard is on the MCP server step
+- **WHEN** the operator enters a server profile
 - **THEN** the wizard validates connectivity with a SpinnerNode
 - **AND** displays success or failure before allowing progression


### PR DESCRIPTION
## Summary

- **PostgreSQL cleanup:** Replaced all stale PostgreSQL references with SQLite across specs, PRDs, wireframes, and context docs. Removed PostgreSQL wizard step and renumbered from 7 to 6 steps.
- **Design addendum:** Resolved open questions in `oauth-first-provider-onboarding/design.md` with concrete provider capability matrix (Anthropic/OpenAI: OAuth+APIKey, OpenRouter: APIKey, Ollama: none), C# type definitions (`AuthMethod`, `ModelDiscoverySource`, `ProviderCapabilities`), wizard state machine, back-navigation clearing rules, multi-provider config structure, and headless TUI testing guidance via Termina `VirtualTerminal`.
- **M1 restructuring:** Split Milestone 1 into Phase A (autonomous — RALPH can execute without operator) and Phase B (interactive — needs real credentials). Phase A covers config types, `ChatClientFactory` cloud cases, wizard scaffold, headless tests, doctor checks, model discovery fallback, and provider failover. Phase B covers OAuth device flow, live validation, provider CLI commands, and E2E smoke test.

## Test plan

- [x] `openspec validate --all --no-interactive` passes (18/18)
- [x] `dotnet build Netclaw.slnx` passes (0 errors, 0 warnings)
- [ ] Review: M1 Phase A tasks are self-contained and executable without live provider credentials
- [ ] Review: Design addendum type definitions align with existing `Netclaw.Configuration` types