### PR TITLE
Eliminate anemic actors, child-scope streams, and add passivation

### DIFF
--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -1,6 +1,5 @@
 using Akka;
 using Akka.Actor;
-using Akka.Event;
 using Akka.Hosting;
 using Akka.Streams;
 using Akka.Streams.Dsl;
@@ -35,18 +34,15 @@ public sealed record SessionPipelineOptions
 public sealed class MaterializedSession : IAsyncDisposable
 {
     private readonly SharedKillSwitch _killSwitch;
-    private readonly Action? _onDispose;
 
     internal MaterializedSession(
         Sink<ChannelInput, NotUsed> input,
         Source<SessionOutput, NotUsed> output,
-        SharedKillSwitch killSwitch,
-        Action? onDispose = null)
+        SharedKillSwitch killSwitch)
     {
         Input = input;
         Output = output;
         _killSwitch = killSwitch;
-        _onDispose = onDispose;
     }
 
     /// <summary>
@@ -79,7 +75,6 @@ public sealed class MaterializedSession : IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         _killSwitch.Shutdown();
-        _onDispose?.Invoke();
         return ValueTask.CompletedTask;
     }
 }
@@ -91,7 +86,7 @@ public sealed class MaterializedSession : IAsyncDisposable
 ///
 /// <para>
 /// Internally wires a subscriber actor (via <c>Source.PreMaterialize</c>)
-/// and a command sink (via <c>Sink.ActorRef</c>) to the session manager,
+/// and a <c>Sink.ForEach</c> command forwarder to the session manager,
 /// with a shared <see cref="SharedKillSwitch"/> for coordinated teardown.
 /// </para>
 /// </summary>
@@ -113,30 +108,36 @@ public sealed class SessionPipeline
     /// </summary>
     /// <param name="sessionId">Session identity (channel owns the naming scheme).</param>
     /// <param name="options">Pipeline configuration (channel type, output filter).</param>
+    /// <param name="materializer">Optional materializer for stream actors. When provided
+    /// (e.g. from an actor context), stream actors become children of the owning actor
+    /// and are stopped automatically on passivation. When null, uses the system-level
+    /// materializer.</param>
     /// <param name="cancellationToken">Cancellation token for session manager resolution.</param>
     /// <returns>A session handle with <see cref="MaterializedSession.Input"/> and
     /// <see cref="MaterializedSession.Output"/> streams.</returns>
     public async Task<MaterializedSession> CreateAsync(
         SessionId sessionId,
         SessionPipelineOptions options,
+        IMaterializer? materializer = null,
         CancellationToken cancellationToken = default)
     {
         var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
         var killSwitch = KillSwitches.Shared($"session-{sessionId.Value}");
-        var commandRelay = _system.ActorOf(
-            SessionCommandRelayActor.CreateProps(sessionManager, sessionId),
-            $"session-command-relay-{Uri.EscapeDataString(sessionId.Value)}-{Guid.NewGuid():N}");
 
-        // Pre-materialize subscriber to capture IActorRef before building streams
-        var (subscriber, responseSource) = Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
-            .PreMaterialize(_system);
+        // Pre-materialize subscriber to capture IActorRef before building streams.
+        // When a materializer is provided, the subscriber actor is a child of the
+        // owning actor — stopped automatically on passivation.
+        var (subscriber, responseSource) = materializer is not null
+            ? Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
+                .PreMaterialize(materializer)
+            : Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
+                .PreMaterialize(_system);
 
-        // Inbound: ChannelInput → SendUserMessage → session manager
+        // Inbound: ChannelInput → SendUserMessage → session manager (direct Tell)
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options))
             .Via(killSwitch.Flow<SendUserMessage>())
-            .To(Sink.ActorRef<SendUserMessage>(commandRelay, Done.Instance,
-                ex => new Status.Failure(ex)));
+            .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd)));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source
         var outputSource = responseSource
@@ -153,8 +154,7 @@ public sealed class SessionPipeline
         return new MaterializedSession(
             inputSink,
             outputSource,
-            killSwitch,
-            onDispose: () => _system.Stop(commandRelay));
+            killSwitch);
     }
 
     private SendUserMessage MapToCommand(
@@ -177,26 +177,4 @@ public sealed class SessionPipeline
             }
         };
     }
-}
-
-internal sealed class SessionCommandRelayActor : ReceiveActor
-{
-    private readonly IActorRef _sessionManager;
-    private readonly SessionId _sessionId;
-    private readonly ILoggingAdapter _log;
-
-    public SessionCommandRelayActor(IActorRef sessionManager, SessionId sessionId)
-    {
-        _sessionManager = sessionManager;
-        _sessionId = sessionId;
-        _log = Context.GetLogger().WithContext("SessionId", sessionId.Value);
-
-        Receive<SendUserMessage>(cmd => _sessionManager.Tell(cmd, Self));
-        Receive<CommandAck>(_ => { });
-        Receive<CommandNack>(nack =>
-            _log.Warning("Session command rejected: {0}", nack.Reason));
-    }
-
-    public static Props CreateProps(IActorRef sessionManager, SessionId sessionId) =>
-        Props.Create(() => new SessionCommandRelayActor(sessionManager, sessionId));
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -136,6 +136,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
 
+        // Passivation: stop after idle timeout, snapshot first for fast recovery
+        if (_config.IdleTimeout > TimeSpan.Zero)
+        {
+            Context.SetReceiveTimeout(_config.IdleTimeout);
+        }
+
+        Command<ReceiveTimeout>(_ =>
+        {
+            _log.Info("Session idle, passivating (timeout={Timeout})", _config.IdleTimeout);
+            SaveSnapshot(_state.ToSnapshot());
+            Context.Stop(Self);
+        });
+
         Command<SendUserMessage>(cmd =>
         {
             _log.Info("Received user message");
@@ -155,6 +168,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private void Processing()
     {
+        // Disable idle timeout while processing — re-enabled in Become(Ready)
+        Context.SetReceiveTimeout(null);
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
 
@@ -310,6 +325,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private void Compacting()
     {
+        // Disable idle timeout while compacting — re-enabled in Become(Ready)
+        Context.SetReceiveTimeout(null);
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
 

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -19,6 +19,13 @@ public sealed class SlackConversationActor : ReceiveActor
             .WithContext("Adapter", "slack")
             .WithContext("SlackChannelId", _conversationId);
 
+        Context.SetReceiveTimeout(TimeSpan.FromHours(2));
+        Receive<ReceiveTimeout>(_ =>
+        {
+            _log.Info("Slack conversation idle for 2 hours, passivating");
+            Context.Stop(Self);
+        });
+
         Receive<SlackInboundMessage>(message =>
         {
             if (!IsAllowedConversation(message))

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -22,6 +22,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
     private bool _sawTextDelta;
     private bool _postedThisTurn;
 
+    private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
     private ISourceQueueWithComplete<ChannelInput>? _inputQueue;
 
@@ -43,6 +44,13 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
         ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
         ReceiveAsync<ThreadOutput>(HandleOutputAsync);
+        Receive<ReceiveTimeout>(_ =>
+        {
+            _log.Info("Slack thread idle for 1 hour, passivating");
+            Context.Stop(Self);
+        });
+
+        Context.SetReceiveTimeout(TimeSpan.FromHours(1));
     }
 
     public static Props CreateProps(
@@ -56,6 +64,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
     {
         _inputQueue?.Complete();
         _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _materializer?.Dispose();
         base.PostStop();
     }
 
@@ -96,19 +105,23 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         _log.Info("Initializing Slack thread binding pipeline");
         var self = Self;
 
+        // Create a materializer scoped to this actor — all stream actors become
+        // children and are stopped automatically when this actor passivates.
+        _materializer = Context.Materializer(namePrefix: "slack-thread");
+
         var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
         {
             ChannelType = "slack",
             Filter = OutputFilter.Full
-        });
+        }, materializer: _materializer);
 
         var inputQueue = Source.Queue<ChannelInput>(32, OverflowStrategy.Backpressure)
             .ToMaterialized(materialized.Input, Keep.Left)
-            .Run(_dependencies.ActorSystem);
+            .Run(_materializer);
 
         materialized.Output
             .To(Sink.ForEach<SessionOutput>(output => self.Tell(new ThreadOutput(output))))
-            .Run(_dependencies.ActorSystem);
+            .Run(_materializer);
 
         _session = materialized;
         _inputQueue = inputQueue;

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -51,6 +51,14 @@ public sealed record SessionConfig
     public int MaxToolIterationsPerTurn { get; init; } = 10;
 
     /// <summary>
+    /// How long a session can be idle before passivating.
+    /// The actor saves a snapshot and stops itself; re-creation by
+    /// <c>GenericChildPerEntityParent</c> on next message recovers state from journal.
+    /// Default 30 minutes. Set to <see cref="TimeSpan.Zero"/> to disable.
+    /// </summary>
+    public TimeSpan IdleTimeout { get; init; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
     /// Effective token limit at which compaction fires.
     /// </summary>
     public int CompactionTokenLimit => (int)(ContextWindowTokens * CompactionThreshold);


### PR DESCRIPTION
## Summary

- **Delete `SessionCommandRelayActor`** — anemic top-level actor that only forwarded messages and handled a `CommandNack` type never instantiated anywhere. Replaced `Sink.ActorRef` with `Sink.ForEach` for direct `Tell` to session manager.
- **Child-scope stream actors** — added optional `IMaterializer` parameter to `SessionPipeline.CreateAsync`. `SlackThreadBindingActor` now creates a context-scoped `ActorMaterializer` so all stream actors are children that stop automatically on passivation (no more orphaned `/user/StreamSupervisor-N/` zombies).
- **ReceiveTimeout passivation** — `LlmSessionActor` (configurable 30min default via `SessionConfig.IdleTimeout`), `SlackThreadBindingActor` (1hr), and `SlackConversationActor` (2hr) now self-stop after idle periods. `LlmSessionActor` saves a final snapshot before stopping for fast journal recovery.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 282/282 pass
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] Manual: start daemon, send Slack messages, verify passivation log messages after idle period
- [ ] Manual: after passivation, send new message to same thread — verify session recovers from journal