### PR TITLE
Auto-link bare URLs in Slack Block Converter

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -258,6 +258,47 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
+    public void BareUrl_ProducesRichTextLink()
+    {
+        var blocks = SlackBlockConverter.Convert("Check out https://github.com/foo/bar for details");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var link = Assert.Single(section.Elements.OfType<RichTextLink>());
+        Assert.Equal("https://github.com/foo/bar", link.Url);
+        Assert.Null(link.Text);
+    }
+
+    [Fact]
+    public void BareUrl_InListItem_ProducesRichTextLink()
+    {
+        var input = "- See https://example.com/docs for more info";
+
+        var blocks = SlackBlockConverter.Convert(input);
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var list = Assert.Single(rtb.Elements.OfType<RichTextList>());
+        var item = list.Elements[0];
+
+        var link = Assert.Single(item.Elements.OfType<RichTextLink>());
+        Assert.Equal("https://example.com/docs", link.Url);
+    }
+
+    [Fact]
+    public void MarkdownLink_TakesPriorityOverBareUrl()
+    {
+        var blocks = SlackBlockConverter.Convert("Visit [Google](https://google.com) today");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var link = Assert.Single(section.Elements.OfType<RichTextLink>());
+        Assert.Equal("https://google.com", link.Url);
+        Assert.Equal("Google", link.Text);
+    }
+
+    [Fact]
     public void BoldAndItalicNested_HandledCorrectly()
     {
         var blocks = SlackBlockConverter.Convert("This is ***bold and italic*** text");

--- a/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
@@ -239,6 +239,10 @@ public static partial class SlackBlockConverter
                 Url = m.Groups[2].Value
             });
 
+        // Bare URLs: https://example.com
+        TryMatch(BareUrlRegex(), text, ref best, (m) =>
+            new RichTextLink { Url = m.Value });
+
         if (best.Element is null)
             return (0, 0, null, null);
 
@@ -318,6 +322,10 @@ public static partial class SlackBlockConverter
     // Links: [text](url)
     [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
     private static partial Regex LinkRegex();
+
+    // Bare URLs: https://example.com
+    [GeneratedRegex(@"https?://[^\s)\]>]+")]
+    private static partial Regex BareUrlRegex();
 
     // Ordered list prefix: 1. or 2. etc.
     [GeneratedRegex(@"^\d+\.\s")]


### PR DESCRIPTION
## Summary
- Bare URLs (e.g. `https://github.com/foo/bar`) in LLM output were rendered as plain unclickable text in Slack messages
- Added `BareUrlRegex` match in `FindEarliestInline()` that converts bare URLs to `RichTextLink` elements
- Placed after `LinkRegex` so markdown links `[text](url)` retain priority at the same position

## Test plan
- [x] `BareUrl_ProducesRichTextLink` — bare URL in paragraph produces clickable link
- [x] `BareUrl_InListItem_ProducesRichTextLink` — bare URL in bullet list item works
- [x] `MarkdownLink_TakesPriorityOverBareUrl` — markdown links still win over bare URL detection
- [x] All 20 SlackBlockConverter tests pass
- [x] `dotnet slopwatch analyze` — 0 issues