### PR TITLE
Slack auth probe and channel name resolution for init wizard

### DIFF
--- a/src/Netclaw.Channels/Slack/SlackProbe.cs
+++ b/src/Netclaw.Channels/Slack/SlackProbe.cs
@@ -13,11 +13,32 @@ public sealed record SlackProbeResult(
     string? BotUserId);
 
 /// <summary>
+/// A Slack channel resolved from a user-provided name to its API ID.
+/// </summary>
+public sealed record ResolvedSlackChannel(string Name, string Id);
+
+/// <summary>
+/// Result of resolving user-provided channel names to Slack channel IDs
+/// via the <c>conversations.list</c> API.
+/// </summary>
+public sealed record SlackChannelResolutionResult(
+    bool Success,
+    string? ErrorMessage,
+    IReadOnlyList<ResolvedSlackChannel> Resolved,
+    IReadOnlyList<string> Unresolved);
+
+/// <summary>
 /// Probes Slack's <c>auth.test</c> endpoint to validate a bot token.
 /// </summary>
 public interface ISlackProbe
 {
     Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves user-provided channel names to Slack channel IDs via <c>conversations.list</c>.
+    /// </summary>
+    Task<SlackChannelResolutionResult> ResolveChannelNamesAsync(
+        string botToken, IReadOnlyList<string> channelNames, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -26,6 +47,7 @@ public interface ISlackProbe
 public sealed class SlackProbe : ISlackProbe
 {
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ChannelResolveTimeout = TimeSpan.FromSeconds(30);
 
     private readonly HttpClient _httpClient;
 
@@ -77,6 +99,115 @@ public sealed class SlackProbe : ISlackProbe
         }
     }
 
+    public async Task<SlackChannelResolutionResult> ResolveChannelNamesAsync(
+        string botToken, IReadOnlyList<string> channelNames, CancellationToken ct = default)
+    {
+        // Normalize input: strip # prefix, trim, deduplicate (case-insensitive)
+        var normalized = channelNames
+            .Select(n => n.TrimStart('#').Trim())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (normalized.Count == 0)
+            return new SlackChannelResolutionResult(true, null, [], []);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ChannelResolveTimeout);
+
+        var remaining = new HashSet<string>(normalized, StringComparer.OrdinalIgnoreCase);
+        var resolved = new List<ResolvedSlackChannel>();
+        string? cursor = null;
+
+        try
+        {
+            do
+            {
+                var url = "https://slack.com/api/conversations.list?types=public_channel,private_channel&exclude_archived=true&limit=200";
+                if (!string.IsNullOrEmpty(cursor))
+                    url += $"&cursor={Uri.EscapeDataString(cursor)}";
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", botToken);
+
+                using var response = await _httpClient.SendAsync(request, timeoutCts.Token);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                var ok = root.TryGetProperty("ok", out var okProp) && okProp.GetBoolean();
+                if (!ok)
+                {
+                    var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "unknown_error";
+                    return new SlackChannelResolutionResult(false, MapSlackError(error), resolved, remaining.ToList());
+                }
+
+                if (root.TryGetProperty("channels", out var channels))
+                {
+                    foreach (var channel in channels.EnumerateArray())
+                    {
+                        var name = channel.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+                        var nameNormalized = channel.TryGetProperty("name_normalized", out var normProp) ? normProp.GetString() : null;
+                        var id = channel.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
+
+                        if (id is null) continue;
+
+                        // Check if this channel matches any remaining name (case-insensitive)
+                        string? matchedInput = null;
+                        foreach (var input in remaining)
+                        {
+                            if (string.Equals(input, name, StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(input, nameNormalized, StringComparison.OrdinalIgnoreCase))
+                            {
+                                matchedInput = input;
+                                break;
+                            }
+                        }
+
+                        if (matchedInput is not null)
+                        {
+                            resolved.Add(new ResolvedSlackChannel(matchedInput, id));
+                            remaining.Remove(matchedInput);
+                        }
+                    }
+                }
+
+                // Early exit when all names resolved
+                if (remaining.Count == 0)
+                    break;
+
+                // Pagination
+                cursor = null;
+                if (root.TryGetProperty("response_metadata", out var meta) &&
+                    meta.TryGetProperty("next_cursor", out var cursorProp))
+                {
+                    var nextCursor = cursorProp.GetString();
+                    if (!string.IsNullOrEmpty(nextCursor))
+                        cursor = nextCursor;
+                }
+            } while (cursor is not null);
+
+            return new SlackChannelResolutionResult(
+                remaining.Count == 0, null, resolved, remaining.ToList());
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new SlackChannelResolutionResult(false,
+                "Channel lookup timed out after 30 seconds.", resolved, remaining.ToList());
+        }
+        catch (OperationCanceledException)
+        {
+            return new SlackChannelResolutionResult(false, "Channel lookup cancelled.", resolved, remaining.ToList());
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SlackChannelResolutionResult(false,
+                $"Channel lookup failed: {ex.Message}", resolved, remaining.ToList());
+        }
+    }
+
     private static string MapSlackError(string? errorCode) => errorCode switch
     {
         "invalid_auth" => "Bot token is invalid. Check your Slack app's Bot User OAuth Token.",
@@ -84,6 +215,7 @@ public sealed class SlackProbe : ISlackProbe
         "token_revoked" => "Bot token has been revoked. Generate a new one.",
         "token_expired" => "Bot token has expired. Generate a new one.",
         "not_authed" => "No authentication token provided.",
+        "missing_scope" => "Bot token lacks channels:read scope.",
         _ => $"Slack API error: {errorCode}"
     };
 }

--- a/src/Netclaw.Channels/Slack/SlackProbe.cs
+++ b/src/Netclaw.Channels/Slack/SlackProbe.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Result of probing the Slack <c>auth.test</c> API.
+/// </summary>
+public sealed record SlackProbeResult(
+    bool Success,
+    string? ErrorMessage,
+    string? TeamName,
+    string? BotUserId);
+
+/// <summary>
+/// Probes Slack's <c>auth.test</c> endpoint to validate a bot token.
+/// </summary>
+public interface ISlackProbe
+{
+    Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Production implementation that calls <c>https://slack.com/api/auth.test</c>.
+/// </summary>
+public sealed class SlackProbe : ISlackProbe
+{
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly HttpClient _httpClient;
+
+    public SlackProbe(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ProbeTimeout);
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://slack.com/api/auth.test");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", botToken);
+
+            using var response = await _httpClient.SendAsync(request, timeoutCts.Token);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var ok = root.TryGetProperty("ok", out var okProp) && okProp.GetBoolean();
+            if (ok)
+            {
+                var team = root.TryGetProperty("team", out var teamProp) ? teamProp.GetString() : null;
+                var userId = root.TryGetProperty("user_id", out var userProp) ? userProp.GetString() : null;
+                return new SlackProbeResult(true, null, team, userId);
+            }
+
+            var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "unknown_error";
+            return new SlackProbeResult(false, MapSlackError(error), null, null);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new SlackProbeResult(false,
+                "Connection timed out after 10 seconds. Check your network connection.", null, null);
+        }
+        catch (OperationCanceledException)
+        {
+            return new SlackProbeResult(false, "Validation cancelled.", null, null);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SlackProbeResult(false, $"Connection failed: {ex.Message}", null, null);
+        }
+    }
+
+    private static string MapSlackError(string? errorCode) => errorCode switch
+    {
+        "invalid_auth" => "Bot token is invalid. Check your Slack app's Bot User OAuth Token.",
+        "account_inactive" => "Bot account is deactivated.",
+        "token_revoked" => "Bot token has been revoked. Generate a new one.",
+        "token_expired" => "Bot token has expired. Generate a new one.",
+        "not_authed" => "No authentication token provided.",
+        _ => $"Slack API error: {errorCode}"
+    };
+}

--- a/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using Netclaw.Channels.Slack;
+using Netclaw.Cli.Doctor;
+using Netclaw.Cli.Tests.Tui;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class SlackAuthDoctorCheckTests
+{
+    [Fact]
+    public async Task ReturnsPass_WhenSlackDisabled()
+    {
+        var (paths, _) = CreateTempPaths();
+        WriteConfig(paths, slackEnabled: false);
+
+        var probe = new FakeSlackProbe();
+        var check = new SlackAuthDoctorCheck(paths, probe);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("disabled", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, probe.ProbeCallCount);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenSlackEnabled_NoBotToken()
+    {
+        var (paths, _) = CreateTempPaths();
+        WriteConfig(paths, slackEnabled: true);
+        // No secrets.json written — bot token missing
+
+        var probe = new FakeSlackProbe();
+        var check = new SlackAuthDoctorCheck(paths, probe);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("no bot token", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.Remediation);
+        Assert.Equal(0, probe.ProbeCallCount);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenSlackEnabled_ProbeSucceeds()
+    {
+        var (paths, _) = CreateTempPaths();
+        WriteConfig(paths, slackEnabled: true);
+        WriteSecrets(paths, botToken: "xoxb-valid-token");
+
+        var probe = new FakeSlackProbe
+        {
+            NextResult = new SlackProbeResult(true, null, "Test Team", "U12345")
+        };
+
+        var check = new SlackAuthDoctorCheck(paths, probe);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("Test Team", result.Message, StringComparison.Ordinal);
+        Assert.Equal(1, probe.ProbeCallCount);
+        Assert.Equal("xoxb-valid-token", probe.LastBotToken);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenSlackEnabled_ProbeFailsInvalidAuth()
+    {
+        var (paths, _) = CreateTempPaths();
+        WriteConfig(paths, slackEnabled: true);
+        WriteSecrets(paths, botToken: "xoxb-bad-token");
+
+        var probe = new FakeSlackProbe
+        {
+            NextResult = new SlackProbeResult(false,
+                "Bot token is invalid. Check your Slack app's Bot User OAuth Token.", null, null)
+        };
+
+        var check = new SlackAuthDoctorCheck(paths, probe);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("invalid", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.Remediation);
+    }
+
+    private static (NetclawPaths paths, string basePath) CreateTempPaths()
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+        return (paths, basePath);
+    }
+
+    private static void WriteConfig(NetclawPaths paths, bool slackEnabled)
+    {
+        var config = new Dictionary<string, object>
+        {
+            ["Slack"] = new Dictionary<string, object>
+            {
+                ["Enabled"] = slackEnabled
+            }
+        };
+
+        File.WriteAllText(paths.NetclawConfigPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static void WriteSecrets(NetclawPaths paths, string botToken)
+    {
+        var secrets = new Dictionary<string, object>
+        {
+            ["Slack"] = new Dictionary<string, object>
+            {
+                ["BotToken"] = botToken
+            }
+        };
+
+        File.WriteAllText(paths.SecretsPath,
+            JsonSerializer.Serialize(secrets, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -1,0 +1,34 @@
+using Netclaw.Channels.Slack;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Test double for <see cref="ISlackProbe"/> that returns canned results
+/// without making real HTTP calls.
+/// </summary>
+public sealed class FakeSlackProbe : ISlackProbe
+{
+    /// <summary>
+    /// The result to return from the next <see cref="ProbeAsync"/> call.
+    /// Defaults to a successful probe.
+    /// </summary>
+    public SlackProbeResult NextResult { get; set; } = new(
+        true, null, "Test Team", "U12345");
+
+    /// <summary>
+    /// Number of times <see cref="ProbeAsync"/> has been called.
+    /// </summary>
+    public int ProbeCallCount { get; private set; }
+
+    /// <summary>
+    /// The bot token from the last call.
+    /// </summary>
+    public string? LastBotToken { get; private set; }
+
+    public Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
+    {
+        ProbeCallCount++;
+        LastBotToken = botToken;
+        return Task.FromResult(NextResult);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -25,10 +25,34 @@ public sealed class FakeSlackProbe : ISlackProbe
     /// </summary>
     public string? LastBotToken { get; private set; }
 
+    /// <summary>
+    /// The result to return from <see cref="ResolveChannelNamesAsync"/>.
+    /// Defaults to a successful empty resolution.
+    /// </summary>
+    public SlackChannelResolutionResult NextResolutionResult { get; set; } = new(true, null, [], []);
+
+    /// <summary>
+    /// Number of times <see cref="ResolveChannelNamesAsync"/> has been called.
+    /// </summary>
+    public int ResolveCallCount { get; private set; }
+
+    /// <summary>
+    /// The channel names from the last <see cref="ResolveChannelNamesAsync"/> call.
+    /// </summary>
+    public IReadOnlyList<string>? LastResolvedNames { get; private set; }
+
     public Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
     {
         ProbeCallCount++;
         LastBotToken = botToken;
         return Task.FromResult(NextResult);
+    }
+
+    public Task<SlackChannelResolutionResult> ResolveChannelNamesAsync(
+        string botToken, IReadOnlyList<string> channelNames, CancellationToken ct = default)
+    {
+        ResolveCallCount++;
+        LastResolvedNames = channelNames;
+        return Task.FromResult(NextResolutionResult);
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -428,6 +428,156 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Contains("invalid", slackCheck.Label, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task HealthCheck_ChannelResolutionSuccess_WritesChannelIdsToConfig()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackChannelNamesInput = "general, dev";
+
+        _fakeSlackProbe.NextResolutionResult = new Channels.Slack.SlackChannelResolutionResult(
+            true, null,
+            [
+                new Channels.Slack.ResolvedSlackChannel("general", "C001"),
+                new Channels.Slack.ResolvedSlackChannel("dev", "C002")
+            ],
+            []);
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(vm.IsComplete.Value);
+        Assert.Equal(1, _fakeSlackProbe.ResolveCallCount);
+
+        // Verify config file has channel IDs
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Slack", out var slack));
+        Assert.Equal("C001", slack.GetProperty("DefaultChannelId").GetString());
+
+        var allowed = slack.GetProperty("AllowedChannelIds");
+        Assert.Equal(2, allowed.GetArrayLength());
+        Assert.Equal("C001", allowed[0].GetString());
+        Assert.Equal("C002", allowed[1].GetString());
+    }
+
+    [Fact]
+    public async Task HealthCheck_BlankChannelInput_SkipsResolution()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackChannelNamesInput = null;
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(vm.IsComplete.Value);
+        Assert.Equal(0, _fakeSlackProbe.ResolveCallCount);
+
+        // Config should not have channel fields
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Slack", out var slack));
+        Assert.False(slack.TryGetProperty("AllowedChannelIds", out _));
+        Assert.False(slack.TryGetProperty("DefaultChannelId", out _));
+    }
+
+    [Fact]
+    public async Task HealthCheck_PartialChannelResolution_WritesOnlyResolved()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackChannelNamesInput = "general, nonexistent";
+
+        _fakeSlackProbe.NextResolutionResult = new Channels.Slack.SlackChannelResolutionResult(
+            false, null,
+            [new Channels.Slack.ResolvedSlackChannel("general", "C001")],
+            ["nonexistent"]);
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Wizard completes despite partial resolution
+        Assert.True(vm.IsComplete.Value);
+
+        // Health check shows the failure
+        var channelCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Slack channels", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(channelCheck);
+        Assert.False(channelCheck.Passed);
+        Assert.Contains("#nonexistent", channelCheck.Label, StringComparison.Ordinal);
+
+        // Only resolved ID written
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var slack = config.RootElement.GetProperty("Slack");
+        var allowed = slack.GetProperty("AllowedChannelIds");
+        Assert.Equal(1, allowed.GetArrayLength());
+        Assert.Equal("C001", allowed[0].GetString());
+    }
+
+    [Fact]
+    public async Task HealthCheck_ChannelResolutionApiError_NonBlocking()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackChannelNamesInput = "general";
+
+        _fakeSlackProbe.NextResolutionResult = new Channels.Slack.SlackChannelResolutionResult(
+            false, "Bot token lacks channels:read scope.", [], ["general"]);
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Wizard completes despite API error
+        Assert.True(vm.IsComplete.Value);
+
+        var channelCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("channel lookup", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(channelCheck);
+        Assert.False(channelCheck.Passed);
+        Assert.Contains("channels:read", channelCheck.Label, StringComparison.Ordinal);
+
+        // No channel IDs in config
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var slack = config.RootElement.GetProperty("Slack");
+        Assert.False(slack.TryGetProperty("AllowedChannelIds", out _));
+    }
+
+    [Fact]
+    public async Task HealthCheck_AuthFailure_SkipsChannelResolution()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-bad-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackChannelNamesInput = "general, dev";
+
+        _fakeSlackProbe.NextResult = new Channels.Slack.SlackProbeResult(
+            false, "Bot token is invalid.", null, null);
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(vm.IsComplete.Value);
+        Assert.Equal(0, _fakeSlackProbe.ResolveCallCount);
+    }
+
     private InitWizardViewModel CreateViewModel()
     {
         return new InitWizardViewModel(_paths, _fakeProbe, _fakeSlackProbe);

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -14,6 +14,7 @@ public sealed class InitWizardViewModelTests : IDisposable
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
     private readonly FakeProviderProbe _fakeProbe = new();
+    private readonly FakeSlackProbe _fakeSlackProbe = new();
 
     public InitWizardViewModelTests()
     {
@@ -377,8 +378,58 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
     }
 
+    [Fact]
+    public async Task HealthCheck_SlackEnabled_ProbeSuccess_ShowsTeamName()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+
+        _fakeSlackProbe.NextResult = new Channels.Slack.SlackProbeResult(
+            true, null, "Acme Corp", "U99999");
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var slackCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Slack", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(slackCheck);
+        Assert.True(slackCheck.Passed);
+        Assert.Contains("Acme Corp", slackCheck.Label, StringComparison.Ordinal);
+        Assert.Equal(1, _fakeSlackProbe.ProbeCallCount);
+        Assert.Equal("xoxb-test-bot-token", _fakeSlackProbe.LastBotToken);
+    }
+
+    [Fact]
+    public async Task HealthCheck_SlackEnabled_ProbeFailure_ShowsError()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-bad-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+
+        _fakeSlackProbe.NextResult = new Channels.Slack.SlackProbeResult(
+            false, "Bot token is invalid. Check your Slack app's Bot User OAuth Token.", null, null);
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var slackCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Slack", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(slackCheck);
+        Assert.False(slackCheck.Passed);
+        Assert.Contains("invalid", slackCheck.Label, StringComparison.OrdinalIgnoreCase);
+    }
+
     private InitWizardViewModel CreateViewModel()
     {
-        return new InitWizardViewModel(_paths, _fakeProbe);
+        return new InitWizardViewModel(_paths, _fakeProbe, _fakeSlackProbe);
     }
 }

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -12,5 +12,6 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<IDoctorCheck, SlackAclDoctorCheck>();
         services.AddSingleton<IDoctorCheck, TelemetryDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, SlackAuthDoctorCheck>();
     }
 }

--- a/src/Netclaw.Cli/Doctor/SlackAuthDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SlackAuthDoctorCheck.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Nodes;
+using Netclaw.Channels.Slack;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class SlackAuthDoctorCheck(NetclawPaths paths, ISlackProbe slackProbe) : IDoctorCheck
+{
+    private const string CheckName = "Slack Auth";
+
+    public async Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, readError) = DoctorJsonConfigReader.TryReadConfig(paths);
+        if (readError is not null)
+            return DoctorCheckResult.Pass(CheckName, "Skipped (base config is missing or invalid).");
+
+        if (root!["Slack"] is not JsonObject slack || !ReadBool(slack, "Enabled"))
+            return DoctorCheckResult.Pass(CheckName, "Slack is disabled.");
+
+        // Read bot token from secrets.json
+        var botToken = ReadBotToken(paths);
+        if (string.IsNullOrWhiteSpace(botToken))
+        {
+            return DoctorCheckResult.Error(CheckName,
+                "Slack is enabled but no bot token found.",
+                "Run `netclaw init` or add Slack:BotToken to secrets.json.");
+        }
+
+        var result = await slackProbe.ProbeAsync(botToken, cancellationToken);
+        if (result.Success)
+            return DoctorCheckResult.Pass(CheckName, $"Bot authenticated (team: {result.TeamName}).");
+
+        return DoctorCheckResult.Error(CheckName, result.ErrorMessage!,
+            "Check your Slack app's Bot User OAuth Token and scopes.");
+    }
+
+    private static string? ReadBotToken(NetclawPaths paths)
+    {
+        if (!File.Exists(paths.SecretsPath))
+            return null;
+
+        try
+        {
+            var secrets = JsonNode.Parse(File.ReadAllText(paths.SecretsPath)) as JsonObject;
+            return secrets?["Slack"]?["BotToken"]?.GetValue<string>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool ReadBool(JsonObject obj, string property)
+        => obj[property] is JsonValue v && v.TryGetValue<bool>(out var b) && b;
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using Netclaw.Channels;
+using Netclaw.Channels.Slack;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
@@ -70,7 +71,10 @@ static async Task RunAsync(string[] args)
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
         if (mode is "doctor")
+        {
+            builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
             builder.Services.AddDoctorChecks();
+        }
 
         // Suppress framework console logging
         builder.Logging.ClearProviders();
@@ -85,6 +89,7 @@ static async Task RunAsync(string[] args)
 
             // Provider probe for credential validation + model discovery
             builder.Services.AddHttpClient<IProviderProbe, ProviderProbe>();
+            builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
 
             builder.Services.AddTermina("/init", termina =>
             {

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -30,6 +30,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     // Step 2: Chat Services (Slack)
     private TextInputNode? _slackBotTokenInput;
     private TextInputNode? _slackAppTokenInput;
+    private TextInputNode? _slackChannelNamesInput;
     private SelectionListNode<string>? _slackEnabledList;
 
     // Step 3: ACL
@@ -43,7 +44,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     // Track sub-step for provider (0=select, 1=auth, 2=credentials, 3=validate, 4=model)
     private int _providerSubStep;
-    private int _chatServicesSubStep; // 0=enable?, 1=bot token, 2=app token
+    private int _chatServicesSubStep; // 0=enable?, 1=bot token, 2=app token, 3=channel names
 
     // Focus tracking for selection lists (mirrors _lastFocusedInput for text inputs)
     private IFocusable? _lastFocusedList;
@@ -191,6 +192,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Select the model to use for conversations.",
                 WizardStep.ChatServices when _chatServicesSubStep == 0 =>
                     "  Enable Slack to connect Netclaw as a Slack bot.",
+                WizardStep.ChatServices when _chatServicesSubStep == 3 =>
+                    "  Channel names separated by commas. Bot needs channels:read scope to resolve.",
                 WizardStep.ChatServices =>
                     "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
                 WizardStep.Acl =>
@@ -533,6 +536,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             0 => BuildSlackEnableSubStep(),
             1 => BuildSlackBotTokenSubStep(),
             2 => BuildSlackAppTokenSubStep(),
+            3 => BuildSlackChannelNamesSubStep(),
             _ => Layouts.Empty()
         };
     }
@@ -612,8 +616,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Subscribe(text =>
             {
                 ViewModel.SlackAppToken = text;
-                _chatServicesSubStep = 0;
-                ViewModel.GoNext();
+                SetChatServicesSubStep(3);
             })
             .DisposeWith(_stepSubs);
 
@@ -624,6 +627,36 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .WithBorder(BorderStyle.Rounded)
                 .WithBorderColor(Color.Gray)
                 .WithContent(_slackAppTokenInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildSlackChannelNamesSubStep()
+    {
+        _slackChannelNamesInput = new TextInputNode()
+            .WithPlaceholder("general, dev, random  (leave blank to skip)");
+
+        if (!string.IsNullOrWhiteSpace(ViewModel.SlackChannelNamesInput))
+            _slackChannelNamesInput.Text = ViewModel.SlackChannelNamesInput;
+
+        _slackChannelNamesInput.OnFocused();
+        _lastFocusedInput = _slackChannelNamesInput;
+
+        _slackChannelNamesInput.Submitted
+            .Subscribe(text =>
+            {
+                ViewModel.SlackChannelNamesInput = string.IsNullOrWhiteSpace(text) ? null : text;
+                _chatServicesSubStep = 0;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Channel names (press Enter to skip):").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Channel Names")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_slackChannelNamesInput)
                 .Height(3));
     }
 
@@ -882,6 +915,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             WizardStep.Provider when _providerSubStep == 4 && _manualModelEntry => _manualModelInput,
             WizardStep.ChatServices when _chatServicesSubStep == 1 => _slackBotTokenInput,
             WizardStep.ChatServices when _chatServicesSubStep == 2 => _slackAppTokenInput,
+            WizardStep.ChatServices when _chatServicesSubStep == 3 => _slackChannelNamesInput,
             WizardStep.Acl => _ownerIdentityInput,
             _ => null
         };

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -69,6 +69,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public string? SlackBotToken { get; set; }
     public string? SlackAppToken { get; set; }
     public bool SlackEnabled { get; set; }
+    public string? SlackChannelNamesInput { get; set; }
+    internal SlackChannelResolutionResult? LastChannelResolution { get; private set; }
 
     // ── Step 3: ACL ──
     public string? OwnerIdentity { get; set; }
@@ -284,6 +286,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
         DiscoveredModels.Clear();
     }
 
+    private static IReadOnlyList<string> ParseChannelNames(string? input)
+        => string.IsNullOrWhiteSpace(input)
+            ? []
+            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(n => n.TrimStart('#').Trim())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
+
     private async Task RunHealthCheckAsync()
     {
         IsHealthCheckRunning.Value = true;
@@ -318,6 +328,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         HealthCheckResults.Add(new HealthCheckItem("Slack configuration", null));
         NotifyHealthCheckChanged();
 
+        var slackAuthOk = false;
         if (!SlackEnabled)
         {
             HealthCheckResults[^1] = new HealthCheckItem(
@@ -331,13 +342,49 @@ public partial class InitWizardViewModel : ReactiveViewModel
         else
         {
             var slackResult = await _slackProbe.ProbeAsync(SlackBotToken!);
-            HealthCheckResults[^1] = slackResult.Success
-                ? new HealthCheckItem(
-                    $"Slack bot authenticated (team: {slackResult.TeamName})", true)
-                : new HealthCheckItem(
+            if (slackResult.Success)
+            {
+                HealthCheckResults[^1] = new HealthCheckItem(
+                    $"Slack bot authenticated (team: {slackResult.TeamName})", true);
+                slackAuthOk = true;
+            }
+            else
+            {
+                HealthCheckResults[^1] = new HealthCheckItem(
                     $"Slack auth failed: {slackResult.ErrorMessage}", false);
+            }
         }
         NotifyHealthCheckChanged();
+
+        // Channel resolution — only when auth succeeded and names were provided
+        var parsedChannelNames = ParseChannelNames(SlackChannelNamesInput);
+        if (slackAuthOk && parsedChannelNames.Count > 0)
+        {
+            HealthCheckResults.Add(new HealthCheckItem("Resolving Slack channels", null));
+            NotifyHealthCheckChanged();
+
+            LastChannelResolution = await _slackProbe.ResolveChannelNamesAsync(
+                SlackBotToken!, parsedChannelNames);
+
+            if (LastChannelResolution.ErrorMessage is not null)
+            {
+                HealthCheckResults[^1] = new HealthCheckItem(
+                    $"Slack channel lookup failed: {LastChannelResolution.ErrorMessage}", false);
+            }
+            else if (LastChannelResolution.Unresolved.Count > 0)
+            {
+                var notFound = string.Join(", ", LastChannelResolution.Unresolved.Select(n => $"#{n}"));
+                HealthCheckResults[^1] = new HealthCheckItem(
+                    $"Slack channels: resolved {LastChannelResolution.Resolved.Count}/{parsedChannelNames.Count}, not found: {notFound}",
+                    false);
+            }
+            else
+            {
+                HealthCheckResults[^1] = new HealthCheckItem(
+                    $"Slack channels resolved ({LastChannelResolution.Resolved.Count})", true);
+            }
+            NotifyHealthCheckChanged();
+        }
 
         // Config write
         HealthCheckResults.Add(new HealthCheckItem("Writing configuration", null));
@@ -425,11 +472,20 @@ public partial class InitWizardViewModel : ReactiveViewModel
         // Slack section
         if (SlackEnabled)
         {
-            config["Slack"] = new Dictionary<string, object>
+            var slackSection = new Dictionary<string, object>
             {
                 ["Enabled"] = true,
                 ["SocketMode"] = true
             };
+
+            if (LastChannelResolution is { Resolved.Count: > 0 })
+            {
+                var ids = LastChannelResolution.Resolved.Select(r => r.Id).ToArray();
+                slackSection["AllowedChannelIds"] = ids;
+                slackSection["DefaultChannelId"] = ids[0];
+            }
+
+            config["Slack"] = slackSection;
         }
 
         // Write netclaw.json

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
 using R3;
 using Termina.Input;
@@ -30,6 +31,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
+    private readonly ISlackProbe _slackProbe;
     private CancellationTokenSource? _probeCts;
 
     public ReactiveProperty<WizardStep> CurrentStep { get; } = new(WizardStep.Provider);
@@ -90,10 +92,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     internal Task? ProbeCompletion { get; private set; }
 
-    public InitWizardViewModel(NetclawPaths paths, IProviderProbe probe)
+    public InitWizardViewModel(NetclawPaths paths, IProviderProbe probe, ISlackProbe slackProbe)
     {
         _paths = paths;
         _probe = probe;
+        _slackProbe = slackProbe;
     }
 
     public override void OnActivated()
@@ -314,16 +317,26 @@ public partial class InitWizardViewModel : ReactiveViewModel
         // Slack check
         HealthCheckResults.Add(new HealthCheckItem("Slack configuration", null));
         NotifyHealthCheckChanged();
-        await Task.Delay(200);
 
-        var slackOk = !SlackEnabled ||
-                       (!string.IsNullOrWhiteSpace(SlackBotToken) &&
-                        !string.IsNullOrWhiteSpace(SlackAppToken));
-        HealthCheckResults[^1] = new HealthCheckItem(
-            SlackEnabled
-                ? "Slack configuration (Socket Mode)"
-                : "Slack configuration (disabled)",
-            slackOk);
+        if (!SlackEnabled)
+        {
+            HealthCheckResults[^1] = new HealthCheckItem(
+                "Slack configuration (disabled)", true);
+        }
+        else if (string.IsNullOrWhiteSpace(SlackBotToken))
+        {
+            HealthCheckResults[^1] = new HealthCheckItem(
+                "Slack configuration (bot token missing)", false);
+        }
+        else
+        {
+            var slackResult = await _slackProbe.ProbeAsync(SlackBotToken!);
+            HealthCheckResults[^1] = slackResult.Success
+                ? new HealthCheckItem(
+                    $"Slack bot authenticated (team: {slackResult.TeamName})", true)
+                : new HealthCheckItem(
+                    $"Slack auth failed: {slackResult.ErrorMessage}", false);
+        }
         NotifyHealthCheckChanged();
 
         // Config write
@@ -363,7 +376,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _paths.EnsureDirectoriesExist();
 
         // Build netclaw.json (non-secret settings)
-        var config = new Dictionary<string, object>();
+        var config = new Dictionary<string, object>
+        {
+            ["configVersion"] = 1
+        };
 
         // Provider section
         var providers = new Dictionary<string, object>();


### PR DESCRIPTION
## Summary

- Add `ISlackProbe` with `auth.test` endpoint validation and `conversations.list` channel name resolution with pagination
- Wire Slack auth probe into `netclaw doctor` as a health check
- Extend init wizard Chat Services step with channel names input (sub-step after app token)
- Resolve comma-separated channel names to IDs during health check, write `AllowedChannelIds` + `DefaultChannelId` to `netclaw.json`
- Channel resolution is non-blocking — wizard completes even on partial/failed resolution

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean build, 0 warnings
- [x] `dotnet test Netclaw.slnx` — 185 tests pass (5 new channel resolution tests + 4 new doctor check tests)
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] Manual: `netclaw init` → enable Slack → enter tokens → enter channel names → health check resolves → `netclaw doctor` shows no ACL warning