### PR TITLE
Add multimodal image pipeline with modality gating and file output

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,8 @@
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
     <PackageVersion Include="Termina" Version="0.7.1" />
+    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
+    <PackageVersion Include="Mime-Detective.Definitions.Condensed" Version="25.8.1" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />

--- a/Netclaw.slnx
+++ b/Netclaw.slnx
@@ -17,5 +17,7 @@
     <Project Path="src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj" />
     <Project Path="src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />
     <Project Path="src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj" />
+    <Project Path="src/Netclaw.Security/Netclaw.Security.csproj" />
+    <Project Path="src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -121,6 +121,8 @@ Named model roles. Each role points to a provider and model ID.
 | `Provider` | string | `"local-ollama"` | Key into the `Providers` dictionary. |
 | `ModelId` | string | `"qwen3:30b"` | Model identifier as used by the provider's API. |
 | `ContextWindow` | int? | `null` | Context window size in tokens. Defaults to 32,768 if not set. Future: auto-discovered from provider. |
+| `InputModalities` | string[]? | `null` | Manual override for input modalities (`"Text"`, `"Image"`, `"Audio"`, `"Video"`). When set, bypasses automated capability detection. |
+| `OutputModalities` | string[]? | `null` | Manual override for output modalities. Same values as `InputModalities`. |
 
 ### Session
 

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/design.md
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/design.md
@@ -1,0 +1,226 @@
+## Context
+
+Netclaw's model layer currently tracks model identity (ID, provider, context
+window) but has no concept of what content types a model accepts or produces.
+The `DiscoveredModel` record has fields for cost and parameter count but nothing
+about modality. The `ProviderProbe` extracts only `ModelId` from provider API
+responses, discarding richer metadata that providers already return.
+
+Meanwhile, the channel edge (`ChannelInput`) already accepts
+`IReadOnlyList<AIContent>`, which is MEAI's multimodal content abstraction.
+The pipeline strips non-text content today. Before we can stop stripping it,
+the system needs to know what the configured model actually supports.
+
+The singleton actor pattern is already established: `SessionManagerActorKey` is
+registered in `ActorRegistry` via `StartActors` and resolved via
+`IRequiredActor<T>` or `ActorRegistry.Get<T>()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Determine input/output modalities for any configured model at runtime.
+- Cache capability lookups in-memory so repeated queries are free.
+- Support all four provider types (Ollama, OpenRouter, Anthropic, OpenAI) with
+  a single query interface.
+- Allow manual override in configuration for models not discoverable through
+  any automated source.
+
+**Non-Goals:**
+
+- Forwarding non-text content through the session pipeline (follow-up change).
+- Persistence of capability data across restarts (in-memory cache rebuilds
+  lazily; capability data is cheap to re-fetch).
+- Real-time capability change detection (models don't change capabilities).
+- Provider-specific behavior in the session actor based on capabilities (the
+  session actor gets flags, not provider details).
+
+## Decisions
+
+### D1: Singleton `ModelCapabilityActor` with in-memory `Dictionary` cache
+
+**Decision**: A single actor per `ActorSystem` owns the capability cache. Other
+actors query it via `Ask<ModelCapabilities>`. The cache is a plain
+`Dictionary<string, ModelCapabilities>` keyed by model ID.
+
+**Rationale**: Actors are the natural concurrency boundary in this codebase. A
+singleton actor avoids concurrent HTTP calls for the same model during startup
+(multiple sessions starting simultaneously). The `ActorRegistry` pattern is
+already proven with `SessionManagerActorKey`.
+
+**Alternatives considered**:
+- **DI singleton service with `ConcurrentDictionary`**: Simpler, but the
+  capability lookup involves async HTTP calls to external APIs. An actor
+  naturally serializes these and can stash duplicate queries while a lookup is
+  in-flight. A service would need manual deduplication with `SemaphoreSlim` or
+  `Lazy<Task<T>>`.
+- **Static cache populated at startup**: Would delay startup while fetching
+  capabilities for all configured models. Lazy per-model lookup is better —
+  most sessions use the same model, so one lookup serves all.
+
+### D2: Three-tier detection hierarchy
+
+**Decision**: When a model's capabilities are not yet cached, resolve them in
+this order:
+
+1. **Provider-native** — If the model's provider supports capability metadata
+   natively, use it:
+   - Ollama: `POST /api/show` → `capabilities` array (e.g., `["completion",
+     "vision"]`)
+   - OpenRouter: already fetched during model listing — `architecture.input_modalities` and `architecture.output_modalities` arrays
+2. **OpenRouter oracle** — For models on providers that don't expose
+   capabilities (Anthropic, OpenAI, GitHub), query OpenRouter's public
+   `GET /api/v1/models` endpoint. Match by model ID (with normalization — see
+   D4). No API key required.
+3. **HuggingFace fallback** — For open-source models not in OpenRouter's
+   catalog, query `GET https://huggingface.co/api/models/{id}` and map
+   `pipeline_tag` to modalities (e.g., `image-text-to-text` →
+   `InputModalities: Text | Image, OutputModalities: Text`).
+4. **Default** — If all lookups fail or are unavailable, default to
+   `InputModalities: Text, OutputModalities: Text`. Log a warning so the
+   operator knows capability detection failed for that model.
+
+**Rationale**: Provider-native data is most authoritative and cheapest (local
+for Ollama, already-fetched for OpenRouter). OpenRouter covers ~400+ models
+across all major providers. HuggingFace covers the long tail of open-source
+models. The default ensures the system never blocks on capability detection.
+
+**Alternatives considered**:
+- **HuggingFace only**: Coverage is excellent for open-source models but
+  inconsistent for proprietary models (Claude, GPT). OpenRouter's structured
+  `input_modalities`/`output_modalities` arrays are more reliable than
+  parsing HuggingFace's `pipeline_tag` taxonomy.
+- **Static table only**: Goes stale, doesn't work for custom/fine-tuned
+  models, requires releases to add new models.
+
+### D3: `ModelModality` as a `[Flags]` enum
+
+**Decision**: Use a `[Flags]` enum for modality representation:
+
+```csharp
+[Flags]
+public enum ModelModality
+{
+    None  = 0,
+    Text  = 1 << 0,
+    Image = 1 << 1,
+    Audio = 1 << 2,
+    Video = 1 << 3,
+}
+```
+
+Capability records carry both `InputModalities` and `OutputModalities` as
+separate `ModelModality` values.
+
+**Rationale**: Flags compose naturally (`Text | Image`), are cheap to test
+(`modalities.HasFlag(ModelModality.Image)`), serialize trivially as integers,
+and are extensible (add `Document = 1 << 4` later without breaking existing
+values).
+
+**Alternatives considered**:
+- **`HashSet<string>`**: More flexible but loses compile-time safety and
+  requires string comparisons. The modality space is small and well-known.
+- **Separate `bool` fields**: `SupportsVision`, `SupportsAudio`, etc. Doesn't
+  compose well and requires new fields for each modality.
+
+### D4: Model ID normalization for cross-provider lookup
+
+**Decision**: When looking up a model via the OpenRouter oracle, normalize the
+model ID to handle provider-specific suffixes and prefixes:
+
+- Strip date suffixes: `claude-sonnet-4-20250514` → `claude-sonnet-4`
+- Map known prefixes: bare `claude-sonnet-4` → `anthropic/claude-sonnet-4`
+- Ollama tag stripping: `llava:latest` → `llava`
+
+Maintain a small normalization table for known provider ID formats. If
+normalization fails to find a match, fall through to the next tier.
+
+**Rationale**: The same model has different IDs across providers. Anthropic uses
+`claude-sonnet-4-20250514`, OpenRouter uses `anthropic/claude-sonnet-4`.
+Without normalization, cross-provider lookup would miss matches.
+
+### D5: Cache populated lazily, never evicted
+
+**Decision**: The cache starts empty. On the first `GetModelCapabilities` query
+for a given model ID, the actor fetches capabilities, caches them, and
+responds. Subsequent queries for the same model ID return immediately from
+cache. Entries are never evicted or refreshed.
+
+**Rationale**: Model capabilities are immutable — providers publish new model
+IDs rather than changing capabilities of existing ones. The cache only grows
+when a new model ID is queried, which happens rarely (model changes are
+infrequent operator actions). Memory footprint is negligible (a few hundred
+bytes per model entry, and operators use a handful of models).
+
+### D6: Capability resolution service behind the actor
+
+**Decision**: Extract the HTTP lookup logic into an `IModelCapabilityResolver`
+service injected via DI. The actor delegates to this service for actual HTTP
+calls. This keeps the actor focused on caching/deduplication and makes the
+resolution logic independently testable.
+
+```
+ModelCapabilityActor (cache + dedup)
+  └── IModelCapabilityResolver (HTTP lookups)
+        ├── OllamaCapabilityResolver
+        ├── OpenRouterOracleResolver
+        └── HuggingFaceCapabilityResolver
+```
+
+**Rationale**: Actor code should be thin. The HTTP parsing logic (mapping
+Ollama's `capabilities` array, OpenRouter's `input_modalities`, HuggingFace's
+`pipeline_tag`) is pure mapping logic that benefits from direct unit testing
+without actor infrastructure.
+
+## Risks / Trade-offs
+
+**[Risk] OpenRouter API availability** → The oracle lookup is a nice-to-have,
+not a hard dependency. If OpenRouter is unreachable, the system falls through
+to HuggingFace and then to `Text`-only default. A 5-second timeout prevents
+blocking. The actor logs the failure and caches the default so it doesn't
+retry on every query.
+
+**[Risk] Model ID normalization misses** → Normalization is heuristic-based.
+Custom fine-tuned models or obscure providers may not match. Mitigation:
+manual override in `ModelReference` config always wins. Log when normalization
+fails so operators can add overrides.
+
+**[Risk] Stale cache after model switch** → If the operator changes the
+configured model (via the parallel model-switching branch), the new model ID
+will trigger a fresh lookup on first query. No cache invalidation needed —
+new ID = new cache entry.
+
+**[Risk] HuggingFace pipeline_tag taxonomy changes** → The mapping from
+`pipeline_tag` values to `ModelModality` flags is a maintained lookup table.
+If HuggingFace adds new tags, we add new mappings. Unmapped tags fall through
+to default.
+
+**[Trade-off] No persistent cache** → Capability data is re-fetched after
+process restart. This is acceptable because: (a) most operators use 1-3
+models, so it's 1-3 HTTP calls; (b) the data is immutable so there's no
+stale-cache risk; (c) avoiding persistence keeps the implementation simple.
+
+## Actor Boundary and Failure Modes
+
+**Actor lifecycle**: The `ModelCapabilityActor` is started in `StartActors`
+alongside `SessionManagerActorKey`. It is a plain actor (no persistence, no
+stash) with a `Dictionary<string, ModelCapabilities>` as state.
+
+**Message protocol**:
+- `GetModelCapabilities(string ModelId)` → query
+- `ModelCapabilities(string ModelId, ModelModality InputModalities, ModelModality OutputModalities)` → response
+- Internal: `CapabilityResolved(string ModelId, ModelCapabilities Result)` for
+  async HTTP completion piping back to the actor
+
+**In-flight deduplication**: If multiple queries arrive for the same model ID
+while a lookup is in progress, the actor stashes duplicates and unstashes them
+when the result arrives — all get the same cached answer.
+
+**Failure recovery**: If the resolver throws (network error, parse error), the
+actor caches `ModelModality.Text` as default for that model ID and logs a
+warning. It does not retry — the operator can restart the process or add a
+manual override if needed. This prevents retry storms against unreachable
+APIs.
+
+**Supervision**: Default supervision strategy (restart on unhandled exception).
+The dictionary cache is lost on restart, which is fine — it rebuilds lazily.

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/proposal.md
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/proposal.md
@@ -1,0 +1,91 @@
+## Why
+
+Netclaw currently treats all model input as text-only. The channel edge
+(`ChannelInput`) already accepts `IReadOnlyList<AIContent>`, but
+`ChannelPipeline.MapToCommand` strips everything except `TextContent` and
+`SendUserMessage.Content` is a plain string. Before we can pass images, audio,
+or other content types through the pipeline, we need to know what the
+configured model actually supports. Without capability detection, we'd either
+silently drop non-text content or send unsupported content types and get
+provider errors at runtime.
+
+This is the foundation for multimodal support — detection first, then plumbing.
+
+## What Changes
+
+- Introduce a `ModelModality` flags enum (`Text`, `Image`, `Audio`, `Video`)
+  representing input and output modalities a model may support.
+- Add `InputModalities` and `OutputModalities` fields to `DiscoveredModel` so
+  capability metadata is captured during model discovery.
+- Create a singleton `ModelCapabilityActor` that maintains an in-memory cache
+  of model capabilities. Other actors query it to determine what a model
+  accepts. The cache refreshes only when a previously-unseen model ID is
+  encountered (model capabilities don't change — new models are published
+  instead).
+- Enrich `ProviderProbe` to extract modality data from provider-native sources:
+  - **Ollama**: `/api/show` returns a `capabilities` array (e.g.,
+    `["completion", "vision"]`).
+  - **OpenRouter**: `/api/v1/models` returns `architecture.input_modalities`
+    and `architecture.output_modalities` arrays.
+- Use **OpenRouter as a capability oracle** for models accessed through any
+  provider. A model's capabilities are intrinsic — Claude supports vision
+  whether accessed via Anthropic, OpenRouter, or GitHub Copilot. The
+  OpenRouter model listing is public (no API key required for reads) and
+  covers most models across all major providers.
+- Add **HuggingFace Hub API** as a fallback for open-source models not listed
+  on OpenRouter, using `pipeline_tag` (e.g., `image-text-to-text`) and model
+  metadata from `/api/models/{id}`.
+- Surface resolved capabilities in `SessionConfig` so the session actor knows
+  what content types it can forward to the LLM.
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-model-capabilities`: Model capability detection, caching, and
+  querying. Covers the `ModelModality` type, the `ModelCapabilityActor`
+  singleton, provider-native detection (Ollama, OpenRouter), cross-provider
+  oracle lookup (OpenRouter public API), HuggingFace fallback, and manual
+  config override.
+
+### Modified Capabilities
+
+- `netclaw-model-providers`: Enrich `DiscoveredModel` with modality fields.
+  Extend `ProviderProbe` to extract capability metadata during model
+  discovery. Add modality awareness to `SessionConfig`.
+
+## Impact
+
+- **`Netclaw.Configuration`**: New `ModelModality` flags enum. New fields on
+  `DiscoveredModel` (`InputModalities`, `OutputModalities`). New optional
+  modality override fields on `ModelReference` for manual config. New fields
+  on `SessionConfig` to surface resolved capabilities to the session actor.
+- **`Netclaw.Actors`**: New `ModelCapabilityActor` — a singleton (one per
+  `ActorSystem`) that owns the in-memory capability cache. Responds to
+  `GetModelCapabilities` queries. Populated lazily on first query per model
+  ID, then cached indefinitely.
+- **`Netclaw.Daemon`**: `ProviderProbe` gains modality extraction logic for
+  Ollama `/api/show` and OpenRouter `/api/v1/models`. New HTTP client
+  integration for OpenRouter oracle and HuggingFace fallback lookups.
+- **`Netclaw.Cli`**: Model listing commands can optionally display supported
+  modalities.
+- **External dependencies**: HTTP calls to OpenRouter `/api/v1/models`
+  (public, no auth) and HuggingFace `/api/models/{id}` (public, no auth) for
+  cross-provider capability lookup. Both are read-only and cacheable.
+- **No breaking changes**: All new fields have sensible defaults
+  (`ModelModality.Text`). Existing configurations continue to work unchanged.
+
+### Out of Scope
+
+- Changing `SendUserMessage.Content` from `string` to `AIContent[]` (follow-up
+  change: multimodal message plumbing).
+- Persisting non-text content in the Protobuf journal (follow-up).
+- Slack image/file extraction and forwarding (follow-up).
+- Image/audio preprocessing or resizing (follow-up).
+
+### PRD References
+
+- PRD-005 (MP-002, MP-003): Provider abstraction and multi-provider support —
+  this change enriches the provider metadata layer.
+- PRD-009 (INPUT-003): Transport agnosticism — capability detection enables
+  adapters to make informed decisions about content forwarding.

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/specs/netclaw-model-capabilities/spec.md
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/specs/netclaw-model-capabilities/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+### Requirement: Model modality type system
+
+The system SHALL represent model capabilities using a `ModelModality` flags
+enum with values `Text`, `Image`, `Audio`, and `Video`. Model capabilities
+SHALL be expressed as a pair of `InputModalities` and `OutputModalities`
+values, each being a combination of `ModelModality` flags.
+
+#### Scenario: Modality flags compose
+
+- **GIVEN** a model that accepts text and images and produces text
+- **WHEN** its capabilities are represented
+- **THEN** `InputModalities` SHALL equal `Text | Image`
+- **AND** `OutputModalities` SHALL equal `Text`
+
+#### Scenario: Default modality is text-only
+
+- **GIVEN** a model whose capabilities cannot be determined
+- **WHEN** the system assigns default capabilities
+- **THEN** `InputModalities` SHALL equal `Text`
+- **AND** `OutputModalities` SHALL equal `Text`
+
+### Requirement: Singleton capability cache actor
+
+The system SHALL maintain a singleton `ModelCapabilityActor` registered in the
+`ActorRegistry`. The actor SHALL maintain an in-memory cache of model
+capabilities keyed by model ID. Other actors SHALL query capabilities via
+`Ask<ModelCapabilities>` using a `GetModelCapabilities` message containing the
+model ID.
+
+#### Scenario: First query triggers lookup
+
+- **GIVEN** the capability cache has no entry for model `anthropic/claude-sonnet-4`
+- **WHEN** an actor sends `GetModelCapabilities("anthropic/claude-sonnet-4")`
+- **THEN** the actor SHALL resolve capabilities from the detection hierarchy
+- **AND** cache the result
+- **AND** respond with `ModelCapabilities` containing the resolved modalities
+
+#### Scenario: Cached query returns immediately
+
+- **GIVEN** the capability cache has an entry for model `qwen3:30b`
+- **WHEN** an actor sends `GetModelCapabilities("qwen3:30b")`
+- **THEN** the actor SHALL respond from cache without external API calls
+
+#### Scenario: Concurrent queries for same model are deduplicated
+
+- **GIVEN** a lookup for model `llava:latest` is in progress
+- **WHEN** additional `GetModelCapabilities("llava:latest")` queries arrive
+- **THEN** the actor SHALL stash duplicate queries
+- **AND** respond to all stashed queries with the same result when the lookup completes
+
+### Requirement: Provider-native capability detection
+
+The system SHALL extract modality data from provider APIs that natively expose
+it, as the highest-priority detection source.
+
+#### Scenario: Ollama capability detection
+
+- **GIVEN** a model is configured on an Ollama provider
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL call `POST /api/show` on the Ollama endpoint
+- **AND** map the `capabilities` array to `ModelModality` flags
+- **AND** `"vision"` in capabilities SHALL map to `InputModalities` including `Image`
+
+#### Scenario: OpenRouter capability detection
+
+- **GIVEN** a model is configured on an OpenRouter provider
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use `architecture.input_modalities` and
+  `architecture.output_modalities` from the OpenRouter model listing
+- **AND** map array values (`"text"`, `"image"`, `"audio"`, `"video"`) to
+  corresponding `ModelModality` flags
+
+### Requirement: OpenRouter oracle for cross-provider lookup
+
+The system SHALL use OpenRouter's public `GET /api/v1/models` endpoint as a
+capability oracle for models accessed through providers that do not expose
+capability metadata (Anthropic, OpenAI). This lookup SHALL NOT require an API
+key.
+
+#### Scenario: Anthropic model resolved via OpenRouter oracle
+
+- **GIVEN** a model `claude-sonnet-4-20250514` is configured on the Anthropic provider
+- **AND** the Anthropic API does not expose modality metadata
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL query OpenRouter's model listing
+- **AND** normalize the model ID for matching (e.g., strip date suffix, add
+  provider prefix)
+- **AND** return capabilities from the matched OpenRouter entry
+
+#### Scenario: OpenRouter oracle unreachable
+
+- **GIVEN** the OpenRouter API is unreachable or times out within 5 seconds
+- **WHEN** capabilities are resolved for a model requiring oracle lookup
+- **THEN** the system SHALL fall through to the next detection tier
+- **AND** log a warning indicating oracle lookup failed
+
+### Requirement: HuggingFace fallback detection
+
+The system SHALL fall back to querying the HuggingFace Hub API at
+`GET https://huggingface.co/api/models/{id}` for models not found via
+provider-native detection or the OpenRouter oracle.
+
+#### Scenario: Open-source model resolved via HuggingFace
+
+- **GIVEN** a model is not found in the OpenRouter catalog
+- **AND** the model has a HuggingFace model ID
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL query the HuggingFace API
+- **AND** map the `pipeline_tag` field to `ModelModality` flags
+- **AND** `"image-text-to-text"` SHALL map to `InputModalities: Text | Image`
+
+#### Scenario: HuggingFace lookup fails
+
+- **GIVEN** the HuggingFace API returns a 404 or is unreachable
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use the default text-only capabilities
+- **AND** log a warning
+
+### Requirement: Model ID normalization
+
+The system SHALL normalize model IDs when performing cross-provider lookups to
+account for provider-specific naming conventions.
+
+#### Scenario: Date suffix stripped for matching
+
+- **GIVEN** a model ID `claude-sonnet-4-20250514`
+- **WHEN** performing an OpenRouter oracle lookup
+- **THEN** the system SHALL attempt matching against `claude-sonnet-4`
+  and `anthropic/claude-sonnet-4`
+
+#### Scenario: Ollama tag stripped for matching
+
+- **GIVEN** a model ID `llava:latest`
+- **WHEN** performing a cross-provider lookup
+- **THEN** the system SHALL attempt matching against `llava`
+
+### Requirement: Manual capability override
+
+The system SHALL allow operators to explicitly declare model capabilities in
+the `ModelReference` configuration. Manual overrides SHALL take precedence
+over all automated detection sources.
+
+#### Scenario: Manual override bypasses detection
+
+- **GIVEN** a `ModelReference` with explicitly configured `InputModalities`
+  and `OutputModalities`
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use the configured values without querying any
+  external API
+
+### Requirement: Capability lookup failure resilience
+
+The system SHALL NOT block session startup or message processing if capability
+detection fails. All detection failures SHALL result in text-only defaults
+with logged warnings.
+
+#### Scenario: All detection tiers fail
+
+- **WHEN** provider-native, OpenRouter oracle, and HuggingFace fallback all
+  fail for a model
+- **THEN** the system SHALL cache `InputModalities: Text, OutputModalities: Text`
+  for that model ID
+- **AND** log a warning with the model ID and failure reasons
+- **AND** the session SHALL proceed normally with text-only behavior

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Multi-provider support
+
+The system SHALL support selecting one provider profile from a supported set.
+All provider interactions SHALL use the Microsoft.Extensions.AI `IChatClient`
+abstraction layer, ensuring provider-agnostic model access throughout the
+application.
+
+Provider model discovery SHALL extract modality metadata where the provider
+API supports it. `DiscoveredModel` records SHALL include `InputModalities`
+and `OutputModalities` fields populated from provider responses.
+
+#### Scenario: Switch provider
+
+- **GIVEN** OpenRouter is configured
+- **WHEN** operator selects Anthropic, OpenAI, or Ollama profile
+- **THEN** runtime uses selected provider through the `IChatClient` interface
+  after validation
+
+#### Scenario: Provider accessed through MEAI abstraction
+
+- **GIVEN** a provider profile is configured
+- **WHEN** the session actor sends a chat completion request
+- **THEN** the request is routed through the `IChatClient` abstraction
+- **AND** no provider-specific types leak into session or actor code
+
+#### Scenario: Ollama discovery includes modality
+
+- **GIVEN** an Ollama provider is configured
+- **WHEN** model discovery runs via `ProviderProbe`
+- **THEN** the returned `DiscoveredModel` records SHALL include
+  `InputModalities` and `OutputModalities` populated from `/api/show`
+  capability data
+
+#### Scenario: OpenRouter discovery includes modality
+
+- **GIVEN** an OpenRouter provider is configured
+- **WHEN** model discovery runs via `ProviderProbe`
+- **THEN** the returned `DiscoveredModel` records SHALL include
+  `InputModalities` and `OutputModalities` populated from
+  `architecture.input_modalities` and `architecture.output_modalities`
+
+### Requirement: Provider diagnostics
+
+The system SHALL expose current provider, model, and model capabilities in
+diagnostics.
+
+#### Scenario: Provider status report
+
+- **WHEN** operator checks status
+- **THEN** diagnostics include provider name, model, and last error state
+
+#### Scenario: Model capabilities in diagnostics
+
+- **WHEN** operator checks status
+- **AND** model capabilities have been resolved
+- **THEN** diagnostics SHALL include the model's input and output modalities
+
+## ADDED Requirements
+
+### Requirement: Session config includes model capabilities
+
+`SessionConfig` SHALL include `InputModalities` and `OutputModalities` fields
+so the session actor knows what content types the configured model supports.
+These fields SHALL default to `ModelModality.Text` when capabilities have not
+been resolved.
+
+#### Scenario: Session config carries modalities
+
+- **GIVEN** model capabilities have been resolved for the configured model
+- **WHEN** a new `SessionConfig` is constructed
+- **THEN** `InputModalities` and `OutputModalities` SHALL reflect the
+  resolved capabilities
+
+#### Scenario: Session config defaults to text
+
+- **GIVEN** model capabilities have not been resolved
+- **WHEN** a new `SessionConfig` is constructed
+- **THEN** `InputModalities` SHALL equal `ModelModality.Text`
+- **AND** `OutputModalities` SHALL equal `ModelModality.Text`

--- a/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/tasks.md
+++ b/openspec/changes/archive/2026-02-28-multimodal-model-capabilities/tasks.md
@@ -1,0 +1,39 @@
+## 1. Core Types
+
+- [x] 1.1 Add `ModelModality` flags enum (`None`, `Text`, `Image`, `Audio`, `Video`) to `Netclaw.Configuration`
+- [x] 1.2 Add `InputModalities` and `OutputModalities` properties to `DiscoveredModel` (default `ModelModality.Text`)
+- [x] 1.3 Add optional `InputModalities` and `OutputModalities` override properties to `ModelReference` for manual config
+- [x] 1.4 Add `InputModalities` and `OutputModalities` properties to `SessionConfig` (default `ModelModality.Text`)
+
+## 2. Capability Resolution
+
+- [x] 2.1 Define `IModelCapabilityResolver` interface with `Task<ResolvedModelCapabilities?> ResolveAsync(string modelId, CancellationToken ct)` in `Netclaw.Configuration`
+- [x] 2.2 Implement `OpenRouterOracleResolver` — calls `GET /api/v1/models` (public, no auth), caches full model list, matches by normalized model ID
+- [x] 2.3 Implement `HuggingFaceCapabilityResolver` — calls `GET https://huggingface.co/api/models/{id}`, maps `pipeline_tag` to `ModelModality` flags
+- [x] 2.4 Implement model ID normalization logic (strip date suffixes, add provider prefixes, strip Ollama `:latest` tags)
+- [x] 2.5 Implement `CompositeCapabilityResolver` that chains resolvers in priority order: OpenRouter oracle → HuggingFace fallback → text-only default
+
+## 3. Capability Cache Actor
+
+- [x] 3.1 Define protocol messages: `GetModelCapabilities`, `ModelCapabilitiesResponse`, internal `CapabilityResolved`
+- [x] 3.2 Implement `ModelCapabilityActor` — singleton actor with `Dictionary<string, ModelCapabilitiesResponse>` cache, lazy lookup, waiting list for in-flight deduplication
+- [x] 3.3 Add `ModelCapabilityActorKey` marker type to `ActorRegistryKeys.cs`
+- [x] 3.4 Register `ModelCapabilityActor` in `NetclawAkkaHostingExtensions.StartActors` alongside session manager
+- [x] 3.5 Register `IModelCapabilityResolver` chain and `HttpClient` dependencies in DI
+
+## 4. Wiring
+
+- [x] 4.1 Pass resolved capabilities through to `SessionConfig` construction
+
+## 5. Testing
+
+- [x] 5.1 Unit test `OpenRouterOracleResolver` with sample model listing JSON (multimodal model, text-only model, model not found)
+- [x] 5.2 Unit test `HuggingFaceCapabilityResolver` with sample model metadata JSON (image-text-to-text, text-generation, 404)
+- [x] 5.3 Unit test model ID normalization (date suffix stripping, provider prefix mapping, Ollama tag stripping)
+- [x] 5.4 Unit test `CompositeCapabilityResolver` fallback chain (oracle succeeds, HuggingFace fallback, all fail → default)
+- [x] 5.5 Actor test `ModelCapabilityActor` — first query triggers lookup, second query returns from cache, concurrent queries are deduplicated
+
+## 6. Schema and Doc Updates
+
+- [x] 6.1 Update JSON config schema with `ModelReference` modality override fields
+- [x] 6.2 Update `docs/spec/configuration.md` with new modality fields

--- a/openspec/changes/multimodal-message-plumbing/.openspec.yaml
+++ b/openspec/changes/multimodal-message-plumbing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-28

--- a/openspec/changes/multimodal-message-plumbing/design.md
+++ b/openspec/changes/multimodal-message-plumbing/design.md
@@ -1,0 +1,220 @@
+## Context
+
+Netclaw's message pipeline is currently string-only end-to-end despite the
+`ChannelInput` abstraction already accepting `IReadOnlyList<AIContent>`. The
+previous change (`multimodal-model-capabilities`) added capability detection,
+so we now know whether a model supports image input. This change wires the
+actual content through.
+
+Key pipeline components and their current state:
+
+- `ChannelInput.Contents` — `IReadOnlyList<AIContent>`, already multimodal-ready
+- `ChannelPipeline.MapToCommand` — extracts `TextContent` only, drops everything else
+- `SendUserMessage.Content` — `string` (Protobuf-persisted)
+- `SerializableChatMessage.Content` — `string` (Protobuf-persisted, event-sourced)
+- `ChatMessageConverter` — handles Text, FunctionCall, FunctionResult only
+- `SessionOutput` — text-only output types
+- `OutputFilter` — no file/media category
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `AIContent[]` flows from `ChannelInput` through to `IChatClient` without
+  lossy string conversion in the middle
+- Images sent by users in Slack reach vision-capable models as `ImageContent`
+- Models that don't support non-text input emit a user-facing acknowledgement
+- The agent can attach files to its output via an `attach_file` tool
+- Channel adapters render file output per their capabilities (Slack upload vs
+  TUI file path)
+- Persistence journal stays compact — file references, not inline binary
+
+**Non-Goals:**
+
+- Audio/video pipeline wiring (modality flags exist, pipeline work deferred)
+- LLM-synthesized image output (DALL-E style)
+- Permanent file storage or cross-session file sharing
+- Image content in compaction summaries (text summary only)
+
+## Decisions
+
+### 1. File-backed media model
+
+**Decision:** All media normalizes to files on disk in the session-scoped temp
+directory. The pipeline carries relative file paths, not binary data.
+
+**Alternatives considered:**
+
+- *Inline base64 in Protobuf*: Simpler round-trip but bloats journal. A 2MB
+  screenshot per turn adds up fast in event-sourced persistence. Rejected.
+- *Content-addressed blob store*: Good for deduplication but over-engineered for
+  MVP single-process host. Can migrate to this later if needed.
+
+**How it works:**
+
+- Inbound (Slack): adapter downloads attachment → writes to
+  `{sessionDir}/media/{guid}.{ext}` → produces `ChannelInput` with file path
+- Outbound (attach_file): file already in session dir → tool validates path →
+  emits `FileOutput`
+- LLM call boundary: `ChatMessageConverter.ToAiMessage` reads file bytes
+  just-in-time to construct MEAI `ImageContent` with `DataContent` property
+- Persistence: `SerializableChatMessage` stores a list of `MediaReference`
+  records (relative path + MIME type + modality) alongside existing `Content`
+  string
+
+File references are ephemeral — they don't survive `/tmp` cleanup. The agent's
+text reasoning about the content persists in conversation history.
+
+### 2. SendUserMessage carries AIContent[]
+
+**Decision:** Add a `Contents` property (`List<SerializableContent>`) to
+`SendUserMessage` alongside the existing `Content` string. The string field
+remains for backward compatibility and carries the text portion. The new field
+carries media references.
+
+**Why not replace Content entirely:** `SendUserMessage` is Protobuf-serialized
+and persisted via event sourcing. Existing journals contain string `Content`.
+Adding a new field (additive Protobuf change) is forward-compatible; removing
+the string field would break recovery of existing sessions.
+
+### 3. SerializableChatMessage gains MediaReferences
+
+**Decision:** Add a `List<SerializableMediaReference>` field to
+`SerializableChatMessage` with Protobuf tag 6. Each reference carries:
+
+- `RelativePath` (string) — path relative to session directory
+- `MimeType` (string) — e.g., `image/png`, `image/jpeg`
+- `Modality` (int) — maps to `ModelModality` enum value
+
+`ChatMessageConverter.ToAiMessage` reads the file at the absolute path
+(session dir + relative path) and constructs the appropriate MEAI content type.
+If the file is missing (e.g., after `/tmp` cleanup), it logs a warning and
+skips the media — the text portion of the message still works.
+
+### 4. Modality gate in session actor
+
+**Decision:** The modality gate runs in `LlmSessionActor` when processing
+`SendUserMessage`, before adding to session state. It compares each content
+item's modality against `SessionConfig.InputModalities`.
+
+Behavior:
+
+1. Separate content into supported and unsupported items
+2. If unsupported items exist, emit a `TextOutput` acknowledgement to
+   subscribers (e.g., "This model doesn't support image input — I can only
+   see the text portion of your message")
+3. Continue processing with supported items only
+4. If ALL content is unsupported (e.g., image-only message to text-only model),
+   emit acknowledgement and skip the LLM call entirely
+
+The gate does not throw or error — it's informational. The session continues
+normally with whatever content the model can handle.
+
+### 5. attach_file tool
+
+**Decision:** `attach_file` is a first-party tool registered in `ToolRegistry`.
+It takes a `path` parameter (string), validates the path is within the session
+directory (path traversal prevention), reads the file metadata, and returns a
+text confirmation to the LLM. As a side effect, it emits a `FileOutput` event
+through the session's broadcast.
+
+**Why a tool, not infrastructure magic:** The agent decides what to share. Tools
+stay text-in/text-out. When a tool (e.g., Playwright screenshot) writes a file
+and returns text mentioning the path, the agent sees this and deliberately calls
+`attach_file` if it wants the user to see the file. This keeps the agent in
+control.
+
+**Implementation:** The tool needs access to the session's subscriber broadcast
+to emit `FileOutput`. This is provided via `ToolExecutionContext` which already
+carries the session ID. The tool emits `FileOutput` through the session actor
+(Tell), which broadcasts to subscribers.
+
+### 6. FileOutput and OutputFilter.Files
+
+**Decision:** Add `FileOutput` as a new `SessionOutput` subtype:
+
+```csharp
+public sealed record FileOutput : SessionOutput
+{
+    public required string FilePath { get; init; }
+    public required string FileName { get; init; }
+    public required string MimeType { get; init; }
+}
+```
+
+Add `Files = 1 << 4` to `OutputFilter`. Update `Full` preset to include it.
+Channel adapters handle `FileOutput`:
+
+- Slack: reads file, calls `files.uploadV2` to attach to thread
+- TUI: prints file path (e.g., `[File: /tmp/.../screenshot.png]`)
+
+### 7. Slack inbound file download
+
+**Decision:** When the Slack adapter receives a message with a `files` array in
+the event payload, it downloads each file using the bot token for
+authentication (`Authorization: Bearer xoxb-...`). Files are written to the
+session media directory and included as media content in `ChannelInput`.
+
+Only supported MIME types are downloaded:
+
+- `image/png`, `image/jpeg`, `image/gif`, `image/webp` — mapped to
+  `ModelModality.Image`
+
+Unsupported file types (PDFs, ZIPs, etc.) are skipped with a debug log. Future
+changes can expand the MIME type allowlist.
+
+Download failures (timeout, auth error, 404) produce a warning log and the file
+is skipped — the text portion of the message still processes normally.
+
+## Risks / Trade-offs
+
+**[Risk] Session temp files lost on reboot** → Accepted for MVP. Media is
+contextual, not archival. The agent's text reasoning persists. Future: could
+move to a persistent blob store.
+
+**[Risk] Large files bloat session directory** → Mitigated by existing
+session cleanup policy. Could add per-file size limit (e.g., 20MB) and total
+session media budget in future.
+
+**[Risk] Slack file download timing** → Slack files may not be immediately
+available after the event fires. Mitigated by retry with short backoff in the
+download step.
+
+**[Risk] Path traversal in attach_file** → Mitigated by validating the
+canonical path starts with the session directory prefix. Reject anything
+outside.
+
+**[Risk] Protobuf schema evolution** → Additive-only change (new fields with
+new tags). Existing journals deserialize correctly — new fields default to
+empty. Forward-compatible.
+
+## Actor Boundaries
+
+- `LlmSessionActor` — owns the modality gate, processes `SendUserMessage`
+  with media references, emits `FileOutput` via subscriber broadcast
+- `SlackThreadBindingActor` — downloads Slack file attachments on inbound,
+  uploads files on `FileOutput` outbound
+- `ModelCapabilityActor` — unchanged, provides capability lookup used by
+  the session actor for modality gate decisions
+
+No new actors are introduced. The `attach_file` tool communicates with the
+session actor via Tell (not Ask) to emit `FileOutput`.
+
+## Failure Modes and Recovery
+
+- **File missing at LLM call time**: `ChatMessageConverter` logs warning, skips
+  media reference, sends text-only message. Session continues.
+- **Slack download fails**: Warning logged, file skipped, text processes
+  normally.
+- **attach_file with invalid path**: Tool returns error text to the LLM
+  ("File not found" or "Path outside session directory").
+- **Session recovery from journal**: Media references in persisted events point
+  to files that may no longer exist. Converter handles gracefully (skip missing
+  files). The text conversation history is intact regardless.
+
+## Open Questions
+
+- Should `attach_file` support attaching multiple files in one call, or should
+  the agent call it once per file?
+- Should there be a configurable per-file size limit for inbound Slack
+  attachments?

--- a/openspec/changes/multimodal-message-plumbing/proposal.md
+++ b/openspec/changes/multimodal-message-plumbing/proposal.md
@@ -1,0 +1,130 @@
+## Why
+
+Source PRDs: PRD-001
+
+Netclaw now detects model modality capabilities (Text, Image, Audio, Video) but
+the message pipeline is string-only end-to-end. Images sent by users in Slack
+are silently discarded at `ChannelPipeline.MapToCommand`. Tool-produced files
+(Playwright screenshots, downloaded documents) can't be shared back to users.
+The agent has no way to send or receive non-text content despite using
+vision-capable models.
+
+## What Changes
+
+- **BREAKING**: `SendUserMessage.Content` changes from `string` to carry
+  `AIContent[]` so non-text content survives the pipeline from channel input to
+  session actor
+- **BREAKING**: `SerializableChatMessage` gains a new Protobuf field for media
+  file references alongside existing `Content` string, enabling persistence of
+  multimodal turns
+- `ChannelPipeline.MapToCommand` passes through all `AIContent` types instead of
+  filtering to `TextContent` only
+- `ChatMessageConverter` reconstructs `ImageContent` (and future media types)
+  from persisted file references at the `IChatClient` boundary
+- New **modality gate** in the session actor: when a user sends content the
+  configured model doesn't support (e.g., image to a text-only model), emit a
+  user-facing acknowledgement instead of silently dropping it
+- New **`attach_file` first-party tool**: the agent calls this to explicitly
+  attach a file from the session directory to its output. Channel adapters
+  render appropriately (Slack: `files.uploadV2`, TUI: print local file path)
+- **Slack inbound adapter** downloads file attachments from Slack's API and
+  writes them to the session-scoped temp directory, producing file-backed
+  `ImageContent` in the `ChannelInput`
+- New **`FileOutput` session output type**: carries a file path and MIME type
+  through the broadcast subscription to channel adapters
+
+### Content model
+
+All media normalizes to **files on disk** in the session-scoped temp directory
+(`/tmp/netclaw-sessions/{sessionId}/`). The pipeline carries file path
+references, not binary data. At the `IChatClient` call boundary, file bytes are
+read just-in-time to construct MEAI `ImageContent`. This keeps the persistence
+journal small, provides a natural security boundary (file paths validated to
+session directory), and gives a consistent model for both inbound (user sends
+image) and outbound (tool produces screenshot) flows.
+
+File references are ephemeral — they don't survive `/tmp` cleanup. The agent's
+text-based reasoning about the content remains in the persisted conversation
+history.
+
+### Modality gate
+
+When the session actor receives content types not supported by the model's
+`InputModalities`, it:
+
+1. Strips the unsupported content from the message
+2. Emits an acknowledgement to the user (e.g., "This model doesn't support
+   image input — I can only see the text portion of your message")
+3. Continues processing any supported content normally
+
+### attach_file tool
+
+The agent decides when to share files with the user — tools stay text-in/text-out.
+When a tool writes a file (e.g., Playwright screenshot), the tool result text
+mentions the path. The agent sees this and calls `attach_file(path)` to
+explicitly attach it to the output. The tool validates the path is within the
+session directory, reads MIME type, and produces a `FileOutput` event in the
+broadcast. Channel adapters render per their capabilities.
+
+### Channel adapter rendering
+
+Each channel adapter renders `FileOutput` according to its capabilities:
+
+- **Slack**: calls `files.uploadV2` to attach the file to the thread
+- **TUI**: prints the local file path (potentially as a clickable `file://` URI)
+- **Future web UI**: could inline the image or serve from a local endpoint
+
+The agent doesn't know or care which channel it's talking to.
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-multimodal-pipeline`: Multimodal content flow through the message
+  pipeline — `AIContent[]` transport, file-backed media persistence, modality
+  gate, and `FileOutput` broadcast type
+- `netclaw-file-attachment`: `attach_file` first-party tool for agent-initiated
+  file sharing with channel-adapter-specific rendering
+
+### Modified Capabilities
+
+- `netclaw-session`: Session actor gains modality gate behavior and `FileOutput`
+  emission; `SerializableChatMessage` gains media file reference field;
+  `ChatMessageConverter` handles multimodal content reconstruction
+- `netclaw-slack-socket`: Slack adapter gains file attachment download (inbound)
+  and `files.uploadV2` upload (outbound via `FileOutput`)
+- `netclaw-input-adapters`: `SendUserMessage` changes from string to `AIContent[]`
+  content; channel pipeline passes through non-text content
+- `netclaw-tools`: Tool registry gains `attach_file` first-party tool definition
+
+## In Scope (MVP)
+
+- Image input (user → vision model) via Slack file attachments
+- Image/file output (agent → user) via `attach_file` tool
+- Modality gate with user-facing acknowledgement
+- Slack and TUI channel adapter support
+- File-backed persistence model
+
+## Out of Scope
+
+- Audio/video content handling (future — modality flags support it, pipeline doesn't yet)
+- LLM-synthesized images (DALL-E style output modalities)
+- Cross-session file sharing or permanent file storage
+- File content in context compaction summaries (text summary only)
+
+## Impact
+
+- **Persistence format**: `SerializableChatMessage` Protobuf schema changes
+  (additive — new field for file references). Existing journals remain compatible.
+- **Protocol**: `SendUserMessage` content type changes from `string` to
+  `AIContent[]`. All channel adapters and tests that construct this message must
+  update.
+- **Session output**: New `FileOutput` type added to `SessionOutput` hierarchy
+  and `OutputFilter` flags.
+- **Dependencies**: Slack file download requires authenticated HTTP calls using
+  the bot token (already available in Slack config).
+- **Security**: `attach_file` validates file paths are within session directory
+  to prevent path traversal. Slack file downloads validated against allowed
+  channels/users per existing ACL.
+- **Disk usage**: Session temp directories accumulate media files. Existing
+  cleanup-on-session-end policy applies.

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-file-attachment/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-file-attachment/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: attach_file first-party tool
+
+The system SHALL provide an `attach_file` first-party tool that the agent
+calls to explicitly share a file with the user. The tool SHALL validate the
+file path, read metadata, and emit a `FileOutput` event through the session
+broadcast.
+
+#### Scenario: Agent attaches a screenshot
+
+- **GIVEN** a tool has written a file to the session directory
+- **AND** the agent sees the file path in the tool result text
+- **WHEN** the agent calls `attach_file` with the file path
+- **THEN** the tool SHALL validate the path is within the session directory
+- **AND** emit a `FileOutput` event with the file path, name, and MIME type
+- **AND** return a text confirmation to the agent (e.g., "Attached: screenshot.png")
+
+#### Scenario: Path traversal rejected
+
+- **GIVEN** the agent calls `attach_file` with a path outside the session
+  directory (e.g., `/etc/passwd`)
+- **WHEN** the tool validates the path
+- **THEN** the tool SHALL return an error message to the agent
+- **AND** SHALL NOT emit a `FileOutput` event
+- **AND** SHALL NOT read the file
+
+#### Scenario: File not found
+
+- **GIVEN** the agent calls `attach_file` with a path that does not exist
+- **WHEN** the tool validates the path
+- **THEN** the tool SHALL return an error message to the agent indicating
+  the file was not found
+
+### Requirement: Channel-specific file rendering
+
+Channel adapters SHALL render `FileOutput` events according to their
+capabilities. The agent SHALL NOT need to know which channel is active.
+
+#### Scenario: Slack uploads file to thread
+
+- **GIVEN** the Slack adapter receives a `FileOutput` event
+- **WHEN** rendering the output for the Slack thread
+- **THEN** the adapter SHALL call `files.uploadV2` to attach the file to the
+  thread
+- **AND** use the bot token for authentication
+
+#### Scenario: TUI prints file path
+
+- **GIVEN** the TUI adapter receives a `FileOutput` event
+- **WHEN** rendering the output for the terminal
+- **THEN** the adapter SHALL print the local file path for the user

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: Transport-agnostic session commands
+
+All input adapters SHALL produce `SendUserMessage` as the universal command
+contract for delivering input to session actors. Session actors SHALL never
+reference adapter-specific types. The `SendUserMessage` command SHALL carry
+both text content and media file references so that non-text content from any
+adapter can reach the session actor. Broadcast events SHALL be the only
+contract between adapters and session actors.
+
+#### Scenario: Slack adapter produces SendUserMessage
+
+- **GIVEN** a Slack `app_mention` event is received
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the message content, entity key, and source
+  metadata
+
+#### Scenario: Slack adapter produces SendUserMessage with image
+
+- **GIVEN** a Slack `app_mention` event is received with file attachments
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter downloads supported image attachments to the session
+  media directory
+- **AND** the `SendUserMessage` command contains both text content and media
+  file references
+
+#### Scenario: Timer adapter produces SendUserMessage
+
+- **GIVEN** an Akka timer fires for a scheduled task
+- **WHEN** the timer adapter processes the tick
+- **THEN** the adapter produces a `SendUserMessage` command
+- **AND** the command contains the task instruction as message content
+
+#### Scenario: Session actor is adapter-agnostic
+
+- **GIVEN** a session actor receives a `SendUserMessage` command
+- **WHEN** the session processes the turn
+- **THEN** the session actor does not import or reference any adapter-specific
+  types
+- **AND** the session behavior is identical regardless of the originating
+  adapter
+
+### Requirement: Broadcast subscription for reply delivery
+
+Input adapters SHALL subscribe to session broadcast events to deliver replies
+back through the originating channel. Adapters SHALL consume broadcast events
+through pub/sub without direct transport coupling to session actors. Adapters
+SHALL handle `FileOutput` events according to their channel capabilities.
+
+#### Scenario: Slack adapter receives reply broadcast
+
+- **GIVEN** the Slack adapter is subscribed to session broadcasts
+- **WHEN** a session actor emits a turn broadcast with a reply
+- **THEN** the Slack adapter receives the broadcast
+- **AND** delivers the reply to the originating Slack thread
+
+#### Scenario: Slack adapter receives FileOutput broadcast
+
+- **GIVEN** the Slack adapter is subscribed to session broadcasts
+- **WHEN** a session actor emits a `FileOutput` event
+- **THEN** the Slack adapter SHALL upload the file to the Slack thread using
+  `files.uploadV2`
+
+#### Scenario: TUI adapter receives FileOutput broadcast
+
+- **GIVEN** the TUI adapter is subscribed to session broadcasts
+- **WHEN** a session actor emits a `FileOutput` event
+- **THEN** the TUI adapter SHALL print the local file path to the terminal
+
+#### Scenario: Timer result broadcast consumed by Slack adapter
+
+- **GIVEN** a scheduled task session completes with results
+- **WHEN** the session emits a result broadcast
+- **THEN** the Slack adapter receives the broadcast
+- **AND** posts the results to the task's configured reporting channel
+
+#### Scenario: Multiple adapters can subscribe to same session
+
+- **GIVEN** both a Slack adapter and a future UI adapter are running
+- **WHEN** a session emits a broadcast
+- **THEN** both adapters receive the broadcast independently
+- **AND** each adapter delivers through its own channel

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-multimodal-pipeline/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-multimodal-pipeline/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: AIContent pipeline transport
+
+The message pipeline SHALL carry `AIContent[]` from channel input through to
+the `IChatClient` call boundary. Non-text content items (images, file
+references) SHALL NOT be silently discarded at any pipeline stage.
+
+#### Scenario: Image content reaches vision model
+
+- **GIVEN** a user sends a message with text and an attached image
+- **AND** the configured model supports `InputModalities` including `Image`
+- **WHEN** the message is processed through the pipeline
+- **THEN** the `IChatClient` SHALL receive a `ChatMessage` containing both
+  `TextContent` and `ImageContent` items
+
+#### Scenario: Text-only message unchanged
+
+- **GIVEN** a user sends a text-only message
+- **WHEN** the message is processed through the pipeline
+- **THEN** behavior SHALL be identical to the existing text-only pipeline
+
+### Requirement: File-backed media persistence
+
+Media content SHALL be persisted as file references (relative path + MIME type)
+in `SerializableChatMessage`, not as inline binary data. File bytes SHALL be
+read just-in-time at the `IChatClient` call boundary.
+
+#### Scenario: Image persisted as file reference
+
+- **GIVEN** a user message includes an image
+- **WHEN** the message is persisted to the event journal
+- **THEN** the `SerializableChatMessage` SHALL contain a `MediaReference` with
+  the file's relative path and MIME type
+- **AND** the journal entry SHALL NOT contain inline image bytes
+
+#### Scenario: Missing file at recovery
+
+- **GIVEN** a persisted message references a media file that no longer exists
+- **WHEN** the session recovers from the journal
+- **THEN** `ChatMessageConverter` SHALL log a warning and skip the missing media
+- **AND** the text portion of the message SHALL be preserved
+- **AND** session processing SHALL continue normally
+
+### Requirement: Modality gate
+
+The session actor SHALL compare inbound content modalities against
+`SessionConfig.InputModalities` before processing. Unsupported content SHALL
+be stripped with a user-facing acknowledgement.
+
+#### Scenario: Image sent to text-only model
+
+- **GIVEN** a model with `InputModalities` equal to `Text` only
+- **WHEN** a user sends a message containing an image
+- **THEN** the session actor SHALL strip the image content
+- **AND** emit a `TextOutput` acknowledgement to subscribers explaining the
+  model does not support image input
+- **AND** continue processing the text portion of the message normally
+
+#### Scenario: Image-only message to text-only model
+
+- **GIVEN** a model with `InputModalities` equal to `Text` only
+- **WHEN** a user sends a message containing only an image with no text
+- **THEN** the session actor SHALL emit a `TextOutput` acknowledgement
+- **AND** SHALL NOT invoke the LLM (no processable content)
+
+#### Scenario: All content supported
+
+- **GIVEN** a model with `InputModalities` including `Text` and `Image`
+- **WHEN** a user sends a message with text and an image
+- **THEN** all content SHALL pass through without acknowledgement
+
+### Requirement: FileOutput broadcast
+
+The session actor SHALL support emitting `FileOutput` events through the
+subscriber broadcast for files the agent wants to share with the user.
+
+#### Scenario: FileOutput delivered to subscribers
+
+- **GIVEN** a subscriber with `OutputFilter` including `Files`
+- **WHEN** the session actor emits a `FileOutput`
+- **THEN** the subscriber SHALL receive the event containing the file path,
+  file name, and MIME type
+
+#### Scenario: FileOutput filtered when not subscribed
+
+- **GIVEN** a subscriber with `OutputFilter` not including `Files`
+- **WHEN** the session actor emits a `FileOutput`
+- **THEN** the subscriber SHALL NOT receive the event

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-session/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-session/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Persisted turn lifecycle
+
+The system SHALL persist each completed turn and emit typed output events to
+subscribers. Subscriber delivery SHALL use a direct subscription model with
+`OutputFilter` bitmask so that subscribers control which output categories they
+receive (Text, Thinking, ToolCalls, Usage, Files). Lifecycle events
+(TurnCompleted, ErrorOutput, SessionTitleOutput) SHALL always be delivered
+regardless of filter.
+
+#### Scenario: Persist and emit assistant reply
+
+- **WHEN** the assistant produces a response
+- **THEN** a `TurnRecorded` event is persisted
+- **AND** typed output events are emitted to subscribers based on their filter
+
+#### Scenario: Multi-subscriber filtered delivery
+
+- **GIVEN** multiple subscribers with different OutputFilter bitmasks
+- **WHEN** a turn completes with text, thinking, usage data, and file attachments
+- **THEN** each subscriber receives only the output categories matching their
+  filter
+- **AND** all subscribers receive lifecycle events regardless of filter
+
+#### Scenario: FileOutput delivered to file-subscribed subscribers
+
+- **GIVEN** a subscriber with `OutputFilter` including `Files`
+- **WHEN** the session actor emits a `FileOutput`
+- **THEN** the subscriber SHALL receive the event containing the file path,
+  file name, and MIME type
+
+## ADDED Requirements
+
+### Requirement: Multimodal message persistence
+
+`SerializableChatMessage` SHALL support persisting media file references
+alongside text content. Media SHALL be stored as relative file paths with MIME
+type metadata, not as inline binary data.
+
+#### Scenario: User message with image persisted
+
+- **GIVEN** a user sends a message with text and an attached image
+- **WHEN** the message is persisted to the event journal
+- **THEN** the `SerializableChatMessage` SHALL contain the text in `Content`
+- **AND** SHALL contain a `MediaReference` with the image file's relative path
+  and MIME type
+
+#### Scenario: Chat message converter reconstructs image content
+
+- **GIVEN** a persisted `SerializableChatMessage` contains media references
+- **WHEN** `ChatMessageConverter.ToAiMessage` converts it for the LLM call
+- **THEN** the converter SHALL read the file bytes from disk
+- **AND** construct MEAI `ImageContent` with the binary data
+- **AND** include both `TextContent` and `ImageContent` in the resulting
+  `ChatMessage`
+
+#### Scenario: Missing media file handled gracefully
+
+- **GIVEN** a persisted message references a media file that no longer exists
+- **WHEN** `ChatMessageConverter.ToAiMessage` attempts to read the file
+- **THEN** the converter SHALL log a warning
+- **AND** skip the missing media reference
+- **AND** include only the text content in the `ChatMessage`
+
+### Requirement: Modality gate
+
+The session actor SHALL compare inbound content modalities against
+`SessionConfig.InputModalities` before adding content to session state.
+Unsupported content SHALL be stripped with a user-facing acknowledgement
+emitted to subscribers.
+
+#### Scenario: Image sent to text-only model
+
+- **GIVEN** a model with `InputModalities` equal to `Text` only
+- **WHEN** a user sends a message containing text and an image
+- **THEN** the session actor SHALL strip the image content
+- **AND** emit a `TextOutput` acknowledgement explaining the model does not
+  support image input
+- **AND** continue processing the text portion normally
+
+#### Scenario: Image-only message to text-only model
+
+- **GIVEN** a model with `InputModalities` equal to `Text` only
+- **WHEN** a user sends a message containing only an image with no text
+- **THEN** the session actor SHALL emit a `TextOutput` acknowledgement
+- **AND** SHALL NOT invoke the LLM
+
+#### Scenario: All content supported passes through
+
+- **GIVEN** a model with `InputModalities` including `Text` and `Image`
+- **WHEN** a user sends a message with text and an image
+- **THEN** all content SHALL pass through without acknowledgement
+- **AND** the LLM SHALL receive both text and image content

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-slack-socket/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-slack-socket/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Slack file attachment download
+
+The Slack adapter SHALL download file attachments from Slack messages and
+write them to the session-scoped media directory. Only supported image MIME
+types SHALL be downloaded. The bot token SHALL be used for authenticated
+download.
+
+#### Scenario: Image attachment downloaded
+
+- **GIVEN** a Slack message event includes a `files` array with an image
+  attachment (MIME type `image/png`, `image/jpeg`, `image/gif`, or
+  `image/webp`)
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter SHALL download the file using the bot token for
+  authentication
+- **AND** write the file to the session media directory
+- **AND** include a media file reference in the `ChannelInput`
+
+#### Scenario: Unsupported file type skipped
+
+- **GIVEN** a Slack message event includes a file attachment with an
+  unsupported MIME type (e.g., `application/pdf`)
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter SHALL skip the file
+- **AND** log a debug message indicating the unsupported file type
+
+#### Scenario: File download failure handled
+
+- **GIVEN** a Slack message event includes a supported image attachment
+- **AND** the file download fails (timeout, auth error, or 404)
+- **WHEN** the Slack adapter processes the event
+- **THEN** the adapter SHALL log a warning with the failure reason
+- **AND** skip the failed file
+- **AND** continue processing the text portion of the message
+
+### Requirement: Slack file upload for outbound media
+
+The Slack adapter SHALL upload files to Slack threads when it receives
+`FileOutput` events from the session broadcast.
+
+#### Scenario: FileOutput triggers Slack upload
+
+- **GIVEN** the Slack adapter receives a `FileOutput` event
+- **WHEN** the adapter processes the event
+- **THEN** the adapter SHALL call `files.uploadV2` to attach the file to the
+  originating Slack thread
+- **AND** use the bot token for authentication
+
+#### Scenario: Upload failure logged
+
+- **GIVEN** the Slack adapter receives a `FileOutput` event
+- **AND** the file upload to Slack fails
+- **WHEN** the adapter processes the event
+- **THEN** the adapter SHALL log a warning with the failure reason
+- **AND** the session SHALL continue normally

--- a/openspec/changes/multimodal-message-plumbing/specs/netclaw-tools/spec.md
+++ b/openspec/changes/multimodal-message-plumbing/specs/netclaw-tools/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: attach_file first-party tool
+
+The system SHALL provide an `attach_file` first-party tool that allows the
+agent to explicitly share files from the session directory with the user. The
+tool SHALL validate file paths for security, read file metadata, and emit a
+`FileOutput` event through the session broadcast.
+
+#### Scenario: Agent attaches a file
+
+- **GIVEN** a file exists in the session directory
+- **WHEN** the agent calls `attach_file` with the file path
+- **THEN** the tool SHALL validate the path is within the session directory
+- **AND** emit a `FileOutput` event with the file path, name, and MIME type
+- **AND** return a text confirmation to the agent
+
+#### Scenario: Path traversal rejected
+
+- **GIVEN** the agent calls `attach_file` with a path outside the session
+  directory (e.g., `/etc/passwd` or `../../sensitive-file`)
+- **WHEN** the tool validates the path
+- **THEN** the tool SHALL return an error message to the agent
+- **AND** SHALL NOT emit a `FileOutput` event
+- **AND** SHALL NOT access the file
+
+#### Scenario: File not found
+
+- **GIVEN** the agent calls `attach_file` with a path that does not exist
+  within the session directory
+- **WHEN** the tool validates the path
+- **THEN** the tool SHALL return an error message indicating the file was not
+  found
+
+#### Scenario: Tool registered at startup
+
+- **WHEN** the Netclaw process starts
+- **THEN** the `attach_file` tool SHALL be registered as an MEAI tool
+  definition
+- **AND** the tool definition SHALL include name, description, and parameter
+  schema

--- a/openspec/changes/multimodal-message-plumbing/tasks.md
+++ b/openspec/changes/multimodal-message-plumbing/tasks.md
@@ -1,0 +1,95 @@
+## 1. Persistence Types
+
+- [ ] 1.1 Add `SerializableMediaReference` record to `SerializableChatMessage.cs` with `RelativePath`, `MimeType`, and `Modality` Protobuf fields
+- [ ] 1.2 Add `List<SerializableMediaReference>` property to `SerializableChatMessage` at Protobuf tag 6
+- [ ] 1.3 Add media references list to `SendUserMessage` at a new Protobuf tag alongside existing `Content` string
+
+## 2. ChatMessageConverter
+
+- [ ] 2.1 Update `ChatMessageConverter.ToAiMessage` to read media reference files from disk and produce `ImageContent` items in the `ChatMessage`
+- [ ] 2.2 Handle missing files gracefully in `ToAiMessage` — log warning, skip media, preserve text
+- [ ] 2.3 Update `ChatMessageConverter.FromAiMessage` to extract `ImageContent` and produce `SerializableMediaReference` entries
+- [ ] 2.4 Unit test round-trip: `SerializableChatMessage` with media references → `ChatMessage` with `ImageContent` → back to serializable
+
+## 3. Pipeline Plumbing
+
+- [ ] 3.1 Update `ChannelPipeline.MapToCommand` to pass through all `AIContent` types — extract text to `Content` string AND convert non-text items to media references
+- [ ] 3.2 Add `FileOutput` record to `SessionOutput.cs` with `FilePath`, `FileName`, and `MimeType` properties
+- [ ] 3.3 Add `Files = 1 << 4` to `OutputFilter` flags and update `Full` preset to include it
+
+## 4. Modality Gate
+
+- [ ] 4.1 Add modality gate logic in `LlmSessionActor` `SendUserMessage` handler — compare content modalities against `SessionConfig.InputModalities`
+- [ ] 4.2 Emit `TextOutput` acknowledgement when unsupported content is stripped
+- [ ] 4.3 Skip LLM call when ALL content is unsupported (image-only message to text-only model)
+- [ ] 4.4 Integration test: image sent to text-only model emits acknowledgement and processes text
+- [ ] 4.5 Integration test: image sent to vision model passes through without acknowledgement
+
+## 5. attach_file Tool
+
+- [ ] 5.1 Implement `AttachFileTool` first-party tool — validates path within session directory, reads MIME type, emits `FileOutput` via session actor
+- [ ] 5.2 Path traversal prevention: canonicalize path and verify it starts with session directory prefix
+- [ ] 5.3 Register `attach_file` in `ToolRegistry` at startup
+- [ ] 5.4 Unit test: valid path within session dir returns confirmation and emits FileOutput
+- [ ] 5.5 Unit test: path traversal attempt returns error, no FileOutput emitted
+- [ ] 5.6 Unit test: nonexistent file returns error
+
+## 6. Slack Inbound (File Download)
+
+- [ ] 6.1 Extend `SlackThreadBindingActor` (or its inbound processing) to detect `files` array in Slack message events
+- [ ] 6.2 Download supported image MIME types (`image/png`, `image/jpeg`, `image/gif`, `image/webp`) using bot token authentication; call `IContentScanner.ScanAsync()` on downloaded bytes before writing to disk
+- [ ] 6.3 Write downloaded files to session media directory (`{sessionDir}/media/{guid}.{ext}`)
+- [ ] 6.4 Include media file references in `ChannelInput.Contents` as appropriate `AIContent` items
+- [ ] 6.5 Skip unsupported MIME types with debug log
+- [ ] 6.6 Handle download failures gracefully — warn log, skip file, continue with text
+
+## 7. Slack Outbound (File Upload)
+
+- [ ] 7.1 Handle `FileOutput` events in the Slack adapter's output rendering — call `files.uploadV2` with bot token
+- [ ] 7.2 Handle upload failures gracefully — warn log, session continues
+
+## 8. TUI Outbound
+
+- [ ] 8.1 Handle `FileOutput` events in TUI adapter — print local file path to terminal
+
+## 9. Testing
+
+- [ ] 9.1 Integration test: full pipeline — `ChannelInput` with image → `SendUserMessage` with media ref → session state → `IChatClient` receives `ImageContent`
+- [ ] 9.2 Integration test: `FakeChatClient` receives both `TextContent` and `ImageContent` in message list for vision model
+- [ ] 9.3 Integration test: `attach_file` tool call emits `FileOutput` to subscriber
+- [ ] 9.4 Serialization round-trip test: `SerializableChatMessage` with `MediaReferences` survives Protobuf serialize/deserialize
+
+## 10. Existing Test Updates
+
+- [ ] 10.1 Update existing integration tests that construct `SendUserMessage` to account for new media references field (additive, should be backward-compatible)
+
+## 11. Content Security Project
+
+- [x] 11.1 Create `Netclaw.Security` project with `Netclaw.Configuration` dependency and `Mime-Detective` package
+- [x] 11.2 Add `IContentScanner` interface — `Task<ContentScanResult> ScanAsync(ReadOnlyMemory<byte>, string, string, CancellationToken)`
+- [x] 11.3 Add `IPromptInjectionDetector` stub interface for future webhook scenarios
+- [x] 11.4 Add `ContentScanResult` record with `IsAllowed`, `Error`, `DetectedMimeType`, `Message`
+- [x] 11.5 Add `ContentScanError` enum — `UnrecognizedFileType`, `MimeTypeMismatch`, `ExecutableContent`, `EmptyContent`, `FileTooLarge`, `AntivirusDetection`, `ScanFailure`
+- [x] 11.6 Add `PromptInjectionResult` record with `Risk` and `PromptInjectionRisk` enum
+- [x] 11.7 Add `MimeType` value object — NO implicit string conversion, use `.Value`
+- [x] 11.8 Add `MagicByteValidator` — magic byte detection using Mime-Detective, executable signature rejection, image-focused allowlist (png, jpeg, gif, webp)
+- [x] 11.9 Add `FilenameSanitizer` — path traversal prevention, double-extension checks, control char stripping
+- [x] 11.10 Add `ContentPolicy` — configurable allowed MIME types, max file size (default 20MB)
+- [x] 11.11 Add `NullContentScanner` — no-op pass-through scanner as default
+- [x] 11.12 Add `NullPromptInjectionDetector` — no-op pass-through detector
+- [x] 11.13 Add `SecurityServiceExtensions.AddContentSecurity()` DI registration
+- [x] 11.14 Add `IContentScanner` to `SlackGatewayDependencies` record
+- [x] 11.15 Add `IContentScanner` to `SlackChannel` constructor and pass to dependencies
+- [x] 11.16 Wire `AddContentSecurity()` in `Program.cs` DI
+- [x] 11.17 Add projects to `Netclaw.slnx`, `Mime-Detective` to `Directory.Packages.props`
+- [x] 11.18 Add `Netclaw.Security` project reference to `Netclaw.Channels.csproj`
+
+## 12. Content Security Tests
+
+- [x] 12.1 Create `Netclaw.Security.Tests` project
+- [x] 12.2 `MagicByteValidatorTests` — PNG/JPEG/GIF/WebP pass with valid magic bytes
+- [x] 12.3 `MagicByteValidatorTests` — executable bytes rejected (EXE, ELF, shebang)
+- [x] 12.4 `MagicByteValidatorTests` — MIME type mismatch rejected, unknown extension rejected, file too large rejected
+- [x] 12.5 `FilenameSanitizerTests` — path traversal variants stripped
+- [x] 12.6 `FilenameSanitizerTests` — double-extension detection, control chars, long names
+- [x] 12.7 `NullScannerTests` — NullContentScanner and NullPromptInjectionDetector pass-through

--- a/openspec/specs/netclaw-model-capabilities/spec.md
+++ b/openspec/specs/netclaw-model-capabilities/spec.md
@@ -1,0 +1,173 @@
+# netclaw-model-capabilities Specification
+
+## Purpose
+
+Define model capability detection, caching, and modality representation for
+multimodal LLM support.
+
+## Requirements
+
+### Requirement: Model modality type system
+
+The system SHALL represent model capabilities using a `ModelModality` flags
+enum with values `Text`, `Image`, `Audio`, and `Video`. Model capabilities
+SHALL be expressed as a pair of `InputModalities` and `OutputModalities`
+values, each being a combination of `ModelModality` flags.
+
+#### Scenario: Modality flags compose
+
+- **GIVEN** a model that accepts text and images and produces text
+- **WHEN** its capabilities are represented
+- **THEN** `InputModalities` SHALL equal `Text | Image`
+- **AND** `OutputModalities` SHALL equal `Text`
+
+#### Scenario: Default modality is text-only
+
+- **GIVEN** a model whose capabilities cannot be determined
+- **WHEN** the system assigns default capabilities
+- **THEN** `InputModalities` SHALL equal `Text`
+- **AND** `OutputModalities` SHALL equal `Text`
+
+### Requirement: Singleton capability cache actor
+
+The system SHALL maintain a singleton `ModelCapabilityActor` registered in the
+`ActorRegistry`. The actor SHALL maintain an in-memory cache of model
+capabilities keyed by model ID. Other actors SHALL query capabilities via
+`Ask<ModelCapabilities>` using a `GetModelCapabilities` message containing the
+model ID.
+
+#### Scenario: First query triggers lookup
+
+- **GIVEN** the capability cache has no entry for model `anthropic/claude-sonnet-4`
+- **WHEN** an actor sends `GetModelCapabilities("anthropic/claude-sonnet-4")`
+- **THEN** the actor SHALL resolve capabilities from the detection hierarchy
+- **AND** cache the result
+- **AND** respond with `ModelCapabilities` containing the resolved modalities
+
+#### Scenario: Cached query returns immediately
+
+- **GIVEN** the capability cache has an entry for model `qwen3:30b`
+- **WHEN** an actor sends `GetModelCapabilities("qwen3:30b")`
+- **THEN** the actor SHALL respond from cache without external API calls
+
+#### Scenario: Concurrent queries for same model are deduplicated
+
+- **GIVEN** a lookup for model `llava:latest` is in progress
+- **WHEN** additional `GetModelCapabilities("llava:latest")` queries arrive
+- **THEN** the actor SHALL stash duplicate queries
+- **AND** respond to all stashed queries with the same result when the lookup completes
+
+### Requirement: Provider-native capability detection
+
+The system SHALL extract modality data from provider APIs that natively expose
+it, as the highest-priority detection source.
+
+#### Scenario: Ollama capability detection
+
+- **GIVEN** a model is configured on an Ollama provider
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL call `POST /api/show` on the Ollama endpoint
+- **AND** map the `capabilities` array to `ModelModality` flags
+- **AND** `"vision"` in capabilities SHALL map to `InputModalities` including `Image`
+
+#### Scenario: OpenRouter capability detection
+
+- **GIVEN** a model is configured on an OpenRouter provider
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use `architecture.input_modalities` and
+  `architecture.output_modalities` from the OpenRouter model listing
+- **AND** map array values (`"text"`, `"image"`, `"audio"`, `"video"`) to
+  corresponding `ModelModality` flags
+
+### Requirement: OpenRouter oracle for cross-provider lookup
+
+The system SHALL use OpenRouter's public `GET /api/v1/models` endpoint as a
+capability oracle for models accessed through providers that do not expose
+capability metadata (Anthropic, OpenAI). This lookup SHALL NOT require an API
+key.
+
+#### Scenario: Anthropic model resolved via OpenRouter oracle
+
+- **GIVEN** a model `claude-sonnet-4-20250514` is configured on the Anthropic provider
+- **AND** the Anthropic API does not expose modality metadata
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL query OpenRouter's model listing
+- **AND** normalize the model ID for matching (e.g., strip date suffix, add
+  provider prefix)
+- **AND** return capabilities from the matched OpenRouter entry
+
+#### Scenario: OpenRouter oracle unreachable
+
+- **GIVEN** the OpenRouter API is unreachable or times out within 5 seconds
+- **WHEN** capabilities are resolved for a model requiring oracle lookup
+- **THEN** the system SHALL fall through to the next detection tier
+- **AND** log a warning indicating oracle lookup failed
+
+### Requirement: HuggingFace fallback detection
+
+The system SHALL fall back to querying the HuggingFace Hub API at
+`GET https://huggingface.co/api/models/{id}` for models not found via
+provider-native detection or the OpenRouter oracle.
+
+#### Scenario: Open-source model resolved via HuggingFace
+
+- **GIVEN** a model is not found in the OpenRouter catalog
+- **AND** the model has a HuggingFace model ID
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL query the HuggingFace API
+- **AND** map the `pipeline_tag` field to `ModelModality` flags
+- **AND** `"image-text-to-text"` SHALL map to `InputModalities: Text | Image`
+
+#### Scenario: HuggingFace lookup fails
+
+- **GIVEN** the HuggingFace API returns a 404 or is unreachable
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use the default text-only capabilities
+- **AND** log a warning
+
+### Requirement: Model ID normalization
+
+The system SHALL normalize model IDs when performing cross-provider lookups to
+account for provider-specific naming conventions.
+
+#### Scenario: Date suffix stripped for matching
+
+- **GIVEN** a model ID `claude-sonnet-4-20250514`
+- **WHEN** performing an OpenRouter oracle lookup
+- **THEN** the system SHALL attempt matching against `claude-sonnet-4`
+  and `anthropic/claude-sonnet-4`
+
+#### Scenario: Ollama tag stripped for matching
+
+- **GIVEN** a model ID `llava:latest`
+- **WHEN** performing a cross-provider lookup
+- **THEN** the system SHALL attempt matching against `llava`
+
+### Requirement: Manual capability override
+
+The system SHALL allow operators to explicitly declare model capabilities in
+the `ModelReference` configuration. Manual overrides SHALL take precedence
+over all automated detection sources.
+
+#### Scenario: Manual override bypasses detection
+
+- **GIVEN** a `ModelReference` with explicitly configured `InputModalities`
+  and `OutputModalities`
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL use the configured values without querying any
+  external API
+
+### Requirement: Capability lookup failure resilience
+
+The system SHALL NOT block session startup or message processing if capability
+detection fails. All detection failures SHALL result in text-only defaults
+with logged warnings.
+
+#### Scenario: All detection tiers fail
+
+- **WHEN** provider-native, OpenRouter oracle, and HuggingFace fallback all
+  fail for a model
+- **THEN** the system SHALL cache `InputModalities: Text, OutputModalities: Text`
+  for that model ID
+- **AND** log a warning with the model ID and failure reasons
+- **AND** the session SHALL proceed normally with text-only behavior

--- a/openspec/specs/netclaw-model-providers/spec.md
+++ b/openspec/specs/netclaw-model-providers/spec.md
@@ -22,6 +22,10 @@ All provider interactions SHALL use the Microsoft.Extensions.AI `IChatClient`
 abstraction layer, ensuring provider-agnostic model access throughout the
 application.
 
+Provider model discovery SHALL extract modality metadata where the provider
+API supports it. `DiscoveredModel` records SHALL include `InputModalities`
+and `OutputModalities` fields populated from provider responses.
+
 #### Scenario: Switch provider
 
 - **GIVEN** OpenRouter is configured
@@ -35,6 +39,22 @@ application.
 - **WHEN** the session actor sends a chat completion request
 - **THEN** the request is routed through the `IChatClient` abstraction
 - **AND** no provider-specific types leak into session or actor code
+
+#### Scenario: Ollama discovery includes modality
+
+- **GIVEN** an Ollama provider is configured
+- **WHEN** model discovery runs via `ProviderProbe`
+- **THEN** the returned `DiscoveredModel` records SHALL include
+  `InputModalities` and `OutputModalities` populated from `/api/show`
+  capability data
+
+#### Scenario: OpenRouter discovery includes modality
+
+- **GIVEN** an OpenRouter provider is configured
+- **WHEN** model discovery runs via `ProviderProbe`
+- **THEN** the returned `DiscoveredModel` records SHALL include
+  `InputModalities` and `OutputModalities` populated from
+  `architecture.input_modalities` and `architecture.output_modalities`
 
 ### Requirement: Optional live smoke provider checks
 
@@ -74,12 +94,19 @@ The system SHALL validate required credentials and model settings per provider.
 
 ### Requirement: Provider diagnostics
 
-The system SHALL expose current provider and model in diagnostics.
+The system SHALL expose current provider, model, and model capabilities in
+diagnostics.
 
 #### Scenario: Provider status report
 
 - **WHEN** operator checks status
 - **THEN** diagnostics include provider name, model, and last error state
+
+#### Scenario: Model capabilities in diagnostics
+
+- **WHEN** operator checks status
+- **AND** model capabilities have been resolved
+- **THEN** diagnostics SHALL include the model's input and output modalities
 
 ### Requirement: Primary and fallback model
 
@@ -128,3 +155,24 @@ is aware of available tools and their capabilities.
 - **WHEN** the system prompt is assembled
 - **THEN** tool metadata (names, descriptions, parameter schemas) is included
   in the prompt context
+
+### Requirement: Session config includes model capabilities
+
+`SessionConfig` SHALL include `InputModalities` and `OutputModalities` fields
+so the session actor knows what content types the configured model supports.
+These fields SHALL default to `ModelModality.Text` when capabilities have not
+been resolved.
+
+#### Scenario: Session config carries modalities
+
+- **GIVEN** model capabilities have been resolved for the configured model
+- **WHEN** a new `SessionConfig` is constructed
+- **THEN** `InputModalities` and `OutputModalities` SHALL reflect the
+  resolved capabilities
+
+#### Scenario: Session config defaults to text
+
+- **GIVEN** model capabilities have not been resolved
+- **WHEN** a new `SessionConfig` is constructed
+- **THEN** `InputModalities` SHALL equal `ModelModality.Text`
+- **AND** `OutputModalities` SHALL equal `ModelModality.Text`

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels.Slack;
+using Netclaw.Security;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -141,6 +142,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
             BotUserId: "UBOT",
             DefaultChannelId: null,
             ReplyClient: new NoopReplyClient(),
+            ContentScanner: new NullContentScanner(),
             ConversationPropsFactory: conversationPropsFactory,
             ThreadPropsFactory: threadPropsFactory);
     }

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -201,5 +201,8 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     {
         public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
+
+        public Task UploadFileToThreadAsync(string channelId, string threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -205,4 +205,170 @@ public class ChatMessageConverterTests
         Assert.Single(msg.ToolCalls);
         Assert.Equal("web_search", msg.ToolCalls[0].Name);
     }
+
+    // ── Media / DataContent round-trip tests ──
+
+    [Fact]
+    public void FromAiMessage_writes_DataContent_to_session_dir_and_produces_media_reference()
+    {
+        using var tempDir = new TempSessionDir();
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }; // PNG header
+        var contents = new List<AIContent>
+        {
+            new TextContent("Check this image"),
+            new DataContent(imageBytes, "image/png")
+        };
+        var ai = new AiChatMessage(AiChatRole.User, contents);
+
+        var msg = ChatMessageConverter.FromAiMessage(ai, sessionDir: tempDir.Path);
+
+        Assert.Equal("Check this image", msg.Content);
+        Assert.Single(msg.MediaReferences);
+        Assert.Equal("image/png", msg.MediaReferences[0].MimeType);
+        Assert.Equal((int)MediaModality.Image, msg.MediaReferences[0].Modality);
+        Assert.EndsWith(".png", msg.MediaReferences[0].RelativePath);
+
+        // Verify file was written to disk
+        var filePath = Path.Combine(tempDir.Path, "media", msg.MediaReferences[0].RelativePath);
+        Assert.True(File.Exists(filePath));
+        Assert.Equal(imageBytes, File.ReadAllBytes(filePath));
+    }
+
+    [Fact]
+    public void ToAiMessage_reads_media_files_and_produces_DataContent()
+    {
+        using var tempDir = new TempSessionDir();
+        var imageBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // JPEG header
+        var mediaDir = Path.Combine(tempDir.Path, "media");
+        Directory.CreateDirectory(mediaDir);
+        File.WriteAllBytes(Path.Combine(mediaDir, "test.jpg"), imageBytes);
+
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = "Look at this",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "test.jpg",
+                    MimeType = "image/jpeg",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        };
+
+        var ai = ChatMessageConverter.ToAiMessage(msg, sessionDir: tempDir.Path);
+
+        Assert.Equal(AiChatRole.User, ai.Role);
+        var textContent = Assert.Single(ai.Contents.OfType<TextContent>());
+        Assert.Equal("Look at this", textContent.Text);
+        var dataContent = Assert.Single(ai.Contents.OfType<DataContent>());
+        Assert.Equal("image/jpeg", dataContent.MediaType);
+        Assert.Equal(imageBytes, dataContent.Data.ToArray());
+    }
+
+    [Fact]
+    public void Full_media_round_trip_through_converter()
+    {
+        using var tempDir = new TempSessionDir();
+        var imageBytes = new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }; // GIF89a header
+
+        // Step 1: AI message with DataContent → SerializableChatMessage
+        var originalAi = new AiChatMessage(AiChatRole.User, new List<AIContent>
+        {
+            new TextContent("Here is a gif"),
+            new DataContent(imageBytes, "image/gif")
+        });
+        var serializable = ChatMessageConverter.FromAiMessage(originalAi, sessionDir: tempDir.Path);
+        Assert.Single(serializable.MediaReferences);
+
+        // Step 2: SerializableChatMessage → AI message (reads file back)
+        var reconstructed = ChatMessageConverter.ToAiMessage(serializable, sessionDir: tempDir.Path);
+
+        var text = Assert.Single(reconstructed.Contents.OfType<TextContent>());
+        Assert.Equal("Here is a gif", text.Text);
+        var data = Assert.Single(reconstructed.Contents.OfType<DataContent>());
+        Assert.Equal("image/gif", data.MediaType);
+        Assert.Equal(imageBytes, data.Data.ToArray());
+    }
+
+    [Fact]
+    public void ToAiMessage_skips_missing_media_files_gracefully()
+    {
+        using var tempDir = new TempSessionDir();
+
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = "Image was deleted",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "nonexistent.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        };
+
+        var ai = ChatMessageConverter.ToAiMessage(msg, sessionDir: tempDir.Path);
+
+        // Text content should still be present, but no DataContent
+        Assert.Equal("Image was deleted", ai.Text);
+        Assert.Empty(ai.Contents.OfType<DataContent>());
+    }
+
+    [Fact]
+    public void FromAiMessage_ignores_empty_DataContent()
+    {
+        using var tempDir = new TempSessionDir();
+        var contents = new List<AIContent>
+        {
+            new TextContent("No actual data"),
+            new DataContent(Array.Empty<byte>(), "image/png")
+        };
+        var ai = new AiChatMessage(AiChatRole.User, contents);
+
+        var msg = ChatMessageConverter.FromAiMessage(ai, sessionDir: tempDir.Path);
+
+        Assert.Equal("No actual data", msg.Content);
+        Assert.Empty(msg.MediaReferences);
+    }
+
+    [Fact]
+    public void MimeToExtension_maps_common_types()
+    {
+        Assert.Equal(".png", ChatMessageConverter.MimeToExtension("image/png"));
+        Assert.Equal(".jpg", ChatMessageConverter.MimeToExtension("image/jpeg"));
+        Assert.Equal(".gif", ChatMessageConverter.MimeToExtension("image/gif"));
+        Assert.Equal(".webp", ChatMessageConverter.MimeToExtension("image/webp"));
+        Assert.Equal(".mp3", ChatMessageConverter.MimeToExtension("audio/mpeg"));
+        Assert.Equal(".bin", ChatMessageConverter.MimeToExtension("application/octet-stream"));
+    }
+
+    [Fact]
+    public void MimeToModality_classifies_correctly()
+    {
+        Assert.Equal(MediaModality.Image, ChatMessageConverter.MimeToModality("image/png"));
+        Assert.Equal(MediaModality.Image, ChatMessageConverter.MimeToModality("image/jpeg"));
+        Assert.Equal(MediaModality.Audio, ChatMessageConverter.MimeToModality("audio/mpeg"));
+        Assert.Equal(MediaModality.Video, ChatMessageConverter.MimeToModality("video/mp4"));
+    }
+
+    /// <summary>Disposable temp directory for session media tests.</summary>
+    private sealed class TempSessionDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+
+        public TempSessionDir() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
 }

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -152,6 +152,84 @@ public sealed class SerializationRoundTripTests
     }
 
     [Fact]
+    public void SerializableChatMessage_round_trips_with_media_references()
+    {
+        var original = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = "Check this image",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "abc123.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                },
+                new SerializableMediaReference
+                {
+                    RelativePath = "def456.jpg",
+                    MimeType = "image/jpeg",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(ChatRole.User, result.Role);
+        Assert.Equal("Check this image", result.Content);
+        Assert.Equal(2, result.MediaReferences.Count);
+        Assert.Equal("abc123.png", result.MediaReferences[0].RelativePath);
+        Assert.Equal("image/png", result.MediaReferences[0].MimeType);
+        Assert.Equal((int)MediaModality.Image, result.MediaReferences[0].Modality);
+        Assert.Equal("def456.jpg", result.MediaReferences[1].RelativePath);
+        Assert.Equal("image/jpeg", result.MediaReferences[1].MimeType);
+    }
+
+    [Fact]
+    public void SendUserMessage_round_trips_with_media_references()
+    {
+        var original = new SendUserMessage
+        {
+            SessionId = new SessionId("C99999/1708531200.000100"),
+            Content = "Look at this",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "photo.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal("Look at this", result.Content);
+        Assert.Single(result.MediaReferences);
+        Assert.Equal("photo.png", result.MediaReferences[0].RelativePath);
+    }
+
+    [Fact]
+    public void SerializableChatMessage_round_trips_without_media_references()
+    {
+        // Verify backward compatibility — messages without media still work
+        var original = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = "Just text"
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal("Just text", result.Content);
+        Assert.Empty(result.MediaReferences);
+    }
+
+    [Fact]
     public void CompactionBroadcast_round_trips()
     {
         var ts = new DateTimeOffset(2026, 2, 21, 11, 0, 1, TimeSpan.Zero);

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -43,6 +43,7 @@ public class CompactionIntegrationTests : TestKit
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
         services.AddSingleton<IMemoryExtractor>(_fakeMemoryExtractor);
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
     }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)

--- a/src/Netclaw.Actors.Tests/Sessions/FakeCapabilityResolver.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/FakeCapabilityResolver.cs
@@ -1,0 +1,14 @@
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Fake resolver for tests — always returns text-only capabilities.
+/// </summary>
+internal sealed class FakeCapabilityResolver : IModelCapabilityResolver
+{
+    public Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId, CancellationToken ct = default)
+        => Task.FromResult<ResolvedModelCapabilities?>(
+            new ResolvedModelCapabilities(modelId, ModelModality.Text, ModelModality.Text));
+}

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -39,6 +39,7 @@ public class LlmSessionIntegrationTests : TestKit
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
     }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -49,6 +49,7 @@ public class MaxToolIterationTests : TestKit
             AIFunctionFactory.Create(() => "search result", "web_search"),
             "web_search");
         services.AddSingleton(registry);
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
     }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -1,0 +1,209 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Configuration;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Tests the modality gate in <see cref="LlmSessionActor"/>:
+/// images sent to a text-only model are stripped; images sent to a vision model pass through.
+/// </summary>
+public class ModalityGateTextOnlyTests : TestKit
+{
+    private readonly FakeChatClient _fakeChatClient = new();
+
+    public ModalityGateTextOnlyTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
+        services.AddSingleton(new SessionConfig
+        {
+            ModelId = "text-only-model",
+            ContextWindowTokens = 128_000,
+            InputModalities = ModelModality.Text // no Image flag
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
+            "You are a test assistant."));
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Image_with_text_strips_images_and_sends_text_to_llm()
+    {
+        var sessionId = new SessionId("test-channel/modality-text-only");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("modality-sub");
+
+        sessionManager.Tell(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        });
+        subscriber.ExpectMsg<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "What is in this picture?",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "photo.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        }, TimeSpan.FromSeconds(5));
+
+        // Should receive the "images removed" acknowledgement
+        var ack = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("Images removed", ack.Text);
+
+        // The LLM should still be called with the text content
+        var textOutput = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("fake", textOutput.Text, StringComparison.OrdinalIgnoreCase);
+
+        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // LLM was called (text was sent through despite images being stripped)
+        Assert.Equal(1, _fakeChatClient.CallCount);
+    }
+
+    [Fact]
+    public async Task Image_only_message_skips_llm_call_entirely()
+    {
+        var sessionId = new SessionId("test-channel/modality-image-only");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("modality-image-only-sub");
+
+        sessionManager.Tell(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        });
+        subscriber.ExpectMsg<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "", // no text content
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "photo.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        }, TimeSpan.FromSeconds(5));
+
+        // Should receive the "images removed" acknowledgement first
+        var stripped = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("Images removed", stripped.Text);
+
+        // Then the "only images" explanation
+        var explanation = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("only images", explanation.Text, StringComparison.OrdinalIgnoreCase);
+
+        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // LLM was NOT called
+        Assert.Equal(0, _fakeChatClient.CallCount);
+    }
+}
+
+/// <summary>
+/// Tests that a vision-capable model accepts image references without stripping them.
+/// </summary>
+public class ModalityGateVisionTests : TestKit
+{
+    private readonly FakeChatClient _fakeChatClient = new();
+
+    public ModalityGateVisionTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
+        services.AddSingleton(new SessionConfig
+        {
+            ModelId = "vision-model",
+            ContextWindowTokens = 128_000,
+            InputModalities = ModelModality.Text | ModelModality.Image // supports vision
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
+            "You are a test assistant."));
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Image_passes_through_to_vision_model()
+    {
+        var sessionId = new SessionId("test-channel/modality-vision");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("vision-sub");
+
+        sessionManager.Tell(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        });
+        subscriber.ExpectMsg<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Describe this image",
+            MediaReferences =
+            {
+                new SerializableMediaReference
+                {
+                    RelativePath = "photo.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                }
+            }
+        }, TimeSpan.FromSeconds(5));
+
+        // Should NOT receive an "images removed" acknowledgement — go straight to LLM response
+        var textOutput = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("fake", textOutput.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Images removed", textOutput.Text);
+
+        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // LLM was called
+        Assert.Equal(1, _fakeChatClient.CallCount);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
@@ -1,0 +1,112 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public class ModelCapabilityActorTests : TestKit
+{
+    private readonly ControllableResolver _resolver = new();
+
+    public ModelCapabilityActorTests(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IModelCapabilityResolver>(_resolver);
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithModelCapabilityCache();
+    }
+
+    [Fact]
+    public async Task FirstQuery_TriggersLookup_ReturnsCachedResult()
+    {
+        _resolver.SetResult("vision-model",
+            new ResolvedModelCapabilities("vision-model",
+                ModelModality.Text | ModelModality.Image, ModelModality.Text));
+
+        var capActor = ActorRegistry.Get<ModelCapabilityActorKey>();
+        var result = await capActor.Ask<ModelCapabilitiesResponse>(
+            new GetModelCapabilities("vision-model"), TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+        Assert.Equal(1, _resolver.CallCount);
+    }
+
+    [Fact]
+    public async Task SecondQuery_ReturnsCachedWithoutLookup()
+    {
+        _resolver.SetResult("cached-model",
+            new ResolvedModelCapabilities("cached-model",
+                ModelModality.Text | ModelModality.Audio, ModelModality.Text));
+
+        var capActor = ActorRegistry.Get<ModelCapabilityActorKey>();
+
+        // First query
+        await capActor.Ask<ModelCapabilitiesResponse>(
+            new GetModelCapabilities("cached-model"), TimeSpan.FromSeconds(5));
+
+        // Second query — should come from cache
+        var result = await capActor.Ask<ModelCapabilitiesResponse>(
+            new GetModelCapabilities("cached-model"), TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ModelModality.Text | ModelModality.Audio, result.InputModalities);
+        Assert.Equal(1, _resolver.CallCount); // only called once
+    }
+
+    [Fact]
+    public async Task ResolverFails_DefaultsToTextOnly()
+    {
+        _resolver.SetThrow("failing-model", new HttpRequestException("Network error"));
+
+        var capActor = ActorRegistry.Get<ModelCapabilityActorKey>();
+        var result = await capActor.Ask<ModelCapabilitiesResponse>(
+            new GetModelCapabilities("failing-model"), TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    /// <summary>
+    /// Test resolver that returns preconfigured results per model ID.
+    /// </summary>
+    private sealed class ControllableResolver : IModelCapabilityResolver
+    {
+        private readonly Dictionary<string, ResolvedModelCapabilities> _results = new();
+        private readonly Dictionary<string, Exception> _errors = new();
+        private int _callCount;
+
+        public int CallCount => _callCount;
+
+        public void SetResult(string modelId, ResolvedModelCapabilities result)
+            => _results[modelId] = result;
+
+        public void SetThrow(string modelId, Exception ex)
+            => _errors[modelId] = ex;
+
+        public Task<ResolvedModelCapabilities?> ResolveAsync(
+            string modelId, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _callCount);
+
+            if (_errors.TryGetValue(modelId, out var ex))
+                throw ex;
+
+            _results.TryGetValue(modelId, out var result);
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -49,6 +49,7 @@ public class ToolExecutionIntegrationTests : TestKit
             AIFunctionFactory.Create(() => "search result", "web_search"),
             "web_search");
         services.AddSingleton(registry);
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
     }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -1,0 +1,148 @@
+using Netclaw.Actors.Tools;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class AttachFileToolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly AttachFileTool _tool = new();
+
+    public AttachFileToolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Valid_file_within_session_directory_succeeds()
+    {
+        var filePath = Path.Combine(_tempDir, "report.png");
+        await File.WriteAllBytesAsync(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("File attached", result);
+        Assert.Contains("report.png", result);
+        Assert.Contains("image/png", result);
+    }
+
+    [Fact]
+    public async Task Path_traversal_attempt_is_rejected()
+    {
+        // Create a file outside the session directory
+        var outsidePath = Path.Combine(Path.GetTempPath(), $"netclaw-outside-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(outsidePath, "sensitive data");
+
+        try
+        {
+            var context = new ToolExecutionContext("test-session", _tempDir);
+            var args = new Dictionary<string, object?>
+            {
+                ["Path"] = outsidePath
+            };
+
+            var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+            Assert.Contains("Error", result);
+            Assert.Contains("session directory", result);
+        }
+        finally
+        {
+            File.Delete(outsidePath);
+        }
+    }
+
+    [Fact]
+    public async Task Dotdot_traversal_is_rejected()
+    {
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = Path.Combine(_tempDir, "..", "..", "etc", "passwd")
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("session directory", result);
+    }
+
+    [Fact]
+    public async Task Missing_file_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "nonexistent.png");
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("not found", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Empty_path_returns_error()
+    {
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = ""
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("Error", result);
+    }
+
+    [Fact]
+    public async Task No_session_directory_returns_error()
+    {
+        var context = new ToolExecutionContext("test-session", null);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = "/tmp/anything.png"
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("session directory", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Display_name_is_used_when_provided()
+    {
+        var filePath = Path.Combine(_tempDir, "abc123.png");
+        await File.WriteAllBytesAsync(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["DisplayName"] = "My Custom Report.png"
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("File attached", result);
+        // FilenameSanitizer will clean the display name
+        Assert.Contains("My Custom Report.png", result);
+    }
+}

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -157,17 +157,48 @@ public sealed class SessionPipeline
             killSwitch);
     }
 
-    private SendUserMessage MapToCommand(
+    private static SendUserMessage MapToCommand(
         ChannelInput input, SessionId sessionId, SessionPipelineOptions options)
     {
-        // Extract text content from AIContent list (multi-modal future enhancement)
         var textParts = input.Contents.OfType<TextContent>().Select(t => t.Text);
         var content = string.Join("\n", textParts);
+
+        // Convert DataContent items to SerializableMediaReferences, writing bytes to session media dir
+        var mediaRefs = new List<SerializableMediaReference>();
+        var dataContents = input.Contents.OfType<DataContent>().ToList();
+        if (dataContents.Count > 0)
+        {
+            var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId);
+            var mediaDir = Path.Combine(sessionDir, "media");
+            Directory.CreateDirectory(mediaDir);
+
+            foreach (var data in dataContents)
+            {
+                var bytes = data.Data.ToArray();
+                if (bytes.Length == 0)
+                    continue;
+
+                var mimeType = data.MediaType ?? "application/octet-stream";
+                var ext = ChatMessageConverter.MimeToExtension(mimeType);
+                var fileName = $"{Guid.NewGuid():N}{ext}";
+                var fullPath = Path.Combine(mediaDir, fileName);
+
+                File.WriteAllBytes(fullPath, bytes);
+
+                mediaRefs.Add(new SerializableMediaReference
+                {
+                    RelativePath = fileName,
+                    MimeType = mimeType,
+                    Modality = (int)ChatMessageConverter.MimeToModality(mimeType)
+                });
+            }
+        }
 
         return new SendUserMessage
         {
             SessionId = sessionId,
             Content = content,
+            MediaReferences = mediaRefs,
             Source = new MessageSource
             {
                 ChannelType = options.ChannelType,

--- a/src/Netclaw.Actors/Hosting/ActorRegistryKeys.cs
+++ b/src/Netclaw.Actors/Hosting/ActorRegistryKeys.cs
@@ -5,3 +5,8 @@ namespace Netclaw.Actors.Hosting;
 /// (GenericChildPerEntityParent routing to LlmSessionActors).
 /// </summary>
 public sealed class SessionManagerActorKey;
+
+/// <summary>
+/// Marker type for ActorRegistry lookup of the model capability cache actor.
+/// </summary>
+public sealed class ModelCapabilityActorKey;

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -1,4 +1,5 @@
 using Akka.Actor;
+using Akka.DependencyInjection;
 using Akka.Hosting;
 using Netclaw.Actors.Routing;
 using Netclaw.Actors.Sessions;
@@ -27,6 +28,23 @@ public static class NetclawAkkaHostingExtensions
     }
 
     /// <summary>
+    /// Registers the model capability cache as a singleton actor.
+    /// Requires <see cref="Netclaw.Configuration.IModelCapabilityResolver"/>
+    /// to be registered in DI.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithModelCapabilityCache(
+        this AkkaConfigurationBuilder builder)
+    {
+        return builder.StartActors((system, registry, resolver) =>
+        {
+            var capabilityActor = system.ActorOf(
+                resolver.Props<ModelCapabilityActor>(),
+                "model-capabilities");
+            registry.Register<ModelCapabilityActorKey>(capabilityActor);
+        });
+    }
+
+    /// <summary>
     /// Convenience method that registers all Netclaw actor infrastructure.
     /// Requires <see cref="SessionConfig"/> and <see cref="Microsoft.Extensions.AI.IChatClient"/>
     /// to be registered in DI.
@@ -34,6 +52,8 @@ public static class NetclawAkkaHostingExtensions
     public static AkkaConfigurationBuilder WithNetclawActors(
         this AkkaConfigurationBuilder builder)
     {
-        return builder.WithSessionManager();
+        return builder
+            .WithModelCapabilityCache()
+            .WithSessionManager();
     }
 }

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
+    <ProjectReference Include="..\Netclaw.Security\Netclaw.Security.csproj" />
     <ProjectReference Include="..\Netclaw.Tools.Abstractions\Netclaw.Tools.Abstractions.csproj" />
     <ProjectReference Include="..\Netclaw.Tools.Generators\Netclaw.Tools.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 
@@ -12,7 +13,7 @@ namespace Netclaw.Actors.Protocol;
 /// </summary>
 public static class ChatMessageConverter
 {
-    public static AiChatMessage ToAiMessage(SerializableChatMessage msg)
+    public static AiChatMessage ToAiMessage(SerializableChatMessage msg, string? sessionDir = null, ILogger? logger = null)
     {
         var role = msg.Role switch
         {
@@ -53,15 +54,42 @@ public static class ChatMessageConverter
             return new AiChatMessage(role, contents);
         }
 
+        // Build contents list, including media references if present
+        if (msg.MediaReferences.Count > 0 && sessionDir is not null)
+        {
+            var contents = new List<AIContent>();
+            if (!string.IsNullOrEmpty(msg.Content))
+                contents.Add(new TextContent(msg.Content));
+
+            foreach (var media in msg.MediaReferences)
+            {
+                var fullPath = Path.Combine(sessionDir, "media", media.RelativePath);
+                if (!File.Exists(fullPath))
+                {
+                    logger?.LogWarning("Media file not found, skipping: {Path}", fullPath);
+                    continue;
+                }
+
+                var bytes = File.ReadAllBytes(fullPath);
+                contents.Add(new DataContent(bytes, media.MimeType));
+            }
+
+            if (contents.Count > 0)
+                return new AiChatMessage(role, contents);
+        }
+
         return new AiChatMessage(role, msg.Content);
     }
 
-    public static List<AiChatMessage> ToAiMessages(IEnumerable<SerializableChatMessage> messages)
+    public static List<AiChatMessage> ToAiMessages(
+        IEnumerable<SerializableChatMessage> messages,
+        string? sessionDir = null,
+        ILogger? logger = null)
     {
-        return messages.Select(ToAiMessage).ToList();
+        return messages.Select(m => ToAiMessage(m, sessionDir, logger)).ToList();
     }
 
-    public static SerializableChatMessage FromAiMessage(AiChatMessage msg)
+    public static SerializableChatMessage FromAiMessage(AiChatMessage msg, string? sessionDir = null)
     {
         var role = msg.Role == AiChatRole.User ? ChatRole.User
             : msg.Role == AiChatRole.Assistant ? ChatRole.Assistant
@@ -102,16 +130,71 @@ public static class ChatMessageConverter
                     result.ToolCallId = toolResult.CallId;
                     result.Content = toolResult.Result?.ToString() ?? string.Empty;
                     break;
+
+                case DataContent data when sessionDir is not null:
+                    var mediaRef = WriteMediaToSession(data, sessionDir);
+                    if (mediaRef is not null)
+                        result.MediaReferences.Add(mediaRef);
+                    break;
             }
         }
 
         // Fallback: if no structured content was found, use .Text
         if (string.IsNullOrEmpty(result.Content) && result.ToolCalls.Count == 0
-            && result.ToolCallId is null)
+            && result.ToolCallId is null && result.MediaReferences.Count == 0)
         {
             result.Content = msg.Text ?? string.Empty;
         }
 
         return result;
+    }
+
+    private static SerializableMediaReference? WriteMediaToSession(DataContent data, string sessionDir)
+    {
+        var mediaDir = Path.Combine(sessionDir, "media");
+        Directory.CreateDirectory(mediaDir);
+
+        var mimeType = data.MediaType ?? "application/octet-stream";
+        var ext = MimeToExtension(mimeType);
+        var fileName = $"{Guid.NewGuid():N}{ext}";
+        var fullPath = Path.Combine(mediaDir, fileName);
+
+        var bytes = data.Data.ToArray();
+        if (bytes.Length == 0)
+            return null;
+
+        File.WriteAllBytes(fullPath, bytes);
+
+        var modality = MimeToModality(mimeType);
+        return new SerializableMediaReference
+        {
+            RelativePath = fileName,
+            MimeType = mimeType,
+            Modality = (int)modality
+        };
+    }
+
+    internal static string MimeToExtension(string mimeType) => mimeType.ToLowerInvariant() switch
+    {
+        "image/png" => ".png",
+        "image/jpeg" or "image/jpg" => ".jpg",
+        "image/gif" => ".gif",
+        "image/webp" => ".webp",
+        "image/svg+xml" => ".svg",
+        "audio/mpeg" => ".mp3",
+        "audio/wav" => ".wav",
+        "video/mp4" => ".mp4",
+        _ => ".bin"
+    };
+
+    internal static MediaModality MimeToModality(string mimeType)
+    {
+        if (mimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            return MediaModality.Image;
+        if (mimeType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
+            return MediaModality.Audio;
+        if (mimeType.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
+            return MediaModality.Video;
+        return MediaModality.Image; // default fallback
     }
 }

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -16,6 +16,12 @@ public sealed class SendUserMessage : IWithSessionId
     public string Content { get; set; } = string.Empty;
 
     /// <summary>
+    /// Media references (images, audio, etc.) attached to this message.
+    /// </summary>
+    [ProtoMember(3)]
+    public List<SerializableMediaReference> MediaReferences { get; set; } = new();
+
+    /// <summary>
     /// Ephemeral channel metadata for ACL/audit. Not persisted.
     /// </summary>
     [ProtoIgnore]

--- a/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
+++ b/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
@@ -1,0 +1,25 @@
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Query the <see cref="ModelCapabilityActor"/> for a model's capabilities.
+/// </summary>
+public sealed record GetModelCapabilities(string ModelId);
+
+/// <summary>
+/// Response from the capability cache containing resolved modalities.
+/// </summary>
+public sealed record ModelCapabilitiesResponse(
+    string ModelId,
+    ModelModality InputModalities,
+    ModelModality OutputModalities);
+
+/// <summary>
+/// Internal message piped back from async resolution to the actor.
+/// </summary>
+internal sealed record CapabilityResolved(
+    string ModelId,
+    ModelModality InputModalities,
+    ModelModality OutputModalities,
+    bool Success);

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -31,6 +31,43 @@ public sealed class SerializableChatMessage
     /// </summary>
     [ProtoMember(5)]
     public string? ToolCallId { get; set; }
+
+    /// <summary>
+    /// Media references (images, audio, etc.) attached to this message.
+    /// Stored as relative paths within the session media directory.
+    /// </summary>
+    [ProtoMember(6)]
+    public List<SerializableMediaReference> MediaReferences { get; set; } = new();
+}
+
+/// <summary>
+/// Persistence-safe reference to a media file stored in the session directory.
+/// </summary>
+[ProtoContract]
+public sealed class SerializableMediaReference
+{
+    /// <summary>Relative path within the session media directory.</summary>
+    [ProtoMember(1)]
+    public string RelativePath { get; set; } = string.Empty;
+
+    /// <summary>MIME type of the media (e.g. "image/png").</summary>
+    [ProtoMember(2)]
+    public string MimeType { get; set; } = string.Empty;
+
+    /// <summary>Content modality as integer for wire safety (maps to <see cref="MediaModality"/>).</summary>
+    [ProtoMember(3)]
+    public int Modality { get; set; }
+}
+
+/// <summary>
+/// Content modality for media references. Matches <see cref="Netclaw.Configuration.ModelModality"/>
+/// values but kept as a separate enum to avoid coupling persistence types to configuration.
+/// </summary>
+public enum MediaModality
+{
+    Image = 1,
+    Audio = 2,
+    Video = 3
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
@@ -1,0 +1,29 @@
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Shared helper for computing session-scoped directories.
+/// Used by <see cref="Sessions.LlmSessionActor"/> and channel pipeline components.
+/// </summary>
+public static class SessionDirectoryHelper
+{
+    /// <summary>
+    /// Computes the session directory path under the OS temp directory.
+    /// </summary>
+    public static string GetSessionDirectory(SessionId sessionId)
+    {
+        var sanitized = SanitizeSessionId(sessionId.Value);
+        return Path.Combine(Path.GetTempPath(), "netclaw-sessions", sanitized);
+    }
+
+    /// <summary>
+    /// Replaces non-alphanumeric characters (except hyphens) with underscores.
+    /// Session IDs may contain slashes (e.g. "C123/1234567890.123456").
+    /// </summary>
+    public static string SanitizeSessionId(string sessionId)
+    {
+        Span<char> buf = stackalloc char[sessionId.Length];
+        for (var i = 0; i < sessionId.Length; i++)
+            buf[i] = char.IsLetterOrDigit(sessionId[i]) || sessionId[i] == '-' ? sessionId[i] : '_';
+        return new string(buf);
+    }
+}

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -150,6 +150,22 @@ public sealed record ErrorOutput : SessionOutput
 }
 
 /// <summary>
+/// A file produced by the LLM or a tool, ready for delivery to the user.
+/// Requires <see cref="OutputFilter.Files"/>.
+/// </summary>
+public sealed record FileOutput : SessionOutput
+{
+    /// <summary>Absolute path to the file on disk.</summary>
+    public required string FilePath { get; init; }
+
+    /// <summary>User-facing filename.</summary>
+    public required string FileName { get; init; }
+
+    /// <summary>MIME type of the file.</summary>
+    public required string MimeType { get; init; }
+}
+
+/// <summary>
 /// Session context was compacted to stay within the context window.
 /// Lifecycle — always delivered regardless of <see cref="OutputFilter"/>.
 /// </summary>

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -48,4 +48,9 @@ public sealed record SessionOutputDto
     // Session Joined
     public string? Title { get; init; }
     public int? TurnCount { get; init; }
+
+    // File Output
+    public string? FilePath { get; init; }
+    public string? FileName { get; init; }
+    public string? MimeType { get; init; }
 }

--- a/src/Netclaw.Actors/Protocol/SessionSubscription.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSubscription.cs
@@ -25,6 +25,9 @@ public enum OutputFilter
     /// <summary><see cref="UsageOutput"/> — token counts and context window consumption.</summary>
     Usage = 1 << 3,
 
+    /// <summary><see cref="FileOutput"/> — file attachments produced by the LLM or tools.</summary>
+    Files = 1 << 4,
+
     // ── Convenience presets ──
 
     /// <summary>Text replies only — suitable for end-user adapters (Slack, TUI chat).</summary>
@@ -34,7 +37,7 @@ public enum OutputFilter
     TextAndUsage = Text | Usage,
 
     /// <summary>Everything — suitable for ops consoles, debugging, and observability.</summary>
-    Full = Text | Thinking | ToolCalls | Usage,
+    Full = Text | Thinking | ToolCalls | Usage | Files,
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -159,7 +159,44 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             if (_availableTools.Count > _baseToolCount)
                 _availableTools.RemoveRange(_baseToolCount, _availableTools.Count - _baseToolCount);
 
-            _state = _state.AddUserMessage(cmd.Content);
+            // Modality gate: strip unsupported media references
+            var mediaRefs = cmd.MediaReferences;
+            if (mediaRefs.Count > 0 && !_config.InputModalities.HasFlag(Configuration.ModelModality.Image))
+            {
+                var imageRefs = mediaRefs.Where(r => r.Modality == (int)MediaModality.Image).ToList();
+                if (imageRefs.Count > 0)
+                {
+                    _log.Info("Stripping {Count} image reference(s) — model does not support vision", imageRefs.Count);
+                    mediaRefs = mediaRefs.Where(r => r.Modality != (int)MediaModality.Image).ToList();
+
+                    EmitOutput(new TextOutput
+                    {
+                        SessionId = _sessionId,
+                        Text = "[Images removed — the current model does not support vision input]"
+                    }, OutputFilter.Text);
+                }
+            }
+
+            // If ALL content is images (no text) and model doesn't support vision, skip entirely
+            if (string.IsNullOrWhiteSpace(cmd.Content) && mediaRefs.Count == 0
+                && cmd.MediaReferences.Count > 0)
+            {
+                _log.Info("Skipping LLM call — message contained only unsupported media");
+                EmitOutput(new TextOutput
+                {
+                    SessionId = _sessionId,
+                    Text = "Your message contained only images, but the current model doesn't support vision. Please send a text message instead."
+                }, OutputFilter.Text);
+                EmitOutput(new TurnCompleted
+                {
+                    SessionId = _sessionId,
+                    TurnNumber = _state.TurnCount
+                });
+                TryReplyAck();
+                return;
+            }
+
+            _state = _state.AddUserMessage(cmd.Content, mediaRefs.Count > 0 ? mediaRefs : null);
             TryReplyAck();
             FireLlmCall();
             Become(Processing);
@@ -428,7 +465,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             _log.Info("Post-compaction: draining {BufferCount} buffered message(s)", _buffer.Count);
             foreach (var buffered in _buffer)
             {
-                _state = _state.AddUserMessage(buffered.Content);
+                var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
+                _state = _state.AddUserMessage(buffered.Content, refs);
             }
             _buffer.Clear();
             FireLlmCall();
@@ -610,7 +648,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 _log.Info("Draining {BufferCount} buffered message(s)", _buffer.Count);
                 foreach (var buffered in _buffer)
                 {
-                    _state = _state.AddUserMessage(buffered.Content);
+                    var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
+                    _state = _state.AddUserMessage(buffered.Content, refs);
                 }
                 _buffer.Clear();
                 FireLlmCall();
@@ -708,7 +747,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private void FireLlmCall(bool forceNoTools = false)
     {
-        var messages = ChatMessageConverter.ToAiMessages(_state.History);
+        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(_sessionId);
+        var messages = ChatMessageConverter.ToAiMessages(_state.History, sessionDir);
         var self = Self;
         var client = _chatClient;
 
@@ -1042,19 +1082,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private static Netclaw.Tools.ToolExecutionContext CreateExecutionContext(SessionId sessionId)
     {
-        // Session directory under OS temp: /tmp/netclaw-sessions/{sanitized-session-id}/
-        var sanitized = SanitizeSessionId(sessionId.Value);
-        var sessionDir = Path.Combine(Path.GetTempPath(), "netclaw-sessions", sanitized);
+        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId);
         return new Netclaw.Tools.ToolExecutionContext(sessionId.Value, sessionDir);
-    }
-
-    private static string SanitizeSessionId(string sessionId)
-    {
-        // Session IDs may contain slashes (e.g. "C123/1234567890.123456") — replace with underscores
-        Span<char> buf = stackalloc char[sessionId.Length];
-        for (var i = 0; i < sessionId.Length; i++)
-            buf[i] = char.IsLetterOrDigit(sessionId[i]) || sessionId[i] == '-' ? sessionId[i] : '_';
-        return new string(buf);
     }
 
     internal void SetTitle(string title)

--- a/src/Netclaw.Actors/Sessions/ModelCapabilityActor.cs
+++ b/src/Netclaw.Actors/Sessions/ModelCapabilityActor.cs
@@ -1,0 +1,102 @@
+using Akka.Actor;
+using Akka.Event;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Singleton actor that caches model capabilities in memory.
+/// Lazily resolves capabilities on first query per model ID.
+/// Deduplicates concurrent queries for the same model using a waiting list.
+/// </summary>
+public sealed class ModelCapabilityActor : UntypedActor
+{
+    private readonly IModelCapabilityResolver _resolver;
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+
+    private readonly Dictionary<string, ModelCapabilitiesResponse> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<IActorRef>> _pending = new(StringComparer.OrdinalIgnoreCase);
+
+    public ModelCapabilityActor(IModelCapabilityResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    protected override void OnReceive(object message)
+    {
+        switch (message)
+        {
+            case GetModelCapabilities query:
+                HandleQuery(query);
+                break;
+
+            case CapabilityResolved resolved:
+                HandleResolved(resolved);
+                break;
+        }
+    }
+
+    private void HandleQuery(GetModelCapabilities query)
+    {
+        // Cache hit — respond immediately
+        if (_cache.TryGetValue(query.ModelId, out var cached))
+        {
+            Sender.Tell(cached);
+            return;
+        }
+
+        // Already in-flight — add sender to waiting list
+        if (_pending.TryGetValue(query.ModelId, out var waiters))
+        {
+            waiters.Add(Sender);
+            return;
+        }
+
+        // First query for this model — start resolution
+        _pending[query.ModelId] = [Sender];
+        var self = Self;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var result = await _resolver.ResolveAsync(query.ModelId, cts.Token);
+
+                var input = result?.InputModalities ?? ModelModality.Text;
+                var output = result?.OutputModalities ?? ModelModality.Text;
+
+                self.Tell(new CapabilityResolved(query.ModelId, input, output, true));
+            }
+            catch
+            {
+                self.Tell(new CapabilityResolved(query.ModelId, ModelModality.Text, ModelModality.Text, false));
+            }
+        });
+    }
+
+    private void HandleResolved(CapabilityResolved resolved)
+    {
+        var response = new ModelCapabilitiesResponse(
+            resolved.ModelId, resolved.InputModalities, resolved.OutputModalities);
+
+        _cache[resolved.ModelId] = response;
+
+        if (!resolved.Success)
+        {
+            _log.Warning("Capability resolution failed for model {0}; cached text-only default", resolved.ModelId);
+        }
+        else
+        {
+            _log.Info("Cached capabilities for model {0}: input={1}, output={2}",
+                resolved.ModelId, resolved.InputModalities, resolved.OutputModalities);
+        }
+
+        if (_pending.Remove(resolved.ModelId, out var waiters))
+        {
+            foreach (var waiter in waiters)
+                waiter.Tell(response);
+        }
+    }
+}

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -75,16 +75,18 @@ public sealed record SessionState
     /// Add a user message to history (before firing an LLM call).
     /// This is transient state that gets persisted as part of <see cref="TurnRecorded"/>.
     /// </summary>
-    public SessionState AddUserMessage(string content)
+    public SessionState AddUserMessage(string content, List<SerializableMediaReference>? mediaReferences = null)
     {
-        return this with
+        var msg = new SerializableChatMessage
         {
-            History = History.Add(new SerializableChatMessage
-            {
-                Role = ChatRole.User,
-                Content = content
-            })
+            Role = ChatRole.User,
+            Content = content
         };
+
+        if (mediaReferences is { Count: > 0 })
+            msg.MediaReferences = mediaReferences;
+
+        return this with { History = History.Add(msg) };
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Attaches a file from the session directory as output to the user.
+/// Validates that the file path is within the session directory to prevent traversal.
+/// </summary>
+[NetclawTool("attach_file",
+    "Attach a file from the session directory to send to the user. The path must be within the session working directory.",
+    Grant = "file")]
+public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
+{
+    public record Params(
+        [property: Description("Absolute path to the file to attach")] string Path,
+        [property: Description("Optional display name for the file")] string? DisplayName = null);
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => Task.FromResult("Error: attach_file requires a session context.");
+
+    protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Path))
+            return Task.FromResult("Error: 'path' parameter is required.");
+
+        if (string.IsNullOrWhiteSpace(context.SessionDirectory))
+            return Task.FromResult("Error: No session directory available.");
+
+        // Canonicalize both paths to prevent traversal attacks
+        var sessionDir = Path.GetFullPath(context.SessionDirectory);
+        var filePath = Path.GetFullPath(args.Path);
+
+        if (!filePath.StartsWith(sessionDir, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult($"Error: File path must be within the session directory ({sessionDir}).");
+
+        if (!File.Exists(filePath))
+            return Task.FromResult($"Error: File not found: {filePath}");
+
+        var rawFilename = args.DisplayName ?? Path.GetFileName(filePath);
+        var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
+        var mimeType = GuessMimeType(filePath);
+
+        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {filePath}");
+    }
+
+    private static string GuessMimeType(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".webp" => "image/webp",
+            ".svg" => "image/svg+xml",
+            ".pdf" => "application/pdf",
+            ".txt" => "text/plain",
+            ".json" => "application/json",
+            ".csv" => "text/csv",
+            ".md" => "text/markdown",
+            ".html" or ".htm" => "text/html",
+            ".mp3" => "audio/mpeg",
+            ".wav" => "audio/wav",
+            ".mp4" => "video/mp4",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -15,6 +15,7 @@ public static class ToolRegistrationExtensions
         registry.Register(new ShellTool(config));
         registry.Register(new FileReadTool(config));
         registry.Register(new FileWriteTool());
+        registry.Register(new AttachFileTool());
         registry.Register(new WebSearchTool(config));
         registry.Register(new WebFetchTool());
 

--- a/src/Netclaw.Channels/Netclaw.Channels.csproj
+++ b/src/Netclaw.Channels/Netclaw.Channels.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="SlackNet" />
   </ItemGroup>
 

--- a/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
@@ -3,4 +3,11 @@ namespace Netclaw.Channels.Slack;
 public interface ISlackReplyClient
 {
     Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default);
+
+    Task UploadFileToThreadAsync(
+        string channelId,
+        string threadTs,
+        string filePath,
+        string? filename = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -3,6 +3,7 @@ using Akka.Pattern;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Channels;
+using Netclaw.Security;
 using SlackNet;
 using SlackNet.Events;
 using SlackNet.WebApi;
@@ -16,6 +17,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private readonly ISlackApiClient _slack;
     private readonly ISlackSocketModeClient _socketModeClient;
     private readonly ISlackReplyClient _replyClient;
+    private readonly IContentScanner _contentScanner;
     private readonly TimeProvider _timeProvider;
     private readonly SlackChannelOptions _options;
     private readonly ILogger<SlackChannel> _logger;
@@ -31,6 +33,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         ISlackApiClient slack,
         ISlackSocketModeClient socketModeClient,
         ISlackReplyClient replyClient,
+        IContentScanner contentScanner,
         TimeProvider timeProvider,
         SlackChannelOptions options,
         ILogger<SlackChannel> logger)
@@ -40,6 +43,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         _slack = slack;
         _socketModeClient = socketModeClient;
         _replyClient = replyClient;
+        _contentScanner = contentScanner;
         _timeProvider = timeProvider;
         _options = options;
         _logger = logger;
@@ -83,7 +87,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 Options: _options,
                 BotUserId: _botUserId,
                 DefaultChannelId: _defaultChannelId,
-                ReplyClient: _replyClient)),
+                ReplyClient: _replyClient,
+                ContentScanner: _contentScanner)),
             "slack-gateway");
 
         await _socketModeClient.Connect(cancellationToken: cancellationToken);

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -18,6 +18,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private readonly ISlackSocketModeClient _socketModeClient;
     private readonly ISlackReplyClient _replyClient;
     private readonly IContentScanner _contentScanner;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly TimeProvider _timeProvider;
     private readonly SlackChannelOptions _options;
     private readonly ILogger<SlackChannel> _logger;
@@ -34,6 +35,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         ISlackSocketModeClient socketModeClient,
         ISlackReplyClient replyClient,
         IContentScanner contentScanner,
+        IHttpClientFactory httpClientFactory,
         TimeProvider timeProvider,
         SlackChannelOptions options,
         ILogger<SlackChannel> logger)
@@ -44,6 +46,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         _socketModeClient = socketModeClient;
         _replyClient = replyClient;
         _contentScanner = contentScanner;
+        _httpClientFactory = httpClientFactory;
         _timeProvider = timeProvider;
         _options = options;
         _logger = logger;
@@ -79,6 +82,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         _botUserId = auth.UserId;
         _defaultChannelId = await ResolveDefaultChannelIdAsync(cancellationToken);
 
+        var httpClient = _httpClientFactory.CreateClient("slack-files");
+
         _gateway = _system.ActorOf(
             SlackGatewayActor.CreateProps(new SlackGatewayDependencies(
                 Pipeline: _pipeline,
@@ -88,7 +93,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 BotUserId: _botUserId,
                 DefaultChannelId: _defaultChannelId,
                 ReplyClient: _replyClient,
-                ContentScanner: _contentScanner)),
+                ContentScanner: _contentScanner,
+                HttpClient: httpClient)),
             "slack-gateway");
 
         await _socketModeClient.Connect(cancellationToken: cancellationToken);
@@ -119,6 +125,9 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
 
     public Task Handle(MessageEvent slackEvent)
     {
+        // Map Slack file attachments to SlackFileReference
+        var files = MapSlackFiles(slackEvent.Files);
+
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
             EventId: BuildEventId(
@@ -135,7 +144,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             Text: slackEvent.Text ?? string.Empty,
             Subtype: slackEvent.Subtype,
             Hidden: slackEvent.Hidden,
-            IsDirectMessage: IsDirectConversation(slackEvent.Channel)));
+            IsDirectMessage: IsDirectConversation(slackEvent.Channel),
+            Files: files));
 
         return Task.CompletedTask;
     }
@@ -161,6 +171,28 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             IsDirectMessage: IsDirectConversation(slackEvent.Channel)));
 
         return Task.CompletedTask;
+    }
+
+    private static IReadOnlyList<SlackFileReference>? MapSlackFiles(IList<SlackNet.File>? files)
+    {
+        if (files is null or { Count: 0 })
+            return null;
+
+        var result = new List<SlackFileReference>(files.Count);
+        foreach (var f in files)
+        {
+            if (string.IsNullOrWhiteSpace(f.UrlPrivateDownload))
+                continue;
+
+            result.Add(new SlackFileReference(
+                Id: f.Id ?? string.Empty,
+                Name: f.Name ?? "attachment",
+                MimeType: f.Mimetype ?? "application/octet-stream",
+                Size: f.Size,
+                UrlPrivateDownload: f.UrlPrivateDownload));
+        }
+
+        return result.Count > 0 ? result : null;
     }
 
     private static bool IsDirectConversation(string channelId)

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -101,7 +101,8 @@ public sealed class SlackConversationActor : ReceiveActor
                 ThreadTs: threadTs,
                 SenderId: message.UserId ?? "slack-user",
                 Text: normalized,
-                ReceivedAt: _dependencies.TimeProvider.GetUtcNow()));
+                ReceivedAt: _dependencies.TimeProvider.GetUtcNow(),
+                Files: message.Files));
         });
     }
 

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -77,5 +77,6 @@ public sealed record SlackGatewayDependencies(
     string? DefaultChannelId,
     ISlackReplyClient ReplyClient,
     IContentScanner ContentScanner,
+    HttpClient? HttpClient = null,
     Func<string, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
     Func<SessionId, string, string, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -3,6 +3,7 @@ using Akka.Event;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels.Telemetry;
+using Netclaw.Security;
 
 namespace Netclaw.Channels.Slack;
 
@@ -75,5 +76,6 @@ public sealed record SlackGatewayDependencies(
     string? BotUserId,
     string? DefaultChannelId,
     ISlackReplyClient ReplyClient,
+    IContentScanner ContentScanner,
     Func<string, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
     Func<SessionId, string, string, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -8,6 +8,13 @@ public enum SlackInboundKind
     AppMention
 }
 
+public sealed record SlackFileReference(
+    string Id,
+    string Name,
+    string MimeType,
+    long Size,
+    string UrlPrivateDownload);
+
 public sealed record SlackInboundMessage(
     SlackInboundKind Kind,
     string EventId,
@@ -19,7 +26,8 @@ public sealed record SlackInboundMessage(
     string Text,
     string? Subtype,
     bool Hidden,
-    bool IsDirectMessage);
+    bool IsDirectMessage,
+    IReadOnlyList<SlackFileReference>? Files = null);
 
 public sealed record SlackThreadInbound(
     SessionId SessionId,
@@ -27,7 +35,8 @@ public sealed record SlackThreadInbound(
     string ThreadTs,
     string SenderId,
     string Text,
-    DateTimeOffset ReceivedAt);
+    DateTimeOffset ReceivedAt,
+    IReadOnlyList<SlackFileReference>? Files = null);
 
 public sealed record SlackPostMessage(
     string ChannelId,

--- a/src/Netclaw.Channels/Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackReplyClient.cs
@@ -17,4 +17,23 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             Blocks = blocks
         });
     }
+
+    public async Task UploadFileToThreadAsync(
+        string channelId,
+        string threadTs,
+        string filePath,
+        string? filename = null,
+        CancellationToken cancellationToken = default)
+    {
+        var resolvedFilename = filename ?? Path.GetFileName(filePath);
+        await using var stream = System.IO.File.OpenRead(filePath);
+        var upload = new FileUpload(resolvedFilename, stream);
+
+        await slackApiClient.Files.Upload(
+            upload,
+            channelId,
+            threadTs,
+            initialComment: null,
+            cancellationToken);
+    }
 }

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -72,11 +72,60 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
     {
         await EnsureInitializedAsync();
 
+        // Build content list: text + downloaded file attachments
+        var contents = new List<AIContent>();
+        if (!string.IsNullOrEmpty(message.Text))
+            contents.Add(new TextContent(message.Text));
+
+        // Download and scan file attachments
+        if (message.Files is { Count: > 0 } && _dependencies.HttpClient is not null)
+        {
+            foreach (var file in message.Files)
+            {
+                // Only process image MIME types for now
+                if (!file.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                {
+                    _log.Debug("Skipping non-image file attachment: {Name} ({MimeType})", file.Name, file.MimeType);
+                    continue;
+                }
+
+                try
+                {
+                    var bytes = await DownloadSlackFileAsync(file);
+                    if (bytes.Length == 0)
+                        continue;
+
+                    var scanResult = await _dependencies.ContentScanner.ScanAsync(
+                        bytes, file.Name, file.MimeType);
+
+                    if (!scanResult.IsAllowed)
+                    {
+                        _log.Warning("Content scan rejected file {Name}: {Message}",
+                            file.Name, scanResult.Message ?? scanResult.Error?.ToString());
+                        continue;
+                    }
+
+                    contents.Add(new DataContent(bytes.ToArray(), file.MimeType));
+                    _log.Info("Downloaded and scanned Slack file: {Name} ({Size} bytes)", file.Name, bytes.Length);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warning(ex, "Failed to download Slack file {Name}, skipping", file.Name);
+                }
+            }
+        }
+
+        if (contents.Count == 0)
+        {
+            _log.Debug("No content to enqueue after file processing");
+            return;
+        }
+
         var result = await _inputQueue!.OfferAsync(new ChannelInput
         {
             SenderId = message.SenderId,
             ChannelId = _channelId,
-            Contents = [new TextContent(message.Text)],
+            Contents = contents,
             ReceivedAt = message.ReceivedAt
         });
 
@@ -95,6 +144,19 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
         if (result is QueueOfferResult.Failure failure)
             _log.Error(failure.Cause, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
+    }
+
+    private async Task<ReadOnlyMemory<byte>> DownloadSlackFileAsync(SlackFileReference file)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, file.UrlPrivateDownload);
+        if (_dependencies.Options.BotToken is { Value: { Length: > 0 } token })
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        using var response = await _dependencies.HttpClient!.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        return bytes;
     }
 
     private async Task EnsureInitializedAsync()
@@ -151,6 +213,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
                 break;
 
+            case FileOutput file:
+                await SafeUploadFileAsync(file);
+                break;
+
             case ErrorOutput err:
                 await SafePostAsync($":warning: {err.Message}");
                 _buffer.Clear();
@@ -191,6 +257,30 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         {
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+        }
+    }
+
+    private async Task SafeUploadFileAsync(FileOutput file)
+    {
+        try
+        {
+            if (!File.Exists(file.FilePath))
+            {
+                _log.Warning("File not found for upload: {Path}", file.FilePath);
+                return;
+            }
+
+            await _dependencies.ReplyClient.UploadFileToThreadAsync(
+                _channelId,
+                _threadTs,
+                file.FilePath,
+                file.FileName);
+
+            _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
         }
     }
 

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -373,6 +373,14 @@ public sealed class DaemonClient : IAsyncDisposable
                 Cause = dto.ErrorDetail is not null
                     ? new Exception(dto.ErrorDetail) : null
             },
+            "file" => new FileOutput
+            {
+                SessionId = sessionId,
+                TimestampMs = dto.TimestampMs,
+                FilePath = dto.FilePath ?? string.Empty,
+                FileName = dto.FileName ?? "file",
+                MimeType = dto.MimeType ?? "application/octet-stream"
+            },
             "compaction" => new CompactionOutput
             {
                 SessionId = sessionId,

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -199,6 +199,11 @@ public sealed class HeadlessChannel : IChannel
                 _receivedThinkingDeltaInCurrentTurn = false;
                 break;
 
+            case FileOutput msg:
+                Console.WriteLine($"[file] {msg.FileName} \u2192 {msg.FilePath}");
+                Log(log, $"FILE: name={msg.FileName} path={msg.FilePath} mime={msg.MimeType}");
+                break;
+
             case CompactionOutput msg:
                 Console.WriteLine($"[compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages");
                 Log(log, $"COMPACTION: before={msg.MessagesBefore} after={msg.MessagesAfter} tool_results_cleared={msg.ToolResultsCleared} summarized={msg.Summarized}");

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -308,6 +308,13 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 _chatHistory.ScrollToBottom();
                 break;
 
+            case FileOutput msg:
+                _chatHistory.AppendLine(
+                    $"  [file] {msg.FileName} \u2192 {msg.FilePath}",
+                    Color.Cyan);
+                _chatHistory.ScrollToBottom();
+                break;
+
             case CompactionOutput msg:
                 _chatHistory.AppendLine(
                     $"  [compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages",

--- a/src/Netclaw.Configuration/DiscoveredModel.cs
+++ b/src/Netclaw.Configuration/DiscoveredModel.cs
@@ -21,4 +21,10 @@ public sealed record DiscoveredModel
 
     /// <summary>Cost per million output tokens in USD, if known.</summary>
     public decimal? CostPerMillionOutputTokens { get; init; }
+
+    /// <summary>Content types the model accepts as input.</summary>
+    public ModelModality InputModalities { get; init; } = ModelModality.Text;
+
+    /// <summary>Content types the model can produce as output.</summary>
+    public ModelModality OutputModalities { get; init; } = ModelModality.Text;
 }

--- a/src/Netclaw.Configuration/IModelCapabilityResolver.cs
+++ b/src/Netclaw.Configuration/IModelCapabilityResolver.cs
@@ -1,0 +1,21 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Resolved capability metadata for a model.
+/// </summary>
+public sealed record ResolvedModelCapabilities(
+    string ModelId,
+    ModelModality InputModalities,
+    ModelModality OutputModalities);
+
+/// <summary>
+/// Resolves model capabilities from a specific source (OpenRouter oracle,
+/// HuggingFace, etc.). Returns null when the source cannot determine
+/// capabilities for the given model.
+/// </summary>
+public interface IModelCapabilityResolver
+{
+    Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId,
+        CancellationToken ct = default);
+}

--- a/src/Netclaw.Configuration/ModelIdNormalizer.cs
+++ b/src/Netclaw.Configuration/ModelIdNormalizer.cs
@@ -1,0 +1,92 @@
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Normalizes model IDs across provider naming conventions to enable
+/// cross-provider capability lookups. Produces candidate IDs for matching.
+/// </summary>
+public static partial class ModelIdNormalizer
+{
+    // Matches date suffixes like -20250514, -20260101
+    [GeneratedRegex(@"-\d{8}$")]
+    private static partial Regex DateSuffixPattern();
+
+    // Known provider prefixes for bare model IDs
+    private static readonly Dictionary<string, string> KnownPrefixes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["claude"] = "anthropic",
+        ["gpt"] = "openai",
+        ["o1"] = "openai",
+        ["o3"] = "openai",
+        ["o4"] = "openai",
+        ["gemini"] = "google",
+        ["gemma"] = "google",
+        ["llama"] = "meta-llama",
+        ["mistral"] = "mistralai",
+        ["mixtral"] = "mistralai",
+        ["qwen"] = "qwen",
+        ["deepseek"] = "deepseek",
+        ["phi"] = "microsoft",
+    };
+
+    /// <summary>
+    /// Produces a set of candidate model IDs for cross-provider lookup.
+    /// The first entry is always the original ID.
+    /// </summary>
+    public static IReadOnlyList<string> GetCandidates(string modelId)
+    {
+        var candidates = new List<string> { modelId };
+        var working = modelId;
+
+        // Strip Ollama tag suffixes (:latest, :7b, :q4_0, etc.)
+        var colonIndex = working.IndexOf(':');
+        if (colonIndex > 0)
+        {
+            var stripped = working[..colonIndex];
+            if (!candidates.Contains(stripped))
+                candidates.Add(stripped);
+            working = stripped;
+        }
+
+        // Strip date suffixes (-20250514)
+        var withoutDate = DateSuffixPattern().Replace(working, "");
+        if (withoutDate != working && !candidates.Contains(withoutDate))
+        {
+            candidates.Add(withoutDate);
+        }
+
+        // If no slash (not already prefixed), try adding known provider prefixes
+        if (!working.Contains('/'))
+        {
+            foreach (var (prefix, provider) in KnownPrefixes)
+            {
+                if (working.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var prefixed = $"{provider}/{working}";
+                    if (!candidates.Contains(prefixed))
+                        candidates.Add(prefixed);
+
+                    // Also try prefixed + date-stripped
+                    if (withoutDate != working)
+                    {
+                        var prefixedNoDate = $"{provider}/{withoutDate}";
+                        if (!candidates.Contains(prefixedNoDate))
+                            candidates.Add(prefixedNoDate);
+                    }
+
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // Already has a prefix — try date-stripped version with prefix
+            var prefixedWithoutDate = DateSuffixPattern().Replace(modelId, "");
+            if (prefixedWithoutDate != modelId && !candidates.Contains(prefixedWithoutDate))
+                candidates.Add(prefixedWithoutDate);
+        }
+
+        return candidates;
+    }
+}

--- a/src/Netclaw.Configuration/ModelModality.cs
+++ b/src/Netclaw.Configuration/ModelModality.cs
@@ -1,0 +1,15 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Content modalities that a model may accept as input or produce as output.
+/// Combine with bitwise OR for models supporting multiple modalities.
+/// </summary>
+[Flags]
+public enum ModelModality
+{
+    None = 0,
+    Text = 1 << 0,
+    Image = 1 << 1,
+    Audio = 1 << 2,
+    Video = 1 << 3,
+}

--- a/src/Netclaw.Configuration/ModelReference.cs
+++ b/src/Netclaw.Configuration/ModelReference.cs
@@ -16,4 +16,16 @@ public sealed class ModelReference
     /// Null for models configured before provenance tracking was added.
     /// </summary>
     public ModelDiscoverySource? Provenance { get; set; }
+
+    /// <summary>
+    /// Manual override for input modalities. When set, bypasses all
+    /// automated capability detection for this model.
+    /// </summary>
+    public ModelModality? InputModalities { get; set; }
+
+    /// <summary>
+    /// Manual override for output modalities. When set, bypasses all
+    /// automated capability detection for this model.
+    /// </summary>
+    public ModelModality? OutputModalities { get; set; }
 }

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -84,7 +84,13 @@
     },
     "Models": {
       "type": "object",
-      "additionalProperties": true
+      "description": "Model selection by role (Main, Fallback, Compaction).",
+      "properties": {
+        "Main": { "$ref": "#/$defs/ModelReference" },
+        "Fallback": { "$ref": "#/$defs/ModelReference" },
+        "Compaction": { "$ref": "#/$defs/ModelReference" }
+      },
+      "additionalProperties": false
     },
     "McpServers": {
       "type": "object",
@@ -118,5 +124,31 @@
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "$defs": {
+    "ModelModality": {
+      "type": "string",
+      "enum": ["Text", "Image", "Audio", "Video"],
+      "description": "A single content modality."
+    },
+    "ModelReference": {
+      "type": "object",
+      "properties": {
+        "Provider": { "type": "string", "description": "Key into the Providers dictionary." },
+        "ModelId": { "type": "string", "description": "Model identifier for API calls." },
+        "ContextWindow": { "type": "integer", "description": "Max context window in tokens." },
+        "InputModalities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ModelModality" },
+          "description": "Manual override for input modalities. Bypasses automated detection."
+        },
+        "OutputModalities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ModelModality" },
+          "description": "Manual override for output modalities. Bypasses automated detection."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -62,4 +62,18 @@ public sealed record SessionConfig
     /// Effective token limit at which compaction fires.
     /// </summary>
     public int CompactionTokenLimit => (int)(ContextWindowTokens * CompactionThreshold);
+
+    /// <summary>
+    /// Content types the configured model accepts as input.
+    /// Defaults to <see cref="ModelModality.Text"/> when capabilities
+    /// have not been resolved.
+    /// </summary>
+    public ModelModality InputModalities { get; init; } = ModelModality.Text;
+
+    /// <summary>
+    /// Content types the configured model can produce as output.
+    /// Defaults to <see cref="ModelModality.Text"/> when capabilities
+    /// have not been resolved.
+    /// </summary>
+    public ModelModality OutputModalities { get; init; } = ModelModality.Text;
 }

--- a/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Providers;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class CompositeCapabilityResolverTests
+{
+    [Fact]
+    public async Task FirstResolver_Succeeds_ReturnsResult()
+    {
+        var first = new FakeResolver(new ResolvedModelCapabilities(
+            "test-model", ModelModality.Text | ModelModality.Image, ModelModality.Text));
+        var second = new FakeResolver(null);
+
+        var composite = new CompositeCapabilityResolver(
+            [first, second],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("test-model");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.False(second.WasCalled);
+    }
+
+    [Fact]
+    public async Task FirstResolver_ReturnsNull_FallsThrough()
+    {
+        var first = new FakeResolver(null);
+        var second = new FakeResolver(new ResolvedModelCapabilities(
+            "test-model", ModelModality.Text | ModelModality.Audio, ModelModality.Text));
+
+        var composite = new CompositeCapabilityResolver(
+            [first, second],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("test-model");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text | ModelModality.Audio, result.InputModalities);
+        Assert.True(second.WasCalled);
+    }
+
+    [Fact]
+    public async Task AllResolvers_ReturnNull_DefaultsToText()
+    {
+        var first = new FakeResolver(null);
+        var second = new FakeResolver(null);
+
+        var composite = new CompositeCapabilityResolver(
+            [first, second],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("unknown-model");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public async Task FirstResolver_Throws_FallsThrough()
+    {
+        var first = new ThrowingResolver();
+        var second = new FakeResolver(new ResolvedModelCapabilities(
+            "test-model", ModelModality.Text, ModelModality.Text));
+
+        var composite = new CompositeCapabilityResolver(
+            [first, second],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("test-model");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+    }
+
+    private sealed class FakeResolver : IModelCapabilityResolver
+    {
+        private readonly ResolvedModelCapabilities? _result;
+        public bool WasCalled { get; private set; }
+
+        public FakeResolver(ResolvedModelCapabilities? result) => _result = result;
+
+        public Task<ResolvedModelCapabilities?> ResolveAsync(
+            string modelId, CancellationToken ct = default)
+        {
+            WasCalled = true;
+            return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class ThrowingResolver : IModelCapabilityResolver
+    {
+        public Task<ResolvedModelCapabilities?> ResolveAsync(
+            string modelId, CancellationToken ct = default)
+            => throw new HttpRequestException("Network error");
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/HuggingFaceCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/HuggingFaceCapabilityResolverTests.cs
@@ -1,0 +1,95 @@
+using Netclaw.Configuration;
+using Netclaw.Daemon.Providers;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class HuggingFaceCapabilityResolverTests
+{
+    [Fact]
+    public void ParseModelInfo_ImageTextToText()
+    {
+        const string json = """
+        {
+          "modelId": "llava-hf/llava-1.5-7b-hf",
+          "pipeline_tag": "image-text-to-text"
+        }
+        """;
+
+        var result = HuggingFaceCapabilityResolver.ParseModelInfo("llava", json);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseModelInfo_TextGeneration()
+    {
+        const string json = """
+        {
+          "modelId": "mistralai/Mistral-7B-v0.1",
+          "pipeline_tag": "text-generation"
+        }
+        """;
+
+        var result = HuggingFaceCapabilityResolver.ParseModelInfo("mistral-7b", json);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseModelInfo_NoPipelineTag_ReturnsNull()
+    {
+        const string json = """
+        {
+          "modelId": "some/model"
+        }
+        """;
+
+        var result = HuggingFaceCapabilityResolver.ParseModelInfo("some/model", json);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseModelInfo_AutomaticSpeechRecognition()
+    {
+        const string json = """
+        {
+          "modelId": "openai/whisper-large-v3",
+          "pipeline_tag": "automatic-speech-recognition"
+        }
+        """;
+
+        var result = HuggingFaceCapabilityResolver.ParseModelInfo("whisper", json);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Audio, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Theory]
+    [InlineData("text-to-image", ModelModality.Text, ModelModality.Image)]
+    [InlineData("text-to-audio", ModelModality.Text, ModelModality.Audio)]
+    [InlineData("text-to-video", ModelModality.Text, ModelModality.Video)]
+    [InlineData("video-text-to-text", ModelModality.Text | ModelModality.Video, ModelModality.Text)]
+    public void MapPipelineTag_KnownTags(string tag, ModelModality expectedInput, ModelModality expectedOutput)
+    {
+        var (input, output) = HuggingFaceCapabilityResolver.MapPipelineTag(tag);
+
+        Assert.Equal(expectedInput, input);
+        Assert.Equal(expectedOutput, output);
+    }
+
+    [Fact]
+    public void MapPipelineTag_UnknownTag_DefaultsToText()
+    {
+        var (input, output) = HuggingFaceCapabilityResolver.MapPipelineTag("something-new");
+
+        Assert.Equal(ModelModality.Text, input);
+        Assert.Equal(ModelModality.Text, output);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/ModelIdNormalizerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/ModelIdNormalizerTests.cs
@@ -1,0 +1,67 @@
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class ModelIdNormalizerTests
+{
+    [Fact]
+    public void OriginalId_AlwaysFirst()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("claude-sonnet-4-20250514");
+        Assert.Equal("claude-sonnet-4-20250514", candidates[0]);
+    }
+
+    [Fact]
+    public void StripDateSuffix()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("claude-sonnet-4-20250514");
+        Assert.Contains("claude-sonnet-4", candidates);
+    }
+
+    [Fact]
+    public void AddProviderPrefix_Claude()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("claude-sonnet-4-20250514");
+        Assert.Contains("anthropic/claude-sonnet-4-20250514", candidates);
+        Assert.Contains("anthropic/claude-sonnet-4", candidates);
+    }
+
+    [Fact]
+    public void AddProviderPrefix_Gpt()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("gpt-4o");
+        Assert.Contains("openai/gpt-4o", candidates);
+    }
+
+    [Fact]
+    public void StripOllamaTag()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("llava:latest");
+        Assert.Contains("llava", candidates);
+    }
+
+    [Fact]
+    public void StripOllamaTag_WithVersion()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("qwen3:30b");
+        Assert.Contains("qwen3", candidates);
+        Assert.Contains("qwen/qwen3", candidates);
+    }
+
+    [Fact]
+    public void AlreadyPrefixed_StripDateOnly()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("anthropic/claude-sonnet-4-20250514");
+        Assert.Contains("anthropic/claude-sonnet-4", candidates);
+        // Should not double-prefix
+        Assert.DoesNotContain("anthropic/anthropic/claude-sonnet-4", candidates);
+    }
+
+    [Fact]
+    public void NoTransformNeeded()
+    {
+        var candidates = ModelIdNormalizer.GetCandidates("anthropic/claude-sonnet-4");
+        Assert.Equal("anthropic/claude-sonnet-4", candidates[0]);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/OpenRouterOracleResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenRouterOracleResolverTests.cs
@@ -1,0 +1,122 @@
+using Netclaw.Configuration;
+using Netclaw.Daemon.Providers;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class OpenRouterOracleResolverTests
+{
+    [Fact]
+    public void ParseCatalog_MultimodalModel()
+    {
+        const string json = """
+        {
+          "data": [
+            {
+              "id": "anthropic/claude-sonnet-4",
+              "architecture": {
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["text"]
+              }
+            }
+          ]
+        }
+        """;
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        Assert.True(catalog.ContainsKey("anthropic/claude-sonnet-4"));
+        var caps = catalog["anthropic/claude-sonnet-4"];
+        Assert.Equal(ModelModality.Text | ModelModality.Image, caps.InputModalities);
+        Assert.Equal(ModelModality.Text, caps.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseCatalog_TextOnlyModel()
+    {
+        const string json = """
+        {
+          "data": [
+            {
+              "id": "mistralai/mistral-7b",
+              "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"]
+              }
+            }
+          ]
+        }
+        """;
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        var caps = catalog["mistralai/mistral-7b"];
+        Assert.Equal(ModelModality.Text, caps.InputModalities);
+        Assert.Equal(ModelModality.Text, caps.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseCatalog_FullMultimodal()
+    {
+        const string json = """
+        {
+          "data": [
+            {
+              "id": "openai/gpt-4o",
+              "architecture": {
+                "input_modalities": ["text", "image", "audio"],
+                "output_modalities": ["text", "audio"]
+              }
+            }
+          ]
+        }
+        """;
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        var caps = catalog["openai/gpt-4o"];
+        Assert.Equal(ModelModality.Text | ModelModality.Image | ModelModality.Audio, caps.InputModalities);
+        Assert.Equal(ModelModality.Text | ModelModality.Audio, caps.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseCatalog_NoArchitecture_DefaultsToText()
+    {
+        const string json = """
+        {
+          "data": [
+            {
+              "id": "some/model"
+            }
+          ]
+        }
+        """;
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        var caps = catalog["some/model"];
+        Assert.Equal(ModelModality.Text, caps.InputModalities);
+        Assert.Equal(ModelModality.Text, caps.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseCatalog_EmptyData()
+    {
+        const string json = """{"data": []}""";
+
+        var catalog = OpenRouterOracleResolver.ParseCatalog(json);
+
+        Assert.Empty(catalog);
+    }
+
+    [Fact]
+    public void ParseModalityArray_UnknownValues_Ignored()
+    {
+        const string json = """["text", "image", "hologram"]""";
+        var element = System.Text.Json.JsonDocument.Parse(json).RootElement;
+
+        var result = OpenRouterOracleResolver.ParseModalityArray(element);
+
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -23,6 +23,7 @@ public static class SlackChannelRegistrationExtensions
         if (slackOptions.SocketMode && (slackOptions.AppToken is null || string.IsNullOrWhiteSpace(slackOptions.AppToken.Value)))
             throw new InvalidOperationException("Slack Socket Mode is enabled but Slack:AppToken is not configured.");
 
+        services.AddHttpClient("slack-files");
         services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
         services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
         services.AddSingleton<IChannel>(sp =>

--- a/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
@@ -99,6 +99,16 @@ public static class SessionOutputMapper
             ErrorDetail = msg.Cause?.ToString()
         },
 
+        FileOutput msg => new SessionOutputDto
+        {
+            Type = "file",
+            SessionId = msg.SessionId.Value,
+            TimestampMs = msg.TimestampMs,
+            FilePath = msg.FilePath,
+            FileName = msg.FileName,
+            MimeType = msg.MimeType
+        },
+
         CompactionOutput msg => new SessionOutputDto
         {
             Type = "compaction",

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -13,6 +13,7 @@ using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Daemon.Providers;
 using Netclaw.Daemon.Services;
 
 try
@@ -155,6 +156,8 @@ static void ConfigureDaemonServices(
         SnapshotInterval = sessionSection.GetValue("SnapshotInterval", 20),
         KeepRecentToolResults = sessionSection.GetValue("KeepRecentToolResults", 3),
         MaxToolIterationsPerTurn = sessionSection.GetValue("MaxToolIterationsPerTurn", 10),
+        InputModalities = models.Main.InputModalities ?? ModelModality.Text,
+        OutputModalities = models.Main.OutputModalities ?? ModelModality.Text,
     });
 
     // Tools (auto-bound, no required properties)
@@ -201,6 +204,17 @@ static void ConfigureDaemonServices(
     services.AddSingleton<SchemaMigrator>();
     services.AddSingleton<SchemaMigrationHostedService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SchemaMigrationHostedService>());
+
+    // Model capability resolution chain: OpenRouter oracle → HuggingFace → text-only default
+    services.AddHttpClient<OpenRouterOracleResolver>();
+    services.AddHttpClient<HuggingFaceCapabilityResolver>();
+    services.AddSingleton<IModelCapabilityResolver>(sp =>
+        new CompositeCapabilityResolver(
+            [
+                sp.GetRequiredService<OpenRouterOracleResolver>(),
+                sp.GetRequiredService<HuggingFaceCapabilityResolver>(),
+            ],
+            sp.GetRequiredService<ILogger<CompositeCapabilityResolver>>()));
 
     // Akka.NET actor system
     services.AddAkka("netclaw", (akkaBuilder, sp) =>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -15,6 +15,7 @@ using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Daemon.Providers;
 using Netclaw.Daemon.Services;
+using Netclaw.Security;
 
 try
 {
@@ -242,6 +243,9 @@ static void ConfigureDaemonServices(
 
         akkaBuilder.WithNetclawActors();
     });
+
+    // Content security (no-op defaults, real scanning plugged in later)
+    services.AddContentSecurity();
 
     // Session pipeline (stream API for channels)
     services.AddSingleton<SessionPipeline>();

--- a/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Providers;
+
+/// <summary>
+/// Chains multiple <see cref="IModelCapabilityResolver"/> instances in priority
+/// order. Returns the first non-null result, or a text-only default if all
+/// resolvers return null or fail.
+/// </summary>
+public sealed class CompositeCapabilityResolver : IModelCapabilityResolver
+{
+    private static readonly TimeSpan ResolverTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IReadOnlyList<IModelCapabilityResolver> _resolvers;
+    private readonly ILogger<CompositeCapabilityResolver> _logger;
+
+    public CompositeCapabilityResolver(
+        IEnumerable<IModelCapabilityResolver> resolvers,
+        ILogger<CompositeCapabilityResolver> logger)
+    {
+        _resolvers = resolvers.ToList();
+        _logger = logger;
+    }
+
+    public async Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId, CancellationToken ct = default)
+    {
+        foreach (var resolver in _resolvers)
+        {
+            try
+            {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(ResolverTimeout);
+
+                var result = await resolver.ResolveAsync(modelId, timeoutCts.Token);
+                if (result is not null)
+                {
+                    _logger.LogDebug(
+                        "Resolved capabilities for {ModelId} via {Resolver}: input={Input}, output={Output}",
+                        modelId, resolver.GetType().Name, result.InputModalities, result.OutputModalities);
+                    return result;
+                }
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                _logger.LogDebug("{Resolver} timed out for model {ModelId}, trying next",
+                    resolver.GetType().Name, modelId);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(ex, "{Resolver} failed for model {ModelId}, trying next",
+                    resolver.GetType().Name, modelId);
+            }
+        }
+
+        // All resolvers failed or returned null — default to text-only
+        _logger.LogWarning(
+            "All capability resolvers failed for model {ModelId}; defaulting to text-only", modelId);
+        return new ResolvedModelCapabilities(modelId, ModelModality.Text, ModelModality.Text);
+    }
+}

--- a/src/Netclaw.Daemon/Providers/HuggingFaceCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/HuggingFaceCapabilityResolver.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Providers;
+
+/// <summary>
+/// Resolves model capabilities from the HuggingFace Hub API by mapping
+/// the <c>pipeline_tag</c> field to <see cref="ModelModality"/> flags.
+/// Fallback source for open-source models not in the OpenRouter catalog.
+/// </summary>
+public sealed class HuggingFaceCapabilityResolver : IModelCapabilityResolver
+{
+    private const string BaseUrl = "https://huggingface.co/api/models/";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<HuggingFaceCapabilityResolver> _logger;
+
+    public HuggingFaceCapabilityResolver(HttpClient httpClient, ILogger<HuggingFaceCapabilityResolver> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId, CancellationToken ct = default)
+    {
+        // HuggingFace IDs use org/model format — skip bare names without a slash
+        // unless they're already a valid HF ID
+        var hfId = modelId;
+
+        // Strip Ollama tags
+        var colonIdx = hfId.IndexOf(':');
+        if (colonIdx > 0)
+            hfId = hfId[..colonIdx];
+
+        var url = $"{BaseUrl}{Uri.EscapeDataString(hfId)}";
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("HuggingFace returned {Status} for model {ModelId}", response.StatusCode, hfId);
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseModelInfo(modelId, json);
+    }
+
+    internal static ResolvedModelCapabilities? ParseModelInfo(string modelId, string json)
+    {
+        var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("pipeline_tag", out var tagProp))
+            return null;
+
+        var tag = tagProp.GetString();
+        if (tag is null) return null;
+
+        var (input, output) = MapPipelineTag(tag);
+        return new ResolvedModelCapabilities(modelId, input, output);
+    }
+
+    internal static (ModelModality Input, ModelModality Output) MapPipelineTag(string pipelineTag)
+    {
+        return pipelineTag.ToLowerInvariant() switch
+        {
+            "text-generation" => (ModelModality.Text, ModelModality.Text),
+            "text2text-generation" => (ModelModality.Text, ModelModality.Text),
+            "image-text-to-text" => (ModelModality.Text | ModelModality.Image, ModelModality.Text),
+            "visual-question-answering" => (ModelModality.Text | ModelModality.Image, ModelModality.Text),
+            "image-to-text" => (ModelModality.Image, ModelModality.Text),
+            "text-to-image" => (ModelModality.Text, ModelModality.Image),
+            "text-to-audio" => (ModelModality.Text, ModelModality.Audio),
+            "text-to-speech" => (ModelModality.Text, ModelModality.Audio),
+            "automatic-speech-recognition" => (ModelModality.Audio, ModelModality.Text),
+            "audio-to-audio" => (ModelModality.Audio, ModelModality.Audio),
+            "text-to-video" => (ModelModality.Text, ModelModality.Video),
+            "video-text-to-text" => (ModelModality.Text | ModelModality.Video, ModelModality.Text),
+            _ => (ModelModality.Text, ModelModality.Text),
+        };
+    }
+}

--- a/src/Netclaw.Daemon/Providers/OpenRouterOracleResolver.cs
+++ b/src/Netclaw.Daemon/Providers/OpenRouterOracleResolver.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Providers;
+
+/// <summary>
+/// Resolves model capabilities by querying OpenRouter's public
+/// <c>GET /api/v1/models</c> endpoint. Caches the full model list
+/// on first call. No API key required for reads.
+/// </summary>
+public sealed class OpenRouterOracleResolver : IModelCapabilityResolver
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OpenRouterOracleResolver> _logger;
+    private Dictionary<string, ResolvedModelCapabilities>? _cache;
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
+
+    public OpenRouterOracleResolver(HttpClient httpClient, ILogger<OpenRouterOracleResolver> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId, CancellationToken ct = default)
+    {
+        var catalog = await GetOrFetchCatalogAsync(ct);
+        if (catalog is null)
+            return null;
+
+        // Try all normalized candidates
+        foreach (var candidate in ModelIdNormalizer.GetCandidates(modelId))
+        {
+            if (catalog.TryGetValue(candidate, out var caps))
+                return caps with { ModelId = modelId };
+        }
+
+        _logger.LogDebug("Model {ModelId} not found in OpenRouter catalog", modelId);
+        return null;
+    }
+
+    private async Task<Dictionary<string, ResolvedModelCapabilities>?> GetOrFetchCatalogAsync(
+        CancellationToken ct)
+    {
+        if (_cache is not null)
+            return _cache;
+
+        await _cacheLock.WaitAsync(ct);
+        try
+        {
+            if (_cache is not null)
+                return _cache;
+
+            _cache = await FetchCatalogAsync(ct);
+            return _cache;
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    private async Task<Dictionary<string, ResolvedModelCapabilities>?> FetchCatalogAsync(
+        CancellationToken ct)
+    {
+        var url = $"{ProviderCapabilities.GetDefaultEndpoint("openrouter")}" +
+                  $"{ProviderCapabilities.GetModelListingPath("openrouter")}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("OpenRouter oracle returned {Status}", response.StatusCode);
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return ParseCatalog(json);
+    }
+
+    internal static Dictionary<string, ResolvedModelCapabilities> ParseCatalog(string json)
+    {
+        var result = new Dictionary<string, ResolvedModelCapabilities>(StringComparer.OrdinalIgnoreCase);
+        var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("data", out var dataArray))
+            return result;
+
+        foreach (var model in dataArray.EnumerateArray())
+        {
+            if (!model.TryGetProperty("id", out var idProp))
+                continue;
+
+            var id = idProp.GetString();
+            if (id is null) continue;
+
+            var input = ModelModality.Text;
+            var output = ModelModality.Text;
+
+            if (model.TryGetProperty("architecture", out var arch))
+            {
+                if (arch.TryGetProperty("input_modalities", out var inputMods))
+                    input = ParseModalityArray(inputMods);
+                if (arch.TryGetProperty("output_modalities", out var outputMods))
+                    output = ParseModalityArray(outputMods);
+            }
+
+            result[id] = new ResolvedModelCapabilities(id, input, output);
+        }
+
+        return result;
+    }
+
+    internal static ModelModality ParseModalityArray(JsonElement array)
+    {
+        var result = ModelModality.None;
+
+        foreach (var item in array.EnumerateArray())
+        {
+            var value = item.GetString();
+            if (value is null) continue;
+
+            result |= value.ToLowerInvariant() switch
+            {
+                "text" => ModelModality.Text,
+                "image" => ModelModality.Image,
+                "audio" => ModelModality.Audio,
+                "video" => ModelModality.Video,
+                _ => ModelModality.None,
+            };
+        }
+
+        return result;
+    }
+}

--- a/src/Netclaw.Security.Tests/FilenameSanitizerTests.cs
+++ b/src/Netclaw.Security.Tests/FilenameSanitizerTests.cs
@@ -1,0 +1,76 @@
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed class FilenameSanitizerTests
+{
+    [Theory]
+    [InlineData("../../etc/passwd", "passwd")]
+    [InlineData("..\\..\\windows\\system32\\config", "config")]
+    [InlineData("/etc/shadow", "shadow")]
+    [InlineData("C:\\Windows\\System32\\cmd.exe", "cmd.exe")]
+    public void Sanitize_PathTraversalAttempts_StripsDirectoryComponents(string input, string expected)
+    {
+        var result = FilenameSanitizer.Sanitize(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, "attachment")]
+    [InlineData("", "attachment")]
+    [InlineData("   ", "attachment")]
+    public void Sanitize_EmptyOrNull_ReturnsDefault(string? input, string expected)
+    {
+        var result = FilenameSanitizer.Sanitize(input!);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_ControlCharacters_Stripped()
+    {
+        var result = FilenameSanitizer.Sanitize("file\x00name\x1F.png");
+        Assert.Equal("filename.png", result);
+    }
+
+    [Fact]
+    public void Sanitize_PlatformProblemChars_Replaced()
+    {
+        var result = FilenameSanitizer.Sanitize("file<name>with|chars?.png");
+        Assert.Equal("file_name_with_chars_.png", result);
+    }
+
+    [Fact]
+    public void Sanitize_DoubleDots_Replaced()
+    {
+        var result = FilenameSanitizer.Sanitize("file..name.png");
+        Assert.Equal("file_name.png", result);
+    }
+
+    [Fact]
+    public void Sanitize_LongFilename_TruncatedPreservingExtension()
+    {
+        var longName = new string('a', 300) + ".png";
+        var result = FilenameSanitizer.Sanitize(longName);
+
+        Assert.True(result.Length <= 255);
+        Assert.EndsWith(".png", result);
+    }
+
+    [Fact]
+    public void HasSuspiciousDoubleExtension_SingleExtension_ReturnsFalse()
+    {
+        Assert.False(FilenameSanitizer.HasSuspiciousDoubleExtension("photo.png"));
+    }
+
+    [Fact]
+    public void HasSuspiciousDoubleExtension_DoubleExtension_ReturnsTrue()
+    {
+        Assert.True(FilenameSanitizer.HasSuspiciousDoubleExtension("malware.exe.png"));
+    }
+
+    [Fact]
+    public void HasSuspiciousDoubleExtension_NoExtension_ReturnsFalse()
+    {
+        Assert.False(FilenameSanitizer.HasSuspiciousDoubleExtension("README"));
+    }
+}

--- a/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
+++ b/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
@@ -1,0 +1,169 @@
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed class MagicByteValidatorTests
+{
+    // Real PNG header bytes
+    private static readonly byte[] PngHeader = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00];
+
+    // Real JPEG header bytes
+    private static readonly byte[] JpegHeader = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+
+    // Real GIF header bytes (GIF89a)
+    private static readonly byte[] GifHeader = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00];
+
+    // Real WebP header bytes (RIFF....WEBP)
+    private static readonly byte[] WebpHeader = [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56];
+
+    // Windows EXE (MZ header)
+    private static readonly byte[] ExeHeader = [0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00];
+
+    // Linux ELF header
+    private static readonly byte[] ElfHeader = [0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00];
+
+    // Shebang script
+    private static readonly byte[] ShebangHeader = [0x23, 0x21, 0x2F, 0x62, 0x69, 0x6E, 0x2F, 0x73, 0x68]; // #!/bin/sh
+
+    [Fact]
+    public void Validate_PngWithValidBytes_Allowed()
+    {
+        var result = MagicByteValidator.Validate(PngHeader, "image/png", "photo.png");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Validate_JpegWithValidBytes_Allowed()
+    {
+        var result = MagicByteValidator.Validate(JpegHeader, "image/jpeg", "photo.jpg");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Validate_JpegWithJpegExtension_Allowed()
+    {
+        var result = MagicByteValidator.Validate(JpegHeader, "image/jpeg", "photo.jpeg");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Validate_GifWithValidBytes_Allowed()
+    {
+        var result = MagicByteValidator.Validate(GifHeader, "image/gif", "animation.gif");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Validate_WebpWithValidBytes_Allowed()
+    {
+        var result = MagicByteValidator.Validate(WebpHeader, "image/webp", "photo.webp");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Validate_EmptyContent_Rejected()
+    {
+        var result = MagicByteValidator.Validate(ReadOnlySpan<byte>.Empty, "image/png", "empty.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.EmptyContent, result.Error);
+    }
+
+    [Fact]
+    public void Validate_ExecutableBytes_AlwaysRejected()
+    {
+        // EXE bytes disguised as PNG
+        var result = MagicByteValidator.Validate(ExeHeader, "image/png", "photo.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.ExecutableContent, result.Error);
+    }
+
+    [Fact]
+    public void Validate_ElfExecutable_AlwaysRejected()
+    {
+        var result = MagicByteValidator.Validate(ElfHeader, "image/png", "photo.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.ExecutableContent, result.Error);
+    }
+
+    [Fact]
+    public void Validate_ShebangScript_AlwaysRejected()
+    {
+        var result = MagicByteValidator.Validate(ShebangHeader, "image/png", "photo.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.ExecutableContent, result.Error);
+    }
+
+    [Fact]
+    public void Validate_PdfMimeType_RejectedAsUnrecognized()
+    {
+        // PDF is not in image-only allowlist
+        byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34]; // %PDF-1.4
+        var result = MagicByteValidator.Validate(pdfBytes, "application/pdf", "doc.pdf");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.UnrecognizedFileType, result.Error);
+    }
+
+    [Fact]
+    public void Validate_MimeTypeMismatch_ExtensionDoesNotMatchDeclaredType()
+    {
+        // PNG bytes but declared as JPEG
+        var result = MagicByteValidator.Validate(PngHeader, "image/jpeg", "photo.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.MimeTypeMismatch, result.Error);
+    }
+
+    [Fact]
+    public void Validate_MagicByteMismatch_JpegBytesWithPngDeclaration()
+    {
+        // JPEG bytes but declared as PNG with .png extension
+        var result = MagicByteValidator.Validate(JpegHeader, "image/png", "photo.png");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.MimeTypeMismatch, result.Error);
+    }
+
+    [Fact]
+    public void Validate_UnknownExtension_Rejected()
+    {
+        var result = MagicByteValidator.Validate(PngHeader, "image/png", "photo.bmp");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.UnrecognizedFileType, result.Error);
+    }
+
+    [Fact]
+    public void Validate_FileTooLarge_Rejected()
+    {
+        var policy = new ContentPolicy { MaxFileSizeBytes = 10 };
+        var result = MagicByteValidator.Validate(PngHeader, "image/png", "photo.png", policy);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ContentScanError.FileTooLarge, result.Error);
+    }
+
+    [Fact]
+    public void HasExecutableSignature_DetectsAllKnownSignatures()
+    {
+        Assert.True(MagicByteValidator.HasExecutableSignature(ExeHeader));
+        Assert.True(MagicByteValidator.HasExecutableSignature(ElfHeader));
+        Assert.True(MagicByteValidator.HasExecutableSignature(ShebangHeader));
+        Assert.False(MagicByteValidator.HasExecutableSignature(PngHeader));
+        Assert.False(MagicByteValidator.HasExecutableSignature(JpegHeader));
+    }
+}

--- a/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
+++ b/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Netclaw.Security/Netclaw.Security.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Security.Tests/NullScannerTests.cs
+++ b/src/Netclaw.Security.Tests/NullScannerTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed class NullScannerTests
+{
+    [Fact]
+    public async Task NullContentScanner_AlwaysAllows()
+    {
+        var scanner = new NullContentScanner();
+        var result = await scanner.ScanAsync(
+            new byte[] { 0x89, 0x50, 0x4E, 0x47 },
+            "photo.png",
+            "image/png");
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task NullPromptInjectionDetector_AlwaysSafe()
+    {
+        var detector = new NullPromptInjectionDetector();
+        var result = await detector.DetectAsync("ignore previous instructions", "slack");
+
+        Assert.Equal(PromptInjectionRisk.None, result.Risk);
+        Assert.Null(result.Message);
+    }
+}

--- a/src/Netclaw.Security/ContentPolicy.cs
+++ b/src/Netclaw.Security/ContentPolicy.cs
@@ -1,0 +1,34 @@
+using System.Collections.Frozen;
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Configurable content security policy for file uploads.
+/// </summary>
+public sealed class ContentPolicy
+{
+    /// <summary>
+    /// Default maximum file size: 20 MB.
+    /// </summary>
+    public const long DefaultMaxFileSizeBytes = 20 * 1024 * 1024;
+
+    /// <summary>
+    /// MIME types allowed through the content scanner.
+    /// Defaults to image types supported by vision models.
+    /// </summary>
+    public FrozenSet<string> AllowedMimeTypes { get; init; } = DefaultAllowedMimeTypes;
+
+    /// <summary>
+    /// Maximum file size in bytes.
+    /// </summary>
+    public long MaxFileSizeBytes { get; init; } = DefaultMaxFileSizeBytes;
+
+    public static readonly FrozenSet<string> DefaultAllowedMimeTypes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp"
+        }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Netclaw.Security/ContentScanResult.cs
+++ b/src/Netclaw.Security/ContentScanResult.cs
@@ -1,0 +1,34 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// Result of scanning file content for security threats.
+/// </summary>
+public sealed record ContentScanResult(
+    bool IsAllowed,
+    ContentScanError? Error = null,
+    MimeType? DetectedMimeType = null,
+    string? Message = null)
+{
+    public static ContentScanResult Allowed(MimeType? detectedMimeType = null) =>
+        new(true, null, detectedMimeType);
+
+    public static ContentScanResult Rejected(
+        ContentScanError error,
+        string message,
+        MimeType? detectedMimeType = null) =>
+        new(false, error, detectedMimeType, message);
+}
+
+/// <summary>
+/// Errors that can occur during content scanning.
+/// </summary>
+public enum ContentScanError
+{
+    UnrecognizedFileType,
+    MimeTypeMismatch,
+    ExecutableContent,
+    EmptyContent,
+    FileTooLarge,
+    AntivirusDetection,
+    ScanFailure
+}

--- a/src/Netclaw.Security/FilenameSanitizer.cs
+++ b/src/Netclaw.Security/FilenameSanitizer.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Sanitizes filenames to prevent path traversal and other attacks.
+/// Adapted from TextForge's AttachmentSecurity.SanitizeFilename().
+/// </summary>
+public static partial class FilenameSanitizer
+{
+    /// <summary>
+    /// Sanitizes a filename by removing directory components, control characters,
+    /// path traversal sequences, and problematic platform characters.
+    /// </summary>
+    public static string Sanitize(string filename)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+            return "attachment";
+
+        // Normalize path separators for cross-platform handling
+        var normalized = filename.Replace('\\', '/');
+
+        // Strip directory components
+        var sanitized = Path.GetFileName(normalized);
+
+        // Remove null bytes and control characters
+        sanitized = ControlCharRegex().Replace(sanitized, "");
+
+        // Remove characters problematic across platforms
+        sanitized = PlatformProblemCharRegex().Replace(sanitized, "_");
+
+        // Remove path traversal sequences
+        sanitized = sanitized.Replace("..", "_");
+
+        // Trim whitespace and dots from ends
+        sanitized = sanitized.Trim().Trim('.');
+
+        // Limit length preserving extension
+        if (sanitized.Length > 255)
+        {
+            var extension = Path.GetExtension(sanitized);
+            var nameWithoutExt = Path.GetFileNameWithoutExtension(sanitized);
+            sanitized = nameWithoutExt[..(255 - extension.Length)] + extension;
+        }
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "attachment" : sanitized;
+    }
+
+    /// <summary>
+    /// Checks if a filename contains double extensions that could indicate
+    /// a social engineering attack (e.g., "report.exe.png").
+    /// </summary>
+    public static bool HasSuspiciousDoubleExtension(string filename)
+    {
+        var remaining = filename;
+        var extensionCount = 0;
+
+        while (true)
+        {
+            var ext = Path.GetExtension(remaining);
+            if (string.IsNullOrEmpty(ext))
+                break;
+
+            extensionCount++;
+            if (extensionCount > 1)
+                return true;
+
+            remaining = Path.GetFileNameWithoutExtension(remaining);
+        }
+
+        return false;
+    }
+
+    [GeneratedRegex(@"[\x00-\x1F\x7F]")]
+    private static partial Regex ControlCharRegex();
+
+    [GeneratedRegex(@"[<>:""/\\|?*]")]
+    private static partial Regex PlatformProblemCharRegex();
+}

--- a/src/Netclaw.Security/IContentScanner.cs
+++ b/src/Netclaw.Security/IContentScanner.cs
@@ -1,0 +1,14 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// Scans file content for security threats before it enters the pipeline.
+/// Called at the channel adapter boundary (e.g., Slack file downloads).
+/// </summary>
+public interface IContentScanner
+{
+    Task<ContentScanResult> ScanAsync(
+        ReadOnlyMemory<byte> content,
+        string filename,
+        string declaredMimeType,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Netclaw.Security/IPromptInjectionDetector.cs
+++ b/src/Netclaw.Security/IPromptInjectionDetector.cs
@@ -1,0 +1,13 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// Detects prompt injection attempts in text content.
+/// Stub interface for future webhook scenarios (e.g., public GitHub repos).
+/// </summary>
+public interface IPromptInjectionDetector
+{
+    Task<PromptInjectionResult> DetectAsync(
+        string text,
+        string sourceContext,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -1,0 +1,214 @@
+using System.Collections.Frozen;
+using MimeDetective;
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Validates file content using magic byte (file signature) analysis.
+/// Narrowed to image types for Netclaw's multimodal pipeline.
+/// Adapted from TextForge's MagicByteValidator.
+/// </summary>
+public static class MagicByteValidator
+{
+    private static readonly Lazy<IContentInspector> Inspector = new(() =>
+        new ContentInspectorBuilder()
+        {
+            Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
+        }.Build());
+
+    private static readonly FrozenSet<string> AllowedImageMimeTypes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp"
+        }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenDictionary<string, FrozenSet<string>> AllowedExtensions =
+        new Dictionary<string, FrozenSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".png"] = new[] { "image/png" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            [".jpg"] = new[] { "image/jpeg" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            [".jpeg"] = new[] { "image/jpeg" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            [".gif"] = new[] { "image/gif" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            [".webp"] = new[] { "image/webp" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Magic byte signatures for executable content — always blocked.
+    /// </summary>
+    private static readonly byte[][] ExecutableSignatures =
+    [
+        [0x4D, 0x5A],                   // MZ — Windows PE (EXE, DLL)
+        [0x7F, 0x45, 0x4C, 0x46],       // ELF — Linux executables
+        [0xCF, 0xFA, 0xED, 0xFE],       // Mach-O 64-bit
+        [0xCE, 0xFA, 0xED, 0xFE],       // Mach-O 32-bit
+        [0xCA, 0xFE, 0xBA, 0xBE],       // Java CLASS or Mach-O Universal
+        [0x23, 0x21]                     // #! — Shebang (shell scripts)
+    ];
+
+    /// <summary>
+    /// Validates file content against its declared MIME type and filename.
+    /// Only image types are allowed through.
+    /// </summary>
+    public static ContentScanResult Validate(
+        ReadOnlySpan<byte> content,
+        string declaredMimeType,
+        string filename,
+        ContentPolicy? policy = null)
+    {
+        if (content.Length == 0)
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.EmptyContent,
+                "File is empty");
+        }
+
+        var effectivePolicy = policy ?? new ContentPolicy();
+        var allowedMimes = effectivePolicy.AllowedMimeTypes;
+
+        if (content.Length > effectivePolicy.MaxFileSizeBytes)
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.FileTooLarge,
+                $"File exceeds maximum size of {effectivePolicy.MaxFileSizeBytes / (1024 * 1024)} MB");
+        }
+
+        // Always check for executables — these are never allowed
+        if (HasExecutableSignature(content))
+        {
+            var detectedType = DetectMimeType(content);
+            return ContentScanResult.Rejected(
+                ContentScanError.ExecutableContent,
+                "Executable content detected",
+                detectedType is not null ? new MimeType(detectedType) : null);
+        }
+
+        // Validate extension is in allowlist
+        var extension = Path.GetExtension(filename);
+        if (string.IsNullOrEmpty(extension) || !AllowedExtensions.ContainsKey(extension))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.UnrecognizedFileType,
+                $"File extension '{extension}' is not allowed");
+        }
+
+        // Validate declared MIME type is allowed
+        if (!allowedMimes.Contains(declaredMimeType))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.UnrecognizedFileType,
+                $"MIME type '{declaredMimeType}' is not allowed");
+        }
+
+        // Validate extension matches declared MIME type
+        var allowedMimesForExtension = AllowedExtensions[extension];
+        if (!allowedMimesForExtension.Contains(declaredMimeType))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.MimeTypeMismatch,
+                $"Extension '{extension}' does not match declared type '{declaredMimeType}'");
+        }
+
+        // Validate magic bytes match expected image type
+        return ValidateImageContent(content, declaredMimeType);
+    }
+
+    public static string? DetectMimeType(ReadOnlySpan<byte> content)
+    {
+        if (content.Length == 0)
+            return null;
+
+        try
+        {
+            var results = Inspector.Value.Inspect(content);
+            var topMatch = results.OrderByDescending(r => r.Points).FirstOrDefault();
+            return topMatch?.Definition.File.MimeType;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool HasExecutableSignature(ReadOnlySpan<byte> content)
+    {
+        if (content.Length < 2)
+            return false;
+
+        foreach (var signature in ExecutableSignatures)
+        {
+            if (content.Length >= signature.Length && content[..signature.Length].SequenceEqual(signature))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static ContentScanResult ValidateImageContent(
+        ReadOnlySpan<byte> content,
+        string declaredMimeType)
+    {
+        var detectedMimeType = DetectMimeType(content);
+
+        if (declaredMimeType.Equals("image/png", StringComparison.OrdinalIgnoreCase))
+        {
+            // PNG: 89 50 4E 47 0D 0A 1A 0A
+            if (content.Length < 8 ||
+                content[0] != 0x89 || content[1] != 0x50 ||
+                content[2] != 0x4E || content[3] != 0x47 ||
+                content[4] != 0x0D || content[5] != 0x0A ||
+                content[6] != 0x1A || content[7] != 0x0A)
+            {
+                return ContentScanResult.Rejected(
+                    ContentScanError.MimeTypeMismatch,
+                    "Content is not a valid PNG file",
+                    detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
+            }
+        }
+        else if (declaredMimeType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase))
+        {
+            // JPEG: FF D8 FF
+            if (content.Length < 3 ||
+                content[0] != 0xFF || content[1] != 0xD8 || content[2] != 0xFF)
+            {
+                return ContentScanResult.Rejected(
+                    ContentScanError.MimeTypeMismatch,
+                    "Content is not a valid JPEG file",
+                    detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
+            }
+        }
+        else if (declaredMimeType.Equals("image/gif", StringComparison.OrdinalIgnoreCase))
+        {
+            // GIF: GIF8 (47 49 46 38)
+            if (content.Length < 4 ||
+                content[0] != 0x47 || content[1] != 0x49 ||
+                content[2] != 0x46 || content[3] != 0x38)
+            {
+                return ContentScanResult.Rejected(
+                    ContentScanError.MimeTypeMismatch,
+                    "Content is not a valid GIF file",
+                    detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
+            }
+        }
+        else if (declaredMimeType.Equals("image/webp", StringComparison.OrdinalIgnoreCase))
+        {
+            // WebP: RIFF....WEBP (52 49 46 46 xx xx xx xx 57 45 42 50)
+            if (content.Length < 12 ||
+                content[0] != 0x52 || content[1] != 0x49 ||
+                content[2] != 0x46 || content[3] != 0x46 ||
+                content[8] != 0x57 || content[9] != 0x45 ||
+                content[10] != 0x42 || content[11] != 0x50)
+            {
+                return ContentScanResult.Rejected(
+                    ContentScanError.MimeTypeMismatch,
+                    "Content is not a valid WebP file",
+                    detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
+            }
+        }
+
+        return ContentScanResult.Allowed(
+            new MimeType(detectedMimeType ?? declaredMimeType));
+    }
+}

--- a/src/Netclaw.Security/MimeType.cs
+++ b/src/Netclaw.Security/MimeType.cs
@@ -1,0 +1,30 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// A MIME type (content type) value object.
+/// Defaults to "application/octet-stream" for unknown or empty types.
+/// NO implicit string conversion — use <see cref="Value"/> for explicit access.
+/// </summary>
+public readonly record struct MimeType
+{
+    public const string DefaultValue = "application/octet-stream";
+
+    public string Value { get; }
+
+    public MimeType(string? mimeType)
+    {
+        Value = string.IsNullOrWhiteSpace(mimeType) ? DefaultValue : mimeType.Trim();
+    }
+
+    public MimeType() : this(DefaultValue)
+    {
+    }
+
+    public static MimeType Default => new(DefaultValue);
+
+    public bool IsImage => Value.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsText => Value.StartsWith("text/", StringComparison.OrdinalIgnoreCase);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Security/Netclaw.Security.csproj
+++ b/src/Netclaw.Security/Netclaw.Security.csproj
@@ -7,18 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Mime-Detective" />
+    <PackageReference Include="Mime-Detective.Definitions.Condensed" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="SlackNet" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
-    <ProjectReference Include="..\Netclaw.Security\Netclaw.Security.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Security/NullContentScanner.cs
+++ b/src/Netclaw.Security/NullContentScanner.cs
@@ -1,0 +1,17 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// No-op content scanner that allows all content through.
+/// Used as the default until a real scanner (e.g., ClamAV) is configured.
+/// </summary>
+public sealed class NullContentScanner : IContentScanner
+{
+    public Task<ContentScanResult> ScanAsync(
+        ReadOnlyMemory<byte> content,
+        string filename,
+        string declaredMimeType,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(ContentScanResult.Allowed());
+    }
+}

--- a/src/Netclaw.Security/NullPromptInjectionDetector.cs
+++ b/src/Netclaw.Security/NullPromptInjectionDetector.cs
@@ -1,0 +1,16 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// No-op prompt injection detector that reports all text as safe.
+/// Used as the default until a real detector is implemented.
+/// </summary>
+public sealed class NullPromptInjectionDetector : IPromptInjectionDetector
+{
+    public Task<PromptInjectionResult> DetectAsync(
+        string text,
+        string sourceContext,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(PromptInjectionResult.Safe());
+    }
+}

--- a/src/Netclaw.Security/PromptInjectionResult.cs
+++ b/src/Netclaw.Security/PromptInjectionResult.cs
@@ -1,0 +1,26 @@
+namespace Netclaw.Security;
+
+/// <summary>
+/// Result of prompt injection detection analysis.
+/// </summary>
+public sealed record PromptInjectionResult(
+    PromptInjectionRisk Risk,
+    string? Message = null)
+{
+    public static PromptInjectionResult Safe() =>
+        new(PromptInjectionRisk.None);
+
+    public static PromptInjectionResult Detected(PromptInjectionRisk risk, string message) =>
+        new(risk, message);
+}
+
+/// <summary>
+/// Risk level for prompt injection detection.
+/// </summary>
+public enum PromptInjectionRisk
+{
+    None,
+    Low,
+    Medium,
+    High
+}

--- a/src/Netclaw.Security/SecurityServiceExtensions.cs
+++ b/src/Netclaw.Security/SecurityServiceExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Netclaw.Security;
+
+public static class SecurityServiceExtensions
+{
+    /// <summary>
+    /// Registers content security services with no-op defaults.
+    /// Replace individual registrations to plug in real scanning.
+    /// </summary>
+    public static IServiceCollection AddContentSecurity(this IServiceCollection services)
+    {
+        services.AddSingleton<ContentPolicy>();
+        services.AddSingleton<IContentScanner, NullContentScanner>();
+        services.AddSingleton<IPromptInjectionDetector, NullPromptInjectionDetector>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds end-to-end multimodal image support: Slack file attachments download, scan, persist, and reach the LLM as `DataContent`
- Modality gate in `LlmSessionActor` strips images for text-only models and skips LLM calls for image-only messages
- `attach_file` tool lets the LLM produce file outputs with path traversal prevention
- `FileOutput` renders in Slack (file upload), TUI (path display), and headless mode
- Builds on the `Netclaw.Security` content scanning infrastructure and model capability detection from prior commits on this branch

### Key changes by layer

**Persistence**: `SerializableMediaReference` (Protobuf), `MediaModality` enum, `MediaReferences` on `SerializableChatMessage` and `SendUserMessage`

**Converter**: `ChatMessageConverter` reads/writes media files to session dir, maps between `DataContent` and `SerializableMediaReference`

**Session**: Modality gate checks `SessionConfig.InputModalities` flag, `SessionDirectoryHelper` extracted for shared session dir computation

**Slack inbound**: `SlackFileReference` record, file download with Bearer auth, content scanning, image MIME filtering

**Slack outbound**: `ISlackReplyClient.UploadFileToThreadAsync` via SlackNet V2 `FileUpload` API

**Pipeline/Output**: `FileOutput` type, `OutputFilter.Files` flag, `SessionOutputDto` file fields

**TUI/SignalR**: `SessionOutputMapper`, `DaemonClient`, `ChatPage`, `HeadlessChannel` all handle `FileOutput`

**Tool**: `AttachFileTool` with canonicalized path validation and `FilenameSanitizer`

## Test plan

- [x] Protobuf round-trip: `SerializableChatMessage` and `SendUserMessage` with `MediaReferences` (3 tests)
- [x] `ChatMessageConverter` media round-trip, missing files, empty content, MIME mapping (7 tests)
- [x] Modality gate integration: text-only strips images, image-only skips LLM, vision passes through (3 tests)
- [x] `AttachFileTool`: valid path, path traversal, dotdot traversal, missing file, empty path, no session dir, display name (7 tests)
- [x] All 366 tests pass, slopwatch clean
- [ ] Manual testing tracked in #63: Slack file ingest, file upload, modality gate with real models, TUI rendering