### PR TITLE
MCP connectivity checks, schema sanitization, and headless UX

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Tools;
 using Xunit;
@@ -52,12 +53,16 @@ public class McpToolAdapterTests
     }
 
     [Fact]
-    public void ToAITool_ReturnsSameInstance()
+    public void ToAITool_ReturnsSanitizedWrapper()
     {
         var fakeTool = AIFunctionFactory.Create(() => "result", "store");
         var adapter = new McpToolAdapter(fakeTool, "memorizer", "store");
 
-        Assert.Same(fakeTool, adapter.ToAITool());
+        var aiTool = adapter.ToAITool();
+        // Should return a sanitized wrapper, not the raw tool
+        Assert.IsAssignableFrom<AIFunction>(aiTool);
+        var func = (AIFunction)aiTool;
+        Assert.Equal("memorizer/store", func.Name);
     }
 
     [Fact]
@@ -82,5 +87,86 @@ public class McpToolAdapterTests
 
         Assert.Contains("connection lost", result);
         Assert.StartsWith("Error:", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CoercesStringArguments()
+    {
+        // Simulate Ollama sending a number as a string
+        string EchoLimit(int limit) => $"limit={limit}";
+        var fakeTool = AIFunctionFactory.Create(EchoLimit, "search");
+        var adapter = new McpToolAdapter(fakeTool, "server", "search");
+
+        var args = new Dictionary<string, object?> { ["limit"] = "10" };
+        var result = await adapter.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Equal("limit=10", result);
+    }
+}
+
+public class McpSchemaSanitizerTests
+{
+    [Fact]
+    public void SanitizeSchema_SimplifiesNullableTypeArray()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string" },
+                    "limit": { "type": ["integer", "null"], "default": 10 }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var limitProp = sanitized.GetProperty("properties").GetProperty("limit");
+
+        // Should be simplified to just "integer"
+        Assert.Equal(JsonValueKind.String, limitProp.GetProperty("type").ValueKind);
+        Assert.Equal("integer", limitProp.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void SanitizeSchema_PreservesNonNullableTypes()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var nameProp = sanitized.GetProperty("properties").GetProperty("name");
+
+        Assert.Equal("string", nameProp.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void CoerceArguments_ConvertsStringNumbers()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["count"] = "42",
+            ["ratio"] = "3.14",
+            ["name"] = "hello",
+            ["flag"] = "true"
+        };
+
+        var coerced = McpSchemaSanitizer.CoerceArguments(args)!;
+
+        Assert.Equal(42L, coerced["count"]);
+        Assert.Equal(3.14, coerced["ratio"]);
+        Assert.Equal("hello", coerced["name"]);
+        Assert.Equal(true, coerced["flag"]);
+    }
+
+    [Fact]
+    public void CoerceArguments_ReturnsNullForNull()
+    {
+        Assert.Null(McpSchemaSanitizer.CoerceArguments(null));
     }
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -178,6 +178,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 return;
             }
 
+            // Guard: if the LLM produced no text and no tool calls, it likely tried to
+            // call an MCP tool that isn't in ChatOptions.Tools yet. Add a nudge and retry.
+            var hasText = lastMessage.Contents.OfType<TextContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
+            if (!hasText && _toolIterationCount == 0)
+            {
+                _log.Warning("LLM produced empty response (no text, no tool calls) — retrying with nudge");
+                _state = _state.AddSystemNudge(
+                    "Your previous response was empty. If you need MCP tools, call search_tools(\"query\") first to load them. "
+                    + "MCP tools listed in the index are NOT directly callable — you must use search_tools to load them before calling.");
+                FireLlmCall();
+                return;
+            }
+
             // Normal text response — persist turn
             HandleTextResponse(lastMessage, response.Usage, msg.StreamedText, msg.StreamedThinking);
         });

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -104,6 +104,22 @@ public sealed record SessionState
     }
 
     /// <summary>
+    /// Add a transient system nudge to history to correct LLM behavior (e.g., empty response recovery).
+    /// Not persisted as a turn — just injected into the conversation to guide the next LLM call.
+    /// </summary>
+    public SessionState AddSystemNudge(string nudge)
+    {
+        return this with
+        {
+            History = History.Add(new SerializableChatMessage
+            {
+                Role = ChatRole.User,
+                Content = $"[system: {nudge}]"
+            })
+        };
+    }
+
+    /// <summary>
     /// Find the last user message in history (for building persistence events).
     /// </summary>
     public SerializableChatMessage? FindLastUserMessage()

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Sanitizes MCP tool JSON schemas and coerces arguments for LLM compatibility.
+/// </summary>
+/// <remarks>
+/// Some LLM providers (notably Ollama) don't handle certain JSON Schema features:
+/// <list type="bullet">
+/// <item>Nullable type arrays like <c>{"type": ["string", "null"]}</c></item>
+/// <item>Complex union types in anyOf/oneOf/allOf</item>
+/// </list>
+/// Additionally, some providers send numbers as strings in tool call arguments.
+/// This class provides static helpers for both schema sanitization and argument coercion.
+/// </remarks>
+public static class McpSchemaSanitizer
+{
+    /// <summary>
+    /// Sanitizes a JSON schema, simplifying nullable type arrays and recursively
+    /// cleaning nested schemas.
+    /// </summary>
+    public static JsonElement SanitizeSchema(JsonElement schema)
+    {
+        using var doc = JsonDocument.Parse(SanitizeElement(schema).GetRawText());
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// Coerces tool call arguments to their expected types.
+    /// Some LLMs (like Ollama) send numbers as strings (e.g., "10" instead of 10).
+    /// </summary>
+    public static IDictionary<string, object?>? CoerceArguments(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null)
+            return null;
+
+        var coerced = new Dictionary<string, object?>(arguments.Count);
+        foreach (var (key, value) in arguments)
+        {
+            coerced[key] = CoerceValue(value);
+        }
+
+        return coerced;
+    }
+
+    // ── Schema sanitization ──
+
+    private static JsonElement SanitizeElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => SanitizeObject(element),
+            JsonValueKind.Array => SanitizeArray(element),
+            _ => element.Clone()
+        };
+    }
+
+    private static JsonElement SanitizeObject(JsonElement obj)
+    {
+        var dict = new Dictionary<string, object?>();
+
+        foreach (var property in obj.EnumerateObject())
+        {
+            var value = property.Name switch
+            {
+                // Handle type arrays like ["string", "null"] -> "string"
+                "type" when property.Value.ValueKind == JsonValueKind.Array =>
+                    SimplifyTypeArray(property.Value),
+
+                // Recursively sanitize properties object
+                "properties" => SanitizePropertiesObject(property.Value),
+
+                // Recursively sanitize items (for array types)
+                "items" => JsonElementToObject(SanitizeElement(property.Value)),
+
+                // Recursively sanitize anyOf/oneOf/allOf
+                "anyOf" or "oneOf" or "allOf" => SanitizeSchemaArray(property.Value),
+
+                // Pass through other properties
+                _ => JsonElementToObject(property.Value)
+            };
+
+            dict[property.Name] = value;
+        }
+
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
+    private static JsonElement SanitizeArray(JsonElement array)
+    {
+        var list = new List<object?>();
+        foreach (var item in array.EnumerateArray())
+        {
+            list.Add(JsonElementToObject(SanitizeElement(item)));
+        }
+
+        return JsonSerializer.SerializeToElement(list);
+    }
+
+    /// <summary>
+    /// Simplifies type arrays like ["string", "null"] to just "string".
+    /// </summary>
+    private static object SimplifyTypeArray(JsonElement typeArray)
+    {
+        var types = new List<string>();
+
+        foreach (var typeItem in typeArray.EnumerateArray())
+        {
+            if (typeItem.ValueKind == JsonValueKind.String)
+            {
+                var typeStr = typeItem.GetString();
+                if (typeStr != null && typeStr != "null")
+                {
+                    types.Add(typeStr);
+                }
+            }
+        }
+
+        return types.Count switch
+        {
+            0 => "string", // Fallback if all types were null
+            1 => types[0],
+            _ => types // Multiple non-null types — return as array
+        };
+    }
+
+    private static object? SanitizePropertiesObject(JsonElement properties)
+    {
+        if (properties.ValueKind != JsonValueKind.Object)
+            return JsonElementToObject(properties);
+
+        var dict = new Dictionary<string, object?>();
+        foreach (var prop in properties.EnumerateObject())
+        {
+            dict[prop.Name] = JsonElementToObject(SanitizeElement(prop.Value));
+        }
+
+        return dict;
+    }
+
+    private static object? SanitizeSchemaArray(JsonElement schemaArray)
+    {
+        if (schemaArray.ValueKind != JsonValueKind.Array)
+            return JsonElementToObject(schemaArray);
+
+        var list = new List<object?>();
+        foreach (var schema in schemaArray.EnumerateArray())
+        {
+            list.Add(JsonElementToObject(SanitizeElement(schema)));
+        }
+
+        return list;
+    }
+
+    private static object? JsonElementToObject(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => JsonElementToDict(element),
+            JsonValueKind.Array => JsonElementToList(element),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.GetRawText()
+        };
+    }
+
+    private static Dictionary<string, object?> JsonElementToDict(JsonElement element)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var prop in element.EnumerateObject())
+        {
+            dict[prop.Name] = JsonElementToObject(prop.Value);
+        }
+
+        return dict;
+    }
+
+    private static List<object?> JsonElementToList(JsonElement element)
+    {
+        var list = new List<object?>();
+        foreach (var item in element.EnumerateArray())
+        {
+            list.Add(JsonElementToObject(item));
+        }
+
+        return list;
+    }
+
+    // ── Argument coercion ──
+
+    private static object? CoerceValue(object? value)
+    {
+        return value switch
+        {
+            string s => CoerceStringValue(s),
+            JsonElement je => ConvertJsonValue(je),
+            IList<object?> list => list.Select(CoerceValue).ToList(),
+            IDictionary<string, object?> dict => dict.ToDictionary(
+                kvp => kvp.Key, kvp => CoerceValue(kvp.Value)),
+            _ => value
+        };
+    }
+
+    /// <summary>
+    /// Coerces string values to appropriate types when possible.
+    /// Some LLMs (like Ollama) incorrectly pass numbers as strings.
+    /// </summary>
+    private static object? CoerceStringValue(string? str)
+    {
+        if (str == null)
+            return null;
+
+        if (long.TryParse(str, out var longVal))
+            return longVal;
+
+        if (double.TryParse(str, out var doubleVal))
+            return doubleVal;
+
+        if (str.Equals("true", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (str.Equals("false", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return str;
+    }
+
+    private static object? ConvertJsonValue(JsonElement value)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => CoerceStringValue(value.GetString()),
+            JsonValueKind.Number => value.TryGetInt64(out var l) ? l : value.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            JsonValueKind.Array => value.EnumerateArray().Select(ConvertJsonValue).ToList(),
+            JsonValueKind.Object => ConvertJsonObject(value),
+            _ => value.GetRawText()
+        };
+    }
+
+    private static Dictionary<string, object?> ConvertJsonObject(JsonElement element)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var prop in element.EnumerateObject())
+        {
+            dict[prop.Name] = ConvertJsonValue(prop.Value);
+        }
+
+        return dict;
+    }
+}

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -7,10 +7,13 @@ namespace Netclaw.Actors.Tools;
 /// <summary>
 /// Wraps an <see cref="AITool"/> from an MCP server as <see cref="INetclawTool"/>.
 /// Tool names are namespaced as <c>{serverName}/{toolName}</c> to avoid collisions.
+/// Schemas are sanitized for broad LLM compatibility (e.g., Ollama can't handle
+/// nullable type arrays) and arguments are coerced from string to native types.
 /// </summary>
 public sealed class McpToolAdapter : INetclawTool
 {
     private readonly AITool _mcpTool;
+    private readonly AITool _sanitizedTool;
     private readonly string _toolName;
 
     public McpToolAdapter(AITool mcpTool, string serverName, string toolName, string? grantCategory = null)
@@ -25,12 +28,15 @@ public sealed class McpToolAdapter : INetclawTool
         if (mcpTool is AIFunction func)
         {
             Description = func.Description ?? "";
-            ParameterSchema = func.JsonSchema;
+            // Sanitize schema for LLM compatibility (strips nullable unions, etc.)
+            ParameterSchema = McpSchemaSanitizer.SanitizeSchema(func.JsonSchema);
+            _sanitizedTool = new SanitizedAIFunction(func, Name, ParameterSchema);
         }
         else
         {
             Description = "";
             ParameterSchema = default;
+            _sanitizedTool = mcpTool;
         }
     }
 
@@ -43,7 +49,10 @@ public sealed class McpToolAdapter : INetclawTool
     /// <summary>The bare tool name without the server prefix.</summary>
     public string BareToolName => _toolName;
 
-    public AITool ToAITool() => _mcpTool;
+    /// <summary>
+    /// Returns the AITool with a sanitized JSON schema for LLM compatibility.
+    /// </summary>
+    public AITool ToAITool() => _sanitizedTool;
 
     public async Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
     {
@@ -52,8 +61,10 @@ public sealed class McpToolAdapter : INetclawTool
 
         try
         {
-            var aiArgs = arguments is not null
-                ? new AIFunctionArguments(arguments)
+            // Coerce arguments — some LLMs send numbers as strings
+            var coerced = McpSchemaSanitizer.CoerceArguments(arguments);
+            var aiArgs = coerced is not null
+                ? new AIFunctionArguments(coerced)
                 : null;
             var result = await func.InvokeAsync(aiArgs, ct);
             return result?.ToString() ?? "";
@@ -61,6 +72,41 @@ public sealed class McpToolAdapter : INetclawTool
         catch (Exception ex)
         {
             return $"Error: MCP tool '{Name}' failed: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Wraps an <see cref="AIFunction"/> with a sanitized JSON schema while
+    /// delegating invocation to the original function.
+    /// </summary>
+    private sealed class SanitizedAIFunction : AIFunction
+    {
+        private readonly AIFunction _inner;
+        private readonly string _namespacedName;
+        private readonly JsonElement _sanitizedSchema;
+
+        public SanitizedAIFunction(AIFunction inner, string namespacedName, JsonElement sanitizedSchema)
+        {
+            _inner = inner;
+            _namespacedName = namespacedName;
+            _sanitizedSchema = sanitizedSchema;
+        }
+
+        // Use the namespaced name (e.g., "memorizer/search_memories") so the LLM
+        // calls the tool by the same name it's registered under in ToolRegistry.
+        public override string Name => _namespacedName;
+        public override string Description => _inner.Description;
+        public override JsonElement JsonSchema => _sanitizedSchema;
+
+        protected override ValueTask<object?> InvokeCoreAsync(
+            AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            // Coerce arguments before forwarding to the MCP client
+            var coerced = McpSchemaSanitizer.CoerceArguments(arguments);
+            var coercedArgs = coerced is not null
+                ? new AIFunctionArguments(coerced)
+                : arguments;
+            return _inner.InvokeAsync(coercedArgs, cancellationToken);
         }
     }
 }

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -103,21 +103,35 @@ public sealed class ToolRegistry
             return string.Empty;
 
         var sb = new StringBuilder();
-        sb.AppendLine("[available tools — use search_tools to load full definitions]");
 
-        var grouped = _tools.GroupBy(t => t.GrantCategory);
-        foreach (var group in grouped)
+        // Separate always-loaded (directly callable) tools from MCP (dynamic) tools
+        var builtinTools = _tools.Where(t => t.Tool is not McpToolAdapter).ToList();
+        var mcpTools = _tools.Where(t => t.Tool is McpToolAdapter).ToList();
+
+        if (builtinTools.Count > 0)
         {
-            var names = group.Select(t =>
+            sb.AppendLine("[directly callable tools]");
+            var builtinGrouped = builtinTools.GroupBy(t => t.GrantCategory);
+            foreach (var group in builtinGrouped)
             {
-                if (t.Tool is McpToolAdapter mcp)
-                    return mcp.BareToolName;
-                return t.Tool.Name;
-            });
-            sb.AppendLine($"{group.Key}: {string.Join(", ", names)}");
+                var names = group.Select(t => t.Tool.Name);
+                sb.AppendLine($"{group.Key}: {string.Join(", ", names)}");
+            }
         }
 
-        sb.AppendLine("→ call search_tools(\"query\") to load any tool above before using it");
+        if (mcpTools.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("[MCP tools — NOT directly callable, must load first via search_tools]");
+            var mcpGrouped = mcpTools.GroupBy(t => t.GrantCategory);
+            foreach (var group in mcpGrouped)
+            {
+                var names = group.Select(t => ((McpToolAdapter)t.Tool).BareToolName);
+                sb.AppendLine($"{group.Key}: {string.Join(", ", names)}");
+            }
+            sb.AppendLine("→ REQUIRED: call search_tools(\"query\") first to load MCP tools, then call them");
+        }
+
         return sb.ToString();
     }
 

--- a/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
@@ -45,7 +45,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task ValidStdioServer_Passes()
+    public async Task ValidStdioServer_UnreachableEndpoint_ReportsError()
     {
         WriteConfig(new
         {
@@ -65,8 +65,9 @@ public sealed class McpServersDoctorCheckTests : IDisposable
         var check = new McpServersDoctorCheck(_paths);
         var result = await check.RunAsync();
 
-        Assert.Equal(DoctorSeverity.Pass, result.Severity);
-        Assert.Contains("1 server(s) configured", result.Message);
+        // Single enabled server that can't connect → Error
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("unreachable", result.Message);
     }
 
     [Fact]
@@ -139,14 +140,13 @@ public sealed class McpServersDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task DisabledServer_CountsCorrectly()
+    public async Task DisabledServer_SkipsProbe()
     {
         WriteConfig(new
         {
             configVersion = 1,
             McpServers = new
             {
-                enabled_one = new { Transport = "stdio", Command = "npx", Enabled = true },
                 disabled_one = new { Transport = "stdio", Command = "npx", Enabled = false }
             }
         });
@@ -154,8 +154,9 @@ public sealed class McpServersDoctorCheckTests : IDisposable
         var check = new McpServersDoctorCheck(_paths);
         var result = await check.RunAsync();
 
+        // Only disabled servers → all pass (no enabled servers to fail)
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
-        Assert.Contains("2 server(s) configured (1 enabled)", result.Message);
+        Assert.Contains("disabled", result.Message);
     }
 
     private void WriteConfig(object config)

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -95,7 +95,7 @@ public sealed class McpCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task List_ShowsConfiguredServers()
+    public async Task List_ShowsConfiguredServersWithStatus()
     {
         // Add a server first
         await McpCommand.RunAsync(
@@ -107,6 +107,24 @@ public sealed class McpCommandTests : IDisposable
 
         Assert.Contains("memorizer", output);
         Assert.Contains("stdio", output);
+        // Server is unreachable in test environment — status column should reflect that
+        Assert.Contains("unreachable", output);
+    }
+
+    [Fact]
+    public async Task List_DisabledServer_ShowsDisabledStatus()
+    {
+        await McpCommand.RunAsync(
+            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            _paths);
+        await McpCommand.RunAsync(
+            new[] { "mcp", "disable", "memorizer" }, _paths);
+
+        var output = CaptureConsoleOutput(async () =>
+            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+
+        Assert.Contains("memorizer", output);
+        Assert.Contains("disabled", output);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
@@ -1,19 +1,20 @@
 using System.Text.Json;
+using Netclaw.Cli.Mcp;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
 
 /// <summary>
-/// Doctor check that validates MCP server configuration entries.
-/// Checks: required fields per transport type, valid transport values.
-/// Non-blocking warning if no MCP servers configured.
+/// Doctor check that validates MCP server configuration entries and connectivity.
+/// First pass: required fields per transport type, valid transport values.
+/// Second pass: probe enabled servers for connectivity.
 /// </summary>
 public sealed class McpServersDoctorCheck(NetclawPaths paths) : IDoctorCheck
 {
-    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    public async Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
     {
         if (!File.Exists(paths.NetclawConfigPath))
-            return Task.FromResult(DoctorCheckResult.Pass("mcp-servers", "No config file (skipped)"));
+            return DoctorCheckResult.Pass("mcp-servers", "No config file (skipped)");
 
         Dictionary<string, McpServerEntry> servers;
         try
@@ -22,46 +23,111 @@ public sealed class McpServersDoctorCheck(NetclawPaths paths) : IDoctorCheck
             using var doc = JsonDocument.Parse(text);
 
             if (!doc.RootElement.TryGetProperty("McpServers", out var mcpSection))
-                return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
-                    "No MCP servers configured (use `netclaw mcp add` to add one)"));
+                return DoctorCheckResult.Pass("mcp-servers",
+                    "No MCP servers configured (use `netclaw mcp add` to add one)");
 
             servers = JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpSection.GetRawText())
                 ?? new();
         }
         catch (Exception ex)
         {
-            return Task.FromResult(DoctorCheckResult.Error("mcp-servers",
-                $"Failed to read MCP config: {ex.Message}"));
+            return DoctorCheckResult.Error("mcp-servers",
+                $"Failed to read MCP config: {ex.Message}");
         }
 
         if (servers.Count == 0)
-            return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
-                "No MCP servers configured"));
+            return DoctorCheckResult.Pass("mcp-servers",
+                "No MCP servers configured");
 
-        var errors = new List<string>();
+        // First pass: static config validation (fail fast on bad config)
+        var configErrors = new List<string>();
+        var validServers = new Dictionary<string, McpServerEntry>();
 
         foreach (var (name, entry) in servers)
         {
             if (entry.Transport is not ("stdio" or "sse" or "http"))
             {
-                errors.Add($"{name}: invalid transport '{entry.Transport}' (must be stdio, sse, or http)");
+                configErrors.Add($"{name}: invalid transport '{entry.Transport}' (must be stdio, sse, or http)");
                 continue;
             }
 
             if (entry.Transport is "stdio" && string.IsNullOrWhiteSpace(entry.Command))
-                errors.Add($"{name}: stdio transport requires 'Command'");
+            {
+                configErrors.Add($"{name}: stdio transport requires 'Command'");
+                continue;
+            }
 
             if (entry.Transport is "sse" or "http" && string.IsNullOrWhiteSpace(entry.Url))
-                errors.Add($"{name}: {entry.Transport} transport requires 'Url'");
+            {
+                configErrors.Add($"{name}: {entry.Transport} transport requires 'Url'");
+                continue;
+            }
+
+            validServers[name] = entry;
         }
 
-        if (errors.Count > 0)
-            return Task.FromResult(DoctorCheckResult.Error("mcp-servers",
-                $"MCP config issues: {string.Join("; ", errors)}",
-                "Run `netclaw mcp list` and fix entries with `netclaw mcp remove` + `netclaw mcp add`"));
+        if (configErrors.Count > 0)
+            return DoctorCheckResult.Error("mcp-servers",
+                $"MCP config issues: {string.Join("; ", configErrors)}",
+                "Run `netclaw mcp list` and fix entries with `netclaw mcp remove` + `netclaw mcp add`");
 
-        var enabledCount = servers.Count(s => s.Value.Enabled);
-        return Task.FromResult(DoctorCheckResult.Pass("mcp-servers",
-            $"{servers.Count} server(s) configured ({enabledCount} enabled)"));
+        // Second pass: connectivity probe for enabled servers with valid config
+        // Merge secrets so probes have auth headers / env vars
+        var fullServers = McpCommand.LoadMcpServers(paths);
+        var statusMessages = new List<string>();
+        var hasAuthFailure = false;
+        var enabledCount = 0;
+        var connectedCount = 0;
+        var failedCount = 0;
+
+        foreach (var (name, entry) in validServers)
+        {
+            // Use full entry (with secrets merged) if available
+            var probeEntry = fullServers.TryGetValue(name, out var full) ? full : entry;
+            var probe = await McpCommand.ProbeServerAsync(name, probeEntry, cancellationToken);
+
+            switch (probe.Status)
+            {
+                case McpProbeStatus.Disabled:
+                    statusMessages.Add($"{name}: disabled");
+                    break;
+                case McpProbeStatus.Connected:
+                    enabledCount++;
+                    connectedCount++;
+                    statusMessages.Add($"{name}: {probe.FormatStatus()}");
+                    break;
+                case McpProbeStatus.AuthFailed:
+                    enabledCount++;
+                    failedCount++;
+                    hasAuthFailure = true;
+                    statusMessages.Add($"{name}: {probe.FormatStatus()}");
+                    break;
+                case McpProbeStatus.Unreachable:
+                    enabledCount++;
+                    failedCount++;
+                    statusMessages.Add($"{name}: {probe.FormatStatus()}");
+                    break;
+            }
+        }
+
+        var summary = string.Join("; ", statusMessages);
+
+        // Auth failures are always Error severity (won't self-resolve)
+        if (hasAuthFailure)
+            return DoctorCheckResult.Error("mcp-servers", summary,
+                "Check API keys and credentials for failing servers");
+
+        // All enabled servers failed
+        if (enabledCount > 0 && failedCount == enabledCount)
+            return DoctorCheckResult.Error("mcp-servers", summary,
+                "No MCP servers are reachable — check network and server configuration");
+
+        // Some enabled servers failed
+        if (failedCount > 0)
+            return DoctorCheckResult.Warning("mcp-servers", summary,
+                "Some MCP servers are unreachable — check network and server configuration");
+
+        // All good
+        return DoctorCheckResult.Pass("mcp-servers", summary);
     }
 }

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -160,13 +160,12 @@ public sealed class HeadlessChannel : IChannel
                     break;
                 }
 
-                Console.WriteLine($"[thinking] {msg.Text}");
+                // Don't write thinking tokens to stdout — only log them
                 Log(log, $"THINKING: {msg.Text}");
                 break;
 
             case ThinkingDeltaOutput msg:
                 _receivedThinkingDeltaInCurrentTurn = true;
-                Console.Write($"[thinking]{msg.Delta}");
                 Log(log, $"THINKING_DELTA: {msg.Delta}");
                 break;
 

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -1,13 +1,27 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using ModelContextProtocol.Client;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Mcp;
 
+internal enum McpProbeStatus { Connected, AuthFailed, Unreachable, Disabled }
+
+internal readonly record struct McpProbeResult(
+    McpProbeStatus Status, int ToolCount, string? ErrorMessage)
+{
+    public string FormatStatus() => Status switch
+    {
+        McpProbeStatus.Connected => $"connected ({ToolCount} tools)",
+        McpProbeStatus.AuthFailed => $"auth failed ({ErrorMessage})",
+        McpProbeStatus.Unreachable => $"unreachable — {ErrorMessage}",
+        McpProbeStatus.Disabled => "disabled",
+        _ => "unknown"
+    };
+}
+
 /// <summary>
-/// Handles <c>netclaw mcp</c> CLI subcommands: add, list, get, remove, enable, disable, validate.
-/// All commands are offline (read/write config files directly) except <c>validate</c>
-/// which spawns one-shot MCP client connections.
+/// Handles <c>netclaw mcp</c> CLI subcommands: add, list, get, remove, enable, disable.
 /// </summary>
 internal static class McpCommand
 {
@@ -20,12 +34,11 @@ internal static class McpCommand
         return subcommand switch
         {
             "add" => RunAdd(args, paths),
-            "list" => RunList(paths),
+            "list" => await RunListAsync(paths),
             "get" => RunGet(args, paths),
             "remove" => RunRemove(args, paths),
             "enable" => RunToggle(args, paths, enabled: true),
             "disable" => RunToggle(args, paths, enabled: false),
-            "validate" => await RunValidateAsync(args, paths),
             "help" or "-h" or "--help" => WriteHelp(),
             _ => WriteHelp()
         };
@@ -174,7 +187,7 @@ internal static class McpCommand
         return 0;
     }
 
-    private static int RunList(NetclawPaths paths)
+    private static async Task<int> RunListAsync(NetclawPaths paths)
     {
         var servers = LoadMcpServers(paths);
 
@@ -185,11 +198,12 @@ internal static class McpCommand
             return 0;
         }
 
-        Console.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status",-10}");
+        Console.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status"}");
         foreach (var (name, entry) in servers)
         {
             var enabled = entry.Enabled ? "yes" : "no";
-            Console.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {"-",-10}");
+            var probe = await ProbeServerAsync(name, entry);
+            Console.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {probe.FormatStatus()}");
         }
 
         return 0;
@@ -310,44 +324,46 @@ internal static class McpCommand
         return 0;
     }
 
-    private static async Task<int> RunValidateAsync(string[] args, NetclawPaths paths)
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(15);
+
+    internal static async Task<McpProbeResult> ProbeServerAsync(
+        string name, McpServerEntry entry, CancellationToken ct = default)
     {
-        var targetName = args.Length >= 3 ? args[2] : null;
-        var servers = LoadMcpServers(paths);
+        if (!entry.Enabled)
+            return new McpProbeResult(McpProbeStatus.Disabled, 0, null);
 
-        if (servers.Count == 0)
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ProbeTimeout);
+
+        try
         {
-            Console.WriteLine("No MCP servers configured.");
-            return 0;
+            await using var client = await CreateOneOffClientAsync(name, entry);
+            var tools = await client.ListToolsAsync(cancellationToken: timeoutCts.Token);
+            return new McpProbeResult(McpProbeStatus.Connected, tools.Count, null);
         }
-
-        var hasFailure = false;
-
-        foreach (var (name, entry) in servers)
+        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.Unauthorized
+            or System.Net.HttpStatusCode.Forbidden)
         {
-            if (targetName is not null && !string.Equals(name, targetName, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            if (!entry.Enabled)
+            var statusText = ex.StatusCode switch
             {
-                Console.WriteLine($"{name}: disabled (skipped)");
-                continue;
-            }
-
-            try
-            {
-                await using var client = await CreateOneOffClientAsync(name, entry);
-                var tools = await client.ListToolsAsync();
-                Console.WriteLine($"{name}: connected ({tools.Count} tools discovered)");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"{name}: failed — {ex.Message}");
-                hasFailure = true;
-            }
+                System.Net.HttpStatusCode.Unauthorized => "401 Unauthorized",
+                System.Net.HttpStatusCode.Forbidden => "403 Forbidden",
+                _ => ex.StatusCode.ToString()
+            };
+            return new McpProbeResult(McpProbeStatus.AuthFailed, 0, statusText);
         }
-
-        return hasFailure ? 1 : 0;
+        catch (HttpRequestException ex)
+        {
+            return new McpProbeResult(McpProbeStatus.Unreachable, 0, ex.Message);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new McpProbeResult(McpProbeStatus.Unreachable, 0, "connection timed out");
+        }
+        catch (Exception ex) when (ex is IOException or SocketException)
+        {
+            return new McpProbeResult(McpProbeStatus.Unreachable, 0, ex.Message);
+        }
     }
 
     internal static async Task<McpClient> CreateOneOffClientAsync(string name, McpServerEntry entry)
@@ -517,13 +533,11 @@ internal static class McpCommand
         Console.WriteLine("  remove     Remove an MCP server profile");
         Console.WriteLine("  enable     Enable a disabled MCP server");
         Console.WriteLine("  disable    Disable an MCP server without removing it");
-        Console.WriteLine("  validate   Test connectivity to MCP server(s)");
         Console.WriteLine();
         Console.WriteLine("Examples:");
         Console.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
         Console.WriteLine("  netclaw mcp add --transport http --header \"Authorization: Bearer tok-...\" myapi https://api.example.com/mcp");
         Console.WriteLine("  netclaw mcp list");
-        Console.WriteLine("  netclaw mcp validate");
         return 0;
     }
 }


### PR DESCRIPTION
## Summary

- **MCP connectivity probing**: `netclaw doctor` and `netclaw mcp list` now test live connectivity to MCP servers, differentiating between connected, auth failed (401/403), unreachable, and disabled states. Removes the redundant `netclaw mcp validate` command.
- **Schema sanitization for Ollama compatibility**: MCP tool JSON schemas are sanitized to strip nullable type arrays (`{"type": ["string", "null"]}` → `"string"`) that Ollama cannot parse. Tool call arguments are coerced from strings to native types (numbers, booleans) to handle Ollama's string-only marshaling. Fixes #51.
- **Dynamic tool discovery fixes**: Compressed tool index now clearly separates directly callable tools from MCP tools. Namespaced tool names (`memorizer/search_memories`) are used consistently through the `SanitizedAIFunction` wrapper so dynamically loaded tools match their `ToolRegistry` keys. Empty LLM responses trigger a system nudge retry.
- **Headless UX**: Thinking tokens are suppressed from stdout in `-p` mode (still logged to session log file).

## Test plan

- [x] 145 Actors tests pass (including new sanitizer and coercion tests)
- [x] 69 CLI tests pass (including updated doctor and mcp list tests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] Live verification: `netclaw -p "Search Memorizer for memories about Akka.NET best practices"` successfully discovers tools via `search_tools`, loads them with sanitized schemas, calls `memorizer/search_memories` with coerced arguments, and returns summarized results