### PR TITLE
CLI model selection and provider management

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -44,6 +44,12 @@ jobs:
       - name: "dotnet build"
         run: dotnet build -c Release
 
+      # Pre-warm the npm cache so MCP stdio smoke tests don't time out downloading
+      # @modelcontextprotocol/server-everything on the first npx invocation.
+      - name: "Warm npm cache for MCP smoke tests"
+        shell: bash
+        run: npx -y @modelcontextprotocol/server-everything --version || true
+
       # .NET Framework tests can't run reliably on Linux, so we only do .NET 8
 
       - name: "dotnet test"

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -10,6 +10,7 @@ services:
     entrypoint: ["/bin/sh", "/usr/local/bin/ollama-init.sh"]
     environment:
       SMOKE_OLLAMA_MODEL: ${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}
+      SMOKE_OLLAMA_ALT_MODEL: ${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}
     depends_on:
       - ollama
     volumes:

--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -139,4 +139,89 @@ if [[ "$stopped_output" == *"Daemon running"* ]]; then
   exit 1
 fi
 
+# ── Model & Provider CLI smoke tests ──
+# These tests exercise the provider/model CLI subcommands against a live
+# Ollama instance. We start fresh — the sandbox has env-var config for the
+# daemon, but the CLI config files are empty. We use the CLI commands
+# themselves to build up config, then verify switching works.
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+ALT_MODEL="${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}"
+
+echo "Testing provider add (local-ollama)..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider add local-ollama ollama --endpoint http://ollama:11434
+
+echo "Testing provider list..."
+provider_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider list)"
+echo "$provider_list"
+if [[ "$provider_list" != *"local-ollama"* ]]; then
+  echo "Expected provider list to include local-ollama."
+  exit 1
+fi
+
+echo "Testing model set (main to $SMOKE_MODEL)..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model set main local-ollama "$SMOKE_MODEL"
+
+echo "Testing model list..."
+model_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model list)"
+echo "$model_list"
+if [[ "$model_list" != *"$SMOKE_MODEL"* ]]; then
+  echo "Expected model list to include $SMOKE_MODEL."
+  exit 1
+fi
+
+echo "Testing model discover..."
+discover_output="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model discover local-ollama)"
+echo "$discover_output"
+if [[ "$discover_output" != *"$SMOKE_MODEL"* ]]; then
+  echo "Expected discovered models to include $SMOKE_MODEL."
+  exit 1
+fi
+
+echo "Testing model switch to alternate model ($ALT_MODEL)..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model set main local-ollama "$ALT_MODEL"
+switched_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model list)"
+echo "$switched_list"
+if [[ "$switched_list" != *"$ALT_MODEL"* ]]; then
+  echo "Expected model list to show $ALT_MODEL after switch."
+  exit 1
+fi
+
+echo "Testing model switch back to original ($SMOKE_MODEL)..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model set main local-ollama "$SMOKE_MODEL"
+restored_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model list)"
+echo "$restored_list"
+if [[ "$restored_list" != *"$SMOKE_MODEL"* ]]; then
+  echo "Expected model list to show $SMOKE_MODEL after switch back."
+  exit 1
+fi
+
+echo "Testing provider add (second provider)..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider add test-ollama ollama --endpoint http://ollama:11434
+added_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider list)"
+echo "$added_list"
+if [[ "$added_list" != *"test-ollama"* ]]; then
+  echo "Expected provider list to include test-ollama after add."
+  exit 1
+fi
+
+echo "Testing provider remove..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider remove test-ollama
+removed_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw provider list)"
+echo "$removed_list"
+if [[ "$removed_list" == *"test-ollama"* ]]; then
+  echo "Expected test-ollama to be removed from provider list."
+  exit 1
+fi
+
+echo "Testing model set fallback then clear..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model set fallback local-ollama "$ALT_MODEL"
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model clear fallback
+cleared_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw model list)"
+echo "$cleared_list"
+if [[ "$cleared_list" == *"$ALT_MODEL"* ]]; then
+  echo "Expected $ALT_MODEL to be cleared from fallback."
+  exit 1
+fi
+
 echo "Smoke sandbox checks passed."

--- a/scripts/smoke/ollama-init.sh
+++ b/scripts/smoke/ollama-init.sh
@@ -2,6 +2,7 @@
 set -eu
 
 MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+ALT_MODEL="${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}"
 
 echo "Waiting for Ollama API to become available..."
 for i in $(seq 1 24); do
@@ -17,7 +18,10 @@ done
 echo "Pulling smoke model: $MODEL"
 curl -fsS -X POST http://ollama:11434/api/pull -d "{\"name\":\"$MODEL\"}"
 
-echo "Verifying model is available: $MODEL"
+echo "Pulling alternate model for model-switch test: $ALT_MODEL"
+curl -fsS -X POST http://ollama:11434/api/pull -d "{\"name\":\"$ALT_MODEL\"}"
+
+echo "Verifying models are available..."
 curl -fsS http://ollama:11434/api/tags
 
 echo "Model init completed."

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -74,7 +74,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = subscriber,
             Filter = OutputFilter.Full
         });
-        subscriber.ExpectMsg<SessionJoined>();
+        subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -118,7 +118,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = subscriber,
             Filter = OutputFilter.Full
         });
-        subscriber.ExpectMsg<SessionJoined>();
+        subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -157,7 +157,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = subscriber,
             Filter = OutputFilter.Full
         });
-        subscriber.ExpectMsg<SessionJoined>();
+        subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -213,7 +213,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = subscriber,
             Filter = OutputFilter.Full
         });
-        subscriber.ExpectMsg<SessionJoined>();
+        subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
 
         // First message — triggers turn then compaction
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -272,7 +272,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = subscriber,
             Filter = OutputFilter.Full
         });
-        subscriber.ExpectMsg<SessionJoined>();
+        subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -301,7 +301,7 @@ public class CompactionIntegrationTests : TestKit
             Subscriber = recoverSub,
             Filter = OutputFilter.Full
         });
-        var recovered = recoverSub.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(5));
+        var recovered = recoverSub.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(10));
         Assert.Equal(sessionId, recovered.SessionId);
 
         // Phase 4: Verify session still works after recovery

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -9,6 +9,7 @@ public sealed class McpCommandTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
+    private readonly StringWriter _output = new();
 
     public McpCommandTests()
     {
@@ -19,6 +20,7 @@ public sealed class McpCommandTests : IDisposable
 
     public void Dispose()
     {
+        _output.Dispose();
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, true);
     }
@@ -27,7 +29,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Add_StdioServer_WritesConfig()
     {
         var args = new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" };
-        var exitCode = await McpCommand.RunAsync(args, _paths);
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -42,7 +44,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Add_HttpServer_WritesConfig()
     {
         var args = new[] { "mcp", "add", "--transport", "http", "textforge", "https://textforge.net/mcp" };
-        var exitCode = await McpCommand.RunAsync(args, _paths);
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -57,7 +59,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Add_WithEnvVar_WritesSecretsFile()
     {
         var args = new[] { "mcp", "add", "--transport", "stdio", "--env", "API_KEY=secret123", "myserver", "--", "dotnet", "run" };
-        var exitCode = await McpCommand.RunAsync(args, _paths);
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -74,7 +76,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Add_WithHeader_WritesSecretsFile()
     {
         var args = new[] { "mcp", "add", "--transport", "http", "--header", "Authorization: Bearer tok-123", "myapi", "https://api.example.com/mcp" };
-        var exitCode = await McpCommand.RunAsync(args, _paths);
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -88,10 +90,9 @@ public sealed class McpCommandTests : IDisposable
     [Fact]
     public async Task List_NoServers_ShowsEmptyMessage()
     {
-        var output = CaptureConsoleOutput(async () =>
-            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+        await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: _output);
 
-        Assert.Contains("No MCP servers configured", output);
+        Assert.Contains("No MCP servers configured", _output.ToString());
     }
 
     [Fact]
@@ -100,10 +101,11 @@ public sealed class McpCommandTests : IDisposable
         // Add a server first
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
 
-        var output = CaptureConsoleOutput(async () =>
-            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+        var listOutput = new StringWriter();
+        await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: listOutput);
+        var output = listOutput.ToString();
 
         Assert.Contains("memorizer", output);
         Assert.Contains("stdio", output);
@@ -116,12 +118,13 @@ public sealed class McpCommandTests : IDisposable
     {
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
         await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths);
+            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
 
-        var output = CaptureConsoleOutput(async () =>
-            await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths));
+        var listOutput = new StringWriter();
+        await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: listOutput);
+        var output = listOutput.ToString();
 
         Assert.Contains("memorizer", output);
         Assert.Contains("disabled", output);
@@ -132,10 +135,11 @@ public sealed class McpCommandTests : IDisposable
     {
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
 
-        var output = CaptureConsoleOutput(async () =>
-            await McpCommand.RunAsync(new[] { "mcp", "get", "memorizer" }, _paths));
+        var getOutput = new StringWriter();
+        await McpCommand.RunAsync(new[] { "mcp", "get", "memorizer" }, _paths, output: getOutput);
+        var output = getOutput.ToString();
 
         Assert.Contains("Name:", output);
         Assert.Contains("memorizer", output);
@@ -147,7 +151,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Get_NotFound_ReturnsError()
     {
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "get", "nonexistent" }, _paths);
+            new[] { "mcp", "get", "nonexistent" }, _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -157,10 +161,10 @@ public sealed class McpCommandTests : IDisposable
     {
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "remove", "memorizer" }, _paths);
+            new[] { "mcp", "remove", "memorizer" }, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -173,7 +177,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Remove_NotFound_ReturnsError()
     {
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "remove", "nonexistent" }, _paths);
+            new[] { "mcp", "remove", "nonexistent" }, _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -183,10 +187,10 @@ public sealed class McpCommandTests : IDisposable
     {
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths);
+            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -199,12 +203,12 @@ public sealed class McpCommandTests : IDisposable
     {
         await McpCommand.RunAsync(
             new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
-            _paths);
+            _paths, output: _output);
         await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths);
+            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "enable", "memorizer" }, _paths);
+            new[] { "mcp", "enable", "memorizer" }, _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -215,21 +219,5 @@ public sealed class McpCommandTests : IDisposable
     private static JsonDocument ReadConfigFile(string path)
     {
         return JsonDocument.Parse(File.ReadAllText(path));
-    }
-
-    private static string CaptureConsoleOutput(Func<Task> action)
-    {
-        var writer = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(writer);
-        try
-        {
-            action().GetAwaiter().GetResult();
-            return writer.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
     }
 }

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using Netclaw.Cli.Model;
+using Netclaw.Cli.Tests.Tui;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Model;
+
+public sealed class ModelCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly FakeProviderProbe _fakeProbe = new();
+
+    public ModelCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task List_NoConfig_ShowsEmptyMessage()
+    {
+        var output = CaptureConsoleOutput(async () =>
+            await ModelCommand.RunAsync(["model", "list"], _paths));
+
+        Assert.Contains("No models configured", output);
+    }
+
+    [Fact]
+    public async Task List_WithConfig_ShowsConfiguredModels()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:30b"
+                }
+            }
+        });
+
+        var output = CaptureConsoleOutput(async () =>
+            await ModelCommand.RunAsync(["model", "list"], _paths));
+
+        Assert.Contains("Main", output);
+        Assert.Contains("my-ollama", output);
+        Assert.Contains("qwen3:30b", output);
+    }
+
+    [Fact]
+    public async Task Set_MainModel_WritesConfig()
+    {
+        // Arrange: need a provider to exist
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "my-ollama", "qwen3:30b", "--context-window", "32768"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("Models", out var models));
+        Assert.True(models.TryGetProperty("Main", out var main));
+        Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
+        Assert.Equal("qwen3:30b", main.GetProperty("ModelId").GetString());
+        Assert.Equal("Manual", main.GetProperty("Provenance").GetString());
+        Assert.Equal(32768, main.GetProperty("ContextWindow").GetInt32());
+    }
+
+    [Fact]
+    public async Task Set_InvalidRole_ReturnsError()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "invalid-role", "my-ollama", "qwen3:30b"],
+            _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Set_NonexistentProvider_ReturnsError()
+    {
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "main", "nonexistent", "qwen3:30b"],
+            _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Discover_ValidProvider_ShowsModels()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        var output = CaptureConsoleOutput(async () =>
+        {
+            var exitCode = await ModelCommand.RunAsync(
+                ["model", "discover", "my-ollama"],
+                _paths, _fakeProbe);
+            Assert.Equal(0, exitCode);
+        });
+
+        Assert.Contains("model-a", output);
+        Assert.Contains("model-b", output);
+        Assert.Contains("2 model(s) found", output);
+        Assert.Equal(1, _fakeProbe.ProbeCallCount);
+    }
+
+    [Fact]
+    public async Task Discover_NonexistentProvider_ReturnsError()
+    {
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "discover", "nonexistent"],
+            _paths, _fakeProbe);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Clear_Fallback_RemovesFromConfig()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:30b"
+                },
+                ["Fallback"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-openrouter",
+                    ["ModelId"] = "meta-llama/llama-3-70b"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "clear", "fallback"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("Models", out var models));
+        Assert.True(models.TryGetProperty("Main", out _)); // Main still exists
+        Assert.False(models.TryGetProperty("Fallback", out _)); // Fallback removed
+    }
+
+    [Fact]
+    public async Task Clear_Main_ReturnsError()
+    {
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "clear", "main"],
+            _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Set_FallbackModel_WritesCorrectRole()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object> { ["Type"] = "ollama" }
+            },
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:30b"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "set", "fallback", "my-ollama", "qwen3:8b"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var models = config.RootElement.GetProperty("Models");
+        Assert.True(models.TryGetProperty("Main", out _)); // Main preserved
+        Assert.True(models.TryGetProperty("Fallback", out var fallback));
+        Assert.Equal("qwen3:8b", fallback.GetProperty("ModelId").GetString());
+    }
+
+    private void WriteConfig(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static JsonDocument ReadConfigFile(string path)
+    {
+        return JsonDocument.Parse(File.ReadAllText(path));
+    }
+
+    private static string CaptureConsoleOutput(Func<Task> action)
+    {
+        var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            action().GetAwaiter().GetResult();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -11,6 +11,7 @@ public sealed class ModelCommandTests : IDisposable
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
     private readonly FakeProviderProbe _fakeProbe = new();
+    private readonly StringWriter _output = new();
 
     public ModelCommandTests()
     {
@@ -21,6 +22,7 @@ public sealed class ModelCommandTests : IDisposable
 
     public void Dispose()
     {
+        _output.Dispose();
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, true);
     }
@@ -28,10 +30,9 @@ public sealed class ModelCommandTests : IDisposable
     [Fact]
     public async Task List_NoConfig_ShowsEmptyMessage()
     {
-        var output = CaptureConsoleOutput(async () =>
-            await ModelCommand.RunAsync(["model", "list"], _paths));
+        await ModelCommand.RunAsync(["model", "list"], _paths, output: _output);
 
-        Assert.Contains("No models configured", output);
+        Assert.Contains("No models configured", _output.ToString());
     }
 
     [Fact]
@@ -50,8 +51,8 @@ public sealed class ModelCommandTests : IDisposable
             }
         });
 
-        var output = CaptureConsoleOutput(async () =>
-            await ModelCommand.RunAsync(["model", "list"], _paths));
+        await ModelCommand.RunAsync(["model", "list"], _paths, output: _output);
+        var output = _output.ToString();
 
         Assert.Contains("Main", output);
         Assert.Contains("my-ollama", output);
@@ -77,7 +78,7 @@ public sealed class ModelCommandTests : IDisposable
 
         var exitCode = await ModelCommand.RunAsync(
             ["model", "set", "main", "my-ollama", "qwen3:30b", "--context-window", "32768"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -107,7 +108,7 @@ public sealed class ModelCommandTests : IDisposable
 
         var exitCode = await ModelCommand.RunAsync(
             ["model", "set", "invalid-role", "my-ollama", "qwen3:30b"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -117,7 +118,7 @@ public sealed class ModelCommandTests : IDisposable
     {
         var exitCode = await ModelCommand.RunAsync(
             ["model", "set", "main", "nonexistent", "qwen3:30b"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -138,13 +139,12 @@ public sealed class ModelCommandTests : IDisposable
             }
         });
 
-        var output = CaptureConsoleOutput(async () =>
-        {
-            var exitCode = await ModelCommand.RunAsync(
-                ["model", "discover", "my-ollama"],
-                _paths, _fakeProbe);
-            Assert.Equal(0, exitCode);
-        });
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "discover", "my-ollama"],
+            _paths, _fakeProbe, output: _output);
+
+        Assert.Equal(0, exitCode);
+        var output = _output.ToString();
 
         Assert.Contains("model-a", output);
         Assert.Contains("model-b", output);
@@ -157,7 +157,7 @@ public sealed class ModelCommandTests : IDisposable
     {
         var exitCode = await ModelCommand.RunAsync(
             ["model", "discover", "nonexistent"],
-            _paths, _fakeProbe);
+            _paths, _fakeProbe, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -185,7 +185,7 @@ public sealed class ModelCommandTests : IDisposable
 
         var exitCode = await ModelCommand.RunAsync(
             ["model", "clear", "fallback"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -200,7 +200,7 @@ public sealed class ModelCommandTests : IDisposable
     {
         var exitCode = await ModelCommand.RunAsync(
             ["model", "clear", "main"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -227,7 +227,7 @@ public sealed class ModelCommandTests : IDisposable
 
         var exitCode = await ModelCommand.RunAsync(
             ["model", "set", "fallback", "my-ollama", "qwen3:8b"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -247,21 +247,5 @@ public sealed class ModelCommandTests : IDisposable
     private static JsonDocument ReadConfigFile(string path)
     {
         return JsonDocument.Parse(File.ReadAllText(path));
-    }
-
-    private static string CaptureConsoleOutput(Func<Task> action)
-    {
-        var writer = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(writer);
-        try
-        {
-            action().GetAwaiter().GetResult();
-            return writer.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
     }
 }

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -9,6 +9,7 @@ public sealed class ProviderCommandTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
+    private readonly StringWriter _output = new();
 
     public ProviderCommandTests()
     {
@@ -19,6 +20,7 @@ public sealed class ProviderCommandTests : IDisposable
 
     public void Dispose()
     {
+        _output.Dispose();
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, true);
     }
@@ -26,10 +28,9 @@ public sealed class ProviderCommandTests : IDisposable
     [Fact]
     public async Task List_NoProviders_ShowsEmptyMessage()
     {
-        var output = CaptureConsoleOutput(async () =>
-            await ProviderCommand.RunAsync(["provider", "list"], _paths));
+        await ProviderCommand.RunAsync(["provider", "list"], _paths, output: _output);
 
-        Assert.Contains("No providers configured", output);
+        Assert.Contains("No providers configured", _output.ToString());
     }
 
     [Fact]
@@ -50,8 +51,8 @@ public sealed class ProviderCommandTests : IDisposable
             }
         });
 
-        var output = CaptureConsoleOutput(async () =>
-            await ProviderCommand.RunAsync(["provider", "list"], _paths));
+        await ProviderCommand.RunAsync(["provider", "list"], _paths, output: _output);
+        var output = _output.ToString();
 
         Assert.Contains("my-ollama", output);
         Assert.Contains("ollama", output);
@@ -63,7 +64,7 @@ public sealed class ProviderCommandTests : IDisposable
     {
         var exitCode = await ProviderCommand.RunAsync(
             ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://big-gpu:11434"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -79,7 +80,7 @@ public sealed class ProviderCommandTests : IDisposable
     {
         var exitCode = await ProviderCommand.RunAsync(
             ["provider", "add", "my-openrouter", "openrouter", "--api-key", "sk-or-test-123"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -102,7 +103,7 @@ public sealed class ProviderCommandTests : IDisposable
     {
         var exitCode = await ProviderCommand.RunAsync(
             ["provider", "add", "my-provider", "unknown-type"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -113,12 +114,12 @@ public sealed class ProviderCommandTests : IDisposable
         // Arrange: add a provider
         await ProviderCommand.RunAsync(
             ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://localhost:11434"],
-            _paths);
+            _paths, output: _output);
 
         // Act
         var exitCode = await ProviderCommand.RunAsync(
             ["provider", "remove", "my-ollama"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -133,7 +134,7 @@ public sealed class ProviderCommandTests : IDisposable
         // Arrange: add provider and assign it to main model role
         await ProviderCommand.RunAsync(
             ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://localhost:11434"],
-            _paths);
+            _paths, output: _output);
 
         // Write a model reference pointing to this provider
         var config = JsonSerializer.Deserialize<Dictionary<string, object>>(
@@ -150,14 +151,12 @@ public sealed class ProviderCommandTests : IDisposable
             JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
 
         // Act
-        var output = CaptureConsoleOutput(async () =>
-        {
-            var exitCode = await ProviderCommand.RunAsync(
-                ["provider", "remove", "my-ollama"],
-                _paths);
-            Assert.Equal(1, exitCode);
-        });
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "remove", "my-ollama"],
+            _paths, output: _output);
 
+        Assert.Equal(1, exitCode);
+        var output = _output.ToString();
         Assert.Contains("Cannot remove", output);
         Assert.Contains("Main", output);
     }
@@ -167,7 +166,7 @@ public sealed class ProviderCommandTests : IDisposable
     {
         var exitCode = await ProviderCommand.RunAsync(
             ["provider", "remove", "nonexistent"],
-            _paths);
+            _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -224,21 +223,5 @@ public sealed class ProviderCommandTests : IDisposable
     private static JsonDocument ReadConfigFile(string path)
     {
         return JsonDocument.Parse(File.ReadAllText(path));
-    }
-
-    private static string CaptureConsoleOutput(Func<Task> action)
-    {
-        var writer = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(writer);
-        try
-        {
-            action().GetAwaiter().GetResult();
-            return writer.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
     }
 }

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+using Netclaw.Cli.Provider;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Provider;
+
+public sealed class ProviderCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public ProviderCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task List_NoProviders_ShowsEmptyMessage()
+    {
+        var output = CaptureConsoleOutput(async () =>
+            await ProviderCommand.RunAsync(["provider", "list"], _paths));
+
+        Assert.Contains("No providers configured", output);
+    }
+
+    [Fact]
+    public async Task List_WithProviders_ShowsFormattedTable()
+    {
+        // Arrange: add a provider manually
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://big-gpu:11434",
+                    ["AuthMethod"] = "None"
+                }
+            }
+        });
+
+        var output = CaptureConsoleOutput(async () =>
+            await ProviderCommand.RunAsync(["provider", "list"], _paths));
+
+        Assert.Contains("my-ollama", output);
+        Assert.Contains("ollama", output);
+        Assert.Contains("http://big-gpu:11434", output);
+    }
+
+    [Fact]
+    public async Task Add_OllamaProvider_WritesConfig()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://big-gpu:11434"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("Providers", out var providers));
+        Assert.True(providers.TryGetProperty("my-ollama", out var entry));
+        Assert.Equal("ollama", entry.GetProperty("Type").GetString());
+        Assert.Equal("http://big-gpu:11434", entry.GetProperty("Endpoint").GetString());
+    }
+
+    [Fact]
+    public async Task Add_ApiKeyProvider_WritesConfigAndSecrets()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "add", "my-openrouter", "openrouter", "--api-key", "sk-or-test-123"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        // Verify config
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        Assert.True(config.RootElement.TryGetProperty("Providers", out var providers));
+        Assert.True(providers.TryGetProperty("my-openrouter", out var entry));
+        Assert.Equal("openrouter", entry.GetProperty("Type").GetString());
+        Assert.Equal("ApiKey", entry.GetProperty("AuthMethod").GetString());
+
+        // Verify secrets
+        var secrets = ReadConfigFile(_paths.SecretsPath);
+        Assert.True(secrets.RootElement.TryGetProperty("Providers", out var secretProviders));
+        Assert.True(secretProviders.TryGetProperty("my-openrouter", out var secretEntry));
+        Assert.Equal("sk-or-test-123", secretEntry.GetProperty("ApiKey").GetString());
+    }
+
+    [Fact]
+    public async Task Add_InvalidType_ReturnsError()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "add", "my-provider", "unknown-type"],
+            _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Remove_UnreferencedProvider_Succeeds()
+    {
+        // Arrange: add a provider
+        await ProviderCommand.RunAsync(
+            ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://localhost:11434"],
+            _paths);
+
+        // Act
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "remove", "my-ollama"],
+            _paths);
+
+        Assert.Equal(0, exitCode);
+
+        // Verify it's gone
+        var providers = ProviderCommand.LoadProviders(_paths);
+        Assert.Empty(providers);
+    }
+
+    [Fact]
+    public async Task Remove_ReferencedProvider_ReturnsError()
+    {
+        // Arrange: add provider and assign it to main model role
+        await ProviderCommand.RunAsync(
+            ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://localhost:11434"],
+            _paths);
+
+        // Write a model reference pointing to this provider
+        var config = JsonSerializer.Deserialize<Dictionary<string, object>>(
+            File.ReadAllText(_paths.NetclawConfigPath))!;
+        config["Models"] = new Dictionary<string, object>
+        {
+            ["Main"] = new Dictionary<string, object>
+            {
+                ["Provider"] = "my-ollama",
+                ["ModelId"] = "qwen3:30b"
+            }
+        };
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
+
+        // Act
+        var output = CaptureConsoleOutput(async () =>
+        {
+            var exitCode = await ProviderCommand.RunAsync(
+                ["provider", "remove", "my-ollama"],
+                _paths);
+            Assert.Equal(1, exitCode);
+        });
+
+        Assert.Contains("Cannot remove", output);
+        Assert.Contains("Main", output);
+    }
+
+    [Fact]
+    public async Task Remove_NotFound_ReturnsError()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "remove", "nonexistent"],
+            _paths);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task LoadProviders_MergesConfigAndSecrets()
+    {
+        // Arrange: set up config and secrets separately
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-anthropic"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "anthropic",
+                    ["Endpoint"] = "https://api.anthropic.com",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-anthropic"] = new Dictionary<string, object>
+                {
+                    ["ApiKey"] = "sk-ant-test"
+                }
+            }
+        });
+
+        var providers = ProviderCommand.LoadProviders(_paths);
+
+        Assert.Single(providers);
+        Assert.True(providers.ContainsKey("my-anthropic"));
+        Assert.Equal("anthropic", providers["my-anthropic"].Type);
+        Assert.Equal("sk-ant-test", providers["my-anthropic"].ApiKey?.Value);
+    }
+
+    private void WriteConfig(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private void WriteSecrets(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.SecretsPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static JsonDocument ReadConfigFile(string path)
+    {
+        return JsonDocument.Parse(File.ReadAllText(path));
+    }
+
+    private static string CaptureConsoleOutput(Func<Task> action)
+    {
+        var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            action().GetAwaiter().GetResult();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
@@ -9,7 +9,18 @@ namespace Netclaw.Cli.Tests.Tui;
 public sealed class FakeProviderProbe : IProviderProbe
 {
     /// <summary>
-    /// The result to return from the next <see cref="ProbeAsync"/> call.
+    /// Per-type results for concurrent probing scenarios.
+    /// When a type is found here, it takes priority over <see cref="NextResult"/>.
+    /// </summary>
+    public Dictionary<string, ProviderProbeResult> TypeResults { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Tracks which provider types were probed, in order.
+    /// </summary>
+    public List<string> ProbedTypes { get; } = [];
+
+    /// <summary>
+    /// The fallback result to return when no per-type result is configured.
     /// Defaults to a successful probe with two sample models.
     /// </summary>
     public ProviderProbeResult NextResult { get; set; } = new(
@@ -35,6 +46,12 @@ public sealed class FakeProviderProbe : IProviderProbe
     {
         ProbeCallCount++;
         LastProviderType = providerType;
-        return Task.FromResult(NextResult);
+        ProbedTypes.Add(providerType);
+
+        var result = TypeResults.TryGetValue(providerType, out var typeResult)
+            ? typeResult
+            : NextResult;
+
+        return Task.FromResult(result);
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+public sealed class ModelManagerViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly FakeProviderProbe _fakeProbe = new();
+
+    public ModelManagerViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void StartsAtRoleOverview()
+    {
+        using var vm = CreateViewModel();
+        Assert.Equal(ModelManagerState.RoleOverview, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void StartAssignment_NoProviders_SetsStatusMessage()
+    {
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        vm.StartAssignment("Main");
+        Assert.Contains("No providers configured", vm.StatusMessage.Value);
+    }
+
+    [Fact]
+    public void StartAssignment_SingleProvider_AutoSelectsAndDiscovers()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        Assert.Single(vm.Providers);
+
+        vm.StartAssignment("Main");
+
+        // Single provider auto-selected, goes to discover
+        Assert.Equal(ModelManagerState.DiscoverModels, vm.CurrentState.Value);
+        Assert.Equal("my-ollama", vm.SelectedProvider);
+    }
+
+    [Fact]
+    public void StartAssignment_MultipleProviders_GoesToSelectProvider()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object> { ["Type"] = "ollama" },
+                ["my-openrouter"] = new Dictionary<string, object> { ["Type"] = "openrouter" }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        Assert.Equal(2, vm.Providers.Count);
+
+        vm.StartAssignment("Main");
+        Assert.Equal(ModelManagerState.SelectProvider, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public async Task ConfirmAssignment_WritesCorrectConfig()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        // Simulate the full assignment flow
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        vm.SelectModel("qwen3:30b");
+        Assert.Equal(ModelManagerState.ConfirmAssignment, vm.CurrentState.Value);
+
+        vm.ConfirmAssignment();
+        Assert.Equal(ModelManagerState.RoleOverview, vm.CurrentState.Value);
+
+        // Verify config
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var main = config.RootElement.GetProperty("Models").GetProperty("Main");
+        Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
+        Assert.Equal("qwen3:30b", main.GetProperty("ModelId").GetString());
+        Assert.Equal("Live", main.GetProperty("Provenance").GetString());
+    }
+
+    [Fact]
+    public void ClearRole_Main_IsRejected()
+    {
+        using var vm = CreateViewModel();
+        vm.ClearRole("Main");
+        Assert.Contains("Cannot clear", vm.StatusMessage.Value);
+    }
+
+    [Fact]
+    public void ClearRole_Fallback_RemovesFromConfig()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:30b"
+                },
+                ["Fallback"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:8b"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.ClearRole("Fallback");
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var models = config.RootElement.GetProperty("Models");
+        Assert.True(models.TryGetProperty("Main", out _));
+        Assert.False(models.TryGetProperty("Fallback", out _));
+    }
+
+    [Fact]
+    public void GoBack_FromSelectProvider_ReturnsToRoleOverview()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["p1"] = new Dictionary<string, object> { ["Type"] = "ollama" },
+                ["p2"] = new Dictionary<string, object> { ["Type"] = "openrouter" }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+        vm.StartAssignment("Main");
+        Assert.Equal(ModelManagerState.SelectProvider, vm.CurrentState.Value);
+
+        vm.GoBack();
+        Assert.Equal(ModelManagerState.RoleOverview, vm.CurrentState.Value);
+    }
+
+    private ModelManagerViewModel CreateViewModel()
+    {
+        return new ModelManagerViewModel(_paths, _fakeProbe);
+    }
+
+    private void WriteConfig(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -24,56 +24,368 @@ public sealed class ProviderManagerViewModelTests : IDisposable
             Directory.Delete(_tempDir, true);
     }
 
+    /// <summary>
+    /// Simulates activation without requiring a bound Page (which provides the Input stream).
+    /// Calls RefreshDisplayProviders + ProbeAllConfiguredAsync directly.
+    /// </summary>
+    private async Task ActivateAndProbeAsync(ProviderManagerViewModel vm)
+    {
+        vm.RefreshDisplayProviders();
+        await vm.ProbeAllConfiguredAsync();
+    }
+
     [Fact]
-    public void StartsAtListState()
+    public void StartsAtLoadingState()
     {
         using var vm = CreateViewModel();
+        Assert.Equal(ProviderManagerState.Loading, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void DisplayProviders_ShowsAllKnownTypes()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        Assert.Equal(ProviderCapabilities.KnownProviderTypes.Count, vm.DisplayProviders.Count);
+        foreach (var type in ProviderCapabilities.KnownProviderTypes)
+        {
+            Assert.Contains(vm.DisplayProviders, p => p.ProviderType == type);
+        }
+    }
+
+    [Fact]
+    public void DisplayProviders_AllUnconfiguredByDefault()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        Assert.All(vm.DisplayProviders, p =>
+        {
+            Assert.False(p.IsConfigured);
+            Assert.Null(p.ConfiguredName);
+            Assert.Null(p.Entry);
+            Assert.StartsWith("(", p.DisplayEndpoint);
+        });
+    }
+
+    [Fact]
+    public void DisplayProviders_MergesConfiguredWithKnown()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        // All 4 types present
+        Assert.Equal(4, vm.DisplayProviders.Count);
+
+        // openrouter is configured
+        var openrouter = vm.DisplayProviders.First(p => p.ProviderType == "openrouter");
+        Assert.True(openrouter.IsConfigured);
+        Assert.Equal("my-openrouter", openrouter.ConfiguredName);
+        Assert.NotNull(openrouter.Entry);
+        Assert.Equal("ApiKey", openrouter.DisplayAuth);
+
+        // others are not configured
+        var ollama = vm.DisplayProviders.First(p => p.ProviderType == "ollama");
+        Assert.False(ollama.IsConfigured);
+    }
+
+    [Fact]
+    public async Task EagerProbe_ProbesAllConfigured()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                },
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        // Both configured providers should have been probed
+        Assert.Contains("openrouter", _fakeProbe.ProbedTypes);
+        Assert.Contains("ollama", _fakeProbe.ProbedTypes);
+        Assert.Equal(2, _fakeProbe.ProbeCallCount);
+    }
+
+    [Fact]
+    public async Task EagerProbe_CompletesToListState()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
         Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
     }
 
     [Fact]
-    public void StartAdd_TransitionsToAddSelectType()
+    public async Task EagerProbe_SetsHealthOnItems()
     {
+        _fakeProbe.TypeResults["openrouter"] = new ProviderProbeResult(true, null,
+            [new DiscoveredModel { ModelId = "gpt-4" }]);
+        _fakeProbe.TypeResults["ollama"] = new ProviderProbeResult(false, "Connection refused", []);
+
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                },
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
         using var vm = CreateViewModel();
-        vm.StartAdd();
-        Assert.Equal(ProviderManagerState.AddSelectType, vm.CurrentState.Value);
+        await ActivateAndProbeAsync(vm);
+
+        var openrouter = vm.DisplayProviders.First(p => p.ProviderType == "openrouter");
+        Assert.Equal(ProviderHealthStatus.Healthy, openrouter.Health);
+
+        var ollama = vm.DisplayProviders.First(p => p.ProviderType == "ollama");
+        Assert.Equal(ProviderHealthStatus.Unhealthy, ollama.Health);
     }
 
     [Fact]
-    public void SelectProviderType_OllamaSkipsAuth_GoesToCredentials()
+    public async Task EagerProbe_NoConfiguredProviders_GoesDirectlyToList()
     {
         using var vm = CreateViewModel();
-        vm.StartAdd();
-        vm.SelectProviderType("ollama");
+        await ActivateAndProbeAsync(vm);
 
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+        Assert.Equal(0, _fakeProbe.ProbeCallCount);
+    }
+
+    [Fact]
+    public void ActivateSelectedProvider_Unconfigured_StartsAddFlow()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+        vm.CurrentState.Value = ProviderManagerState.List;
+
+        // Find an unconfigured provider (all are unconfigured with empty config)
+        var ollamaIndex = vm.DisplayProviders.FindIndex(p => p.ProviderType == "ollama");
+        vm.SelectedProviderIndex = ollamaIndex;
+        vm.ActivateSelectedProvider();
+
+        // Ollama has [None] auth, so goes straight to AddCredentials
         Assert.Equal(ProviderManagerState.AddCredentials, vm.CurrentState.Value);
-        Assert.Equal(AuthMethod.None, vm.NewAuthMethod);
+        Assert.Equal("ollama", vm.NewProviderType);
     }
 
     [Fact]
-    public void SelectProviderType_AnthropicShowsAuth()
+    public void ActivateSelectedProvider_Unconfigured_ApiKeyProvider_GoesToAuthSelect()
     {
         using var vm = CreateViewModel();
-        vm.StartAdd();
-        vm.SelectProviderType("anthropic");
+        vm.RefreshDisplayProviders();
+        vm.CurrentState.Value = ProviderManagerState.List;
+
+        var anthropicIndex = vm.DisplayProviders.FindIndex(p => p.ProviderType == "anthropic");
+        vm.SelectedProviderIndex = anthropicIndex;
+        vm.ActivateSelectedProvider();
 
         Assert.Equal(ProviderManagerState.AddSelectAuth, vm.CurrentState.Value);
+        Assert.Equal("anthropic", vm.NewProviderType);
+    }
+
+    [Fact]
+    public async Task ActivateSelectedProvider_Healthy_TransitionsToDetails()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        var openrouterIndex = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = openrouterIndex;
+        vm.ActivateSelectedProvider();
+
+        Assert.Equal(ProviderManagerState.Details, vm.CurrentState.Value);
+        Assert.NotNull(vm.DetailProvider);
+        Assert.Equal("openrouter", vm.DetailProvider.ProviderType);
+    }
+
+    [Fact]
+    public async Task ActivateSelectedProvider_Unhealthy_TransitionsToFixCredentials()
+    {
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "Unauthorized", []);
+
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        var openrouterIndex = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = openrouterIndex;
+        vm.ActivateSelectedProvider();
+
+        Assert.Equal(ProviderManagerState.FixCredentials, vm.CurrentState.Value);
+        Assert.NotNull(vm.DetailProvider);
+        Assert.True(vm.IsFixFlow);
+    }
+
+    [Fact]
+    public async Task FixCredentials_Success_ReturnsToList()
+    {
+        // Start with a failed probe
+        _fakeProbe.TypeResults["openrouter"] = new ProviderProbeResult(false, "Unauthorized", []);
+
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        // Navigate to fix credentials
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+        Assert.Equal(ProviderManagerState.FixCredentials, vm.CurrentState.Value);
+
+        // Now the re-probe should succeed — update the per-type result
+        _fakeProbe.TypeResults["openrouter"] = new ProviderProbeResult(true, null,
+            [new DiscoveredModel { ModelId = "model-a" }]);
+
+        vm.FixApiKey = "sk-new-key";
+        vm.SubmitFixCredentials();
+
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+        Assert.False(vm.IsFixFlow);
+    }
+
+    [Fact]
+    public async Task Details_RemoveAction_TransitionsToRemoveConfirm()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        // Navigate to details
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+        Assert.Equal(ProviderManagerState.Details, vm.CurrentState.Value);
+
+        // Remove action
+        vm.StartRemove();
+        Assert.Equal(ProviderManagerState.RemoveConfirm, vm.CurrentState.Value);
+        Assert.Equal("my-openrouter", vm.RemoveProviderName);
     }
 
     [Fact]
     public async Task AddProvider_WritesCorrectConfigStructure()
     {
         using var vm = CreateViewModel();
-        vm.StartAdd();
-        vm.SelectProviderType("openrouter");
+        await ActivateAndProbeAsync(vm);
+
+        // Start add flow for openrouter (unconfigured)
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+
         vm.SelectAuthMethod(AuthMethod.ApiKey);
         vm.NewApiKey = "sk-test-key";
         vm.SubmitCredentials();
 
-        // Wait for probe
         await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // Probe succeeded — confirm add
         vm.ConfirmAdd();
 
         Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
@@ -91,9 +403,8 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
-    public void RemoveProvider_ReferencedByModelRole_IsRejected()
+    public async Task RemoveProvider_ReferencedByModelRole_IsRejected()
     {
-        // Arrange: create provider + model reference
         WriteConfig(new Dictionary<string, object>
         {
             ["configVersion"] = 1,
@@ -116,10 +427,14 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         });
 
         using var vm = CreateViewModel();
-        vm.RefreshProviders();
-        Assert.Single(vm.Providers);
+        await ActivateAndProbeAsync(vm);
 
-        vm.SelectedProviderIndex = 0;
+        // Navigate to details for ollama
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "ollama");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+
+        // Remove action
         vm.StartRemove();
 
         Assert.Equal(ProviderManagerState.RemoveConfirm, vm.CurrentState.Value);
@@ -128,21 +443,60 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
-    public void GoBack_FromAddSelectAuth_ReturnsToSelectType()
+    public void GoBack_FromAddSelectAuth_ReturnsToList()
     {
         using var vm = CreateViewModel();
-        vm.StartAdd();
-        vm.SelectProviderType("anthropic");
+        vm.RefreshDisplayProviders();
+        vm.CurrentState.Value = ProviderManagerState.List;
+
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "anthropic");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
         Assert.Equal(ProviderManagerState.AddSelectAuth, vm.CurrentState.Value);
 
         vm.GoBack();
-        Assert.Equal(ProviderManagerState.AddSelectType, vm.CurrentState.Value);
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void GoBack_FromDetails_ReturnsToList()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        // Manually set up a details state
+        var item = new ProviderDisplayItem
+        {
+            ProviderType = "openrouter",
+            IsConfigured = true,
+            ConfiguredName = "my-openrouter",
+            Health = ProviderHealthStatus.Healthy
+        };
+        vm.DetailProvider = item;
+        vm.CurrentState.Value = ProviderManagerState.Details;
+
+        vm.GoBack();
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+        Assert.Null(vm.DetailProvider);
+    }
+
+    [Fact]
+    public void GoBack_FromFixCredentials_ReturnsToList()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        vm.CurrentState.Value = ProviderManagerState.FixCredentials;
+
+        vm.GoBack();
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
     }
 
     [Fact]
     public void GoBack_FromList_ShutdownSignal()
     {
         using var vm = CreateViewModel();
+        vm.CurrentState.Value = ProviderManagerState.List;
         // GoBack from list should call Shutdown (which we can't easily test without a host,
         // but we can verify it doesn't crash)
         vm.GoBack();

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+public sealed class ProviderManagerViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly FakeProviderProbe _fakeProbe = new();
+
+    public ProviderManagerViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void StartsAtListState()
+    {
+        using var vm = CreateViewModel();
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void StartAdd_TransitionsToAddSelectType()
+    {
+        using var vm = CreateViewModel();
+        vm.StartAdd();
+        Assert.Equal(ProviderManagerState.AddSelectType, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void SelectProviderType_OllamaSkipsAuth_GoesToCredentials()
+    {
+        using var vm = CreateViewModel();
+        vm.StartAdd();
+        vm.SelectProviderType("ollama");
+
+        Assert.Equal(ProviderManagerState.AddCredentials, vm.CurrentState.Value);
+        Assert.Equal(AuthMethod.None, vm.NewAuthMethod);
+    }
+
+    [Fact]
+    public void SelectProviderType_AnthropicShowsAuth()
+    {
+        using var vm = CreateViewModel();
+        vm.StartAdd();
+        vm.SelectProviderType("anthropic");
+
+        Assert.Equal(ProviderManagerState.AddSelectAuth, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public async Task AddProvider_WritesCorrectConfigStructure()
+    {
+        using var vm = CreateViewModel();
+        vm.StartAdd();
+        vm.SelectProviderType("openrouter");
+        vm.SelectAuthMethod(AuthMethod.ApiKey);
+        vm.NewApiKey = "sk-test-key";
+        vm.SubmitCredentials();
+
+        // Wait for probe
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Probe succeeded — confirm add
+        vm.ConfirmAdd();
+
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+
+        // Verify config file
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Providers", out var providers));
+        var providerNames = providers.EnumerateObject().Select(p => p.Name).ToList();
+        Assert.Single(providerNames);
+        Assert.StartsWith("my-openrouter", providerNames[0]);
+
+        // Verify secrets file
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        Assert.True(secrets.RootElement.TryGetProperty("Providers", out _));
+    }
+
+    [Fact]
+    public void RemoveProvider_ReferencedByModelRole_IsRejected()
+    {
+        // Arrange: create provider + model reference
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            },
+            ["Models"] = new Dictionary<string, object>
+            {
+                ["Main"] = new Dictionary<string, object>
+                {
+                    ["Provider"] = "my-ollama",
+                    ["ModelId"] = "qwen3:30b"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.RefreshProviders();
+        Assert.Single(vm.Providers);
+
+        vm.SelectedProviderIndex = 0;
+        vm.StartRemove();
+
+        Assert.Equal(ProviderManagerState.RemoveConfirm, vm.CurrentState.Value);
+        Assert.NotEmpty(vm.RemoveBlockingRoles);
+        Assert.Contains("Main", vm.RemoveBlockingRoles);
+    }
+
+    [Fact]
+    public void GoBack_FromAddSelectAuth_ReturnsToSelectType()
+    {
+        using var vm = CreateViewModel();
+        vm.StartAdd();
+        vm.SelectProviderType("anthropic");
+        Assert.Equal(ProviderManagerState.AddSelectAuth, vm.CurrentState.Value);
+
+        vm.GoBack();
+        Assert.Equal(ProviderManagerState.AddSelectType, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void GoBack_FromList_ShutdownSignal()
+    {
+        using var vm = CreateViewModel();
+        // GoBack from list should call Shutdown (which we can't easily test without a host,
+        // but we can verify it doesn't crash)
+        vm.GoBack();
+    }
+
+    private ProviderManagerViewModel CreateViewModel()
+    {
+        return new ProviderManagerViewModel(_paths, _fakeProbe);
+    }
+
+    private void WriteConfig(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -331,7 +331,10 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         vm.FixApiKey = "sk-new-key";
         vm.SubmitFixCredentials();
 
+        // Wait for the single-provider probe to complete
         await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        // Fix flow triggers RefreshAndProbeAll — wait for the eager re-probe too
+        await vm.EagerProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
         Assert.False(vm.IsFixFlow);
@@ -387,6 +390,9 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
 
         vm.ConfirmAdd();
+
+        // ConfirmAdd triggers RefreshAndProbeAll — wait for re-probe
+        await vm.EagerProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
 

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+
+namespace Netclaw.Cli.Config;
+
+/// <summary>
+/// Shared helpers for reading and writing netclaw.json and secrets.json config files.
+/// Extracted from McpCommand for reuse by ProviderCommand, ModelCommand, and TUI flows.
+/// </summary>
+internal static class ConfigFileHelper
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Load both netclaw.json and secrets.json as mutable dictionaries.
+    /// Missing files get a default <c>{ "configVersion": 1 }</c> skeleton.
+    /// </summary>
+    internal static (Dictionary<string, object> config, Dictionary<string, object> secrets)
+        LoadConfigFiles(Configuration.NetclawPaths paths)
+    {
+        var config = LoadJsonDict(paths.NetclawConfigPath);
+        var secrets = LoadJsonDict(paths.SecretsPath);
+        return (config, secrets);
+    }
+
+    /// <summary>
+    /// Load a JSON file as a mutable dictionary. Returns a default skeleton if the file doesn't exist.
+    /// </summary>
+    internal static Dictionary<string, object> LoadJsonDict(string path)
+    {
+        if (!File.Exists(path))
+            return new Dictionary<string, object> { ["configVersion"] = 1 };
+
+        var text = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<Dictionary<string, object>>(text)
+            ?? new Dictionary<string, object> { ["configVersion"] = 1 };
+    }
+
+    /// <summary>
+    /// Get or create a nested dictionary section. Handles JsonElement deserialization
+    /// when the section was loaded from a file.
+    /// </summary>
+    internal static Dictionary<string, object> GetOrCreateSection(
+        Dictionary<string, object> dict, string key)
+    {
+        if (dict.TryGetValue(key, out var existing))
+        {
+            if (existing is JsonElement je)
+            {
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
+                    ?? new Dictionary<string, object>();
+                dict[key] = parsed;
+                return parsed;
+            }
+
+            return (Dictionary<string, object>)existing;
+        }
+
+        var section = new Dictionary<string, object>();
+        dict[key] = section;
+        return section;
+    }
+
+    /// <summary>
+    /// Get an existing nested dictionary section, or null if it doesn't exist.
+    /// </summary>
+    internal static Dictionary<string, object>? GetSectionOrNull(
+        Dictionary<string, object> dict, string key)
+    {
+        if (!dict.TryGetValue(key, out var existing))
+            return null;
+
+        if (existing is JsonElement je)
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
+                ?? new Dictionary<string, object>();
+            dict[key] = parsed;
+            return parsed;
+        }
+
+        return existing as Dictionary<string, object>;
+    }
+
+    /// <summary>
+    /// Serialize a config dictionary and write it to disk, creating parent directories if needed.
+    /// </summary>
+    internal static void WriteConfigFile(string path, Dictionary<string, object> data)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (dir is not null)
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(path, JsonSerializer.Serialize(data, JsonOptions));
+    }
+}

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using ModelContextProtocol.Client;
+using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Mcp;
@@ -25,7 +26,7 @@ internal readonly record struct McpProbeResult(
 /// </summary>
 internal static class McpCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private static JsonSerializerOptions JsonOptions => ConfigFileHelper.JsonOptions;
 
     public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
     {
@@ -404,23 +405,19 @@ internal static class McpCommand
         });
     }
 
-    // ── Config file helpers ──
+    // ── Config file helpers (delegated to ConfigFileHelper) ──
 
-    private static (Dictionary<string, object> config, Dictionary<string, object> secrets) LoadConfigFiles(NetclawPaths paths)
-    {
-        var config = LoadJsonDict(paths.NetclawConfigPath);
-        var secrets = LoadJsonDict(paths.SecretsPath);
-        return (config, secrets);
-    }
+    private static (Dictionary<string, object> config, Dictionary<string, object> secrets)
+        LoadConfigFiles(NetclawPaths paths) => ConfigFileHelper.LoadConfigFiles(paths);
 
-    private static Dictionary<string, object> LoadJsonDict(string path)
-    {
-        if (!File.Exists(path))
-            return new Dictionary<string, object> { ["configVersion"] = 1 };
+    private static Dictionary<string, object> GetOrCreateSection(
+        Dictionary<string, object> dict, string key) => ConfigFileHelper.GetOrCreateSection(dict, key);
 
-        var text = File.ReadAllText(path);
-        return JsonSerializer.Deserialize<Dictionary<string, object>>(text) ?? new Dictionary<string, object> { ["configVersion"] = 1 };
-    }
+    private static Dictionary<string, object>? GetSectionOrNull(
+        Dictionary<string, object> dict, string key) => ConfigFileHelper.GetSectionOrNull(dict, key);
+
+    private static void WriteConfigFile(string path, Dictionary<string, object> data)
+        => ConfigFileHelper.WriteConfigFile(path, data);
 
     internal static Dictionary<string, McpServerEntry> LoadMcpServers(NetclawPaths paths)
     {
@@ -471,55 +468,11 @@ internal static class McpCommand
         return result;
     }
 
-    private static Dictionary<string, object> GetOrCreateSection(Dictionary<string, object> dict, string key)
-    {
-        if (dict.TryGetValue(key, out var existing))
-        {
-            if (existing is JsonElement je)
-            {
-                var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
-                    ?? new Dictionary<string, object>();
-                dict[key] = parsed;
-                return parsed;
-            }
-
-            return (Dictionary<string, object>)existing;
-        }
-
-        var section = new Dictionary<string, object>();
-        dict[key] = section;
-        return section;
-    }
-
-    private static Dictionary<string, object>? GetSectionOrNull(Dictionary<string, object> dict, string key)
-    {
-        if (!dict.TryGetValue(key, out var existing))
-            return null;
-
-        if (existing is JsonElement je)
-        {
-            var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
-                ?? new Dictionary<string, object>();
-            dict[key] = parsed;
-            return parsed;
-        }
-
-        return existing as Dictionary<string, object>;
-    }
-
     private static JsonElement SerializeEntry(McpServerEntry entry)
     {
         var json = JsonSerializer.Serialize(entry, JsonOptions);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
-    }
-
-    private static void WriteConfigFile(string path, Dictionary<string, object> data)
-    {
-        var dir = Path.GetDirectoryName(path);
-        if (dir is not null)
-            Directory.CreateDirectory(dir);
-        File.WriteAllText(path, JsonSerializer.Serialize(data, JsonOptions));
     }
 
     private static int WriteHelp()

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -28,24 +28,25 @@ internal static class McpCommand
 {
     private static JsonSerializerOptions JsonOptions => ConfigFileHelper.JsonOptions;
 
-    public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, TextWriter? output = null)
     {
+        var writer = output ?? Console.Out;
         var subcommand = args.Length > 1 ? args[1] : "help";
 
         return subcommand switch
         {
-            "add" => RunAdd(args, paths),
-            "list" => await RunListAsync(paths),
-            "get" => RunGet(args, paths),
-            "remove" => RunRemove(args, paths),
-            "enable" => RunToggle(args, paths, enabled: true),
-            "disable" => RunToggle(args, paths, enabled: false),
-            "help" or "-h" or "--help" => WriteHelp(),
-            _ => WriteHelp()
+            "add" => RunAdd(args, paths, writer),
+            "list" => await RunListAsync(paths, writer),
+            "get" => RunGet(args, paths, writer),
+            "remove" => RunRemove(args, paths, writer),
+            "enable" => RunToggle(args, paths, enabled: true, writer),
+            "disable" => RunToggle(args, paths, enabled: false, writer),
+            "help" or "-h" or "--help" => WriteHelp(writer),
+            _ => WriteHelp(writer)
         };
     }
 
-    private static int RunAdd(string[] args, NetclawPaths paths)
+    private static int RunAdd(string[] args, NetclawPaths paths, TextWriter writer)
     {
         // Parse: netclaw mcp add [--transport <type>] [--env KEY=VALUE]... [--header "Key: Value"]... <name> [command/url] [-- args...]
         string? transport = null;
@@ -102,7 +103,7 @@ internal static class McpCommand
 
         if (positional.Count < 1)
         {
-            Console.WriteLine("Usage: netclaw mcp add [--transport stdio|http|sse] [--env KEY=VALUE] <name> [command|url] [-- args...]");
+            writer.WriteLine("Usage: netclaw mcp add [--transport stdio|http|sse] [--env KEY=VALUE] <name> [command|url] [-- args...]");
             return 1;
         }
 
@@ -126,7 +127,7 @@ internal static class McpCommand
 
             if (string.IsNullOrWhiteSpace(commandOrUrl))
             {
-                Console.WriteLine("Error: stdio transport requires a command. Usage: netclaw mcp add --transport stdio <name> -- <command> [args...]");
+                writer.WriteLine("Error: stdio transport requires a command. Usage: netclaw mcp add --transport stdio <name> -- <command> [args...]");
                 return 1;
             }
         }
@@ -138,7 +139,7 @@ internal static class McpCommand
 
             if (string.IsNullOrWhiteSpace(commandOrUrl))
             {
-                Console.WriteLine($"Error: {transport} transport requires a URL. Usage: netclaw mcp add --transport {transport} <name> <url>");
+                writer.WriteLine($"Error: {transport} transport requires a URL. Usage: netclaw mcp add --transport {transport} <name> <url>");
                 return 1;
             }
         }
@@ -184,37 +185,37 @@ internal static class McpCommand
             WriteConfigFile(paths.SecretsPath, secrets);
         }
 
-        Console.WriteLine($"Added MCP server '{name}' ({transport})");
+        writer.WriteLine($"Added MCP server '{name}' ({transport})");
         return 0;
     }
 
-    private static async Task<int> RunListAsync(NetclawPaths paths)
+    private static async Task<int> RunListAsync(NetclawPaths paths, TextWriter writer)
     {
         var servers = LoadMcpServers(paths);
 
         if (servers.Count == 0)
         {
-            Console.WriteLine("No MCP servers configured.");
-            Console.WriteLine("Run `netclaw mcp add` to add one.");
+            writer.WriteLine("No MCP servers configured.");
+            writer.WriteLine("Run `netclaw mcp add` to add one.");
             return 0;
         }
 
-        Console.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status"}");
+        writer.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status"}");
         foreach (var (name, entry) in servers)
         {
             var enabled = entry.Enabled ? "yes" : "no";
             var probe = await ProbeServerAsync(name, entry);
-            Console.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {probe.FormatStatus()}");
+            writer.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {probe.FormatStatus()}");
         }
 
         return 0;
     }
 
-    private static int RunGet(string[] args, NetclawPaths paths)
+    private static int RunGet(string[] args, NetclawPaths paths, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine("Usage: netclaw mcp get <name>");
+            writer.WriteLine("Usage: netclaw mcp get <name>");
             return 1;
         }
 
@@ -223,48 +224,48 @@ internal static class McpCommand
 
         if (!servers.TryGetValue(name, out var entry))
         {
-            Console.WriteLine($"MCP server '{name}' not found.");
+            writer.WriteLine($"MCP server '{name}' not found.");
             return 1;
         }
 
-        Console.WriteLine($"Name:       {name}");
-        Console.WriteLine($"Transport:  {entry.Transport}");
+        writer.WriteLine($"Name:       {name}");
+        writer.WriteLine($"Transport:  {entry.Transport}");
 
         if (entry.Command is not null)
         {
             var cmdLine = entry.Arguments is { Length: > 0 }
                 ? $"{entry.Command} {string.Join(' ', entry.Arguments)}"
                 : entry.Command;
-            Console.WriteLine($"Command:    {cmdLine}");
+            writer.WriteLine($"Command:    {cmdLine}");
         }
 
         if (entry.Url is not null)
-            Console.WriteLine($"URL:        {entry.Url}");
+            writer.WriteLine($"URL:        {entry.Url}");
 
-        Console.WriteLine($"Enabled:    {(entry.Enabled ? "yes" : "no")}");
+        writer.WriteLine($"Enabled:    {(entry.Enabled ? "yes" : "no")}");
 
         if (entry.EnvironmentVariables is { Count: > 0 })
         {
-            Console.WriteLine("Env vars:");
+            writer.WriteLine("Env vars:");
             foreach (var (k, _) in entry.EnvironmentVariables)
-                Console.WriteLine($"  {k}=***REDACTED***");
+                writer.WriteLine($"  {k}=***REDACTED***");
         }
 
         if (entry.Headers is { Count: > 0 })
         {
-            Console.WriteLine("Headers:");
+            writer.WriteLine("Headers:");
             foreach (var (k, _) in entry.Headers)
-                Console.WriteLine($"  {k}: ***REDACTED***");
+                writer.WriteLine($"  {k}: ***REDACTED***");
         }
 
         return 0;
     }
 
-    private static int RunRemove(string[] args, NetclawPaths paths)
+    private static int RunRemove(string[] args, NetclawPaths paths, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine("Usage: netclaw mcp remove <name>");
+            writer.WriteLine("Usage: netclaw mcp remove <name>");
             return 1;
         }
 
@@ -288,19 +289,19 @@ internal static class McpCommand
 
         if (removed)
         {
-            Console.WriteLine($"Removed MCP server '{name}'");
+            writer.WriteLine($"Removed MCP server '{name}'");
             return 0;
         }
 
-        Console.WriteLine($"MCP server '{name}' not found.");
+        writer.WriteLine($"MCP server '{name}' not found.");
         return 1;
     }
 
-    private static int RunToggle(string[] args, NetclawPaths paths, bool enabled)
+    private static int RunToggle(string[] args, NetclawPaths paths, bool enabled, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine($"Usage: netclaw mcp {(enabled ? "enable" : "disable")} <name>");
+            writer.WriteLine($"Usage: netclaw mcp {(enabled ? "enable" : "disable")} <name>");
             return 1;
         }
 
@@ -310,7 +311,7 @@ internal static class McpCommand
         var mcpServers = GetSectionOrNull(config, "McpServers");
         if (mcpServers is null || !mcpServers.ContainsKey(name))
         {
-            Console.WriteLine($"MCP server '{name}' not found.");
+            writer.WriteLine($"MCP server '{name}' not found.");
             return 1;
         }
 
@@ -321,7 +322,7 @@ internal static class McpCommand
         mcpServers[name] = SerializeEntry(entry);
 
         WriteConfigFile(paths.NetclawConfigPath, config);
-        Console.WriteLine($"{(enabled ? "Enabled" : "Disabled")} MCP server '{name}'");
+        writer.WriteLine($"{(enabled ? "Enabled" : "Disabled")} MCP server '{name}'");
         return 0;
     }
 
@@ -475,22 +476,22 @@ internal static class McpCommand
         return doc.RootElement.Clone();
     }
 
-    private static int WriteHelp()
+    private static int WriteHelp(TextWriter writer)
     {
-        Console.WriteLine("Usage: netclaw mcp <subcommand>");
-        Console.WriteLine();
-        Console.WriteLine("Subcommands:");
-        Console.WriteLine("  add        Add an MCP server profile");
-        Console.WriteLine("  list       List configured MCP servers");
-        Console.WriteLine("  get        Show details for an MCP server");
-        Console.WriteLine("  remove     Remove an MCP server profile");
-        Console.WriteLine("  enable     Enable a disabled MCP server");
-        Console.WriteLine("  disable    Disable an MCP server without removing it");
-        Console.WriteLine();
-        Console.WriteLine("Examples:");
-        Console.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
-        Console.WriteLine("  netclaw mcp add --transport http --header \"Authorization: Bearer tok-...\" myapi https://api.example.com/mcp");
-        Console.WriteLine("  netclaw mcp list");
+        writer.WriteLine("Usage: netclaw mcp <subcommand>");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("  add        Add an MCP server profile");
+        writer.WriteLine("  list       List configured MCP servers");
+        writer.WriteLine("  get        Show details for an MCP server");
+        writer.WriteLine("  remove     Remove an MCP server profile");
+        writer.WriteLine("  enable     Enable a disabled MCP server");
+        writer.WriteLine("  disable    Disable an MCP server without removing it");
+        writer.WriteLine();
+        writer.WriteLine("Examples:");
+        writer.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
+        writer.WriteLine("  netclaw mcp add --transport http --header \"Authorization: Bearer tok-...\" myapi https://api.example.com/mcp");
+        writer.WriteLine("  netclaw mcp list");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -15,64 +15,65 @@ internal static class ModelCommand
     {
         Converters = { new JsonStringEnumConverter() }
     };
-    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, IProviderProbe? probe = null)
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, IProviderProbe? probe = null, TextWriter? output = null)
     {
+        var writer = output ?? Console.Out;
         var subcommand = args.Length > 1 ? args[1] : "help";
 
         return subcommand switch
         {
-            "list" => RunList(paths),
-            "set" => RunSet(args, paths),
-            "discover" => await RunDiscoverAsync(args, paths, probe),
-            "clear" => RunClear(args, paths),
-            "help" or "-h" or "--help" => WriteHelp(),
-            _ => WriteHelp()
+            "list" => RunList(paths, writer),
+            "set" => RunSet(args, paths, writer),
+            "discover" => await RunDiscoverAsync(args, paths, probe, writer),
+            "clear" => RunClear(args, paths, writer),
+            "help" or "-h" or "--help" => WriteHelp(writer),
+            _ => WriteHelp(writer)
         };
     }
 
-    private static int RunList(NetclawPaths paths)
+    private static int RunList(NetclawPaths paths, TextWriter writer)
     {
         var models = LoadModelSelection(paths);
         if (models is null)
         {
-            Console.WriteLine("No models configured.");
-            Console.WriteLine("Run `netclaw model set` or `netclaw model` (TUI) to configure models.");
+            writer.WriteLine("No models configured.");
+            writer.WriteLine("Run `netclaw model set` or `netclaw model` (TUI) to configure models.");
             return 0;
         }
 
-        Console.WriteLine($"{"Role",-12} {"Provider",-20} {"Model ID",-30} {"Context Window"}");
+        writer.WriteLine($"{"Role",-12} {"Provider",-20} {"Model ID",-30} {"Context Window"}");
 
-        WriteModelRow("Main", models.Main);
+        WriteModelRow("Main", models.Main, writer);
 
         if (models.Fallback is not null)
-            WriteModelRow("Fallback", models.Fallback);
+            WriteModelRow("Fallback", models.Fallback, writer);
         else
-            Console.WriteLine($"{"Fallback",-12} {"(not set)",-20}");
+            writer.WriteLine($"{"Fallback",-12} {"(not set)",-20}");
 
         if (models.Compaction is not null)
-            WriteModelRow("Compaction", models.Compaction);
+            WriteModelRow("Compaction", models.Compaction, writer);
         else
-            Console.WriteLine($"{"Compaction",-12} {"(not set)",-20}");
+            writer.WriteLine($"{"Compaction",-12} {"(not set)",-20}");
 
         return 0;
     }
 
-    private static void WriteModelRow(string role, ModelReference model)
+    private static void WriteModelRow(string role, ModelReference model, TextWriter writer)
     {
         var ctxWindow = model.ContextWindow.HasValue
             ? $"{model.ContextWindow.Value:N0} tokens"
             : "(default)";
-        Console.WriteLine($"{role,-12} {model.Provider,-20} {model.ModelId,-30} {ctxWindow}");
+        writer.WriteLine($"{role,-12} {model.Provider,-20} {model.ModelId,-30} {ctxWindow}");
     }
 
-    private static int RunSet(string[] args, NetclawPaths paths)
+    private static int RunSet(string[] args, NetclawPaths paths, TextWriter writer)
     {
         // Parse: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]
         if (args.Length < 5)
         {
-            Console.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]");
-            Console.WriteLine();
-            Console.WriteLine("Roles: main, fallback, compaction");
+            writer.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]");
+            writer.WriteLine();
+            writer.WriteLine("Roles: main, fallback, compaction");
             return 1;
         }
 
@@ -87,7 +88,7 @@ internal static class ModelCommand
             {
                 if (!int.TryParse(args[++i], out var cw) || cw <= 0)
                 {
-                    Console.WriteLine("Error: --context-window must be a positive integer.");
+                    writer.WriteLine("Error: --context-window must be a positive integer.");
                     return 1;
                 }
 
@@ -106,7 +107,7 @@ internal static class ModelCommand
 
         if (roleKey is null)
         {
-            Console.WriteLine($"Error: Unknown role '{role}'. Valid roles: main, fallback, compaction");
+            writer.WriteLine($"Error: Unknown role '{role}'. Valid roles: main, fallback, compaction");
             return 1;
         }
 
@@ -114,8 +115,8 @@ internal static class ModelCommand
         var providers = ProviderCommand.LoadProviders(paths);
         if (!providers.ContainsKey(providerName))
         {
-            Console.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
-            Console.WriteLine("Configured providers: " +
+            writer.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
+            writer.WriteLine("Configured providers: " +
                 (providers.Count > 0
                     ? string.Join(", ", providers.Keys)
                     : "(none — run `netclaw provider add` first)"));
@@ -128,8 +129,8 @@ internal static class ModelCommand
         {
             if (contextWindow.Value < currentModels.Main.ContextWindow.Value)
             {
-                Console.WriteLine($"Warning: Context window shrinking from {currentModels.Main.ContextWindow.Value:N0} to {contextWindow.Value:N0} tokens.");
-                Console.WriteLine("         Existing sessions with longer history may fail until compacted.");
+                writer.WriteLine($"Warning: Context window shrinking from {currentModels.Main.ContextWindow.Value:N0} to {contextWindow.Value:N0} tokens.");
+                writer.WriteLine("         Existing sessions with longer history may fail until compacted.");
             }
         }
 
@@ -150,16 +151,16 @@ internal static class ModelCommand
         modelsSection[roleKey] = modelEntry;
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
-        Console.WriteLine($"Set {role} model to {providerName}/{modelId}");
-        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        writer.WriteLine($"Set {role} model to {providerName}/{modelId}");
+        writer.WriteLine("Note: Restart the daemon for changes to take effect.");
         return 0;
     }
 
-    private static async Task<int> RunDiscoverAsync(string[] args, NetclawPaths paths, IProviderProbe? probe)
+    private static async Task<int> RunDiscoverAsync(string[] args, NetclawPaths paths, IProviderProbe? probe, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine("Usage: netclaw model discover <provider>");
+            writer.WriteLine("Usage: netclaw model discover <provider>");
             return 1;
         }
 
@@ -168,13 +169,13 @@ internal static class ModelCommand
 
         if (!providers.TryGetValue(providerName, out var entry))
         {
-            Console.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
+            writer.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
             return 1;
         }
 
         probe ??= CreateDefaultProbe();
 
-        Console.WriteLine($"Discovering models from '{providerName}' ({entry.Type})...");
+        writer.WriteLine($"Discovering models from '{providerName}' ({entry.Type})...");
 
         var result = await probe.ProbeAsync(
             entry.Type,
@@ -184,18 +185,18 @@ internal static class ModelCommand
 
         if (!result.Success)
         {
-            Console.WriteLine($"Error: {result.ErrorMessage}");
+            writer.WriteLine($"Error: {result.ErrorMessage}");
             return 1;
         }
 
         if (result.Models.Count == 0)
         {
-            Console.WriteLine("No models found.");
+            writer.WriteLine("No models found.");
             return 0;
         }
 
-        Console.WriteLine();
-        Console.WriteLine($"{"Model ID",-40} {"Context Window",-16} {"Cost (in/out per 1M)"}");
+        writer.WriteLine();
+        writer.WriteLine($"{"Model ID",-40} {"Context Window",-16} {"Cost (in/out per 1M)"}");
         foreach (var model in result.Models.OrderBy(m => m.ModelId, StringComparer.OrdinalIgnoreCase))
         {
             var ctx = model.ContextWindowTokens.HasValue
@@ -206,21 +207,21 @@ internal static class ModelCommand
                 (not null, not null) => $"${model.CostPerMillionInputTokens:F2} / ${model.CostPerMillionOutputTokens:F2}",
                 _ => "-"
             };
-            Console.WriteLine($"{model.ModelId,-40} {ctx,-16} {cost}");
+            writer.WriteLine($"{model.ModelId,-40} {ctx,-16} {cost}");
         }
 
-        Console.WriteLine();
-        Console.WriteLine($"{result.Models.Count} model(s) found.");
+        writer.WriteLine();
+        writer.WriteLine($"{result.Models.Count} model(s) found.");
         return 0;
     }
 
-    private static int RunClear(string[] args, NetclawPaths paths)
+    private static int RunClear(string[] args, NetclawPaths paths, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine("Usage: netclaw model clear <role>");
-            Console.WriteLine();
-            Console.WriteLine("Roles: fallback, compaction (cannot clear main)");
+            writer.WriteLine("Usage: netclaw model clear <role>");
+            writer.WriteLine();
+            writer.WriteLine("Roles: fallback, compaction (cannot clear main)");
             return 1;
         }
 
@@ -228,7 +229,7 @@ internal static class ModelCommand
 
         if (role is "main")
         {
-            Console.WriteLine("Error: Cannot clear the main model role. Use `netclaw model set main` to change it instead.");
+            writer.WriteLine("Error: Cannot clear the main model role. Use `netclaw model set main` to change it instead.");
             return 1;
         }
 
@@ -241,7 +242,7 @@ internal static class ModelCommand
 
         if (roleKey is null)
         {
-            Console.WriteLine($"Error: Unknown role '{role}'. Valid roles for clear: fallback, compaction");
+            writer.WriteLine($"Error: Unknown role '{role}'. Valid roles for clear: fallback, compaction");
             return 1;
         }
 
@@ -250,15 +251,15 @@ internal static class ModelCommand
 
         if (modelsSection is null || !modelsSection.ContainsKey(roleKey))
         {
-            Console.WriteLine($"Role '{role}' is not configured.");
+            writer.WriteLine($"Role '{role}' is not configured.");
             return 0;
         }
 
         modelsSection.Remove(roleKey);
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
-        Console.WriteLine($"Cleared {role} model role.");
-        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        writer.WriteLine($"Cleared {role} model role.");
+        writer.WriteLine("Note: Restart the daemon for changes to take effect.");
         return 0;
     }
 
@@ -282,28 +283,28 @@ internal static class ModelCommand
         return new Tui.ProviderProbe(new HttpClient());
     }
 
-    private static int WriteHelp()
+    private static int WriteHelp(TextWriter writer)
     {
-        Console.WriteLine("Usage: netclaw model <subcommand>");
-        Console.WriteLine();
-        Console.WriteLine("Subcommands:");
-        Console.WriteLine("  list                                     Show current model assignments");
-        Console.WriteLine("  set <role> <provider> <model-id>         Assign model to role");
-        Console.WriteLine("  discover <provider>                      List available models from provider");
-        Console.WriteLine("  clear <role>                             Clear fallback or compaction role");
-        Console.WriteLine();
-        Console.WriteLine("Run `netclaw model` (no subcommand) for interactive TUI management.");
-        Console.WriteLine();
-        Console.WriteLine("Roles: main, fallback, compaction");
-        Console.WriteLine();
-        Console.WriteLine("Options for 'set':");
-        Console.WriteLine("  --context-window <tokens>    Override context window size");
-        Console.WriteLine();
-        Console.WriteLine("Examples:");
-        Console.WriteLine("  netclaw model list");
-        Console.WriteLine("  netclaw model discover my-ollama");
-        Console.WriteLine("  netclaw model set main my-ollama qwen3:30b --context-window 32768");
-        Console.WriteLine("  netclaw model clear fallback");
+        writer.WriteLine("Usage: netclaw model <subcommand>");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("  list                                     Show current model assignments");
+        writer.WriteLine("  set <role> <provider> <model-id>         Assign model to role");
+        writer.WriteLine("  discover <provider>                      List available models from provider");
+        writer.WriteLine("  clear <role>                             Clear fallback or compaction role");
+        writer.WriteLine();
+        writer.WriteLine("Run `netclaw model` (no subcommand) for interactive TUI management.");
+        writer.WriteLine();
+        writer.WriteLine("Roles: main, fallback, compaction");
+        writer.WriteLine();
+        writer.WriteLine("Options for 'set':");
+        writer.WriteLine("  --context-window <tokens>    Override context window size");
+        writer.WriteLine();
+        writer.WriteLine("Examples:");
+        writer.WriteLine("  netclaw model list");
+        writer.WriteLine("  netclaw model discover my-ollama");
+        writer.WriteLine("  netclaw model set main my-ollama qwen3:30b --context-window 32768");
+        writer.WriteLine("  netclaw model clear fallback");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -1,0 +1,309 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Cli.Config;
+using Netclaw.Cli.Provider;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Model;
+
+/// <summary>
+/// Handles <c>netclaw model</c> CLI subcommands: list, set, discover, clear.
+/// </summary>
+internal static class ModelCommand
+{
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, IProviderProbe? probe = null)
+    {
+        var subcommand = args.Length > 1 ? args[1] : "help";
+
+        return subcommand switch
+        {
+            "list" => RunList(paths),
+            "set" => RunSet(args, paths),
+            "discover" => await RunDiscoverAsync(args, paths, probe),
+            "clear" => RunClear(args, paths),
+            "help" or "-h" or "--help" => WriteHelp(),
+            _ => WriteHelp()
+        };
+    }
+
+    private static int RunList(NetclawPaths paths)
+    {
+        var models = LoadModelSelection(paths);
+        if (models is null)
+        {
+            Console.WriteLine("No models configured.");
+            Console.WriteLine("Run `netclaw model set` or `netclaw model` (TUI) to configure models.");
+            return 0;
+        }
+
+        Console.WriteLine($"{"Role",-12} {"Provider",-20} {"Model ID",-30} {"Context Window"}");
+
+        WriteModelRow("Main", models.Main);
+
+        if (models.Fallback is not null)
+            WriteModelRow("Fallback", models.Fallback);
+        else
+            Console.WriteLine($"{"Fallback",-12} {"(not set)",-20}");
+
+        if (models.Compaction is not null)
+            WriteModelRow("Compaction", models.Compaction);
+        else
+            Console.WriteLine($"{"Compaction",-12} {"(not set)",-20}");
+
+        return 0;
+    }
+
+    private static void WriteModelRow(string role, ModelReference model)
+    {
+        var ctxWindow = model.ContextWindow.HasValue
+            ? $"{model.ContextWindow.Value:N0} tokens"
+            : "(default)";
+        Console.WriteLine($"{role,-12} {model.Provider,-20} {model.ModelId,-30} {ctxWindow}");
+    }
+
+    private static int RunSet(string[] args, NetclawPaths paths)
+    {
+        // Parse: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]
+        if (args.Length < 5)
+        {
+            Console.WriteLine("Usage: netclaw model set <role> <provider> <model-id> [--context-window <tokens>]");
+            Console.WriteLine();
+            Console.WriteLine("Roles: main, fallback, compaction");
+            return 1;
+        }
+
+        var role = args[2].ToLowerInvariant();
+        var providerName = args[3];
+        var modelId = args[4];
+        int? contextWindow = null;
+
+        for (var i = 5; i < args.Length; i++)
+        {
+            if (args[i] is "--context-window" && i + 1 < args.Length)
+            {
+                if (!int.TryParse(args[++i], out var cw) || cw <= 0)
+                {
+                    Console.WriteLine("Error: --context-window must be a positive integer.");
+                    return 1;
+                }
+
+                contextWindow = cw;
+            }
+        }
+
+        // Validate role
+        var roleKey = role switch
+        {
+            "main" => "Main",
+            "fallback" => "Fallback",
+            "compaction" => "Compaction",
+            _ => null
+        };
+
+        if (roleKey is null)
+        {
+            Console.WriteLine($"Error: Unknown role '{role}'. Valid roles: main, fallback, compaction");
+            return 1;
+        }
+
+        // Validate provider exists
+        var providers = ProviderCommand.LoadProviders(paths);
+        if (!providers.ContainsKey(providerName))
+        {
+            Console.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
+            Console.WriteLine("Configured providers: " +
+                (providers.Count > 0
+                    ? string.Join(", ", providers.Keys)
+                    : "(none — run `netclaw provider add` first)"));
+            return 1;
+        }
+
+        // Check for context window downgrade
+        var currentModels = LoadModelSelection(paths);
+        if (roleKey == "Main" && currentModels?.Main.ContextWindow is > 0 && contextWindow.HasValue)
+        {
+            if (contextWindow.Value < currentModels.Main.ContextWindow.Value)
+            {
+                Console.WriteLine($"Warning: Context window shrinking from {currentModels.Main.ContextWindow.Value:N0} to {contextWindow.Value:N0} tokens.");
+                Console.WriteLine("         Existing sessions with longer history may fail until compacted.");
+            }
+        }
+
+        // Write to config
+        var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
+        var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
+
+        var modelEntry = new Dictionary<string, object>
+        {
+            ["Provider"] = providerName,
+            ["ModelId"] = modelId,
+            ["Provenance"] = ModelDiscoverySource.Manual.ToString()
+        };
+
+        if (contextWindow.HasValue)
+            modelEntry["ContextWindow"] = contextWindow.Value;
+
+        modelsSection[roleKey] = modelEntry;
+        ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
+
+        Console.WriteLine($"Set {role} model to {providerName}/{modelId}");
+        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        return 0;
+    }
+
+    private static async Task<int> RunDiscoverAsync(string[] args, NetclawPaths paths, IProviderProbe? probe)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine("Usage: netclaw model discover <provider>");
+            return 1;
+        }
+
+        var providerName = args[2];
+        var providers = ProviderCommand.LoadProviders(paths);
+
+        if (!providers.TryGetValue(providerName, out var entry))
+        {
+            Console.WriteLine($"Error: Provider '{providerName}' not found in configuration.");
+            return 1;
+        }
+
+        probe ??= CreateDefaultProbe();
+
+        Console.WriteLine($"Discovering models from '{providerName}' ({entry.Type})...");
+
+        var result = await probe.ProbeAsync(
+            entry.Type,
+            string.IsNullOrWhiteSpace(entry.Endpoint) ? null : entry.Endpoint,
+            entry.ApiKey?.Value,
+            CancellationToken.None);
+
+        if (!result.Success)
+        {
+            Console.WriteLine($"Error: {result.ErrorMessage}");
+            return 1;
+        }
+
+        if (result.Models.Count == 0)
+        {
+            Console.WriteLine("No models found.");
+            return 0;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{"Model ID",-40} {"Context Window",-16} {"Cost (in/out per 1M)"}");
+        foreach (var model in result.Models.OrderBy(m => m.ModelId, StringComparer.OrdinalIgnoreCase))
+        {
+            var ctx = model.ContextWindowTokens.HasValue
+                ? $"{model.ContextWindowTokens.Value:N0}"
+                : "-";
+            var cost = (model.CostPerMillionInputTokens, model.CostPerMillionOutputTokens) switch
+            {
+                (not null, not null) => $"${model.CostPerMillionInputTokens:F2} / ${model.CostPerMillionOutputTokens:F2}",
+                _ => "-"
+            };
+            Console.WriteLine($"{model.ModelId,-40} {ctx,-16} {cost}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{result.Models.Count} model(s) found.");
+        return 0;
+    }
+
+    private static int RunClear(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine("Usage: netclaw model clear <role>");
+            Console.WriteLine();
+            Console.WriteLine("Roles: fallback, compaction (cannot clear main)");
+            return 1;
+        }
+
+        var role = args[2].ToLowerInvariant();
+
+        if (role is "main")
+        {
+            Console.WriteLine("Error: Cannot clear the main model role. Use `netclaw model set main` to change it instead.");
+            return 1;
+        }
+
+        var roleKey = role switch
+        {
+            "fallback" => "Fallback",
+            "compaction" => "Compaction",
+            _ => null
+        };
+
+        if (roleKey is null)
+        {
+            Console.WriteLine($"Error: Unknown role '{role}'. Valid roles for clear: fallback, compaction");
+            return 1;
+        }
+
+        var (config, _) = ConfigFileHelper.LoadConfigFiles(paths);
+        var modelsSection = ConfigFileHelper.GetSectionOrNull(config, "Models");
+
+        if (modelsSection is null || !modelsSection.ContainsKey(roleKey))
+        {
+            Console.WriteLine($"Role '{role}' is not configured.");
+            return 0;
+        }
+
+        modelsSection.Remove(roleKey);
+        ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
+
+        Console.WriteLine($"Cleared {role} model role.");
+        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Load model selection from config file.
+    /// </summary>
+    internal static ModelSelection? LoadModelSelection(NetclawPaths paths)
+    {
+        if (!File.Exists(paths.NetclawConfigPath))
+            return null;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
+        if (!doc.RootElement.TryGetProperty("Models", out var modelsElement))
+            return null;
+
+        return JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), DeserializeOptions);
+    }
+
+    private static IProviderProbe CreateDefaultProbe()
+    {
+        return new Tui.ProviderProbe(new HttpClient());
+    }
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw model <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  list                                     Show current model assignments");
+        Console.WriteLine("  set <role> <provider> <model-id>         Assign model to role");
+        Console.WriteLine("  discover <provider>                      List available models from provider");
+        Console.WriteLine("  clear <role>                             Clear fallback or compaction role");
+        Console.WriteLine();
+        Console.WriteLine("Run `netclaw model` (no subcommand) for interactive TUI management.");
+        Console.WriteLine();
+        Console.WriteLine("Roles: main, fallback, compaction");
+        Console.WriteLine();
+        Console.WriteLine("Options for 'set':");
+        Console.WriteLine("  --context-window <tokens>    Override context window size");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  netclaw model list");
+        Console.WriteLine("  netclaw model discover my-ollama");
+        Console.WriteLine("  netclaw model set main my-ollama qwen3:30b --context-window 32768");
+        Console.WriteLine("  netclaw model clear fallback");
+        return 0;
+    }
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -9,6 +9,8 @@ using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Mcp;
+using Netclaw.Cli.Model;
+using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Termina.Diagnostics;
@@ -266,6 +268,64 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    // ── Provider management ──
+    if (mode is "provider")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+
+        // Bare invocation → TUI; subcommands → plain CLI
+        if (args.Length == 1)
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Services.AddHttpClient<IProviderProbe, ProviderProbe>();
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-provider-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+
+            builder.Services.AddTermina("/provider", t =>
+                t.RegisterRoute<ProviderManagerPage, ProviderManagerViewModel>("/provider"));
+
+            await builder.Build().RunAsync();
+            return;
+        }
+
+        Environment.ExitCode = await ProviderCommand.RunAsync(args, paths);
+        return;
+    }
+
+    // ── Model management ──
+    if (mode is "model")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+
+        // Bare invocation → TUI; subcommands → plain CLI
+        if (args.Length == 1)
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Services.AddHttpClient<IProviderProbe, ProviderProbe>();
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-model-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+
+            builder.Services.AddTermina("/model", t =>
+                t.RegisterRoute<ModelManagerPage, ModelManagerViewModel>("/model"));
+
+            await builder.Build().RunAsync();
+            return;
+        }
+
+        Environment.ExitCode = await ModelCommand.RunAsync(args, paths);
+        return;
+    }
+
     // ── Config management stubs ──
     if (mode is "config")
     {
@@ -364,10 +424,12 @@ static void WriteGeneralHelp()
     Console.WriteLine("  status                   Runtime status from daemon health JSON endpoint");
     Console.WriteLine("  daemon <subcommand>      Manage daemon lifecycle");
     Console.WriteLine("  mcp                      Manage MCP server profiles");
-    Console.WriteLine("  init                     First-run setup wizard (planned)");
+    Console.WriteLine("  provider                 Manage LLM providers (TUI) or use subcommands");
+    Console.WriteLine("  model                    Manage model assignments (TUI) or use subcommands");
+    Console.WriteLine("  init                     First-run setup wizard");
     Console.WriteLine("  config                   Configuration management (planned)");
     Console.WriteLine();
-    Console.WriteLine("Run `netclaw daemon --help`, `netclaw doctor --help`, or `netclaw status --help` for details.");
+    Console.WriteLine("Run `netclaw <command> --help` for details on any command.");
 }
 
 static void WriteDaemonHelp()

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -9,48 +9,49 @@ namespace Netclaw.Cli.Provider;
 /// </summary>
 internal static class ProviderCommand
 {
-    public static Task<int> RunAsync(string[] args, NetclawPaths paths)
+    public static Task<int> RunAsync(string[] args, NetclawPaths paths, TextWriter? output = null)
     {
+        var writer = output ?? Console.Out;
         var subcommand = args.Length > 1 ? args[1] : "help";
 
         return subcommand switch
         {
-            "list" => Task.FromResult(RunList(paths)),
-            "add" => Task.FromResult(RunAdd(args, paths)),
-            "remove" => Task.FromResult(RunRemove(args, paths)),
-            "help" or "-h" or "--help" => Task.FromResult(WriteHelp()),
-            _ => Task.FromResult(WriteHelp())
+            "list" => Task.FromResult(RunList(paths, writer)),
+            "add" => Task.FromResult(RunAdd(args, paths, writer)),
+            "remove" => Task.FromResult(RunRemove(args, paths, writer)),
+            "help" or "-h" or "--help" => Task.FromResult(WriteHelp(writer)),
+            _ => Task.FromResult(WriteHelp(writer))
         };
     }
 
-    private static int RunList(NetclawPaths paths)
+    private static int RunList(NetclawPaths paths, TextWriter writer)
     {
         var providers = LoadProviders(paths);
 
         if (providers.Count == 0)
         {
-            Console.WriteLine("No providers configured.");
-            Console.WriteLine("Run `netclaw provider add` or `netclaw provider` (TUI) to add one.");
+            writer.WriteLine("No providers configured.");
+            writer.WriteLine("Run `netclaw provider add` or `netclaw provider` (TUI) to add one.");
             return 0;
         }
 
-        Console.WriteLine($"{"Name",-20} {"Type",-12} {"Auth",-10} {"Endpoint"}");
+        writer.WriteLine($"{"Name",-20} {"Type",-12} {"Auth",-10} {"Endpoint"}");
         foreach (var (name, entry) in providers.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
         {
-            Console.WriteLine($"{name,-20} {entry.Type,-12} {entry.AuthMethod,-10} {entry.Endpoint}");
+            writer.WriteLine($"{name,-20} {entry.Type,-12} {entry.AuthMethod,-10} {entry.Endpoint}");
         }
 
         return 0;
     }
 
-    private static int RunAdd(string[] args, NetclawPaths paths)
+    private static int RunAdd(string[] args, NetclawPaths paths, TextWriter writer)
     {
         // Parse: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]
         if (args.Length < 4)
         {
-            Console.WriteLine("Usage: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]");
-            Console.WriteLine();
-            Console.WriteLine("Types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+            writer.WriteLine("Usage: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]");
+            writer.WriteLine();
+            writer.WriteLine("Types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
             return 1;
         }
 
@@ -59,8 +60,8 @@ internal static class ProviderCommand
 
         if (!ProviderCapabilities.KnownProviderTypes.Contains(type))
         {
-            Console.WriteLine($"Error: Unknown provider type '{type}'.");
-            Console.WriteLine("Known types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+            writer.WriteLine($"Error: Unknown provider type '{type}'.");
+            writer.WriteLine("Known types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
             return 1;
         }
 
@@ -95,19 +96,19 @@ internal static class ProviderCommand
             // OAuth-capable providers without --api-key: guide user to TUI
             if (supportedAuth.Contains(AuthMethod.OAuthDevice))
             {
-                WriteProviderGuidance(type);
-                Console.WriteLine();
-                Console.WriteLine("Tip: Use `netclaw provider` (TUI) for OAuth device flow setup,");
-                Console.WriteLine("     or pass --api-key to use an API key instead.");
+                WriteProviderGuidance(type, writer);
+                writer.WriteLine();
+                writer.WriteLine("Tip: Use `netclaw provider` (TUI) for OAuth device flow setup,");
+                writer.WriteLine("     or pass --api-key to use an API key instead.");
                 return 1;
             }
 
             // API-key-only provider without key — prompt
-            Console.Write($"API key for {type}: ");
+            writer.Write($"API key for {type}: ");
             apiKey = Console.ReadLine()?.Trim();
             if (string.IsNullOrWhiteSpace(apiKey))
             {
-                Console.WriteLine("Error: API key is required.");
+                writer.WriteLine("Error: API key is required.");
                 return 1;
             }
 
@@ -140,18 +141,18 @@ internal static class ProviderCommand
             ConfigFileHelper.WriteConfigFile(paths.SecretsPath, secrets);
         }
 
-        Console.WriteLine($"Added provider '{name}' ({type})");
-        WriteProviderGuidance(type);
-        Console.WriteLine();
-        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        writer.WriteLine($"Added provider '{name}' ({type})");
+        WriteProviderGuidance(type, writer);
+        writer.WriteLine();
+        writer.WriteLine("Note: Restart the daemon for changes to take effect.");
         return 0;
     }
 
-    private static int RunRemove(string[] args, NetclawPaths paths)
+    private static int RunRemove(string[] args, NetclawPaths paths, TextWriter writer)
     {
         if (args.Length < 3)
         {
-            Console.WriteLine("Usage: netclaw provider remove <name>");
+            writer.WriteLine("Usage: netclaw provider remove <name>");
             return 1;
         }
 
@@ -161,8 +162,8 @@ internal static class ProviderCommand
         var referencingRoles = GetReferencingModelRoles(name, paths);
         if (referencingRoles.Count > 0)
         {
-            Console.WriteLine($"Error: Cannot remove provider '{name}' — referenced by model role(s): {string.Join(", ", referencingRoles)}");
-            Console.WriteLine("Run `netclaw model set` to reassign these roles first, or `netclaw model clear` for optional roles.");
+            writer.WriteLine($"Error: Cannot remove provider '{name}' — referenced by model role(s): {string.Join(", ", referencingRoles)}");
+            writer.WriteLine("Run `netclaw model set` to reassign these roles first, or `netclaw model clear` for optional roles.");
             return 1;
         }
 
@@ -185,12 +186,12 @@ internal static class ProviderCommand
 
         if (removed)
         {
-            Console.WriteLine($"Removed provider '{name}'");
-            Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+            writer.WriteLine($"Removed provider '{name}'");
+            writer.WriteLine("Note: Restart the daemon for changes to take effect.");
             return 0;
         }
 
-        Console.WriteLine($"Provider '{name}' not found.");
+        writer.WriteLine($"Provider '{name}' not found.");
         return 1;
     }
 
@@ -269,7 +270,7 @@ internal static class ProviderCommand
         return roles;
     }
 
-    private static void WriteProviderGuidance(string providerType)
+    private static void WriteProviderGuidance(string providerType, TextWriter writer)
     {
         var guidance = providerType switch
         {
@@ -281,30 +282,30 @@ internal static class ProviderCommand
         };
 
         if (guidance is not null)
-            Console.WriteLine(guidance);
+            writer.WriteLine(guidance);
     }
 
-    private static int WriteHelp()
+    private static int WriteHelp(TextWriter writer)
     {
-        Console.WriteLine("Usage: netclaw provider <subcommand>");
-        Console.WriteLine();
-        Console.WriteLine("Subcommands:");
-        Console.WriteLine("  list                         List configured providers");
-        Console.WriteLine("  add <name> <type> [options]   Add a provider");
-        Console.WriteLine("  remove <name>                Remove a provider");
-        Console.WriteLine();
-        Console.WriteLine("Run `netclaw provider` (no subcommand) for interactive TUI management.");
-        Console.WriteLine();
-        Console.WriteLine("Options for 'add':");
-        Console.WriteLine("  --api-key <key>       API key (or prompted interactively)");
-        Console.WriteLine("  --endpoint <url>      Custom endpoint URL");
-        Console.WriteLine();
-        Console.WriteLine("Provider types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
-        Console.WriteLine();
-        Console.WriteLine("Examples:");
-        Console.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://big-gpu:11434");
-        Console.WriteLine("  netclaw provider add my-anthropic anthropic --api-key sk-ant-...");
-        Console.WriteLine("  netclaw provider remove my-ollama");
+        writer.WriteLine("Usage: netclaw provider <subcommand>");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("  list                         List configured providers");
+        writer.WriteLine("  add <name> <type> [options]   Add a provider");
+        writer.WriteLine("  remove <name>                Remove a provider");
+        writer.WriteLine();
+        writer.WriteLine("Run `netclaw provider` (no subcommand) for interactive TUI management.");
+        writer.WriteLine();
+        writer.WriteLine("Options for 'add':");
+        writer.WriteLine("  --api-key <key>       API key (or prompted interactively)");
+        writer.WriteLine("  --endpoint <url>      Custom endpoint URL");
+        writer.WriteLine();
+        writer.WriteLine("Provider types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+        writer.WriteLine();
+        writer.WriteLine("Examples:");
+        writer.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://big-gpu:11434");
+        writer.WriteLine("  netclaw provider add my-anthropic anthropic --api-key sk-ant-...");
+        writer.WriteLine("  netclaw provider remove my-ollama");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -1,0 +1,310 @@
+using System.Text.Json;
+using Netclaw.Cli.Config;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Provider;
+
+/// <summary>
+/// Handles <c>netclaw provider</c> CLI subcommands: list, add, remove.
+/// </summary>
+internal static class ProviderCommand
+{
+    public static Task<int> RunAsync(string[] args, NetclawPaths paths)
+    {
+        var subcommand = args.Length > 1 ? args[1] : "help";
+
+        return subcommand switch
+        {
+            "list" => Task.FromResult(RunList(paths)),
+            "add" => Task.FromResult(RunAdd(args, paths)),
+            "remove" => Task.FromResult(RunRemove(args, paths)),
+            "help" or "-h" or "--help" => Task.FromResult(WriteHelp()),
+            _ => Task.FromResult(WriteHelp())
+        };
+    }
+
+    private static int RunList(NetclawPaths paths)
+    {
+        var providers = LoadProviders(paths);
+
+        if (providers.Count == 0)
+        {
+            Console.WriteLine("No providers configured.");
+            Console.WriteLine("Run `netclaw provider add` or `netclaw provider` (TUI) to add one.");
+            return 0;
+        }
+
+        Console.WriteLine($"{"Name",-20} {"Type",-12} {"Auth",-10} {"Endpoint"}");
+        foreach (var (name, entry) in providers.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"{name,-20} {entry.Type,-12} {entry.AuthMethod,-10} {entry.Endpoint}");
+        }
+
+        return 0;
+    }
+
+    private static int RunAdd(string[] args, NetclawPaths paths)
+    {
+        // Parse: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]
+        if (args.Length < 4)
+        {
+            Console.WriteLine("Usage: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]");
+            Console.WriteLine();
+            Console.WriteLine("Types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+            return 1;
+        }
+
+        var name = args[2];
+        var type = args[3].ToLowerInvariant();
+
+        if (!ProviderCapabilities.KnownProviderTypes.Contains(type))
+        {
+            Console.WriteLine($"Error: Unknown provider type '{type}'.");
+            Console.WriteLine("Known types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+            return 1;
+        }
+
+        string? apiKey = null;
+        string? endpoint = null;
+
+        for (var i = 4; i < args.Length; i++)
+        {
+            if (args[i] is "--api-key" && i + 1 < args.Length)
+            {
+                apiKey = args[++i];
+                continue;
+            }
+
+            if (args[i] is "--endpoint" && i + 1 < args.Length)
+            {
+                endpoint = args[++i];
+                continue;
+            }
+        }
+
+        var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(type);
+        var authMethod = AuthMethod.None;
+
+        if (supportedAuth.Contains(AuthMethod.ApiKey) && apiKey is not null)
+        {
+            authMethod = AuthMethod.ApiKey;
+        }
+        else if (supportedAuth.Contains(AuthMethod.ApiKey) && apiKey is null
+            && !supportedAuth.Contains(AuthMethod.None))
+        {
+            // OAuth-capable providers without --api-key: guide user to TUI
+            if (supportedAuth.Contains(AuthMethod.OAuthDevice))
+            {
+                WriteProviderGuidance(type);
+                Console.WriteLine();
+                Console.WriteLine("Tip: Use `netclaw provider` (TUI) for OAuth device flow setup,");
+                Console.WriteLine("     or pass --api-key to use an API key instead.");
+                return 1;
+            }
+
+            // API-key-only provider without key — prompt
+            Console.Write($"API key for {type}: ");
+            apiKey = Console.ReadLine()?.Trim();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                Console.WriteLine("Error: API key is required.");
+                return 1;
+            }
+
+            authMethod = AuthMethod.ApiKey;
+        }
+
+        endpoint ??= ProviderCapabilities.GetDefaultEndpoint(type);
+
+        // Write to netclaw.json
+        var (config, secrets) = ConfigFileHelper.LoadConfigFiles(paths);
+
+        var providers = ConfigFileHelper.GetOrCreateSection(config, "Providers");
+        var providerEntry = new Dictionary<string, object>
+        {
+            ["Type"] = type,
+            ["Endpoint"] = endpoint,
+            ["AuthMethod"] = authMethod.ToString()
+        };
+        providers[name] = providerEntry;
+        ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
+
+        // Write secret to secrets.json
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            var secretProviders = ConfigFileHelper.GetOrCreateSection(secrets, "Providers");
+            secretProviders[name] = new Dictionary<string, object>
+            {
+                ["ApiKey"] = apiKey
+            };
+            ConfigFileHelper.WriteConfigFile(paths.SecretsPath, secrets);
+        }
+
+        Console.WriteLine($"Added provider '{name}' ({type})");
+        WriteProviderGuidance(type);
+        Console.WriteLine();
+        Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+        return 0;
+    }
+
+    private static int RunRemove(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.WriteLine("Usage: netclaw provider remove <name>");
+            return 1;
+        }
+
+        var name = args[2];
+
+        // Check if any model roles reference this provider
+        var referencingRoles = GetReferencingModelRoles(name, paths);
+        if (referencingRoles.Count > 0)
+        {
+            Console.WriteLine($"Error: Cannot remove provider '{name}' — referenced by model role(s): {string.Join(", ", referencingRoles)}");
+            Console.WriteLine("Run `netclaw model set` to reassign these roles first, or `netclaw model clear` for optional roles.");
+            return 1;
+        }
+
+        var (config, secrets) = ConfigFileHelper.LoadConfigFiles(paths);
+
+        var removed = false;
+        var providers = ConfigFileHelper.GetSectionOrNull(config, "Providers");
+        if (providers?.Remove(name) == true)
+        {
+            ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
+            removed = true;
+        }
+
+        var secretProviders = ConfigFileHelper.GetSectionOrNull(secrets, "Providers");
+        if (secretProviders?.Remove(name) == true)
+        {
+            ConfigFileHelper.WriteConfigFile(paths.SecretsPath, secrets);
+            removed = true;
+        }
+
+        if (removed)
+        {
+            Console.WriteLine($"Removed provider '{name}'");
+            Console.WriteLine("Note: Restart the daemon for changes to take effect.");
+            return 0;
+        }
+
+        Console.WriteLine($"Provider '{name}' not found.");
+        return 1;
+    }
+
+    /// <summary>
+    /// Load provider entries from merged config + secrets files.
+    /// </summary>
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    /// <summary>
+    /// Load provider entries from merged config + secrets files.
+    /// </summary>
+    internal static Dictionary<string, ProviderEntry> LoadProviders(NetclawPaths paths)
+    {
+        var configText = File.Exists(paths.NetclawConfigPath)
+            ? File.ReadAllText(paths.NetclawConfigPath) : "{}";
+        var secretsText = File.Exists(paths.SecretsPath)
+            ? File.ReadAllText(paths.SecretsPath) : "{}";
+
+        using var configDoc = JsonDocument.Parse(configText);
+        using var secretsDoc = JsonDocument.Parse(secretsText);
+
+        var result = new Dictionary<string, ProviderEntry>();
+
+        if (configDoc.RootElement.TryGetProperty("Providers", out var configProviders))
+        {
+            foreach (var prop in configProviders.EnumerateObject())
+            {
+                var entry = JsonSerializer.Deserialize<ProviderEntry>(prop.Value.GetRawText(), DeserializeOptions)
+                    ?? new ProviderEntry();
+                result[prop.Name] = entry;
+            }
+        }
+
+        // Merge secrets on top
+        if (secretsDoc.RootElement.TryGetProperty("Providers", out var secretProviders))
+        {
+            foreach (var prop in secretProviders.EnumerateObject())
+            {
+                if (!result.TryGetValue(prop.Name, out var entry))
+                    continue;
+
+                if (prop.Value.TryGetProperty("ApiKey", out var apiKey))
+                    entry.ApiKey = new SensitiveString(apiKey.GetString() ?? "");
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Check which model roles reference the given provider name.
+    /// </summary>
+    internal static List<string> GetReferencingModelRoles(string providerName, NetclawPaths paths)
+    {
+        var roles = new List<string>();
+        if (!File.Exists(paths.NetclawConfigPath))
+            return roles;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(paths.NetclawConfigPath));
+        if (!doc.RootElement.TryGetProperty("Models", out var models))
+            return roles;
+
+        foreach (var roleName in new[] { "Main", "Fallback", "Compaction" })
+        {
+            if (models.TryGetProperty(roleName, out var role) &&
+                role.TryGetProperty("Provider", out var provider) &&
+                string.Equals(provider.GetString(), providerName, StringComparison.OrdinalIgnoreCase))
+            {
+                roles.Add(roleName);
+            }
+        }
+
+        return roles;
+    }
+
+    private static void WriteProviderGuidance(string providerType)
+    {
+        var guidance = providerType switch
+        {
+            "ollama" => "Ollama runs locally. No authentication required.",
+            "openrouter" => "Get your API key at https://openrouter.ai/keys",
+            "anthropic" => "Get your API key at https://console.anthropic.com/settings/keys or use `netclaw provider` for OAuth device flow",
+            "openai" => "Get your API key at https://platform.openai.com/api-keys or use `netclaw provider` for OAuth device flow",
+            _ => null
+        };
+
+        if (guidance is not null)
+            Console.WriteLine(guidance);
+    }
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw provider <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  list                         List configured providers");
+        Console.WriteLine("  add <name> <type> [options]   Add a provider");
+        Console.WriteLine("  remove <name>                Remove a provider");
+        Console.WriteLine();
+        Console.WriteLine("Run `netclaw provider` (no subcommand) for interactive TUI management.");
+        Console.WriteLine();
+        Console.WriteLine("Options for 'add':");
+        Console.WriteLine("  --api-key <key>       API key (or prompted interactively)");
+        Console.WriteLine("  --endpoint <url>      Custom endpoint URL");
+        Console.WriteLine();
+        Console.WriteLine("Provider types: " + string.Join(", ", ProviderCapabilities.KnownProviderTypes));
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://big-gpu:11434");
+        Console.WriteLine("  netclaw provider add my-anthropic anthropic --api-key sk-ant-...");
+        Console.WriteLine("  netclaw provider remove my-ollama");
+        return 0;
+    }
+}

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -1,0 +1,403 @@
+using Netclaw.Configuration;
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Termina page for the <c>netclaw model</c> interactive TUI.
+/// Provides viewing model role assignments, discovering models, and assigning them.
+/// </summary>
+public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
+{
+    private static readonly string[] SpinnerFrames = ["\u280b", "\u2819", "\u2838", "\u2834", "\u2826", "\u2807"];
+
+    private SelectionListNode<string>? _roleList;
+    private SelectionListNode<string>? _providerList;
+    private SelectionListNode<string>? _modelList;
+    private TextInputNode? _manualModelInput;
+    private SelectionListNode<string>? _confirmList;
+
+    private IFocusable? _lastFocusedList;
+    private TextInputNode? _lastFocusedInput;
+    private DynamicLayoutNode? _contentNode;
+    private readonly CompositeDisposable _stepSubs = new();
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Model Manager")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(BuildInnerLayout())
+                    .Fill());
+    }
+
+    private ILayoutNode BuildInnerLayout()
+    {
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(BuildContent())
+            .WithChild(Layouts.Empty().Fill())
+            .WithChild(BuildStatusBar())
+            .WithChild(BuildKeyBindings());
+    }
+
+    private LayoutNode BuildContent()
+    {
+        _contentNode = new DynamicLayoutNode(() =>
+        {
+            _lastFocusedList = null;
+            _lastFocusedInput = null;
+            _stepSubs.Clear();
+
+            return ViewModel.CurrentState.Value switch
+            {
+                ModelManagerState.RoleOverview => BuildRoleOverview(),
+                ModelManagerState.SelectProvider => BuildProviderSelection(),
+                ModelManagerState.DiscoverModels => BuildDiscoverModels(),
+                ModelManagerState.ConfirmAssignment => BuildConfirmAssignment(),
+                _ => Layouts.Empty()
+            };
+        });
+
+        ViewModel.StateVersion
+            .Subscribe(_ => _contentNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return _contentNode;
+    }
+
+    private LayoutNode BuildStatusBar()
+    {
+        return ViewModel.StatusMessage
+            .Select(msg => (ILayoutNode)(string.IsNullOrWhiteSpace(msg)
+                ? Layouts.Empty()
+                : new TextNode($"  {msg}").WithForeground(Color.Green)))
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildKeyBindings()
+    {
+        return ViewModel.CurrentState
+            .Select(state =>
+            {
+                var text = state switch
+                {
+                    ModelManagerState.RoleOverview =>
+                        " [\u2191/\u2193] Navigate  [Enter] Assign  [D] Discover  [C] Clear  [Esc] Quit",
+                    ModelManagerState.ConfirmAssignment =>
+                        " [Enter] Confirm  [Esc] Cancel",
+                    _ =>
+                        " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit"
+                };
+                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Content views
+    // ═══════════════════════════════════════════════════════════════════
+
+    private ILayoutNode BuildRoleOverview()
+    {
+        var models = ViewModel.Models;
+        var items = new List<string>
+        {
+            FormatRoleItem("Main", models?.Main),
+            FormatRoleItem("Fallback", models?.Fallback),
+            FormatRoleItem("Compaction", models?.Compaction)
+        };
+
+        _roleList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _roleList.OnFocused();
+        _lastFocusedList = _roleList;
+
+        _roleList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    var role = selected[0].Split(' ', 2)[0].Trim();
+                    ViewModel.StartAssignment(role);
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Model Role Assignments").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode($"  {"Role",-12} {"Provider",-18} {"Model ID",-28} Status")
+                .WithForeground(Color.Gray))
+            .WithChild(_roleList)
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  [Enter] Assign model  [D] Discover models  [C] Clear optional role")
+                .WithForeground(Color.Gray));
+    }
+
+    private static string FormatRoleItem(string role, ModelReference? model)
+    {
+        if (model is null)
+            return $"{role,-12} {"(not set)",-18} {"\u2014",-28} \u2014";
+
+        return $"{role,-12} {model.Provider,-18} {model.ModelId,-28} {(model.Provenance?.ToString() ?? "unknown")}";
+    }
+
+    private ILayoutNode BuildProviderSelection()
+    {
+        var items = ViewModel.Providers.Select(p => p.Name).ToList();
+
+        _providerList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _providerList.OnFocused();
+        _lastFocusedList = _providerList;
+
+        _providerList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                    ViewModel.SelectProvider(selected[0]);
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Select provider for {ViewModel.SelectedRole ?? "role"}:")
+                .WithForeground(Color.White))
+            .WithChild(_providerList);
+    }
+
+    private ILayoutNode BuildDiscoverModels()
+    {
+        if (ViewModel.IsProbing.Value)
+        {
+            var elapsed = ViewModel.ProbeElapsedSeconds.Value;
+            var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  {frame} Discovering models from '{ViewModel.SelectedProvider}'... ({elapsed}s)")
+                    .WithForeground(Color.Yellow));
+        }
+
+        var result = ViewModel.ProbeResult.Value;
+        if (result is { Success: false })
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  \u2718 Discovery failed: {result.ErrorMessage}")
+                    .WithForeground(Color.Red))
+                .WithChild(new TextNode("  Press [Enter] to retry, [Esc] to go back.")
+                    .WithForeground(Color.Gray));
+        }
+
+        if (ViewModel.DiscoveredModels.Count == 0 && result is not null)
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode("  No models found on this provider.")
+                    .WithForeground(Color.Gray))
+                .WithChild(new TextNode("  Press [Esc] to go back.")
+                    .WithForeground(Color.Gray));
+        }
+
+        // Check if manual entry is active
+        if (ViewModel.ManualModelEntry)
+        {
+            _manualModelInput = new TextInputNode()
+                .WithPlaceholder("Enter model ID...");
+            _manualModelInput.OnFocused();
+            _lastFocusedInput = _manualModelInput;
+
+            _manualModelInput.Submitted
+                .Where(text => !string.IsNullOrWhiteSpace(text))
+                .Subscribe(text =>
+                {
+                    if (ViewModel.SelectedRole is not null)
+                        ViewModel.SelectModel(text);
+                })
+                .DisposeWith(_stepSubs);
+
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  Models from '{ViewModel.SelectedProvider}' ({ViewModel.DiscoveredModels.Count} found):")
+                    .WithForeground(Color.White))
+                .WithChild(new TextNode("").Height(1))
+                .WithChild(new TextNode("  Enter model ID:").WithForeground(Color.White))
+                .WithChild(new PanelNode()
+                    .WithTitle("Model ID")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Gray)
+                    .WithContent(_manualModelInput)
+                    .Height(3));
+        }
+
+        // Build model list with manual entry option
+        var items = ViewModel.DiscoveredModels
+            .Select(m => m.ModelId)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        items.Add("Enter model ID manually...");
+
+        _modelList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _modelList.OnFocused();
+        _lastFocusedList = _modelList;
+
+        _modelList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0) return;
+
+                if (selected[0] == "Enter model ID manually...")
+                {
+                    ViewModel.ManualModelEntry = true;
+                    ViewModel.StateVersion.Value++;
+                    ViewModel.RequestRedraw();
+                }
+                else if (ViewModel.SelectedRole is not null)
+                {
+                    ViewModel.SelectModel(selected[0]);
+                }
+                else
+                {
+                    ViewModel.StatusMessage.Value = $"Model: {selected[0]}";
+                    ViewModel.RequestRedraw();
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        var title = ViewModel.SelectedRole is not null
+            ? $"  Select model for {ViewModel.SelectedRole} (from '{ViewModel.SelectedProvider}'):"
+            : $"  Models from '{ViewModel.SelectedProvider}' ({ViewModel.DiscoveredModels.Count} found):";
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode(title).WithForeground(Color.White))
+            .WithChild(_modelList);
+    }
+
+    private ILayoutNode BuildConfirmAssignment()
+    {
+        var items = new List<string> { "Yes, assign", "No, cancel" };
+        _confirmList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Green);
+
+        _confirmList.OnFocused();
+        _lastFocusedList = _confirmList;
+
+        _confirmList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0 && selected[0].StartsWith("Yes", StringComparison.Ordinal))
+                    ViewModel.ConfirmAssignment();
+                else
+                    ViewModel.GoBack();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Assign {ViewModel.SelectedRole} model?")
+                .WithForeground(Color.White).Bold())
+            .WithChild(new TextNode($"    Provider: {ViewModel.SelectedProvider}")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode($"    Model:    {ViewModel.SelectedModelId}")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(_confirmList);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Input handling
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+        var state = ViewModel.CurrentState.Value;
+
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            ViewModel.GoBack();
+            return;
+        }
+
+        // Role overview shortcuts
+        if (state == ModelManagerState.RoleOverview)
+        {
+            switch (keyInfo.Key)
+            {
+                case ConsoleKey.D:
+                    if (ViewModel.Providers.Count == 1)
+                        ViewModel.StartDiscovery(ViewModel.Providers[0].Name);
+                    else if (ViewModel.Providers.Count > 1)
+                    {
+                        ViewModel.SelectedRole = null;
+                        ViewModel.CurrentState.Value = ModelManagerState.SelectProvider;
+                        ViewModel.StateVersion.Value++;
+                        ViewModel.RequestRedraw();
+                    }
+                    return;
+                case ConsoleKey.C:
+                    if (_roleList is not null)
+                    {
+                        var selectedItems = _roleList.SelectedItems;
+                        if (selectedItems.Count > 0)
+                        {
+                            var role = selectedItems[0].Split(' ', 2)[0].Trim();
+                            ViewModel.ClearRole(role);
+                        }
+                    }
+                    return;
+            }
+        }
+
+        // Retry on discover failure
+        if (state == ModelManagerState.DiscoverModels && keyInfo.Key == ConsoleKey.Enter)
+        {
+            var result = ViewModel.ProbeResult.Value;
+            if (result is { Success: false })
+            {
+                ViewModel.StartProbe();
+                return;
+            }
+        }
+
+        RouteInputToActiveComponent(keyInfo);
+    }
+
+    private void RouteInputToActiveComponent(ConsoleKeyInfo keyInfo)
+    {
+        if (_lastFocusedInput is not null)
+        {
+            _lastFocusedInput.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+            return;
+        }
+
+        if (_lastFocusedList is not null)
+        {
+            ((SelectionListNode<string>)_lastFocusedList).HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+        }
+    }
+}

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -1,0 +1,360 @@
+using System.Text.Json;
+using Netclaw.Cli.Config;
+using Netclaw.Configuration;
+using R3;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// States for the model manager TUI.
+/// </summary>
+public enum ModelManagerState
+{
+    RoleOverview,
+    SelectProvider,
+    DiscoverModels,
+    ConfirmAssignment
+}
+
+/// <summary>
+/// Reactive ViewModel for the <c>netclaw model</c> interactive TUI.
+/// Manages viewing model role assignments, discovering models, and assigning them.
+/// </summary>
+public sealed class ModelManagerViewModel : ReactiveViewModel
+{
+    private const int MaxDisplayedModels = 30;
+
+    private readonly NetclawPaths _paths;
+    private readonly IProviderProbe _probe;
+    private CancellationTokenSource? _probeCts;
+
+    public ReactiveProperty<ModelManagerState> CurrentState { get; } = new(ModelManagerState.RoleOverview);
+    public ReactiveProperty<string> StatusMessage { get; } = new("");
+    public ReactiveProperty<bool> IsProbing { get; } = new(false);
+    public ReactiveProperty<ProviderProbeResult?> ProbeResult { get; } = new(null);
+    public ReactiveProperty<int> ProbeElapsedSeconds { get; } = new(0);
+
+    /// <summary>
+    /// Version counter for state changes that require DynamicLayoutNode invalidation.
+    /// </summary>
+    internal ReactiveProperty<int> StateVersion { get; } = new(0);
+
+    // ── Loaded state ──
+    public ModelSelection? Models { get; private set; }
+    public List<(string Name, ProviderEntry Entry)> Providers { get; } = [];
+
+    // ── Assignment flow ──
+    public string? SelectedRole { get; set; }
+    public string? SelectedProvider { get; set; }
+    public string? SelectedModelId { get; set; }
+    public List<DiscoveredModel> DiscoveredModels { get; } = [];
+    public bool ManualModelEntry { get; set; }
+
+    /// <summary>
+    /// Completes when the provider probe finishes. Used for testing.
+    /// </summary>
+    internal Task? ProbeCompletion { get; private set; }
+
+    public ModelManagerViewModel(NetclawPaths paths, IProviderProbe probe)
+    {
+        _paths = paths;
+        _probe = probe;
+    }
+
+    public override void OnActivated()
+    {
+        base.OnActivated();
+        Refresh();
+
+        Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleGlobalKey)
+            .DisposeWith(Subscriptions);
+    }
+
+    public void Refresh()
+    {
+        Models = Model.ModelCommand.LoadModelSelection(_paths);
+        Providers.Clear();
+        var loaded = Provider.ProviderCommand.LoadProviders(_paths);
+        foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+            Providers.Add((name, entry));
+    }
+
+    /// <summary>
+    /// Start assigning a model to the given role.
+    /// </summary>
+    public void StartAssignment(string role)
+    {
+        SelectedRole = role;
+        SelectedProvider = null;
+        SelectedModelId = null;
+        ManualModelEntry = false;
+        DiscoveredModels.Clear();
+
+        if (Providers.Count == 0)
+        {
+            StatusMessage.Value = "No providers configured. Run `netclaw provider add` first.";
+            RequestRedraw();
+            return;
+        }
+
+        if (Providers.Count == 1)
+        {
+            // Auto-select the only provider
+            SelectProvider(Providers[0].Name);
+            return;
+        }
+
+        CurrentState.Value = ModelManagerState.SelectProvider;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Select a provider and start model discovery.
+    /// </summary>
+    public void SelectProvider(string providerName)
+    {
+        SelectedProvider = providerName;
+        CurrentState.Value = ModelManagerState.DiscoverModels;
+        NotifyStateChanged();
+        StartProbe();
+    }
+
+    /// <summary>
+    /// Select a discovered model and move to confirmation.
+    /// </summary>
+    public void SelectModel(string modelId)
+    {
+        SelectedModelId = modelId;
+        CurrentState.Value = ModelManagerState.ConfirmAssignment;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Write the model assignment to config.
+    /// </summary>
+    public void ConfirmAssignment()
+    {
+        if (SelectedRole is null || SelectedProvider is null || SelectedModelId is null)
+            return;
+
+        var roleKey = SelectedRole switch
+        {
+            "Main" => "Main",
+            "Fallback" => "Fallback",
+            "Compaction" => "Compaction",
+            _ => SelectedRole
+        };
+
+        var provenance = ManualModelEntry
+            ? ModelDiscoverySource.Manual
+            : ModelDiscoverySource.Live;
+
+        var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
+        var modelsSection = ConfigFileHelper.GetOrCreateSection(config, "Models");
+
+        var modelEntry = new Dictionary<string, object>
+        {
+            ["Provider"] = SelectedProvider,
+            ["ModelId"] = SelectedModelId,
+            ["Provenance"] = provenance.ToString()
+        };
+
+        modelsSection[roleKey] = modelEntry;
+        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+
+        Refresh();
+        StatusMessage.Value = $"Set {SelectedRole} to {SelectedProvider}/{SelectedModelId}. Restart daemon for changes to take effect.";
+        ClearAssignmentState();
+        CurrentState.Value = ModelManagerState.RoleOverview;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Clear an optional role (Fallback or Compaction).
+    /// </summary>
+    public void ClearRole(string role)
+    {
+        if (role is "Main")
+        {
+            StatusMessage.Value = "Cannot clear the main model role.";
+            RequestRedraw();
+            return;
+        }
+
+        var roleKey = role switch
+        {
+            "Fallback" => "Fallback",
+            "Compaction" => "Compaction",
+            _ => role
+        };
+
+        var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
+        var modelsSection = ConfigFileHelper.GetSectionOrNull(config, "Models");
+        if (modelsSection?.Remove(roleKey) == true)
+        {
+            ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+            Refresh();
+            StatusMessage.Value = $"Cleared {role} role. Restart daemon for changes to take effect.";
+            NotifyStateChanged();
+        }
+    }
+
+    /// <summary>
+    /// Start model discovery for a specific provider without assigning.
+    /// </summary>
+    public void StartDiscovery(string providerName)
+    {
+        SelectedProvider = providerName;
+        SelectedRole = null;
+        CurrentState.Value = ModelManagerState.DiscoverModels;
+        NotifyStateChanged();
+        StartProbe();
+    }
+
+    public void GoBack()
+    {
+        switch (CurrentState.Value)
+        {
+            case ModelManagerState.SelectProvider:
+            case ModelManagerState.ConfirmAssignment:
+                ClearAssignmentState();
+                CurrentState.Value = ModelManagerState.RoleOverview;
+                NotifyStateChanged();
+                break;
+            case ModelManagerState.DiscoverModels:
+                CancelProbe();
+                if (Providers.Count > 1 && SelectedRole is not null)
+                {
+                    CurrentState.Value = ModelManagerState.SelectProvider;
+                    NotifyStateChanged();
+                }
+                else
+                {
+                    ClearAssignmentState();
+                    CurrentState.Value = ModelManagerState.RoleOverview;
+                    NotifyStateChanged();
+                }
+                break;
+            default:
+                Shutdown();
+                break;
+        }
+    }
+
+    public void RequestQuit()
+    {
+        Shutdown();
+    }
+
+    // ── Probe ──
+
+    internal void StartProbe()
+    {
+        CancelProbe();
+        ProbeCompletion = ProbeProviderAsync();
+    }
+
+    internal void CancelProbe()
+    {
+        if (_probeCts is not null)
+        {
+            _probeCts.Cancel();
+            _probeCts.Dispose();
+            _probeCts = null;
+        }
+    }
+
+    internal async Task ProbeProviderAsync()
+    {
+        var providerName = SelectedProvider;
+        if (providerName is null)
+            return;
+
+        var provider = Providers.FirstOrDefault(p =>
+            string.Equals(p.Name, providerName, StringComparison.OrdinalIgnoreCase));
+        if (provider.Entry is null)
+            return;
+
+        _probeCts = new CancellationTokenSource();
+        var ct = _probeCts.Token;
+
+        IsProbing.Value = true;
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+        DiscoveredModels.Clear();
+        RequestRedraw();
+
+        _ = RunProbeTimerAsync(ct);
+
+        var result = await _probe.ProbeAsync(
+            provider.Entry.Type,
+            string.IsNullOrWhiteSpace(provider.Entry.Endpoint) ? null : provider.Entry.Endpoint,
+            provider.Entry.ApiKey?.Value,
+            ct);
+
+        CancelProbe();
+
+        if (result.Success)
+            DiscoveredModels.AddRange(result.Models.Take(MaxDisplayedModels));
+
+        ProbeResult.Value = result;
+        IsProbing.Value = false;
+        NotifyStateChanged();
+    }
+
+    private async Task RunProbeTimerAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(1000, ct); }
+            catch (OperationCanceledException) { return; }
+
+            ProbeElapsedSeconds.Value++;
+            RequestRedraw();
+        }
+    }
+
+    // ── Helpers ──
+
+    private void ClearAssignmentState()
+    {
+        CancelProbe();
+        SelectedRole = null;
+        SelectedProvider = null;
+        SelectedModelId = null;
+        ManualModelEntry = false;
+        DiscoveredModels.Clear();
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+    }
+
+    private void NotifyStateChanged()
+    {
+        StateVersion.Value++;
+        RequestRedraw();
+    }
+
+    private void HandleGlobalKey(KeyPressed key)
+    {
+        if (key.KeyInfo.Key == ConsoleKey.Q &&
+            key.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            Shutdown();
+        }
+    }
+
+    public override void Dispose()
+    {
+        CancelProbe();
+        CurrentState.Dispose();
+        StatusMessage.Dispose();
+        IsProbing.Dispose();
+        ProbeResult.Dispose();
+        ProbeElapsedSeconds.Dispose();
+        StateVersion.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -1,0 +1,464 @@
+using Netclaw.Configuration;
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Termina page for the <c>netclaw provider</c> interactive TUI.
+/// Provides browsing, adding, and removing provider configurations.
+/// </summary>
+public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
+{
+    private static readonly string[] SpinnerFrames = ["\u280b", "\u2819", "\u2838", "\u2834", "\u2826", "\u2807"];
+
+    private SelectionListNode<string>? _providerList;
+    private SelectionListNode<string>? _typeList;
+    private SelectionListNode<string>? _authList;
+    private TextInputNode? _apiKeyInput;
+    private TextInputNode? _endpointInput;
+    private SelectionListNode<string>? _confirmList;
+
+    private IFocusable? _lastFocusedList;
+    private TextInputNode? _lastFocusedInput;
+    private DynamicLayoutNode? _contentNode;
+    private readonly CompositeDisposable _stepSubs = new();
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Provider Manager")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(BuildInnerLayout())
+                    .Fill());
+    }
+
+    private ILayoutNode BuildInnerLayout()
+    {
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(BuildContent())
+            .WithChild(Layouts.Empty().Fill())
+            .WithChild(BuildStatusBar())
+            .WithChild(BuildKeyBindings());
+    }
+
+    private LayoutNode BuildContent()
+    {
+        _contentNode = new DynamicLayoutNode(() =>
+        {
+            _lastFocusedList = null;
+            _lastFocusedInput = null;
+            _stepSubs.Clear();
+
+            return ViewModel.CurrentState.Value switch
+            {
+                ProviderManagerState.List => BuildProviderListView(),
+                ProviderManagerState.AddSelectType => BuildAddTypeView(),
+                ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
+                ProviderManagerState.AddCredentials => BuildCredentialsView(),
+                ProviderManagerState.AddValidating => BuildValidatingView(),
+                ProviderManagerState.AddComplete => BuildAddCompleteView(),
+                ProviderManagerState.RemoveConfirm => BuildRemoveConfirmView(),
+                _ => Layouts.Empty()
+            };
+        });
+
+        ViewModel.StateVersion
+            .Subscribe(_ => _contentNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return _contentNode;
+    }
+
+    private LayoutNode BuildStatusBar()
+    {
+        return ViewModel.StatusMessage
+            .Select(msg => (ILayoutNode)(string.IsNullOrWhiteSpace(msg)
+                ? Layouts.Empty()
+                : new TextNode($"  {msg}").WithForeground(Color.Green)))
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildKeyBindings()
+    {
+        return ViewModel.CurrentState
+            .Select(state =>
+            {
+                var text = state switch
+                {
+                    ProviderManagerState.List =>
+                        " [\u2191/\u2193] Navigate  [A] Add  [R] Remove  [Esc] Quit  [Ctrl+Q] Quit",
+                    ProviderManagerState.RemoveConfirm =>
+                        " [Enter] Confirm  [Esc] Cancel  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddComplete =>
+                        " [Enter] Save  [Esc] Cancel  [Ctrl+Q] Quit",
+                    _ =>
+                        " [\u2191/\u2193] Navigate  [Enter] Next  [Esc] Back  [Ctrl+Q] Quit"
+                };
+                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Content views
+    // ═══════════════════════════════════════════════════════════════════
+
+    private ILayoutNode BuildProviderListView()
+    {
+        if (ViewModel.Providers.Count == 0)
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode("  No providers configured.").WithForeground(Color.Gray))
+                .WithChild(new TextNode("  Press [A] to add a provider.").WithForeground(Color.Gray));
+        }
+
+        var items = ViewModel.Providers
+            .Select(p =>
+            {
+                var authStr = p.Entry.AuthMethod == AuthMethod.None ? "none" : p.Entry.AuthMethod.ToString();
+                return $"{p.Name,-18} {p.Entry.Type,-10} {authStr,-10} {p.Entry.Endpoint}";
+            })
+            .ToList();
+
+        _providerList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _providerList.OnFocused();
+        _lastFocusedList = _providerList;
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  {"Name",-18} {"Type",-10} {"Auth",-10} Endpoint")
+                .WithForeground(Color.White).Bold())
+            .WithChild(_providerList);
+    }
+
+    private ILayoutNode BuildAddTypeView()
+    {
+        _typeList = Layouts.SelectionList(
+                ProviderCapabilities.KnownProviderTypes.ToList())
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _typeList.OnFocused();
+        _lastFocusedList = _typeList;
+
+        _typeList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                    ViewModel.SelectProviderType(selected[0]);
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Select provider type:").WithForeground(Color.White))
+            .WithChild(_typeList)
+            .WithChild(BuildProviderTypeHelp());
+    }
+
+    private ILayoutNode BuildProviderTypeHelp()
+    {
+        return Layouts.Vertical()
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  Ollama     \u2014 local inference, no auth needed").WithForeground(Color.Gray))
+            .WithChild(new TextNode("  OpenRouter \u2014 model marketplace with unified API").WithForeground(Color.Gray))
+            .WithChild(new TextNode("  Anthropic  \u2014 Claude models (API key or OAuth)").WithForeground(Color.Gray))
+            .WithChild(new TextNode("  OpenAI     \u2014 GPT models (API key or OAuth)").WithForeground(Color.Gray));
+    }
+
+    private ILayoutNode BuildAddAuthView()
+    {
+        var providerType = ViewModel.NewProviderType ?? "unknown";
+        var supportedMethods = ProviderCapabilities.GetSupportedAuthMethods(providerType)
+            .Where(m => m != AuthMethod.None)
+            .Select(m => m switch
+            {
+                AuthMethod.ApiKey => "API Key",
+                AuthMethod.OAuthDevice => "OAuth Device Flow (coming soon)",
+                _ => m.ToString()
+            })
+            .ToList();
+
+        _authList = Layouts.SelectionList(supportedMethods)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _authList.OnFocused();
+        _lastFocusedList = _authList;
+
+        _authList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    var method = selected[0].StartsWith("API", StringComparison.Ordinal)
+                        ? AuthMethod.ApiKey
+                        : AuthMethod.OAuthDevice;
+                    ViewModel.SelectAuthMethod(method);
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Authentication for {providerType}:")
+                .WithForeground(Color.White))
+            .WithChild(_authList);
+    }
+
+    private ILayoutNode BuildCredentialsView()
+    {
+        var children = Layouts.Vertical();
+
+        children.WithChild(new TextNode($"  Provider: {ViewModel.NewProviderType} (name: {ViewModel.NewProviderName})")
+            .WithForeground(Color.White));
+
+        if (ViewModel.NewAuthMethod == AuthMethod.ApiKey)
+        {
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode("  API Key:").WithForeground(Color.White));
+
+            _apiKeyInput = new TextInputNode()
+                .AsPassword()
+                .WithPlaceholder($"Enter {ViewModel.NewProviderType} API key...");
+            _apiKeyInput.OnFocused();
+            _lastFocusedInput = _apiKeyInput;
+
+            _apiKeyInput.Submitted
+                .Subscribe(text =>
+                {
+                    ViewModel.NewApiKey = text;
+                    ViewModel.SubmitCredentials();
+                })
+                .DisposeWith(_stepSubs);
+
+            children.WithChild(new PanelNode()
+                .WithTitle("API Key")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_apiKeyInput)
+                .Height(3));
+
+            var guidance = ViewModel.NewProviderType switch
+            {
+                "openrouter" => "  Get your API key at https://openrouter.ai/keys",
+                "anthropic" => "  Get your API key at https://console.anthropic.com/settings/keys",
+                "openai" => "  Get your API key at https://platform.openai.com/api-keys",
+                _ => null
+            };
+
+            if (guidance is not null)
+            {
+                children.WithChild(new TextNode("").Height(1));
+                children.WithChild(new TextNode(guidance).WithForeground(Color.Gray));
+            }
+        }
+        else if (ViewModel.NewProviderType == "ollama")
+        {
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode("  Endpoint (default: http://localhost:11434):")
+                .WithForeground(Color.White));
+
+            var ollamaDefault = ProviderCapabilities.GetDefaultEndpoint("ollama");
+            _endpointInput = new TextInputNode()
+                .WithPlaceholder(ollamaDefault);
+            _endpointInput.OnFocused();
+            _lastFocusedInput = _endpointInput;
+
+            _endpointInput.Submitted
+                .Subscribe(text =>
+                {
+                    ViewModel.NewEndpoint = string.IsNullOrWhiteSpace(text) ? null : text;
+                    ViewModel.SubmitCredentials();
+                })
+                .DisposeWith(_stepSubs);
+
+            children.WithChild(new PanelNode()
+                .WithTitle("Endpoint")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_endpointInput)
+                .Height(3));
+
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode("  Ollama runs locally. No authentication required.")
+                .WithForeground(Color.Gray));
+        }
+
+        return children;
+    }
+
+    private ILayoutNode BuildValidatingView()
+    {
+        var elapsed = ViewModel.ProbeElapsedSeconds.Value;
+        var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+        var result = ViewModel.ProbeResult.Value;
+
+        if (ViewModel.IsProbing.Value)
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  {frame} Validating connection... ({elapsed}s)")
+                    .WithForeground(Color.Yellow));
+        }
+
+        if (result is { Success: true })
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  \u2714 Connection successful! ({result.Models.Count} models found)")
+                    .WithForeground(Color.Green))
+                .WithChild(new TextNode("  Press [Enter] to save, [Esc] to cancel.")
+                    .WithForeground(Color.Gray));
+        }
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  \u2718 Validation failed: {result?.ErrorMessage ?? "unknown error"}")
+                .WithForeground(Color.Red))
+            .WithChild(new TextNode("  Press [Enter] to retry, [Esc] to go back.")
+                .WithForeground(Color.Gray));
+    }
+
+    private ILayoutNode BuildAddCompleteView()
+    {
+        var result = ViewModel.ProbeResult.Value;
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  \u2714 Provider '{ViewModel.NewProviderName}' ready to save")
+                .WithForeground(Color.Green))
+            .WithChild(new TextNode($"    Type: {ViewModel.NewProviderType}")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode($"    Auth: {ViewModel.NewAuthMethod}")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode($"    Models: {result?.Models.Count ?? 0} discovered")
+                .WithForeground(Color.White))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  Press [Enter] to save, [Esc] to cancel.")
+                .WithForeground(Color.Gray));
+    }
+
+    private ILayoutNode BuildRemoveConfirmView()
+    {
+        if (ViewModel.RemoveBlockingRoles.Count > 0)
+        {
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  Cannot remove '{ViewModel.RemoveProviderName}'")
+                    .WithForeground(Color.Red))
+                .WithChild(new TextNode($"  Referenced by model role(s): {string.Join(", ", ViewModel.RemoveBlockingRoles)}")
+                    .WithForeground(Color.Red))
+                .WithChild(new TextNode("").Height(1))
+                .WithChild(new TextNode("  Reassign these roles first with `netclaw model set`.")
+                    .WithForeground(Color.Gray))
+                .WithChild(new TextNode("  Press [Esc] to go back.")
+                    .WithForeground(Color.Gray));
+        }
+
+        var items = new List<string> { "Yes, remove", "No, cancel" };
+        _confirmList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Red);
+
+        _confirmList.OnFocused();
+        _lastFocusedList = _confirmList;
+
+        _confirmList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0 && selected[0].StartsWith("Yes", StringComparison.Ordinal))
+                    ViewModel.ConfirmRemove();
+                else
+                    ViewModel.GoBackToList();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Remove provider '{ViewModel.RemoveProviderName}'?")
+                .WithForeground(Color.Yellow))
+            .WithChild(_confirmList);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Input handling
+    // ═══════════════════════════════════════════════════════════════════
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+        var state = ViewModel.CurrentState.Value;
+
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            ViewModel.GoBack();
+            return;
+        }
+
+        // List-state shortcuts
+        if (state == ProviderManagerState.List)
+        {
+            switch (keyInfo.Key)
+            {
+                case ConsoleKey.A:
+                    ViewModel.StartAdd();
+                    return;
+                case ConsoleKey.R:
+                    ViewModel.StartRemove();
+                    return;
+            }
+        }
+
+        // Enter in validating state
+        if (state == ProviderManagerState.AddValidating && keyInfo.Key == ConsoleKey.Enter)
+        {
+            var result = ViewModel.ProbeResult.Value;
+            if (result is { Success: true })
+                ViewModel.ConfirmAdd();
+            else if (result is not null)
+                ViewModel.StartProbe(); // retry
+            return;
+        }
+
+        // Enter in complete state
+        if (state == ProviderManagerState.AddComplete && keyInfo.Key == ConsoleKey.Enter)
+        {
+            ViewModel.ConfirmAdd();
+            return;
+        }
+
+        // Route to focused component
+        RouteInputToActiveComponent(keyInfo);
+    }
+
+    private void RouteInputToActiveComponent(ConsoleKeyInfo keyInfo)
+    {
+        if (_lastFocusedInput is not null)
+        {
+            _lastFocusedInput.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+            return;
+        }
+
+        if (_lastFocusedList is not null)
+        {
+            ((SelectionListNode<string>)_lastFocusedList).HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+        }
+    }
+}

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -11,14 +11,14 @@ namespace Netclaw.Cli.Tui;
 
 /// <summary>
 /// Termina page for the <c>netclaw provider</c> interactive TUI.
-/// Provides browsing, adding, and removing provider configurations.
+/// Shows all known provider types as a dashboard and provides
+/// context-sensitive actions based on provider state.
 /// </summary>
 public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 {
     private static readonly string[] SpinnerFrames = ["\u280b", "\u2819", "\u2838", "\u2834", "\u2826", "\u2807"];
 
     private SelectionListNode<string>? _providerList;
-    private SelectionListNode<string>? _typeList;
     private SelectionListNode<string>? _authList;
     private TextInputNode? _apiKeyInput;
     private TextInputNode? _endpointInput;
@@ -70,12 +70,14 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
             return ViewModel.CurrentState.Value switch
             {
+                ProviderManagerState.Loading => BuildLoadingView(),
                 ProviderManagerState.List => BuildProviderListView(),
-                ProviderManagerState.AddSelectType => BuildAddTypeView(),
                 ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
                 ProviderManagerState.AddCredentials => BuildCredentialsView(),
                 ProviderManagerState.AddValidating => BuildValidatingView(),
                 ProviderManagerState.AddComplete => BuildAddCompleteView(),
+                ProviderManagerState.Details => BuildDetailsView(),
+                ProviderManagerState.FixCredentials => BuildFixCredentialsView(),
                 ProviderManagerState.RemoveConfirm => BuildRemoveConfirmView(),
                 _ => Layouts.Empty()
             };
@@ -105,8 +107,12 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             {
                 var text = state switch
                 {
+                    ProviderManagerState.Loading =>
+                        " Checking providers...  [Ctrl+Q] Quit",
                     ProviderManagerState.List =>
-                        " [\u2191/\u2193] Navigate  [A] Add  [R] Remove  [Esc] Quit  [Ctrl+Q] Quit",
+                        " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
+                    ProviderManagerState.Details =>
+                        " [K] Update key  [R] Remove  [V] Re-validate  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.RemoveConfirm =>
                         " [Enter] Confirm  [Esc] Cancel  [Ctrl+Q] Quit",
                     ProviderManagerState.AddComplete =>
@@ -124,20 +130,48 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
     // Content views
     // ═══════════════════════════════════════════════════════════════════
 
-    private ILayoutNode BuildProviderListView()
+    private ILayoutNode BuildLoadingView()
     {
-        if (ViewModel.Providers.Count == 0)
+        var elapsed = ViewModel.EagerProbeElapsedSeconds.Value;
+        var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+
+        var children = Layouts.Vertical();
+        children.WithChild(new TextNode($"  {frame} Checking configured providers...")
+            .WithForeground(Color.Yellow));
+        children.WithChild(new TextNode("").Height(1));
+
+        foreach (var item in ViewModel.DisplayProviders)
         {
-            return Layouts.Vertical()
-                .WithChild(new TextNode("  No providers configured.").WithForeground(Color.Gray))
-                .WithChild(new TextNode("  Press [A] to add a provider.").WithForeground(Color.Gray));
+            if (!item.IsConfigured) continue;
+
+            var (statusChar, color) = item.Health switch
+            {
+                ProviderHealthStatus.Healthy => ("\u2713", Color.Green),
+                ProviderHealthStatus.Unhealthy => ("\u26a0", Color.Red),
+                _ => (SpinnerFrames[elapsed % SpinnerFrames.Length], Color.Yellow)
+            };
+
+            children.WithChild(new TextNode($"  {statusChar} {item.ProviderType}")
+                .WithForeground(color));
         }
 
-        var items = ViewModel.Providers
+        return children;
+    }
+
+    private ILayoutNode BuildProviderListView()
+    {
+        var items = ViewModel.DisplayProviders
             .Select(p =>
             {
-                var authStr = p.Entry.AuthMethod == AuthMethod.None ? "none" : p.Entry.AuthMethod.ToString();
-                return $"{p.Name,-18} {p.Entry.Type,-10} {authStr,-10} {p.Entry.Endpoint}";
+                var statusChar = p switch
+                {
+                    { IsConfigured: true, Health: ProviderHealthStatus.Healthy } => "\u2713",
+                    { IsConfigured: true, Health: ProviderHealthStatus.Unhealthy } => "\u26a0",
+                    { IsConfigured: true, Health: ProviderHealthStatus.Probing } => "\u2026",
+                    _ => " "
+                };
+
+                return $"{statusChar} {p.ProviderType,-16} {p.DisplayAuth,-12} {p.DisplayEndpoint}";
             })
             .ToList();
 
@@ -148,44 +182,25 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         _providerList.OnFocused();
         _lastFocusedList = _providerList;
 
-        return Layouts.Vertical()
-            .WithChild(new TextNode($"  {"Name",-18} {"Type",-10} {"Auth",-10} Endpoint")
-                .WithForeground(Color.White).Bold())
-            .WithChild(_providerList);
-    }
-
-    private ILayoutNode BuildAddTypeView()
-    {
-        _typeList = Layouts.SelectionList(
-                ProviderCapabilities.KnownProviderTypes.ToList())
-            .WithMode(SelectionMode.Single)
-            .WithHighlightColors(Color.Black, Color.Cyan);
-
-        _typeList.OnFocused();
-        _lastFocusedList = _typeList;
-
-        _typeList.SelectionConfirmed
+        _providerList.SelectionConfirmed
             .Subscribe(selected =>
             {
                 if (selected.Count > 0)
-                    ViewModel.SelectProviderType(selected[0]);
+                {
+                    var idx = items.IndexOf(selected[0]);
+                    if (idx >= 0)
+                    {
+                        ViewModel.SelectedProviderIndex = idx;
+                        ViewModel.ActivateSelectedProvider();
+                    }
+                }
             })
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode("  Select provider type:").WithForeground(Color.White))
-            .WithChild(_typeList)
-            .WithChild(BuildProviderTypeHelp());
-    }
-
-    private ILayoutNode BuildProviderTypeHelp()
-    {
-        return Layouts.Vertical()
-            .WithChild(new TextNode("").Height(1))
-            .WithChild(new TextNode("  Ollama     \u2014 local inference, no auth needed").WithForeground(Color.Gray))
-            .WithChild(new TextNode("  OpenRouter \u2014 model marketplace with unified API").WithForeground(Color.Gray))
-            .WithChild(new TextNode("  Anthropic  \u2014 Claude models (API key or OAuth)").WithForeground(Color.Gray))
-            .WithChild(new TextNode("  OpenAI     \u2014 GPT models (API key or OAuth)").WithForeground(Color.Gray));
+            .WithChild(new TextNode($"  {"",2}{"Type",-16} {"Auth",-12} Endpoint")
+                .WithForeground(Color.White).Bold())
+            .WithChild(_providerList);
     }
 
     private ILayoutNode BuildAddAuthView()
@@ -324,6 +339,13 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
         if (result is { Success: true })
         {
+            if (ViewModel.IsFixFlow)
+            {
+                return Layouts.Vertical()
+                    .WithChild(new TextNode($"  \u2714 Connection restored! ({result.Models.Count} models found)")
+                        .WithForeground(Color.Green));
+            }
+
             return Layouts.Vertical()
                 .WithChild(new TextNode($"  \u2714 Connection successful! ({result.Models.Count} models found)")
                     .WithForeground(Color.Green))
@@ -353,6 +375,130 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .WithChild(new TextNode("").Height(1))
             .WithChild(new TextNode("  Press [Enter] to save, [Esc] to cancel.")
                 .WithForeground(Color.Gray));
+    }
+
+    private ILayoutNode BuildDetailsView()
+    {
+        var item = ViewModel.DetailProvider;
+        if (item is null)
+            return Layouts.Empty();
+
+        var healthStr = item.Health switch
+        {
+            ProviderHealthStatus.Healthy => "\u2713 Healthy",
+            ProviderHealthStatus.Unhealthy => "\u26a0 Unhealthy",
+            ProviderHealthStatus.Probing => "\u2026 Checking...",
+            _ => "Unknown"
+        };
+
+        var healthColor = item.Health switch
+        {
+            ProviderHealthStatus.Healthy => Color.Green,
+            ProviderHealthStatus.Unhealthy => Color.Red,
+            _ => Color.Yellow
+        };
+
+        var modelCount = item.ProbeResult?.Models.Count ?? 0;
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  Provider: {item.ConfiguredName}").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode($"    Type:     {item.ProviderType}").WithForeground(Color.White))
+            .WithChild(new TextNode($"    Auth:     {item.DisplayAuth}").WithForeground(Color.White))
+            .WithChild(new TextNode($"    Endpoint: {item.DisplayEndpoint}").WithForeground(Color.White))
+            .WithChild(new TextNode($"    Status:   {healthStr}").WithForeground(healthColor))
+            .WithChild(new TextNode($"    Models:   {modelCount} discovered").WithForeground(Color.White));
+    }
+
+    private ILayoutNode BuildFixCredentialsView()
+    {
+        var item = ViewModel.DetailProvider;
+        if (item is null)
+            return Layouts.Empty();
+
+        var children = Layouts.Vertical();
+
+        children.WithChild(new TextNode($"  Fix credentials for: {item.ConfiguredName} ({item.ProviderType})")
+            .WithForeground(Color.White).Bold());
+
+        if (item.ProbeResult is { Success: false, ErrorMessage: not null })
+        {
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode($"  Error: {item.ProbeResult.ErrorMessage}")
+                .WithForeground(Color.Red));
+        }
+
+        var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(item.ProviderType);
+
+        if (item.ProviderType == "ollama")
+        {
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode("  Endpoint:").WithForeground(Color.White));
+
+            _endpointInput = new TextInputNode()
+                .WithPlaceholder(item.Entry?.Endpoint ?? ProviderCapabilities.GetDefaultEndpoint("ollama"));
+            _endpointInput.OnFocused();
+            _lastFocusedInput = _endpointInput;
+
+            _endpointInput.Submitted
+                .Subscribe(text =>
+                {
+                    ViewModel.FixEndpoint = string.IsNullOrWhiteSpace(text)
+                        ? item.Entry?.Endpoint
+                        : text;
+                    ViewModel.SubmitFixCredentials();
+                })
+                .DisposeWith(_stepSubs);
+
+            children.WithChild(new PanelNode()
+                .WithTitle("Endpoint")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_endpointInput)
+                .Height(3));
+        }
+        else if (supportedAuth.Contains(AuthMethod.ApiKey))
+        {
+            children.WithChild(new TextNode("").Height(1));
+            children.WithChild(new TextNode("  New API Key:").WithForeground(Color.White));
+
+            _apiKeyInput = new TextInputNode()
+                .AsPassword()
+                .WithPlaceholder($"Enter new {item.ProviderType} API key...");
+            _apiKeyInput.OnFocused();
+            _lastFocusedInput = _apiKeyInput;
+
+            _apiKeyInput.Submitted
+                .Subscribe(text =>
+                {
+                    ViewModel.FixApiKey = text;
+                    ViewModel.SubmitFixCredentials();
+                })
+                .DisposeWith(_stepSubs);
+
+            children.WithChild(new PanelNode()
+                .WithTitle("API Key")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_apiKeyInput)
+                .Height(3));
+
+            var guidance = item.ProviderType switch
+            {
+                "openrouter" => "  Get your API key at https://openrouter.ai/keys",
+                "anthropic" => "  Get your API key at https://console.anthropic.com/settings/keys",
+                "openai" => "  Get your API key at https://platform.openai.com/api-keys",
+                _ => null
+            };
+
+            if (guidance is not null)
+            {
+                children.WithChild(new TextNode("").Height(1));
+                children.WithChild(new TextNode(guidance).WithForeground(Color.Gray));
+            }
+        }
+
+        return children;
     }
 
     private ILayoutNode BuildRemoveConfirmView()
@@ -410,25 +556,32 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             return;
         }
 
-        // List-state shortcuts
-        if (state == ProviderManagerState.List)
+        // Details state shortcuts
+        if (state == ProviderManagerState.Details)
         {
             switch (keyInfo.Key)
             {
-                case ConsoleKey.A:
-                    ViewModel.StartAdd();
+                case ConsoleKey.K:
+                    if (ViewModel.DetailProvider is not null)
+                        ViewModel.StartFixCredentials(ViewModel.DetailProvider);
                     return;
                 case ConsoleKey.R:
                     ViewModel.StartRemove();
                     return;
+                case ConsoleKey.V:
+                    ViewModel.RevalidateDetailProvider();
+                    return;
             }
         }
+
+        // List state: Enter is handled by SelectionConfirmed subscription,
+        // arrow keys are routed through RouteInputToActiveComponent
 
         // Enter in validating state
         if (state == ProviderManagerState.AddValidating && keyInfo.Key == ConsoleKey.Enter)
         {
             var result = ViewModel.ProbeResult.Value;
-            if (result is { Success: true })
+            if (result is { Success: true } && !ViewModel.IsFixFlow)
                 ViewModel.ConfirmAdd();
             else if (result is not null)
                 ViewModel.StartProbe(); // retry

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -400,11 +400,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public void ConfirmAdd()
     {
         WriteProviderConfig();
-        RefreshDisplayProviders();
-        CurrentState.Value = ProviderManagerState.List;
         StatusMessage.Value = $"Added provider '{NewProviderName}'. Restart daemon for changes to take effect.";
         ClearAddState();
-        NotifyStateChanged();
+        RefreshAndProbeAll();
     }
 
     /// <summary>
@@ -446,12 +444,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         if (secretProviders?.Remove(RemoveProviderName) == true)
             ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
 
-        RefreshDisplayProviders();
         StatusMessage.Value = $"Removed provider '{RemoveProviderName}'. Restart daemon for changes to take effect.";
         RemoveProviderName = null;
         DetailProvider = null;
-        CurrentState.Value = ProviderManagerState.List;
-        NotifyStateChanged();
+        RefreshAndProbeAll();
     }
 
     /// <summary>
@@ -556,6 +552,19 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
     // ── Probe ──
 
+    /// <summary>
+    /// Refresh the display list from config and re-probe all configured providers.
+    /// Transitions through Loading → List with health indicators.
+    /// Preserves <see cref="StatusMessage"/> so callers can set it before calling.
+    /// </summary>
+    internal void RefreshAndProbeAll()
+    {
+        RefreshDisplayProviders();
+        CurrentState.Value = ProviderManagerState.Loading;
+        NotifyStateChanged();
+        EagerProbeCompletion = ProbeAllConfiguredAsync();
+    }
+
     internal void StartProbe()
     {
         CancelProbe();
@@ -598,17 +607,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         {
             if (IsFixFlow)
             {
-                // Fix flow: update the detail provider's health and return to list
-                if (DetailProvider is not null)
-                {
-                    DetailProvider.ProbeResult = result;
-                    DetailProvider.Health = ProviderHealthStatus.Healthy;
-                }
-
-                RefreshDisplayProviders();
+                // Fix flow: re-probe all providers so list shows fresh health
                 IsFixFlow = false;
-                CurrentState.Value = ProviderManagerState.List;
                 StatusMessage.Value = "Credentials updated successfully. Restart daemon for changes to take effect.";
+                RefreshAndProbeAll();
             }
             else
             {

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -1,0 +1,414 @@
+using System.Text.Json;
+using Netclaw.Cli.Config;
+using Netclaw.Configuration;
+using R3;
+using Termina.Input;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// States for the provider manager TUI.
+/// </summary>
+public enum ProviderManagerState
+{
+    List,
+    AddSelectType,
+    AddSelectAuth,
+    AddCredentials,
+    AddValidating,
+    AddComplete,
+    RemoveConfirm
+}
+
+/// <summary>
+/// Reactive ViewModel for the <c>netclaw provider</c> interactive TUI.
+/// Manages browsing, adding, and removing provider configurations.
+/// </summary>
+public sealed class ProviderManagerViewModel : ReactiveViewModel
+{
+    private readonly NetclawPaths _paths;
+    private readonly IProviderProbe _probe;
+    private CancellationTokenSource? _probeCts;
+
+    public ReactiveProperty<ProviderManagerState> CurrentState { get; } = new(ProviderManagerState.List);
+    public ReactiveProperty<string> StatusMessage { get; } = new("");
+    public ReactiveProperty<bool> IsProbing { get; } = new(false);
+    public ReactiveProperty<ProviderProbeResult?> ProbeResult { get; } = new(null);
+    public ReactiveProperty<int> ProbeElapsedSeconds { get; } = new(0);
+
+    /// <summary>
+    /// Version counter for state changes that require DynamicLayoutNode invalidation.
+    /// </summary>
+    internal ReactiveProperty<int> StateVersion { get; } = new(0);
+
+    // ── Loaded providers ──
+    public List<(string Name, ProviderEntry Entry)> Providers { get; } = [];
+    public int SelectedProviderIndex { get; set; }
+
+    // ── Add flow state ──
+    public string? NewProviderName { get; set; }
+    public string? NewProviderType { get; set; }
+    public AuthMethod NewAuthMethod { get; set; } = AuthMethod.None;
+    public string? NewApiKey { get; set; }
+    public string? NewEndpoint { get; set; }
+
+    // ── Remove flow state ──
+    public string? RemoveProviderName { get; set; }
+    public List<string> RemoveBlockingRoles { get; } = [];
+
+    /// <summary>
+    /// Completes when the provider probe finishes. Used for testing.
+    /// </summary>
+    internal Task? ProbeCompletion { get; private set; }
+
+    public ProviderManagerViewModel(NetclawPaths paths, IProviderProbe probe)
+    {
+        _paths = paths;
+        _probe = probe;
+    }
+
+    public override void OnActivated()
+    {
+        base.OnActivated();
+        RefreshProviders();
+
+        Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleGlobalKey)
+            .DisposeWith(Subscriptions);
+    }
+
+    public void RefreshProviders()
+    {
+        Providers.Clear();
+        var loaded = Provider.ProviderCommand.LoadProviders(_paths);
+        foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+            Providers.Add((name, entry));
+    }
+
+    /// <summary>
+    /// Enter the add-provider flow.
+    /// </summary>
+    public void StartAdd()
+    {
+        ClearAddState();
+        CurrentState.Value = ProviderManagerState.AddSelectType;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Select provider type and advance to auth selection (or credentials for auth-free providers).
+    /// </summary>
+    public void SelectProviderType(string type)
+    {
+        NewProviderType = type;
+        // Auto-generate a default name
+        NewProviderName = GenerateProviderName(type);
+
+        var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(type);
+        if (supportedAuth is [AuthMethod.None])
+        {
+            NewAuthMethod = AuthMethod.None;
+            CurrentState.Value = ProviderManagerState.AddCredentials;
+        }
+        else
+        {
+            CurrentState.Value = ProviderManagerState.AddSelectAuth;
+        }
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Select auth method and advance to credential input.
+    /// </summary>
+    public void SelectAuthMethod(AuthMethod method)
+    {
+        NewAuthMethod = method;
+        CurrentState.Value = ProviderManagerState.AddCredentials;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Submit credentials and start validation probe.
+    /// </summary>
+    public void SubmitCredentials()
+    {
+        if (NewAuthMethod == AuthMethod.ApiKey && string.IsNullOrWhiteSpace(NewApiKey))
+        {
+            StatusMessage.Value = "API key is required.";
+            RequestRedraw();
+            return;
+        }
+
+        CurrentState.Value = ProviderManagerState.AddValidating;
+        NotifyStateChanged();
+        StartProbe();
+    }
+
+    /// <summary>
+    /// Write the new provider to config files after successful validation.
+    /// </summary>
+    public void ConfirmAdd()
+    {
+        WriteProviderConfig();
+        RefreshProviders();
+        CurrentState.Value = ProviderManagerState.List;
+        StatusMessage.Value = $"Added provider '{NewProviderName}'. Restart daemon for changes to take effect.";
+        ClearAddState();
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Start remove confirmation for the currently selected provider.
+    /// </summary>
+    public void StartRemove()
+    {
+        if (Providers.Count == 0 || SelectedProviderIndex >= Providers.Count)
+            return;
+
+        var (name, _) = Providers[SelectedProviderIndex];
+        RemoveProviderName = name;
+        RemoveBlockingRoles.Clear();
+
+        var roles = Provider.ProviderCommand.GetReferencingModelRoles(name, _paths);
+        RemoveBlockingRoles.AddRange(roles);
+
+        CurrentState.Value = ProviderManagerState.RemoveConfirm;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Execute provider removal after confirmation.
+    /// </summary>
+    public void ConfirmRemove()
+    {
+        if (RemoveBlockingRoles.Count > 0 || RemoveProviderName is null)
+        {
+            GoBackToList();
+            return;
+        }
+
+        var (config, secrets) = ConfigFileHelper.LoadConfigFiles(_paths);
+
+        var providers = ConfigFileHelper.GetSectionOrNull(config, "Providers");
+        if (providers?.Remove(RemoveProviderName) == true)
+            ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+
+        var secretProviders = ConfigFileHelper.GetSectionOrNull(secrets, "Providers");
+        if (secretProviders?.Remove(RemoveProviderName) == true)
+            ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+
+        RefreshProviders();
+        StatusMessage.Value = $"Removed provider '{RemoveProviderName}'. Restart daemon for changes to take effect.";
+        RemoveProviderName = null;
+        CurrentState.Value = ProviderManagerState.List;
+        NotifyStateChanged();
+    }
+
+    public void GoBackToList()
+    {
+        CancelProbe();
+        ClearAddState();
+        RemoveProviderName = null;
+        RemoveBlockingRoles.Clear();
+        StatusMessage.Value = "";
+        CurrentState.Value = ProviderManagerState.List;
+        NotifyStateChanged();
+    }
+
+    public void GoBack()
+    {
+        switch (CurrentState.Value)
+        {
+            case ProviderManagerState.AddSelectType:
+                GoBackToList();
+                break;
+            case ProviderManagerState.AddSelectAuth:
+                CurrentState.Value = ProviderManagerState.AddSelectType;
+                NotifyStateChanged();
+                break;
+            case ProviderManagerState.AddCredentials:
+                var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(NewProviderType ?? "");
+                if (supportedAuth is [AuthMethod.None])
+                    CurrentState.Value = ProviderManagerState.AddSelectType;
+                else
+                    CurrentState.Value = ProviderManagerState.AddSelectAuth;
+                NotifyStateChanged();
+                break;
+            case ProviderManagerState.AddValidating:
+                CancelProbe();
+                CurrentState.Value = ProviderManagerState.AddCredentials;
+                NotifyStateChanged();
+                break;
+            case ProviderManagerState.AddComplete:
+                GoBackToList();
+                break;
+            case ProviderManagerState.RemoveConfirm:
+                GoBackToList();
+                break;
+            default:
+                Shutdown();
+                break;
+        }
+    }
+
+    public void RequestQuit()
+    {
+        Shutdown();
+    }
+
+    // ── Probe ──
+
+    internal void StartProbe()
+    {
+        CancelProbe();
+        ProbeCompletion = ProbeProviderAsync();
+    }
+
+    internal void CancelProbe()
+    {
+        if (_probeCts is not null)
+        {
+            _probeCts.Cancel();
+            _probeCts.Dispose();
+            _probeCts = null;
+        }
+    }
+
+    internal async Task ProbeProviderAsync()
+    {
+        _probeCts = new CancellationTokenSource();
+        var ct = _probeCts.Token;
+
+        IsProbing.Value = true;
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+        RequestRedraw();
+
+        _ = RunProbeTimerAsync(ct);
+
+        var result = await _probe.ProbeAsync(
+            NewProviderType ?? "unknown",
+            NewEndpoint,
+            NewApiKey,
+            ct);
+
+        CancelProbe();
+        ProbeResult.Value = result;
+        IsProbing.Value = false;
+
+        if (result.Success)
+        {
+            CurrentState.Value = ProviderManagerState.AddComplete;
+        }
+
+        NotifyStateChanged();
+    }
+
+    private async Task RunProbeTimerAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(1000, ct); }
+            catch (OperationCanceledException) { return; }
+
+            ProbeElapsedSeconds.Value++;
+            RequestRedraw();
+        }
+    }
+
+    // ── Config writing ──
+
+    private void WriteProviderConfig()
+    {
+        _paths.EnsureDirectoriesExist();
+
+        var (config, secrets) = ConfigFileHelper.LoadConfigFiles(_paths);
+
+        var providers = ConfigFileHelper.GetOrCreateSection(config, "Providers");
+        var providerEntry = new Dictionary<string, object>
+        {
+            ["Type"] = NewProviderType!
+        };
+
+        if (NewAuthMethod != AuthMethod.None)
+            providerEntry["AuthMethod"] = NewAuthMethod.ToString();
+
+        var endpoint = NewEndpoint;
+        if (string.IsNullOrWhiteSpace(endpoint) && NewProviderType == "ollama")
+            endpoint = ProviderCapabilities.GetDefaultEndpoint("ollama");
+        endpoint ??= ProviderCapabilities.GetDefaultEndpoint(NewProviderType!);
+
+        providerEntry["Endpoint"] = endpoint;
+        providers[NewProviderName!] = providerEntry;
+        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+
+        if (!string.IsNullOrWhiteSpace(NewApiKey))
+        {
+            var secretProviders = ConfigFileHelper.GetOrCreateSection(secrets, "Providers");
+            secretProviders[NewProviderName!] = new Dictionary<string, object>
+            {
+                ["ApiKey"] = NewApiKey
+            };
+            ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+        }
+    }
+
+    // ── Helpers ──
+
+    private string GenerateProviderName(string type)
+    {
+        var baseName = $"my-{type}";
+        if (!Providers.Any(p => string.Equals(p.Name, baseName, StringComparison.OrdinalIgnoreCase)))
+            return baseName;
+
+        for (var i = 2; i < 100; i++)
+        {
+            var candidate = $"my-{type}-{i}";
+            if (!Providers.Any(p => string.Equals(p.Name, candidate, StringComparison.OrdinalIgnoreCase)))
+                return candidate;
+        }
+
+        return $"my-{type}-{Guid.NewGuid():N[..6]}";
+    }
+
+    private void ClearAddState()
+    {
+        CancelProbe();
+        NewProviderName = null;
+        NewProviderType = null;
+        NewAuthMethod = AuthMethod.None;
+        NewApiKey = null;
+        NewEndpoint = null;
+        ProbeResult.Value = null;
+        ProbeElapsedSeconds.Value = 0;
+    }
+
+    private void NotifyStateChanged()
+    {
+        StateVersion.Value++;
+        RequestRedraw();
+    }
+
+    private void HandleGlobalKey(KeyPressed key)
+    {
+        if (key.KeyInfo.Key == ConsoleKey.Q &&
+            key.KeyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            Shutdown();
+        }
+    }
+
+    public override void Dispose()
+    {
+        CancelProbe();
+        CurrentState.Dispose();
+        StatusMessage.Dispose();
+        IsProbing.Dispose();
+        ProbeResult.Dispose();
+        ProbeElapsedSeconds.Dispose();
+        StateVersion.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -12,18 +12,48 @@ namespace Netclaw.Cli.Tui;
 /// </summary>
 public enum ProviderManagerState
 {
+    Loading,
     List,
-    AddSelectType,
     AddSelectAuth,
     AddCredentials,
     AddValidating,
     AddComplete,
+    Details,
+    FixCredentials,
     RemoveConfirm
 }
 
 /// <summary>
+/// Health status of a provider as determined by probing.
+/// </summary>
+public enum ProviderHealthStatus
+{
+    Unchecked,
+    Probing,
+    Healthy,
+    Unhealthy
+}
+
+/// <summary>
+/// Display model for a single row in the provider list.
+/// Mutable so probe results can update Health/ProbeResult in place.
+/// </summary>
+public sealed class ProviderDisplayItem
+{
+    public string ProviderType { get; init; } = "";
+    public bool IsConfigured { get; init; }
+    public string? ConfiguredName { get; init; }
+    public ProviderEntry? Entry { get; init; }
+    public ProviderHealthStatus Health { get; set; } = ProviderHealthStatus.Unchecked;
+    public ProviderProbeResult? ProbeResult { get; set; }
+    public string DisplayEndpoint { get; init; } = "";
+    public string DisplayAuth { get; init; } = "\u2014";
+}
+
+/// <summary>
 /// Reactive ViewModel for the <c>netclaw provider</c> interactive TUI.
-/// Manages browsing, adding, and removing provider configurations.
+/// Shows all known provider types as a dashboard with health status,
+/// and provides context-sensitive actions based on provider state.
 /// </summary>
 public sealed class ProviderManagerViewModel : ReactiveViewModel
 {
@@ -31,20 +61,32 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     private readonly IProviderProbe _probe;
     private CancellationTokenSource? _probeCts;
 
-    public ReactiveProperty<ProviderManagerState> CurrentState { get; } = new(ProviderManagerState.List);
+    public ReactiveProperty<ProviderManagerState> CurrentState { get; } = new(ProviderManagerState.Loading);
     public ReactiveProperty<string> StatusMessage { get; } = new("");
     public ReactiveProperty<bool> IsProbing { get; } = new(false);
     public ReactiveProperty<ProviderProbeResult?> ProbeResult { get; } = new(null);
     public ReactiveProperty<int> ProbeElapsedSeconds { get; } = new(0);
+    public ReactiveProperty<bool> IsEagerProbing { get; } = new(false);
+    public ReactiveProperty<int> EagerProbeElapsedSeconds { get; } = new(0);
 
     /// <summary>
     /// Version counter for state changes that require DynamicLayoutNode invalidation.
     /// </summary>
     internal ReactiveProperty<int> StateVersion { get; } = new(0);
 
-    // ── Loaded providers ──
-    public List<(string Name, ProviderEntry Entry)> Providers { get; } = [];
+    // ── Display model ──
+    public List<ProviderDisplayItem> DisplayProviders { get; } = [];
     public int SelectedProviderIndex { get; set; }
+
+    /// <summary>
+    /// The provider currently being viewed in Details or FixCredentials state.
+    /// </summary>
+    public ProviderDisplayItem? DetailProvider { get; set; }
+
+    /// <summary>
+    /// When true, validation after fix-credentials returns to List (not AddComplete).
+    /// </summary>
+    public bool IsFixFlow { get; set; }
 
     // ── Add flow state ──
     public string? NewProviderName { get; set; }
@@ -52,6 +94,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public AuthMethod NewAuthMethod { get; set; } = AuthMethod.None;
     public string? NewApiKey { get; set; }
     public string? NewEndpoint { get; set; }
+
+    // ── Fix flow state ──
+    public string? FixApiKey { get; set; }
+    public string? FixEndpoint { get; set; }
 
     // ── Remove flow state ──
     public string? RemoveProviderName { get; set; }
@@ -62,6 +108,11 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     /// </summary>
     internal Task? ProbeCompletion { get; private set; }
 
+    /// <summary>
+    /// Completes when the eager probe finishes. Used for testing.
+    /// </summary>
+    internal Task? EagerProbeCompletion { get; private set; }
+
     public ProviderManagerViewModel(NetclawPaths paths, IProviderProbe probe)
     {
         _paths = paths;
@@ -71,38 +122,166 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public override void OnActivated()
     {
         base.OnActivated();
-        RefreshProviders();
+        RefreshDisplayProviders();
 
         Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleGlobalKey)
             .DisposeWith(Subscriptions);
-    }
 
-    public void RefreshProviders()
-    {
-        Providers.Clear();
-        var loaded = Provider.ProviderCommand.LoadProviders(_paths);
-        foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
-            Providers.Add((name, entry));
+        // Start eager probing of configured providers
+        EagerProbeCompletion = ProbeAllConfiguredAsync();
     }
 
     /// <summary>
-    /// Enter the add-provider flow.
+    /// Build DisplayProviders from known types merged with loaded config.
     /// </summary>
-    public void StartAdd()
+    public void RefreshDisplayProviders()
     {
-        ClearAddState();
-        CurrentState.Value = ProviderManagerState.AddSelectType;
+        DisplayProviders.Clear();
+        var loaded = Provider.ProviderCommand.LoadProviders(_paths);
+
+        foreach (var type in ProviderCapabilities.KnownProviderTypes)
+        {
+            // Find configured provider of this type
+            var configured = loaded
+                .FirstOrDefault(p => string.Equals(p.Value.Type, type, StringComparison.OrdinalIgnoreCase));
+
+            if (configured.Key is not null)
+            {
+                var authStr = configured.Value.AuthMethod == AuthMethod.None
+                    ? "\u2014"
+                    : configured.Value.AuthMethod.ToString();
+
+                DisplayProviders.Add(new ProviderDisplayItem
+                {
+                    ProviderType = type,
+                    IsConfigured = true,
+                    ConfiguredName = configured.Key,
+                    Entry = configured.Value,
+                    DisplayEndpoint = configured.Value.Endpoint,
+                    DisplayAuth = authStr
+                });
+            }
+            else
+            {
+                var defaultEndpoint = ProviderCapabilities.GetDefaultEndpoint(type);
+                DisplayProviders.Add(new ProviderDisplayItem
+                {
+                    ProviderType = type,
+                    IsConfigured = false,
+                    DisplayEndpoint = $"({defaultEndpoint})",
+                    DisplayAuth = "\u2014"
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Probe all configured providers concurrently on activation.
+    /// </summary>
+    internal async Task ProbeAllConfiguredAsync()
+    {
+        var configuredItems = DisplayProviders.Where(p => p.IsConfigured).ToList();
+        if (configuredItems.Count == 0)
+        {
+            CurrentState.Value = ProviderManagerState.List;
+            NotifyStateChanged();
+            return;
+        }
+
+        IsEagerProbing.Value = true;
+        EagerProbeElapsedSeconds.Value = 0;
+
+        foreach (var item in configuredItems)
+            item.Health = ProviderHealthStatus.Probing;
+
+        NotifyStateChanged();
+
+        using var timerCts = new CancellationTokenSource();
+        _ = RunEagerProbeTimerAsync(timerCts.Token);
+
+        var probeTasks = configuredItems.Select(async item =>
+        {
+            try
+            {
+                var result = await _probe.ProbeAsync(
+                    item.ProviderType,
+                    item.Entry?.Endpoint,
+                    item.Entry?.ApiKey?.Value,
+                    CancellationToken.None);
+
+                item.ProbeResult = result;
+                item.Health = result.Success
+                    ? ProviderHealthStatus.Healthy
+                    : ProviderHealthStatus.Unhealthy;
+            }
+            catch
+            {
+                item.Health = ProviderHealthStatus.Unhealthy;
+            }
+
+            NotifyStateChanged();
+        });
+
+        await Task.WhenAll(probeTasks);
+
+        timerCts.Cancel();
+        IsEagerProbing.Value = false;
+        CurrentState.Value = ProviderManagerState.List;
         NotifyStateChanged();
     }
 
-    /// <summary>
-    /// Select provider type and advance to auth selection (or credentials for auth-free providers).
-    /// </summary>
-    public void SelectProviderType(string type)
+    private async Task RunEagerProbeTimerAsync(CancellationToken ct)
     {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(1000, ct); }
+            catch (OperationCanceledException) { return; }
+
+            EagerProbeElapsedSeconds.Value++;
+            RequestRedraw();
+        }
+    }
+
+    /// <summary>
+    /// Activate the currently selected provider based on its state.
+    /// </summary>
+    public void ActivateSelectedProvider()
+    {
+        if (SelectedProviderIndex < 0 || SelectedProviderIndex >= DisplayProviders.Count)
+            return;
+
+        var item = DisplayProviders[SelectedProviderIndex];
+
+        if (!item.IsConfigured)
+        {
+            StartAddForType(item.ProviderType);
+            return;
+        }
+
+        switch (item.Health)
+        {
+            case ProviderHealthStatus.Healthy:
+                DetailProvider = item;
+                CurrentState.Value = ProviderManagerState.Details;
+                NotifyStateChanged();
+                break;
+
+            case ProviderHealthStatus.Unhealthy:
+                StartFixCredentials(item);
+                break;
+
+            // Probing or Unchecked — no-op
+        }
+    }
+
+    /// <summary>
+    /// Start the add flow for a specific provider type (skips type selection).
+    /// </summary>
+    public void StartAddForType(string type)
+    {
+        ClearAddState();
         NewProviderType = type;
-        // Auto-generate a default name
         NewProviderName = GenerateProviderName(type);
 
         var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(type);
@@ -116,6 +295,19 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             CurrentState.Value = ProviderManagerState.AddSelectAuth;
         }
 
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Start the fix-credentials flow for an unhealthy provider.
+    /// </summary>
+    public void StartFixCredentials(ProviderDisplayItem item)
+    {
+        DetailProvider = item;
+        FixApiKey = null;
+        FixEndpoint = item.Entry?.Endpoint;
+        IsFixFlow = true;
+        CurrentState.Value = ProviderManagerState.FixCredentials;
         NotifyStateChanged();
     }
 
@@ -147,12 +339,68 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     }
 
     /// <summary>
+    /// Submit fixed credentials and start validation probe.
+    /// </summary>
+    public void SubmitFixCredentials()
+    {
+        if (DetailProvider is null) return;
+
+        var type = DetailProvider.ProviderType;
+        var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(type);
+
+        if (supportedAuth.Contains(AuthMethod.ApiKey) && string.IsNullOrWhiteSpace(FixApiKey))
+        {
+            StatusMessage.Value = "API key is required.";
+            RequestRedraw();
+            return;
+        }
+
+        // Write updated credentials
+        if (DetailProvider.ConfiguredName is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(FixApiKey))
+            {
+                var (_, secrets) = ConfigFileHelper.LoadConfigFiles(_paths);
+                var secretProviders = ConfigFileHelper.GetOrCreateSection(secrets, "Providers");
+                secretProviders[DetailProvider.ConfiguredName] = new Dictionary<string, object>
+                {
+                    ["ApiKey"] = FixApiKey
+                };
+                ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+            }
+
+            if (FixEndpoint is not null && DetailProvider.Entry is not null
+                && !string.Equals(FixEndpoint, DetailProvider.Entry.Endpoint, StringComparison.Ordinal))
+            {
+                var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
+                var providers = ConfigFileHelper.GetOrCreateSection(config, "Providers");
+                if (providers.TryGetValue(DetailProvider.ConfiguredName, out var existing) &&
+                    existing is Dictionary<string, object> providerDict)
+                {
+                    providerDict["Endpoint"] = FixEndpoint;
+                    ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+                }
+            }
+        }
+
+        // Set up probe using fix credentials
+        NewProviderType = type;
+        NewEndpoint = FixEndpoint;
+        NewApiKey = FixApiKey ?? DetailProvider.Entry?.ApiKey?.Value;
+        IsFixFlow = true;
+
+        CurrentState.Value = ProviderManagerState.AddValidating;
+        NotifyStateChanged();
+        StartProbe();
+    }
+
+    /// <summary>
     /// Write the new provider to config files after successful validation.
     /// </summary>
     public void ConfirmAdd()
     {
         WriteProviderConfig();
-        RefreshProviders();
+        RefreshDisplayProviders();
         CurrentState.Value = ProviderManagerState.List;
         StatusMessage.Value = $"Added provider '{NewProviderName}'. Restart daemon for changes to take effect.";
         ClearAddState();
@@ -160,18 +408,17 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     }
 
     /// <summary>
-    /// Start remove confirmation for the currently selected provider.
+    /// Start remove confirmation for the detail provider.
     /// </summary>
     public void StartRemove()
     {
-        if (Providers.Count == 0 || SelectedProviderIndex >= Providers.Count)
+        if (DetailProvider is not { IsConfigured: true, ConfiguredName: not null })
             return;
 
-        var (name, _) = Providers[SelectedProviderIndex];
-        RemoveProviderName = name;
+        RemoveProviderName = DetailProvider.ConfiguredName;
         RemoveBlockingRoles.Clear();
 
-        var roles = Provider.ProviderCommand.GetReferencingModelRoles(name, _paths);
+        var roles = Provider.ProviderCommand.GetReferencingModelRoles(RemoveProviderName, _paths);
         RemoveBlockingRoles.AddRange(roles);
 
         CurrentState.Value = ProviderManagerState.RemoveConfirm;
@@ -199,10 +446,48 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         if (secretProviders?.Remove(RemoveProviderName) == true)
             ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
 
-        RefreshProviders();
+        RefreshDisplayProviders();
         StatusMessage.Value = $"Removed provider '{RemoveProviderName}'. Restart daemon for changes to take effect.";
         RemoveProviderName = null;
+        DetailProvider = null;
         CurrentState.Value = ProviderManagerState.List;
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Re-probe the detail provider inline from the Details state.
+    /// </summary>
+    public void RevalidateDetailProvider()
+    {
+        if (DetailProvider is not { IsConfigured: true, Entry: not null })
+            return;
+
+        DetailProvider.Health = ProviderHealthStatus.Probing;
+        NotifyStateChanged();
+
+        _ = RevalidateAsync(DetailProvider);
+    }
+
+    private async Task RevalidateAsync(ProviderDisplayItem item)
+    {
+        try
+        {
+            var result = await _probe.ProbeAsync(
+                item.ProviderType,
+                item.Entry?.Endpoint,
+                item.Entry?.ApiKey?.Value,
+                CancellationToken.None);
+
+            item.ProbeResult = result;
+            item.Health = result.Success
+                ? ProviderHealthStatus.Healthy
+                : ProviderHealthStatus.Unhealthy;
+        }
+        catch
+        {
+            item.Health = ProviderHealthStatus.Unhealthy;
+        }
+
         NotifyStateChanged();
     }
 
@@ -210,6 +495,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     {
         CancelProbe();
         ClearAddState();
+        DetailProvider = null;
+        IsFixFlow = false;
+        FixApiKey = null;
+        FixEndpoint = null;
         RemoveProviderName = null;
         RemoveBlockingRoles.Clear();
         StatusMessage.Value = "";
@@ -221,27 +510,34 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     {
         switch (CurrentState.Value)
         {
-            case ProviderManagerState.AddSelectType:
-                GoBackToList();
-                break;
             case ProviderManagerState.AddSelectAuth:
-                CurrentState.Value = ProviderManagerState.AddSelectType;
-                NotifyStateChanged();
+                GoBackToList();
                 break;
             case ProviderManagerState.AddCredentials:
                 var supportedAuth = ProviderCapabilities.GetSupportedAuthMethods(NewProviderType ?? "");
                 if (supportedAuth is [AuthMethod.None])
-                    CurrentState.Value = ProviderManagerState.AddSelectType;
+                    GoBackToList();
                 else
                     CurrentState.Value = ProviderManagerState.AddSelectAuth;
                 NotifyStateChanged();
                 break;
             case ProviderManagerState.AddValidating:
                 CancelProbe();
-                CurrentState.Value = ProviderManagerState.AddCredentials;
+                if (IsFixFlow)
+                {
+                    CurrentState.Value = ProviderManagerState.FixCredentials;
+                }
+                else
+                {
+                    CurrentState.Value = ProviderManagerState.AddCredentials;
+                }
                 NotifyStateChanged();
                 break;
             case ProviderManagerState.AddComplete:
+                GoBackToList();
+                break;
+            case ProviderManagerState.Details:
+            case ProviderManagerState.FixCredentials:
                 GoBackToList();
                 break;
             case ProviderManagerState.RemoveConfirm:
@@ -300,7 +596,24 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
         if (result.Success)
         {
-            CurrentState.Value = ProviderManagerState.AddComplete;
+            if (IsFixFlow)
+            {
+                // Fix flow: update the detail provider's health and return to list
+                if (DetailProvider is not null)
+                {
+                    DetailProvider.ProbeResult = result;
+                    DetailProvider.Health = ProviderHealthStatus.Healthy;
+                }
+
+                RefreshDisplayProviders();
+                IsFixFlow = false;
+                CurrentState.Value = ProviderManagerState.List;
+                StatusMessage.Value = "Credentials updated successfully. Restart daemon for changes to take effect.";
+            }
+            else
+            {
+                CurrentState.Value = ProviderManagerState.AddComplete;
+            }
         }
 
         NotifyStateChanged();
@@ -360,13 +673,17 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     private string GenerateProviderName(string type)
     {
         var baseName = $"my-{type}";
-        if (!Providers.Any(p => string.Equals(p.Name, baseName, StringComparison.OrdinalIgnoreCase)))
+        if (!DisplayProviders.Any(p =>
+            p.ConfiguredName is not null &&
+            string.Equals(p.ConfiguredName, baseName, StringComparison.OrdinalIgnoreCase)))
             return baseName;
 
         for (var i = 2; i < 100; i++)
         {
             var candidate = $"my-{type}-{i}";
-            if (!Providers.Any(p => string.Equals(p.Name, candidate, StringComparison.OrdinalIgnoreCase)))
+            if (!DisplayProviders.Any(p =>
+                p.ConfiguredName is not null &&
+                string.Equals(p.ConfiguredName, candidate, StringComparison.OrdinalIgnoreCase)))
                 return candidate;
         }
 
@@ -383,6 +700,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         NewEndpoint = null;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
+        IsFixFlow = false;
     }
 
     private void NotifyStateChanged()
@@ -408,6 +726,8 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         IsProbing.Dispose();
         ProbeResult.Dispose();
         ProbeElapsedSeconds.Dispose();
+        IsEagerProbing.Dispose();
+        EagerProbeElapsedSeconds.Dispose();
         StateVersion.Dispose();
         base.Dispose();
     }

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -39,6 +39,7 @@ public class McpStdioSmokeTests : IAsyncDisposable
         _client = await McpClient.CreateAsync(transport, new McpClientOptions
         {
             ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+            InitializationTimeout = TimeSpan.FromMinutes(3),
         }, cancellationToken: CancellationToken.None);
 
         var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);
@@ -70,6 +71,7 @@ public class McpStdioSmokeTests : IAsyncDisposable
         _client = await McpClient.CreateAsync(transport, new McpClientOptions
         {
             ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+            InitializationTimeout = TimeSpan.FromMinutes(3),
         }, cancellationToken: CancellationToken.None);
 
         var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);
@@ -115,6 +117,7 @@ public class McpStdioSmokeTests : IAsyncDisposable
         _client = await McpClient.CreateAsync(transport, new McpClientOptions
         {
             ClientInfo = new() { Name = "netclaw-smoke-test", Version = "0.1.0" },
+            InitializationTimeout = TimeSpan.FromMinutes(3),
         }, cancellationToken: CancellationToken.None);
 
         var tools = await _client.ListToolsAsync(cancellationToken: CancellationToken.None);


### PR DESCRIPTION
## Summary
- Add CLI model and provider management commands with TUI support
- Redesign Provider Manager TUI to show all known types as dashboard
- Re-probe all providers after add, remove, or fix-credentials
- Inject TextWriter into CLI commands to fix Console.Out race condition in parallel tests

## Changes
- `netclaw provider` — list, add, remove providers with interactive TUI
- `netclaw model` — list, set, discover, clear model roles
- `netclaw mcp` — add, list, get, remove, enable/disable MCP servers
- Provider Manager TUI redesigned as dashboard showing all known provider types
- CLI commands accept `TextWriter? output` parameter to eliminate process-global `Console.SetOut()` race in tests
- Removed `CaptureConsoleOutput` helper and `[Collection("ConsoleOutput")]` serialization from tests

## Test plan
- [x] 116 CLI tests pass across 3 consecutive runs (determinism verified)
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Live CLI smoke tests: `provider list`, `model list`, `mcp list`, and all help commands produce correct output