### PR TITLE
Introduce Slack identifier value objects

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -45,7 +45,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         var deps = CreateDependencies(
             threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
 
-        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-1");
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps), "slack-conversation-test-1");
 
         conversation.Tell(CreateMessage(
             eventId: "C1:200",
@@ -85,7 +85,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         var deps = CreateDependencies(
             threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
 
-        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("D1", deps), "slack-conversation-test-2");
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps(new SlackChannelId("D1"), deps), "slack-conversation-test-2");
 
         conversation.Tell(CreateMessage(
             eventId: "D1:300",
@@ -107,7 +107,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         var deps = CreateDependencies(
             threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
 
-        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-files-1");
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps), "slack-conversation-test-files-1");
 
         var files = new List<SlackFileReference>
         {
@@ -135,7 +135,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         var deps = CreateDependencies(
             threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
 
-        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-files-2");
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps), "slack-conversation-test-files-2");
 
         var files = new List<SlackFileReference>
         {
@@ -164,16 +164,16 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         var deps = CreateDependencies(
             threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
 
-        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-3");
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps), "slack-conversation-test-3");
 
         conversation.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
-            EventId: "C1:400",
-            ChannelId: "C1",
-            ThreadTs: "400.1",
-            EventTs: "400.2",
-            UserId: "UBOT",
-            BotId: "B1",
+            EventId: new SlackEventId("C1:400"),
+            ChannelId: new SlackChannelId("C1"),
+            ThreadTs: new SlackThreadTs("400.1"),
+            EventTs: new SlackEventTs("400.2"),
+            UserId: new SlackUserId("UBOT"),
+            BotId: new SlackBotId("B1"),
             Text: "bot output",
             Subtype: "bot_message",
             Hidden: false,
@@ -183,8 +183,8 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     }
 
     private static SlackGatewayDependencies CreateDependencies(
-        Func<string, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
-        Func<SessionId, string, string, SlackGatewayDependencies, Props>? threadPropsFactory = null)
+        Func<SlackChannelId, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
+        Func<SessionId, SlackChannelId, SlackThreadTs, SlackGatewayDependencies, Props>? threadPropsFactory = null)
     {
         return new SlackGatewayDependencies(
             Pipeline: null!,
@@ -196,7 +196,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
                 AllowDirectMessages = true,
                 AllowedChannelIds = ["C1"]
             },
-            BotUserId: "UBOT",
+            BotUserId: new SlackUserId("UBOT"),
             DefaultChannelId: null,
             ReplyClient: new NoopReplyClient(),
             ContentScanner: new NullContentScanner(),
@@ -215,11 +215,11 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
-            EventId: eventId,
-            ChannelId: channelId,
-            ThreadTs: threadTs,
-            EventTs: eventTs,
-            UserId: "U1",
+            EventId: new SlackEventId(eventId),
+            ChannelId: new SlackChannelId(channelId),
+            ThreadTs: threadTs is not null ? new SlackThreadTs(threadTs) : null,
+            EventTs: new SlackEventTs(eventTs),
+            UserId: new SlackUserId("U1"),
             BotId: null,
             Text: text,
             Subtype: null,
@@ -237,11 +237,11 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: eventId,
-            ChannelId: channelId,
+            EventId: new SlackEventId(eventId),
+            ChannelId: new SlackChannelId(channelId),
             ThreadTs: null,
-            EventTs: eventTs,
-            UserId: "U1",
+            EventTs: new SlackEventTs(eventTs),
+            UserId: new SlackUserId("U1"),
             BotId: null,
             Text: text,
             Subtype: null,
@@ -263,7 +263,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
 
-        public Task UploadFileToThreadAsync(string channelId, string threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
+        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -101,6 +101,63 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     }
 
     [Fact]
+    public void Conversation_forwards_files_from_app_mention()
+    {
+        var sink = CreateTestProbe("files-mention-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-files-1");
+
+        var files = new List<SlackFileReference>
+        {
+            new("F1", "image.png", "image/png", 2048, "https://files.slack.com/F1/image.png")
+        };
+
+        conversation.Tell(CreateAppMention(
+            eventId: "C1:500",
+            channelId: "C1",
+            eventTs: "500.1",
+            text: "<@UBOT> check this",
+            files: files));
+
+        var inbound = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal("check this", inbound.Text);
+        Assert.NotNull(inbound.Files);
+        Assert.Single(inbound.Files);
+        Assert.Equal("F1", inbound.Files[0].Id);
+    }
+
+    [Fact]
+    public void Conversation_forwards_files_when_normalized_text_empty()
+    {
+        var sink = CreateTestProbe("files-empty-text-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(SlackConversationActor.CreateProps("C1", deps), "slack-conversation-test-files-2");
+
+        var files = new List<SlackFileReference>
+        {
+            new("F2", "photo.jpg", "image/jpeg", 4096, "https://files.slack.com/F2/photo.jpg")
+        };
+
+        // AppMention with only the bot mention — normalized text will be empty but files exist
+        conversation.Tell(CreateAppMention(
+            eventId: "C1:600",
+            channelId: "C1",
+            eventTs: "600.1",
+            text: "<@UBOT>",
+            files: files));
+
+        var inbound = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal(string.Empty, inbound.Text);
+        Assert.NotNull(inbound.Files);
+        Assert.Single(inbound.Files);
+        Assert.Equal("F2", inbound.Files[0].Id);
+    }
+
+    [Fact]
     public void Conversation_ignores_bot_messages_to_prevent_feedback_loop()
     {
         var sink = CreateTestProbe("bot-loop-sink");
@@ -153,7 +210,8 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         string eventTs,
         string text = "hello",
         string? threadTs = null,
-        bool isDirectMessage = false)
+        bool isDirectMessage = false,
+        IReadOnlyList<SlackFileReference>? files = null)
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
@@ -166,14 +224,16 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
             Text: text,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: isDirectMessage);
+            IsDirectMessage: isDirectMessage,
+            Files: files);
     }
 
     private static SlackInboundMessage CreateAppMention(
         string eventId,
         string channelId,
         string eventTs,
-        string text)
+        string text,
+        IReadOnlyList<SlackFileReference>? files = null)
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
@@ -186,7 +246,8 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
             Text: text,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: false);
+            IsDirectMessage: false,
+            Files: files);
     }
 
     private sealed class ForwardActor : ReceiveActor

--- a/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
@@ -158,11 +158,11 @@ public class SlackRoutingPolicyTests
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
-            EventId: "C0:1",
-            ChannelId: isDirectMessage ? "D0" : "C0",
-            ThreadTs: threadTs,
-            EventTs: "1740468000.000001",
-            UserId: "U123",
+            EventId: new SlackEventId("C0:1"),
+            ChannelId: new SlackChannelId(isDirectMessage ? "D0" : "C0"),
+            ThreadTs: threadTs is not null ? new SlackThreadTs(threadTs) : null,
+            EventTs: new SlackEventTs("1740468000.000001"),
+            UserId: new SlackUserId("U123"),
             BotId: null,
             Text: text,
             Subtype: null,
@@ -178,11 +178,11 @@ public class SlackRoutingPolicyTests
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: "C0:2",
-            ChannelId: "C0",
-            ThreadTs: threadTs,
-            EventTs: "1740468000.000002",
-            UserId: "U123",
+            EventId: new SlackEventId("C0:2"),
+            ChannelId: new SlackChannelId("C0"),
+            ThreadTs: threadTs is not null ? new SlackThreadTs(threadTs) : null,
+            EventTs: new SlackEventTs("1740468000.000002"),
+            UserId: new SlackUserId("U123"),
             BotId: null,
             Text: text,
             Subtype: null,

--- a/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
@@ -97,7 +97,64 @@ public class SlackRoutingPolicyTests
         Assert.Equal(SlackRoutingDecision.Ignore, decision);
     }
 
-    private static SlackInboundMessage CreateMessage(string text, string? threadTs, bool isDirectMessage)
+    [Fact]
+    public void FileOnlyMessage_ContinuesExistingThread()
+    {
+        var files = new List<SlackFileReference>
+        {
+            new("F1", "image.png", "image/png", 1024, "https://files.slack.com/F1/image.png")
+        };
+        var message = CreateMessage(text: "", threadTs: "1740468105.120900", isDirectMessage: false, files: files);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: true,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.ContinueOnly, decision);
+    }
+
+    [Fact]
+    public void FileOnlyAppMention_StartsThread()
+    {
+        var files = new List<SlackFileReference>
+        {
+            new("F1", "image.png", "image/png", 1024, "https://files.slack.com/F1/image.png")
+        };
+        var message = CreateAppMention(text: "", threadTs: null, files: files);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            threadExists: false,
+            containsBotMention: true);
+
+        Assert.Equal(SlackRoutingDecision.StartOrContinue, decision);
+    }
+
+    [Fact]
+    public void NoTextNoFiles_Ignored()
+    {
+        var message = CreateMessage(text: "", threadTs: null, isDirectMessage: false);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: false,
+            allowDirectMessages: false,
+            threadExists: false,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.Ignore, decision);
+    }
+
+    private static SlackInboundMessage CreateMessage(
+        string text,
+        string? threadTs,
+        bool isDirectMessage,
+        IReadOnlyList<SlackFileReference>? files = null)
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
@@ -110,10 +167,14 @@ public class SlackRoutingPolicyTests
             Text: text,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: isDirectMessage);
+            IsDirectMessage: isDirectMessage,
+            Files: files);
     }
 
-    private static SlackInboundMessage CreateAppMention(string text, string? threadTs)
+    private static SlackInboundMessage CreateAppMention(
+        string text,
+        string? threadTs,
+        IReadOnlyList<SlackFileReference>? files = null)
     {
         return new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
@@ -126,6 +187,7 @@ public class SlackRoutingPolicyTests
             Text: text,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: false);
+            IsDirectMessage: false,
+            Files: files);
     }
 }

--- a/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/ISlackReplyClient.cs
@@ -5,8 +5,8 @@ public interface ISlackReplyClient
     Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default);
 
     Task UploadFileToThreadAsync(
-        string channelId,
-        string threadTs,
+        SlackChannelId channelId,
+        SlackThreadTs threadTs,
         string filePath,
         string? filename = null,
         CancellationToken cancellationToken = default);

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -152,6 +152,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
 
     public Task Handle(AppMention slackEvent)
     {
+        var files = MapSlackFiles(slackEvent.Files);
+
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
             EventId: BuildEventId(
@@ -168,7 +170,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             Text: slackEvent.Text ?? string.Empty,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: IsDirectConversation(slackEvent.Channel)));
+            IsDirectMessage: IsDirectConversation(slackEvent.Channel),
+            Files: files));
 
         return Task.CompletedTask;
     }
@@ -181,7 +184,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         var result = new List<SlackFileReference>(files.Count);
         foreach (var f in files)
         {
-            if (string.IsNullOrWhiteSpace(f.UrlPrivateDownload))
+            var downloadUrl = f.UrlPrivateDownload ?? f.UrlPrivate;
+            if (string.IsNullOrWhiteSpace(downloadUrl))
                 continue;
 
             result.Add(new SlackFileReference(
@@ -189,7 +193,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 Name: f.Name ?? "attachment",
                 MimeType: f.Mimetype ?? "application/octet-stream",
                 Size: f.Size,
-                UrlPrivateDownload: f.UrlPrivateDownload));
+                UrlPrivateDownload: downloadUrl));
         }
 
         return result.Count > 0 ? result : null;

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -24,8 +24,8 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private readonly ILogger<SlackChannel> _logger;
 
     private IActorRef? _gateway;
-    private string? _botUserId;
-    private string? _defaultChannelId;
+    private SlackUserId? _botUserId;
+    private SlackChannelId? _defaultChannelId;
     private volatile bool _connected;
 
     public SlackChannel(
@@ -79,8 +79,9 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             throw new InvalidOperationException("Slack channel currently supports Socket Mode only.");
 
         var auth = await _slack.Auth.Test(cancellationToken);
-        _botUserId = auth.UserId;
-        _defaultChannelId = await ResolveDefaultChannelIdAsync(cancellationToken);
+        _botUserId = !string.IsNullOrWhiteSpace(auth.UserId) ? new SlackUserId(auth.UserId) : null;
+        var resolvedChannelId = await ResolveDefaultChannelIdAsync(cancellationToken);
+        _defaultChannelId = resolvedChannelId is not null ? new SlackChannelId(resolvedChannelId) : null;
 
         var httpClient = _httpClientFactory.CreateClient("slack-files");
 
@@ -127,6 +128,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     {
         // Map Slack file attachments to SlackFileReference
         var files = MapSlackFiles(slackEvent.Files);
+        var channelId = new SlackChannelId(slackEvent.Channel);
 
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.Message,
@@ -136,15 +138,15 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 threadTs: slackEvent.ThreadTs,
                 userId: slackEvent.User,
                 text: slackEvent.Text),
-            ChannelId: slackEvent.Channel,
-            ThreadTs: slackEvent.ThreadTs,
-            EventTs: slackEvent.Ts,
-            UserId: slackEvent.User,
-            BotId: slackEvent.BotId,
+            ChannelId: channelId,
+            ThreadTs: !string.IsNullOrWhiteSpace(slackEvent.ThreadTs) ? new SlackThreadTs(slackEvent.ThreadTs) : null,
+            EventTs: new SlackEventTs(slackEvent.Ts),
+            UserId: !string.IsNullOrWhiteSpace(slackEvent.User) ? new SlackUserId(slackEvent.User) : null,
+            BotId: !string.IsNullOrWhiteSpace(slackEvent.BotId) ? new SlackBotId(slackEvent.BotId) : null,
             Text: slackEvent.Text ?? string.Empty,
             Subtype: slackEvent.Subtype,
             Hidden: slackEvent.Hidden,
-            IsDirectMessage: IsDirectConversation(slackEvent.Channel),
+            IsDirectMessage: IsDirectConversation(channelId),
             Files: files));
 
         return Task.CompletedTask;
@@ -153,6 +155,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     public Task Handle(AppMention slackEvent)
     {
         var files = MapSlackFiles(slackEvent.Files);
+        var channelId = new SlackChannelId(slackEvent.Channel);
 
         _gateway?.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
@@ -162,15 +165,15 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
                 threadTs: slackEvent.ThreadTs,
                 userId: slackEvent.User,
                 text: slackEvent.Text),
-            ChannelId: slackEvent.Channel,
-            ThreadTs: slackEvent.ThreadTs,
-            EventTs: slackEvent.Ts,
-            UserId: slackEvent.User,
+            ChannelId: channelId,
+            ThreadTs: !string.IsNullOrWhiteSpace(slackEvent.ThreadTs) ? new SlackThreadTs(slackEvent.ThreadTs) : null,
+            EventTs: new SlackEventTs(slackEvent.Ts),
+            UserId: !string.IsNullOrWhiteSpace(slackEvent.User) ? new SlackUserId(slackEvent.User) : null,
             BotId: null,
             Text: slackEvent.Text ?? string.Empty,
             Subtype: null,
             Hidden: false,
-            IsDirectMessage: IsDirectConversation(slackEvent.Channel),
+            IsDirectMessage: IsDirectConversation(channelId),
             Files: files));
 
         return Task.CompletedTask;
@@ -199,15 +202,15 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         return result.Count > 0 ? result : null;
     }
 
-    private static bool IsDirectConversation(string channelId)
+    private static bool IsDirectConversation(SlackChannelId channelId)
     {
-        if (string.IsNullOrWhiteSpace(channelId))
+        if (string.IsNullOrWhiteSpace(channelId.Value))
             return false;
 
-        return channelId.StartsWith('D');
+        return channelId.Value.StartsWith('D');
     }
 
-    private static string BuildEventId(
+    private static SlackEventId BuildEventId(
         string? channelId,
         string? eventTs,
         string? threadTs,
@@ -215,7 +218,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         string? text)
     {
         if (!string.IsNullOrWhiteSpace(channelId) && !string.IsNullOrWhiteSpace(eventTs))
-            return $"{channelId}:{eventTs}";
+            return new SlackEventId($"{channelId}:{eventTs}");
 
         var fallback = string.Join("|", [
             channelId ?? string.Empty,
@@ -225,7 +228,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             text ?? string.Empty
         ]);
 
-        return fallback;
+        return new SlackEventId(fallback);
     }
 
     private async Task<string?> ResolveDefaultChannelIdAsync(CancellationToken cancellationToken)

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -7,11 +7,11 @@ namespace Netclaw.Channels.Slack;
 
 public sealed class SlackConversationActor : ReceiveActor
 {
-    private readonly string _conversationId;
+    private readonly SlackChannelId _conversationId;
     private readonly SlackGatewayDependencies _dependencies;
     private readonly ILoggingAdapter _log;
 
-    public SlackConversationActor(string conversationId, SlackGatewayDependencies dependencies)
+    public SlackConversationActor(SlackChannelId conversationId, SlackGatewayDependencies dependencies)
     {
         _conversationId = conversationId;
         _dependencies = dependencies;
@@ -50,8 +50,8 @@ public sealed class SlackConversationActor : ReceiveActor
             }
 
             var containsMention = ContainsBotMention(message.Text);
-            var threadTs = string.IsNullOrWhiteSpace(message.ThreadTs) ? message.EventTs : message.ThreadTs!;
-            var threadActorName = Uri.EscapeDataString(threadTs);
+            var threadTs = message.ThreadTs ?? SlackThreadTs.FromEventTs(message.EventTs);
+            var threadActorName = Uri.EscapeDataString(threadTs.Value);
             var existingThread = Context.Child(threadActorName);
             var threadExists = !existingThread.IsNobody();
 
@@ -88,9 +88,9 @@ public sealed class SlackConversationActor : ReceiveActor
                 return;
             }
 
-            var sessionId = new SessionId($"{_conversationId}/{threadTs}");
+            var sessionId = new SessionId($"{_conversationId.Value}/{threadTs.Value}");
             var log = _log
-                .WithContext("SlackThreadTs", threadTs)
+                .WithContext("SlackThreadTs", threadTs.Value)
                 .WithContext("SessionId", sessionId.Value);
 
             log.Debug("Routing Slack event {0} to session thread actor", message.EventId);
@@ -99,14 +99,14 @@ public sealed class SlackConversationActor : ReceiveActor
                 SessionId: sessionId,
                 ChannelId: message.ChannelId,
                 ThreadTs: threadTs,
-                SenderId: message.UserId ?? "slack-user",
+                SenderId: message.UserId?.Value ?? "slack-user",
                 Text: normalized,
                 ReceivedAt: _dependencies.TimeProvider.GetUtcNow(),
                 Files: message.Files));
         });
     }
 
-    public static Props CreateProps(string conversationId, SlackGatewayDependencies dependencies) =>
+    public static Props CreateProps(SlackChannelId conversationId, SlackGatewayDependencies dependencies) =>
         Props.Create(() => new SlackConversationActor(conversationId, dependencies));
 
     private bool IsAllowedConversation(SlackInboundMessage message)
@@ -114,22 +114,22 @@ public sealed class SlackConversationActor : ReceiveActor
         if (message.IsDirectMessage)
             return _dependencies.Options.AllowDirectMessages;
 
-        var matchesDefaultChannel = !string.IsNullOrWhiteSpace(_dependencies.DefaultChannelId)
-            && string.Equals(message.ChannelId, _dependencies.DefaultChannelId, StringComparison.Ordinal);
+        var matchesDefaultChannel = _dependencies.DefaultChannelId is not null
+            && message.ChannelId == _dependencies.DefaultChannelId.Value;
 
         var matchesAllowedChannel = _dependencies.Options.AllowedChannelIds
-            .Contains(message.ChannelId, StringComparer.Ordinal);
+            .Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
         return matchesDefaultChannel || matchesAllowedChannel;
     }
 
     private bool IsBotMessage(SlackInboundMessage message)
     {
-        if (!string.IsNullOrWhiteSpace(message.BotId))
+        if (message.BotId is not null)
             return true;
 
-        if (!string.IsNullOrWhiteSpace(_dependencies.BotUserId)
-            && string.Equals(message.UserId, _dependencies.BotUserId, StringComparison.Ordinal))
+        if (_dependencies.BotUserId is not null
+            && message.UserId == _dependencies.BotUserId)
             return true;
 
         return false;
@@ -140,32 +140,32 @@ public sealed class SlackConversationActor : ReceiveActor
         if (_dependencies.Options.AllowedUserIds.Length == 0)
             return true;
 
-        if (string.IsNullOrWhiteSpace(message.UserId))
+        if (message.UserId is not { } userId)
             return false;
 
-        return _dependencies.Options.AllowedUserIds.Contains(message.UserId, StringComparer.Ordinal);
+        return _dependencies.Options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
     }
 
     private bool ContainsBotMention(string text)
     {
-        if (string.IsNullOrWhiteSpace(_dependencies.BotUserId))
+        if (_dependencies.BotUserId is not { } botUserId)
             return false;
 
-        return text.Contains($"<@{_dependencies.BotUserId}>", StringComparison.Ordinal);
+        return text.Contains($"<@{botUserId.Value}>", StringComparison.Ordinal);
     }
 
     private string NormalizeInboundText(string text)
     {
-        if (string.IsNullOrWhiteSpace(_dependencies.BotUserId))
+        if (_dependencies.BotUserId is not { } botUserId)
             return text.Trim();
 
-        var mention = $"<@{_dependencies.BotUserId}>";
+        var mention = $"<@{botUserId.Value}>";
         return text.Replace(mention, string.Empty, StringComparison.Ordinal).Trim();
     }
 
-    private Props CreateThreadProps(string channelId, string threadTs)
+    private Props CreateThreadProps(SlackChannelId channelId, SlackThreadTs threadTs)
     {
-        var sessionId = new SessionId($"{_conversationId}/{threadTs}");
+        var sessionId = new SessionId($"{_conversationId.Value}/{threadTs.Value}");
 
         if (_dependencies.ThreadPropsFactory is not null)
             return _dependencies.ThreadPropsFactory(sessionId, channelId, threadTs, _dependencies);

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -81,9 +81,9 @@ public sealed class SlackConversationActor : ReceiveActor
                 : existingThread;
 
             var normalized = NormalizeInboundText(message.Text);
-            if (string.IsNullOrWhiteSpace(normalized))
+            if (string.IsNullOrWhiteSpace(normalized) && message.Files is not { Count: > 0 })
             {
-                _log.Debug("Ignoring Slack event {0}: normalized text is empty", message.EventId);
+                _log.Debug("Ignoring Slack event {0}: normalized text is empty and no files", message.EventId);
                 ChannelTelemetry.RecordSlackEventDropped("empty_text");
                 return;
             }

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -13,8 +13,8 @@ public sealed class SlackGatewayActor : ReceiveActor
 
     private readonly SlackGatewayDependencies _dependencies;
     private readonly ILoggingAdapter _log;
-    private readonly Dictionary<string, byte> _processedEventIds = new(StringComparer.Ordinal);
-    private readonly Queue<string> _processedEventOrder = new();
+    private readonly Dictionary<SlackEventId, byte> _processedEventIds = new();
+    private readonly Queue<SlackEventId> _processedEventOrder = new();
 
     public SlackGatewayActor(SlackGatewayDependencies dependencies)
     {
@@ -32,7 +32,7 @@ public sealed class SlackGatewayActor : ReceiveActor
                 return;
             }
 
-            var actorName = Uri.EscapeDataString(message.ChannelId);
+            var actorName = Uri.EscapeDataString(message.ChannelId.Value);
             var conversationProps = _dependencies.ConversationPropsFactory?.Invoke(message.ChannelId, _dependencies)
                 ?? SlackConversationActor.CreateProps(message.ChannelId, _dependencies);
             var conversation = Context.Child(actorName)
@@ -49,9 +49,9 @@ public sealed class SlackGatewayActor : ReceiveActor
     public static Props CreateProps(SlackGatewayDependencies dependencies) =>
         Props.Create(() => new SlackGatewayActor(dependencies));
 
-    private bool TryMarkEventProcessed(string eventId)
+    private bool TryMarkEventProcessed(SlackEventId eventId)
     {
-        if (string.IsNullOrWhiteSpace(eventId))
+        if (string.IsNullOrWhiteSpace(eventId.Value))
             return true;
 
         if (_processedEventIds.ContainsKey(eventId))
@@ -73,10 +73,10 @@ public sealed record SlackGatewayDependencies(
     ActorSystem ActorSystem,
     TimeProvider TimeProvider,
     SlackChannelOptions Options,
-    string? BotUserId,
-    string? DefaultChannelId,
+    SlackUserId? BotUserId,
+    SlackChannelId? DefaultChannelId,
     ISlackReplyClient ReplyClient,
     IContentScanner ContentScanner,
     HttpClient? HttpClient = null,
-    Func<string, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
-    Func<SessionId, string, string, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);
+    Func<SlackChannelId, SlackGatewayDependencies, Props>? ConversationPropsFactory = null,
+    Func<SessionId, SlackChannelId, SlackThreadTs, SlackGatewayDependencies, Props>? ThreadPropsFactory = null);

--- a/src/Netclaw.Channels/Slack/SlackIdentifiers.cs
+++ b/src/Netclaw.Channels/Slack/SlackIdentifiers.cs
@@ -1,0 +1,67 @@
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Slack channel ID (e.g. <c>C...</c> for public, <c>D...</c> for DM).
+/// </summary>
+public readonly record struct SlackChannelId(string Value)
+{
+    public static explicit operator SlackChannelId(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Slack thread timestamp — identifies the root message of a thread.
+/// </summary>
+public readonly record struct SlackThreadTs(string Value)
+{
+    /// <summary>
+    /// Converts an event timestamp to a thread timestamp. Used when a message
+    /// has no explicit <c>thread_ts</c> and becomes its own thread root.
+    /// </summary>
+    public static SlackThreadTs FromEventTs(SlackEventTs eventTs) => new(eventTs.Value);
+
+    public static explicit operator SlackThreadTs(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Slack event timestamp — unique per event within a channel.
+/// </summary>
+public readonly record struct SlackEventTs(string Value)
+{
+    public static explicit operator SlackEventTs(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Deduplication key for Slack events, typically <c>{channelId}:{eventTs}</c>.
+/// </summary>
+public readonly record struct SlackEventId(string Value)
+{
+    public static explicit operator SlackEventId(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Slack user ID (e.g. <c>U...</c>).
+/// </summary>
+public readonly record struct SlackUserId(string Value)
+{
+    public static explicit operator SlackUserId(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Slack bot ID (e.g. <c>B...</c>).
+/// </summary>
+public readonly record struct SlackBotId(string Value)
+{
+    public static explicit operator SlackBotId(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -17,12 +17,12 @@ public sealed record SlackFileReference(
 
 public sealed record SlackInboundMessage(
     SlackInboundKind Kind,
-    string EventId,
-    string ChannelId,
-    string? ThreadTs,
-    string EventTs,
-    string? UserId,
-    string? BotId,
+    SlackEventId EventId,
+    SlackChannelId ChannelId,
+    SlackThreadTs? ThreadTs,
+    SlackEventTs EventTs,
+    SlackUserId? UserId,
+    SlackBotId? BotId,
     string Text,
     string? Subtype,
     bool Hidden,
@@ -31,14 +31,14 @@ public sealed record SlackInboundMessage(
 
 public sealed record SlackThreadInbound(
     SessionId SessionId,
-    string ChannelId,
-    string ThreadTs,
+    SlackChannelId ChannelId,
+    SlackThreadTs ThreadTs,
     string SenderId,
     string Text,
     DateTimeOffset ReceivedAt,
     IReadOnlyList<SlackFileReference>? Files = null);
 
 public sealed record SlackPostMessage(
-    string ChannelId,
-    string ThreadTs,
+    SlackChannelId ChannelId,
+    SlackThreadTs ThreadTs,
     string Text);

--- a/src/Netclaw.Channels/Slack/SlackProbe.cs
+++ b/src/Netclaw.Channels/Slack/SlackProbe.cs
@@ -10,7 +10,7 @@ public sealed record SlackProbeResult(
     bool Success,
     string? ErrorMessage,
     string? TeamName,
-    string? BotUserId);
+    SlackUserId? BotUserId);
 
 /// <summary>
 /// A Slack channel resolved from a user-provided name to its API ID.
@@ -78,7 +78,8 @@ public sealed class SlackProbe : ISlackProbe
             {
                 var team = root.TryGetProperty("team", out var teamProp) ? teamProp.GetString() : null;
                 var userId = root.TryGetProperty("user_id", out var userProp) ? userProp.GetString() : null;
-                return new SlackProbeResult(true, null, team, userId);
+                return new SlackProbeResult(true, null, team,
+                    userId is not null ? new SlackUserId(userId) : null);
             }
 
             var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "unknown_error";

--- a/src/Netclaw.Channels/Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackReplyClient.cs
@@ -11,16 +11,16 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
 
         return slackApiClient.Chat.PostMessage(new Message
         {
-            Channel = message.ChannelId,
-            ThreadTs = message.ThreadTs,
+            Channel = message.ChannelId.Value,
+            ThreadTs = message.ThreadTs.Value,
             Text = message.Text, // fallback for notifications
             Blocks = blocks
         });
     }
 
     public async Task UploadFileToThreadAsync(
-        string channelId,
-        string threadTs,
+        SlackChannelId channelId,
+        SlackThreadTs threadTs,
         string filePath,
         string? filename = null,
         CancellationToken cancellationToken = default)
@@ -31,8 +31,8 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
 
         await slackApiClient.Files.Upload(
             upload,
-            channelId,
-            threadTs,
+            channelId.Value,
+            threadTs.Value,
             initialComment: null,
             cancellationToken);
     }

--- a/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
+++ b/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
@@ -33,8 +33,8 @@ public static class SlackRoutingPolicy
         // the message has a ThreadTs different from its EventTs, meaning
         // Slack knows this is a reply in an existing thread. Re-create
         // the thread actor and continue the persisted session.
-        var isThreadReply = !string.IsNullOrWhiteSpace(message.ThreadTs)
-            && !string.Equals(message.ThreadTs, message.EventTs, StringComparison.Ordinal);
+        var isThreadReply = message.ThreadTs is { } threadTs
+            && !string.Equals(threadTs.Value, message.EventTs.Value, StringComparison.Ordinal);
         if (isThreadReply)
             return SlackRoutingDecision.StartOrContinue;
 

--- a/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
+++ b/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
@@ -9,7 +9,9 @@ public static class SlackRoutingPolicy
         bool threadExists,
         bool containsBotMention)
     {
-        if (string.IsNullOrWhiteSpace(message.Text))
+        var hasContent = !string.IsNullOrWhiteSpace(message.Text)
+                        || message.Files is { Count: > 0 };
+        if (!hasContent)
             return SlackRoutingDecision.Ignore;
 
         if (message.Kind is SlackInboundKind.AppMention)

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -13,8 +13,8 @@ namespace Netclaw.Channels.Slack;
 internal sealed class SlackThreadBindingActor : ReceiveActor
 {
     private readonly SessionId _sessionId;
-    private readonly string _channelId;
-    private readonly string _threadTs;
+    private readonly SlackChannelId _channelId;
+    private readonly SlackThreadTs _threadTs;
     private readonly SlackGatewayDependencies _dependencies;
     private readonly ILoggingAdapter _log;
 
@@ -28,8 +28,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
     public SlackThreadBindingActor(
         SessionId sessionId,
-        string channelId,
-        string threadTs,
+        SlackChannelId channelId,
+        SlackThreadTs threadTs,
         SlackGatewayDependencies dependencies)
     {
         _sessionId = sessionId;
@@ -55,8 +55,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
     public static Props CreateProps(
         SessionId sessionId,
-        string channelId,
-        string threadTs,
+        SlackChannelId channelId,
+        SlackThreadTs threadTs,
         SlackGatewayDependencies dependencies) =>
         Props.Create(() => new SlackThreadBindingActor(sessionId, channelId, threadTs, dependencies));
 
@@ -124,7 +124,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         var result = await _inputQueue!.OfferAsync(new ChannelInput
         {
             SenderId = message.SenderId,
-            ChannelId = _channelId,
+            ChannelId = _channelId.Value,
             Contents = contents,
             ReceivedAt = message.ReceivedAt
         });

--- a/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
@@ -50,7 +50,7 @@ public sealed class SlackAuthDoctorCheckTests
 
         var probe = new FakeSlackProbe
         {
-            NextResult = new SlackProbeResult(true, null, "Test Team", "U12345")
+            NextResult = new SlackProbeResult(true, null, "Test Team", new SlackUserId("U12345"))
         };
 
         var check = new SlackAuthDoctorCheck(paths, probe);

--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -13,7 +13,7 @@ public sealed class FakeSlackProbe : ISlackProbe
     /// Defaults to a successful probe.
     /// </summary>
     public SlackProbeResult NextResult { get; set; } = new(
-        true, null, "Test Team", "U12345");
+        true, null, "Test Team", new SlackUserId("U12345"));
 
     /// <summary>
     /// Number of times <see cref="ProbeAsync"/> has been called.

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -388,7 +388,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackAppToken = "xapp-test-app-token";
 
         _fakeSlackProbe.NextResult = new Channels.Slack.SlackProbeResult(
-            true, null, "Acme Corp", "U99999");
+            true, null, "Acme Corp", new Channels.Slack.SlackUserId("U99999"));
 
         vm.CurrentStep.Value = WizardStep.HealthCheck;
         vm.GoNext();


### PR DESCRIPTION
## Summary
- Adds 6 `readonly record struct` value objects (`SlackChannelId`, `SlackThreadTs`, `SlackEventTs`, `SlackEventId`, `SlackUserId`, `SlackBotId`) following the existing `SessionId` pattern
- Replaces raw `string` identifiers throughout the Slack inbound pipeline so that swapping a channel ID where a thread timestamp is expected becomes a **compile-time error**
- Includes `SlackThreadTs.FromEventTs()` factory to make the EventTs→ThreadTs fallback explicitly typed
- Also includes the #66 fix for Slack file uploads not persisted to session media directory

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 435 tests pass
- [x] `dotnet slopwatch analyze` — 0 new violations
- [ ] Verify intentionally swapping `SlackChannelId` / `SlackThreadTs` in a test causes a compile error