### PR TITLE
M1.A1-A4: Provider config, init wizard with validation and model selection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
-    <PackageVersion Include="Termina" Version="0.7.0" />
+    <PackageVersion Include="Termina" Version="0.7.1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,10 +15,12 @@
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.Hosting" Version="$(AkkaPersistenceSqlHostingVersion)" />
     <PackageVersion Include="Aaron.Akka.Reminders" Version="$(AkkaRemindersVersion)" />
+    <PackageVersion Include="Anthropic" Version="12.8.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
-    <PackageVersion Include="Termina" Version="0.6.0" />
+    <PackageVersion Include="Termina" Version="0.7.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -97,7 +97,7 @@ rules, provider capability matrix, and headless testing guidance).
 
 Done when:
 - [ ] `AuthMethod` enum added (`None`, `ApiKey`, `OAuthDevice`).
-- [ ] `ModelDiscoverySource` enum added (`Live`, `Cache`, `Defaults`, `Manual`).
+- [ ] `ModelDiscoverySource` enum added (`Live`, `Defaults`, `Manual`).
 - [ ] `ProviderEntry` extended with `AuthMethod` property (default `None`), OAuth token fields (`OAuthAccessToken`, `OAuthRefreshToken`, `OAuthTokenExpiry`).
 - [ ] `ModelReference` extended with `Provenance` property (`ModelDiscoverySource?`).
 - [ ] `ProviderCapabilities` static class mapping provider type → supported auth methods and model discovery support.
@@ -160,7 +160,7 @@ Done when:
 
 Done when:
 - [ ] `netclaw doctor` validates provider entry has required fields for its auth method (API key present for `ApiKey`, OAuth tokens for `OAuthDevice`).
-- [ ] Doctor checks model provenance and warns (exit 2) when model source is `Cache`, `Defaults`, or `Manual`.
+- [ ] Doctor checks model provenance and warns (exit 2) when model source is `Defaults` or `Manual`.
 - [ ] Doctor checks primary model provider is reachable (ping endpoint, verify auth).
 - [ ] Remediation-first output for each failure with specific fix commands.
 
@@ -173,8 +173,7 @@ Done when:
 **Verification:** L2
 
 Done when:
-- [ ] Model discovery fallback order implemented: live catalog → cache → curated defaults → manual entry.
-- [ ] Cached catalogs stored per provider type in `~/.netclaw/cache/models/`.
+- [ ] Model discovery fallback order implemented: live catalog → curated defaults → manual entry.
 - [ ] `ModelDiscoverySource` provenance persisted with `ModelReference` in config.
 - [ ] Tests with mocked discovery API verify fallback cascade and provenance tagging.
 

--- a/docs/ui/TUI-001-command-wireframes.md
+++ b/docs/ui/TUI-001-command-wireframes.md
@@ -254,7 +254,7 @@ $ netclaw provider remove my-openrouter
 ## `netclaw model` — Dual-Mode Model Selection
 
 **Bare invocation** launches Termina TUI — a tree-based model browser showing all
-configured providers, their available models (via live/cached discovery), and
+configured providers, their available models (via live discovery or curated defaults), and
 current role assignments. Operator selects a role, browses models, and assigns.
 
 **With args** (`--role`, `--provider`, `--model`) runs as single-shot assignment.
@@ -301,7 +301,7 @@ PanelNode (outer: "Model Selection")
 
 ### Behaviors
 
-- Tree populated via model discovery (live → cache → defaults) across all
+- Tree populated via model discovery (live → curated defaults) across all
   configured providers
 - SpinnerNode shown while discovering models from each provider
 - Provider auth status shown inline (✓ valid / ⚠ expired / ✗ unreachable)

--- a/openspec/changes/oauth-first-provider-onboarding/design.md
+++ b/openspec/changes/oauth-first-provider-onboarding/design.md
@@ -47,7 +47,7 @@ Alternatives considered:
 
 ### Decision: Model discovery uses tiered fallback path with explicit provenance
 
-Model selection will attempt, in order: (1) live provider catalog API, (2) cached last-known-good catalog, (3) curated provider defaults in config templates, (4) operator manual model entry with validation.
+Model selection will attempt, in order: (1) live provider catalog API, (2) curated provider defaults in config templates, (3) operator manual model entry with validation.
 
 Rationale:
 - Preserves onboarding momentum during transient provider outages.
@@ -71,7 +71,7 @@ Alternatives considered:
 ## Risks / Trade-offs
 
 - [OAuth polling variability across providers] -> Mitigation: normalize polling interval/backoff policy in provider profile metadata and surface wait state in Termina progress components.
-- [Catalog fallback picks outdated models] -> Mitigation: annotate model provenance in config and doctor output, warn when using cache/default/manual sources.
+- [Catalog fallback picks outdated models] -> Mitigation: annotate model provenance in config and doctor output, warn when using default/manual sources.
 - [Increased onboarding complexity] -> Mitigation: render branch context headers in Termina ("Provider: X | Auth: OAuth device flow") and allow back-navigation without data loss.
 - [Security regression from mixed credential modes] -> Mitigation: enforce masked input, redact logs, and fail closed when required auth artifacts are missing for selected branch.
 
@@ -112,10 +112,12 @@ model selection just used a degraded source. Doctor output will include the
 provenance and a suggestion to re-run model discovery when the catalog is
 available again.
 
-### Q: Should onboarding cache model catalogs per profile or per provider name?
+### Q: Should onboarding cache model catalogs?
 
-**Resolved.** Per provider name. Multiple profiles pointing to the same provider
-type share cached catalog data. Cache location: `~/.netclaw/cache/models/`.
+**Resolved.** No. Model selection is infrequent (onboarding and occasional
+`netclaw model` invocation). The fallback to curated defaults already covers
+the "provider is down" case. A stale cache would create more confusion than
+a slightly slower live lookup.
 
 ---
 
@@ -141,7 +143,6 @@ public enum AuthMethod
 public enum ModelDiscoverySource
 {
     Live,     // From provider's model listing API
-    Cache,    // From cached last-known-good catalog
     Defaults, // From curated defaults in config templates
     Manual    // Operator typed it in
 }
@@ -154,14 +155,15 @@ public sealed class ProviderEntry
 {
     public string Type { get; set; } = "ollama";
     public string Endpoint { get; set; } = "http://localhost:11434";
-    public string? ApiKey { get; set; }
 
     // NEW: resolved auth method for this provider instance
     public AuthMethod AuthMethod { get; set; } = AuthMethod.None;
 
-    // NEW: OAuth artifacts (populated after successful device flow)
-    public string? OAuthAccessToken { get; set; }
-    public string? OAuthRefreshToken { get; set; }
+    // Secret fields use SensitiveString — ToString() returns "***REDACTED***"
+    // to prevent accidental logging. TypeConverter enables config binding.
+    public SensitiveString? ApiKey { get; set; }
+    public SensitiveString? OAuthAccessToken { get; set; }
+    public SensitiveString? OAuthRefreshToken { get; set; }
     public DateTimeOffset? OAuthTokenExpiry { get; set; }
 }
 ```
@@ -242,7 +244,7 @@ Step 1: Provider Selection
 │       └── TextInputNode: "Ollama endpoint" (default: http://localhost:11434)
 │
 └── Step 1c: Model Selection
-    ├── Attempt live discovery → cache → defaults → manual
+    ├── Attempt live discovery → defaults → manual
     ├── SelectionListNode: [discovered models] or TextInputNode for manual
     └── TextNode: "Source: {provenance}" (live/cache/defaults/manual)
 
@@ -335,7 +337,7 @@ Bare `netclaw model` launches Termina with a tree-based model browser:
 ╰──────────────────────────────────────────────────────────────╯
 ```
 
-The tree is populated from model discovery (live → cache → defaults) across all
+The tree is populated from model discovery (live → curated defaults) across all
 configured providers. The model selector component is shared with the wizard's
 Step 1c.
 

--- a/openspec/changes/oauth-first-provider-onboarding/design.md
+++ b/openspec/changes/oauth-first-provider-onboarding/design.md
@@ -441,3 +441,52 @@ credential-dependent interactive work:
 - `netclaw provider` TUI and `provider add/list/remove` single-shot commands
 - `netclaw model` TUI and single-shot model role assignment
 - End-to-end onboarding smoke test with real provider
+
+---
+
+## Implementation Notes (from Phase A build-out)
+
+Findings from implementing the init wizard provider validation and model
+discovery (Feb 2026). These affect Phase B planning.
+
+### Anthropic OAuth Device Flow — confirmed viable
+
+In Feb 2026, Anthropic initially appeared to ban all third-party OAuth use but
+quickly clarified it was a "docs clean up" that caused confusion. The actual
+policy:
+
+- **OAuth via Agent SDK for local/personal use: allowed.** This is Netclaw's
+  use case (homelab assistant).
+- **Commercial businesses built on OAuth tokens: should use API keys instead.**
+- Quote from Anthropic: "Nothing is changing about how you can use the Agent SDK
+  and MAX subscriptions."
+
+Sources:
+- https://thenewstack.io/anthropic-agent-sdk-confusion/
+- https://alternativeto.net/news/2026/2/anthropic-officially-bans-using-subscription-authentication-for-third-party-claude-use/
+
+The Anthropic SDK handles token lifecycle (refresh, expiry). Phase B
+implementation needs RFC 8628 device authorization grant polling loop +
+storing/refreshing tokens via the SDK.
+
+### OpenRouter model listing is public
+
+OpenRouter's `GET /api/v1/models` returns 200 with the full model catalog
+regardless of whether the bearer token is valid. The API key is only validated
+on actual inference calls. This means:
+
+- **Probe validates connectivity but NOT key validity** for OpenRouter.
+- Users with a bogus key will successfully complete onboarding and only discover
+  the key is bad when they try to chat.
+- A future `netclaw doctor` check could hit a key-validation endpoint (e.g.,
+  `/api/v1/auth/key`) to catch this, but that's separate from onboarding.
+
+### Termina DynamicLayoutNode factory purity rule
+
+DynamicLayoutNode factories must be **pure render functions** — no state
+mutations, no `Invalidate()` calls, no sub-step transitions. Calling
+`SetProviderSubStep()` inside a factory re-entrantly invalidates the node during
+its own evaluation, blanking the screen.
+
+State transitions belong in reactive subscriptions outside the factory. Filed
+as Termina issue: https://github.com/Aaronontheweb/termina/issues/159

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-model-providers/spec.md
@@ -57,18 +57,18 @@ authorization as a first-class provider onboarding method.
 ### Requirement: Model discovery fallback sequence
 
 Model selection SHALL use deterministic fallback when live model discovery is
-unavailable. The fallback order SHALL be: live provider catalog, cached
-last-known-good catalog, curated provider defaults, then manual model entry.
+unavailable. The fallback order SHALL be: live provider catalog, curated
+provider defaults, then manual model entry.
 
 #### Scenario: Live catalog unavailable
 - **GIVEN** provider profile and auth are configured
 - **WHEN** live model catalog request fails
-- **THEN** system attempts cached catalog and then curated defaults in order
-- **AND** onboarding prompts for manual entry only if prior fallback paths fail
+- **THEN** system attempts curated defaults
+- **AND** onboarding prompts for manual entry only if curated defaults fail
 
 #### Scenario: Model provenance recorded
 - **GIVEN** model is selected through any discovery path
 - **WHEN** provider configuration is saved
-- **THEN** system records the model source as one of `live`, `cache`,
-  `defaults`, or `manual`
+- **THEN** system records the model source as one of `live`, `defaults`,
+  or `manual`
 - **AND** diagnostics expose this provenance to operators

--- a/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/oauth-first-provider-onboarding/specs/netclaw-onboarding/spec.md
@@ -27,8 +27,8 @@ configuration is functional.
 #### Scenario: Model discovery fallback branch
 - **GIVEN** provider and auth branch are selected
 - **WHEN** live model catalog discovery fails or returns no usable models
-- **THEN** onboarding executes fallback in order: cached catalog, curated
-  defaults, manual model entry
+- **THEN** onboarding executes fallback in order: curated defaults, manual
+  model entry
 - **AND** the selected model source provenance is recorded for diagnostics
 
 #### Scenario: Health check on completion

--- a/openspec/changes/oauth-first-provider-onboarding/tasks.md
+++ b/openspec/changes/oauth-first-provider-onboarding/tasks.md
@@ -12,8 +12,8 @@
 
 ## 3. Model Discovery Fallback Paths
 
-- [ ] 3.1 Implement model discovery fallback order (live catalog -> cache -> curated defaults -> manual entry)
-- [ ] 3.2 Persist model provenance (`live`, `cache`, `defaults`, `manual`) with provider config
+- [ ] 3.1 Implement model discovery fallback order (live catalog -> curated defaults -> manual entry)
+- [ ] 3.2 Persist model provenance (`live`, `defaults`, `manual`) with provider config
 - [ ] 3.3 Add onboarding completion summary details for selected model source and fallback/degraded state
 
 ## 4. Doctor Follow-Up Checks

--- a/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
@@ -1,3 +1,5 @@
+using Netclaw.Configuration;
+
 namespace Netclaw.Channels.Slack;
 
 public sealed class SlackChannelOptions
@@ -6,9 +8,9 @@ public sealed class SlackChannelOptions
 
     public bool SocketMode { get; init; } = true;
 
-    public string? BotToken { get; init; }
+    public SensitiveString? BotToken { get; init; }
 
-    public string? AppToken { get; init; }
+    public SensitiveString? AppToken { get; init; }
 
     public string? DefaultChannelId { get; init; }
 

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Builder;
+using R3;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;

--- a/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
@@ -1,0 +1,41 @@
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Test double for <see cref="IProviderProbe"/> that returns canned results
+/// without making real HTTP calls.
+/// </summary>
+public sealed class FakeProviderProbe : IProviderProbe
+{
+    /// <summary>
+    /// The result to return from the next <see cref="ProbeAsync"/> call.
+    /// Defaults to a successful probe with two sample models.
+    /// </summary>
+    public ProviderProbeResult NextResult { get; set; } = new(
+        true, null,
+        [
+            new DiscoveredModel { ModelId = "model-a" },
+            new DiscoveredModel { ModelId = "model-b" }
+        ]);
+
+    /// <summary>
+    /// Number of times <see cref="ProbeAsync"/> has been called.
+    /// </summary>
+    public int ProbeCallCount { get; private set; }
+
+    /// <summary>
+    /// The provider type from the last call.
+    /// </summary>
+    public string? LastProviderType { get; private set; }
+
+    public Task<ProviderProbeResult> ProbeAsync(
+        string providerType, string? endpoint, string? apiKey,
+        CancellationToken ct = default)
+    {
+        ProbeCallCount++;
+        LastProviderType = providerType;
+        return Task.FromResult(NextResult);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Tests for <see cref="InitWizardViewModel"/> state machine, back-navigation
+/// clearing rules, and config file writing.
+/// </summary>
+public sealed class InitWizardViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public InitWizardViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void StartsAtProviderStep()
+    {
+        using var vm = CreateViewModel();
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+    }
+
+    [Fact]
+    public void GoNext_AdvancesStep()
+    {
+        using var vm = CreateViewModel();
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+
+        vm.GoNext();
+        Assert.Equal(WizardStep.Slack, vm.CurrentStep);
+
+        vm.GoNext();
+        Assert.Equal(WizardStep.Acl, vm.CurrentStep);
+
+        vm.GoNext();
+        Assert.Equal(WizardStep.Mcp, vm.CurrentStep);
+
+        vm.GoNext();
+        Assert.Equal(WizardStep.Exposure, vm.CurrentStep);
+
+        vm.GoNext();
+        Assert.Equal(WizardStep.HealthCheck, vm.CurrentStep);
+    }
+
+    [Fact]
+    public void GoBack_ReturnsToPreviousStep()
+    {
+        using var vm = CreateViewModel();
+        vm.GoNext(); // → Slack
+        vm.GoNext(); // → Acl
+
+        vm.GoBack(); // → Slack
+        Assert.Equal(WizardStep.Slack, vm.CurrentStep);
+
+        vm.GoBack(); // → Provider
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+    }
+
+    [Fact]
+    public void GoBack_FromProvider_ClearsAuthState()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openai";
+        vm.SelectedAuthMethod = AuthMethod.ApiKey;
+        vm.ApiKeyInput = "sk-test-key";
+        vm.EndpointInput = "https://custom.endpoint";
+
+        vm.GoNext(); // → Slack
+        vm.GoBack(); // → Provider (should clear auth state)
+
+        Assert.Equal(AuthMethod.None, vm.SelectedAuthMethod);
+        Assert.Null(vm.ApiKeyInput);
+        Assert.Null(vm.EndpointInput);
+    }
+
+    [Fact]
+    public void ClearFromProvider_ClearsAuthAndCredentials()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedAuthMethod = AuthMethod.ApiKey;
+        vm.ApiKeyInput = "sk-test";
+        vm.EndpointInput = "http://localhost:11434";
+
+        vm.ClearFromProvider();
+
+        Assert.Equal(AuthMethod.None, vm.SelectedAuthMethod);
+        Assert.Null(vm.ApiKeyInput);
+        Assert.Null(vm.EndpointInput);
+    }
+
+    [Fact]
+    public async Task HealthCheck_WritesOllamaConfig()
+    {
+        using var vm = CreateViewModel();
+
+        vm.SelectedProviderType = "ollama";
+        vm.SelectedAuthMethod = AuthMethod.None;
+        vm.EndpointInput = "http://big-gpu:11434";
+        vm.SlackEnabled = false;
+
+        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.GoNext(); // triggers health check
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete);
+
+        // Verify netclaw.json
+        Assert.True(File.Exists(_paths.NetclawConfigPath));
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+
+        Assert.True(config.RootElement.TryGetProperty("Providers", out var providers));
+        Assert.True(providers.TryGetProperty("ollama", out var ollamaEntry));
+        Assert.Equal("ollama", ollamaEntry.GetProperty("Type").GetString());
+        Assert.Equal("http://big-gpu:11434", ollamaEntry.GetProperty("Endpoint").GetString());
+
+        // Ollama has no API key — secrets.json should not have provider secrets
+        if (File.Exists(_paths.SecretsPath))
+        {
+            var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+            Assert.False(secrets.RootElement.TryGetProperty("Providers", out _),
+                "Ollama should not have provider secrets");
+        }
+    }
+
+    [Fact]
+    public async Task HealthCheck_WritesApiKeyToSecrets()
+    {
+        using var vm = CreateViewModel();
+
+        vm.SelectedProviderType = "openrouter";
+        vm.SelectedAuthMethod = AuthMethod.ApiKey;
+        vm.ApiKeyInput = "sk-or-test-1234567890";
+        vm.SlackEnabled = false;
+
+        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete);
+
+        // secrets.json contains the API key
+        Assert.True(File.Exists(_paths.SecretsPath));
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        Assert.True(secrets.RootElement.TryGetProperty("Providers", out var providers));
+        Assert.True(providers.TryGetProperty("openrouter", out var entry));
+        Assert.Equal("sk-or-test-1234567890", entry.GetProperty("ApiKey").GetString());
+
+        // netclaw.json must NOT contain the API key
+        Assert.DoesNotContain("sk-or-test", File.ReadAllText(_paths.NetclawConfigPath));
+    }
+
+    [Fact]
+    public async Task HealthCheck_WritesSlackTokensToSecrets()
+    {
+        using var vm = CreateViewModel();
+
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+
+        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete);
+
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        Assert.True(secrets.RootElement.TryGetProperty("Slack", out var slack));
+        Assert.Equal("xoxb-test-bot-token", slack.GetProperty("BotToken").GetString());
+        Assert.Equal("xapp-test-app-token", slack.GetProperty("AppToken").GetString());
+
+        // Tokens must NOT appear in netclaw.json
+        var configJson = File.ReadAllText(_paths.NetclawConfigPath);
+        Assert.DoesNotContain("xoxb-test", configJson);
+        Assert.DoesNotContain("xapp-test", configJson);
+    }
+
+    [Fact]
+    public async Task HealthCheck_ReportsProviderValidation()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "anthropic";
+        vm.SelectedAuthMethod = AuthMethod.ApiKey;
+        vm.ApiKeyInput = "sk-ant-test-key";
+
+        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete);
+        Assert.NotEmpty(vm.HealthCheckResults);
+
+        var providerCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("LLM provider", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(providerCheck);
+        Assert.True(providerCheck.Passed);
+    }
+
+    [Fact]
+    public async Task HealthCheck_ReportsSlackDisabled()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = false;
+
+        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var slackCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Slack", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(slackCheck);
+        Assert.True(slackCheck.Passed);
+        Assert.Contains("disabled", slackCheck.Label, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TotalSteps_IsSix()
+    {
+        Assert.Equal(6, InitWizardViewModel.TotalSteps);
+    }
+
+    private InitWizardViewModel CreateViewModel()
+    {
+        return new InitWizardViewModel(_paths);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -7,12 +7,13 @@ namespace Netclaw.Cli.Tests.Tui;
 
 /// <summary>
 /// Tests for <see cref="InitWizardViewModel"/> state machine, back-navigation
-/// clearing rules, and config file writing.
+/// clearing rules, ACL skip logic, provider probing, and config file writing.
 /// </summary>
 public sealed class InitWizardViewModelTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
+    private readonly FakeProviderProbe _fakeProbe = new();
 
     public InitWizardViewModelTests()
     {
@@ -38,10 +39,11 @@ public sealed class InitWizardViewModelTests : IDisposable
     public void GoNext_AdvancesStep()
     {
         using var vm = CreateViewModel();
+        vm.SlackEnabled = true; // enable chat services so ACL is not skipped
         Assert.Equal(WizardStep.Provider, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Slack, vm.CurrentStep.Value);
+        Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
 
         vm.GoNext();
         Assert.Equal(WizardStep.Acl, vm.CurrentStep.Value);
@@ -60,11 +62,12 @@ public sealed class InitWizardViewModelTests : IDisposable
     public void GoBack_ReturnsToPreviousStep()
     {
         using var vm = CreateViewModel();
-        vm.GoNext(); // → Slack
+        vm.SlackEnabled = true;
+        vm.GoNext(); // → ChatServices
         vm.GoNext(); // → Acl
 
-        vm.GoBack(); // → Slack
-        Assert.Equal(WizardStep.Slack, vm.CurrentStep.Value);
+        vm.GoBack(); // → ChatServices
+        Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
 
         vm.GoBack(); // → Provider
         Assert.Equal(WizardStep.Provider, vm.CurrentStep.Value);
@@ -79,7 +82,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.ApiKeyInput = "sk-test-key";
         vm.EndpointInput = "https://custom.endpoint";
 
-        vm.GoNext(); // → Slack
+        vm.GoNext(); // → ChatServices
         vm.GoBack(); // → Provider (should clear auth state)
 
         Assert.Equal(AuthMethod.None, vm.SelectedAuthMethod);
@@ -100,6 +103,89 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Equal(AuthMethod.None, vm.SelectedAuthMethod);
         Assert.Null(vm.ApiKeyInput);
         Assert.Null(vm.EndpointInput);
+    }
+
+    [Fact]
+    public void ClearFromProvider_ClearsProbeResultAndModel()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedModelId = "test-model";
+        vm.DiscoveredModels.Add(new DiscoveredModel { ModelId = "test-model" });
+        vm.ProbeResult.Value = new ProviderProbeResult(true, null,
+            [new DiscoveredModel { ModelId = "test-model" }]);
+
+        vm.ClearFromProvider();
+
+        Assert.Null(vm.SelectedModelId);
+        Assert.Empty(vm.DiscoveredModels);
+        Assert.Null(vm.ProbeResult.Value);
+    }
+
+    [Fact]
+    public void GoNext_SkipsAcl_WhenNoChatServicesEnabled()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = false;
+
+        vm.GoNext(); // Provider → ChatServices
+        Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
+
+        vm.GoNext(); // ChatServices → should skip ACL → Mcp
+        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
+    }
+
+    [Fact]
+    public void GoBack_SkipsAcl_WhenNoChatServicesEnabled()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = false;
+
+        vm.GoNext(); // → ChatServices
+        vm.GoNext(); // → Mcp (ACL skipped)
+        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
+
+        vm.GoBack(); // → ChatServices (ACL skipped going back)
+        Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
+    }
+
+    [Fact]
+    public async Task ProbeProvider_StoresDiscoveredModels()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.EndpointInput = "http://localhost:11434";
+
+        _fakeProbe.NextResult = new ProviderProbeResult(true, null,
+        [
+            new DiscoveredModel { ModelId = "llama3:latest" },
+            new DiscoveredModel { ModelId = "qwen3:30b" }
+        ]);
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(vm.ProbeResult.Value!.Success);
+        Assert.Equal(2, vm.DiscoveredModels.Count);
+        Assert.Equal("llama3:latest", vm.DiscoveredModels[0].ModelId);
+        Assert.Equal("qwen3:30b", vm.DiscoveredModels[1].ModelId);
+        Assert.Equal("ollama", _fakeProbe.LastProviderType);
+    }
+
+    [Fact]
+    public async Task ProbeProvider_ReportsFailure()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openrouter";
+        vm.ApiKeyInput = "bad-key";
+
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "Invalid API key", []);
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(vm.ProbeResult.Value!.Success);
+        Assert.Equal("Invalid API key", vm.ProbeResult.Value.ErrorMessage);
+        Assert.Empty(vm.DiscoveredModels);
     }
 
     [Fact]
@@ -191,6 +277,30 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task HealthCheck_WritesModelIdToConfig()
+    {
+        using var vm = CreateViewModel();
+
+        vm.SelectedProviderType = "openrouter";
+        vm.SelectedAuthMethod = AuthMethod.ApiKey;
+        vm.ApiKeyInput = "sk-or-test-key";
+        vm.SelectedModelId = "anthropic/claude-sonnet-4-20250514";
+        vm.SlackEnabled = false;
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete.Value);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Models", out var models));
+        Assert.True(models.TryGetProperty("Main", out var main));
+        Assert.Equal("openrouter", main.GetProperty("Provider").GetString());
+        Assert.Equal("anthropic/claude-sonnet-4-20250514", main.GetProperty("ModelId").GetString());
+    }
+
+    [Fact]
     public async Task HealthCheck_ReportsProviderValidation()
     {
         using var vm = CreateViewModel();
@@ -236,8 +346,39 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Equal(6, InitWizardViewModel.TotalSteps);
     }
 
+    [Fact]
+    public void ActiveStepCount_IsFive_WhenNoChatServices()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = false;
+        Assert.Equal(5, vm.ActiveStepCount);
+    }
+
+    [Fact]
+    public void ActiveStepCount_IsSix_WhenChatServicesEnabled()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = true;
+        Assert.Equal(6, vm.ActiveStepCount);
+    }
+
+    [Fact]
+    public void GetDisplayStepNumber_AdjustsForSkippedAcl()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = false;
+
+        // Provider = 1, ChatServices = 2, Acl would be 3 but skipped
+        // Mcp = 3 (adjusted from 4), Exposure = 4, HealthCheck = 5
+        Assert.Equal(1, vm.GetDisplayStepNumber(WizardStep.Provider));
+        Assert.Equal(2, vm.GetDisplayStepNumber(WizardStep.ChatServices));
+        Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Mcp));
+        Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.Exposure));
+        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
+    }
+
     private InitWizardViewModel CreateViewModel()
     {
-        return new InitWizardViewModel(_paths);
+        return new InitWizardViewModel(_paths, _fakeProbe);
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -31,29 +31,29 @@ public sealed class InitWizardViewModelTests : IDisposable
     public void StartsAtProviderStep()
     {
         using var vm = CreateViewModel();
-        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep.Value);
     }
 
     [Fact]
     public void GoNext_AdvancesStep()
     {
         using var vm = CreateViewModel();
-        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Slack, vm.CurrentStep);
+        Assert.Equal(WizardStep.Slack, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Acl, vm.CurrentStep);
+        Assert.Equal(WizardStep.Acl, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Mcp, vm.CurrentStep);
+        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Exposure, vm.CurrentStep);
+        Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.HealthCheck, vm.CurrentStep);
+        Assert.Equal(WizardStep.HealthCheck, vm.CurrentStep.Value);
     }
 
     [Fact]
@@ -64,10 +64,10 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.GoNext(); // → Acl
 
         vm.GoBack(); // → Slack
-        Assert.Equal(WizardStep.Slack, vm.CurrentStep);
+        Assert.Equal(WizardStep.Slack, vm.CurrentStep.Value);
 
         vm.GoBack(); // → Provider
-        Assert.Equal(WizardStep.Provider, vm.CurrentStep);
+        Assert.Equal(WizardStep.Provider, vm.CurrentStep.Value);
     }
 
     [Fact]
@@ -112,11 +112,11 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.EndpointInput = "http://big-gpu:11434";
         vm.SlackEnabled = false;
 
-        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext(); // triggers health check
 
         await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(vm.IsComplete);
+        Assert.True(vm.IsComplete.Value);
 
         // Verify netclaw.json
         Assert.True(File.Exists(_paths.NetclawConfigPath));
@@ -146,11 +146,11 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.ApiKeyInput = "sk-or-test-1234567890";
         vm.SlackEnabled = false;
 
-        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext();
 
         await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(vm.IsComplete);
+        Assert.True(vm.IsComplete.Value);
 
         // secrets.json contains the API key
         Assert.True(File.Exists(_paths.SecretsPath));
@@ -173,11 +173,11 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackBotToken = "xoxb-test-bot-token";
         vm.SlackAppToken = "xapp-test-app-token";
 
-        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext();
 
         await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(vm.IsComplete);
+        Assert.True(vm.IsComplete.Value);
 
         var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
         Assert.True(secrets.RootElement.TryGetProperty("Slack", out var slack));
@@ -198,11 +198,11 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SelectedAuthMethod = AuthMethod.ApiKey;
         vm.ApiKeyInput = "sk-ant-test-key";
 
-        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext();
 
         await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(vm.IsComplete);
+        Assert.True(vm.IsComplete.Value);
         Assert.NotEmpty(vm.HealthCheckResults);
 
         var providerCheck = vm.HealthCheckResults
@@ -218,7 +218,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SelectedProviderType = "ollama";
         vm.SlackEnabled = false;
 
-        vm.CurrentStep = WizardStep.HealthCheck;
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext();
 
         await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -1,6 +1,5 @@
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Microsoft.AspNetCore.SignalR.Client;
+using R3;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
@@ -90,8 +89,8 @@ public sealed class DaemonClient : IAsyncDisposable
         };
     }
 
-    public IObservable<SessionOutput> SessionOutput => _outputSubject.AsObservable();
-    public IObservable<DaemonConnectionEvent> ConnectionEvents => _connectionSubject.AsObservable();
+    public Observable<SessionOutput> SessionOutput => _outputSubject.AsObservable();
+    public Observable<DaemonConnectionEvent> ConnectionEvents => _connectionSubject.AsObservable();
 
     public bool IsConnected => _connection.State is HubConnectionState.Connected;
 

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -5,6 +5,7 @@ using Netclaw.Configuration;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels;
 using Netclaw.Cli.Daemon;
+using R3;
 
 namespace Netclaw.Cli;
 

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -9,6 +9,7 @@ using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
+using Termina.Diagnostics;
 using Termina.Hosting;
 
 try
@@ -77,6 +78,14 @@ static async Task RunAsync(string[] args)
 
         if (mode is "init")
         {
+            // Enable Termina trace logging for debugging TUI input/rendering issues
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-init-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+            Console.Error.WriteLine($"Trace log: {traceFile}");
+
+            // Provider probe for credential validation + model discovery
+            builder.Services.AddHttpClient<IProviderProbe, ProviderProbe>();
+
             builder.Services.AddTermina("/init", termina =>
             {
                 termina.RegisterRoute<InitWizardPage, InitWizardViewModel>("/init");

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -75,10 +75,15 @@ static async Task RunAsync(string[] args)
         builder.Logging.ClearProviders();
         builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
-        // TODO: init → Termina TUI wizard (Task 1.22)
         if (mode is "init")
         {
-            Console.WriteLine("netclaw init: not yet implemented");
+            builder.Services.AddTermina("/init", termina =>
+            {
+                termina.RegisterRoute<InitWizardPage, InitWizardViewModel>("/init");
+            });
+
+            var initApp = builder.Build();
+            await initApp.RunAsync();
             return;
         }
 

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -1,7 +1,6 @@
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Text;
 using Netclaw.Actors.Protocol;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Extensions;
 using Termina.Input;
@@ -48,13 +47,13 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         _promptInput = new TextInputNode()
             .WithPlaceholder("Type a message...");
 
-        // Handle prompt submission — Buffer coalesces rapid-fire submissions
+        // Handle prompt submission — Chunk coalesces rapid-fire submissions
         // (e.g., pasting multi-line text where each CRLF triggers Submitted)
         // into a single message. Normal typing produces one item per buffer window.
         _promptInput.Submitted
             .Where(text => !string.IsNullOrWhiteSpace(text))
-            .Buffer(TimeSpan.FromMilliseconds(100))
-            .Where(batch => batch.Count > 0)
+            .Chunk(TimeSpan.FromMilliseconds(100))
+            .Where(batch => batch.Length > 0)
             .Subscribe(batch =>
             {
                 _promptInput.Clear();
@@ -73,22 +72,21 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
 
         // Subscribe to session output
         ViewModel.SessionOutput
-            .ObserveOn(System.Reactive.Concurrency.CurrentThreadScheduler.Instance)
             .Subscribe(HandleOutput)
             .DisposeWith(Subscriptions);
 
         // Route keyboard input
-        ViewModel.Input.OfType<KeyPressed>()
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
 
         // Route bracketed paste events directly to the text input node
-        ViewModel.Input.OfType<PasteEvent>()
+        ViewModel.Input.OfType<IInputEvent, PasteEvent>()
             .Subscribe(paste => _promptInput.HandlePaste(paste))
             .DisposeWith(Subscriptions);
 
         // Route mouse wheel scrolling to chat history
-        ViewModel.Input.OfType<MouseScrollEvent>()
+        ViewModel.Input.OfType<IInputEvent, MouseScrollEvent>()
             .Subscribe(HandleMouseScroll)
             .DisposeWith(Subscriptions);
     }
@@ -120,10 +118,10 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
     private LayoutNode BuildStatusBar()
     {
         return Observable.CombineLatest(
-                ViewModel.IsGeneratingChanged,
-                ViewModel.IsInputEnabledChanged,
-                ViewModel.StatusMessageChanged,
-                ViewModel.UsageDisplayChanged.StartWith((string?)null),
+                ViewModel.IsGenerating,
+                ViewModel.IsInputEnabled,
+                ViewModel.StatusMessage,
+                ViewModel.UsageDisplay,
                 (isGenerating, isInputEnabled, status, usage) =>
                 {
                     var keys = isGenerating
@@ -166,7 +164,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
         // Escape: cancel or quit
         if (keyInfo.Key == ConsoleKey.Escape)
         {
-            if (ViewModel.IsGenerating)
+            if (ViewModel.IsGenerating.Value)
             {
                 // TODO: cancel generation when supported
             }
@@ -295,7 +293,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 var ctxPart = usagePercent.HasValue
                     ? $" ({usagePercent.Value:P0} ctx)"
                     : "";
-                ViewModel.UsageDisplay = $"in={msg.InputTokens ?? 0} out={msg.OutputTokens ?? 0}{ctxPart}";
+                ViewModel.UsageDisplay.Value = $"in={msg.InputTokens ?? 0} out={msg.OutputTokens ?? 0}{ctxPart}";
                 break;
 
             case ErrorOutput msg:
@@ -306,7 +304,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
             case TurnCompleted:
                 RemoveThinkingSpinner();
                 FinalizeAssistantSegmentIfNeeded();
-                ViewModel.StatusMessage = "Ready";
+                ViewModel.StatusMessage.Value = "Ready";
                 _chatHistory.ScrollToBottom();
                 break;
 

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -1,10 +1,9 @@
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
+using R3;
 using Termina.Reactive;
 
 namespace Netclaw.Cli.Tui;
@@ -26,19 +25,17 @@ public partial class ChatViewModel : ReactiveViewModel
     private bool _sessionReady;
     private int _connectAttempts;
 
-#pragma warning disable CS0169, CS0414 // Backing fields used by [Reactive] source generator
-    [Reactive] private bool _isGenerating;
-    [Reactive] private bool _isInputEnabled = true;
-    [Reactive] private string _statusMessage = "Connecting...";
-    [Reactive] private string? _sessionIdDisplay;
-    [Reactive] private string? _usageDisplay;
-#pragma warning restore CS0169, CS0414
+    public ReactiveProperty<bool> IsGenerating { get; } = new(false);
+    public ReactiveProperty<bool> IsInputEnabled { get; } = new(true);
+    public ReactiveProperty<string> StatusMessage { get; } = new("Connecting...");
+    public ReactiveProperty<string?> SessionIdDisplay { get; } = new(null);
+    public ReactiveProperty<string?> UsageDisplay { get; } = new(null);
 
     /// <summary>
     /// Observable stream of session output events. The page subscribes to this
     /// to render chat messages, tool activity, usage, etc.
     /// </summary>
-    public IObservable<SessionOutput> SessionOutput => _outputSubject.AsObservable();
+    public Observable<SessionOutput> SessionOutput => _outputSubject.AsObservable();
 
     /// <summary>
     /// The configured model identifier for display in the status bar.
@@ -73,10 +70,10 @@ public partial class ChatViewModel : ReactiveViewModel
                 switch (output)
                 {
                     case TurnCompleted:
-                        IsGenerating = false;
+                        IsGenerating.Value = false;
                         break;
                     case ErrorOutput:
-                        IsGenerating = false;
+                        IsGenerating.Value = false;
                         break;
                 }
 
@@ -96,10 +93,10 @@ public partial class ChatViewModel : ReactiveViewModel
                     _ = EnsureSessionAndFlushAsync();
                 }
 
-                if (IsGenerating && evt.State is DaemonConnectionState.Connected)
-                    StatusMessage = "Generating...";
+                if (IsGenerating.Value && evt.State is DaemonConnectionState.Connected)
+                    StatusMessage.Value = "Generating...";
                 else
-                    StatusMessage = evt.Message;
+                    StatusMessage.Value = evt.Message;
 
                 RequestRedraw();
             });
@@ -119,16 +116,16 @@ public partial class ChatViewModel : ReactiveViewModel
         if (!_sessionReady || !_daemonClient.IsConnected)
         {
             _pendingMessages.Enqueue(text);
-            IsGenerating = false;
-            IsInputEnabled = true;
-            StatusMessage = $"Queued {_pendingMessages.Count} message(s). Reconnecting...";
+            IsGenerating.Value = false;
+            IsInputEnabled.Value = true;
+            StatusMessage.Value = $"Queued {_pendingMessages.Count} message(s). Reconnecting...";
             RequestRedraw();
             _ = ConnectUntilReadyAsync();
             return;
         }
 
-        IsGenerating = true;
-        StatusMessage = "Generating...";
+        IsGenerating.Value = true;
+        StatusMessage.Value = "Generating...";
 
         try
         {
@@ -143,11 +140,11 @@ public partial class ChatViewModel : ReactiveViewModel
         }
         catch (Exception ex)
         {
-            IsGenerating = false;
+            IsGenerating.Value = false;
             _sessionReady = false;
-            IsInputEnabled = true;
+            IsInputEnabled.Value = true;
             _pendingMessages.Enqueue(text);
-            StatusMessage = $"Send failed ({ex.Message}). Reconnecting...";
+            StatusMessage.Value = $"Send failed ({ex.Message}). Reconnecting...";
             RequestRedraw();
             _ = ConnectUntilReadyAsync();
         }
@@ -164,7 +161,11 @@ public partial class ChatViewModel : ReactiveViewModel
         _daemonConnectionSubscription?.Dispose();
         _outputSubject.Dispose();
 
-        DisposeReactiveFields();
+        IsGenerating.Dispose();
+        IsInputEnabled.Dispose();
+        StatusMessage.Dispose();
+        SessionIdDisplay.Dispose();
+        UsageDisplay.Dispose();
         base.Dispose();
     }
 
@@ -190,7 +191,7 @@ public partial class ChatViewModel : ReactiveViewModel
             {
                 _connectAttempts++;
                 var idx = Math.Min(_connectAttempts - 1, delays.Length - 1);
-                StatusMessage = $"Connecting... retry {_connectAttempts} in {delays[idx].TotalSeconds:0}s";
+                StatusMessage.Value = $"Connecting... retry {_connectAttempts} in {delays[idx].TotalSeconds:0}s";
                 RequestRedraw();
                 await Task.Delay(delays[idx]);
             }
@@ -200,9 +201,9 @@ public partial class ChatViewModel : ReactiveViewModel
     private async Task EnsureSessionAndFlushAsync()
     {
         var sessionId = await _daemonClient.EnsureSessionAsync("tui");
-        SessionIdDisplay = sessionId;
+        SessionIdDisplay.Value = sessionId;
         _sessionReady = true;
-        IsInputEnabled = true;
+        IsInputEnabled.Value = true;
         _connectAttempts = 0;
 
         while (_pendingMessages.Count > 0)
@@ -216,8 +217,8 @@ public partial class ChatViewModel : ReactiveViewModel
             });
         }
 
-        if (!IsGenerating)
-            StatusMessage = "Ready";
+        if (!IsGenerating.Value)
+            StatusMessage.Value = "Ready";
 
         RequestRedraw();
     }

--- a/src/Netclaw.Cli/Tui/ElapsedTimeSegment.cs
+++ b/src/Netclaw.Cli/Tui/ElapsedTimeSegment.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using R3;
 using Termina.Components.Streaming;
 using Termina.Rendering;
 using Termina.Terminal;
@@ -21,7 +19,7 @@ public sealed class ElapsedTimeSegment : IAnimatedTextSegment
     private readonly TextStyle _style;
     private bool _disposed;
 
-    public IObservable<Unit> Invalidated => _invalidated.AsObservable();
+    public Observable<Unit> Invalidated => _invalidated.AsObservable();
 
     public bool IsAnimating => _timer.Enabled;
 

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -43,20 +43,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
 
-    // Dynamic layout node for step content — invalidated on sub-step changes
+    // Dynamic layout nodes — invalidation-driven (Termina 0.7.1+).
+    // Factory runs once on creation, then only on Invalidate().
     private DynamicLayoutNode? _stepContentNode;
     private DynamicLayoutNode? _helpTextNode;
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Content caching — DynamicLayoutNode calls its factory on EVERY
-    // render cycle. Without caching, new component instances are created
-    // each frame, destroying highlight position, typed text, and focus.
-    // ═══════════════════════════════════════════════════════════════════
-    private record struct ContentCacheKey(WizardStep Step, int ProviderSub, int SlackSub);
-    private ContentCacheKey _contentKey;
-    private ILayoutNode? _cachedStepContent;
-    private ContentCacheKey _helpKey;
-    private ILayoutNode? _cachedHelpContent;
 
     // Step-specific subscriptions — cleared when step content is rebuilt
     // so old subscriptions on disposed components don't linger.
@@ -92,9 +82,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithSpacing(1)
             // Step indicator + progress
             .WithChild(BuildStepIndicator())
-            // Step content (dynamic — rebuilds only on step/sub-step changes)
+            // Step content (rebuilds on Invalidate only)
             .WithChild(BuildStepContent())
-            // Help text (dynamic — rebuilds only on step/sub-step changes)
+            // Help text (rebuilds on Invalidate only)
             .WithChild(BuildHelpText())
             // Status message
             .WithChild(BuildStatusBar())
@@ -132,26 +122,18 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private LayoutNode BuildStepContent()
     {
-        // DynamicLayoutNode re-evaluates the factory on every render cycle.
-        // We cache the result and only rebuild when the step or sub-step
-        // actually changes, so components retain their state across frames.
         _stepContentNode = new DynamicLayoutNode(() =>
         {
             var step = ViewModel.CurrentStep.Value;
 
-            // Health check always rebuilds — results change during the check
+            // Health check has no stateful components — safe to rebuild on every invalidation
             if (step == WizardStep.HealthCheck)
                 return BuildHealthCheckStep();
 
-            var key = new ContentCacheKey(step, _providerSubStep, _slackSubStep);
-            if (key == _contentKey && _cachedStepContent != null)
-                return _cachedStepContent;
-
-            // New step/sub-step — clear subscriptions from previous content
+            // Clear subscriptions from previous step content before building new
             _stepSubs.Clear();
 
-            _contentKey = key;
-            _cachedStepContent = step switch
+            return step switch
             {
                 WizardStep.Provider => BuildProviderStep(),
                 WizardStep.Slack => BuildSlackStep(),
@@ -160,7 +142,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.Exposure => BuildExposureStep(),
                 _ => Layouts.Empty()
             };
-            return _cachedStepContent;
         });
 
         return _stepContentNode.Fill();
@@ -171,11 +152,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         _helpTextNode = new DynamicLayoutNode(() =>
         {
             var step = ViewModel.CurrentStep.Value;
-            var key = new ContentCacheKey(step, _providerSubStep, _slackSubStep);
-            if (key == _helpKey && _cachedHelpContent != null)
-                return _cachedHelpContent;
-
-            _helpKey = key;
             var text = step switch
             {
                 WizardStep.Provider when _providerSubStep == 0 =>
@@ -198,8 +174,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Validating your configuration...",
                 _ => ""
             };
-            _cachedHelpContent = (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
-            return _cachedHelpContent;
+            return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
         });
 
         return _helpTextNode.Height(2);
@@ -749,6 +724,17 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
                 _stepContentNode?.Invalidate();
                 _helpTextNode?.Invalidate();
+            })
+            .DisposeWith(Subscriptions);
+
+        // Health check results change between Invalidate calls (via RequestRedraw).
+        // With invalidation-driven DynamicLayoutNode, we need explicit Invalidate
+        // when the ViewModel signals that health check results have updated.
+        ViewModel.HealthCheckResultVersion
+            .Subscribe(_ =>
+            {
+                if (ViewModel.CurrentStep.Value == WizardStep.HealthCheck)
+                    _stepContentNode?.Invalidate();
             })
             .DisposeWith(Subscriptions);
     }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -88,10 +88,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithSpacing(1)
             // Step indicator + progress
             .WithChild(BuildStepIndicator())
-            // Step content (rebuilds on Invalidate only)
+            // Step content (no Fill — only takes the height it needs)
             .WithChild(BuildStepContent())
-            // Help text (rebuilds on Invalidate only)
+            // Help text (immediately below step content)
             .WithChild(BuildHelpText())
+            // Spacer pushes status + key bindings to bottom
+            .WithChild(Layouts.Empty().Fill())
             // Status message
             .WithChild(BuildStatusBar())
             // Key bindings
@@ -167,7 +169,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             };
         });
 
-        return _stepContentNode.Fill();
+        return _stepContentNode;
     }
 
     private LayoutNode BuildHelpText()
@@ -201,7 +203,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Validating your configuration...",
                 _ => ""
             };
-            return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            return (ILayoutNode)new TextNode(text).WithForeground(Color.Gray);
         });
 
         return _helpTextNode.Height(2);

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -137,6 +137,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             if (step == WizardStep.HealthCheck)
                 return BuildHealthCheckStep();
 
+            // Validation sub-step (provider step 3) is also stateless — just a spinner
+            // or error text. Skip clearing focus/subs so the spinner can tick without
+            // disposing interactive state from the previous sub-step. More importantly,
+            // this factory must NEVER call SetProviderSubStep() — that would re-entrantly
+            // invalidate _stepContentNode during its own evaluation, blanking the screen.
+            if (step == WizardStep.Provider && _providerSubStep == 3)
+                return BuildValidationSubStep();
+
             // Clear stale focus references BEFORE building new content.
             // The old components are about to be replaced/disposed by DynamicLayoutNode.
             // If we leave _lastFocused* pointing at disposed components, the next
@@ -387,6 +395,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .Height(3));
     }
 
+    /// <summary>
+    /// Render-only: shows spinner while probing, success flash, or error message.
+    /// MUST NOT call SetProviderSubStep — that would re-entrantly invalidate
+    /// the DynamicLayoutNode during its own factory evaluation.
+    /// Auto-advance on success is handled by the ProbeResult subscription
+    /// in InitializeComponents.
+    /// </summary>
     private ILayoutNode BuildValidationSubStep()
     {
         var probeResult = ViewModel.ProbeResult.Value;
@@ -406,9 +421,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
         if (probeResult.Success)
         {
-            // Auto-advance to model selection on success
-            SetProviderSubStep(4);
-            return Layouts.Empty(); // will be replaced by model selection on next invalidation
+            // Brief success flash — the ProbeResult subscription will advance
+            // to sub-step 4 (model selection) on the next cycle.
+            var modelCount = probeResult.Models.Count;
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  \u2713 Connected! Found {modelCount} model{(modelCount == 1 ? "" : "s")}.")
+                    .WithForeground(Color.Green));
         }
 
         // Failure — show error and prompt to retry or go back
@@ -905,15 +923,22 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             })
             .DisposeWith(Subscriptions);
 
-        // Invalidate when probe result changes (validation sub-step transitions)
+        // Probe result changed — invalidate to show success/failure, then auto-advance
+        // on success after a brief flash. This runs OUTSIDE the DynamicLayoutNode factory,
+        // so SetProviderSubStep is safe here (no re-entrant invalidation).
         ViewModel.ProbeResult
-            .Subscribe(_ =>
+            .Subscribe(result =>
             {
-                if (ViewModel.CurrentStep.Value == WizardStep.Provider && _providerSubStep == 3)
-                {
-                    _stepContentNode?.Invalidate();
-                    _helpTextNode?.Invalidate();
-                }
+                if (ViewModel.CurrentStep.Value != WizardStep.Provider || _providerSubStep != 3)
+                    return;
+
+                // Always invalidate to render the new state (success flash or error)
+                _stepContentNode?.Invalidate();
+                _helpTextNode?.Invalidate();
+
+                // Auto-advance to model selection on success
+                if (result is { Success: true })
+                    SetProviderSubStep(4);
             })
             .DisposeWith(Subscriptions);
 

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -15,13 +15,19 @@ namespace Netclaw.Cli.Tui;
 /// </summary>
 public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 {
-    // Step 1: Provider selection list + auth input
+    private const int MaxDisplayedModels = 30;
+    private static readonly string[] SpinnerFrames = ["\u280b", "\u2819", "\u2838", "\u2834", "\u2826", "\u2807"];
+
+    // Step 1: Provider selection list + auth input + model selection
     private SelectionListNode<string>? _providerList;
     private SelectionListNode<string>? _authMethodList;
     private TextInputNode? _apiKeyInput;
     private TextInputNode? _endpointInput;
+    private SelectionListNode<string>? _modelList;
+    private TextInputNode? _manualModelInput;
+    private bool _manualModelEntry; // true when user chose "Enter model ID manually..."
 
-    // Step 2: Slack tokens
+    // Step 2: Chat Services (Slack)
     private TextInputNode? _slackBotTokenInput;
     private TextInputNode? _slackAppTokenInput;
     private SelectionListNode<string>? _slackEnabledList;
@@ -35,9 +41,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     // Step 5: Exposure
     private SelectionListNode<string>? _exposureList;
 
-    // Track sub-step for provider (selection → auth → key)
-    private int _providerSubStep; // 0=select provider, 1=select auth, 2=enter key/endpoint
-    private int _slackSubStep;    // 0=enable?, 1=bot token, 2=app token
+    // Track sub-step for provider (0=select, 1=auth, 2=credentials, 3=validate, 4=model)
+    private int _providerSubStep;
+    private int _chatServicesSubStep; // 0=enable?, 1=bot token, 2=app token
 
     // Focus tracking for selection lists (mirrors _lastFocusedInput for text inputs)
     private IFocusable? _lastFocusedList;
@@ -97,14 +103,15 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         return ViewModel.CurrentStep
             .Select(step =>
             {
-                var stepNum = (int)step;
-                var filled = new string('\u25a0', stepNum);
-                var empty = new string('\u25a1', InitWizardViewModel.TotalSteps - stepNum);
-                var pct = stepNum * 100 / InitWizardViewModel.TotalSteps;
+                var activeCount = ViewModel.ActiveStepCount;
+                var displayNum = ViewModel.GetDisplayStepNumber(step);
+                var filled = new string('\u25a0', displayNum);
+                var empty = new string('\u25a1', activeCount - displayNum);
+                var pct = displayNum * 100 / activeCount;
                 var title = step switch
                 {
                     WizardStep.Provider => "LLM Provider",
-                    WizardStep.Slack => "Slack Configuration",
+                    WizardStep.ChatServices => "Chat Services",
                     WizardStep.Acl => "Access Control",
                     WizardStep.Mcp => "MCP Servers",
                     WizardStep.Exposure => "Exposure Mode",
@@ -112,7 +119,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     _ => ""
                 };
                 return (ILayoutNode)new TextNode(
-                        $"  Step {stepNum} of {InitWizardViewModel.TotalSteps}: {title}        [{filled}{empty}] {pct}%")
+                        $"  Step {displayNum} of {activeCount}: {title}        [{filled}{empty}] {pct}%")
                     .WithForeground(Color.White)
                     .Bold();
             })
@@ -130,13 +137,21 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             if (step == WizardStep.HealthCheck)
                 return BuildHealthCheckStep();
 
+            // Clear stale focus references BEFORE building new content.
+            // The old components are about to be replaced/disposed by DynamicLayoutNode.
+            // If we leave _lastFocused* pointing at disposed components, the next
+            // RouteInputToActiveComponent call will OnBlurred() a disposed component,
+            // throwing ObjectDisposedException and killing the input subscription.
+            _lastFocusedList = null;
+            _lastFocusedInput = null;
+
             // Clear subscriptions from previous step content before building new
             _stepSubs.Clear();
 
             return step switch
             {
                 WizardStep.Provider => BuildProviderStep(),
-                WizardStep.Slack => BuildSlackStep(),
+                WizardStep.ChatServices => BuildChatServicesStep(),
                 WizardStep.Acl => BuildAclStep(),
                 WizardStep.Mcp => BuildMcpStep(),
                 WizardStep.Exposure => BuildExposureStep(),
@@ -160,9 +175,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Choose how to authenticate with this provider.",
                 WizardStep.Provider when _providerSubStep == 2 =>
                     "  Enter your API key. It will be stored in secrets.json.",
-                WizardStep.Slack when _slackSubStep == 0 =>
+                WizardStep.Provider when _providerSubStep == 3 =>
+                    "  Validating connection and discovering available models...",
+                WizardStep.Provider when _providerSubStep == 4 =>
+                    "  Select the model to use for conversations.",
+                WizardStep.ChatServices when _chatServicesSubStep == 0 =>
                     "  Enable Slack to connect Netclaw as a Slack bot.",
-                WizardStep.Slack =>
+                WizardStep.ChatServices =>
                     "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
                 WizardStep.Acl =>
                     "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
@@ -218,6 +237,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             0 => BuildProviderSelectionSubStep(),
             1 => BuildAuthMethodSubStep(),
             2 => BuildCredentialInputSubStep(),
+            3 => BuildValidationSubStep(),
+            4 => BuildModelSelectionSubStep(),
             _ => Layouts.Empty()
         };
     }
@@ -319,7 +340,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .Subscribe(text =>
                 {
                     ViewModel.EndpointInput = string.IsNullOrWhiteSpace(text) ? "http://localhost:11434" : text;
-                    ViewModel.GoNext();
+                    // Start validation instead of advancing to next step
+                    SetProviderSubStep(3);
+                    ViewModel.StartProbe();
                 })
                 .DisposeWith(_stepSubs);
 
@@ -348,7 +371,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Subscribe(text =>
             {
                 ViewModel.ApiKeyInput = text;
-                ViewModel.GoNext();
+                // Start validation instead of advancing to next step
+                SetProviderSubStep(3);
+                ViewModel.StartProbe();
             })
             .DisposeWith(_stepSubs);
 
@@ -362,9 +387,126 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .Height(3));
     }
 
-    private ILayoutNode BuildSlackStep()
+    private ILayoutNode BuildValidationSubStep()
     {
-        return _slackSubStep switch
+        var probeResult = ViewModel.ProbeResult.Value;
+
+        if (ViewModel.IsProbing.Value || probeResult is null)
+        {
+            // Animated spinner + elapsed timer
+            var elapsed = ViewModel.ProbeElapsedSeconds.Value;
+            var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+            var timerText = elapsed > 0 ? $" ({elapsed}s)" : "";
+            var provider = ViewModel.SelectedProviderType ?? "provider";
+
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  {frame} Validating connection to {provider}...{timerText}")
+                    .WithForeground(Color.Yellow));
+        }
+
+        if (probeResult.Success)
+        {
+            // Auto-advance to model selection on success
+            SetProviderSubStep(4);
+            return Layouts.Empty(); // will be replaced by model selection on next invalidation
+        }
+
+        // Failure — show error and prompt to retry or go back
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  \u2717 {probeResult.ErrorMessage}").WithForeground(Color.Red))
+            .WithChild(new TextNode(""))
+            .WithChild(new TextNode("  Press Enter to retry, or Esc to go back.").WithForeground(Color.BrightBlack));
+    }
+
+    private ILayoutNode BuildModelSelectionSubStep()
+    {
+        if (_manualModelEntry)
+        {
+            return BuildManualModelInput();
+        }
+
+        var models = ViewModel.DiscoveredModels;
+        var items = new List<string>();
+
+        // Limit display for large catalogs (e.g., OpenRouter)
+        var displayCount = Math.Min(models.Count, MaxDisplayedModels);
+        for (var i = 0; i < displayCount; i++)
+            items.Add(models[i].ModelId);
+
+        if (models.Count > MaxDisplayedModels)
+            items.Add($"... and {models.Count - MaxDisplayedModels} more (enter manually)");
+
+        items.Add("Enter model ID manually...");
+
+        _modelList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _modelList.OnFocused();
+        _lastFocusedList = _modelList;
+
+        _modelList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    var choice = selected[0];
+                    if (choice == "Enter model ID manually..." || choice.StartsWith("... and ", StringComparison.Ordinal))
+                    {
+                        _manualModelEntry = true;
+                        InvalidateProviderSubStep();
+                    }
+                    else
+                    {
+                        ViewModel.SelectedModelId = choice;
+                        _providerSubStep = 0;
+                        ViewModel.GoNext();
+                    }
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        var header = models.Count > 0
+            ? $"  Select a model ({models.Count} available):"
+            : "  No models discovered. Enter a model ID manually:";
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode(header).WithForeground(Color.White))
+            .WithChild(_modelList);
+    }
+
+    private ILayoutNode BuildManualModelInput()
+    {
+        _manualModelInput = new TextInputNode()
+            .WithPlaceholder("e.g., anthropic/claude-sonnet-4-20250514");
+
+        _manualModelInput.OnFocused();
+        _lastFocusedInput = _manualModelInput;
+
+        _manualModelInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.SelectedModelId = text;
+                _manualModelEntry = false;
+                _providerSubStep = 0;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Enter model ID:").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Model ID")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_manualModelInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildChatServicesStep()
+    {
+        return _chatServicesSubStep switch
         {
             0 => BuildSlackEnableSubStep(),
             1 => BuildSlackBotTokenSubStep(),
@@ -390,11 +532,11 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.SlackEnabled = selected[0].StartsWith("Yes", StringComparison.Ordinal);
                     if (ViewModel.SlackEnabled)
                     {
-                        SetSlackSubStep(1);
+                        SetChatServicesSubStep(1);
                     }
                     else
                     {
-                        _slackSubStep = 0;
+                        _chatServicesSubStep = 0;
                         ViewModel.GoNext();
                     }
                 }
@@ -420,7 +562,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Subscribe(text =>
             {
                 ViewModel.SlackBotToken = text;
-                SetSlackSubStep(2);
+                SetChatServicesSubStep(2);
             })
             .DisposeWith(_stepSubs);
 
@@ -448,7 +590,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Subscribe(text =>
             {
                 ViewModel.SlackAppToken = text;
-                _slackSubStep = 0;
+                _chatServicesSubStep = 0;
                 ViewModel.GoNext();
             })
             .DisposeWith(_stepSubs);
@@ -600,13 +742,27 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         {
             if (_providerSubStep == 2)
                 ViewModel.ClearFromProvider();
+            if (_providerSubStep == 4)
+            {
+                // Going back from model selection to validation — re-probe or skip to credentials
+                _manualModelEntry = false;
+                SetProviderSubStep(2);
+                return true;
+            }
+            if (_providerSubStep == 3)
+            {
+                // Going back from validation to credentials — cancel in-flight probe
+                ViewModel.CancelProbe();
+                SetProviderSubStep(2);
+                return true;
+            }
             SetProviderSubStep(_providerSubStep - 1);
             return true;
         }
 
-        if (ViewModel.CurrentStep.Value == WizardStep.Slack && _slackSubStep > 0)
+        if (ViewModel.CurrentStep.Value == WizardStep.ChatServices && _chatServicesSubStep > 0)
         {
-            SetSlackSubStep(_slackSubStep - 1);
+            SetChatServicesSubStep(_chatServicesSubStep - 1);
             return true;
         }
 
@@ -658,6 +814,19 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             return;
         }
 
+        // On validation sub-step with failed result, Enter triggers retry
+        if (ViewModel.CurrentStep.Value == WizardStep.Provider
+            && _providerSubStep == 3
+            && keyInfo.Key == ConsoleKey.Enter
+            && ViewModel.ProbeResult.Value is { Success: false })
+        {
+            ViewModel.StartProbe();
+            _stepContentNode?.Invalidate();
+            _helpTextNode?.Invalidate();
+            ViewModel.RequestRedraw();
+            return;
+        }
+
         // On health check step, Enter triggers the check
         if (ViewModel.CurrentStep.Value == WizardStep.HealthCheck && keyInfo.Key == ConsoleKey.Enter)
         {
@@ -674,7 +843,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         {
             WizardStep.Provider when _providerSubStep == 0 => _providerList,
             WizardStep.Provider when _providerSubStep == 1 => _authMethodList,
-            WizardStep.Slack when _slackSubStep == 0 => _slackEnabledList,
+            WizardStep.Provider when _providerSubStep == 4 && !_manualModelEntry => _modelList,
+            WizardStep.ChatServices when _chatServicesSubStep == 0 => _slackEnabledList,
             WizardStep.Mcp => _mcpList,
             WizardStep.Exposure => _exposureList,
             _ => null
@@ -687,8 +857,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         {
             WizardStep.Provider when _providerSubStep == 2 && _endpointInput is not null => _endpointInput,
             WizardStep.Provider when _providerSubStep == 2 => _apiKeyInput,
-            WizardStep.Slack when _slackSubStep == 1 => _slackBotTokenInput,
-            WizardStep.Slack when _slackSubStep == 2 => _slackAppTokenInput,
+            WizardStep.Provider when _providerSubStep == 4 && _manualModelEntry => _manualModelInput,
+            WizardStep.ChatServices when _chatServicesSubStep == 1 => _slackBotTokenInput,
+            WizardStep.ChatServices when _chatServicesSubStep == 2 => _slackAppTokenInput,
             WizardStep.Acl => _ownerIdentityInput,
             _ => null
         };
@@ -702,9 +873,16 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         ViewModel.RequestRedraw();
     }
 
-    private void SetSlackSubStep(int step)
+    private void InvalidateProviderSubStep()
     {
-        _slackSubStep = step;
+        _stepContentNode?.Invalidate();
+        _helpTextNode?.Invalidate();
+        ViewModel.RequestRedraw();
+    }
+
+    private void SetChatServicesSubStep(int step)
+    {
+        _chatServicesSubStep = step;
         _stepContentNode?.Invalidate();
         _helpTextNode?.Invalidate();
         ViewModel.RequestRedraw();
@@ -719,11 +897,32 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             {
                 if (step == WizardStep.Provider)
                     _providerSubStep = 0;
-                if (step == WizardStep.Slack)
-                    _slackSubStep = 0;
+                if (step == WizardStep.ChatServices)
+                    _chatServicesSubStep = 0;
 
                 _stepContentNode?.Invalidate();
                 _helpTextNode?.Invalidate();
+            })
+            .DisposeWith(Subscriptions);
+
+        // Invalidate when probe result changes (validation sub-step transitions)
+        ViewModel.ProbeResult
+            .Subscribe(_ =>
+            {
+                if (ViewModel.CurrentStep.Value == WizardStep.Provider && _providerSubStep == 3)
+                {
+                    _stepContentNode?.Invalidate();
+                    _helpTextNode?.Invalidate();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        // Animate spinner on validation sub-step every second
+        ViewModel.ProbeElapsedSeconds
+            .Subscribe(_ =>
+            {
+                if (ViewModel.CurrentStep.Value == WizardStep.Provider && _providerSubStep == 3)
+                    _stepContentNode?.Invalidate();
             })
             .DisposeWith(Subscriptions);
 

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -47,10 +47,20 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private DynamicLayoutNode? _stepContentNode;
     private DynamicLayoutNode? _helpTextNode;
 
-    public InitWizardPage()
-    {
-        FocusPolicy = FocusPolicy.FirstFocusable;
-    }
+    // ═══════════════════════════════════════════════════════════════════
+    // Content caching — DynamicLayoutNode calls its factory on EVERY
+    // render cycle. Without caching, new component instances are created
+    // each frame, destroying highlight position, typed text, and focus.
+    // ═══════════════════════════════════════════════════════════════════
+    private record struct ContentCacheKey(WizardStep Step, int ProviderSub, int SlackSub);
+    private ContentCacheKey _contentKey;
+    private ILayoutNode? _cachedStepContent;
+    private ContentCacheKey _helpKey;
+    private ILayoutNode? _cachedHelpContent;
+
+    // Step-specific subscriptions — cleared when step content is rebuilt
+    // so old subscriptions on disposed components don't linger.
+    private readonly CompositeDisposable _stepSubs = new();
 
     protected override void OnBound()
     {
@@ -82,9 +92,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithSpacing(1)
             // Step indicator + progress
             .WithChild(BuildStepIndicator())
-            // Step content (dynamic — rebuilds on step and sub-step changes)
+            // Step content (dynamic — rebuilds only on step/sub-step changes)
             .WithChild(BuildStepContent())
-            // Help text (dynamic — rebuilds on step and sub-step changes)
+            // Help text (dynamic — rebuilds only on step/sub-step changes)
             .WithChild(BuildHelpText())
             // Status message
             .WithChild(BuildStatusBar())
@@ -123,17 +133,34 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private LayoutNode BuildStepContent()
     {
         // DynamicLayoutNode re-evaluates the factory on every render cycle.
-        // Step changes trigger RequestRedraw via the observable subscription in InitializeComponents.
-        // Sub-step changes call Invalidate() directly.
-        _stepContentNode = new DynamicLayoutNode(() => ViewModel.CurrentStep.Value switch
+        // We cache the result and only rebuild when the step or sub-step
+        // actually changes, so components retain their state across frames.
+        _stepContentNode = new DynamicLayoutNode(() =>
         {
-            WizardStep.Provider => BuildProviderStep(),
-            WizardStep.Slack => BuildSlackStep(),
-            WizardStep.Acl => BuildAclStep(),
-            WizardStep.Mcp => BuildMcpStep(),
-            WizardStep.Exposure => BuildExposureStep(),
-            WizardStep.HealthCheck => BuildHealthCheckStep(),
-            _ => Layouts.Empty()
+            var step = ViewModel.CurrentStep.Value;
+
+            // Health check always rebuilds — results change during the check
+            if (step == WizardStep.HealthCheck)
+                return BuildHealthCheckStep();
+
+            var key = new ContentCacheKey(step, _providerSubStep, _slackSubStep);
+            if (key == _contentKey && _cachedStepContent != null)
+                return _cachedStepContent;
+
+            // New step/sub-step — clear subscriptions from previous content
+            _stepSubs.Clear();
+
+            _contentKey = key;
+            _cachedStepContent = step switch
+            {
+                WizardStep.Provider => BuildProviderStep(),
+                WizardStep.Slack => BuildSlackStep(),
+                WizardStep.Acl => BuildAclStep(),
+                WizardStep.Mcp => BuildMcpStep(),
+                WizardStep.Exposure => BuildExposureStep(),
+                _ => Layouts.Empty()
+            };
+            return _cachedStepContent;
         });
 
         return _stepContentNode.Fill();
@@ -144,6 +171,11 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         _helpTextNode = new DynamicLayoutNode(() =>
         {
             var step = ViewModel.CurrentStep.Value;
+            var key = new ContentCacheKey(step, _providerSubStep, _slackSubStep);
+            if (key == _helpKey && _cachedHelpContent != null)
+                return _cachedHelpContent;
+
+            _helpKey = key;
             var text = step switch
             {
                 WizardStep.Provider when _providerSubStep == 0 =>
@@ -166,7 +198,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Validating your configuration...",
                 _ => ""
             };
-            return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            _cachedHelpContent = (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            return _cachedHelpContent;
         });
 
         return _helpTextNode.Height(2);
@@ -193,7 +226,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
                     var backLabel = step == WizardStep.Provider ? "Quit" : "Back";
                     return (ILayoutNode)new TextNode(
-                        $" [Enter] Next  [Esc] {backLabel}  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
+                        $" [\u2191/\u2193] Navigate  [Enter] Next  [Esc] {backLabel}  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
                 })
             .AsLayout()
             .Height(1);
@@ -221,7 +254,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
-        // Auto-focus so the highlight bar is visible immediately
         _providerList.OnFocused();
         _lastFocusedList = _providerList;
 
@@ -234,7 +266,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(selected[0]);
                     if (supportedAuth is [AuthMethod.None])
                     {
-                        // Ollama — no auth needed, skip to endpoint
                         ViewModel.SelectedAuthMethod = AuthMethod.None;
                         SetProviderSubStep(2);
                     }
@@ -244,7 +275,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     }
                 }
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Choose your LLM provider:").WithForeground(Color.White))
@@ -268,7 +299,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
-        // Auto-focus so the highlight bar is visible immediately
         _authMethodList.OnFocused();
         _lastFocusedList = _authMethodList;
 
@@ -283,14 +313,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     SetProviderSubStep(2);
                 }
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         _authMethodList.Cancelled
             .Subscribe(_ =>
             {
                 SetProviderSubStep(0);
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode($"  Authentication for {providerType}:").WithForeground(Color.White))
@@ -303,12 +333,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
         if (providerType == "ollama")
         {
-            // Ollama needs endpoint only
             _endpointInput = new TextInputNode()
                 .WithPlaceholder("http://localhost:11434");
             _endpointInput.Text = ViewModel.EndpointInput ?? "http://localhost:11434";
 
-            // Auto-focus for cursor display
             _endpointInput.OnFocused();
             _lastFocusedInput = _endpointInput;
 
@@ -318,7 +346,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.EndpointInput = string.IsNullOrWhiteSpace(text) ? "http://localhost:11434" : text;
                     ViewModel.GoNext();
                 })
-                .DisposeWith(Subscriptions);
+                .DisposeWith(_stepSubs);
 
             return Layouts.Vertical()
                 .WithChild(new TextNode("  Ollama endpoint:").WithForeground(Color.White))
@@ -330,7 +358,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     .Height(3));
         }
 
-        // API key input for cloud providers
         _apiKeyInput = new TextInputNode()
             .AsPassword()
             .WithPlaceholder($"Enter {providerType} API key...");
@@ -338,7 +365,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         if (!string.IsNullOrWhiteSpace(ViewModel.ApiKeyInput))
             _apiKeyInput.Text = ViewModel.ApiKeyInput;
 
-        // Auto-focus for cursor display
         _apiKeyInput.OnFocused();
         _lastFocusedInput = _apiKeyInput;
 
@@ -349,7 +375,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 ViewModel.ApiKeyInput = text;
                 ViewModel.GoNext();
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode($"  {providerType} API key:").WithForeground(Color.White))
@@ -374,11 +400,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private ILayoutNode BuildSlackEnableSubStep()
     {
-        _slackEnabledList = Layouts.SelectionList("Yes — configure Slack bot", "No — skip for now")
+        _slackEnabledList = Layouts.SelectionList("Yes \u2014 configure Slack bot", "No \u2014 skip for now")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
-        // Auto-focus so the highlight bar is visible immediately
         _slackEnabledList.OnFocused();
         _lastFocusedList = _slackEnabledList;
 
@@ -399,7 +424,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     }
                 }
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Enable Slack integration?").WithForeground(Color.White))
@@ -412,7 +437,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .AsPassword()
             .WithPlaceholder("xoxb-...");
 
-        // Auto-focus for cursor display
         _slackBotTokenInput.OnFocused();
         _lastFocusedInput = _slackBotTokenInput;
 
@@ -423,7 +447,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 ViewModel.SlackBotToken = text;
                 SetSlackSubStep(2);
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Slack Bot Token:").WithForeground(Color.White))
@@ -441,7 +465,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .AsPassword()
             .WithPlaceholder("xapp-...");
 
-        // Auto-focus for cursor display
         _slackAppTokenInput.OnFocused();
         _lastFocusedInput = _slackAppTokenInput;
 
@@ -453,7 +476,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 _slackSubStep = 0;
                 ViewModel.GoNext();
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Slack App Token (Socket Mode):").WithForeground(Color.White))
@@ -473,7 +496,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         if (!string.IsNullOrWhiteSpace(ViewModel.OwnerIdentity))
             _ownerIdentityInput.Text = ViewModel.OwnerIdentity;
 
-        // Auto-focus for cursor display
         _ownerIdentityInput.OnFocused();
         _lastFocusedInput = _ownerIdentityInput;
 
@@ -483,7 +505,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 ViewModel.OwnerIdentity = string.IsNullOrWhiteSpace(text) ? null : text;
                 ViewModel.GoNext();
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Owner identity (press Enter to skip):").WithForeground(Color.White))
@@ -498,13 +520,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private ILayoutNode BuildMcpStep()
     {
         _mcpList = Layouts.SelectionList(
-                "Memorizer (recommended — persistent memory)",
+                "Memorizer (recommended \u2014 persistent memory)",
                 "Custom MCP server (configure later)",
-                "Skip — no MCP servers")
+                "Skip \u2014 no MCP servers")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
-        // Auto-focus so the highlight bar is visible immediately
         _mcpList.OnFocused();
         _lastFocusedList = _mcpList;
 
@@ -517,7 +538,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.GoNext();
                 }
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  MCP tool servers:").WithForeground(Color.White))
@@ -533,7 +554,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
-        // Auto-focus so the highlight bar is visible immediately
         _exposureList.OnFocused();
         _lastFocusedList = _exposureList;
 
@@ -546,7 +566,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.GoNext();
                 }
             })
-            .DisposeWith(Subscriptions);
+            .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Network exposure:").WithForeground(Color.White))
@@ -624,14 +644,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         var activeList = GetActiveSelectionList();
         if (activeList is not null)
         {
-            // Blur any previously focused text input
             if (_lastFocusedInput is not null)
             {
                 _lastFocusedInput.OnBlurred();
                 _lastFocusedInput = null;
             }
 
-            // Focus the selection list if it changed
             if (_lastFocusedList != activeList)
             {
                 _lastFocusedList?.OnBlurred();
@@ -648,14 +666,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         var activeInput = GetActiveTextInput();
         if (activeInput is not null)
         {
-            // Blur any previously focused selection list
             if (_lastFocusedList is not null)
             {
                 _lastFocusedList.OnBlurred();
                 _lastFocusedList = null;
             }
 
-            // Auto-focus the text input for cursor display
             if (_lastFocusedInput != activeInput)
             {
                 _lastFocusedInput?.OnBlurred();
@@ -721,10 +737,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private void InitializeComponents()
     {
-        // Invalidate dynamic layouts when step changes so they re-evaluate their factories
+        // Invalidate dynamic layouts when step changes so they re-evaluate their factories.
+        // Also reset sub-step counters when entering a step.
         ViewModel.CurrentStep
             .Subscribe(step =>
             {
+                if (step == WizardStep.Provider)
+                    _providerSubStep = 0;
                 if (step == WizardStep.Slack)
                     _slackSubStep = 0;
 
@@ -732,5 +751,11 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 _helpTextNode?.Invalidate();
             })
             .DisposeWith(Subscriptions);
+    }
+
+    public override void Dispose()
+    {
+        _stepSubs.Dispose();
+        base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -1,6 +1,5 @@
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using Netclaw.Configuration;
+using R3;
 using Termina.Extensions;
 using Termina.Input;
 using Termina.Layout;
@@ -40,13 +39,26 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private int _providerSubStep; // 0=select provider, 1=select auth, 2=enter key/endpoint
     private int _slackSubStep;    // 0=enable?, 1=bot token, 2=app token
 
+    // Focus tracking for selection lists (mirrors _lastFocusedInput for text inputs)
+    private IFocusable? _lastFocusedList;
+    private TextInputNode? _lastFocusedInput;
+
+    // Dynamic layout node for step content — invalidated on sub-step changes
+    private DynamicLayoutNode? _stepContentNode;
+    private DynamicLayoutNode? _helpTextNode;
+
+    public InitWizardPage()
+    {
+        FocusPolicy = FocusPolicy.FirstFocusable;
+    }
+
     protected override void OnBound()
     {
         base.OnBound();
         InitializeComponents();
 
         // Route keyboard input
-        ViewModel.Input.OfType<KeyPressed>()
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
             .DisposeWith(Subscriptions);
     }
@@ -70,9 +82,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithSpacing(1)
             // Step indicator + progress
             .WithChild(BuildStepIndicator())
-            // Step content (reactive)
+            // Step content (dynamic — rebuilds on step and sub-step changes)
             .WithChild(BuildStepContent())
-            // Help text (reactive)
+            // Help text (dynamic — rebuilds on step and sub-step changes)
             .WithChild(BuildHelpText())
             // Status message
             .WithChild(BuildStatusBar())
@@ -82,7 +94,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private LayoutNode BuildStepIndicator()
     {
-        return ViewModel.CurrentStepChanged
+        return ViewModel.CurrentStep
             .Select(step =>
             {
                 var stepNum = (int)step;
@@ -110,57 +122,59 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private LayoutNode BuildStepContent()
     {
-        return ViewModel.CurrentStepChanged
-            .Select(step => (ILayoutNode)(step switch
-            {
-                WizardStep.Provider => BuildProviderStep(),
-                WizardStep.Slack => BuildSlackStep(),
-                WizardStep.Acl => BuildAclStep(),
-                WizardStep.Mcp => BuildMcpStep(),
-                WizardStep.Exposure => BuildExposureStep(),
-                WizardStep.HealthCheck => BuildHealthCheckStep(),
-                _ => Layouts.Empty()
-            }))
-            .AsLayout()
-            .Fill();
+        // DynamicLayoutNode re-evaluates the factory on every render cycle.
+        // Step changes trigger RequestRedraw via the observable subscription in InitializeComponents.
+        // Sub-step changes call Invalidate() directly.
+        _stepContentNode = new DynamicLayoutNode(() => ViewModel.CurrentStep.Value switch
+        {
+            WizardStep.Provider => BuildProviderStep(),
+            WizardStep.Slack => BuildSlackStep(),
+            WizardStep.Acl => BuildAclStep(),
+            WizardStep.Mcp => BuildMcpStep(),
+            WizardStep.Exposure => BuildExposureStep(),
+            WizardStep.HealthCheck => BuildHealthCheckStep(),
+            _ => Layouts.Empty()
+        });
+
+        return _stepContentNode.Fill();
     }
 
     private LayoutNode BuildHelpText()
     {
-        return ViewModel.CurrentStepChanged
-            .Select(step =>
+        _helpTextNode = new DynamicLayoutNode(() =>
+        {
+            var step = ViewModel.CurrentStep.Value;
+            var text = step switch
             {
-                var text = step switch
-                {
-                    WizardStep.Provider when _providerSubStep == 0 =>
-                        "  Select your LLM provider. Ollama runs locally (no auth required).",
-                    WizardStep.Provider when _providerSubStep == 1 =>
-                        "  Choose how to authenticate with this provider.",
-                    WizardStep.Provider when _providerSubStep == 2 =>
-                        "  Enter your API key. It will be stored in secrets.json.",
-                    WizardStep.Slack when _slackSubStep == 0 =>
-                        "  Enable Slack to connect Netclaw as a Slack bot.",
-                    WizardStep.Slack =>
-                        "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
-                    WizardStep.Acl =>
-                        "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
-                    WizardStep.Mcp =>
-                        "  MCP servers provide external tools. Memorizer adds persistent memory.",
-                    WizardStep.Exposure =>
-                        "  Local-only is recommended for homelab use.",
-                    WizardStep.HealthCheck =>
-                        "  Validating your configuration...",
-                    _ => ""
-                };
-                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
-            })
-            .AsLayout()
-            .Height(2);
+                WizardStep.Provider when _providerSubStep == 0 =>
+                    "  Select your LLM provider. Ollama runs locally (no auth required).",
+                WizardStep.Provider when _providerSubStep == 1 =>
+                    "  Choose how to authenticate with this provider.",
+                WizardStep.Provider when _providerSubStep == 2 =>
+                    "  Enter your API key. It will be stored in secrets.json.",
+                WizardStep.Slack when _slackSubStep == 0 =>
+                    "  Enable Slack to connect Netclaw as a Slack bot.",
+                WizardStep.Slack =>
+                    "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
+                WizardStep.Acl =>
+                    "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
+                WizardStep.Mcp =>
+                    "  MCP servers provide external tools. Memorizer adds persistent memory.",
+                WizardStep.Exposure =>
+                    "  Local-only is recommended for homelab use.",
+                WizardStep.HealthCheck =>
+                    "  Validating your configuration...",
+                _ => ""
+            };
+            return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+        });
+
+        return _helpTextNode.Height(2);
     }
 
     private LayoutNode BuildStatusBar()
     {
-        return ViewModel.StatusMessageChanged
+        return ViewModel.StatusMessage
             .Select(msg => (ILayoutNode)(string.IsNullOrWhiteSpace(msg)
                 ? Layouts.Empty()
                 : new TextNode($"  {msg}").WithForeground(Color.Green)))
@@ -170,17 +184,17 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private LayoutNode BuildKeyBindings()
     {
-        return ViewModel.CurrentStepChanged
-            .CombineLatest(ViewModel.IsCompleteChanged, (step, complete) =>
-            {
-                if (complete)
-                    return (ILayoutNode)new TextNode(
-                        " [Enter] Exit  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
+        return Observable.CombineLatest(ViewModel.CurrentStep, ViewModel.IsComplete,
+                (step, complete) =>
+                {
+                    if (complete)
+                        return (ILayoutNode)new TextNode(
+                            " [Enter] Exit  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
 
-                var backLabel = step == WizardStep.Provider ? "Quit" : "Back";
-                return (ILayoutNode)new TextNode(
-                    $" [Enter] Next  [Esc] {backLabel}  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
-            })
+                    var backLabel = step == WizardStep.Provider ? "Quit" : "Back";
+                    return (ILayoutNode)new TextNode(
+                        $" [Enter] Next  [Esc] {backLabel}  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
+                })
             .AsLayout()
             .Height(1);
     }
@@ -207,6 +221,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
+        // Auto-focus so the highlight bar is visible immediately
+        _providerList.OnFocused();
+        _lastFocusedList = _providerList;
+
         _providerList.SelectionConfirmed
             .Subscribe(selected =>
             {
@@ -218,13 +236,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     {
                         // Ollama — no auth needed, skip to endpoint
                         ViewModel.SelectedAuthMethod = AuthMethod.None;
-                        _providerSubStep = 2;
+                        SetProviderSubStep(2);
                     }
                     else
                     {
-                        _providerSubStep = 1;
+                        SetProviderSubStep(1);
                     }
-                    ViewModel.RequestRedraw();
                 }
             })
             .DisposeWith(Subscriptions);
@@ -251,6 +268,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
+        // Auto-focus so the highlight bar is visible immediately
+        _authMethodList.OnFocused();
+        _lastFocusedList = _authMethodList;
+
         _authMethodList.SelectionConfirmed
             .Subscribe(selected =>
             {
@@ -259,8 +280,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.SelectedAuthMethod = selected[0].StartsWith("API", StringComparison.Ordinal)
                         ? AuthMethod.ApiKey
                         : AuthMethod.OAuthDevice;
-                    _providerSubStep = 2;
-                    ViewModel.RequestRedraw();
+                    SetProviderSubStep(2);
                 }
             })
             .DisposeWith(Subscriptions);
@@ -268,8 +288,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         _authMethodList.Cancelled
             .Subscribe(_ =>
             {
-                _providerSubStep = 0;
-                ViewModel.RequestRedraw();
+                SetProviderSubStep(0);
             })
             .DisposeWith(Subscriptions);
 
@@ -288,6 +307,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             _endpointInput = new TextInputNode()
                 .WithPlaceholder("http://localhost:11434");
             _endpointInput.Text = ViewModel.EndpointInput ?? "http://localhost:11434";
+
+            // Auto-focus for cursor display
+            _endpointInput.OnFocused();
+            _lastFocusedInput = _endpointInput;
 
             _endpointInput.Submitted
                 .Subscribe(text =>
@@ -314,6 +337,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
         if (!string.IsNullOrWhiteSpace(ViewModel.ApiKeyInput))
             _apiKeyInput.Text = ViewModel.ApiKeyInput;
+
+        // Auto-focus for cursor display
+        _apiKeyInput.OnFocused();
+        _lastFocusedInput = _apiKeyInput;
 
         _apiKeyInput.Submitted
             .Where(text => !string.IsNullOrWhiteSpace(text))
@@ -351,6 +378,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
+        // Auto-focus so the highlight bar is visible immediately
+        _slackEnabledList.OnFocused();
+        _lastFocusedList = _slackEnabledList;
+
         _slackEnabledList.SelectionConfirmed
             .Subscribe(selected =>
             {
@@ -359,8 +390,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     ViewModel.SlackEnabled = selected[0].StartsWith("Yes", StringComparison.Ordinal);
                     if (ViewModel.SlackEnabled)
                     {
-                        _slackSubStep = 1;
-                        ViewModel.RequestRedraw();
+                        SetSlackSubStep(1);
                     }
                     else
                     {
@@ -382,13 +412,16 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .AsPassword()
             .WithPlaceholder("xoxb-...");
 
+        // Auto-focus for cursor display
+        _slackBotTokenInput.OnFocused();
+        _lastFocusedInput = _slackBotTokenInput;
+
         _slackBotTokenInput.Submitted
             .Where(text => !string.IsNullOrWhiteSpace(text))
             .Subscribe(text =>
             {
                 ViewModel.SlackBotToken = text;
-                _slackSubStep = 2;
-                ViewModel.RequestRedraw();
+                SetSlackSubStep(2);
             })
             .DisposeWith(Subscriptions);
 
@@ -407,6 +440,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         _slackAppTokenInput = new TextInputNode()
             .AsPassword()
             .WithPlaceholder("xapp-...");
+
+        // Auto-focus for cursor display
+        _slackAppTokenInput.OnFocused();
+        _lastFocusedInput = _slackAppTokenInput;
 
         _slackAppTokenInput.Submitted
             .Where(text => !string.IsNullOrWhiteSpace(text))
@@ -436,6 +473,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         if (!string.IsNullOrWhiteSpace(ViewModel.OwnerIdentity))
             _ownerIdentityInput.Text = ViewModel.OwnerIdentity;
 
+        // Auto-focus for cursor display
+        _ownerIdentityInput.OnFocused();
+        _lastFocusedInput = _ownerIdentityInput;
+
         _ownerIdentityInput.Submitted
             .Subscribe(text =>
             {
@@ -463,6 +504,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
+        // Auto-focus so the highlight bar is visible immediately
+        _mcpList.OnFocused();
+        _lastFocusedList = _mcpList;
+
         _mcpList.SelectionConfirmed
             .Subscribe(selected =>
             {
@@ -487,6 +532,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 "Cloudflare Tunnel (configure later)")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
+
+        // Auto-focus so the highlight bar is visible immediately
+        _exposureList.OnFocused();
+        _lastFocusedList = _exposureList;
 
         _exposureList.SelectionConfirmed
             .Subscribe(selected =>
@@ -552,26 +601,22 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private bool HandleSubStepBack()
     {
-        if (ViewModel.CurrentStep == WizardStep.Provider && _providerSubStep > 0)
+        if (ViewModel.CurrentStep.Value == WizardStep.Provider && _providerSubStep > 0)
         {
             if (_providerSubStep == 2)
                 ViewModel.ClearFromProvider();
-            _providerSubStep--;
-            ViewModel.RequestRedraw();
+            SetProviderSubStep(_providerSubStep - 1);
             return true;
         }
 
-        if (ViewModel.CurrentStep == WizardStep.Slack && _slackSubStep > 0)
+        if (ViewModel.CurrentStep.Value == WizardStep.Slack && _slackSubStep > 0)
         {
-            _slackSubStep--;
-            ViewModel.RequestRedraw();
+            SetSlackSubStep(_slackSubStep - 1);
             return true;
         }
 
         return false;
     }
-
-    private TextInputNode? _lastFocusedInput;
 
     private void RouteInputToActiveComponent(ConsoleKeyInfo keyInfo)
     {
@@ -585,7 +630,17 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 _lastFocusedInput.OnBlurred();
                 _lastFocusedInput = null;
             }
+
+            // Focus the selection list if it changed
+            if (_lastFocusedList != activeList)
+            {
+                _lastFocusedList?.OnBlurred();
+                activeList.OnFocused();
+                _lastFocusedList = activeList;
+            }
+
             activeList.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
             return;
         }
 
@@ -593,6 +648,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         var activeInput = GetActiveTextInput();
         if (activeInput is not null)
         {
+            // Blur any previously focused selection list
+            if (_lastFocusedList is not null)
+            {
+                _lastFocusedList.OnBlurred();
+                _lastFocusedList = null;
+            }
+
             // Auto-focus the text input for cursor display
             if (_lastFocusedInput != activeInput)
             {
@@ -601,13 +663,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 _lastFocusedInput = activeInput;
             }
             activeInput.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
             return;
         }
 
         // On health check step, Enter triggers the check
-        if (ViewModel.CurrentStep == WizardStep.HealthCheck && keyInfo.Key == ConsoleKey.Enter)
+        if (ViewModel.CurrentStep.Value == WizardStep.HealthCheck && keyInfo.Key == ConsoleKey.Enter)
         {
-            if (ViewModel.IsComplete)
+            if (ViewModel.IsComplete.Value)
                 ViewModel.RequestQuit();
             else
                 ViewModel.GoNext();
@@ -616,7 +679,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private IFocusable? GetActiveSelectionList()
     {
-        return ViewModel.CurrentStep switch
+        return ViewModel.CurrentStep.Value switch
         {
             WizardStep.Provider when _providerSubStep == 0 => _providerList,
             WizardStep.Provider when _providerSubStep == 1 => _authMethodList,
@@ -629,7 +692,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private TextInputNode? GetActiveTextInput()
     {
-        return ViewModel.CurrentStep switch
+        return ViewModel.CurrentStep.Value switch
         {
             WizardStep.Provider when _providerSubStep == 2 && _endpointInput is not null => _endpointInput,
             WizardStep.Provider when _providerSubStep == 2 => _apiKeyInput,
@@ -640,22 +703,33 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         };
     }
 
+    private void SetProviderSubStep(int step)
+    {
+        _providerSubStep = step;
+        _stepContentNode?.Invalidate();
+        _helpTextNode?.Invalidate();
+        ViewModel.RequestRedraw();
+    }
+
+    private void SetSlackSubStep(int step)
+    {
+        _slackSubStep = step;
+        _stepContentNode?.Invalidate();
+        _helpTextNode?.Invalidate();
+        ViewModel.RequestRedraw();
+    }
+
     private void InitializeComponents()
     {
-        // Components are lazily created per step, so nothing to do here yet.
-        // Reset sub-steps when step changes
-        ViewModel.CurrentStepChanged
+        // Invalidate dynamic layouts when step changes so they re-evaluate their factories
+        ViewModel.CurrentStep
             .Subscribe(step =>
             {
-                // Reset sub-steps when entering a step fresh
-                if (step == WizardStep.Provider)
-                {
-                    // Don't reset if we're already in the provider step with sub-steps
-                }
-                else if (step == WizardStep.Slack)
-                {
+                if (step == WizardStep.Slack)
                     _slackSubStep = 0;
-                }
+
+                _stepContentNode?.Invalidate();
+                _helpTextNode?.Invalidate();
             })
             .DisposeWith(Subscriptions);
     }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -1,0 +1,662 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Netclaw.Configuration;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Termina page for the <c>netclaw init</c> onboarding wizard.
+/// Layout: outer panel with step indicator, step-specific content, help text, key bindings.
+/// </summary>
+public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
+{
+    // Step 1: Provider selection list + auth input
+    private SelectionListNode<string>? _providerList;
+    private SelectionListNode<string>? _authMethodList;
+    private TextInputNode? _apiKeyInput;
+    private TextInputNode? _endpointInput;
+
+    // Step 2: Slack tokens
+    private TextInputNode? _slackBotTokenInput;
+    private TextInputNode? _slackAppTokenInput;
+    private SelectionListNode<string>? _slackEnabledList;
+
+    // Step 3: ACL
+    private TextInputNode? _ownerIdentityInput;
+
+    // Step 4: MCP
+    private SelectionListNode<string>? _mcpList;
+
+    // Step 5: Exposure
+    private SelectionListNode<string>? _exposureList;
+
+    // Track sub-step for provider (selection → auth → key)
+    private int _providerSubStep; // 0=select provider, 1=select auth, 2=enter key/endpoint
+    private int _slackSubStep;    // 0=enable?, 1=bot token, 2=app token
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+        InitializeComponents();
+
+        // Route keyboard input
+        ViewModel.Input.OfType<KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            // Outer panel
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Netclaw Setup")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(BuildInnerLayout())
+                    .Fill());
+    }
+
+    private ILayoutNode BuildInnerLayout()
+    {
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            // Step indicator + progress
+            .WithChild(BuildStepIndicator())
+            // Step content (reactive)
+            .WithChild(BuildStepContent())
+            // Help text (reactive)
+            .WithChild(BuildHelpText())
+            // Status message
+            .WithChild(BuildStatusBar())
+            // Key bindings
+            .WithChild(BuildKeyBindings());
+    }
+
+    private LayoutNode BuildStepIndicator()
+    {
+        return ViewModel.CurrentStepChanged
+            .Select(step =>
+            {
+                var stepNum = (int)step;
+                var filled = new string('\u25a0', stepNum);
+                var empty = new string('\u25a1', InitWizardViewModel.TotalSteps - stepNum);
+                var pct = stepNum * 100 / InitWizardViewModel.TotalSteps;
+                var title = step switch
+                {
+                    WizardStep.Provider => "LLM Provider",
+                    WizardStep.Slack => "Slack Configuration",
+                    WizardStep.Acl => "Access Control",
+                    WizardStep.Mcp => "MCP Servers",
+                    WizardStep.Exposure => "Exposure Mode",
+                    WizardStep.HealthCheck => "Health Check",
+                    _ => ""
+                };
+                return (ILayoutNode)new TextNode(
+                        $"  Step {stepNum} of {InitWizardViewModel.TotalSteps}: {title}        [{filled}{empty}] {pct}%")
+                    .WithForeground(Color.White)
+                    .Bold();
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildStepContent()
+    {
+        return ViewModel.CurrentStepChanged
+            .Select(step => (ILayoutNode)(step switch
+            {
+                WizardStep.Provider => BuildProviderStep(),
+                WizardStep.Slack => BuildSlackStep(),
+                WizardStep.Acl => BuildAclStep(),
+                WizardStep.Mcp => BuildMcpStep(),
+                WizardStep.Exposure => BuildExposureStep(),
+                WizardStep.HealthCheck => BuildHealthCheckStep(),
+                _ => Layouts.Empty()
+            }))
+            .AsLayout()
+            .Fill();
+    }
+
+    private LayoutNode BuildHelpText()
+    {
+        return ViewModel.CurrentStepChanged
+            .Select(step =>
+            {
+                var text = step switch
+                {
+                    WizardStep.Provider when _providerSubStep == 0 =>
+                        "  Select your LLM provider. Ollama runs locally (no auth required).",
+                    WizardStep.Provider when _providerSubStep == 1 =>
+                        "  Choose how to authenticate with this provider.",
+                    WizardStep.Provider when _providerSubStep == 2 =>
+                        "  Enter your API key. It will be stored in secrets.json.",
+                    WizardStep.Slack when _slackSubStep == 0 =>
+                        "  Enable Slack to connect Netclaw as a Slack bot.",
+                    WizardStep.Slack =>
+                        "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
+                    WizardStep.Acl =>
+                        "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
+                    WizardStep.Mcp =>
+                        "  MCP servers provide external tools. Memorizer adds persistent memory.",
+                    WizardStep.Exposure =>
+                        "  Local-only is recommended for homelab use.",
+                    WizardStep.HealthCheck =>
+                        "  Validating your configuration...",
+                    _ => ""
+                };
+                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(2);
+    }
+
+    private LayoutNode BuildStatusBar()
+    {
+        return ViewModel.StatusMessageChanged
+            .Select(msg => (ILayoutNode)(string.IsNullOrWhiteSpace(msg)
+                ? Layouts.Empty()
+                : new TextNode($"  {msg}").WithForeground(Color.Green)))
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildKeyBindings()
+    {
+        return ViewModel.CurrentStepChanged
+            .CombineLatest(ViewModel.IsCompleteChanged, (step, complete) =>
+            {
+                if (complete)
+                    return (ILayoutNode)new TextNode(
+                        " [Enter] Exit  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
+
+                var backLabel = step == WizardStep.Provider ? "Quit" : "Back";
+                return (ILayoutNode)new TextNode(
+                    $" [Enter] Next  [Esc] {backLabel}  [Ctrl+Q] Quit").WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Step-specific layouts
+    // ═══════════════════════════════════════════════════════════════════
+
+    private ILayoutNode BuildProviderStep()
+    {
+        return _providerSubStep switch
+        {
+            0 => BuildProviderSelectionSubStep(),
+            1 => BuildAuthMethodSubStep(),
+            2 => BuildCredentialInputSubStep(),
+            _ => Layouts.Empty()
+        };
+    }
+
+    private ILayoutNode BuildProviderSelectionSubStep()
+    {
+        _providerList = Layouts.SelectionList(
+                ProviderCapabilities.KnownProviderTypes)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _providerList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.SelectedProviderType = selected[0];
+                    var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(selected[0]);
+                    if (supportedAuth is [AuthMethod.None])
+                    {
+                        // Ollama — no auth needed, skip to endpoint
+                        ViewModel.SelectedAuthMethod = AuthMethod.None;
+                        _providerSubStep = 2;
+                    }
+                    else
+                    {
+                        _providerSubStep = 1;
+                    }
+                    ViewModel.RequestRedraw();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Choose your LLM provider:").WithForeground(Color.White))
+            .WithChild(_providerList);
+    }
+
+    private ILayoutNode BuildAuthMethodSubStep()
+    {
+        var providerType = ViewModel.SelectedProviderType ?? "unknown";
+        var supportedMethods = ProviderCapabilities.GetSupportedAuthMethods(providerType)
+            .Where(m => m != AuthMethod.None)
+            .Select(m => m switch
+            {
+                AuthMethod.ApiKey => "API Key",
+                AuthMethod.OAuthDevice => "OAuth Device Flow (coming soon)",
+                _ => m.ToString()
+            })
+            .ToList();
+
+        _authMethodList = Layouts.SelectionList(supportedMethods)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _authMethodList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.SelectedAuthMethod = selected[0].StartsWith("API", StringComparison.Ordinal)
+                        ? AuthMethod.ApiKey
+                        : AuthMethod.OAuthDevice;
+                    _providerSubStep = 2;
+                    ViewModel.RequestRedraw();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        _authMethodList.Cancelled
+            .Subscribe(_ =>
+            {
+                _providerSubStep = 0;
+                ViewModel.RequestRedraw();
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Authentication for {providerType}:").WithForeground(Color.White))
+            .WithChild(_authMethodList);
+    }
+
+    private ILayoutNode BuildCredentialInputSubStep()
+    {
+        var providerType = ViewModel.SelectedProviderType ?? "unknown";
+
+        if (providerType == "ollama")
+        {
+            // Ollama needs endpoint only
+            _endpointInput = new TextInputNode()
+                .WithPlaceholder("http://localhost:11434");
+            _endpointInput.Text = ViewModel.EndpointInput ?? "http://localhost:11434";
+
+            _endpointInput.Submitted
+                .Subscribe(text =>
+                {
+                    ViewModel.EndpointInput = string.IsNullOrWhiteSpace(text) ? "http://localhost:11434" : text;
+                    ViewModel.GoNext();
+                })
+                .DisposeWith(Subscriptions);
+
+            return Layouts.Vertical()
+                .WithChild(new TextNode("  Ollama endpoint:").WithForeground(Color.White))
+                .WithChild(new PanelNode()
+                    .WithTitle("Endpoint")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Gray)
+                    .WithContent(_endpointInput)
+                    .Height(3));
+        }
+
+        // API key input for cloud providers
+        _apiKeyInput = new TextInputNode()
+            .AsPassword()
+            .WithPlaceholder($"Enter {providerType} API key...");
+
+        if (!string.IsNullOrWhiteSpace(ViewModel.ApiKeyInput))
+            _apiKeyInput.Text = ViewModel.ApiKeyInput;
+
+        _apiKeyInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.ApiKeyInput = text;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  {providerType} API key:").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("API Key")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_apiKeyInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildSlackStep()
+    {
+        return _slackSubStep switch
+        {
+            0 => BuildSlackEnableSubStep(),
+            1 => BuildSlackBotTokenSubStep(),
+            2 => BuildSlackAppTokenSubStep(),
+            _ => Layouts.Empty()
+        };
+    }
+
+    private ILayoutNode BuildSlackEnableSubStep()
+    {
+        _slackEnabledList = Layouts.SelectionList("Yes — configure Slack bot", "No — skip for now")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _slackEnabledList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.SlackEnabled = selected[0].StartsWith("Yes", StringComparison.Ordinal);
+                    if (ViewModel.SlackEnabled)
+                    {
+                        _slackSubStep = 1;
+                        ViewModel.RequestRedraw();
+                    }
+                    else
+                    {
+                        _slackSubStep = 0;
+                        ViewModel.GoNext();
+                    }
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Enable Slack integration?").WithForeground(Color.White))
+            .WithChild(_slackEnabledList);
+    }
+
+    private ILayoutNode BuildSlackBotTokenSubStep()
+    {
+        _slackBotTokenInput = new TextInputNode()
+            .AsPassword()
+            .WithPlaceholder("xoxb-...");
+
+        _slackBotTokenInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.SlackBotToken = text;
+                _slackSubStep = 2;
+                ViewModel.RequestRedraw();
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Slack Bot Token:").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Bot Token")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_slackBotTokenInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildSlackAppTokenSubStep()
+    {
+        _slackAppTokenInput = new TextInputNode()
+            .AsPassword()
+            .WithPlaceholder("xapp-...");
+
+        _slackAppTokenInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.SlackAppToken = text;
+                _slackSubStep = 0;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Slack App Token (Socket Mode):").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("App Token")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_slackAppTokenInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildAclStep()
+    {
+        _ownerIdentityInput = new TextInputNode()
+            .WithPlaceholder("U01234ABCDE (your Slack user ID)");
+
+        if (!string.IsNullOrWhiteSpace(ViewModel.OwnerIdentity))
+            _ownerIdentityInput.Text = ViewModel.OwnerIdentity;
+
+        _ownerIdentityInput.Submitted
+            .Subscribe(text =>
+            {
+                ViewModel.OwnerIdentity = string.IsNullOrWhiteSpace(text) ? null : text;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Owner identity (press Enter to skip):").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Owner ID")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_ownerIdentityInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildMcpStep()
+    {
+        _mcpList = Layouts.SelectionList(
+                "Memorizer (recommended — persistent memory)",
+                "Custom MCP server (configure later)",
+                "Skip — no MCP servers")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _mcpList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.McpSelection = selected[0];
+                    ViewModel.GoNext();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  MCP tool servers:").WithForeground(Color.White))
+            .WithChild(_mcpList);
+    }
+
+    private ILayoutNode BuildExposureStep()
+    {
+        _exposureList = Layouts.SelectionList(
+                "Local only (recommended for homelab)",
+                "Tailscale (configure later)",
+                "Cloudflare Tunnel (configure later)")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _exposureList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    ViewModel.ExposureMode = selected[0];
+                    ViewModel.GoNext();
+                }
+            })
+            .DisposeWith(Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Network exposure:").WithForeground(Color.White))
+            .WithChild(_exposureList);
+    }
+
+    private ILayoutNode BuildHealthCheckStep()
+    {
+        var items = ViewModel.HealthCheckResults;
+        var lines = new List<ILayoutNode>();
+
+        foreach (var item in items)
+        {
+            var (icon, color) = item.Passed switch
+            {
+                true => ("\u2713", Color.Green),
+                false => ("\u2717", Color.Red),
+                null => ("\u25cf", Color.Yellow)
+            };
+            lines.Add(new TextNode($"  {icon}  {item.Label}").WithForeground(color));
+        }
+
+        if (lines.Count == 0)
+            lines.Add(new TextNode("  Press Enter to run health checks...").WithForeground(Color.BrightBlack));
+
+        var layout = Layouts.Vertical();
+        foreach (var line in lines)
+            layout.WithChild(line);
+        return layout;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Input handling
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+
+        // Escape: go back (or sub-step back)
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            if (HandleSubStepBack())
+                return;
+            ViewModel.GoBack();
+            return;
+        }
+
+        // Route input to active component
+        RouteInputToActiveComponent(keyInfo);
+    }
+
+    private bool HandleSubStepBack()
+    {
+        if (ViewModel.CurrentStep == WizardStep.Provider && _providerSubStep > 0)
+        {
+            if (_providerSubStep == 2)
+                ViewModel.ClearFromProvider();
+            _providerSubStep--;
+            ViewModel.RequestRedraw();
+            return true;
+        }
+
+        if (ViewModel.CurrentStep == WizardStep.Slack && _slackSubStep > 0)
+        {
+            _slackSubStep--;
+            ViewModel.RequestRedraw();
+            return true;
+        }
+
+        return false;
+    }
+
+    private TextInputNode? _lastFocusedInput;
+
+    private void RouteInputToActiveComponent(ConsoleKeyInfo keyInfo)
+    {
+        // Try active selection lists first
+        var activeList = GetActiveSelectionList();
+        if (activeList is not null)
+        {
+            // Blur any previously focused text input
+            if (_lastFocusedInput is not null)
+            {
+                _lastFocusedInput.OnBlurred();
+                _lastFocusedInput = null;
+            }
+            activeList.HandleInput(keyInfo);
+            return;
+        }
+
+        // Try active text inputs
+        var activeInput = GetActiveTextInput();
+        if (activeInput is not null)
+        {
+            // Auto-focus the text input for cursor display
+            if (_lastFocusedInput != activeInput)
+            {
+                _lastFocusedInput?.OnBlurred();
+                activeInput.OnFocused();
+                _lastFocusedInput = activeInput;
+            }
+            activeInput.HandleInput(keyInfo);
+            return;
+        }
+
+        // On health check step, Enter triggers the check
+        if (ViewModel.CurrentStep == WizardStep.HealthCheck && keyInfo.Key == ConsoleKey.Enter)
+        {
+            if (ViewModel.IsComplete)
+                ViewModel.RequestQuit();
+            else
+                ViewModel.GoNext();
+        }
+    }
+
+    private IFocusable? GetActiveSelectionList()
+    {
+        return ViewModel.CurrentStep switch
+        {
+            WizardStep.Provider when _providerSubStep == 0 => _providerList,
+            WizardStep.Provider when _providerSubStep == 1 => _authMethodList,
+            WizardStep.Slack when _slackSubStep == 0 => _slackEnabledList,
+            WizardStep.Mcp => _mcpList,
+            WizardStep.Exposure => _exposureList,
+            _ => null
+        };
+    }
+
+    private TextInputNode? GetActiveTextInput()
+    {
+        return ViewModel.CurrentStep switch
+        {
+            WizardStep.Provider when _providerSubStep == 2 && _endpointInput is not null => _endpointInput,
+            WizardStep.Provider when _providerSubStep == 2 => _apiKeyInput,
+            WizardStep.Slack when _slackSubStep == 1 => _slackBotTokenInput,
+            WizardStep.Slack when _slackSubStep == 2 => _slackAppTokenInput,
+            WizardStep.Acl => _ownerIdentityInput,
+            _ => null
+        };
+    }
+
+    private void InitializeComponents()
+    {
+        // Components are lazily created per step, so nothing to do here yet.
+        // Reset sub-steps when step changes
+        ViewModel.CurrentStepChanged
+            .Subscribe(step =>
+            {
+                // Reset sub-steps when entering a step fresh
+                if (step == WizardStep.Provider)
+                {
+                    // Don't reset if we're already in the provider step with sub-steps
+                }
+                else if (step == WizardStep.Slack)
+                {
+                    _slackSubStep = 0;
+                }
+            })
+            .DisposeWith(Subscriptions);
+    }
+}

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1,7 +1,6 @@
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Text.Json;
 using Netclaw.Configuration;
+using R3;
 using Termina.Input;
 using Termina.Reactive;
 
@@ -30,12 +29,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
 
-#pragma warning disable CS0169, CS0414
-    [Reactive] private WizardStep _currentStep = WizardStep.Provider;
-    [Reactive] private string _statusMessage = "";
-    [Reactive] private bool _isHealthCheckRunning;
-    [Reactive] private bool _isComplete;
-#pragma warning restore CS0169, CS0414
+    public ReactiveProperty<WizardStep> CurrentStep { get; } = new(WizardStep.Provider);
+    public ReactiveProperty<string> StatusMessage { get; } = new("");
+    public ReactiveProperty<bool> IsHealthCheckRunning { get; } = new(false);
+    public ReactiveProperty<bool> IsComplete { get; } = new(false);
 
     // ── Step 1: Provider ──
     public string? SelectedProviderType { get; set; }
@@ -74,7 +71,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     {
         base.OnActivated();
 
-        Input.OfType<KeyPressed>()
+        Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleGlobalKey)
             .DisposeWith(Subscriptions);
     }
@@ -84,16 +81,16 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     public void GoNext()
     {
-        if (CurrentStep == WizardStep.HealthCheck)
+        if (CurrentStep.Value == WizardStep.HealthCheck)
         {
-            if (!IsHealthCheckRunning && !IsComplete)
+            if (!IsHealthCheckRunning.Value && !IsComplete.Value)
                 HealthCheckCompletion = RunHealthCheckAsync();
             return;
         }
 
-        var next = (WizardStep)((int)CurrentStep + 1);
-        CurrentStep = next;
-        StatusMessage = "";
+        var next = (WizardStep)((int)CurrentStep.Value + 1);
+        CurrentStep.Value = next;
+        StatusMessage.Value = "";
         RequestRedraw();
     }
 
@@ -103,14 +100,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     public void GoBack()
     {
-        if (CurrentStep == WizardStep.Provider)
+        if (CurrentStep.Value == WizardStep.Provider)
         {
             // Can't go back from step 1 — quit
             Shutdown();
             return;
         }
 
-        var previous = (WizardStep)((int)CurrentStep - 1);
+        var previous = (WizardStep)((int)CurrentStep.Value - 1);
 
         // Back-navigation clearing rules from design doc:
         // Provider change clears auth + model downstream
@@ -119,8 +116,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
             ClearFromProvider();
         }
 
-        CurrentStep = previous;
-        StatusMessage = "";
+        CurrentStep.Value = previous;
+        StatusMessage.Value = "";
         RequestRedraw();
     }
 
@@ -147,7 +144,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     private async Task RunHealthCheckAsync()
     {
-        IsHealthCheckRunning = true;
+        IsHealthCheckRunning.Value = true;
         HealthCheckResults.Clear();
         RequestRedraw();
 
@@ -192,9 +189,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 $"Configuration write failed: {ex.Message}", false);
         }
 
-        IsHealthCheckRunning = false;
-        IsComplete = true;
-        StatusMessage = "Setup complete! Run `netclaw daemon start` to begin.";
+        IsHealthCheckRunning.Value = false;
+        IsComplete.Value = true;
+        StatusMessage.Value = "Setup complete! Run `netclaw daemon start` to begin.";
         RequestRedraw();
     }
 
@@ -290,7 +287,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     public override void Dispose()
     {
-        DisposeReactiveFields();
+        CurrentStep.Dispose();
+        StatusMessage.Dispose();
+        IsHealthCheckRunning.Dispose();
+        IsComplete.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -34,6 +34,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public ReactiveProperty<bool> IsHealthCheckRunning { get; } = new(false);
     public ReactiveProperty<bool> IsComplete { get; } = new(false);
 
+    /// <summary>
+    /// Monotonically increasing counter that ticks whenever health check results
+    /// change. The page subscribes to this to invalidate its DynamicLayoutNode,
+    /// since RequestRedraw alone won't trigger factory re-evaluation in Termina 0.7.1+.
+    /// </summary>
+    internal ReactiveProperty<int> HealthCheckResultVersion { get; } = new(0);
+
     // ── Step 1: Provider ──
     public string? SelectedProviderType { get; set; }
     public AuthMethod SelectedAuthMethod { get; set; } = AuthMethod.None;
@@ -146,22 +153,22 @@ public partial class InitWizardViewModel : ReactiveViewModel
     {
         IsHealthCheckRunning.Value = true;
         HealthCheckResults.Clear();
-        RequestRedraw();
+        NotifyHealthCheckChanged();
 
         // Provider check
         HealthCheckResults.Add(new HealthCheckItem("LLM provider configured", null));
-        RequestRedraw();
+        NotifyHealthCheckChanged();
         await Task.Delay(200); // simulate validation
 
         var providerOk = !string.IsNullOrWhiteSpace(SelectedProviderType);
         HealthCheckResults[^1] = new HealthCheckItem(
             $"LLM provider configured ({SelectedProviderType ?? "none"})",
             providerOk);
-        RequestRedraw();
+        NotifyHealthCheckChanged();
 
         // Slack check
         HealthCheckResults.Add(new HealthCheckItem("Slack configuration", null));
-        RequestRedraw();
+        NotifyHealthCheckChanged();
         await Task.Delay(200);
 
         var slackOk = !SlackEnabled ||
@@ -172,11 +179,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 ? "Slack configuration (Socket Mode)"
                 : "Slack configuration (disabled)",
             slackOk);
-        RequestRedraw();
+        NotifyHealthCheckChanged();
 
         // Config write
         HealthCheckResults.Add(new HealthCheckItem("Writing configuration", null));
-        RequestRedraw();
+        NotifyHealthCheckChanged();
 
         try
         {
@@ -192,6 +199,17 @@ public partial class InitWizardViewModel : ReactiveViewModel
         IsHealthCheckRunning.Value = false;
         IsComplete.Value = true;
         StatusMessage.Value = "Setup complete! Run `netclaw daemon start` to begin.";
+        NotifyHealthCheckChanged();
+    }
+
+    /// <summary>
+    /// Bumps the health check version counter and requests a redraw.
+    /// The page subscribes to HealthCheckResultVersion to invalidate its
+    /// DynamicLayoutNode, which won't rebuild from RequestRedraw alone.
+    /// </summary>
+    private void NotifyHealthCheckChanged()
+    {
+        HealthCheckResultVersion.Value++;
         RequestRedraw();
     }
 
@@ -291,6 +309,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         StatusMessage.Dispose();
         IsHealthCheckRunning.Dispose();
         IsComplete.Dispose();
+        HealthCheckResultVersion.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1,0 +1,298 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using Netclaw.Configuration;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Wizard steps for the init flow.
+/// </summary>
+public enum WizardStep
+{
+    Provider = 1,
+    Slack = 2,
+    Acl = 3,
+    Mcp = 4,
+    Exposure = 5,
+    HealthCheck = 6
+}
+
+/// <summary>
+/// Reactive ViewModel for the <c>netclaw init</c> onboarding wizard.
+/// Drives a 6-step wizard state machine with back-navigation support.
+/// </summary>
+public partial class InitWizardViewModel : ReactiveViewModel
+{
+    public const int TotalSteps = 6;
+
+    private readonly NetclawPaths _paths;
+
+#pragma warning disable CS0169, CS0414
+    [Reactive] private WizardStep _currentStep = WizardStep.Provider;
+    [Reactive] private string _statusMessage = "";
+    [Reactive] private bool _isHealthCheckRunning;
+    [Reactive] private bool _isComplete;
+#pragma warning restore CS0169, CS0414
+
+    // ── Step 1: Provider ──
+    public string? SelectedProviderType { get; set; }
+    public AuthMethod SelectedAuthMethod { get; set; } = AuthMethod.None;
+    public string? ApiKeyInput { get; set; }
+    public string? EndpointInput { get; set; }
+
+    // ── Step 2: Slack ──
+    public string? SlackBotToken { get; set; }
+    public string? SlackAppToken { get; set; }
+    public bool SlackEnabled { get; set; }
+
+    // ── Step 3: ACL ──
+    public string? OwnerIdentity { get; set; }
+
+    // ── Step 4: MCP ──
+    public string? McpSelection { get; set; }
+
+    // ── Step 5: Exposure ──
+    public string? ExposureMode { get; set; }
+
+    // ── Step 6: Health Check ──
+    public List<HealthCheckItem> HealthCheckResults { get; } = [];
+
+    public InitWizardViewModel(NetclawPaths paths)
+    {
+        _paths = paths;
+    }
+
+    public override void OnActivated()
+    {
+        base.OnActivated();
+
+        Input.OfType<KeyPressed>()
+            .Subscribe(HandleGlobalKey)
+            .DisposeWith(Subscriptions);
+    }
+
+    /// <summary>
+    /// Advance to the next wizard step, or write config on the final step.
+    /// </summary>
+    public void GoNext()
+    {
+        if (CurrentStep == WizardStep.HealthCheck)
+        {
+            if (!IsHealthCheckRunning && !IsComplete)
+                _ = RunHealthCheckAsync();
+            return;
+        }
+
+        var next = (WizardStep)((int)CurrentStep + 1);
+        CurrentStep = next;
+        StatusMessage = "";
+        RequestRedraw();
+    }
+
+    /// <summary>
+    /// Go back one step. Clears downstream state per the design doc's
+    /// back-navigation clearing rules.
+    /// </summary>
+    public void GoBack()
+    {
+        if (CurrentStep == WizardStep.Provider)
+        {
+            // Can't go back from step 1 — quit
+            Shutdown();
+            return;
+        }
+
+        var previous = (WizardStep)((int)CurrentStep - 1);
+
+        // Back-navigation clearing rules from design doc:
+        // Provider change clears auth + model downstream
+        if (previous == WizardStep.Provider)
+        {
+            ClearFromProvider();
+        }
+
+        CurrentStep = previous;
+        StatusMessage = "";
+        RequestRedraw();
+    }
+
+    public void RequestQuit()
+    {
+        Shutdown();
+    }
+
+    private void HandleGlobalKey(KeyPressed key)
+    {
+        if (key.KeyInfo.Key == ConsoleKey.Q &&
+            key.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            Shutdown();
+        }
+    }
+
+    internal void ClearFromProvider()
+    {
+        SelectedAuthMethod = AuthMethod.None;
+        ApiKeyInput = null;
+        EndpointInput = null;
+    }
+
+    private async Task RunHealthCheckAsync()
+    {
+        IsHealthCheckRunning = true;
+        HealthCheckResults.Clear();
+        RequestRedraw();
+
+        // Provider check
+        HealthCheckResults.Add(new HealthCheckItem("LLM provider configured", null));
+        RequestRedraw();
+        await Task.Delay(200); // simulate validation
+
+        var providerOk = !string.IsNullOrWhiteSpace(SelectedProviderType);
+        HealthCheckResults[^1] = new HealthCheckItem(
+            $"LLM provider configured ({SelectedProviderType ?? "none"})",
+            providerOk);
+        RequestRedraw();
+
+        // Slack check
+        HealthCheckResults.Add(new HealthCheckItem("Slack configuration", null));
+        RequestRedraw();
+        await Task.Delay(200);
+
+        var slackOk = !SlackEnabled ||
+                       (!string.IsNullOrWhiteSpace(SlackBotToken) &&
+                        !string.IsNullOrWhiteSpace(SlackAppToken));
+        HealthCheckResults[^1] = new HealthCheckItem(
+            SlackEnabled
+                ? "Slack configuration (Socket Mode)"
+                : "Slack configuration (disabled)",
+            slackOk);
+        RequestRedraw();
+
+        // Config write
+        HealthCheckResults.Add(new HealthCheckItem("Writing configuration", null));
+        RequestRedraw();
+
+        try
+        {
+            WriteConfig();
+            HealthCheckResults[^1] = new HealthCheckItem("Configuration written", true);
+        }
+        catch (Exception ex)
+        {
+            HealthCheckResults[^1] = new HealthCheckItem(
+                $"Configuration write failed: {ex.Message}", false);
+        }
+
+        IsHealthCheckRunning = false;
+        IsComplete = true;
+        StatusMessage = "Setup complete! Run `netclaw daemon start` to begin.";
+        RequestRedraw();
+    }
+
+    private void WriteConfig()
+    {
+        _paths.EnsureDirectoriesExist();
+
+        // Build netclaw.json (non-secret settings)
+        var config = new Dictionary<string, object>();
+
+        // Provider section
+        var providers = new Dictionary<string, object>();
+        if (!string.IsNullOrWhiteSpace(SelectedProviderType))
+        {
+            var providerName = SelectedProviderType!.ToLowerInvariant();
+            var providerEntry = new Dictionary<string, object>
+            {
+                ["Type"] = providerName
+            };
+
+            if (SelectedAuthMethod != AuthMethod.None)
+                providerEntry["AuthMethod"] = SelectedAuthMethod.ToString();
+
+            if (!string.IsNullOrWhiteSpace(EndpointInput))
+                providerEntry["Endpoint"] = EndpointInput;
+            else if (providerName == "ollama")
+                providerEntry["Endpoint"] = "http://localhost:11434";
+
+            providers[providerName] = providerEntry;
+        }
+
+        if (providers.Count > 0)
+            config["Providers"] = providers;
+
+        // Models section — set the main model provider
+        if (!string.IsNullOrWhiteSpace(SelectedProviderType))
+        {
+            config["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = SelectedProviderType.ToLowerInvariant()
+                }
+            };
+        }
+
+        // Slack section
+        if (SlackEnabled)
+        {
+            config["Slack"] = new Dictionary<string, object>
+            {
+                ["Enabled"] = true,
+                ["SocketMode"] = true
+            };
+        }
+
+        // Write netclaw.json
+        var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(config, jsonOptions));
+
+        // Build secrets.json (sensitive values)
+        var secrets = new Dictionary<string, object>();
+
+        if (!string.IsNullOrWhiteSpace(ApiKeyInput) && !string.IsNullOrWhiteSpace(SelectedProviderType))
+        {
+            secrets["Providers"] = new Dictionary<string, object>
+            {
+                [SelectedProviderType.ToLowerInvariant()] = new Dictionary<string, object>
+                {
+                    ["ApiKey"] = ApiKeyInput
+                }
+            };
+        }
+
+        if (SlackEnabled)
+        {
+            var slackSecrets = new Dictionary<string, object>();
+            if (!string.IsNullOrWhiteSpace(SlackBotToken))
+                slackSecrets["BotToken"] = SlackBotToken;
+            if (!string.IsNullOrWhiteSpace(SlackAppToken))
+                slackSecrets["AppToken"] = SlackAppToken;
+            if (slackSecrets.Count > 0)
+                secrets["Slack"] = slackSecrets;
+        }
+
+        if (secrets.Count > 0)
+        {
+            File.WriteAllText(_paths.SecretsPath,
+                JsonSerializer.Serialize(secrets, jsonOptions));
+        }
+    }
+
+    public override void Dispose()
+    {
+        DisposeReactiveFields();
+        base.Dispose();
+    }
+}
+
+/// <summary>
+/// Result of a single health check probe.
+/// </summary>
+/// <param name="Label">Display text.</param>
+/// <param name="Passed">Null while running, true/false when complete.</param>
+public sealed record HealthCheckItem(string Label, bool? Passed);

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -60,6 +60,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
     // ── Step 6: Health Check ──
     public List<HealthCheckItem> HealthCheckResults { get; } = [];
 
+    /// <summary>
+    /// Completes when the health check finishes. Used for testing without polling.
+    /// </summary>
+    internal Task? HealthCheckCompletion { get; private set; }
+
     public InitWizardViewModel(NetclawPaths paths)
     {
         _paths = paths;
@@ -82,7 +87,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (CurrentStep == WizardStep.HealthCheck)
         {
             if (!IsHealthCheckRunning && !IsComplete)
-                _ = RunHealthCheckAsync();
+                HealthCheckCompletion = RunHealthCheckAsync();
             return;
         }
 

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -12,7 +12,7 @@ namespace Netclaw.Cli.Tui;
 public enum WizardStep
 {
     Provider = 1,
-    Slack = 2,
+    ChatServices = 2,
     Acl = 3,
     Mcp = 4,
     Exposure = 5,
@@ -22,17 +22,29 @@ public enum WizardStep
 /// <summary>
 /// Reactive ViewModel for the <c>netclaw init</c> onboarding wizard.
 /// Drives a 6-step wizard state machine with back-navigation support.
+/// ACL step is conditionally skipped when no chat services are enabled.
 /// </summary>
 public partial class InitWizardViewModel : ReactiveViewModel
 {
     public const int TotalSteps = 6;
 
     private readonly NetclawPaths _paths;
+    private readonly IProviderProbe _probe;
+    private CancellationTokenSource? _probeCts;
 
     public ReactiveProperty<WizardStep> CurrentStep { get; } = new(WizardStep.Provider);
     public ReactiveProperty<string> StatusMessage { get; } = new("");
     public ReactiveProperty<bool> IsHealthCheckRunning { get; } = new(false);
     public ReactiveProperty<bool> IsComplete { get; } = new(false);
+    public ReactiveProperty<bool> IsProbing { get; } = new(false);
+    public ReactiveProperty<ProviderProbeResult?> ProbeResult { get; } = new(null);
+
+    /// <summary>
+    /// Elapsed seconds since the current probe started. Ticks once per second
+    /// while <see cref="IsProbing"/> is true. The page uses this to animate the
+    /// validation spinner and show a live timer.
+    /// </summary>
+    public ReactiveProperty<int> ProbeElapsedSeconds { get; } = new(0);
 
     /// <summary>
     /// Monotonically increasing counter that ticks whenever health check results
@@ -47,7 +59,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public string? ApiKeyInput { get; set; }
     public string? EndpointInput { get; set; }
 
-    // ── Step 2: Slack ──
+    // ── Step 1 (continued): Model selection ──
+    public string? SelectedModelId { get; set; }
+    public List<DiscoveredModel> DiscoveredModels { get; } = [];
+
+    // ── Step 2: Chat Services ──
     public string? SlackBotToken { get; set; }
     public string? SlackAppToken { get; set; }
     public bool SlackEnabled { get; set; }
@@ -69,9 +85,15 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     internal Task? HealthCheckCompletion { get; private set; }
 
-    public InitWizardViewModel(NetclawPaths paths)
+    /// <summary>
+    /// Completes when the provider probe finishes. Used for testing without polling.
+    /// </summary>
+    internal Task? ProbeCompletion { get; private set; }
+
+    public InitWizardViewModel(NetclawPaths paths, IProviderProbe probe)
     {
         _paths = paths;
+        _probe = probe;
     }
 
     public override void OnActivated()
@@ -84,7 +106,29 @@ public partial class InitWizardViewModel : ReactiveViewModel
     }
 
     /// <summary>
+    /// Returns true if any chat service is enabled (extensible for future services).
+    /// </summary>
+    public bool AnyChatServicesEnabled() => SlackEnabled;
+
+    /// <summary>
+    /// Returns the number of active steps (skipping ACL when no chat services).
+    /// </summary>
+    public int ActiveStepCount => AnyChatServicesEnabled() ? TotalSteps : TotalSteps - 1;
+
+    /// <summary>
+    /// Returns the display number for the given step, accounting for skipped steps.
+    /// </summary>
+    public int GetDisplayStepNumber(WizardStep step)
+    {
+        var num = (int)step;
+        if (!AnyChatServicesEnabled() && step > WizardStep.ChatServices)
+            return num - 1;
+        return num;
+    }
+
+    /// <summary>
     /// Advance to the next wizard step, or write config on the final step.
+    /// Skips ACL when no chat services are enabled.
     /// </summary>
     public void GoNext()
     {
@@ -96,6 +140,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
         }
 
         var next = (WizardStep)((int)CurrentStep.Value + 1);
+
+        // Skip ACL when no chat services are enabled
+        if (next == WizardStep.Acl && !AnyChatServicesEnabled())
+            next = (WizardStep)((int)next + 1);
+
         CurrentStep.Value = next;
         StatusMessage.Value = "";
         RequestRedraw();
@@ -103,7 +152,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     /// <summary>
     /// Go back one step. Clears downstream state per the design doc's
-    /// back-navigation clearing rules.
+    /// back-navigation clearing rules. Skips ACL when no chat services.
     /// </summary>
     public void GoBack()
     {
@@ -115,6 +164,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         }
 
         var previous = (WizardStep)((int)CurrentStep.Value - 1);
+
+        // Skip ACL when going back too
+        if (previous == WizardStep.Acl && !AnyChatServicesEnabled())
+            previous = (WizardStep)((int)previous - 1);
 
         // Back-navigation clearing rules from design doc:
         // Provider change clears auth + model downstream
@@ -133,6 +186,80 @@ public partial class InitWizardViewModel : ReactiveViewModel
         Shutdown();
     }
 
+    /// <summary>
+    /// Probe the provider to validate credentials and discover models.
+    /// Cancels any in-flight probe before starting a new one.
+    /// </summary>
+    public void StartProbe()
+    {
+        CancelProbe();
+        ProbeCompletion = ProbeProviderAsync();
+    }
+
+    /// <summary>
+    /// Cancel any in-flight probe (e.g., on back-navigation).
+    /// </summary>
+    public void CancelProbe()
+    {
+        if (_probeCts is not null)
+        {
+            _probeCts.Cancel();
+            _probeCts.Dispose();
+            _probeCts = null;
+        }
+    }
+
+    internal async Task ProbeProviderAsync()
+    {
+        _probeCts = new CancellationTokenSource();
+        var ct = _probeCts.Token;
+
+        IsProbing.Value = true;
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+        RequestRedraw();
+
+        // Fire-and-forget timer — self-cancels via the shared CTS.
+        // RunProbeTimerAsync handles OperationCanceledException internally
+        // and exits cleanly, so no need to await it after cancellation.
+        _ = RunProbeTimerAsync(ct);
+
+        var result = await _probe.ProbeAsync(
+            SelectedProviderType ?? "unknown",
+            EndpointInput,
+            ApiKeyInput,
+            ct);
+
+        // Stop the timer
+        CancelProbe();
+
+        DiscoveredModels.Clear();
+        if (result.Success)
+            DiscoveredModels.AddRange(result.Models);
+
+        ProbeResult.Value = result;
+        IsProbing.Value = false;
+        RequestRedraw();
+    }
+
+    private async Task RunProbeTimerAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(1000, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            ProbeElapsedSeconds.Value++;
+            RequestRedraw();
+        }
+    }
+
     private void HandleGlobalKey(KeyPressed key)
     {
         if (key.KeyInfo.Key == ConsoleKey.Q &&
@@ -144,9 +271,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     internal void ClearFromProvider()
     {
+        CancelProbe();
         SelectedAuthMethod = AuthMethod.None;
         ApiKeyInput = null;
         EndpointInput = null;
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+        SelectedModelId = null;
+        DiscoveredModels.Clear();
     }
 
     private async Task RunHealthCheckAsync()
@@ -164,6 +296,19 @@ public partial class InitWizardViewModel : ReactiveViewModel
         HealthCheckResults[^1] = new HealthCheckItem(
             $"LLM provider configured ({SelectedProviderType ?? "none"})",
             providerOk);
+        NotifyHealthCheckChanged();
+
+        // Model check
+        HealthCheckResults.Add(new HealthCheckItem("Model selected", null));
+        NotifyHealthCheckChanged();
+        await Task.Delay(200);
+
+        var modelOk = !string.IsNullOrWhiteSpace(SelectedModelId);
+        HealthCheckResults[^1] = new HealthCheckItem(
+            modelOk
+                ? $"Model selected ({SelectedModelId})"
+                : "Model selected (none — will use provider default)",
+            true); // not a hard failure
         NotifyHealthCheckChanged();
 
         // Slack check
@@ -244,15 +389,20 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (providers.Count > 0)
             config["Providers"] = providers;
 
-        // Models section — set the main model provider
+        // Models section — set the main model provider + model ID
         if (!string.IsNullOrWhiteSpace(SelectedProviderType))
         {
+            var modelEntry = new Dictionary<string, object>
+            {
+                ["Provider"] = SelectedProviderType.ToLowerInvariant()
+            };
+
+            if (!string.IsNullOrWhiteSpace(SelectedModelId))
+                modelEntry["ModelId"] = SelectedModelId;
+
             config["Models"] = new Dictionary<string, object>
             {
-                ["Main"] = new Dictionary<string, object>
-                {
-                    ["Provider"] = SelectedProviderType.ToLowerInvariant()
-                }
+                ["Main"] = modelEntry
             };
         }
 
@@ -305,10 +455,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     public override void Dispose()
     {
+        CancelProbe();
         CurrentStep.Dispose();
         StatusMessage.Dispose();
         IsHealthCheckRunning.Dispose();
         IsComplete.Dispose();
+        IsProbing.Dispose();
+        ProbeResult.Dispose();
+        ProbeElapsedSeconds.Dispose();
         HealthCheckResultVersion.Dispose();
         base.Dispose();
     }

--- a/src/Netclaw.Cli/Tui/ProviderProbe.cs
+++ b/src/Netclaw.Cli/Tui/ProviderProbe.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Result of probing a provider's model listing API.
+/// Validates credentials and discovers available models in one call.
+/// </summary>
+public sealed record ProviderProbeResult(
+    bool Success,
+    string? ErrorMessage,
+    IReadOnlyList<DiscoveredModel> Models);
+
+/// <summary>
+/// Probes a provider's model listing API to validate credentials
+/// and discover available models.
+/// </summary>
+public interface IProviderProbe
+{
+    Task<ProviderProbeResult> ProbeAsync(
+        string providerType, string? endpoint, string? apiKey,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Production implementation of <see cref="IProviderProbe"/> that uses
+/// raw HttpClient calls to each provider's model listing API.
+/// </summary>
+public sealed class ProviderProbe : IProviderProbe
+{
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly HttpClient _httpClient;
+
+    public ProviderProbe(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<ProviderProbeResult> ProbeAsync(
+        string providerType, string? endpoint, string? apiKey,
+        CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ProbeTimeout);
+
+        try
+        {
+            return providerType.ToLowerInvariant() switch
+            {
+                "ollama" => await ProbeOllamaAsync(endpoint, timeoutCts.Token),
+                "openrouter" => await ProbeOpenRouterAsync(apiKey, timeoutCts.Token),
+                "anthropic" => await ProbeAnthropicAsync(apiKey, timeoutCts.Token),
+                "openai" => await ProbeOpenAiAsync(apiKey, timeoutCts.Token),
+                _ => new ProviderProbeResult(false, $"Unknown provider type: {providerType}", [])
+            };
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // Our timeout fired, not the caller's token
+            return new ProviderProbeResult(false,
+                "Connection timed out after 10 seconds. Check that the endpoint is reachable.", []);
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled (e.g., back navigation)
+            return new ProviderProbeResult(false, "Validation cancelled.", []);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new ProviderProbeResult(false, $"Connection failed: {ex.Message}", []);
+        }
+    }
+
+    private async Task<ProviderProbeResult> ProbeOllamaAsync(string? endpoint, CancellationToken ct)
+    {
+        var baseUrl = string.IsNullOrWhiteSpace(endpoint) ? "http://localhost:11434" : endpoint.TrimEnd('/');
+        var url = $"{baseUrl}/api/tags";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+            return FailForStatus(response.StatusCode, "ollama", baseUrl);
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var doc = JsonDocument.Parse(json);
+
+        var models = new List<DiscoveredModel>();
+        if (doc.RootElement.TryGetProperty("models", out var modelsArray))
+        {
+            foreach (var model in modelsArray.EnumerateArray())
+            {
+                if (model.TryGetProperty("name", out var name))
+                {
+                    models.Add(new DiscoveredModel { ModelId = name.GetString()! });
+                }
+            }
+        }
+
+        return new ProviderProbeResult(true, null, models);
+    }
+
+    private async Task<ProviderProbeResult> ProbeOpenRouterAsync(string? apiKey, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return new ProviderProbeResult(false, "API key is required for OpenRouter.", []);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://openrouter.ai/api/v1/models");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+            return FailForStatus(response.StatusCode, "openrouter");
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseOpenAiStyleModels(json);
+    }
+
+    private async Task<ProviderProbeResult> ProbeAnthropicAsync(string? apiKey, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return new ProviderProbeResult(false, "API key is required for Anthropic.", []);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.anthropic.com/v1/models");
+        request.Headers.Add("x-api-key", apiKey);
+        request.Headers.Add("anthropic-version", "2023-06-01");
+
+        using var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+            return FailForStatus(response.StatusCode, "anthropic");
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseOpenAiStyleModels(json);
+    }
+
+    private async Task<ProviderProbeResult> ProbeOpenAiAsync(string? apiKey, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            return new ProviderProbeResult(false, "API key is required for OpenAI.", []);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.openai.com/v1/models");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+            return FailForStatus(response.StatusCode, "openai");
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseOpenAiStyleModels(json);
+    }
+
+    /// <summary>
+    /// Produces a human-readable error message from an HTTP status code.
+    /// </summary>
+    private static ProviderProbeResult FailForStatus(
+        HttpStatusCode statusCode, string provider, string? endpoint = null)
+    {
+        var message = statusCode switch
+        {
+            HttpStatusCode.Unauthorized =>
+                $"Invalid credentials. Double-check your {provider} API key.",
+            HttpStatusCode.Forbidden =>
+                $"Access denied. Your {provider} API key may lack model-listing permissions.",
+            HttpStatusCode.NotFound when endpoint is not null =>
+                $"Endpoint not found at {endpoint}. Is the service running?",
+            HttpStatusCode.NotFound =>
+                $"The {provider} models API was not found. The service may be down.",
+            HttpStatusCode.TooManyRequests =>
+                $"Rate limited by {provider}. Wait a moment and try again.",
+            HttpStatusCode.InternalServerError or HttpStatusCode.BadGateway
+                or HttpStatusCode.ServiceUnavailable or HttpStatusCode.GatewayTimeout =>
+                $"The {provider} service returned {(int)statusCode}. It may be experiencing issues.",
+            _ =>
+                $"{provider} returned HTTP {(int)statusCode}."
+        };
+
+        return new ProviderProbeResult(false, message, []);
+    }
+
+    /// <summary>
+    /// Parses the OpenAI-style model listing response (used by OpenRouter, Anthropic, OpenAI).
+    /// Expects: { "data": [ { "id": "model-id" }, ... ] }
+    /// </summary>
+    private static ProviderProbeResult ParseOpenAiStyleModels(string json)
+    {
+        var doc = JsonDocument.Parse(json);
+        var models = new List<DiscoveredModel>();
+
+        if (doc.RootElement.TryGetProperty("data", out var dataArray))
+        {
+            foreach (var model in dataArray.EnumerateArray())
+            {
+                if (model.TryGetProperty("id", out var id))
+                {
+                    models.Add(new DiscoveredModel { ModelId = id.GetString()! });
+                }
+            }
+        }
+
+        return new ProviderProbeResult(true, null, models);
+    }
+}

--- a/src/Netclaw.Configuration/AuthMethod.cs
+++ b/src/Netclaw.Configuration/AuthMethod.cs
@@ -1,0 +1,16 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Authentication methods supported by LLM providers.
+/// </summary>
+public enum AuthMethod
+{
+    /// <summary>No authentication required (e.g., local Ollama).</summary>
+    None,
+
+    /// <summary>Static API key stored in secrets.json.</summary>
+    ApiKey,
+
+    /// <summary>OAuth 2.0 device authorization grant (RFC 8628).</summary>
+    OAuthDevice
+}

--- a/src/Netclaw.Configuration/ModelDiscoverySource.cs
+++ b/src/Netclaw.Configuration/ModelDiscoverySource.cs
@@ -1,0 +1,18 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Tracks how a model ID was resolved during onboarding or model selection.
+/// Used for provenance tagging so doctor and diagnostics can report
+/// confidence level of the selected model.
+/// </summary>
+public enum ModelDiscoverySource
+{
+    /// <summary>Discovered from the provider's live model listing API.</summary>
+    Live,
+
+    /// <summary>Resolved from curated provider defaults shipped with the application.</summary>
+    Defaults,
+
+    /// <summary>Manually entered by the operator.</summary>
+    Manual
+}

--- a/src/Netclaw.Configuration/ModelReference.cs
+++ b/src/Netclaw.Configuration/ModelReference.cs
@@ -10,4 +10,10 @@ public sealed class ModelReference
     public string Provider { get; set; } = "local-ollama";
     public string ModelId { get; set; } = "qwen3:30b";
     public int? ContextWindow { get; set; }
+
+    /// <summary>
+    /// How this model ID was resolved during onboarding or model selection.
+    /// Null for models configured before provenance tracking was added.
+    /// </summary>
+    public ModelDiscoverySource? Provenance { get; set; }
 }

--- a/src/Netclaw.Configuration/ProviderCapabilities.cs
+++ b/src/Netclaw.Configuration/ProviderCapabilities.cs
@@ -1,0 +1,38 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Static metadata about what each provider type supports.
+/// Not persisted — compiled into the application. Used by the onboarding
+/// wizard, model selector, and doctor to determine valid auth methods
+/// and discovery capabilities for a given provider type.
+/// </summary>
+public static class ProviderCapabilities
+{
+    /// <summary>
+    /// Returns the authentication methods supported by the given provider type.
+    /// Methods are ordered by preference (first = recommended).
+    /// </summary>
+    public static IReadOnlyList<AuthMethod> GetSupportedAuthMethods(string providerType)
+        => providerType.ToLowerInvariant() switch
+        {
+            "anthropic" => [AuthMethod.OAuthDevice, AuthMethod.ApiKey],
+            "openai" => [AuthMethod.OAuthDevice, AuthMethod.ApiKey],
+            "openrouter" => [AuthMethod.ApiKey],
+            "ollama" => [AuthMethod.None],
+            _ => [AuthMethod.ApiKey]
+        };
+
+    /// <summary>
+    /// Returns true if the provider type supports runtime model discovery
+    /// via a catalog API (e.g., Ollama /api/tags, OpenRouter /api/v1/models).
+    /// </summary>
+    public static bool SupportsModelDiscovery(string providerType)
+        => providerType.ToLowerInvariant() is
+            "ollama" or "openrouter" or "anthropic" or "openai";
+
+    /// <summary>
+    /// Known provider type identifiers. Used for validation and display.
+    /// </summary>
+    public static IReadOnlyList<string> KnownProviderTypes { get; } =
+        ["anthropic", "openai", "openrouter", "ollama"];
+}

--- a/src/Netclaw.Configuration/ProviderEntry.cs
+++ b/src/Netclaw.Configuration/ProviderEntry.cs
@@ -2,12 +2,19 @@ namespace Netclaw.Configuration;
 
 /// <summary>
 /// Credential container for an LLM provider. Bound from the
-/// "Providers" configuration section. Each named entry represents
-/// a provider endpoint and its authentication.
+/// "Providers" configuration section (netclaw.json + secrets.json overlay).
+/// Each named entry represents a provider endpoint and its authentication.
+/// Non-secret fields (Type, Endpoint, AuthMethod) live in netclaw.json.
+/// Secret fields (ApiKey, OAuth tokens) live in secrets.json and use
+/// <see cref="SensitiveString"/> to prevent accidental logging.
 /// </summary>
 public sealed class ProviderEntry
 {
     public string Type { get; set; } = "ollama";
     public string Endpoint { get; set; } = "http://localhost:11434";
-    public string? ApiKey { get; set; }
+    public AuthMethod AuthMethod { get; set; } = AuthMethod.None;
+    public SensitiveString? ApiKey { get; set; }
+    public SensitiveString? OAuthAccessToken { get; set; }
+    public SensitiveString? OAuthRefreshToken { get; set; }
+    public DateTimeOffset? OAuthTokenExpiry { get; set; }
 }

--- a/src/Netclaw.Configuration/SensitiveString.cs
+++ b/src/Netclaw.Configuration/SensitiveString.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Wraps a secret value (API key, OAuth token) to prevent accidental
+/// exposure in logs, debug output, or string interpolation.
+/// Access the inner value explicitly via <see cref="Value"/>.
+/// </summary>
+/// <param name="Value">The secret value.</param>
+[TypeConverter(typeof(SensitiveStringTypeConverter))]
+public sealed record SensitiveString(string Value)
+{
+    public override string ToString() => "***REDACTED***";
+}
+
+/// <summary>
+/// Enables Microsoft.Extensions.Configuration to bind JSON string values
+/// directly to <see cref="SensitiveString"/> properties.
+/// </summary>
+public sealed class SensitiveStringTypeConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    public override object? ConvertFrom(
+        ITypeDescriptorContext? context,
+        CultureInfo? culture,
+        object value)
+    {
+        if (value is string s)
+            return new SensitiveString(s);
+
+        return base.ConvertFrom(context, culture, value);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/ChatClientFactoryTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ChatClientFactoryTests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class ChatClientFactoryTests
+{
+    [Fact]
+    public void CreatesOllamaClient()
+    {
+        var factory = CreateFactory(("local", new ProviderEntry
+        {
+            Type = "ollama",
+            Endpoint = "http://localhost:11434"
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "local",
+            ModelId = "qwen3:30b"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreatesOpenAIClient()
+    {
+        var factory = CreateFactory(("my-openai", new ProviderEntry
+        {
+            Type = "openai",
+            AuthMethod = AuthMethod.ApiKey,
+            ApiKey = new SensitiveString("sk-test-fake-key")
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "my-openai",
+            ModelId = "gpt-4o-mini"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreatesAnthropicClient()
+    {
+        var factory = CreateFactory(("my-anthropic", new ProviderEntry
+        {
+            Type = "anthropic",
+            AuthMethod = AuthMethod.ApiKey,
+            ApiKey = new SensitiveString("sk-ant-test-fake-key")
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "my-anthropic",
+            ModelId = "claude-sonnet-4-20250514"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreatesOpenRouterClient()
+    {
+        var factory = CreateFactory(("my-openrouter", new ProviderEntry
+        {
+            Type = "openrouter",
+            Endpoint = "https://openrouter.ai/api/v1",
+            AuthMethod = AuthMethod.ApiKey,
+            ApiKey = new SensitiveString("sk-or-test-fake-key")
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "my-openrouter",
+            ModelId = "anthropic/claude-sonnet-4-20250514"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreatesOpenRouterClient_WithDefaultEndpoint()
+    {
+        var factory = CreateFactory(("or", new ProviderEntry
+        {
+            Type = "openrouter",
+            Endpoint = "", // empty — should use default
+            AuthMethod = AuthMethod.ApiKey,
+            ApiKey = new SensitiveString("sk-or-test-fake-key")
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "or",
+            ModelId = "google/gemini-2.5-pro"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreatesClient_WithOAuthToken_WhenNoApiKey()
+    {
+        var factory = CreateFactory(("oauth-provider", new ProviderEntry
+        {
+            Type = "anthropic",
+            AuthMethod = AuthMethod.OAuthDevice,
+            OAuthAccessToken = new SensitiveString("oauth-test-token")
+        }));
+
+        var client = factory.Create(new ModelReference
+        {
+            Provider = "oauth-provider",
+            ModelId = "claude-sonnet-4-20250514"
+        });
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void ThrowsForUnknownProvider()
+    {
+        var factory = CreateFactory(("x", new ProviderEntry
+        {
+            Type = "unknown-provider"
+        }));
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            factory.Create(new ModelReference { Provider = "x", ModelId = "m" }));
+
+        Assert.Contains("Unknown provider type", ex.Message);
+        Assert.Contains("unknown-provider", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsForMissingProviderName()
+    {
+        var factory = CreateFactory(("existing", new ProviderEntry
+        {
+            Type = "ollama"
+        }));
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            factory.Create(new ModelReference { Provider = "nonexistent", ModelId = "m" }));
+
+        Assert.Contains("not found", ex.Message);
+        Assert.Contains("existing", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsForMissingCredentials()
+    {
+        var factory = CreateFactory(("no-creds", new ProviderEntry
+        {
+            Type = "openai",
+            AuthMethod = AuthMethod.ApiKey
+            // No ApiKey or OAuthAccessToken set
+        }));
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            factory.Create(new ModelReference { Provider = "no-creds", ModelId = "gpt-4o" }));
+
+        Assert.Contains("requires authentication", ex.Message);
+    }
+
+    private static ChatClientFactory CreateFactory(params (string name, ProviderEntry entry)[] providers)
+    {
+        var dict = new Dictionary<string, ProviderEntry>();
+        foreach (var (name, entry) in providers)
+            dict[name] = entry;
+        return new ChatClientFactory(dict);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/ChatClientFactory.cs
+++ b/src/Netclaw.Daemon/Configuration/ChatClientFactory.cs
@@ -1,6 +1,9 @@
+using System.ClientModel;
+using Anthropic;
 using Microsoft.Extensions.AI;
 using Netclaw.Configuration;
 using OllamaSharp;
+using OpenAI;
 
 namespace Netclaw.Daemon.Configuration;
 
@@ -8,7 +11,6 @@ namespace Netclaw.Daemon.Configuration;
 /// Creates <see cref="IChatClient"/> instances from provider credentials
 /// and model references. Looks up the named provider from the configured
 /// dictionary and dispatches to the correct SDK.
-/// Future provider types (OpenRouter, Anthropic, OpenAI) add cases here.
 /// </summary>
 public sealed class ChatClientFactory
 {
@@ -26,10 +28,62 @@ public sealed class ChatClientFactory
 
         return provider.Type.ToLowerInvariant() switch
         {
-            "ollama" => new OllamaApiClient(
-                new Uri(provider.Endpoint), model.ModelId),
+            "ollama" => CreateOllamaClient(provider, model),
+            "openai" => CreateOpenAIClient(provider, model),
+            "anthropic" => CreateAnthropicClient(provider, model),
+            "openrouter" => CreateOpenRouterClient(provider, model),
             _ => throw new InvalidOperationException(
-                $"Unknown provider type '{provider.Type}'. Supported: ollama")
+                $"Unknown provider type '{provider.Type}'. "
+                + $"Supported: {string.Join(", ", ProviderCapabilities.KnownProviderTypes)}")
         };
+    }
+
+    private static IChatClient CreateOllamaClient(ProviderEntry provider, ModelReference model)
+        => new OllamaApiClient(new Uri(provider.Endpoint), model.ModelId);
+
+    private static IChatClient CreateOpenAIClient(ProviderEntry provider, ModelReference model)
+    {
+        var apiKey = GetRequiredApiKey(provider, "openai");
+        return new OpenAI.Chat.ChatClient(model.ModelId, apiKey)
+            .AsIChatClient();
+    }
+
+    private static IChatClient CreateAnthropicClient(ProviderEntry provider, ModelReference model)
+    {
+        var apiKey = GetRequiredApiKey(provider, "anthropic");
+        var client = new AnthropicClient(new()
+        {
+            ApiKey = apiKey
+        });
+        return client.AsIChatClient(model.ModelId);
+    }
+
+    private static IChatClient CreateOpenRouterClient(ProviderEntry provider, ModelReference model)
+    {
+        var apiKey = GetRequiredApiKey(provider, "openrouter");
+        var endpoint = string.IsNullOrWhiteSpace(provider.Endpoint)
+            ? new Uri("https://openrouter.ai/api/v1")
+            : new Uri(provider.Endpoint);
+
+        var client = new OpenAIClient(
+            new ApiKeyCredential(apiKey),
+            new OpenAIClientOptions { Endpoint = endpoint });
+
+        return client.GetChatClient(model.ModelId).AsIChatClient();
+    }
+
+    private static string GetRequiredApiKey(ProviderEntry provider, string providerType)
+    {
+        // Check API key first (works for all keyed providers)
+        if (provider.ApiKey is { } apiKey && !string.IsNullOrWhiteSpace(apiKey.Value))
+            return apiKey.Value;
+
+        // Check OAuth access token as fallback for OAuth-capable providers
+        if (provider.OAuthAccessToken is { } oauthToken && !string.IsNullOrWhiteSpace(oauthToken.Value))
+            return oauthToken.Value;
+
+        throw new InvalidOperationException(
+            $"Provider type '{providerType}' requires authentication. "
+            + "Configure ApiKey or OAuthAccessToken in secrets.json.");
     }
 }

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -17,10 +17,10 @@ public static class SlackChannelRegistrationExtensions
         if (!slackOptions.Enabled)
             return;
 
-        if (string.IsNullOrWhiteSpace(slackOptions.BotToken))
+        if (slackOptions.BotToken is null || string.IsNullOrWhiteSpace(slackOptions.BotToken.Value))
             throw new InvalidOperationException("Slack is enabled but Slack:BotToken is not configured.");
 
-        if (slackOptions.SocketMode && string.IsNullOrWhiteSpace(slackOptions.AppToken))
+        if (slackOptions.SocketMode && (slackOptions.AppToken is null || string.IsNullOrWhiteSpace(slackOptions.AppToken.Value)))
             throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
 
         services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
@@ -32,10 +32,10 @@ public static class SlackChannelRegistrationExtensions
 
         services.AddSlackNet(c =>
         {
-            c.UseApiToken(slackOptions.BotToken!);
+            c.UseApiToken(slackOptions.BotToken!.Value);
 
             if (slackOptions.SocketMode)
-                c.UseAppLevelToken(slackOptions.AppToken!);
+                c.UseAppLevelToken(slackOptions.AppToken!.Value);
 
             c.RegisterEventHandler<MessageEvent, SlackChannel>();
             c.RegisterEventHandler<AppMention, SlackChannel>();

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -17,7 +17,9 @@
     <PackageReference Include="Akka.Hosting" />
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
+    <PackageReference Include="Anthropic" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />


### PR DESCRIPTION
## Summary

Implements Milestone 1 tasks A1–A4 for the `netclaw init` onboarding wizard:

- **M1.A1**: Provider config types (`ProviderType`, `AuthMethod`, `SensitiveString`), capability registry, and `DiscoveredModel`
- **M1.A2**: `ChatClientFactory` cloud provider cases (Anthropic, OpenAI, OpenRouter, Ollama)
- **M1.A3**: Init wizard scaffold using Termina TUI — 6-step reactive wizard with back-navigation
- **M1.A4**: ViewModel unit tests for wizard state machine

Plus iterative enhancements from manual testing:

- **Provider validation**: Probes each provider's model listing API to validate credentials and discover models in a single HTTP call (10s timeout, human-readable error messages from HTTP status codes)
- **Model selection**: After successful validation, presents discovered models (capped at 30 for large catalogs like OpenRouter) with manual entry fallback
- **Chat Services step**: Renamed from "Slack" — extensible architecture for future services
- **Conditional ACL skip**: ACL step is skipped when no chat services are enabled, with dynamic step indicator (`Step 3 of 5` vs `Step 4 of 6`)
- **Animated validation spinner**: Braille spinner with elapsed timer during provider probe
- **DynamicLayoutNode factory purity fix**: Moved auto-advance logic out of render factory into reactive subscription to prevent re-entrant invalidation (filed Termina issue #159)
- **Layout improvements**: Help text positioned adjacent to step content, improved color readability

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean build
- [x] `dotnet test Netclaw.slnx` — all 174 tests pass (20 wizard tests covering navigation, ACL skip, probe success/failure, config writing with ModelId)
- [x] `dotnet slopwatch analyze` — no new violations
- [x] Manual: `dotnet run --project src/Netclaw.Cli -- init` tested with OpenRouter (valid + bogus key), Ollama, and Anthropic
- [x] Verified `~/.netclaw/config/netclaw.json` includes `ModelId` after completion