### PR TITLE
Fix JoinSession race condition in session tests

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -68,13 +68,13 @@ public class CompactionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("compact-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -112,13 +112,13 @@ public class CompactionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("no-compact-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -151,13 +151,13 @@ public class CompactionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("sys-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -207,13 +207,13 @@ public class CompactionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("buffer-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         // First message — triggers turn then compaction
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -266,13 +266,13 @@ public class CompactionIntegrationTests : TestKit
         var subscriber = CreateTestProbe("recover-sub");
 
         // Phase 1: Send message, trigger compaction
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -291,17 +291,17 @@ public class CompactionIntegrationTests : TestKit
         var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
         Watch(child);
         Sys.Stop(child);
-        ExpectTerminated(child);
+        await ExpectTerminatedAsync(child);
 
         // Phase 3: Recover — join again
         var recoverSub = CreateTestProbe("recover-sub-2");
-        sessionManager.Tell(new JoinSession
+        var recovered = await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = recoverSub,
             Filter = OutputFilter.Full
-        });
-        var recovered = recoverSub.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(5));
+        }, TimeSpan.FromSeconds(3));
+        recoverSub.ExpectMsg<SessionJoined>(); // Drain subscriber notification
         Assert.Equal(sessionId, recovered.SessionId);
 
         // Phase 4: Verify session still works after recovery

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -50,20 +50,18 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
-    public void JoinSession_receives_SessionJoined_acknowledgement()
+    public async Task JoinSession_receives_SessionJoined_acknowledgement()
     {
         var sessionId = new SessionId("test-channel/join-test");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("join-probe");
 
-        sessionManager.Tell(new JoinSession
+        var joined = await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.TextOnly
-        });
-
-        var joined = subscriber.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(3));
+        }, TimeSpan.FromSeconds(3));
         Assert.Equal(sessionId, joined.SessionId);
         Assert.Equal(0, joined.TurnCount);
         Assert.Null(joined.Title);
@@ -76,13 +74,13 @@ public class LlmSessionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("adapter-probe");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.TextOnly
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         var ack = await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -111,28 +109,29 @@ public class LlmSessionIntegrationTests : TestKit
         var textAndUsageSub = CreateTestProbe("text-usage");
         var fullSub = CreateTestProbe("full");
 
-        // Three subscribers with different filter bitmasks
-        sessionManager.Tell(new JoinSession
+        // Three subscribers with different filter bitmasks — sequential Ask
+        // ensures each join is fully processed before the next
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = textOnlySub,
             Filter = OutputFilter.TextOnly
-        });
-        sessionManager.Tell(new JoinSession
+        }, TimeSpan.FromSeconds(3));
+        textOnlySub.ExpectMsg<SessionJoined>(); // Drain subscriber notification
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = textAndUsageSub,
             Filter = OutputFilter.TextAndUsage
-        });
-        sessionManager.Tell(new JoinSession
+        }, TimeSpan.FromSeconds(3));
+        textAndUsageSub.ExpectMsg<SessionJoined>(); // Drain subscriber notification
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = fullSub,
             Filter = OutputFilter.Full
-        });
-        textOnlySub.ExpectMsg<SessionJoined>();
-        textAndUsageSub.ExpectMsg<SessionJoined>();
-        fullSub.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        fullSub.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -171,20 +170,20 @@ public class LlmSessionIntegrationTests : TestKit
         var sub1 = CreateTestProbe("adapter-1");
         var sub2 = CreateTestProbe("adapter-2");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = session1,
             Subscriber = sub1,
             Filter = OutputFilter.TextOnly
-        });
-        sessionManager.Tell(new JoinSession
+        }, TimeSpan.FromSeconds(3));
+        sub1.ExpectMsg<SessionJoined>(); // Drain subscriber notification
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = session2,
             Subscriber = sub2,
             Filter = OutputFilter.TextOnly
-        });
-        sub1.ExpectMsg<SessionJoined>();
-        sub2.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        sub2.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -219,13 +218,13 @@ public class LlmSessionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("adapter-batch");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.TextOnly
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         // First message — actor enters Processing
         var ack1 = await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -269,13 +268,13 @@ public class LlmSessionIntegrationTests : TestKit
         var subscriber = CreateTestProbe("recovery-sub");
 
         // Phase 1: Build up state — two completed turns
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.TextOnly
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -299,18 +298,18 @@ public class LlmSessionIntegrationTests : TestKit
         var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
         Watch(child);
         Sys.Stop(child);
-        ExpectTerminated(child);
+        await ExpectTerminatedAsync(child);
 
         // Phase 3: Recover — send JoinSession to the same session ID.
         // GenericChildPerEntityParent creates a new actor that recovers from journal.
         var recoverSub = CreateTestProbe("recovery-sub-2");
-        sessionManager.Tell(new JoinSession
+        var recovered = await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = recoverSub,
             Filter = OutputFilter.TextOnly
-        });
-        var recovered = recoverSub.ExpectMsg<SessionJoined>(TimeSpan.FromSeconds(5));
+        }, TimeSpan.FromSeconds(5));
+        recoverSub.ExpectMsg<SessionJoined>(); // Drain subscriber notification
         Assert.Equal(sessionId, recovered.SessionId);
         Assert.Equal(2, recovered.TurnCount); // Both turns recovered
 

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -75,13 +75,13 @@ public class MaxToolIterationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("max-iter-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -124,13 +124,13 @@ public class MaxToolIterationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("iter-reset-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         // Turn 1: hits the limit at 3
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -178,13 +178,13 @@ public class MaxToolIterationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("normal-tool-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -75,13 +75,13 @@ public class ToolExecutionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("tool-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -130,13 +130,13 @@ public class ToolExecutionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("multi-tool-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -170,13 +170,13 @@ public class ToolExecutionIntegrationTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("error-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -638,12 +638,22 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
             _log.Info("{Subscriber} joined (filter={Filter})", cmd.Subscriber, cmd.Filter);
 
-            cmd.Subscriber.Tell(new SessionJoined
+            var joined = new SessionJoined
             {
                 SessionId = _sessionId,
                 Title = _state.Title,
                 TurnCount = _state.TurnCount
-            });
+            };
+
+            cmd.Subscriber.Tell(joined);
+
+            // Also reply to Sender so callers can use Ask<SessionJoined> for
+            // deterministic confirmation that the join was processed.
+            if (!Sender.IsNobody() && !Equals(Sender, Context.System.DeadLetters)
+                                   && !Equals(Sender, cmd.Subscriber))
+            {
+                Sender.Tell(joined);
+            }
         });
 
         Command<LeaveSession>(cmd =>


### PR DESCRIPTION
## Summary
- LlmSessionActor now replies to `Sender` with `SessionJoined` (in addition to `cmd.Subscriber`), enabling `Ask<SessionJoined>` for deterministic join confirmation
- All 4 session integration test files converted from racy `Tell` + `ExpectMsg<SessionJoined>` to deterministic `Ask<SessionJoined>` pattern
- Also converts sync `ExpectTerminated` to async `ExpectTerminatedAsync` in recovery tests

## Root cause
`JoinSession` was processed via fire-and-forget `Tell`, and tests synchronized on `subscriber.ExpectMsg<SessionJoined>()`. This was racy because the child actor's persistence recovery (`Persist` inside `RecoveryCompleted`) could delay `JoinSession` processing non-deterministically, causing CI failures like the `CompactionIntegrationTests.Buffer_drains_after_compaction` timeout on Windows.

## Test plan
- [x] All 45 session tests pass locally
- [x] `CompactionIntegrationTests` (previously failing) passes deterministically
- [x] `ToolExecutionIntegrationTests` passes
- [x] `MaxToolIterationTests` passes
- [x] `LlmSessionIntegrationTests` passes (including multi-subscriber and recovery scenarios)