### PR TITLE
Daemon restart on config file change

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class ConfigWatcherServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly DaemonRestartSignal _restartSignal;
+    private readonly FakeApplicationLifetime _lifetime;
+    private readonly ConfigWatcherService _sut;
+
+    public ConfigWatcherServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+
+        _restartSignal = new DaemonRestartSignal();
+        _lifetime = new FakeApplicationLifetime();
+
+        _sut = new ConfigWatcherService(
+            _paths,
+            TimeProvider.System,
+            _lifetime,
+            _restartSignal,
+            NullLogger<ConfigWatcherService>.Instance);
+    }
+
+    [Fact]
+    public void ValidConfigChange_TriggersRestart()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
+        File.WriteAllText(_paths.SecretsPath, """{ "ApiKeys": {} }""");
+
+        _sut.ApplyReload();
+
+        Assert.True(_restartSignal.RestartRequested);
+        Assert.True(_lifetime.StopRequested);
+    }
+
+    [Fact]
+    public void InvalidJson_DoesNotTriggerRestart()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, """{ broken json """);
+        // secrets.json doesn't exist — that's fine (optional)
+
+        _sut.ApplyReload();
+
+        Assert.False(_restartSignal.RestartRequested);
+        Assert.False(_lifetime.StopRequested);
+    }
+
+    [Fact]
+    public void MissingConfigFiles_TriggersRestart()
+    {
+        // Both files are optional in the config chain — missing = valid
+        Assert.False(File.Exists(_paths.NetclawConfigPath));
+        Assert.False(File.Exists(_paths.SecretsPath));
+
+        _sut.ApplyReload();
+
+        Assert.True(_restartSignal.RestartRequested);
+        Assert.True(_lifetime.StopRequested);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    private sealed class FakeApplicationLifetime : IHostApplicationLifetime
+    {
+        public bool StopRequested { get; private set; }
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => StopRequested = true;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -73,8 +73,8 @@ public sealed class ConfigWatcherServiceTests : IDisposable
     public void Dispose()
     {
         _sut.Dispose();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best-effort cleanup */ }
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
     }
 
     private sealed class FakeApplicationLifetime : IHostApplicationLifetime

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -19,7 +19,12 @@ using Netclaw.Security;
 
 try
 {
-    await RunAsync(args);
+    var restartSignal = new DaemonRestartSignal();
+    do
+    {
+        restartSignal.Reset();
+        await RunDaemonAsync(args, restartSignal);
+    } while (restartSignal.RestartRequested);
 }
 catch (Exception ex)
 {
@@ -27,12 +32,15 @@ catch (Exception ex)
     throw;
 }
 
-static async Task RunAsync(string[] args)
+static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSignal)
 {
     var builder = WebApplication.CreateBuilder(args);
 
     // Use port 5199 to avoid conflicts with Aspire (5000) and other defaults
     builder.WebHost.UseUrls("http://127.0.0.1:5199");
+
+    // Register process-lifetime restart signal so services can trigger a restart
+    builder.Services.AddSingleton(restartSignal);
 
     var paths = ConfigureConfigServices(builder.Services, builder.Configuration);
     var daemonLogLevel = builder.ConfigureNetclawLogging();
@@ -223,6 +231,12 @@ static void ConfigureDaemonServices(
     // Akka.NET actor system
     services.AddAkka("netclaw", (akkaBuilder, sp) =>
     {
+        // Prevent coordinated shutdown from calling Environment.Exit(),
+        // which would kill the process before the restart loop can iterate.
+        akkaBuilder.AddHocon(
+            "akka.coordinated-shutdown.exit-clr = off",
+            HoconAddMode.Prepend);
+
         akkaBuilder = akkaBuilder.ConfigureLoggers(setup =>
         {
             setup.ClearLoggers();

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
@@ -20,6 +21,8 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
 {
     private readonly NetclawPaths _paths;
     private readonly TimeProvider _timeProvider;
+    private readonly IHostApplicationLifetime _appLifetime;
+    private readonly DaemonRestartSignal _restartSignal;
     private readonly ILogger<ConfigWatcherService> _logger;
 
     private FileSystemWatcher? _watcher;
@@ -29,10 +32,14 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
     public ConfigWatcherService(
         NetclawPaths paths,
         TimeProvider timeProvider,
+        IHostApplicationLifetime appLifetime,
+        DaemonRestartSignal restartSignal,
         ILogger<ConfigWatcherService> logger)
     {
         _paths = paths;
         _timeProvider = timeProvider;
+        _appLifetime = appLifetime;
+        _restartSignal = restartSignal;
         _logger = logger;
     }
 
@@ -106,22 +113,49 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
         }, CancellationToken.None);
     }
 
-    private void ApplyReload()
+    internal void ApplyReload()
     {
         try
         {
-            // TODO: Read and validate new configuration
-            // TODO: Rebuild IChatClientProvider on valid change
-            // TODO: Notify actor system of config changes via Akka pub/sub
-            // TODO: Log validation errors on invalid change, preserve previous config
-
             _logger.LogInformation(
-                "[{Timestamp:o}] Config reload triggered (validation not yet implemented)",
+                "[{Timestamp:o}] Config change detected, validating before restart...",
                 _timeProvider.GetUtcNow());
+
+            // Validate JSON structure of both config files before triggering restart.
+            // Full semantic validation happens during the next startup cycle.
+            if (!ValidateConfigJson(_paths.NetclawConfigPath) ||
+                !ValidateConfigJson(_paths.SecretsPath))
+            {
+                _logger.LogWarning("Config validation failed. Keeping current config — no restart.");
+                return;
+            }
+
+            _logger.LogInformation("Config valid. Requesting daemon restart.");
+            _restartSignal.RequestRestart();
+            _appLifetime.StopApplication();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Config reload failed. Keeping previous config.");
+        }
+    }
+
+    private bool ValidateConfigJson(string path)
+    {
+        if (!File.Exists(path))
+            return true; // Missing files are OK — they're optional in the config chain
+
+        try
+        {
+            var bytes = File.ReadAllBytes(path);
+            var reader = new Utf8JsonReader(bytes);
+            while (reader.Read()) { } // Walk the entire document to catch syntax errors
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning("Invalid JSON in {ConfigFile}: {Error}", path, ex.Message);
+            return false;
         }
     }
 

--- a/src/Netclaw.Daemon/Services/DaemonRestartSignal.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartSignal.cs
@@ -1,0 +1,18 @@
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Process-lifetime flag coordinating config-triggered restarts between
+/// <see cref="ConfigWatcherService"/> (writer) and the outer restart loop
+/// in Program.cs (reader). Created once in Program.cs, registered into
+/// each host iteration's DI container.
+/// </summary>
+public sealed class DaemonRestartSignal
+{
+    private volatile bool _restartRequested;
+
+    public bool RestartRequested => _restartRequested;
+
+    public void RequestRestart() => _restartRequested = true;
+
+    public void Reset() => _restartRequested = false;
+}

--- a/src/Netclaw.Daemon/Services/PidFileService.cs
+++ b/src/Netclaw.Daemon/Services/PidFileService.cs
@@ -11,11 +11,13 @@ namespace Netclaw.Daemon.Services;
 public sealed class PidFileService : IHostedService
 {
     private readonly NetclawPaths _paths;
+    private readonly DaemonRestartSignal _restartSignal;
     private readonly ILogger<PidFileService> _logger;
 
-    public PidFileService(NetclawPaths paths, ILogger<PidFileService> logger)
+    public PidFileService(NetclawPaths paths, DaemonRestartSignal restartSignal, ILogger<PidFileService> logger)
     {
         _paths = paths;
+        _restartSignal = restartSignal;
         _logger = logger;
     }
 
@@ -32,6 +34,12 @@ public sealed class PidFileService : IHostedService
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        if (_restartSignal.RestartRequested)
+        {
+            _logger.LogDebug("Restart requested — keeping PID file (same process): {PidFilePath}", _paths.PidFilePath);
+            return Task.CompletedTask;
+        }
+
         try
         {
             if (File.Exists(_paths.PidFilePath))


### PR DESCRIPTION
## Summary

- Implements graceful daemon restart when `~/.netclaw/config/netclaw.json` or `secrets.json` change on disk
- Replaces the stubbed `ConfigWatcherService.ApplyReload()` with JSON validation + host restart loop
- Adds `DaemonRestartSignal` as a process-lifetime coordinator between the config watcher and the outer restart loop in `Program.cs`
- PID file is preserved across restart iterations (same process, same PID)
- Disables Akka `exit-clr` to prevent `Environment.Exit()` during coordinated shutdown, allowing the restart loop to iterate

## How it works

```
DaemonRestartSignal (created once in Program.cs)
        │
        ├── ConfigWatcherService: validates JSON → sets flag → calls StopApplication()
        │
        └── Program.cs do/while loop: reads flag → rebuilds fresh WebApplication
```

Invalid JSON on disk is rejected with a warning — no restart, current config preserved. Bad config that passes JSON parse but fails semantic validation during startup will crash-log and exit (no infinite restart loop).

## Test plan

- [x] `dotnet build` — compiles clean
- [x] `dotnet test` — 433 tests pass (3 new for ConfigWatcherService)
- [x] `dotnet slopwatch analyze` — zero violations
- [ ] Manual: run daemon, edit `netclaw.json`, observe restart in logs