### PR TITLE
MCP tool integration with dynamic discovery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Aaron.Akka.Reminders" Version="$(AkkaRemindersVersion)" />
     <PackageVersion Include="Anthropic" Version="12.8.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+    <PackageVersion Include="ModelContextProtocol.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -504,3 +504,7 @@ the linked research documents.
   sub-agent isolation patterns
 - `docs/research/agent-gateway-architecture.md` — Architecture analysis
   (OpenClaw, IronClaw, PicoClaw). Informed the daemon + thin client split.
+- `docs/research/dynamic-context-discovery.md` — Tool/memory/skill
+  discovery patterns (Anthropic defer_loading, Cursor file-based, DCL
+  three-tier). Compressed index design, deferred memory retrieval
+  decisions. Informs M2 (MCP) and M5 (memory) architecture.

--- a/docs/prd/PRD-006-mcp-tool-integration.md
+++ b/docs/prd/PRD-006-mcp-tool-integration.md
@@ -118,3 +118,4 @@ Runtime SHALL degrade gracefully when MCP server is unavailable:
 - CLI validation: PRD-004
 - Provider tool calling: PRD-005 (MP-010)
 - Local memory tier: PRD-007
+- Dynamic context discovery research: `docs/research/dynamic-context-discovery.md`

--- a/docs/research/dynamic-context-discovery.md
+++ b/docs/research/dynamic-context-discovery.md
@@ -1,0 +1,579 @@
+# Dynamic Context Discovery Research
+
+Date: 2026-02-27
+Task: M2.1–M2.3, M5.1–M5.2 (IMPLEMENTATION_PLAN.md)
+Context: Before building MCP tool integration, research how production AI
+agents handle large tool catalogs, memory retrieval, and skill/context loading
+without bloating the context window. This research informs the architectural
+decision on how Netclaw surfaces tools, memories, and future skill files to the
+LLM agent.
+
+---
+
+## 1. The Problem: Context Window Bloat
+
+### 1.1 Tool Definition Costs
+
+Every tool exposed to an LLM costs tokens. A typical MCP tool definition with
+name, description, and JSON Schema parameters runs 200–500 tokens. At scale:
+
+| MCP Servers | Tools/Server | Total Tools | Estimated Tokens |
+|-------------|-------------|-------------|-----------------|
+| 1 | 6 | 6 | ~2K |
+| 3 | 15 | 45 | ~15K |
+| 5 | 20 | 100 | ~55K |
+| 20 | 20 | 400 | ~100K+ |
+
+A 5-server setup (GitHub, Slack, Sentry, Grafana, Memorizer) consumes ~55K
+tokens in tool definitions before the model does any work. This is not
+hypothetical — it is the documented reality from Cursor, Anthropic, and
+multiple production systems.
+
+Source: [Anthropic Tool Search Tool docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
+
+### 1.2 Tool Selection Accuracy Degradation
+
+The problem is not just tokens — it is accuracy. Models get worse at picking
+the right tool as the number of available tools grows:
+
+| Study | Finding |
+|-------|---------|
+| Anthropic (internal) | Selection accuracy "degrades significantly" past 30–50 tools |
+| RAG-MCP (2025) | Baseline accuracy dropped to 13.62% at scale (1→11,100 tools) |
+| TaskBench (NeurIPS 2024) | Graph accuracy dropped from 96% (1 tool) to 25% (8-tool chains) |
+| MCPVerse (2025) | "Most models suffered performance degradation" with larger tool sets |
+
+The 30–50 tool threshold is consistent across studies. Beyond that, the model
+is essentially guessing.
+
+Sources:
+- [RAG-MCP: Mitigating Prompt Bloat](https://arxiv.org/pdf/2505.03275)
+- [TaskBench: Benchmarking LLMs for Task Automation](https://proceedings.neurips.cc/paper_files/paper/2024/file/085185ea97db31ae6dcac7497616fd3e-Paper-Datasets_and_Benchmarks_Track.pdf)
+- [MCPVerse: Real-World Benchmark for Agentic Tool Use](https://arxiv.org/html/2508.16260v1)
+
+### 1.3 The Problem Generalizes Beyond Tools
+
+The same pressure applies to any large body of retrievable context:
+
+- **Memories**: A knowledge base with hundreds of entries cannot be injected
+  wholesale into every turn.
+- **Skills/Instruction Files**: As the agent gains capabilities (project-specific
+  rules, workflow instructions, domain knowledge), the volume of "potentially
+  relevant" text grows unboundedly.
+- **Reference Documents**: Project docs, API specs, runbooks.
+
+All of these share the same shape: the agent needs *awareness* of what exists
+and *access* to specific items on demand, without paying the token cost of
+loading everything upfront.
+
+---
+
+## 2. Production Approaches
+
+### 2.1 Anthropic: Server-Side Tool Search (defer_loading)
+
+Anthropic's approach, used in Claude Code and the Claude API, is the most
+mature production implementation.
+
+**Mechanism:**
+
+1. All tool definitions are sent in the API `tools` parameter, but marked with
+   `defer_loading: true`.
+2. The model sees only a `tool_search_tool` (regex or BM25 variant) plus 3–5
+   non-deferred "always loaded" tools.
+3. When the model needs a capability, it calls the search tool with a keyword
+   or regex pattern.
+4. The API returns 3–5 `tool_reference` blocks that get automatically expanded
+   into full tool definitions in the model's context.
+5. The model then calls the discovered tool normally.
+
+**Key implementation details:**
+
+- Two search variants: regex (`tool_search_tool_regex_20251119`) and BM25
+  (`tool_search_tool_bm25_20251119`).
+- Search indexes tool names, descriptions, argument names, and argument
+  descriptions.
+- Maximum 10,000 tools in catalog; 3–5 returned per search.
+- Works with MCP via `mcp_toolset` with `default_config.defer_loading: true`.
+- Custom client-side implementations supported — return `tool_reference`
+  blocks from your own search tool.
+
+**Results:**
+
+- **85% token reduction** in tool definitions.
+- Selection accuracy improved: Opus 4 from 49% → 74%, Opus 4.5 from 79.5% →
+  88.1%.
+- Available on Sonnet 4.0+, Opus 4.0+ (not Haiku).
+
+**What Claude Code does specifically:**
+
+Claude Code checks if MCP tool descriptions exceed 10K tokens. If so, tools
+are deferred. The model receives a `ToolSearch` tool and short descriptions
+listing available deferred tools. When the model needs a tool, it searches by
+keyword, and 3–5 relevant tools (~3K tokens) get loaded per query.
+
+Source: [Anthropic Tool Search Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool),
+[Advanced Tool Use](https://www.anthropic.com/engineering/advanced-tool-use)
+
+### 2.2 Cursor: File-Based Dynamic Context Discovery
+
+Cursor's approach treats files as the universal primitive for context
+discovery, not just tools.
+
+**Mechanism:**
+
+1. MCP tool descriptions are synced to a filesystem folder structure (one
+   folder per MCP server).
+2. The agent receives only tool *names* in static context — not full schemas.
+3. When the agent needs a tool, it uses standard file operations (`rg`, `jq`,
+   `cat`) to read the full tool description from the synced folder.
+4. Long tool responses are written to files; the agent uses `tail` to check
+   endpoints and reads selectively.
+5. Chat history during summarization is saved as files the agent can reference
+   to recover lost context.
+
+**Why files over search:**
+
+Cursor explicitly rejected a flat search index approach. Their reasoning:
+"We considered a tool search approach, but that would scatter tools across a
+flat index." Files keep each server's tools logically grouped, enabling
+cohesive understanding. The agent can browse by server, use grep with full
+regex support, or filter with `jq`.
+
+**Results:**
+
+- **46.9% token reduction** in runs that called an MCP tool (A/B test,
+  statistically significant, high variance based on number of MCPs installed).
+
+**Key insight — the approach generalizes:**
+
+Cursor applies the same file-based pattern to five categories:
+1. Large tool outputs → written to files, selectively read
+2. Chat history → saved as files for later reference
+3. Domain-specific capabilities → stored as browsable files
+4. MCP tool details → synced to folder, fetched on demand
+5. Terminal output → synced to filesystem for grep-based searching
+
+The unifying principle: "Files are a simple and powerful primitive" that models
+already know how to navigate.
+
+Source: [Cursor: Dynamic Context Discovery](https://cursor.com/blog/dynamic-context-discovery),
+[InfoQ Coverage](https://www.infoq.com/news/2026/01/cursor-dynamic-context-discovery/)
+
+### 2.3 Dynamic Context Loading (Three-Tier Progressive Disclosure)
+
+A community pattern that formalizes progressive disclosure for MCP tools.
+
+**Mechanism — three levels:**
+
+| Level | What's in context | Token cost |
+|-------|-------------------|------------|
+| 1 — Server summaries | One-line per MCP server: "memorizer: persistent memory store" | ~50 tokens |
+| 2 — Tool summaries | One-line per tool: "store: persist a text memory with tags" | ~200 tokens/server |
+| 3 — Full definitions | Complete JSON Schema for selected tools | ~500 tokens/tool |
+
+The model starts at Level 1. A "loader" meta-tool lets it drill down:
+1. Agent sees server summaries → decides it needs memorizer tools
+2. Calls loader("memorizer") → gets tool summaries for that server
+3. Decides it needs `store` → calls loader("memorizer/store") → full schema
+   loaded
+
+**Key property:** The agent only pays the token cost of the tools it actually
+uses. Everything else stays at summary level.
+
+Source: [Dynamic Context Loading for LLMs & MCP](https://cefboud.com/posts/dynamic-context-loading-llm-mcp/)
+
+### 2.4 Comparison Matrix
+
+| Property | Anthropic (defer_loading) | Cursor (file-based) | DCL (three-tier) |
+|----------|--------------------------|--------------------|--------------------|
+| Token reduction | 85% | 46.9% | Not benchmarked |
+| Search mechanism | Server-side regex/BM25 | File system ops (rg, jq) | Meta-tool calls |
+| Provider-agnostic | No (Claude API only) | Yes | Yes |
+| Works for non-tools | No (tool-specific API) | Yes (files for everything) | Adaptable |
+| Requires file system | No | Yes | No |
+| Implementation effort | Low (API flag) | Medium (sync infrastructure) | Medium (loader tool) |
+| Agent awareness | Deferred tools invisible until searched | Names visible, details on demand | Server names visible, drill down |
+
+---
+
+## 3. Compressed Index Pattern (System Prompt Router)
+
+### 3.1 The Vercel-Style Approach
+
+Independently of the dynamic loading mechanisms above, there is a
+complementary technique: injecting a **compressed index** into the system
+prompt that gives the agent permanent awareness of available capabilities
+without paying the full token cost.
+
+This pattern is used in the dotnet-skills repository for routing agent
+decisions to the correct skill files. Two formats exist:
+
+**Readable format (~400 tokens):**
+
+```markdown
+## Agent Guidance: dotnet-skills
+
+Routing (invoke by name)
+- C# / code quality: modern-csharp-coding-standards, csharp-concurrency-patterns
+- Testing: testcontainers-integration-tests, snapshot-testing
+
+Quality gates (use when applicable)
+- dotnet-slopwatch: after substantial new/refactor/LLM-authored code
+```
+
+**Compressed format (~200 tokens):**
+
+```
+[dotnet-skills]|IMPORTANT: Prefer retrieval-led reasoning over pretraining.
+|flow:{skim repo patterns -> consult by name -> implement -> note conflicts}
+|route:
+|csharp:{modern-csharp-coding-standards,csharp-concurrency-patterns}
+|testing:{testcontainers-integration-tests,snapshot-testing}
+|quality-gates:{dotnet-slopwatch(after:substantial new/refactor/LLM code)}
+```
+
+The compressed format uses pipe delimiters to maximize information density.
+The unusual formatting signals "this is machine-structured routing data" to
+the model, potentially improving consistency in parsing.
+
+Source: dotnet-skills `skills/skills-index-snippets/SKILL.md`,
+Memorizer entry `da8d2175` (AGENTS.md dotnet-skills snippet)
+
+### 3.2 Why the Compressed Index Matters
+
+The index solves a problem that dynamic loading alone cannot: **the agent
+doesn't know what it doesn't know.** Without an index, the agent has no reason
+to search for a memorizer tool — it doesn't know memorizer exists. With the
+index, the agent sees `mcp:memorizer:{store,search,get}` in every turn and can
+reason about when to use it.
+
+The index is a router, not documentation. It does not explain what `store`
+does — it tells the agent "this exists, go look it up when you need it."
+
+### 3.3 Generation
+
+The dotnet-skills repository includes
+`scripts/generate-skill-index-snippets.sh` which reads skill metadata from
+`.claude-plugin/plugin.json` and generates the compressed index automatically.
+The same pattern can generate tool indexes at runtime from `ToolRegistry`
+contents.
+
+---
+
+## 4. How the Agent Knows When to Load
+
+The hardest design question is not *how* to load dynamically, but *when* the
+agent should decide to load. Four mechanisms exist:
+
+### 4.1 Explicit System Prompt Instruction
+
+The system prompt directly tells the agent to search before assuming it cannot
+do something. Claude Code's `ToolSearch` tool description says: "You MUST use
+this tool to load deferred tools BEFORE calling them."
+
+This is brute force but effective. Combined with the compressed index
+(Section 3), the agent has both the instruction to search and the awareness
+of what to search for.
+
+### 4.2 Task-Driven Reasoning
+
+The agent pattern-matches the user's intent against the compressed index.
+"Save this for next time" → matches `mcp:memorizer` → agent searches for
+memory tools. This works when the user's request clearly implies a capability.
+
+### 4.3 Failure and Retry
+
+The agent tries to call a tool that is not loaded, gets an error, and retries
+with a search. This is the worst mechanism — it wastes a turn and tokens on a
+guaranteed failure. No system should design for this as the primary path, but
+it serves as a fallback.
+
+### 4.4 Automatic Pre-Turn Retrieval (System-Initiated)
+
+For memories specifically, none of the above mechanisms work well. The agent
+cannot reason about memories it does not know exist. Unlike tools (where the
+task implies the capability) or skills (where the domain implies the
+instruction), memories are opaque — the agent has no signal that relevant
+prior knowledge exists.
+
+The solution is system-initiated retrieval: before the LLM call, the system
+performs a search (keyword or semantic) against the memory store using the
+current conversation context, and injects relevant results as context. The
+agent does not "decide" to load memories — the system pre-fetches them.
+
+This is the standard RAG pattern applied to agent memory.
+
+---
+
+## 5. Memory Retrieval: Deferred Design Decisions
+
+Memory retrieval strategy does not block MCP tool support (Milestone 2). The
+agent can use Memorizer's `search` tool explicitly via MCP from day one. The
+more sophisticated automatic retrieval is an optimization layered on after
+memories exist to retrieve.
+
+The following decisions should be revisited when implementing Milestone 5
+(Agent Memory System).
+
+### 5.1 Search Strategy: Keyword vs. Vector vs. Hybrid
+
+| Strategy | Strengths | Weaknesses |
+|----------|-----------|------------|
+| Keyword (current Memorizer) | Fast, predictable, no infrastructure | Misses semantic relationships; agent must know what to search for |
+| Vector/Embedding | Finds semantically related content the agent would not think to search for | Requires embedding infrastructure; similarity thresholds need tuning |
+| Hybrid (keyword + vector) | Best of both — precise when the agent knows, serendipitous when it does not | Most complex; needs ranking/fusion strategy |
+
+**Recommendation (deferred):** Start with keyword search via explicit MCP tool
+calls (M2). When implementing automatic pre-turn retrieval (M5), add vector
+search. Memorizer would embed memory content at `store` time and persist the
+vector alongside the text. The pre-turn search becomes a cosine similarity
+query.
+
+### 5.2 What to Search Against
+
+The quality of retrieval depends heavily on the query signal:
+
+| Query Source | Signal Quality | Notes |
+|-------------|---------------|-------|
+| Raw user message | Low | "help me debug this actor" matches everything mentioning actors |
+| Last N messages | Medium | Adds conversational continuity |
+| Assembled turn context (system prompt + recent history + current message) | High | Topic + intent + continuity combined |
+| Extracted keywords/entities from turn context | Highest (for keyword search) | Reduces noise; requires extraction step |
+
+**Recommendation (deferred):** For vector search, embed against the assembled
+turn context (last N messages + current message), not the raw user message
+alone. For keyword search, extract entities/topics from the current turn to
+form the query.
+
+### 5.3 Injection Budget
+
+Pre-turn memory injection must be bounded to avoid the same context bloat
+problem it aims to solve.
+
+**Recommendation (deferred):**
+- Maximum 3–5 memories per turn (configurable).
+- Minimum similarity threshold (e.g., 0.75 for vector search).
+- Total injection budget: ~2K tokens for memories.
+- Injected as a clearly delimited section in the system prompt or as a
+  prefixed user message.
+- The agent's explicit `memory_search` tool call has no budget limit — if the
+  agent chooses to search, it gets full results.
+
+### 5.4 When to Embed
+
+Two options for when vector embeddings are created:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| At store time | No latency at retrieval; embedding is amortized | Requires re-embedding on memory update |
+| At search time | Always fresh; no storage overhead | Adds latency to every turn; wasteful if same memory searched repeatedly |
+
+**Recommendation (deferred):** Embed at store time. Memorizer already persists
+the text — adding a vector column is incremental. Re-embed on update. This
+keeps the pre-turn retrieval path fast (one similarity query, no embedding
+call).
+
+### 5.5 Embedding Provider
+
+The embedding model should be configurable but default to a practical choice:
+
+- If Ollama is configured: use a local embedding model (e.g.,
+  `nomic-embed-text` or `mxbai-embed-large`).
+- If a cloud provider is configured: use the provider's embedding API.
+- Memorizer may also have its own embedding infrastructure — in that case,
+  delegate to it entirely.
+
+**Decision needed at M5 time:** Whether Netclaw or Memorizer owns the
+embedding pipeline. If Memorizer already embeds content at store time, Netclaw
+just calls `search` with a text query and Memorizer handles the vector
+matching internally.
+
+---
+
+## 6. Proposal: Netclaw Dynamic Context Architecture
+
+### 6.1 Two-Layer Design
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    System Prompt                     │
+│                                                     │
+│  Layer 1: Compressed Index (always present)          │
+│  ┌─────────────────────────────────────────────┐    │
+│  │ [tools]|route:                               │    │
+│  │ |builtin:{shell,file_read,file_write}        │    │
+│  │ |mcp:memorizer:{store,search,get,delete}     │    │
+│  │ |mcp:github:{create_issue,search_repos,...}  │    │
+│  │ |search:use search_tools for unlisted caps   │    │
+│  └─────────────────────────────────────────────┘    │
+│                  ~200–400 tokens                     │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│               ChatOptions.Tools                      │
+│                                                     │
+│  Layer 2: Active Tool Definitions                    │
+│  ┌─────────────────────────────────────────────┐    │
+│  │ Always loaded (full schema):                 │    │
+│  │   shell_execute, file_read, file_write       │    │
+│  │                                              │    │
+│  │ search_tools meta-tool (full schema):        │    │
+│  │   Searches ToolRegistry by keyword           │    │
+│  │   Returns tool definitions for loading       │    │
+│  │                                              │    │
+│  │ Dynamically loaded (on demand):              │    │
+│  │   [empty until agent calls search_tools]     │    │
+│  └─────────────────────────────────────────────┘    │
+│              ~2K tokens base, grows per search       │
+└─────────────────────────────────────────────────────┘
+```
+
+### 6.2 Compressed Index Generation
+
+At session start, the system generates the compressed index from `ToolRegistry`
+contents:
+
+1. Query `ToolRegistry` for all registered tools.
+2. Group by source: `builtin` for first-party tools, `mcp:{server_name}` for
+   MCP tools.
+3. For each group, emit tool names only (no descriptions, no schemas).
+4. Append routing instruction: "Use search_tools when you need a capability
+   not listed above or need the full definition of a listed tool."
+5. Inject into system prompt as a clearly delimited section.
+
+### 6.3 The `search_tools` Meta-Tool
+
+A first-party `INetclawTool` that searches the registry:
+
+```
+Name: search_tools
+Description: Search for tools by keyword. Returns matching tool definitions
+  that will be loaded for use. Use this when you need a capability from the
+  tool index or need the full schema of a known tool.
+Parameters:
+  query: string — keyword or tool name to search for
+  server: string? — optional MCP server name to scope search
+Returns:
+  List of matching tool definitions (name, description, parameter summary)
+```
+
+**Implementation:** Search tool names, descriptions, and parameter names using
+case-insensitive substring matching. Return top 5 matches. The session actor
+adds matched tools to the active `ChatOptions.Tools` for subsequent turns in
+the same conversation.
+
+**Provider-specific optimization:** When the backend is Claude (Anthropic),
+use native `defer_loading: true` on the API call instead of the custom
+meta-tool. The compressed index still serves as the awareness layer. This
+gives the best of both worlds: native 85% token savings on Claude, and
+provider-agnostic fallback for Ollama/OpenRouter.
+
+### 6.4 Generalization to Non-Tool Context
+
+The same two-layer pattern applies to memories, skills, and reference docs.
+The index and search mechanism are shared; the *injection target* differs:
+
+| Context Type | Index Entry Example | Search Tool | Injection Target |
+|-------------|--------------------|----|------------------|
+| MCP Tools | `mcp:memorizer:{store,search,get}` | `search_tools` | `ChatOptions.Tools` (callable) |
+| Memories | `[memories]|topics:{slack-config,provider-setup,debugging}` | `search_memories` | Conversation messages (readable text) |
+| Skills | `[skills]|available:{git-workflow,release-management}` | `search_skills` | Conversation messages (readable text) |
+
+Tools are special because they must become callable `AITool` definitions.
+Everything else is text injection into the conversation.
+
+The shared infrastructure is:
+- `IDiscoveryIndex` — generates compressed index entries for the system prompt
+- `IContextSearch` — searches a registry by keyword, returns items
+- Per-type specialization — tools go into `ChatOptions.Tools`; memories/skills
+  go into messages
+
+### 6.5 Automatic Memory Pre-Fetch (Future — M5)
+
+For memories, supplement the explicit `search_memories` tool with automatic
+pre-turn retrieval:
+
+1. Before each LLM call, extract the current turn context.
+2. Run a vector similarity search against embedded memories.
+3. Inject top 3–5 results (above threshold) as a prefixed system message:
+   "Relevant memories from prior sessions: ..."
+4. The agent reads these passively — no tool call needed.
+
+This is additive to the explicit search tool — the agent can still call
+`search_memories` for targeted lookups. The pre-fetch catches things the agent
+would not think to search for.
+
+---
+
+## 7. Implementation Sequencing
+
+| Phase | What | Depends On |
+|-------|------|-----------|
+| **M2 (MCP)** | MCP client, `McpToolAdapter`, tool discovery, `search_tools` meta-tool, compressed index generation | Nothing |
+| **M2 (MCP)** | Provider-specific optimization (Claude `defer_loading`) | M2 core |
+| **M2.3 (Memorizer)** | Memorizer as MCP server, explicit `memorizer/search` tool | M2 core |
+| **M5.1 (Memory extraction)** | `IMemoryExtractor` writes to Memorizer during compaction | M2.3 |
+| **M5.2 (Memory retrieval)** | `search_memories` meta-tool, pre-turn vector retrieval | M5.1 + embedding infrastructure |
+| **Future (Skills)** | `search_skills` meta-tool, skill file discovery | M2 pattern established |
+
+### What to build now (M2):
+
+1. MCP client (JSON-RPC over stdio/SSE)
+2. `McpToolAdapter : INetclawTool`
+3. `search_tools` meta-tool against `ToolRegistry`
+4. Compressed index generation from `ToolRegistry` at session start
+5. System prompt injection of compressed index
+6. Keep 3–5 core tools always loaded; defer the rest
+
+### What to defer:
+
+- Vector embedding infrastructure (M5)
+- Automatic pre-turn memory retrieval (M5)
+- Skill file discovery and loading (post-MVP)
+- Claude-specific `defer_loading` optimization (nice-to-have during M2)
+
+---
+
+## 8. Summary
+
+| Area | Recommendation | Priority |
+|------|---------------|----------|
+| Tool loading | Two-layer: compressed index + search meta-tool | M2 (now) |
+| Always-loaded tools | 3–5 core tools (shell, file ops) with full schemas | M2 (now) |
+| Compressed index | Auto-generated from ToolRegistry, Vercel-style pipe format | M2 (now) |
+| Provider optimization | Use Claude `defer_loading` when available | M2 (nice-to-have) |
+| Memory search (explicit) | Agent calls `memorizer/search` via MCP | M2.3 |
+| Memory search (automatic) | Pre-turn vector retrieval against turn context | M5 (deferred) |
+| Embedding strategy | Embed at store time; search against assembled turn context | M5 (deferred) |
+| Skill discovery | Same pattern as tools — index + search meta-tool | Post-MVP |
+| Generalized interface | `IDiscoveryIndex` + `IContextSearch` shared infrastructure | M2 (design for it, build incrementally) |
+
+---
+
+## Sources
+
+### Documentation
+- [Anthropic: Tool Search Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
+- [Anthropic: Advanced Tool Use](https://www.anthropic.com/engineering/advanced-tool-use)
+- [MCP Specification: Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+
+### Industry Analysis
+- [Cursor: Dynamic Context Discovery](https://cursor.com/blog/dynamic-context-discovery)
+- [InfoQ: Cursor Dynamic Context Discovery](https://www.infoq.com/news/2026/01/cursor-dynamic-context-discovery/)
+- [Dynamic Context Loading for LLMs & MCP](https://cefboud.com/posts/dynamic-context-loading-llm-mcp/)
+- [MCP and Context Overload](https://eclipsesource.com/blogs/2026/01/22/mcp-context-overload/)
+- [Tool RAG: Scalable AI Agents](https://next.redhat.com/2025/11/26/tool-rag-the-next-breakthrough-in-scalable-ai-agents/)
+
+### Research Papers
+- [RAG-MCP: Mitigating Prompt Bloat in LLM Tool Selection](https://arxiv.org/pdf/2505.03275)
+- [TaskBench: Benchmarking LLMs for Task Automation (NeurIPS 2024)](https://proceedings.neurips.cc/paper_files/paper/2024/file/085185ea97db31ae6dcac7497616fd3e-Paper-Datasets_and_Benchmarks_Track.pdf)
+- [MCPVerse: Real-World Benchmark for Agentic Tool Use](https://arxiv.org/html/2508.16260v1)
+
+### Internal References
+- dotnet-skills: `skills/skills-index-snippets/SKILL.md` (Vercel-style compressed index pattern)
+- Memorizer entry `da8d2175`: AGENTS.md dotnet-skills snippet (router + quality gates)
+- Netclaw PRD-006: MCP Tool Integration
+- Netclaw `openspec/specs/netclaw-mcp/spec.md`
+- Netclaw `openspec/specs/netclaw-agent-memory/spec.md`
+- Spring AI: [Smart Tool Selection with Dynamic Tool Discovery](https://spring.io/blog/2025/12/11/spring-ai-tool-search-tools-tzolov/) (34–64% token savings)

--- a/openspec/specs/netclaw-agent-memory/spec.md
+++ b/openspec/specs/netclaw-agent-memory/spec.md
@@ -1,5 +1,9 @@
 # netclaw-agent-memory Specification
 
+Research: `docs/research/agent-patterns.md`,
+`docs/research/dynamic-context-discovery.md` (§5 — deferred memory retrieval
+decisions: keyword vs. vector search, embedding strategy, injection budgets)
+
 ## Purpose
 
 Define agent personality (soul files), local memory (project registry,

--- a/openspec/specs/netclaw-mcp/spec.md
+++ b/openspec/specs/netclaw-mcp/spec.md
@@ -1,5 +1,7 @@
 # netclaw-mcp Specification
 
+Research: `docs/research/dynamic-context-discovery.md`
+
 ## Purpose
 
 Define MCP server integration, validation, policy enforcement, and diagnostics.
@@ -93,6 +95,13 @@ On startup, the system SHALL discover tools from all enabled MCP server
 profiles and register them as Microsoft.Extensions.AI (MEAI) tool definitions.
 Tool discovery SHALL refresh on each session start to pick up newly added or
 removed tools from MCP servers.
+
+To avoid context window bloat with large tool catalogs (see
+`docs/research/dynamic-context-discovery.md` §1–2), the system SHALL use a
+two-layer discovery strategy: a compressed tool index injected into the system
+prompt for agent awareness, and a `search_tools` meta-tool for on-demand
+loading of full tool definitions. Core tools (shell, file operations) SHALL
+remain always-loaded; MCP tools SHALL be deferred by default.
 
 #### Scenario: Startup tool discovery
 

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class McpToolAdapterTests
+{
+    [Fact]
+    public void Name_IsNamespaced()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
+
+        Assert.Equal("memorizer/store", adapter.Name);
+    }
+
+    [Fact]
+    public void BareToolName_ReturnsUnprefixedName()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
+
+        Assert.Equal("store", adapter.BareToolName);
+    }
+
+    [Fact]
+    public void GrantCategory_DefaultsToMcpPrefix()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
+
+        Assert.Equal("mcp:memorizer", adapter.GrantCategory);
+    }
+
+    [Fact]
+    public void GrantCategory_UsesExplicitOverride()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store", "custom:grant");
+
+        Assert.Equal("custom:grant", adapter.GrantCategory);
+    }
+
+    [Fact]
+    public void ServerName_IsSet()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
+
+        Assert.Equal("memorizer", adapter.ServerName);
+    }
+
+    [Fact]
+    public void ToAITool_ReturnsSameInstance()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "result", "store");
+        var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
+
+        Assert.Same(fakeTool, adapter.ToAITool());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvokesUnderlyingTool()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "hello from mcp", "greet");
+        var adapter = new McpToolAdapter(fakeTool, "server", "greet");
+
+        var result = await adapter.ExecuteAsync(new Dictionary<string, object?>(), CancellationToken.None);
+
+        Assert.Equal("hello from mcp", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        string ThrowingFunc() => throw new InvalidOperationException("connection lost");
+        var fakeTool = AIFunctionFactory.Create((Func<string>)ThrowingFunc, "fail_tool");
+        var adapter = new McpToolAdapter(fakeTool, "server", "fail_tool");
+
+        var result = await adapter.ExecuteAsync(new Dictionary<string, object?>(), CancellationToken.None);
+
+        Assert.Contains("connection lost", result);
+        Assert.StartsWith("Error:", result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class SearchToolsToolTests
+{
+    [Fact]
+    public async Task Search_MatchesByName()
+    {
+        var registry = CreateRegistryWithMcpTools();
+        var tool = new SearchToolsTool(registry);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "store" },
+            CancellationToken.None);
+
+        Assert.Contains("memorizer/store", result);
+    }
+
+    [Fact]
+    public async Task Search_MatchesByDescription()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeAIFunction("search_memories", "Find stored memories"),
+            "memorizer", "search_memories"));
+
+        var tool = new SearchToolsTool(registry);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "memories" },
+            CancellationToken.None);
+
+        Assert.Contains("memorizer/search_memories", result);
+    }
+
+    [Fact]
+    public async Task Search_NoResults()
+    {
+        var registry = CreateRegistryWithMcpTools();
+        var tool = new SearchToolsTool(registry);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "nonexistent_xyz" },
+            CancellationToken.None);
+
+        Assert.Contains("No tools found", result);
+    }
+
+    [Fact]
+    public async Task Search_FiltersServer()
+    {
+        var registry = CreateRegistryWithMcpTools();
+        var tool = new SearchToolsTool(registry);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?>
+            {
+                ["Query"] = "store",
+                ["Server"] = "github"
+            },
+            CancellationToken.None);
+
+        // "github" server has no "store" tool — only memorizer does
+        Assert.Contains("No tools found", result);
+    }
+
+    [Fact]
+    public async Task Search_IncludesNonMcpToolsWithoutServerFilter()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateFakeToolInRegistry("shell_execute", "Execute shell command"), "shell");
+
+        var tool = new SearchToolsTool(registry);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "shell" },
+            CancellationToken.None);
+
+        // Without server filter, non-MCP tools are included in search results
+        Assert.Contains("shell_execute", result);
+    }
+
+    [Fact]
+    public void GrantCategory_IsBuiltin()
+    {
+        var registry = new ToolRegistry();
+        var tool = new SearchToolsTool(registry);
+
+        Assert.Equal("builtin", tool.GrantCategory);
+    }
+
+    private static ToolRegistry CreateRegistryWithMcpTools()
+    {
+        var registry = new ToolRegistry();
+
+        registry.Register(new McpToolAdapter(
+            CreateFakeAIFunction("store", "Store a value"), "memorizer", "store"));
+        registry.Register(new McpToolAdapter(
+            CreateFakeAIFunction("search", "Search stored values"), "memorizer", "search"));
+        registry.Register(new McpToolAdapter(
+            CreateFakeAIFunction("create_issue", "Create a GitHub issue"), "github", "create_issue"));
+
+        return registry;
+    }
+
+    private static AIFunction CreateFakeAIFunction(string name, string description)
+    {
+        return AIFunctionFactory.Create(() => "result", name, description);
+    }
+
+    private static AITool CreateFakeToolInRegistry(string name, string description)
+    {
+        return AIFunctionFactory.Create(() => "result", name, description);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
@@ -67,6 +67,79 @@ public class ToolRegistryTests
         Assert.Equal(2, tools.Count);
     }
 
+    [Fact]
+    public void GetAlwaysLoadedTools_returns_non_mcp_tools()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateFakeTool("shell_execute"), "shell");
+        registry.Register(CreateFakeTool("search_tools"), "builtin");
+        registry.Register(CreateFakeTool("file_read"), "file");
+        // MCP tools should be excluded
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("store"), "memorizer", "store"));
+
+        var alwaysLoaded = registry.GetAlwaysLoadedTools();
+
+        Assert.Equal(3, alwaysLoaded.Count);
+        Assert.DoesNotContain(alwaysLoaded, t => t is AIFunction f && f.Name == "store");
+    }
+
+    [Fact]
+    public void SearchTools_finds_matching_tools()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("store"), "memorizer", "store"));
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("search"), "memorizer", "search"));
+
+        var results = registry.SearchTools("store", null, 10);
+
+        Assert.Single(results);
+        Assert.Equal("memorizer/store", results[0].Name);
+    }
+
+    [Fact]
+    public void SearchTools_filters_by_server()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("store"), "memorizer", "store"));
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("store"), "github", "store"));
+
+        var results = registry.SearchTools("store", "memorizer", 10);
+
+        Assert.Single(results);
+        Assert.Equal("memorizer/store", results[0].Name);
+    }
+
+    [Fact]
+    public void GenerateCompressedIndex_groups_by_category()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("store"), "memorizer", "store"));
+        registry.Register(new McpToolAdapter(
+            CreateFakeTool("search"), "memorizer", "search"));
+        registry.Register(CreateFakeTool("shell_execute"), "shell");
+
+        var index = registry.GenerateCompressedIndex();
+
+        Assert.Contains("mcp:memorizer: store, search", index);
+        Assert.Contains("shell: shell_execute", index);
+        Assert.Contains("search_tools", index);
+    }
+
+    [Fact]
+    public void GenerateCompressedIndex_empty_registry_returns_empty()
+    {
+        var registry = new ToolRegistry();
+        var index = registry.GenerateCompressedIndex();
+
+        Assert.Empty(index);
+    }
+
     private static AIFunction CreateFakeTool(string name)
     {
         return AIFunctionFactory.Create(() => "result", name);

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Aaron.Akka.Reminders" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="protobuf-net" />
   </ItemGroup>
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -42,7 +42,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     // Transient state (not persisted)
     private readonly List<SendUserMessage> _buffer = new();
     private readonly Dictionary<IActorRef, OutputFilter> _subscribers = new();
-    private IReadOnlyList<AITool> _availableTools = [];
+    private readonly List<AITool> _availableTools = new();
+    private readonly ToolRegistry? _fullRegistry;
 
     // Last observed input token count from LLM response (for compaction trigger)
     private long _lastInputTokenCount;
@@ -85,10 +86,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         // Enrich logger with session context — all log messages automatically include SessionId
         _log = Context.GetLogger().WithContext("SessionId", _sessionId.Value);
 
-        // Load available tools from registry (all tools for now; policy filtering comes in Task 1.5)
+        // Load all non-MCP tools for initial LLM calls.
+        // MCP tools are loaded dynamically via search_tools meta-tool.
+        _fullRegistry = toolRegistry;
         if (toolRegistry is not null)
         {
-            _availableTools = toolRegistry.GetAllTools();
+            _availableTools.AddRange(toolRegistry.GetAlwaysLoadedTools());
         }
 
         // ── Recovery handlers ──
@@ -200,6 +203,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             foreach (var result in msg.ToolResults)
             {
                 _state = _state with { History = _state.History.Add(result) };
+            }
+
+            // Dynamic tool loading: if search_tools was called, load discovered tools
+            // into the available tools list so they can be called in subsequent turns
+            if (_fullRegistry is not null)
+            {
+                foreach (var result in msg.ToolResults)
+                {
+                    if (result.Name is "search_tools" && result.Content is not null)
+                    {
+                        LoadDiscoveredTools(result.Content);
+                    }
+                }
             }
 
             _toolIterationCount++;
@@ -840,6 +856,40 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             ToolCallId = tc.CallId,
             Name = tc.Name
         };
+    }
+
+    /// <summary>
+    /// Parse tool names from search_tools output and add their AITool definitions
+    /// to <see cref="_availableTools"/> so the LLM can call them in subsequent iterations.
+    /// </summary>
+    private void LoadDiscoveredTools(string searchToolOutput)
+    {
+        if (_fullRegistry is null) return;
+
+        // Parse tool names from the search output format: "  server/toolname — description"
+        foreach (var line in searchToolOutput.Split('\n'))
+        {
+            var trimmed = line.TrimStart();
+            if (!trimmed.Contains(" — "))
+                continue;
+
+            var toolName = trimmed.Split(" — ")[0].Trim();
+            if (string.IsNullOrEmpty(toolName))
+                continue;
+
+            var tool = _fullRegistry.GetByName(toolName);
+            if (tool is null)
+                continue;
+
+            // Don't add duplicates
+            var aiTool = tool.ToAITool();
+            if (_availableTools.Any(existing =>
+                existing is AIFunction ef && aiTool is AIFunction nf && ef.Name == nf.Name))
+                continue;
+
+            _availableTools.Add(aiTool);
+            _log.Info("Dynamically loaded tool '{ToolName}' into session", toolName);
+        }
     }
 
     private void MaybeSnapshot()

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Wraps an <see cref="AITool"/> from an MCP server as <see cref="INetclawTool"/>.
+/// Tool names are namespaced as <c>{serverName}/{toolName}</c> to avoid collisions.
+/// </summary>
+public sealed class McpToolAdapter : INetclawTool
+{
+    private readonly AITool _mcpTool;
+    private readonly string _toolName;
+
+    public McpToolAdapter(AITool mcpTool, string serverName, string toolName, string? grantCategory = null)
+    {
+        _mcpTool = mcpTool;
+        _toolName = toolName;
+        ServerName = serverName;
+        Name = $"{serverName}/{toolName}";
+        GrantCategory = grantCategory ?? $"mcp:{serverName}";
+
+        // Extract description and schema from the underlying AITool
+        if (mcpTool is AIFunction func)
+        {
+            Description = func.Description ?? "";
+            ParameterSchema = func.JsonSchema;
+        }
+        else
+        {
+            Description = "";
+            ParameterSchema = default;
+        }
+    }
+
+    public string Name { get; }
+    public string Description { get; }
+    public string GrantCategory { get; }
+    public string ServerName { get; }
+    public JsonElement ParameterSchema { get; }
+
+    /// <summary>The bare tool name without the server prefix.</summary>
+    public string BareToolName => _toolName;
+
+    public AITool ToAITool() => _mcpTool;
+
+    public async Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
+    {
+        if (_mcpTool is not AIFunction func)
+            return "Error: MCP tool is not invocable.";
+
+        try
+        {
+            var aiArgs = arguments is not null
+                ? new AIFunctionArguments(arguments)
+                : null;
+            var result = await func.InvokeAsync(aiArgs, ct);
+            return result?.ToString() ?? "";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: MCP tool '{Name}' failed: {ex.Message}";
+        }
+    }
+}

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Text;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Meta-tool that searches the <see cref="ToolRegistry"/> for available tools.
+/// Returns compressed summaries of matching tools so the LLM can decide which
+/// to load dynamically. Used as part of the two-layer discovery architecture.
+/// </summary>
+[NetclawTool("search_tools",
+    "Search for available tools by keyword. Returns tool names, descriptions, and parameter names. "
+    + "Use this to discover tools before calling them.",
+    Grant = "builtin")]
+public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params>
+{
+    private readonly ToolRegistry _registry;
+    private const int MaxResults = 10;
+
+    public record Params(
+        [property: Description("Search query to match against tool names and descriptions")]
+        string Query,
+        [property: Description("Optional MCP server name to filter results (e.g., 'memorizer')")]
+        string? Server = null);
+
+    public SearchToolsTool(ToolRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        var query = args.Query.Trim();
+        var results = _registry.SearchTools(query, args.Server, MaxResults);
+
+        if (results.Count == 0)
+            return Task.FromResult($"No tools found matching '{query}'.");
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Found {results.Count} tool(s):");
+        sb.AppendLine();
+
+        foreach (var tool in results)
+        {
+            var desc = tool.Description.Length > 80
+                ? tool.Description[..77] + "..."
+                : tool.Description;
+            sb.AppendLine($"  {tool.Name} — {desc}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Call any tool above by its full name. Tools are now loaded and available.");
+        return Task.FromResult(sb.ToString());
+    }
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Tools;
@@ -13,6 +15,25 @@ public static class ToolRegistrationExtensions
         registry.Register(new ShellTool(config));
         registry.Register(new FileReadTool(config));
         registry.Register(new FileWriteTool());
+
+        // Register search_tools meta-tool (always loaded, "builtin" grant)
+        registry.Register(new SearchToolsTool(registry));
+
+        return registry;
+    }
+
+    /// <summary>
+    /// Register MCP tools discovered from an MCP server into the tool registry.
+    /// Tools are wrapped as <see cref="McpToolAdapter"/> with namespaced names.
+    /// </summary>
+    public static ToolRegistry WithMcpTools(
+        this ToolRegistry registry,
+        string serverName,
+        IList<McpClientTool> tools,
+        string? grantCategory = null)
+    {
+        foreach (var tool in tools)
+            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory));
 
         return registry;
     }

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.AI;
 using Netclaw.Tools;
 
@@ -45,6 +46,82 @@ public sealed class ToolRegistry
         _tools.FirstOrDefault(t => t.Tool.Name == name)?.Tool;
 
     /// <summary>
+    /// Returns tools that should always be loaded into the LLM context.
+    /// All non-MCP tools are always loaded; MCP tools use dynamic discovery via search_tools.
+    /// </summary>
+    public IReadOnlyList<AITool> GetAlwaysLoadedTools() =>
+        _tools
+            .Where(t => t.Tool is not McpToolAdapter)
+            .Select(t => t.Tool.ToAITool())
+            .ToList();
+
+    /// <summary>
+    /// Returns all registered tool registrations (for search and dynamic loading).
+    /// </summary>
+    public IReadOnlyList<ToolRegistration> GetAllRegistrations() => _tools;
+
+    /// <summary>
+    /// Search tools by keyword, matching against name and description.
+    /// Returns up to <paramref name="maxResults"/> matching tools.
+    /// </summary>
+    public IReadOnlyList<INetclawTool> SearchTools(string query, string? serverFilter, int maxResults)
+    {
+        var queryLower = query.ToLowerInvariant();
+        var queryParts = queryLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        return _tools
+            .Where(t =>
+            {
+                // Apply server filter if specified
+                if (serverFilter is not null && t.Tool is McpToolAdapter mcp)
+                {
+                    if (!string.Equals(mcp.ServerName, serverFilter, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+                else if (serverFilter is not null)
+                {
+                    return false; // non-MCP tools filtered out when server filter is set
+                }
+
+                var nameLower = t.Tool.Name.ToLowerInvariant();
+                var descLower = t.Tool.Description.ToLowerInvariant();
+
+                return queryParts.Any(p => nameLower.Contains(p) || descLower.Contains(p));
+            })
+            .Take(maxResults)
+            .Select(t => t.Tool)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Generates a compressed tool index for the system prompt.
+    /// Groups tools by grant category for compact representation.
+    /// </summary>
+    public string GenerateCompressedIndex()
+    {
+        if (_tools.Count == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("[available tools — use search_tools to load full definitions]");
+
+        var grouped = _tools.GroupBy(t => t.GrantCategory);
+        foreach (var group in grouped)
+        {
+            var names = group.Select(t =>
+            {
+                if (t.Tool is McpToolAdapter mcp)
+                    return mcp.BareToolName;
+                return t.Tool.Name;
+            });
+            sb.AppendLine($"{group.Key}: {string.Join(", ", names)}");
+        }
+
+        sb.AppendLine("→ call search_tools(\"query\") to load any tool above before using it");
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Adapter to wrap bare <see cref="AITool"/> instances (e.g. test fakes) as <see cref="INetclawTool"/>.
     /// </summary>
     private sealed class AIToolAdapter : INetclawTool
@@ -55,8 +132,8 @@ public sealed class ToolRegistry
         {
             _tool = tool;
             GrantCategory = grantCategory;
-            Name = tool.GetType().Name;
-            Description = "";
+            Name = tool is AIFunction f ? f.Name : tool.GetType().Name;
+            Description = tool is AIFunction fn ? (fn.Description ?? "") : "";
             ParameterSchema = default;
         }
 

--- a/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class McpServersDoctorCheckTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public McpServersDoctorCheckTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task NoConfigFile_Passes()
+    {
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task NoMcpServersSection_Passes()
+    {
+        WriteConfig(new { configVersion = 1 });
+        var check = new McpServersDoctorCheck(_paths);
+
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("No MCP servers", result.Message);
+    }
+
+    [Fact]
+    public async Task ValidStdioServer_Passes()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            McpServers = new
+            {
+                memorizer = new
+                {
+                    Transport = "stdio",
+                    Command = "npx",
+                    Arguments = new[] { "-y", "@memorizer/mcp-server" },
+                    Enabled = true
+                }
+            }
+        });
+
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("1 server(s) configured", result.Message);
+    }
+
+    [Fact]
+    public async Task StdioServerMissingCommand_ReportsError()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            McpServers = new
+            {
+                broken = new
+                {
+                    Transport = "stdio",
+                    Enabled = true
+                }
+            }
+        });
+
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("requires 'Command'", result.Message);
+    }
+
+    [Fact]
+    public async Task HttpServerMissingUrl_ReportsError()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            McpServers = new
+            {
+                broken = new
+                {
+                    Transport = "http",
+                    Enabled = true
+                }
+            }
+        });
+
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("requires 'Url'", result.Message);
+    }
+
+    [Fact]
+    public async Task InvalidTransport_ReportsError()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            McpServers = new
+            {
+                broken = new
+                {
+                    Transport = "grpc",
+                    Enabled = true
+                }
+            }
+        });
+
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("invalid transport", result.Message);
+    }
+
+    [Fact]
+    public async Task DisabledServer_CountsCorrectly()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            McpServers = new
+            {
+                enabled_one = new { Transport = "stdio", Command = "npx", Enabled = true },
+                disabled_one = new { Transport = "stdio", Command = "npx", Enabled = false }
+            }
+        });
+
+        var check = new McpServersDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("2 server(s) configured (1 enabled)", result.Message);
+    }
+
+    private void WriteConfig(object config)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using Netclaw.Cli.Mcp;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Mcp;
+
+public sealed class McpCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public McpCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task Add_StdioServer_WritesConfig()
+    {
+        var args = new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("McpServers", out var servers));
+        Assert.True(servers.TryGetProperty("memorizer", out var entry));
+        Assert.Equal("stdio", entry.GetProperty("Transport").GetString());
+        Assert.Equal("npx", entry.GetProperty("Command").GetString());
+    }
+
+    [Fact]
+    public async Task Add_HttpServer_WritesConfig()
+    {
+        var args = new[] { "mcp", "add", "--transport", "http", "textforge", "https://textforge.net/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("McpServers", out var servers));
+        Assert.True(servers.TryGetProperty("textforge", out var entry));
+        Assert.Equal("http", entry.GetProperty("Transport").GetString());
+        Assert.Equal("https://textforge.net/mcp", entry.GetProperty("Url").GetString());
+    }
+
+    [Fact]
+    public async Task Add_WithEnvVar_WritesSecretsFile()
+    {
+        var args = new[] { "mcp", "add", "--transport", "stdio", "--env", "API_KEY=secret123", "myserver", "--", "dotnet", "run" };
+        var exitCode = await McpCommand.RunAsync(args, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        // Check secrets.json has the env var
+        Assert.True(File.Exists(_paths.SecretsPath));
+        var secrets = ReadConfigFile(_paths.SecretsPath);
+        Assert.True(secrets.RootElement.TryGetProperty("McpServers", out var mcpSecrets));
+        Assert.True(mcpSecrets.TryGetProperty("myserver", out var serverSecrets));
+        Assert.True(serverSecrets.TryGetProperty("EnvironmentVariables", out var envVars));
+        Assert.Equal("secret123", envVars.GetProperty("API_KEY").GetString());
+    }
+
+    [Fact]
+    public async Task Add_WithHeader_WritesSecretsFile()
+    {
+        var args = new[] { "mcp", "add", "--transport", "http", "--header", "Authorization: Bearer tok-123", "myapi", "https://api.example.com/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var secrets = ReadConfigFile(_paths.SecretsPath);
+        Assert.True(secrets.RootElement.TryGetProperty("McpServers", out var mcpSecrets));
+        Assert.True(mcpSecrets.TryGetProperty("myapi", out var serverSecrets));
+        Assert.True(serverSecrets.TryGetProperty("Headers", out var headers));
+        Assert.Equal("Bearer tok-123", headers.GetProperty("Authorization").GetString());
+    }
+
+    [Fact]
+    public async Task List_NoServers_ShowsEmptyMessage()
+    {
+        var output = CaptureConsoleOutput(async () =>
+            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+
+        Assert.Contains("No MCP servers configured", output);
+    }
+
+    [Fact]
+    public async Task List_ShowsConfiguredServers()
+    {
+        // Add a server first
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+
+        var output = CaptureConsoleOutput(async () =>
+            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+
+        Assert.Contains("memorizer", output);
+        Assert.Contains("stdio", output);
+    }
+
+    [Fact]
+    public async Task Get_ShowsServerDetails()
+    {
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+
+        var output = CaptureConsoleOutput(async () =>
+            await McpCommand.RunAsync(new[] { "mcp", "get", "memorizer" }, _paths));
+
+        Assert.Contains("Name:", output);
+        Assert.Contains("memorizer", output);
+        Assert.Contains("Transport:", output);
+        Assert.Contains("stdio", output);
+    }
+
+    [Fact]
+    public async Task Get_NotFound_ReturnsError()
+    {
+        var exitCode = await McpCommand.RunAsync(
+            new[] { "mcp", "get", "nonexistent" }, _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Remove_DeletesFromConfig()
+    {
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+
+        var exitCode = await McpCommand.RunAsync(
+            new[] { "mcp", "remove", "memorizer" }, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        // Verify it's gone
+        var servers = McpCommand.LoadMcpServers(_paths);
+        Assert.Empty(servers);
+    }
+
+    [Fact]
+    public async Task Remove_NotFound_ReturnsError()
+    {
+        var exitCode = await McpCommand.RunAsync(
+            new[] { "mcp", "remove", "nonexistent" }, _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Disable_TogglesEnabled()
+    {
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+
+        var exitCode = await McpCommand.RunAsync(
+            new[] { "mcp", "disable", "memorizer" }, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var servers = McpCommand.LoadMcpServers(_paths);
+        Assert.False(servers["memorizer"].Enabled);
+    }
+
+    [Fact]
+    public async Task Enable_TogglesEnabled()
+    {
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+        await McpCommand.RunAsync(
+            new[] { "mcp", "disable", "memorizer" }, _paths);
+
+        var exitCode = await McpCommand.RunAsync(
+            new[] { "mcp", "enable", "memorizer" }, _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var servers = McpCommand.LoadMcpServers(_paths);
+        Assert.True(servers["memorizer"].Enabled);
+    }
+
+    private static JsonDocument ReadConfigFile(string path)
+    {
+        return JsonDocument.Parse(File.ReadAllText(path));
+    }
+
+    private static string CaptureConsoleOutput(Func<Task> action)
+    {
+        var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            action().GetAwaiter().GetResult();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -50,9 +50,6 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Equal(WizardStep.Acl, vm.CurrentStep.Value);
 
         vm.GoNext();
-        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
-
-        vm.GoNext();
         Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
 
         vm.GoNext();
@@ -131,8 +128,8 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.GoNext(); // Provider → ChatServices
         Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
 
-        vm.GoNext(); // ChatServices → should skip ACL → Mcp
-        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
+        vm.GoNext(); // ChatServices → should skip ACL → Exposure
+        Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
     }
 
     [Fact]
@@ -142,8 +139,8 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackEnabled = false;
 
         vm.GoNext(); // → ChatServices
-        vm.GoNext(); // → Mcp (ACL skipped)
-        Assert.Equal(WizardStep.Mcp, vm.CurrentStep.Value);
+        vm.GoNext(); // → Exposure (ACL skipped)
+        Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
 
         vm.GoBack(); // → ChatServices (ACL skipped going back)
         Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
@@ -342,25 +339,25 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
-    public void TotalSteps_IsSix()
+    public void TotalSteps_IsFive()
     {
-        Assert.Equal(6, InitWizardViewModel.TotalSteps);
+        Assert.Equal(5, InitWizardViewModel.TotalSteps);
     }
 
     [Fact]
-    public void ActiveStepCount_IsFive_WhenNoChatServices()
+    public void ActiveStepCount_IsFour_WhenNoChatServices()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = false;
-        Assert.Equal(5, vm.ActiveStepCount);
+        Assert.Equal(4, vm.ActiveStepCount);
     }
 
     [Fact]
-    public void ActiveStepCount_IsSix_WhenChatServicesEnabled()
+    public void ActiveStepCount_IsFive_WhenChatServicesEnabled()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = true;
-        Assert.Equal(6, vm.ActiveStepCount);
+        Assert.Equal(5, vm.ActiveStepCount);
     }
 
     [Fact]
@@ -370,12 +367,11 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackEnabled = false;
 
         // Provider = 1, ChatServices = 2, Acl would be 3 but skipped
-        // Mcp = 3 (adjusted from 4), Exposure = 4, HealthCheck = 5
+        // Exposure = 3 (adjusted from 4), HealthCheck = 4
         Assert.Equal(1, vm.GetDisplayStepNumber(WizardStep.Provider));
         Assert.Equal(2, vm.GetDisplayStepNumber(WizardStep.ChatServices));
-        Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Mcp));
-        Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.Exposure));
-        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
+        Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Exposure));
+        Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -13,5 +13,6 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<IDoctorCheck, TelemetryDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SlackAuthDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, McpServersDoctorCheck>();
     }
 }

--- a/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+/// <summary>
+/// Doctor check that validates MCP server configuration entries.
+/// Checks: required fields per transport type, valid transport values.
+/// Non-blocking warning if no MCP servers configured.
+/// </summary>
+public sealed class McpServersDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(paths.NetclawConfigPath))
+            return Task.FromResult(DoctorCheckResult.Pass("mcp-servers", "No config file (skipped)"));
+
+        Dictionary<string, McpServerEntry> servers;
+        try
+        {
+            var text = File.ReadAllText(paths.NetclawConfigPath);
+            using var doc = JsonDocument.Parse(text);
+
+            if (!doc.RootElement.TryGetProperty("McpServers", out var mcpSection))
+                return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
+                    "No MCP servers configured (use `netclaw mcp add` to add one)"));
+
+            servers = JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpSection.GetRawText())
+                ?? new();
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(DoctorCheckResult.Error("mcp-servers",
+                $"Failed to read MCP config: {ex.Message}"));
+        }
+
+        if (servers.Count == 0)
+            return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
+                "No MCP servers configured"));
+
+        var errors = new List<string>();
+
+        foreach (var (name, entry) in servers)
+        {
+            if (entry.Transport is not ("stdio" or "sse" or "http"))
+            {
+                errors.Add($"{name}: invalid transport '{entry.Transport}' (must be stdio, sse, or http)");
+                continue;
+            }
+
+            if (entry.Transport is "stdio" && string.IsNullOrWhiteSpace(entry.Command))
+                errors.Add($"{name}: stdio transport requires 'Command'");
+
+            if (entry.Transport is "sse" or "http" && string.IsNullOrWhiteSpace(entry.Url))
+                errors.Add($"{name}: {entry.Transport} transport requires 'Url'");
+        }
+
+        if (errors.Count > 0)
+            return Task.FromResult(DoctorCheckResult.Error("mcp-servers",
+                $"MCP config issues: {string.Join("; ", errors)}",
+                "Run `netclaw mcp list` and fix entries with `netclaw mcp remove` + `netclaw mcp add`"));
+
+        var enabledCount = servers.Count(s => s.Value.Enabled);
+        return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
+            $"{servers.Count} server(s) configured ({enabledCount} enabled)"));
+    }
+}

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -1,0 +1,529 @@
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Mcp;
+
+/// <summary>
+/// Handles <c>netclaw mcp</c> CLI subcommands: add, list, get, remove, enable, disable, validate.
+/// All commands are offline (read/write config files directly) except <c>validate</c>
+/// which spawns one-shot MCP client connections.
+/// </summary>
+internal static class McpCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
+    {
+        var subcommand = args.Length > 1 ? args[1] : "help";
+
+        return subcommand switch
+        {
+            "add" => RunAdd(args, paths),
+            "list" => RunList(paths),
+            "get" => RunGet(args, paths),
+            "remove" => RunRemove(args, paths),
+            "enable" => RunToggle(args, paths, enabled: true),
+            "disable" => RunToggle(args, paths, enabled: false),
+            "validate" => await RunValidateAsync(args, paths),
+            "help" or "-h" or "--help" => WriteHelp(),
+            _ => WriteHelp()
+        };
+    }
+
+    private static int RunAdd(string[] args, NetclawPaths paths)
+    {
+        // Parse: netclaw mcp add [--transport <type>] [--env KEY=VALUE]... [--header "Key: Value"]... <name> [command/url] [-- args...]
+        string? transport = null;
+        var envVars = new Dictionary<string, string>();
+        var headers = new Dictionary<string, string>();
+        string? name = null;
+        string? commandOrUrl = null;
+        string[]? commandArgs = null;
+
+        var positional = new List<string>();
+        var afterDash = false;
+        var dashArgs = new List<string>();
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            if (afterDash)
+            {
+                dashArgs.Add(args[i]);
+                continue;
+            }
+
+            if (args[i] == "--")
+            {
+                afterDash = true;
+                continue;
+            }
+
+            if (args[i] is "--transport" or "-t" && i + 1 < args.Length)
+            {
+                transport = args[++i];
+                continue;
+            }
+
+            if (args[i] == "--env" && i + 1 < args.Length)
+            {
+                var kv = args[++i];
+                var eqIdx = kv.IndexOf('=');
+                if (eqIdx > 0)
+                    envVars[kv[..eqIdx]] = kv[(eqIdx + 1)..];
+                continue;
+            }
+
+            if (args[i] == "--header" && i + 1 < args.Length)
+            {
+                var hv = args[++i];
+                var colonIdx = hv.IndexOf(':');
+                if (colonIdx > 0)
+                    headers[hv[..colonIdx].Trim()] = hv[(colonIdx + 1)..].Trim();
+                continue;
+            }
+
+            positional.Add(args[i]);
+        }
+
+        if (positional.Count < 1)
+        {
+            Console.WriteLine("Usage: netclaw mcp add [--transport stdio|http|sse] [--env KEY=VALUE] <name> [command|url] [-- args...]");
+            return 1;
+        }
+
+        name = positional[0];
+        transport ??= "stdio";
+
+        if (transport is "stdio")
+        {
+            if (afterDash && dashArgs.Count > 0)
+            {
+                // netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server
+                commandOrUrl = dashArgs[0];
+                commandArgs = dashArgs.Skip(1).ToArray();
+            }
+            else if (positional.Count >= 2)
+            {
+                // netclaw mcp add --transport stdio memorizer npx
+                commandOrUrl = positional[1];
+                commandArgs = positional.Skip(2).ToArray();
+            }
+
+            if (string.IsNullOrWhiteSpace(commandOrUrl))
+            {
+                Console.WriteLine("Error: stdio transport requires a command. Usage: netclaw mcp add --transport stdio <name> -- <command> [args...]");
+                return 1;
+            }
+        }
+        else
+        {
+            // http/sse — positional[1] is the URL
+            if (positional.Count >= 2)
+                commandOrUrl = positional[1];
+
+            if (string.IsNullOrWhiteSpace(commandOrUrl))
+            {
+                Console.WriteLine($"Error: {transport} transport requires a URL. Usage: netclaw mcp add --transport {transport} <name> <url>");
+                return 1;
+            }
+        }
+
+        // Build entry for netclaw.json (non-secret parts)
+        var entry = new McpServerEntry
+        {
+            Transport = transport,
+            Enabled = true
+        };
+
+        if (transport is "stdio")
+        {
+            entry.Command = commandOrUrl;
+            entry.Arguments = commandArgs is { Length: > 0 } ? commandArgs : null;
+        }
+        else
+        {
+            entry.Url = commandOrUrl;
+        }
+
+        // Non-sensitive env vars go to netclaw.json; all env vars also go to secrets.json for security
+        // Headers always go to secrets.json (they may contain auth tokens)
+        var (config, secrets) = LoadConfigFiles(paths);
+
+        var mcpServers = GetOrCreateSection(config, "McpServers");
+        mcpServers[name] = SerializeEntry(entry);
+
+        WriteConfigFile(paths.NetclawConfigPath, config);
+
+        // Write sensitive values to secrets.json
+        if (envVars.Count > 0 || headers.Count > 0)
+        {
+            var secretMcp = GetOrCreateSection(secrets, "McpServers");
+            var serverSecrets = new Dictionary<string, object>();
+
+            if (envVars.Count > 0)
+                serverSecrets["EnvironmentVariables"] = envVars;
+            if (headers.Count > 0)
+                serverSecrets["Headers"] = headers;
+
+            secretMcp[name] = JsonSerializer.SerializeToElement(serverSecrets);
+            WriteConfigFile(paths.SecretsPath, secrets);
+        }
+
+        Console.WriteLine($"Added MCP server '{name}' ({transport})");
+        return 0;
+    }
+
+    private static int RunList(NetclawPaths paths)
+    {
+        var servers = LoadMcpServers(paths);
+
+        if (servers.Count == 0)
+        {
+            Console.WriteLine("No MCP servers configured.");
+            Console.WriteLine("Run `netclaw mcp add` to add one.");
+            return 0;
+        }
+
+        Console.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status",-10}");
+        foreach (var (name, entry) in servers)
+        {
+            var enabled = entry.Enabled ? "yes" : "no";
+            Console.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {"-",-10}");
+        }
+
+        return 0;
+    }
+
+    private static int RunGet(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine("Usage: netclaw mcp get <name>");
+            return 1;
+        }
+
+        var name = args[2];
+        var servers = LoadMcpServers(paths);
+
+        if (!servers.TryGetValue(name, out var entry))
+        {
+            Console.WriteLine($"MCP server '{name}' not found.");
+            return 1;
+        }
+
+        Console.WriteLine($"Name:       {name}");
+        Console.WriteLine($"Transport:  {entry.Transport}");
+
+        if (entry.Command is not null)
+        {
+            var cmdLine = entry.Arguments is { Length: > 0 }
+                ? $"{entry.Command} {string.Join(' ', entry.Arguments)}"
+                : entry.Command;
+            Console.WriteLine($"Command:    {cmdLine}");
+        }
+
+        if (entry.Url is not null)
+            Console.WriteLine($"URL:        {entry.Url}");
+
+        Console.WriteLine($"Enabled:    {(entry.Enabled ? "yes" : "no")}");
+
+        if (entry.EnvironmentVariables is { Count: > 0 })
+        {
+            Console.WriteLine("Env vars:");
+            foreach (var (k, _) in entry.EnvironmentVariables)
+                Console.WriteLine($"  {k}=***REDACTED***");
+        }
+
+        if (entry.Headers is { Count: > 0 })
+        {
+            Console.WriteLine("Headers:");
+            foreach (var (k, _) in entry.Headers)
+                Console.WriteLine($"  {k}: ***REDACTED***");
+        }
+
+        return 0;
+    }
+
+    private static int RunRemove(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine("Usage: netclaw mcp remove <name>");
+            return 1;
+        }
+
+        var name = args[2];
+        var (config, secrets) = LoadConfigFiles(paths);
+
+        var removed = false;
+        var mcpServers = GetSectionOrNull(config, "McpServers");
+        if (mcpServers?.Remove(name) == true)
+        {
+            WriteConfigFile(paths.NetclawConfigPath, config);
+            removed = true;
+        }
+
+        var secretMcp = GetSectionOrNull(secrets, "McpServers");
+        if (secretMcp?.Remove(name) == true)
+        {
+            WriteConfigFile(paths.SecretsPath, secrets);
+            removed = true;
+        }
+
+        if (removed)
+        {
+            Console.WriteLine($"Removed MCP server '{name}'");
+            return 0;
+        }
+
+        Console.WriteLine($"MCP server '{name}' not found.");
+        return 1;
+    }
+
+    private static int RunToggle(string[] args, NetclawPaths paths, bool enabled)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine($"Usage: netclaw mcp {(enabled ? "enable" : "disable")} <name>");
+            return 1;
+        }
+
+        var name = args[2];
+        var (config, _) = LoadConfigFiles(paths);
+
+        var mcpServers = GetSectionOrNull(config, "McpServers");
+        if (mcpServers is null || !mcpServers.ContainsKey(name))
+        {
+            Console.WriteLine($"MCP server '{name}' not found.");
+            return 1;
+        }
+
+        // Deserialize, toggle, re-serialize
+        var entry = JsonSerializer.Deserialize<McpServerEntry>(
+            JsonSerializer.Serialize(mcpServers[name]), JsonOptions) ?? new McpServerEntry();
+        entry.Enabled = enabled;
+        mcpServers[name] = SerializeEntry(entry);
+
+        WriteConfigFile(paths.NetclawConfigPath, config);
+        Console.WriteLine($"{(enabled ? "Enabled" : "Disabled")} MCP server '{name}'");
+        return 0;
+    }
+
+    private static async Task<int> RunValidateAsync(string[] args, NetclawPaths paths)
+    {
+        var targetName = args.Length >= 3 ? args[2] : null;
+        var servers = LoadMcpServers(paths);
+
+        if (servers.Count == 0)
+        {
+            Console.WriteLine("No MCP servers configured.");
+            return 0;
+        }
+
+        var hasFailure = false;
+
+        foreach (var (name, entry) in servers)
+        {
+            if (targetName is not null && !string.Equals(name, targetName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!entry.Enabled)
+            {
+                Console.WriteLine($"{name}: disabled (skipped)");
+                continue;
+            }
+
+            try
+            {
+                await using var client = await CreateOneOffClientAsync(name, entry);
+                var tools = await client.ListToolsAsync();
+                Console.WriteLine($"{name}: connected ({tools.Count} tools discovered)");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{name}: failed — {ex.Message}");
+                hasFailure = true;
+            }
+        }
+
+        return hasFailure ? 1 : 0;
+    }
+
+    internal static async Task<McpClient> CreateOneOffClientAsync(string name, McpServerEntry entry)
+    {
+        IClientTransport transport;
+
+        if (entry.Transport is "stdio")
+        {
+            var envVars = entry.EnvironmentVariables is { Count: > 0 }
+                ? new Dictionary<string, string?>(entry.EnvironmentVariables!)
+                : null;
+
+            transport = new StdioClientTransport(new StdioClientTransportOptions
+            {
+                Command = entry.Command!,
+                Arguments = entry.Arguments ?? [],
+                EnvironmentVariables = envVars,
+                Name = name,
+                ShutdownTimeout = TimeSpan.FromSeconds(10),
+            });
+        }
+        else
+        {
+            transport = new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = new Uri(entry.Url!),
+                Name = name,
+                AdditionalHeaders = entry.Headers is { Count: > 0 }
+                    ? new Dictionary<string, string>(entry.Headers) : null,
+                TransportMode = entry.Transport is "sse"
+                    ? HttpTransportMode.Sse : HttpTransportMode.AutoDetect,
+            });
+        }
+
+        return await McpClient.CreateAsync(transport, new McpClientOptions
+        {
+            ClientInfo = new() { Name = "netclaw", Version = "0.1.0" },
+        });
+    }
+
+    // ── Config file helpers ──
+
+    private static (Dictionary<string, object> config, Dictionary<string, object> secrets) LoadConfigFiles(NetclawPaths paths)
+    {
+        var config = LoadJsonDict(paths.NetclawConfigPath);
+        var secrets = LoadJsonDict(paths.SecretsPath);
+        return (config, secrets);
+    }
+
+    private static Dictionary<string, object> LoadJsonDict(string path)
+    {
+        if (!File.Exists(path))
+            return new Dictionary<string, object> { ["configVersion"] = 1 };
+
+        var text = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<Dictionary<string, object>>(text) ?? new Dictionary<string, object> { ["configVersion"] = 1 };
+    }
+
+    internal static Dictionary<string, McpServerEntry> LoadMcpServers(NetclawPaths paths)
+    {
+        // Merge netclaw.json and secrets.json McpServers sections
+        var configText = File.Exists(paths.NetclawConfigPath)
+            ? File.ReadAllText(paths.NetclawConfigPath) : "{}";
+        var secretsText = File.Exists(paths.SecretsPath)
+            ? File.ReadAllText(paths.SecretsPath) : "{}";
+
+        using var configDoc = JsonDocument.Parse(configText);
+        using var secretsDoc = JsonDocument.Parse(secretsText);
+
+        var result = new Dictionary<string, McpServerEntry>();
+
+        if (configDoc.RootElement.TryGetProperty("McpServers", out var configServers))
+        {
+            foreach (var prop in configServers.EnumerateObject())
+            {
+                var entry = JsonSerializer.Deserialize<McpServerEntry>(prop.Value.GetRawText()) ?? new McpServerEntry();
+                result[prop.Name] = entry;
+            }
+        }
+
+        // Merge secrets on top
+        if (secretsDoc.RootElement.TryGetProperty("McpServers", out var secretServers))
+        {
+            foreach (var prop in secretServers.EnumerateObject())
+            {
+                if (!result.TryGetValue(prop.Name, out var entry))
+                    continue;
+
+                if (prop.Value.TryGetProperty("EnvironmentVariables", out var envVars))
+                {
+                    entry.EnvironmentVariables ??= new Dictionary<string, string>();
+                    foreach (var ev in envVars.EnumerateObject())
+                        entry.EnvironmentVariables[ev.Name] = ev.Value.GetString() ?? "";
+                }
+
+                if (prop.Value.TryGetProperty("Headers", out var hdrs))
+                {
+                    entry.Headers ??= new Dictionary<string, string>();
+                    foreach (var h in hdrs.EnumerateObject())
+                        entry.Headers[h.Name] = h.Value.GetString() ?? "";
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, object> GetOrCreateSection(Dictionary<string, object> dict, string key)
+    {
+        if (dict.TryGetValue(key, out var existing))
+        {
+            if (existing is JsonElement je)
+            {
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
+                    ?? new Dictionary<string, object>();
+                dict[key] = parsed;
+                return parsed;
+            }
+
+            return (Dictionary<string, object>)existing;
+        }
+
+        var section = new Dictionary<string, object>();
+        dict[key] = section;
+        return section;
+    }
+
+    private static Dictionary<string, object>? GetSectionOrNull(Dictionary<string, object> dict, string key)
+    {
+        if (!dict.TryGetValue(key, out var existing))
+            return null;
+
+        if (existing is JsonElement je)
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
+                ?? new Dictionary<string, object>();
+            dict[key] = parsed;
+            return parsed;
+        }
+
+        return existing as Dictionary<string, object>;
+    }
+
+    private static JsonElement SerializeEntry(McpServerEntry entry)
+    {
+        var json = JsonSerializer.Serialize(entry, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static void WriteConfigFile(string path, Dictionary<string, object> data)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (dir is not null)
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(path, JsonSerializer.Serialize(data, JsonOptions));
+    }
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw mcp <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  add        Add an MCP server profile");
+        Console.WriteLine("  list       List configured MCP servers");
+        Console.WriteLine("  get        Show details for an MCP server");
+        Console.WriteLine("  remove     Remove an MCP server profile");
+        Console.WriteLine("  enable     Enable a disabled MCP server");
+        Console.WriteLine("  disable    Disable an MCP server without removing it");
+        Console.WriteLine("  validate   Test connectivity to MCP server(s)");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
+        Console.WriteLine("  netclaw mcp add --transport http --header \"Authorization: Bearer tok-...\" myapi https://api.example.com/mcp");
+        Console.WriteLine("  netclaw mcp list");
+        Console.WriteLine("  netclaw mcp validate");
+        return 0;
+    }
+}

--- a/src/Netclaw.Cli/Netclaw.Cli.csproj
+++ b/src/Netclaw.Cli/Netclaw.Cli.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" />
+    <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="Termina" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
   </ItemGroup>

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -8,6 +8,7 @@ using Netclaw.Channels.Slack;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
+using Netclaw.Cli.Mcp;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Termina.Diagnostics;
@@ -256,6 +257,15 @@ static async Task RunAsync(string[] args)
         }
     }
 
+    // ── MCP server management (offline) ──
+    if (mode is "mcp")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+        Environment.ExitCode = await McpCommand.RunAsync(args, paths);
+        return;
+    }
+
     // ── Config management stubs ──
     if (mode is "config")
     {
@@ -353,6 +363,7 @@ static void WriteGeneralHelp()
     Console.WriteLine("  doctor                   Configuration diagnostics (offline)");
     Console.WriteLine("  status                   Runtime status from daemon health JSON endpoint");
     Console.WriteLine("  daemon <subcommand>      Manage daemon lifecycle");
+    Console.WriteLine("  mcp                      Manage MCP server profiles");
     Console.WriteLine("  init                     First-run setup wizard (planned)");
     Console.WriteLine("  config                   Configuration management (planned)");
     Console.WriteLine();

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -36,10 +36,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     // Step 3: ACL
     private TextInputNode? _ownerIdentityInput;
 
-    // Step 4: MCP
-    private SelectionListNode<string>? _mcpList;
-
-    // Step 5: Exposure
+    // Step 4: Exposure
     private SelectionListNode<string>? _exposureList;
 
     // Track sub-step for provider (0=select, 1=auth, 2=credentials, 3=validate, 4=model)
@@ -116,7 +113,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     WizardStep.Provider => "LLM Provider",
                     WizardStep.ChatServices => "Chat Services",
                     WizardStep.Acl => "Access Control",
-                    WizardStep.Mcp => "MCP Servers",
                     WizardStep.Exposure => "Exposure Mode",
                     WizardStep.HealthCheck => "Health Check",
                     _ => ""
@@ -164,7 +160,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.Provider => BuildProviderStep(),
                 WizardStep.ChatServices => BuildChatServicesStep(),
                 WizardStep.Acl => BuildAclStep(),
-                WizardStep.Mcp => BuildMcpStep(),
                 WizardStep.Exposure => BuildExposureStep(),
                 _ => Layouts.Empty()
             };
@@ -198,8 +193,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
                 WizardStep.Acl =>
                     "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
-                WizardStep.Mcp =>
-                    "  MCP servers provide external tools. Memorizer adds persistent memory.",
                 WizardStep.Exposure =>
                     "  Local-only is recommended for homelab use.",
                 WizardStep.HealthCheck =>
@@ -689,34 +682,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .Height(3));
     }
 
-    private ILayoutNode BuildMcpStep()
-    {
-        _mcpList = Layouts.SelectionList(
-                "Memorizer (recommended \u2014 persistent memory)",
-                "Custom MCP server (configure later)",
-                "Skip \u2014 no MCP servers")
-            .WithMode(SelectionMode.Single)
-            .WithHighlightColors(Color.Black, Color.Cyan);
-
-        _mcpList.OnFocused();
-        _lastFocusedList = _mcpList;
-
-        _mcpList.SelectionConfirmed
-            .Subscribe(selected =>
-            {
-                if (selected.Count > 0)
-                {
-                    ViewModel.McpSelection = selected[0];
-                    ViewModel.GoNext();
-                }
-            })
-            .DisposeWith(_stepSubs);
-
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  MCP tool servers:").WithForeground(Color.White))
-            .WithChild(_mcpList);
-    }
-
     private ILayoutNode BuildExposureStep()
     {
         _exposureList = Layouts.SelectionList(
@@ -900,7 +865,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             WizardStep.Provider when _providerSubStep == 1 => _authMethodList,
             WizardStep.Provider when _providerSubStep == 4 && !_manualModelEntry => _modelList,
             WizardStep.ChatServices when _chatServicesSubStep == 0 => _slackEnabledList,
-            WizardStep.Mcp => _mcpList,
             WizardStep.Exposure => _exposureList,
             _ => null
         };

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -15,19 +15,18 @@ public enum WizardStep
     Provider = 1,
     ChatServices = 2,
     Acl = 3,
-    Mcp = 4,
-    Exposure = 5,
-    HealthCheck = 6
+    Exposure = 4,
+    HealthCheck = 5
 }
 
 /// <summary>
 /// Reactive ViewModel for the <c>netclaw init</c> onboarding wizard.
-/// Drives a 6-step wizard state machine with back-navigation support.
+/// Drives a 5-step wizard state machine with back-navigation support.
 /// ACL step is conditionally skipped when no chat services are enabled.
 /// </summary>
 public partial class InitWizardViewModel : ReactiveViewModel
 {
-    public const int TotalSteps = 6;
+    public const int TotalSteps = 5;
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -75,13 +74,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
     // ── Step 3: ACL ──
     public string? OwnerIdentity { get; set; }
 
-    // ── Step 4: MCP ──
-    public string? McpSelection { get; set; }
-
-    // ── Step 5: Exposure ──
+    // ── Step 4: Exposure ──
     public string? ExposureMode { get; set; }
 
-    // ── Step 6: Health Check ──
+    // ── Step 5: Health Check ──
     public List<HealthCheckItem> HealthCheckResults { get; } = [];
 
     /// <summary>

--- a/src/Netclaw.Configuration/ISystemPromptProvider.cs
+++ b/src/Netclaw.Configuration/ISystemPromptProvider.cs
@@ -40,23 +40,35 @@ public sealed class NullSystemPromptProvider : ISystemPromptProvider
 
 /// <summary>
 /// Loads system prompt layers from the filesystem under <see cref="NetclawPaths.SoulDirectory"/>.
-/// Missing files are silently skipped.
+/// Missing files are silently skipped. Optionally appends a compressed tool index.
 /// </summary>
 public sealed class FileSystemPromptProvider : ISystemPromptProvider
 {
     private readonly NetclawPaths _paths;
+    private string? _toolIndex;
 
     public FileSystemPromptProvider(NetclawPaths paths)
     {
         _paths = paths;
     }
 
+    /// <summary>
+    /// Set the compressed tool index to append to the system prompt.
+    /// Called once after tool registration is complete.
+    /// </summary>
+    public void SetToolIndex(string toolIndex)
+    {
+        _toolIndex = toolIndex;
+    }
+
     public string GetSystemPrompt()
     {
-        return SystemPromptAssembler.Assemble(
+        var prompt = SystemPromptAssembler.Assemble(
             personality: TryReadFile(_paths.PersonalityPath),
             instructions: TryReadFile(_paths.InstructionsPath),
             userPreferences: TryReadFile(_paths.UserPreferencesPath));
+
+        return AppendToolIndex(prompt);
     }
 
     /// <summary>
@@ -64,11 +76,23 @@ public sealed class FileSystemPromptProvider : ISystemPromptProvider
     /// </summary>
     public string GetSystemPrompt(string projectAgentsPath)
     {
-        return SystemPromptAssembler.Assemble(
+        var prompt = SystemPromptAssembler.Assemble(
             personality: TryReadFile(_paths.PersonalityPath),
             instructions: TryReadFile(_paths.InstructionsPath),
             userPreferences: TryReadFile(_paths.UserPreferencesPath),
             projectAgents: TryReadFile(projectAgentsPath));
+
+        return AppendToolIndex(prompt);
+    }
+
+    private string AppendToolIndex(string prompt)
+    {
+        if (string.IsNullOrWhiteSpace(_toolIndex))
+            return prompt;
+
+        return string.IsNullOrWhiteSpace(prompt)
+            ? _toolIndex
+            : $"{prompt}\n\n{_toolIndex}";
     }
 
     private static string? TryReadFile(string path)

--- a/src/Netclaw.Configuration/McpServerEntry.cs
+++ b/src/Netclaw.Configuration/McpServerEntry.cs
@@ -1,0 +1,32 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for a single MCP server profile.
+/// Bound from the <c>McpServers</c> section of <c>netclaw.json</c> + <c>secrets.json</c>.
+/// </summary>
+public sealed class McpServerEntry
+{
+    /// <summary>Transport type: "stdio", "sse", or "http".</summary>
+    public string Transport { get; set; } = "stdio";
+
+    /// <summary>Executable command for stdio transport.</summary>
+    public string? Command { get; set; }
+
+    /// <summary>Arguments for the stdio command.</summary>
+    public string[]? Arguments { get; set; }
+
+    /// <summary>Endpoint URL for sse/http transport.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Environment variable overlay for the MCP process.</summary>
+    public Dictionary<string, string>? EnvironmentVariables { get; set; }
+
+    /// <summary>Additional HTTP headers (for http/sse transport).</summary>
+    public Dictionary<string, string>? Headers { get; set; }
+
+    /// <summary>Whether this server is enabled. Disabled servers are skipped at startup.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>ACL grant category. Defaults to "mcp:{name}" when null.</summary>
+    public string? GrantCategory { get; set; }
+}

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -85,6 +85,37 @@
     "Models": {
       "type": "object",
       "additionalProperties": true
+    },
+    "McpServers": {
+      "type": "object",
+      "description": "MCP server profiles keyed by name.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "Transport": {
+            "type": "string",
+            "enum": ["stdio", "sse", "http"],
+            "default": "stdio"
+          },
+          "Command": { "type": "string" },
+          "Arguments": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "Url": { "type": "string", "format": "uri" },
+          "EnvironmentVariables": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "Headers": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "Enabled": { "type": "boolean", "default": true },
+          "GrantCategory": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": true

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Mcp;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+/// <summary>
+/// End-to-end smoke tests that connect to a real MCP server over stdio.
+/// Uses @modelcontextprotocol/server-everything (the official test server).
+/// Requires Node.js/npx on the PATH.
+/// </summary>
+public class McpStdioSmokeTests : IAsyncDisposable
+{
+    private McpClient? _client;
+
+    [Fact]
+    public async Task ConnectToStdioServer_DiscoversTools()
+    {
+        var entry = new McpServerEntry
+        {
+            Transport = "stdio",
+            Command = "npx",
+            Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+            Enabled = true,
+        };
+
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = entry.Command,
+            Arguments = entry.Arguments,
+            Name = "everything-test",
+            ShutdownTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        _client = await McpClient.CreateAsync(transport, new McpClientOptions
+        {
+            ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+        }, cancellationToken: CancellationToken.None);
+
+        var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);
+
+        // server-everything exposes several test tools
+        Assert.NotEmpty(tools);
+        Assert.True(tools.Count >= 1, $"Expected at least 1 tool, got {tools.Count}");
+    }
+
+    [Fact]
+    public async Task McpToolAdapter_WrapsDiscoveredTools()
+    {
+        var entry = new McpServerEntry
+        {
+            Transport = "stdio",
+            Command = "npx",
+            Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+            Enabled = true,
+        };
+
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = entry.Command,
+            Arguments = entry.Arguments,
+            Name = "everything-adapter-test",
+            ShutdownTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        _client = await McpClient.CreateAsync(transport, new McpClientOptions
+        {
+            ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+        }, cancellationToken: CancellationToken.None);
+
+        var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);
+
+        // Wrap with our adapter and verify namespacing
+        var registry = new ToolRegistry();
+        registry.WithMcpTools("everything", tools);
+
+        var allTools = registry.GetAllRegistrations();
+        Assert.NotEmpty(allTools);
+
+        // All tool names should be namespaced with server name
+        foreach (var reg in allTools)
+        {
+            Assert.StartsWith("everything/", reg.Tool.Name);
+            Assert.Equal("mcp:everything", reg.GrantCategory);
+        }
+
+        // Tools should NOT be in always-loaded set (MCP tools are dynamic)
+        var alwaysLoaded = registry.GetAlwaysLoadedTools();
+        Assert.Empty(alwaysLoaded);
+    }
+
+    [Fact]
+    public async Task SearchTools_FindsMcpToolsByName()
+    {
+        var entry = new McpServerEntry
+        {
+            Transport = "stdio",
+            Command = "npx",
+            Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+            Enabled = true,
+        };
+
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = entry.Command,
+            Arguments = entry.Arguments,
+            Name = "everything-search-test",
+            ShutdownTimeout = TimeSpan.FromSeconds(10),
+        });
+
+        _client = await McpClient.CreateAsync(transport, new McpClientOptions
+        {
+            ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+        }, cancellationToken: CancellationToken.None);
+
+        var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);
+
+        var registry = new ToolRegistry();
+        registry.WithMcpTools("everything", tools);
+
+        // Pick the first tool name and search for it
+        var firstTool = tools[0];
+        var results = registry.SearchTools(firstTool.Name, null, 10);
+
+        Assert.NotEmpty(results);
+        Assert.Contains(results, t => t.Name == $"everything/{firstTool.Name}");
+    }
+
+    [Fact]
+    public async Task McpClientManager_ConnectsAndRegistersTools()
+    {
+        var entry = new McpServerEntry
+        {
+            Transport = "stdio",
+            Command = "npx",
+            Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+            Enabled = true,
+        };
+
+        var serverEntries = new Dictionary<string, McpServerEntry>
+        {
+            ["everything"] = entry
+        };
+
+        var registry = new ToolRegistry();
+        var logger = NullLogger<McpClientManager>.Instance;
+        var manager = new McpClientManager(serverEntries, registry, logger);
+
+        try
+        {
+            await manager.StartAsync(CancellationToken.None);
+
+            var statuses = manager.GetServerStatuses();
+            Assert.True(statuses.ContainsKey("everything"));
+
+            var status = statuses["everything"];
+            Assert.Equal(McpConnectionState.Connected, status.State);
+            Assert.True(status.ToolCount > 0, $"Expected tools, got {status.ToolCount}");
+            Assert.Null(status.ErrorMessage);
+
+            // Verify tools were registered in the registry
+            var allRegs = registry.GetAllRegistrations();
+            Assert.NotEmpty(allRegs);
+            Assert.All(allRegs, r => Assert.StartsWith("everything/", r.Tool.Name));
+
+            // GetClient should return a live client
+            var client = manager.GetClient("everything");
+            Assert.NotNull(client);
+        }
+        finally
+        {
+            await manager.StopAsync(CancellationToken.None);
+            manager.Dispose();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+            _client = null;
+        }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
+++ b/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -1,0 +1,164 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Mcp;
+
+/// <summary>
+/// Manages MCP client connections at daemon startup. Creates clients for each enabled
+/// <see cref="McpServerEntry"/>, discovers tools, and registers them in <see cref="ToolRegistry"/>.
+/// Failed connections are logged but don't block startup.
+/// </summary>
+internal sealed class McpClientManager : IHostedService, IDisposable
+{
+    private readonly Dictionary<string, McpServerEntry> _serverEntries;
+    private readonly ToolRegistry _toolRegistry;
+    private readonly ILogger<McpClientManager> _logger;
+    private readonly Dictionary<string, McpClient> _clients = new();
+    private readonly Dictionary<string, McpServerStatus> _statuses = new();
+
+    public McpClientManager(
+        Dictionary<string, McpServerEntry> serverEntries,
+        ToolRegistry toolRegistry,
+        ILogger<McpClientManager> logger)
+    {
+        _serverEntries = serverEntries;
+        _toolRegistry = toolRegistry;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        foreach (var (name, entry) in _serverEntries)
+        {
+            if (!entry.Enabled)
+            {
+                _statuses[name] = new McpServerStatus(name, McpConnectionState.Disabled, 0, null);
+                _logger.LogInformation("MCP server '{Name}' is disabled, skipping", name);
+                continue;
+            }
+
+            await ConnectAsync(name, entry, cancellationToken);
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        foreach (var (name, client) in _clients)
+        {
+            try
+            {
+                await client.DisposeAsync();
+                _logger.LogInformation("MCP client '{Name}' shut down", name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error shutting down MCP client '{Name}'", name);
+            }
+        }
+
+        _clients.Clear();
+    }
+
+    public McpClient? GetClient(string serverName)
+    {
+        return _clients.GetValueOrDefault(serverName);
+    }
+
+    public IReadOnlyDictionary<string, McpServerStatus> GetServerStatuses() => _statuses;
+
+    public async Task<bool> TryReconnectAsync(string serverName, CancellationToken ct = default)
+    {
+        if (!_serverEntries.TryGetValue(serverName, out var entry) || !entry.Enabled)
+            return false;
+
+        // Dispose existing client if any
+        if (_clients.TryGetValue(serverName, out var existing))
+        {
+            try { await existing.DisposeAsync(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Error disposing MCP client '{Name}' during reconnect", serverName); }
+            _clients.Remove(serverName);
+        }
+
+        return await ConnectAsync(serverName, entry, ct);
+    }
+
+    private async Task<bool> ConnectAsync(string name, McpServerEntry entry, CancellationToken ct)
+    {
+        try
+        {
+            IClientTransport transport;
+
+            if (entry.Transport is "stdio")
+            {
+                transport = new StdioClientTransport(new StdioClientTransportOptions
+                {
+                    Command = entry.Command!,
+                    Arguments = entry.Arguments ?? [],
+                    EnvironmentVariables = entry.EnvironmentVariables is { Count: > 0 }
+                        ? new Dictionary<string, string?>(entry.EnvironmentVariables!)
+                        : null,
+                    Name = name,
+                    ShutdownTimeout = TimeSpan.FromSeconds(10),
+                });
+            }
+            else
+            {
+                transport = new HttpClientTransport(new HttpClientTransportOptions
+                {
+                    Endpoint = new Uri(entry.Url!),
+                    Name = name,
+                    AdditionalHeaders = entry.Headers is { Count: > 0 }
+                        ? new Dictionary<string, string>(entry.Headers)
+                        : null,
+                    TransportMode = entry.Transport is "sse"
+                        ? HttpTransportMode.Sse : HttpTransportMode.AutoDetect,
+                });
+            }
+
+            var client = await McpClient.CreateAsync(transport, new McpClientOptions
+            {
+                ClientInfo = new() { Name = "netclaw", Version = "0.1.0" },
+            }, cancellationToken: ct);
+
+            var tools = await client.ListToolsAsync(cancellationToken: ct);
+            _clients[name] = client;
+            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory);
+            _statuses[name] = new McpServerStatus(name, McpConnectionState.Connected, tools.Count, null);
+
+            _logger.LogInformation("MCP server '{Name}' connected ({ToolCount} tools)", name, tools.Count);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _statuses[name] = new McpServerStatus(name, McpConnectionState.Error, 0, ex.Message);
+            _logger.LogWarning(ex, "Failed to connect to MCP server '{Name}'", name);
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var client in _clients.Values)
+        {
+            try { (client as IDisposable)?.Dispose(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Error disposing MCP client during shutdown"); }
+        }
+        _clients.Clear();
+    }
+}
+
+internal enum McpConnectionState
+{
+    Disabled,
+    Connected,
+    Error
+}
+
+internal sealed record McpServerStatus(
+    string Name,
+    McpConnectionState State,
+    int ToolCount,
+    string? ErrorMessage);

--- a/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
+++ b/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Mcp;
+
+/// <summary>
+/// Refreshes the compressed tool index in the system prompt after MCP startup completes.
+/// Runs after <see cref="McpClientManager"/> so MCP tools are included in the index.
+/// </summary>
+internal sealed class ToolIndexUpdater : IHostedService
+{
+    private readonly FileSystemPromptProvider _promptProvider;
+    private readonly ToolRegistry _toolRegistry;
+    private readonly ILogger<ToolIndexUpdater> _logger;
+
+    public ToolIndexUpdater(
+        FileSystemPromptProvider promptProvider,
+        ToolRegistry toolRegistry,
+        ILogger<ToolIndexUpdater> logger)
+    {
+        _promptProvider = promptProvider;
+        _toolRegistry = toolRegistry;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var index = _toolRegistry.GenerateCompressedIndex();
+        _promptProvider.SetToolIndex(index);
+        _logger.LogInformation("Tool index updated ({ToolCount} registrations)", _toolRegistry.GetAllRegistrations().Count);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
     <PackageReference Include="Anthropic" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
+using Netclaw.Daemon.Mcp;
 using Netclaw.Daemon.Services;
 
 try
@@ -166,13 +167,31 @@ static void ConfigureDaemonServices(
     services.AddSingleton(toolRegistry);
     services.AddSingleton<IToolExecutor>(new DispatchingToolExecutor(toolRegistry));
 
+    // MCP server lifecycle management
+    var mcpServers = configuration.GetSection("McpServers")
+        .Get<Dictionary<string, McpServerEntry>>() ?? new();
+    services.AddSingleton(mcpServers);
+    services.AddSingleton<McpClientManager>();
+    services.AddHostedService(sp => sp.GetRequiredService<McpClientManager>());
+
+    // Refresh tool index in system prompt after MCP tools are discovered
+    services.AddHostedService<ToolIndexUpdater>();
+
     // System prompt (file-based, with first-run seed)
     if (!File.Exists(paths.PersonalityPath))
         File.WriteAllText(paths.PersonalityPath,
             "You are Netclaw, a helpful homelab operations assistant. "
             + "Be concise and direct.");
-    services.AddSingleton<ISystemPromptProvider>(
-        new FileSystemPromptProvider(paths));
+    var promptProvider = new FileSystemPromptProvider(paths);
+
+    // Set initial compressed tool index from first-party tools.
+    // MCP tools will be added by McpClientManager at startup, which updates
+    // the tool registry — but the prompt provider gets the index at construction
+    // time. For MCP tools to appear in the index, the ToolIndexUpdater hosted
+    // service refreshes it after MCP startup completes.
+    promptProvider.SetToolIndex(toolRegistry.GenerateCompressedIndex());
+    services.AddSingleton<ISystemPromptProvider>(promptProvider);
+    services.AddSingleton(promptProvider); // also register concrete type for ToolIndexUpdater
 
     var sqlitePath = string.IsNullOrWhiteSpace(persistence.Sqlite.Path)
         ? paths.SqliteDbPath

--- a/src/Netclaw.Daemon/Properties/AssemblyInfo.cs
+++ b/src/Netclaw.Daemon/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Netclaw.Actors.Tests")]
+[assembly: InternalsVisibleTo("Netclaw.Daemon.Tests")]


### PR DESCRIPTION
## Summary

- Add Model Context Protocol (MCP) client support using the official `ModelContextProtocol.Core` v1.0.0 NuGet SDK
- Implement two-layer discovery architecture: compressed tool index in system prompt + `search_tools` meta-tool for on-demand loading of MCP tools
- Add `netclaw mcp` CLI command family (add/list/get/remove/enable/disable/validate) for managing MCP server profiles
- Add `McpClientManager` IHostedService for daemon-side MCP client lifecycle (connect, discover tools, reconnect, shutdown)
- Wrap MCP tools as `INetclawTool` via `McpToolAdapter` with namespaced names (`server/tool`) and per-server grant categories
- Add `SearchToolsTool` builtin meta-tool for keyword-based tool discovery across the registry
- Update `LlmSessionActor` for dynamic tool loading: non-MCP tools loaded eagerly, MCP tools loaded lazily after `search_tools` invocation
- Remove MCP step from init wizard (MCP is a power-user workflow via CLI, not first-run onboarding)
- Add `McpServersDoctorCheck` for config validation
- Add research doc on dynamic context discovery patterns

## Test plan

- [x] 227 tests pass (140 Actors + 68 Cli + 19 Daemon)
- [x] 4 STDIO smoke tests against `@modelcontextprotocol/server-everything` validate full pipeline: connection, tool discovery, adapter wrapping, registry search, McpClientManager lifecycle
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Unit tests for McpToolAdapter, SearchToolsTool, ToolRegistry extensions, McpServersDoctorCheck, McpCommand config operations
- [x] Init wizard tests updated for 5-step flow (MCP step removed)
- [x] MaxToolIteration tests continue passing with dynamic tool loading changes