### PR TITLE
Reset dynamically-loaded MCP tools per turn

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -44,6 +44,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     private readonly Dictionary<IActorRef, OutputFilter> _subscribers = new();
     private readonly List<AITool> _availableTools = new();
     private readonly ToolRegistry? _fullRegistry;
+    private int _baseToolCount; // count of always-loaded tools; dynamic tools appended after this
 
     // Last observed input token count from LLM response (for compaction trigger)
     private long _lastInputTokenCount;
@@ -87,12 +88,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         _log = Context.GetLogger().WithContext("SessionId", _sessionId.Value);
 
         // Load all non-MCP tools for initial LLM calls.
-        // MCP tools are loaded dynamically via search_tools meta-tool.
+        // MCP tools are loaded dynamically via search_tools meta-tool and reset each turn.
         _fullRegistry = toolRegistry;
         if (toolRegistry is not null)
         {
             _availableTools.AddRange(toolRegistry.GetAlwaysLoadedTools());
         }
+        _baseToolCount = _availableTools.Count;
 
         // ── Recovery handlers ──
         Recover<SystemPromptSet>(evt =>
@@ -139,6 +141,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             _log.Info("Received user message");
 
             _toolIterationCount = 0;
+
+            // Reset dynamically-loaded MCP tools — the LLM can re-discover via search_tools
+            if (_availableTools.Count > _baseToolCount)
+                _availableTools.RemoveRange(_baseToolCount, _availableTools.Count - _baseToolCount);
+
             _state = _state.AddUserMessage(cmd.Content);
             TryReplyAck();
             FireLlmCall();


### PR DESCRIPTION
## Summary

- Prevent unbounded tool accumulation in `ChatOptions.Tools` across long conversations by resetting dynamically-loaded MCP tools at the start of each user turn
- Track `_baseToolCount` (non-MCP tools) and truncate back to that baseline when a new `SendUserMessage` arrives
- The LLM can re-discover tools via `search_tools` since prior tool calls remain visible in conversation history

## Test plan

- [x] All 227 tests pass (no behavioral change for existing flows)
- [x] MaxToolIteration tests continue passing (tool reset doesn't interfere with within-turn tool loops)
- [ ] Real LLM smoke test deferred to #49 (blocked on provider integration)