### PR TITLE
Search provider abstraction with init wizard integration

### DIFF
--- a/Netclaw.slnx
+++ b/Netclaw.slnx
@@ -17,6 +17,8 @@
     <Project Path="src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj" />
     <Project Path="src/Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />
     <Project Path="src/Netclaw.Tools.Generators/Netclaw.Tools.Generators.csproj" />
+    <Project Path="src/Netclaw.Search/Netclaw.Search.csproj" />
+    <Project Path="src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj" />
     <Project Path="src/Netclaw.Security/Netclaw.Security.csproj" />
     <Project Path="src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj" />
   </Folder>

--- a/openspec/changes/search-provider-abstraction/.openspec.yaml
+++ b/openspec/changes/search-provider-abstraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/search-provider-abstraction/design.md
+++ b/openspec/changes/search-provider-abstraction/design.md
@@ -1,0 +1,160 @@
+## Context
+
+`WebSearchTool` in `Netclaw.Actors` is a monolithic class that hardcodes
+DuckDuckGo Lite HTML scraping, including user-agent randomization, rate
+limiting, and CAPTCHA detection. The spec calls for configurable backends
+(Brave Search, SearXNG) but no abstraction layer exists. The tool's interface
+to the agent (`web_search(query, max_results?)` returning title/URL/snippet)
+is stable and SHALL remain unchanged.
+
+Current dependency chain:
+
+```
+Netclaw.Actors → HtmlAgilityPack (for DDG HTML parsing)
+Netclaw.Configuration → ToolConfig (shell timeout, max output chars only)
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce `ISearchBackend` abstraction so the agent-facing `WebSearchTool`
+  delegates to a swappable backend selected at startup via DI.
+- Ship three backends: DuckDuckGo (migrated), Brave Search (new), SearXNG (new).
+- DuckDuckGo is the default backend — zero configuration required.
+- Add `SearchConfig` to `Netclaw.Configuration` for backend selection and
+  credentials.
+- Keep `web_search` tool interface identical to the agent — same name, same
+  params, same output format.
+
+**Non-Goals:**
+
+- Init wizard changes (deferred — search works out of the box with DDG).
+- Runtime backend switching (backend is selected at startup, not per-request).
+- Search result caching or deduplication across backends.
+- Custom search engines beyond the three named backends.
+
+## Decisions
+
+### Decision 1: New `Netclaw.Search` project for backend implementations
+
+**Choice:** Create `Netclaw.Search` with `ISearchBackend`, `SearchResult`,
+and all three backend implementations.
+
+**Alternatives considered:**
+- Keep backends in `Netclaw.Actors` behind an interface — rejected because
+  HtmlAgilityPack dependency would bleed into the actor project unnecessarily,
+  and the search concern is distinct from actor orchestration.
+- Put interface in `Netclaw.Tools.Abstractions` — rejected because search is
+  not a tool abstraction; it's a domain concern consumed by a tool.
+
+**Rationale:** Follows the existing project naming convention (`Netclaw.Channels`,
+`Netclaw.Security`). Scopes HtmlAgilityPack to `Netclaw.Search` only. Clean
+dependency: `Netclaw.Search` → `Netclaw.Configuration`.
+
+### Decision 2: `SearchConfig` lives in `Netclaw.Configuration`
+
+**Choice:** Add `SearchConfig` class to `Netclaw.Configuration` alongside
+existing config types (`ToolConfig`, `SlackConfig`, etc.).
+
+**Rationale:** All config shapes live in `Netclaw.Configuration` so the wizard,
+daemon, and CLI can reference them without depending on implementation projects.
+
+Config shape:
+
+```csharp
+public sealed class SearchConfig
+{
+    public string Backend { get; set; } = "duckduckgo";
+    public string? BraveApiKey { get; set; }
+    public string? SearXngEndpoint { get; set; }
+}
+```
+
+In `netclaw.json`:
+```json
+{ "Search": { "Backend": "brave" } }
+```
+
+In `secrets.json`:
+```json
+{ "Search": { "BraveApiKey": "BSA-xxx..." } }
+```
+
+### Decision 3: DuckDuckGo as default backend
+
+**Choice:** DuckDuckGo is the default when no search config is present.
+
+**Alternatives considered:**
+- Brave as default (current spec) — rejected because it requires an API key,
+  violating zero-config first-run UX.
+- No default (require explicit config) — rejected because search should work
+  out of the box.
+
+**Rationale:** A fresh `netclaw init` should produce a working agent without
+touching search config. Users upgrade to Brave/SearXNG when they hit DDG's
+bot detection limits.
+
+### Decision 4: Backend error semantics
+
+**Choice:** `ISearchBackend.SearchAsync` returns `SearchBackendResult` — a
+discriminated result type that separates success (results list) from backend
+errors (message string). This lets `WebSearchTool` give the agent actionable
+error messages (e.g., "DuckDuckGo blocked by CAPTCHA" vs "Brave API key
+invalid" vs "SearXNG unreachable").
+
+**Alternatives considered:**
+- Throw exceptions — rejected because search failures are expected operational
+  events (DDG CAPTCHAs), not exceptional conditions.
+- Return empty list — rejected because the agent can't distinguish "no results"
+  from "backend broken."
+
+### Decision 5: `WebSearchTool` becomes a thin delegate
+
+**Choice:** `WebSearchTool` constructor takes `ISearchBackend`. It validates
+params, calls `_backend.SearchAsync(...)`, and formats the result. All
+DDG-specific logic (HTML parsing, UA spoofing, rate limiting) moves to
+`DuckDuckGoBackend`.
+
+The `SearchResult` record moves to `Netclaw.Search` as a shared type.
+
+### Decision 6: DI wiring in daemon
+
+**Choice:** The daemon's DI setup reads `SearchConfig.Backend` and registers
+the corresponding `ISearchBackend` implementation. Unknown backend values log
+a warning and fall back to DuckDuckGo rather than crashing startup.
+
+```
+SearchConfig.Backend → "duckduckgo" → DuckDuckGoBackend
+                     → "brave"      → BraveSearchBackend (requires BraveApiKey)
+                     → "searxng"    → SearXngBackend (requires SearXngEndpoint)
+```
+
+If Brave is selected but no API key is configured, the web search tool is not
+registered and a warning is logged (fail-closed for missing credentials,
+consistent with spec).
+
+## Risks / Trade-offs
+
+**[Risk] DuckDuckGo bot detection degrades over time** → Mitigation: DDG is
+the fallback default, not the recommended backend. The CAPTCHA error message
+now points users to configure Brave or SearXNG as alternatives.
+
+**[Risk] Brave Search free tier rate limits** → Mitigation: Free tier allows
+2,000 queries/month. For a homelab assistant this is likely sufficient. Paid
+tier is $5/1,000 requests. Rate limiting is not in scope for this change.
+
+**[Risk] SearXNG JSON format disabled by default** → Mitigation: The
+`SearXngBackend` validates the response content type. If JSON is not enabled,
+it returns a clear error message telling the user to enable `json` in their
+SearXNG `settings.yml`.
+
+**[Trade-off] No init wizard step for search** → Accepted for this change.
+Search works out of the box with DDG. Adding a wizard step is a follow-up
+concern in `netclaw-onboarding` once the backend abstraction is stable.
+
+## Open Questions
+
+- Should the health check in the init wizard validate search backend
+  connectivity? Deferred to a follow-up change since DDG default needs no
+  validation.

--- a/openspec/changes/search-provider-abstraction/proposal.md
+++ b/openspec/changes/search-provider-abstraction/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The current web search tool is hardcoded to DuckDuckGo Lite via HTML scraping.
+DDG frequently triggers bot detection (CAPTCHAs), making search unreliable for
+an always-on homelab agent. PRD-001 specifies "Brave Search API or equivalent"
+as the search backend (line 228). Users need the ability to choose a search
+provider that fits their setup — DuckDuckGo for zero-config default, Brave
+Search for reliability with a free API key, or SearXNG for self-hosted privacy.
+
+## What Changes
+
+- Extract search backend logic from `WebSearchTool` into a new `Netclaw.Search`
+  project with an `ISearchBackend` interface.
+- Implement three backends: `DuckDuckGoBackend` (existing logic, migrated),
+  `BraveSearchBackend` (new, JSON API), and `SearXngBackend` (new, JSON API).
+- Add `SearchConfig` to `Netclaw.Configuration` for backend selection and
+  credentials (API key for Brave, endpoint URL for SearXNG).
+- Refactor `WebSearchTool` to be a thin delegate — same tool name, same params,
+  same output format to the agent. Backend is selected at startup via DI.
+- DuckDuckGo is the default backend (no configuration required). Spec currently
+  says Brave is default — this change corrects that to match zero-config UX.
+- Update `netclaw.json` / `secrets.json` config writing to support search
+  backend selection.
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-search`: Search provider abstraction, backend implementations
+  (DuckDuckGo, Brave Search, SearXNG), and configuration model.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Update configurable search backend requirement to reflect
+  DuckDuckGo as default (was Brave) and add DuckDuckGo as a named backend
+  option with a bot-detection warning.
+- `netclaw-onboarding`: Init wizard gains optional search provider selection
+  step with backend-specific validation probes.
+
+## Impact
+
+- **New project**: `Netclaw.Search` — `ISearchBackend`, `SearchResult`,
+  three backend implementations.
+- **Modified projects**: `Netclaw.Configuration` (add `SearchConfig`),
+  `Netclaw.Actors` (thin `WebSearchTool`, remove DDG logic), `Netclaw.Cli`
+  (wizard step), `Netclaw.Daemon` (DI wiring).
+- **New dependency**: None for Brave/SearXNG (just `HttpClient` + STJ).
+  HtmlAgilityPack moves from `Netclaw.Actors` to `Netclaw.Search`.
+- **Test migration**: DDG HTML fixture tests move from `Netclaw.Actors.Tests`
+  to a new `Netclaw.Search.Tests` project.
+- **Config schema**: `netclaw.json` gains a `Search` section; `secrets.json`
+  gains `Search.BraveApiKey`.
+- **Security**: Brave API key stored in `secrets.json` (same pattern as
+  provider API keys). SearXNG endpoint is non-secret config.
+- **No breaking changes**: `web_search` tool interface to the agent is unchanged.

--- a/openspec/changes/search-provider-abstraction/specs/netclaw-search/spec.md
+++ b/openspec/changes/search-provider-abstraction/specs/netclaw-search/spec.md
@@ -1,0 +1,138 @@
+## ADDED Requirements
+
+### Requirement: Search backend abstraction
+
+The system SHALL define an `ISearchBackend` interface that all search
+providers implement. The interface SHALL accept a query string, maximum result
+count, and cancellation token, and SHALL return a result type that
+distinguishes successful results from backend errors.
+
+#### Scenario: Backend returns search results
+
+- **GIVEN** a configured search backend
+- **WHEN** `SearchAsync` is called with a query and max result count
+- **THEN** the backend returns a list of `SearchResult` records (title, URL,
+  snippet)
+
+#### Scenario: Backend returns error
+
+- **GIVEN** a configured search backend that encounters a failure
+- **WHEN** `SearchAsync` is called
+- **THEN** the backend returns an error result with a human-readable message
+- **AND** the error does not throw an exception
+
+### Requirement: DuckDuckGo search backend
+
+The system SHALL provide a `DuckDuckGoBackend` that searches via DuckDuckGo
+Lite HTML scraping. The backend SHALL use randomized user-agent headers and
+rate limiting to reduce bot detection. The backend SHALL detect CAPTCHA
+responses and return an error result suggesting alternative backends.
+
+#### Scenario: Successful DuckDuckGo search
+
+- **GIVEN** the DuckDuckGo backend is configured
+- **WHEN** a search query is submitted
+- **THEN** the backend sends an HTTP request to DuckDuckGo Lite
+- **AND** parses HTML results into `SearchResult` records
+- **AND** returns up to the requested maximum number of results
+
+#### Scenario: DuckDuckGo bot detection triggered
+
+- **GIVEN** the DuckDuckGo backend is configured
+- **WHEN** DuckDuckGo returns a CAPTCHA/bot detection page
+- **THEN** the backend returns an error result indicating bot detection
+- **AND** the error message suggests configuring Brave Search or SearXNG
+
+#### Scenario: Rate limiting between requests
+
+- **GIVEN** multiple search requests are made in rapid succession
+- **WHEN** the DuckDuckGo backend processes requests
+- **THEN** a randomized delay (500-2000ms) is enforced between requests
+
+### Requirement: Brave Search backend
+
+The system SHALL provide a `BraveSearchBackend` that searches via the Brave
+Search API. The backend SHALL authenticate using the `X-Subscription-Token`
+header with the configured API key.
+
+#### Scenario: Successful Brave Search query
+
+- **GIVEN** the Brave Search backend is configured with a valid API key
+- **WHEN** a search query is submitted
+- **THEN** the backend sends a GET request to
+  `https://api.search.brave.com/res/v1/web/search`
+- **AND** includes the API key in the `X-Subscription-Token` header
+- **AND** parses JSON results into `SearchResult` records
+
+#### Scenario: Brave Search authentication failure
+
+- **GIVEN** the Brave Search backend is configured with an invalid API key
+- **WHEN** a search query is submitted
+- **THEN** the backend returns an error result indicating authentication failure
+
+#### Scenario: Brave Search rate limit exceeded
+
+- **GIVEN** the Brave Search free tier rate limit is exceeded
+- **WHEN** a search query is submitted
+- **THEN** the backend returns an error result indicating rate limit exceeded
+
+### Requirement: SearXNG search backend
+
+The system SHALL provide a `SearXngBackend` that searches via a self-hosted
+SearXNG instance. The backend SHALL send queries to the configured endpoint
+with `format=json`.
+
+#### Scenario: Successful SearXNG search
+
+- **GIVEN** the SearXNG backend is configured with a reachable endpoint
+- **WHEN** a search query is submitted
+- **THEN** the backend sends a GET request to `{endpoint}/search?q={query}&format=json`
+- **AND** parses JSON results into `SearchResult` records
+
+#### Scenario: SearXNG endpoint unreachable
+
+- **GIVEN** the SearXNG backend is configured with an unreachable endpoint
+- **WHEN** a search query is submitted
+- **THEN** the backend returns an error result indicating the endpoint is
+  unreachable
+
+#### Scenario: SearXNG JSON format not enabled
+
+- **GIVEN** the SearXNG instance does not have JSON format enabled
+- **WHEN** a search query is submitted and the response is not valid JSON
+- **THEN** the backend returns an error result indicating JSON format must be
+  enabled in SearXNG settings
+
+### Requirement: Search configuration
+
+The system SHALL read search backend configuration from `SearchConfig` in
+`Netclaw.Configuration`. The default backend SHALL be `duckduckgo` when no
+configuration is present.
+
+#### Scenario: Default backend when unconfigured
+
+- **GIVEN** no search configuration is present in `netclaw.json`
+- **WHEN** the daemon starts
+- **THEN** the DuckDuckGo backend is used
+
+#### Scenario: Brave backend configured
+
+- **GIVEN** `netclaw.json` specifies `Search.Backend` as `"brave"`
+- **AND** `secrets.json` contains `Search.BraveApiKey`
+- **WHEN** the daemon starts
+- **THEN** the Brave Search backend is registered with the configured API key
+
+#### Scenario: SearXNG backend configured
+
+- **GIVEN** `netclaw.json` specifies `Search.Backend` as `"searxng"`
+- **AND** `netclaw.json` contains `Search.SearXngEndpoint`
+- **WHEN** the daemon starts
+- **THEN** the SearXNG backend is registered with the configured endpoint
+
+#### Scenario: Brave backend without API key
+
+- **GIVEN** `netclaw.json` specifies `Search.Backend` as `"brave"`
+- **AND** no API key is configured
+- **WHEN** the daemon starts
+- **THEN** the web search tool is not registered
+- **AND** a warning is logged indicating the Brave API key is missing

--- a/openspec/changes/search-provider-abstraction/specs/netclaw-tools/spec.md
+++ b/openspec/changes/search-provider-abstraction/specs/netclaw-tools/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Web search tool
+
+The system SHALL provide a web search tool that delegates to a configured
+`ISearchBackend` implementation. The tool SHALL accept a query and optional
+max results parameter and SHALL return structured search results (title, URL,
+snippet) suitable for LLM consumption. The tool interface to the agent SHALL
+remain identical regardless of which backend is configured.
+
+#### Scenario: Web search via configured backend
+
+- **GIVEN** a search backend is configured and registered
+- **WHEN** the agent invokes the web search tool with a query
+- **THEN** the tool delegates to the configured `ISearchBackend`
+- **AND** returns structured results (title, URL, snippet) to the LLM
+
+#### Scenario: Web search with default backend
+
+- **GIVEN** no search backend is explicitly configured
+- **WHEN** the agent invokes the web search tool
+- **THEN** the tool uses the DuckDuckGo backend
+- **AND** returns results in the same format as any other backend
+
+#### Scenario: Backend error returned to agent
+
+- **GIVEN** the configured search backend returns an error
+- **WHEN** the agent invokes the web search tool
+- **THEN** the tool returns the backend's error message to the LLM
+- **AND** the error does not crash the session
+
+#### Scenario: Missing API key prevents tool registration
+
+- **GIVEN** a backend requiring credentials is configured (e.g., Brave Search)
+- **WHEN** no credentials are provided in configuration
+- **THEN** the web search tool is not registered at startup
+- **AND** a warning is logged indicating the tool is unavailable
+
+### Requirement: Configurable search backend
+
+The system SHALL support configuring DuckDuckGo, Brave Search API, or SearXNG
+as the web search backend. The choice SHALL be made through configuration
+without code changes. DuckDuckGo SHALL be the default when no configuration
+is present.
+
+#### Scenario: DuckDuckGo as default backend
+
+- **GIVEN** no search backend is specified in configuration
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses DuckDuckGo for queries
+
+#### Scenario: Brave Search configured
+
+- **GIVEN** the configuration specifies `Search.Backend: "brave"` with a valid
+  API key
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses Brave Search API for queries
+
+#### Scenario: SearXNG configured as alternative
+
+- **GIVEN** the configuration specifies `Search.Backend: "searxng"` with an
+  endpoint URL
+- **WHEN** the web search tool is registered
+- **THEN** the tool uses the SearXNG endpoint for queries
+
+#### Scenario: Invalid search backend rejected at startup
+
+- **GIVEN** the configuration specifies an unrecognized search backend value
+- **WHEN** the Netclaw process starts
+- **THEN** the web search tool is not registered
+- **AND** a configuration validation warning is logged

--- a/openspec/changes/search-provider-abstraction/tasks.md
+++ b/openspec/changes/search-provider-abstraction/tasks.md
@@ -1,0 +1,63 @@
+## 1. Project scaffolding and shared types
+
+- [x] 1.1 Create `Netclaw.Search` project (net10.0, reference `Netclaw.Configuration`)
+- [x] 1.2 Create `Netclaw.Search.Tests` project (reference `Netclaw.Search`, xUnit)
+- [x] 1.3 Add `SearchConfig` to `Netclaw.Configuration` (Backend string defaulting to "duckduckgo", nullable BraveApiKey, nullable SearXngEndpoint)
+- [x] 1.4 Define `SearchResult` record in `Netclaw.Search` (Title, Url, Snippet)
+- [x] 1.5 Define `SearchBackendResult` discriminated result type (success with results list, error with message)
+- [x] 1.6 Define `ISearchBackend` interface (`Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)`)
+
+## 2. DuckDuckGo backend (migrate existing logic)
+
+- [x] 2.1 Create `DuckDuckGoBackend` in `Netclaw.Search` implementing `ISearchBackend`
+- [x] 2.2 Move HTML parsing logic from `WebSearchTool.ParseResults` to `DuckDuckGoBackend`
+- [x] 2.3 Move rate limiting, UA randomization, and CAPTCHA detection to `DuckDuckGoBackend`
+- [x] 2.4 Move HtmlAgilityPack package reference from `Netclaw.Actors` to `Netclaw.Search`
+- [x] 2.5 Migrate DDG HTML fixture tests from `Netclaw.Actors.Tests` to `Netclaw.Search.Tests`
+- [x] 2.6 Update CAPTCHA error message to suggest Brave Search or SearXNG as alternatives
+
+## 3. Brave Search backend
+
+- [x] 3.1 Create `BraveSearchBackend` in `Netclaw.Search` implementing `ISearchBackend`
+- [x] 3.2 Implement HTTP GET to `https://api.search.brave.com/res/v1/web/search` with `X-Subscription-Token` header
+- [x] 3.3 Parse Brave Search JSON response into `SearchResult` records
+- [x] 3.4 Handle 401 (invalid key) and 429 (rate limit) responses as error results
+- [x] 3.5 Add fixture-based tests for Brave Search JSON parsing
+- [x] 3.6 Add error handling tests (auth failure, rate limit, network error)
+
+## 4. SearXNG backend
+
+- [x] 4.1 Create `SearXngBackend` in `Netclaw.Search` implementing `ISearchBackend`
+- [x] 4.2 Implement HTTP GET to `{endpoint}/search?q={query}&format=json`
+- [x] 4.3 Parse SearXNG JSON response into `SearchResult` records
+- [x] 4.4 Detect non-JSON responses and return error indicating JSON format must be enabled
+- [x] 4.5 Handle unreachable endpoint as error result
+- [x] 4.6 Add fixture-based tests for SearXNG JSON parsing
+- [x] 4.7 Add error handling tests (unreachable, non-JSON response)
+
+## 5. Refactor WebSearchTool to delegate
+
+- [x] 5.1 Add `Netclaw.Search` reference to `Netclaw.Actors` project
+- [x] 5.2 Change `WebSearchTool` constructor to accept `ISearchBackend`
+- [x] 5.3 Replace inline DDG logic with `_backend.SearchAsync(...)` delegation
+- [x] 5.4 Map `SearchBackendResult` error case to tool error string for the agent
+- [x] 5.5 Remove DDG-specific code from `WebSearchTool` (HTML parsing, UA headers, rate limiting)
+- [x] 5.6 Remove HtmlAgilityPack reference from `Netclaw.Actors.csproj`
+- [x] 5.7 Update `WebSearchTool` tests in `Netclaw.Actors.Tests` (mock `ISearchBackend`)
+
+## 6. DI wiring and configuration
+
+- [x] 6.1 Register `SearchConfig` binding in daemon startup (from `netclaw.json` + `secrets.json`)
+- [x] 6.2 Add backend factory logic: read `SearchConfig.Backend`, register matching `ISearchBackend`
+- [x] 6.3 Handle missing Brave API key: skip web search tool registration, log warning
+- [x] 6.4 Handle missing SearXNG endpoint: skip web search tool registration, log warning
+- [x] 6.5 Handle unknown backend value: log warning, fall back to DuckDuckGo
+- [x] 6.6 Update `ToolRegistrationExtensions.WithFirstPartyTools` to accept `ISearchBackend`
+
+## 7. Verification
+
+- [x] 7.1 All existing tests pass (`dotnet test`)
+- [x] 7.2 Run `dotnet slopwatch analyze` — no new violations
+- [x] 7.3 Verify DDG backend works end-to-end with no config (default path)
+- [x] 7.4 Verify Brave backend works with API key configured
+- [x] 7.5 Verify SearXNG backend works with endpoint configured

--- a/src/Netclaw.Actors.Tests/Tools/WebSearchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebSearchToolTests.cs
@@ -1,4 +1,5 @@
 using Netclaw.Actors.Tools;
+using Netclaw.Search;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -6,96 +7,53 @@ namespace Netclaw.Actors.Tests.Tools;
 public class WebSearchToolTests
 {
     [Fact]
-    public void ParseResults_extracts_all_results_from_akka_fixture()
+    public async Task ExecuteAsync_returns_formatted_results_from_backend()
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 30);
+        var backend = new FakeSearchBackend(new SearchBackendResult.Success(
+        [
+            new SearchResult("Akka.NET", "https://getakka.net", "Actor framework for .NET"),
+            new SearchResult("GitHub", "https://github.com/akkadotnet/akka.net", "Source code"),
+        ]));
 
-        Assert.Equal(10, results.Count);
+        var tool = new WebSearchTool(backend);
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "akka.net" });
+
+        Assert.Contains("Akka.NET", result);
+        Assert.Contains("https://getakka.net", result);
+        Assert.Contains("Actor framework", result);
     }
 
     [Fact]
-    public void ParseResults_extracts_titles_and_urls()
+    public async Task ExecuteAsync_returns_error_from_backend()
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 30);
+        var backend = new FakeSearchBackend(
+            new SearchBackendResult.Error("Bot detection triggered"));
 
-        var first = results[0];
-        Assert.Contains("akka.net", first.Url);
-        Assert.Contains("GitHub", first.Title);
+        var tool = new WebSearchTool(backend);
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "test" });
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Bot detection triggered", result);
     }
 
     [Fact]
-    public void ParseResults_extracts_snippets()
+    public async Task ExecuteAsync_returns_no_results_message()
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 30);
+        var backend = new FakeSearchBackend(
+            new SearchBackendResult.Success([]));
 
-        var first = results[0];
-        Assert.NotEmpty(first.Snippet);
-        Assert.Contains("actor", first.Snippet, StringComparison.OrdinalIgnoreCase);
+        var tool = new WebSearchTool(backend);
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "xyzzy" });
+
+        Assert.Contains("No results found", result);
     }
 
-    [Fact]
-    public void ParseResults_respects_max_results()
+    private sealed class FakeSearchBackend(SearchBackendResult result) : ISearchBackend
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 3);
-
-        Assert.Equal(3, results.Count);
-    }
-
-    [Fact]
-    public void ParseResults_handles_pizza_recipe_fixture()
-    {
-        var html = LoadFixture("ddg-lite-pizza-recipe.html");
-        var results = WebSearchTool.ParseResults(html, 30);
-
-        Assert.NotEmpty(results);
-        // All results should have non-empty URLs
-        Assert.All(results, r => Assert.False(string.IsNullOrEmpty(r.Url)));
-        Assert.All(results, r => Assert.False(string.IsNullOrEmpty(r.Title)));
-    }
-
-    [Fact]
-    public void ParseResults_returns_empty_for_no_results()
-    {
-        var html = "<html><body><table></table></body></html>";
-        var results = WebSearchTool.ParseResults(html, 10);
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void ParseResults_decodes_html_entities_in_snippets()
-    {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 30);
-
-        // HTML entities like &amp; &#x27; should be decoded
-        Assert.All(results, r =>
-        {
-            Assert.DoesNotContain("&amp;", r.Snippet);
-            Assert.DoesNotContain("&#x27;", r.Snippet);
-        });
-    }
-
-    [Fact]
-    public void ParseResults_urls_are_absolute()
-    {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
-        var results = WebSearchTool.ParseResults(html, 30);
-
-        Assert.All(results, r => Assert.StartsWith("http", r.Url));
-    }
-
-    private static string LoadFixture(string filename)
-    {
-        var assembly = typeof(WebSearchToolTests).Assembly;
-        var resourceName = $"Netclaw.Actors.Tests.Tools.Fixtures.{filename}";
-        using var stream = assembly.GetManifestResourceStream(resourceName)
-            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        public Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
+            => Task.FromResult(result);
     }
 }

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Akka.Cluster.Sharding" />
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Aaron.Akka.Reminders" />
-    <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="protobuf-net" />
@@ -22,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
+    <ProjectReference Include="..\Netclaw.Search\Netclaw.Search.csproj" />
     <ProjectReference Include="..\Netclaw.Security\Netclaw.Security.csproj" />
     <ProjectReference Include="..\Netclaw.Tools.Abstractions\Netclaw.Tools.Abstractions.csproj" />
     <ProjectReference Include="..\Netclaw.Tools.Generators\Netclaw.Tools.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
 using Netclaw.Configuration;
+using Netclaw.Search;
 
 namespace Netclaw.Actors.Tools;
 
@@ -10,13 +11,14 @@ namespace Netclaw.Actors.Tools;
 /// </summary>
 public static class ToolRegistrationExtensions
 {
-    public static ToolRegistry WithFirstPartyTools(this ToolRegistry registry, ToolConfig config, NetclawPaths? paths = null)
+    public static ToolRegistry WithFirstPartyTools(this ToolRegistry registry, ToolConfig config, ISearchBackend? searchBackend = null, NetclawPaths? paths = null)
     {
         registry.Register(new ShellTool(config));
         registry.Register(new FileReadTool(config));
         registry.Register(new FileWriteTool());
         registry.Register(new AttachFileTool());
-        registry.Register(new WebSearchTool(config));
+        if (searchBackend is not null)
+            registry.Register(new WebSearchTool(searchBackend));
         registry.Register(new WebFetchTool());
 
         // Identity self-modification tools (always loaded, "identity" grant)

--- a/src/Netclaw.Actors/Tools/WebSearchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebSearchTool.cs
@@ -1,64 +1,30 @@
 using System.ComponentModel;
-using System.Net;
 using System.Text;
-using HtmlAgilityPack;
-using Netclaw.Configuration;
+using Netclaw.Search;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Searches the web via DuckDuckGo Lite and returns results as text.
-/// Uses randomized user-agent headers and rate limiting to be a good citizen.
+/// Searches the web and returns results as text.
+/// Delegates to a configured <see cref="ISearchBackend"/> for the actual search.
 /// </summary>
 [NetclawTool("web_search",
     "Search the web and return a list of results with titles, URLs, and snippets",
     Grant = "web")]
 public sealed partial class WebSearchTool : NetclawTool<WebSearchTool.Params>
 {
-    private const string DdgLiteUrl = "https://lite.duckduckgo.com/lite/";
     private const int DefaultMaxResults = 10;
 
-    private static readonly string[] UserAgents =
-    [
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
-    ];
-
-    private static readonly string[] AcceptLanguages =
-    [
-        "en-US,en;q=0.9",
-        "en-US,en;q=0.9,es;q=0.8",
-        "en-GB,en;q=0.9,en-US;q=0.8",
-        "en-US,en;q=0.5",
-        "en-CA,en;q=0.9,en-US;q=0.8",
-    ];
-
-    private readonly HttpClient _httpClient;
-    private readonly ToolConfig _config;
-    private readonly Random _random = new();
-
-    // Rate limiting: randomized delay between requests (500-2000ms)
-    private static readonly object _rateLimitLock = new();
-    private static DateTimeOffset _lastRequestTime = DateTimeOffset.MinValue;
+    private readonly ISearchBackend _backend;
 
     public record Params(
         [property: Description("The search query")] string Query,
         [property: Description("Maximum number of results to return (default 10, max 30)")] int? MaxResults = null);
 
-    public WebSearchTool(ToolConfig config, HttpClient? httpClient = null)
+    public WebSearchTool(ISearchBackend backend)
     {
-        _config = config;
-        _httpClient = httpClient ?? new HttpClient();
+        _backend = backend;
     }
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
@@ -68,125 +34,21 @@ public sealed partial class WebSearchTool : NetclawTool<WebSearchTool.Params>
 
         var maxResults = Math.Clamp(args.MaxResults ?? DefaultMaxResults, 1, 30);
 
-        // Randomized rate limiting (500-2000ms gap between requests)
-        await MaybeDelaySearchAsync(ct);
+        var result = await _backend.SearchAsync(args.Query, maxResults, ct);
 
-        try
+        return result switch
         {
-            var html = await FetchSearchResultsAsync(args.Query, ct);
-
-            // Detect DuckDuckGo CAPTCHA / bot detection
-            if (html.Contains("anomaly-modal", StringComparison.OrdinalIgnoreCase))
-                return "Error: Search blocked by DuckDuckGo bot detection (CAPTCHA). Try again later or use a different search provider.";
-
-            var results = ParseResults(html, maxResults);
-
-            if (results.Count == 0)
-                return $"No results found for: {args.Query}";
-
-            return FormatResults(results, args.Query);
-        }
-        catch (HttpRequestException ex)
-        {
-            return $"Error: Search request failed: {ex.Message}";
-        }
-        catch (TaskCanceledException)
-        {
-            return "Error: Search request timed out.";
-        }
+            SearchBackendResult.Success success when success.Results.Count == 0
+                => $"No results found for: {args.Query}",
+            SearchBackendResult.Success success
+                => FormatResults(success.Results, args.Query),
+            SearchBackendResult.Error error
+                => $"Error: {error.Message}",
+            _ => "Error: Unexpected search backend result."
+        };
     }
 
-    private async Task<string> FetchSearchResultsAsync(string query, CancellationToken ct)
-    {
-        var url = $"{DdgLiteUrl}?q={Uri.EscapeDataString(query)}";
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-
-        // Full browser header fingerprint to avoid bot detection
-        request.Headers.UserAgent.ParseAdd(UserAgents[_random.Next(UserAgents.Length)]);
-        request.Headers.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-        request.Headers.AcceptLanguage.ParseAdd(AcceptLanguages[_random.Next(AcceptLanguages.Length)]);
-        request.Headers.TryAddWithoutValidation("Accept-Encoding", "identity");
-        request.Headers.Connection.Add("keep-alive");
-        request.Headers.TryAddWithoutValidation("Upgrade-Insecure-Requests", "1");
-        request.Headers.TryAddWithoutValidation("Sec-Fetch-Dest", "document");
-        request.Headers.TryAddWithoutValidation("Sec-Fetch-Mode", "navigate");
-        request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "none");
-        request.Headers.TryAddWithoutValidation("Sec-Fetch-User", "?1");
-        request.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { MaxAge = TimeSpan.Zero };
-        if (_random.Next(2) == 0)
-            request.Headers.TryAddWithoutValidation("DNT", "1");
-
-        using var response = await _httpClient.SendAsync(request, ct);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(ct);
-    }
-
-    private async Task MaybeDelaySearchAsync(CancellationToken ct)
-    {
-        TimeSpan delay;
-        lock (_rateLimitLock)
-        {
-            var minGap = TimeSpan.FromMilliseconds(500 + _random.Next(1500));
-            var elapsed = DateTimeOffset.UtcNow - _lastRequestTime;
-            if (elapsed >= minGap)
-            {
-                _lastRequestTime = DateTimeOffset.UtcNow;
-                return;
-            }
-            delay = minGap - elapsed;
-            _lastRequestTime = DateTimeOffset.UtcNow + delay;
-        }
-        await Task.Delay(delay, ct);
-    }
-
-    /// <summary>
-    /// Parse DuckDuckGo Lite HTML into search results.
-    /// Each result is a group of table rows: result-link anchor, result-snippet td, link-text span.
-    /// </summary>
-    internal static List<SearchResult> ParseResults(string html, int maxResults)
-    {
-        var doc = new HtmlDocument();
-        doc.LoadHtml(html);
-
-        var results = new List<SearchResult>();
-
-        // Find all result links
-        var links = doc.DocumentNode.SelectNodes("//a[@class='result-link']");
-        if (links is null)
-            return results;
-
-        foreach (var link in links)
-        {
-            if (results.Count >= maxResults)
-                break;
-
-            var rawUrl = WebUtility.HtmlDecode(link.GetAttributeValue("href", ""));
-            var url = CleanDuckDuckGoUrl(rawUrl);
-            var title = WebUtility.HtmlDecode(link.InnerText).Trim();
-
-            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(title))
-                continue;
-
-            // The snippet is in the next tr's td.result-snippet
-            // Navigate: a -> td -> tr -> next sibling tr -> td.result-snippet
-            var parentTr = link.Ancestors("tr").FirstOrDefault();
-            var snippetTr = parentTr?.NextSibling;
-            // Skip whitespace text nodes
-            while (snippetTr is { NodeType: not HtmlNodeType.Element })
-                snippetTr = snippetTr.NextSibling;
-
-            var snippetTd = snippetTr?.SelectSingleNode(".//td[@class='result-snippet']");
-            var snippet = snippetTd is not null
-                ? WebUtility.HtmlDecode(snippetTd.InnerText).Trim()
-                : "";
-
-            results.Add(new SearchResult(title, url, snippet));
-        }
-
-        return results;
-    }
-
-    private static string FormatResults(List<SearchResult> results, string query)
+    private static string FormatResults(IReadOnlyList<SearchResult> results, string query)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"Search results for: {query}");
@@ -204,29 +66,4 @@ public sealed partial class WebSearchTool : NetclawTool<WebSearchTool.Params>
 
         return sb.ToString().TrimEnd();
     }
-
-    /// <summary>
-    /// DDG Lite wraps result URLs in a redirect: //duckduckgo.com/l/?uddg=ENCODED_URL&amp;...
-    /// Extract the real destination URL.
-    /// </summary>
-    internal static string CleanDuckDuckGoUrl(string rawUrl)
-    {
-        if (rawUrl.Contains("duckduckgo.com/l/?uddg=", StringComparison.Ordinal))
-        {
-            var uddgIndex = rawUrl.IndexOf("uddg=", StringComparison.Ordinal);
-            if (uddgIndex >= 0)
-            {
-                var encoded = rawUrl[(uddgIndex + 5)..];
-                var ampIndex = encoded.IndexOf('&');
-                if (ampIndex >= 0)
-                    encoded = encoded[..ampIndex];
-                var decoded = Uri.UnescapeDataString(encoded);
-                if (!string.IsNullOrEmpty(decoded))
-                    return decoded;
-            }
-        }
-        return rawUrl;
-    }
-
-    internal record SearchResult(string Title, string Url, string Snippet);
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -50,6 +50,9 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Equal(WizardStep.Acl, vm.CurrentStep.Value);
 
         vm.GoNext();
+        Assert.Equal(WizardStep.Search, vm.CurrentStep.Value);
+
+        vm.GoNext();
         Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
 
         vm.GoNext();
@@ -131,8 +134,8 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.GoNext(); // Provider → ChatServices
         Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
 
-        vm.GoNext(); // ChatServices → should skip ACL → Exposure
-        Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
+        vm.GoNext(); // ChatServices → should skip ACL → Search
+        Assert.Equal(WizardStep.Search, vm.CurrentStep.Value);
     }
 
     [Fact]
@@ -142,8 +145,8 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackEnabled = false;
 
         vm.GoNext(); // → ChatServices
-        vm.GoNext(); // → Exposure (ACL skipped)
-        Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
+        vm.GoNext(); // → Search (ACL skipped)
+        Assert.Equal(WizardStep.Search, vm.CurrentStep.Value);
 
         vm.GoBack(); // → ChatServices (ACL skipped going back)
         Assert.Equal(WizardStep.ChatServices, vm.CurrentStep.Value);
@@ -342,25 +345,25 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
-    public void TotalSteps_IsSix()
+    public void TotalSteps_IsSeven()
     {
-        Assert.Equal(6, InitWizardViewModel.TotalSteps);
+        Assert.Equal(7, InitWizardViewModel.TotalSteps);
     }
 
     [Fact]
-    public void ActiveStepCount_IsFive_WhenNoChatServices()
+    public void ActiveStepCount_IsSix_WhenNoChatServices()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = false;
-        Assert.Equal(5, vm.ActiveStepCount);
+        Assert.Equal(6, vm.ActiveStepCount);
     }
 
     [Fact]
-    public void ActiveStepCount_IsSix_WhenChatServicesEnabled()
+    public void ActiveStepCount_IsSeven_WhenChatServicesEnabled()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = true;
-        Assert.Equal(6, vm.ActiveStepCount);
+        Assert.Equal(7, vm.ActiveStepCount);
     }
 
     [Fact]
@@ -370,12 +373,13 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.SlackEnabled = false;
 
         // Provider = 1, ChatServices = 2, Acl would be 3 but skipped
-        // Exposure = 3 (adjusted from 4), Identity = 4, HealthCheck = 5
+        // Search = 3 (adjusted from 4), Exposure = 4 (adjusted from 5), Identity = 5, HealthCheck = 6
         Assert.Equal(1, vm.GetDisplayStepNumber(WizardStep.Provider));
         Assert.Equal(2, vm.GetDisplayStepNumber(WizardStep.ChatServices));
-        Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Exposure));
-        Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.Identity));
-        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
+        Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Search));
+        Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.Exposure));
+        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.Identity));
+        Assert.Equal(6, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
     }
 
     [Fact]
@@ -576,6 +580,73 @@ public sealed class InitWizardViewModelTests : IDisposable
 
         Assert.True(vm.IsComplete.Value);
         Assert.Equal(0, _fakeSlackProbe.ResolveCallCount);
+    }
+
+    [Fact]
+    public async Task HealthCheck_WritesBraveSearchConfig()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = false;
+        vm.SelectedSearchBackend = "brave";
+        vm.BraveApiKeyInput = "BSA-test-key-123";
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete.Value);
+
+        // netclaw.json has Search.Backend = "brave"
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Search", out var search));
+        Assert.Equal("brave", search.GetProperty("Backend").GetString());
+
+        // secrets.json has Search.BraveApiKey
+        Assert.True(File.Exists(_paths.SecretsPath));
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        Assert.True(secrets.RootElement.TryGetProperty("Search", out var searchSecrets));
+        Assert.Equal("BSA-test-key-123", searchSecrets.GetProperty("BraveApiKey").GetString());
+
+        // API key must NOT appear in netclaw.json
+        Assert.DoesNotContain("BSA-test-key", File.ReadAllText(_paths.NetclawConfigPath));
+    }
+
+    [Fact]
+    public async Task HealthCheck_WritesSearXngSearchConfig()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = false;
+        vm.SelectedSearchBackend = "searxng";
+        vm.SearXngEndpointInput = "http://searxng.local:8080";
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete.Value);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Search", out var search));
+        Assert.Equal("searxng", search.GetProperty("Backend").GetString());
+        Assert.Equal("http://searxng.local:8080", search.GetProperty("SearXngEndpoint").GetString());
+    }
+
+    [Fact]
+    public async Task HealthCheck_DuckDuckGoDefault_OmitsSearchSection()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = false;
+        // SelectedSearchBackend defaults to "duckduckgo"
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete.Value);
+
+        // DDG is the default — no Search section needed in config
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.False(config.RootElement.TryGetProperty("Search", out _));
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -36,10 +36,16 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     // Step 3: ACL
     private TextInputNode? _ownerIdentityInput;
 
-    // Step 4: Exposure
+    // Step 4: Search
+    private SelectionListNode<string>? _searchBackendList;
+    private TextInputNode? _braveApiKeyInput;
+    private TextInputNode? _searxngEndpointInput;
+    private int _searchSubStep; // 0=backend selection, 1=credentials (brave key or searxng endpoint)
+
+    // Step 5: Exposure
     private SelectionListNode<string>? _exposureList;
 
-    // Step 5: Identity
+    // Step 6: Identity
     private TextInputNode? _agentNameInput;
     private SelectionListNode<string>? _commStyleList;
     private TextInputNode? _userNameInput;
@@ -121,6 +127,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     WizardStep.Provider => "LLM Provider",
                     WizardStep.ChatServices => "Chat Services",
                     WizardStep.Acl => "Access Control",
+                    WizardStep.Search => "Web Search",
                     WizardStep.Exposure => "Exposure Mode",
                     WizardStep.Identity => "Identity",
                     WizardStep.HealthCheck => "Health Check",
@@ -169,6 +176,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.Provider => BuildProviderStep(),
                 WizardStep.ChatServices => BuildChatServicesStep(),
                 WizardStep.Acl => BuildAclStep(),
+                WizardStep.Search => BuildSearchStep(),
                 WizardStep.Exposure => BuildExposureStep(),
                 WizardStep.Identity => BuildIdentityStep(),
                 _ => Layouts.Empty()
@@ -203,6 +211,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
                 WizardStep.Acl =>
                     "  Your Slack user ID (e.g., U01234ABCDE) for admin access.",
+                WizardStep.Search when _searchSubStep == 0 =>
+                    "  DuckDuckGo works without config but may hit bot detection. Brave Search is more reliable.",
+                WizardStep.Search when _searchSubStep == 1 && ViewModel.SelectedSearchBackend == "brave" =>
+                    "  Get a free API key at https://brave.com/search/api/. Stored in secrets.json.",
+                WizardStep.Search when _searchSubStep == 1 && ViewModel.SelectedSearchBackend == "searxng" =>
+                    "  Enter the base URL of your SearXNG instance. JSON format must be enabled in settings.yml.",
                 WizardStep.Exposure =>
                     "  Local-only is recommended for homelab use.",
                 WizardStep.Identity when _identitySubStep == 0 =>
@@ -702,6 +716,123 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .Height(3));
     }
 
+    private ILayoutNode BuildSearchStep()
+    {
+        return _searchSubStep switch
+        {
+            0 => BuildSearchBackendSelectionSubStep(),
+            1 => BuildSearchCredentialSubStep(),
+            _ => Layouts.Empty()
+        };
+    }
+
+    private ILayoutNode BuildSearchBackendSelectionSubStep()
+    {
+        _searchBackendList = Layouts.SelectionList(
+                "DuckDuckGo (default \u2014 no config needed, may hit bot detection)",
+                "Brave Search (API key required \u2014 reliable, fast)",
+                "SearXNG (self-hosted \u2014 endpoint required)")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _searchBackendList.OnFocused();
+        _lastFocusedList = _searchBackendList;
+
+        _searchBackendList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    var choice = selected[0];
+                    if (choice.StartsWith("DuckDuckGo", StringComparison.Ordinal))
+                    {
+                        ViewModel.SelectedSearchBackend = "duckduckgo";
+                        _searchSubStep = 0;
+                        ViewModel.GoNext();
+                    }
+                    else if (choice.StartsWith("Brave", StringComparison.Ordinal))
+                    {
+                        ViewModel.SelectedSearchBackend = "brave";
+                        SetSearchSubStep(1);
+                    }
+                    else if (choice.StartsWith("SearXNG", StringComparison.Ordinal))
+                    {
+                        ViewModel.SelectedSearchBackend = "searxng";
+                        SetSearchSubStep(1);
+                    }
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Choose your web search provider:").WithForeground(Color.White))
+            .WithChild(_searchBackendList);
+    }
+
+    private ILayoutNode BuildSearchCredentialSubStep()
+    {
+        if (ViewModel.SelectedSearchBackend == "brave")
+        {
+            _braveApiKeyInput = new TextInputNode()
+                .AsPassword()
+                .WithPlaceholder("Enter Brave Search API key...");
+
+            if (!string.IsNullOrWhiteSpace(ViewModel.BraveApiKeyInput))
+                _braveApiKeyInput.Text = ViewModel.BraveApiKeyInput;
+
+            _braveApiKeyInput.OnFocused();
+            _lastFocusedInput = _braveApiKeyInput;
+
+            _braveApiKeyInput.Submitted
+                .Where(text => !string.IsNullOrWhiteSpace(text))
+                .Subscribe(text =>
+                {
+                    ViewModel.BraveApiKeyInput = text;
+                    _searchSubStep = 0;
+                    ViewModel.GoNext();
+                })
+                .DisposeWith(_stepSubs);
+
+            return Layouts.Vertical()
+                .WithChild(new TextNode("  Brave Search API key:").WithForeground(Color.White))
+                .WithChild(new PanelNode()
+                    .WithTitle("API Key")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Gray)
+                    .WithContent(_braveApiKeyInput)
+                    .Height(3));
+        }
+
+        // SearXNG endpoint
+        _searxngEndpointInput = new TextInputNode()
+            .WithPlaceholder("http://searxng.local:8080");
+
+        if (!string.IsNullOrWhiteSpace(ViewModel.SearXngEndpointInput))
+            _searxngEndpointInput.Text = ViewModel.SearXngEndpointInput;
+
+        _searxngEndpointInput.OnFocused();
+        _lastFocusedInput = _searxngEndpointInput;
+
+        _searxngEndpointInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Subscribe(text =>
+            {
+                ViewModel.SearXngEndpointInput = text;
+                _searchSubStep = 0;
+                ViewModel.GoNext();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  SearXNG endpoint URL:").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Endpoint")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_searxngEndpointInput)
+                .Height(3));
+    }
+
     private ILayoutNode BuildExposureStep()
     {
         _exposureList = Layouts.SelectionList(
@@ -956,6 +1087,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             return true;
         }
 
+        if (ViewModel.CurrentStep.Value == WizardStep.Search && _searchSubStep > 0)
+        {
+            SetSearchSubStep(_searchSubStep - 1);
+            return true;
+        }
+
         if (ViewModel.CurrentStep.Value == WizardStep.ChatServices && _chatServicesSubStep > 0)
         {
             SetChatServicesSubStep(_chatServicesSubStep - 1);
@@ -1047,6 +1184,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             WizardStep.Provider when _providerSubStep == 1 => _authMethodList,
             WizardStep.Provider when _providerSubStep == 4 && !_manualModelEntry => _modelList,
             WizardStep.ChatServices when _chatServicesSubStep == 0 => _slackEnabledList,
+            WizardStep.Search when _searchSubStep == 0 => _searchBackendList,
             WizardStep.Exposure => _exposureList,
             WizardStep.Identity when _identitySubStep == 1 => _commStyleList,
             _ => null
@@ -1063,6 +1201,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             WizardStep.ChatServices when _chatServicesSubStep == 1 => _slackBotTokenInput,
             WizardStep.ChatServices when _chatServicesSubStep == 2 => _slackAppTokenInput,
             WizardStep.ChatServices when _chatServicesSubStep == 3 => _slackChannelNamesInput,
+            WizardStep.Search when _searchSubStep == 1 && _braveApiKeyInput is not null => _braveApiKeyInput,
+            WizardStep.Search when _searchSubStep == 1 => _searxngEndpointInput,
             WizardStep.Acl => _ownerIdentityInput,
             WizardStep.Identity when _identitySubStep == 0 => _agentNameInput,
             WizardStep.Identity when _identitySubStep == 2 => _userNameInput,
@@ -1095,6 +1235,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         ViewModel.RequestRedraw();
     }
 
+    private void SetSearchSubStep(int step)
+    {
+        _searchSubStep = step;
+        _stepContentNode?.Invalidate();
+        _helpTextNode?.Invalidate();
+        ViewModel.RequestRedraw();
+    }
+
     private void SetIdentitySubStep(int step)
     {
         _identitySubStep = step;
@@ -1114,6 +1262,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     _providerSubStep = 0;
                 if (step == WizardStep.ChatServices)
                     _chatServicesSubStep = 0;
+                if (step == WizardStep.Search)
+                    _searchSubStep = 0;
                 if (step == WizardStep.Identity)
                     _identitySubStep = 0;
 

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -16,9 +16,10 @@ public enum WizardStep
     Provider = 1,
     ChatServices = 2,
     Acl = 3,
-    Exposure = 4,
-    Identity = 5,
-    HealthCheck = 6
+    Search = 4,
+    Exposure = 5,
+    Identity = 6,
+    HealthCheck = 7
 }
 
 /// <summary>
@@ -28,7 +29,7 @@ public enum WizardStep
 /// </summary>
 public partial class InitWizardViewModel : ReactiveViewModel
 {
-    public const int TotalSteps = 6;
+    public const int TotalSteps = 7;
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -78,10 +79,15 @@ public partial class InitWizardViewModel : ReactiveViewModel
     // ── Step 3: ACL ──
     public string? OwnerIdentity { get; set; }
 
-    // ── Step 4: Exposure ──
+    // ── Step 4: Search ──
+    public string SelectedSearchBackend { get; set; } = "duckduckgo";
+    public string? BraveApiKeyInput { get; set; }
+    public string? SearXngEndpointInput { get; set; }
+
+    // ── Step 5: Exposure ──
     public string? ExposureMode { get; set; }
 
-    // ── Step 5: Identity ──
+    // ── Step 6: Identity ──
     public string AgentName { get; set; } = "Netclaw";
     public string? CommunicationStyle { get; set; }
     public string? UserName { get; set; }
@@ -575,6 +581,20 @@ public partial class InitWizardViewModel : ReactiveViewModel
             config["Slack"] = slackSection;
         }
 
+        // Search section
+        if (SelectedSearchBackend != "duckduckgo")
+        {
+            var searchSection = new Dictionary<string, object>
+            {
+                ["Backend"] = SelectedSearchBackend
+            };
+
+            if (SelectedSearchBackend == "searxng" && !string.IsNullOrWhiteSpace(SearXngEndpointInput))
+                searchSection["SearXngEndpoint"] = SearXngEndpointInput;
+
+            config["Search"] = searchSection;
+        }
+
         // Write identity files
         WriteIdentityFiles();
 
@@ -606,6 +626,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 slackSecrets["AppToken"] = SlackAppToken;
             if (slackSecrets.Count > 0)
                 secrets["Slack"] = slackSecrets;
+        }
+
+        if (SelectedSearchBackend == "brave" && !string.IsNullOrWhiteSpace(BraveApiKeyInput))
+        {
+            secrets["Search"] = new Dictionary<string, object>
+            {
+                ["BraveApiKey"] = BraveApiKeyInput
+            };
         }
 
         if (secrets.Count > 0)

--- a/src/Netclaw.Configuration/SearchConfig.cs
+++ b/src/Netclaw.Configuration/SearchConfig.cs
@@ -1,0 +1,25 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for the web search backend. Bound from the "Search" section
+/// of netclaw.json (backend, endpoint) and secrets.json (API key).
+/// </summary>
+public sealed class SearchConfig
+{
+    /// <summary>
+    /// Search backend identifier: "duckduckgo", "brave", or "searxng".
+    /// </summary>
+    public string Backend { get; set; } = "duckduckgo";
+
+    /// <summary>
+    /// Brave Search API subscription token. Required when Backend is "brave".
+    /// Stored in secrets.json under Search.BraveApiKey.
+    /// </summary>
+    public string? BraveApiKey { get; set; }
+
+    /// <summary>
+    /// SearXNG instance base URL (e.g., "http://searxng.local:8080").
+    /// Required when Backend is "searxng".
+    /// </summary>
+    public string? SearXngEndpoint { get; set; }
+}

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
     <ProjectReference Include="..\Netclaw.Channels\Netclaw.Channels.csproj" />
+    <ProjectReference Include="..\Netclaw.Search\Netclaw.Search.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -15,6 +15,7 @@ using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Daemon.Providers;
 using Netclaw.Daemon.Services;
+using Netclaw.Search;
 using Netclaw.Security;
 
 try
@@ -170,8 +171,13 @@ static void ConfigureDaemonServices(
         .Get<ToolConfig>() ?? new ToolConfig();
     services.AddSingleton(toolConfig);
 
+    // Search backend selection
+    var searchConfig = configuration.GetSection("Search")
+        .Get<SearchConfig>() ?? new SearchConfig();
+    var searchBackend = CreateSearchBackend(searchConfig);
+
     var toolRegistry = new ToolRegistry();
-    toolRegistry.WithFirstPartyTools(toolConfig, paths);
+    toolRegistry.WithFirstPartyTools(toolConfig, searchBackend, paths);
     services.AddSingleton(toolRegistry);
     services.AddSingleton<IToolExecutor>(new DispatchingToolExecutor(toolRegistry));
 
@@ -276,6 +282,36 @@ static void ConfigureDaemonServices(
     // Active session cleanup during host shutdown
     services.AddSingleton<SessionRegistryShutdownService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionRegistryShutdownService>());
+}
+
+static ISearchBackend? CreateSearchBackend(SearchConfig config)
+{
+    var backend = config.Backend.ToLowerInvariant();
+    switch (backend)
+    {
+        case "brave":
+            if (string.IsNullOrWhiteSpace(config.BraveApiKey))
+            {
+                Console.Error.WriteLine("warn: Brave Search configured but no API key provided (Search.BraveApiKey). Web search tool will not be registered.");
+                return null;
+            }
+            return new BraveSearchBackend(config.BraveApiKey);
+
+        case "searxng":
+            if (string.IsNullOrWhiteSpace(config.SearXngEndpoint))
+            {
+                Console.Error.WriteLine("warn: SearXNG configured but no endpoint provided (Search.SearXngEndpoint). Web search tool will not be registered.");
+                return null;
+            }
+            return new SearXngBackend(config.SearXngEndpoint);
+
+        case "duckduckgo":
+            return new DuckDuckGoBackend();
+
+        default:
+            Console.Error.WriteLine($"warn: Unknown search backend '{backend}'. Falling back to DuckDuckGo.");
+            return new DuckDuckGoBackend();
+    }
 }
 
 static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -64,6 +64,21 @@ public class BraveSearchBackendTests
     }
 
     [Fact]
+    public void ParseResults_strips_html_tags_and_decodes_entities()
+    {
+        var json = LoadFixture("brave-search-akka-dotnet.json");
+        var results = BraveSearchBackend.ParseResults(json, 30);
+
+        var first = results[0];
+        // Fixture description contains "<strong>a .NET port...</strong>" and "&amp;"
+        Assert.DoesNotContain("<strong>", first.Snippet);
+        Assert.DoesNotContain("</strong>", first.Snippet);
+        Assert.DoesNotContain("&amp;", first.Snippet);
+        // Verify the decoded content is present
+        Assert.Contains("a .NET port", first.Snippet);
+    }
+
+    [Fact]
     public void ParseResults_skips_entries_missing_url()
     {
         var json = """

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -1,0 +1,94 @@
+using Netclaw.Search;
+using Xunit;
+
+namespace Netclaw.Search.Tests;
+
+public class BraveSearchBackendTests
+{
+    [Fact]
+    public void ParseResults_extracts_results_from_fixture()
+    {
+        var json = LoadFixture("brave-search-akka-dotnet.json");
+        var results = BraveSearchBackend.ParseResults(json, 30);
+
+        Assert.Equal(3, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_extracts_titles_and_urls()
+    {
+        var json = LoadFixture("brave-search-akka-dotnet.json");
+        var results = BraveSearchBackend.ParseResults(json, 30);
+
+        var first = results[0];
+        Assert.Contains("akka.net", first.Url);
+        Assert.Contains("akkadotnet", first.Title.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ParseResults_extracts_descriptions()
+    {
+        var json = LoadFixture("brave-search-akka-dotnet.json");
+        var results = BraveSearchBackend.ParseResults(json, 30);
+
+        var first = results[0];
+        Assert.NotEmpty(first.Snippet);
+        Assert.Contains("Akka", first.Snippet, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ParseResults_respects_max_results()
+    {
+        var json = LoadFixture("brave-search-akka-dotnet.json");
+        var results = BraveSearchBackend.ParseResults(json, 2);
+
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_returns_empty_for_missing_web_section()
+    {
+        var json = """{"query":{"original":"test"}}""";
+        var results = BraveSearchBackend.ParseResults(json, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ParseResults_returns_empty_for_empty_results()
+    {
+        var json = """{"web":{"type":"search","results":[]}}""";
+        var results = BraveSearchBackend.ParseResults(json, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ParseResults_skips_entries_missing_url()
+    {
+        var json = """
+        {
+          "web": {
+            "results": [
+              {"title": "No URL", "description": "Missing url field"},
+              {"title": "Has URL", "url": "https://example.com", "description": "Valid"}
+            ]
+          }
+        }
+        """;
+        var results = BraveSearchBackend.ParseResults(json, 10);
+
+        Assert.Single(results);
+        Assert.Equal("https://example.com", results[0].Url);
+    }
+
+    private static string LoadFixture(string filename)
+    {
+        var assembly = typeof(BraveSearchBackendTests).Assembly;
+        var resourceName = $"Netclaw.Search.Tests.Fixtures.{filename}";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Netclaw.Search.Tests/DuckDuckGoBackendTests.cs
+++ b/src/Netclaw.Search.Tests/DuckDuckGoBackendTests.cs
@@ -1,0 +1,99 @@
+using Netclaw.Search;
+using Xunit;
+
+namespace Netclaw.Search.Tests;
+
+public class DuckDuckGoBackendTests
+{
+    [Fact]
+    public void ParseResults_extracts_all_results_from_akka_fixture()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        Assert.Equal(10, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_extracts_titles_and_urls()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        var first = results[0];
+        Assert.Contains("akka.net", first.Url);
+        Assert.Contains("GitHub", first.Title);
+    }
+
+    [Fact]
+    public void ParseResults_extracts_snippets()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        var first = results[0];
+        Assert.NotEmpty(first.Snippet);
+        Assert.Contains("actor", first.Snippet, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ParseResults_respects_max_results()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 3);
+
+        Assert.Equal(3, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_handles_pizza_recipe_fixture()
+    {
+        var html = LoadFixture("ddg-lite-pizza-recipe.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.False(string.IsNullOrEmpty(r.Url)));
+        Assert.All(results, r => Assert.False(string.IsNullOrEmpty(r.Title)));
+    }
+
+    [Fact]
+    public void ParseResults_returns_empty_for_no_results()
+    {
+        var html = "<html><body><table></table></body></html>";
+        var results = DuckDuckGoBackend.ParseResults(html, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ParseResults_decodes_html_entities_in_snippets()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        Assert.All(results, r =>
+        {
+            Assert.DoesNotContain("&amp;", r.Snippet);
+            Assert.DoesNotContain("&#x27;", r.Snippet);
+        });
+    }
+
+    [Fact]
+    public void ParseResults_urls_are_absolute()
+    {
+        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var results = DuckDuckGoBackend.ParseResults(html, 30);
+
+        Assert.All(results, r => Assert.StartsWith("http", r.Url));
+    }
+
+    private static string LoadFixture(string filename)
+    {
+        var assembly = typeof(DuckDuckGoBackendTests).Assembly;
+        var resourceName = $"Netclaw.Search.Tests.Fixtures.{filename}";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Netclaw.Search.Tests/Fixtures/brave-search-akka-dotnet.json
+++ b/src/Netclaw.Search.Tests/Fixtures/brave-search-akka-dotnet.json
@@ -20,7 +20,7 @@
         "url": "https://github.com/akkadotnet/akka.net",
         "is_source_local": false,
         "is_source_both": false,
-        "description": "Akka.NET is a .NET port of the popular Akka framework for building highly concurrent, distributed, and fault-tolerant event-driven applications.",
+        "description": "Akka.NET is <strong>a .NET port of the popular Akka framework</strong> for building highly concurrent, distributed, and fault-tolerant event-driven applications.",
         "language": "en",
         "family_friendly": true
       },
@@ -29,7 +29,7 @@
         "url": "https://getakka.net/",
         "is_source_local": false,
         "is_source_both": false,
-        "description": "Akka.NET is a professional-grade port of the popular Java/Scala framework Akka distributed actor framework to .NET.",
+        "description": "Akka.NET is a professional-grade port of the popular Java/Scala framework Akka distributed actor framework to .NET &amp; Mono.",
         "language": "en",
         "family_friendly": true
       },

--- a/src/Netclaw.Search.Tests/Fixtures/brave-search-akka-dotnet.json
+++ b/src/Netclaw.Search.Tests/Fixtures/brave-search-akka-dotnet.json
@@ -1,0 +1,47 @@
+{
+  "query": {
+    "original": "akka.net dotnet",
+    "show_strict_warning": false,
+    "is_navigational": false,
+    "local_decision": "drop",
+    "local_locations_idx": 0,
+    "is_news_breaking": false,
+    "spellcheck_off": true,
+    "country": "us",
+    "bad_results": false,
+    "should_fallback": false,
+    "language": "en"
+  },
+  "web": {
+    "type": "search",
+    "results": [
+      {
+        "title": "akkadotnet/akka.net: Akka.NET - a toolkit and runtime for building concurrent, distributed systems",
+        "url": "https://github.com/akkadotnet/akka.net",
+        "is_source_local": false,
+        "is_source_both": false,
+        "description": "Akka.NET is a .NET port of the popular Akka framework for building highly concurrent, distributed, and fault-tolerant event-driven applications.",
+        "language": "en",
+        "family_friendly": true
+      },
+      {
+        "title": "Akka.NET | Akka.NET",
+        "url": "https://getakka.net/",
+        "is_source_local": false,
+        "is_source_both": false,
+        "description": "Akka.NET is a professional-grade port of the popular Java/Scala framework Akka distributed actor framework to .NET.",
+        "language": "en",
+        "family_friendly": true
+      },
+      {
+        "title": "Introduction to Akka.NET | Petabridge",
+        "url": "https://petabridge.com/blog/intro-to-akka-net/",
+        "is_source_local": false,
+        "is_source_both": false,
+        "description": "Learn how to build concurrent and distributed applications using Akka.NET, the .NET implementation of the actor model.",
+        "language": "en",
+        "family_friendly": true
+      }
+    ]
+  }
+}

--- a/src/Netclaw.Search.Tests/Fixtures/ddg-lite-akka-dotnet.html
+++ b/src/Netclaw.Search.Tests/Fixtures/ddg-lite-akka-dotnet.html
@@ -1,0 +1,735 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=1;">
+  <meta name="referrer" content="origin">
+  <meta name="HandheldFriendly" content="true" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>dotnet akka.net actor model at DuckDuckGo</title>
+  <link title="DuckDuckGo (Lite)" type="application/opensearchdescription+xml" rel="search" href="//duckduckgo.com/opensearch_lite_v2.xml">
+  <link href="//duckduckgo.com/favicon.ico" rel="shortcut icon" />
+  <link rel="icon" href="//duckduckgo.com/favicon.ico" type="image/x-icon" />
+  <link id="icon60" rel="apple-touch-icon" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_60x60.png?v=2"/>
+  <link id="icon76" rel="apple-touch-icon" sizes="76x76" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_76x76.png?v=2"/>
+  <link id="icon120" rel="apple-touch-icon" sizes="120x120" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_120x120.png?v=2"/>
+  <link id="icon152" rel="apple-touch-icon" sizes="152x152" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_152x152.png?v=2"/>
+  <link rel="image_src" href="//duckduckgo.com/assets/icons/meta/DDG-icon_256x256.png">
+  <link rel="stylesheet" media="handheld, all" href="//duckduckgo.com/dist/lr.ee29b42e9c3cc71a19de.css" type="text/css"/>
+</head>
+
+<body>
+  <p class='extra'>&nbsp;</p>
+  <div class="header">
+    DuckDuckGo
+  </div>
+  <p class='extra'>&nbsp;</p>
+
+  <form action="/lite/" method="post">
+      <input class='query' type="text" size="40" name="q" value="dotnet akka.net actor model">
+      <input class='submit' type="submit" value="Search">
+      
+      
+      
+      
+
+      <div class="filters">
+        <select class="submit" name="kl">
+          
+            <option value="" >All Regions</option>
+          
+            <option value="ar-es" >Argentina</option>
+          
+            <option value="au-en" >Australia</option>
+          
+            <option value="at-de" >Austria</option>
+          
+            <option value="be-fr" >Belgium (fr)</option>
+          
+            <option value="be-nl" >Belgium (nl)</option>
+          
+            <option value="br-pt" >Brazil</option>
+          
+            <option value="bg-bg" >Bulgaria</option>
+          
+            <option value="ca-en" >Canada (en)</option>
+          
+            <option value="ca-fr" >Canada (fr)</option>
+          
+            <option value="ct-ca" >Catalonia</option>
+          
+            <option value="cl-es" >Chile</option>
+          
+            <option value="cn-zh" >China</option>
+          
+            <option value="co-es" >Colombia</option>
+          
+            <option value="hr-hr" >Croatia</option>
+          
+            <option value="cz-cs" >Czech Republic</option>
+          
+            <option value="dk-da" >Denmark</option>
+          
+            <option value="ee-et" >Estonia</option>
+          
+            <option value="fi-fi" >Finland</option>
+          
+            <option value="fr-fr" >France</option>
+          
+            <option value="de-de" >Germany</option>
+          
+            <option value="gr-el" >Greece</option>
+          
+            <option value="hk-tzh" >Hong Kong</option>
+          
+            <option value="hu-hu" >Hungary</option>
+          
+            <option value="is-is" >Iceland</option>
+          
+            <option value="in-en" >India (en)</option>
+          
+            <option value="id-en" >Indonesia (en)</option>
+          
+            <option value="ie-en" >Ireland</option>
+          
+            <option value="il-en" >Israel (en)</option>
+          
+            <option value="it-it" >Italy</option>
+          
+            <option value="jp-jp" >Japan</option>
+          
+            <option value="kr-kr" >Korea</option>
+          
+            <option value="lv-lv" >Latvia</option>
+          
+            <option value="lt-lt" >Lithuania</option>
+          
+            <option value="my-en" >Malaysia (en)</option>
+          
+            <option value="mx-es" >Mexico</option>
+          
+            <option value="nl-nl" >Netherlands</option>
+          
+            <option value="nz-en" >New Zealand</option>
+          
+            <option value="no-no" >Norway</option>
+          
+            <option value="pk-en" >Pakistan (en)</option>
+          
+            <option value="pe-es" >Peru</option>
+          
+            <option value="ph-en" >Philippines (en)</option>
+          
+            <option value="pl-pl" >Poland</option>
+          
+            <option value="pt-pt" >Portugal</option>
+          
+            <option value="ro-ro" >Romania</option>
+          
+            <option value="ru-ru" >Russia</option>
+          
+            <option value="xa-ar" >Saudi Arabia</option>
+          
+            <option value="sg-en" >Singapore</option>
+          
+            <option value="sk-sk" >Slovakia</option>
+          
+            <option value="sl-sl" >Slovenia</option>
+          
+            <option value="za-en" >South Africa</option>
+          
+            <option value="es-ca" >Spain (ca)</option>
+          
+            <option value="es-es" >Spain (es)</option>
+          
+            <option value="se-sv" >Sweden</option>
+          
+            <option value="ch-de" >Switzerland (de)</option>
+          
+            <option value="ch-fr" >Switzerland (fr)</option>
+          
+            <option value="tw-tzh" >Taiwan</option>
+          
+            <option value="th-en" >Thailand (en)</option>
+          
+            <option value="tr-tr" >Turkey</option>
+          
+            <option value="us-en" >US (English)</option>
+          
+            <option value="us-es" >US (Spanish)</option>
+          
+            <option value="ua-uk" >Ukraine</option>
+          
+            <option value="uk-en" >United Kingdom</option>
+          
+            <option value="vn-en" >Vietnam (en)</option>
+          
+        </select>
+
+        <select class="submit" name="df">
+          
+            <option value="" selected>Any Time</option>
+          
+            <option value="d" >Past Day</option>
+          
+            <option value="w" >Past Week</option>
+          
+            <option value="m" >Past Month</option>
+          
+            <option value="y" >Past Year</option>
+          
+        </select>
+      </div>
+  </form>
+
+  
+    <p class="extra">&nbsp;</p>
+    <table border="0">
+      <tr>
+        <td>
+          
+        </td>
+        <td>
+          
+            <!-- Next Page Button Sub-template -->
+<form class="next_form" action="/lite/" method="post">
+    <input type="submit" class='navbutton' value="Next Page &gt;">
+    <input type="hidden" name="q" value="dotnet akka.net actor model">
+    <input type="hidden" name="s" value="10">
+    <input type="hidden" name="nextParams" value="">
+    <input type="hidden" name="v" value="l">
+    <input type="hidden" name="o" value="json">
+    <input type="hidden" name="dc" value="11">
+    <input type="hidden" name="api" value="d.js">
+    <input type="hidden" name="vqd" value="4-296009230863807793856865299947347079020">
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    
+    
+    
+      <input name="kl" value="wt-wt" type="hidden">
+    
+    
+    
+    
+</form>
+          
+        </td>
+      </tr>
+    </table>
+  
+
+  
+
+  <p class='extra'>&nbsp;</p>
+
+  <table border="0">
+    
+  </table>
+
+  <table border="0">
+    
+      
+      <!-- Web results are present -->
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    1.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://github.com/akkadotnet/akka.net" class='result-link'>GitHub - akkadotnet/akka.net: Canonical actor model implementation for ...</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Akka.NET</b> is a .NET port of the popular Akka project from the Scala / Java community. We are an idiomatic .NET implementation of the <b>actor</b> <b>model</b> built on top of the .NET Common Language Runtime.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>github.com/akkadotnet/akka.net</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    2.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://getakka.net/articles/concepts/actors.html" class='result-link'>Actors | Akka.NET Documentation</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Actors</b> The previous section about <b>Actor</b> Systems explained how <b>actors</b> form hierarchies and are the smallest unit when building an application. This section looks at one such <b>actor</b> in isolation, explaining the concepts you encounter while implementing it. For a more in depth reference with all the details please refer to F# API or C# API. An <b>actor</b> is a container for State, Behavior, a Mailbox ...
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>getakka.net/articles/concepts/actors.html</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    3.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.c-sharpcorner.com/article/akka-net-is-the-best-choice-for-reactive-systems-in-c-sharp-net-9/" class='result-link'>Akka.NET is the Best Choice for Reactive Systems in C# .NET 9</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Akka.NET</b> is an open-source .NET framework that implements the <b>actor</b> <b>model</b> — a proven approach to building concurrent systems. Each <b>actor</b> is an independent unit that processes messages asynchronously and maintains its own internal state.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.c-sharpcorner.com/article/akka-net-is-the-best-choice-for-reactive-systems-in-c-sharp-net-9/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-04-26T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    4.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://doc.akka.io/libraries/guide/concepts/akka-actor.html" class='result-link'>Actor model :: Akka Guide</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Akka&#x27;s use of the <b>actor</b> <b>model</b> provides a level of abstraction that makes it easier to write correct concurrent, parallel and distributed systems. The <b>actor</b> <b>model</b> spans the full set of Akka libraries, providing you with a consistent way of understanding and using them. Thus, Akka offers a depth of integration that you cannot achieve by picking libraries to solve individual problems and trying ...
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>doc.akka.io/libraries/guide/concepts/akka-actor.html</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    5.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.beyondthesemicolon.com/from-threads-to-actors-building-truly-reactive-systems-with-akka-net-on-net-9/" class='result-link'>From Threads to Actors: Building Truly Reactive Systems with Akka.NET ...</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Moving from thread-based, lock-heavy code to an <b>actor</b>-based <b>model</b> is not just a syntax change—it is a mental shift. <b>Akka.NET</b> lets you write business logic that reads like straightforward message handling while the framework tackles concurrency, back-pressure, supervision and scaling.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.beyondthesemicolon.com/from-threads-to-actors-building-truly-reactive-systems-with-akka-net-on-net-9/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-07-25T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    6.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://getakka.net/" class='result-link'>Akka.NET Home | Akka.NET Documentation</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Akka.NET</b> is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications on .NET &amp; Mono. This community-driven port brings C# &amp; F# developers the capabilities of the original Akka framework in Java/Scala.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>getakka.net</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    7.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://dave.agileways.com/posts/actor-model-dotnet/" class='result-link'>The Actor Model in a C# World - Musings from AgileDave</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    This post is the first in an occasional series on building a distributed system using <b>Akka.NET</b>. Check back as I add to this series. I was reminded of how much the <b>Actor</b> <b>Model</b> influenced me as a developer when I recently read Petabridge&#x27;s post about reflecting on 10 years of building <b>Akka.NET</b>. At first I thought, &quot;oh my goodness - it&#x27;s been 10 years!!&quot; and reflected on how much my life ...
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>dave.agileways.com/posts/actor-model-dotnet/</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    8.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://devtink3r.blogspot.com/2025/09/akka-net-part-1.html" class='result-link'>Part 1 - What is the Actor Model? A Complete Guide for C# Developers</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    🎯 The <b>Actor</b> <b>Model</b> eliminates traditional concurrency problems by using isolated <b>actors</b> that communicate only through messages. 🎯 <b>Akka.NET</b> provides a production-ready <b>actor</b> framework for .NET applications with high performance and scalability.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>devtink3r.blogspot.com/2025/09/akka-net-part-1.html</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-09-18T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    9.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://medium.com/@hasanmcse/why-akka-net-is-the-best-choice-for-reactive-systems-in-c-net-9-389ff7206201" class='result-link'>Why Akka.NET is the Best Choice for Reactive Systems in C# .NET 9</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>A</b> <b>kka.NET</b> is the ultimate choice for building scalable, fault-tolerant reactive systems in C# .NET 9. This article explores how <b>Akka.NET&#x27;s</b> <b>actor</b> <b>model</b> simplifies concurrency, enhances resilience ...
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>medium.com/@hasanmcse/why-akka-net-is-the-best-choice-for-reactive-systems-in-c-net-9-389ff7206201</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-02-22T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    10.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://github.com/akkadotnet" class='result-link'>Akka.NET · GitHub</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Akka.NET</b> is a .NET port of the popular Akka project from the Scala / Java community. We are an idiomatic .NET implementation of the <b>actor</b> <b>model</b> built on top of the .NET Common Language Runtime.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>github.com/akkadotnet</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+    
+
+    
+      
+      <tr>
+        <td colspan=2>
+          
+          
+            <!-- Next Page Button Sub-template -->
+<form class="next_form" action="/lite/" method="post">
+    <input type="submit" class='navbutton' value="Next Page &gt;">
+    <input type="hidden" name="q" value="dotnet akka.net actor model">
+    <input type="hidden" name="s" value="10">
+    <input type="hidden" name="nextParams" value="">
+    <input type="hidden" name="v" value="l">
+    <input type="hidden" name="o" value="json">
+    <input type="hidden" name="dc" value="11">
+    <input type="hidden" name="api" value="d.js">
+    <input type="hidden" name="vqd" value="4-296009230863807793856865299947347079020">
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    
+    
+    
+      <input name="kl" value="wt-wt" type="hidden">
+    
+    
+    
+    
+</form>
+          
+          
+        </td>
+      </tr>
+    
+  </table>
+
+  <p class='extra'>&nbsp;</p>
+
+  <form action="/lite/" method="post">
+      <input class='query' type="text" size="40" name="q" value="dotnet akka.net actor model" >
+      <input class='submit' type="submit" value="Search">
+      
+      
+      
+      
+      
+        <input name="kl" value="wt-wt" type="hidden">
+      
+  </form>
+
+  <p class='extra'>&nbsp;</p>
+
+  
+    <img src="//duckduckgo.com/t/sl_l"/>
+  
+  <div id='end-spacer'>&nbsp;</div>
+
+</body>
+</html>

--- a/src/Netclaw.Search.Tests/Fixtures/ddg-lite-pizza-recipe.html
+++ b/src/Netclaw.Search.Tests/Fixtures/ddg-lite-pizza-recipe.html
@@ -1,0 +1,791 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=1;">
+  <meta name="referrer" content="origin">
+  <meta name="HandheldFriendly" content="true" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>best pizza recipe at DuckDuckGo</title>
+  <link title="DuckDuckGo (Lite)" type="application/opensearchdescription+xml" rel="search" href="//duckduckgo.com/opensearch_lite_v2.xml">
+  <link href="//duckduckgo.com/favicon.ico" rel="shortcut icon" />
+  <link rel="icon" href="//duckduckgo.com/favicon.ico" type="image/x-icon" />
+  <link id="icon60" rel="apple-touch-icon" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_60x60.png?v=2"/>
+  <link id="icon76" rel="apple-touch-icon" sizes="76x76" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_76x76.png?v=2"/>
+  <link id="icon120" rel="apple-touch-icon" sizes="120x120" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_120x120.png?v=2"/>
+  <link id="icon152" rel="apple-touch-icon" sizes="152x152" href="//duckduckgo.com/assets/icons/meta/DDG-iOS-icon_152x152.png?v=2"/>
+  <link rel="image_src" href="//duckduckgo.com/assets/icons/meta/DDG-icon_256x256.png">
+  <link rel="stylesheet" media="handheld, all" href="//duckduckgo.com/dist/lr.ee29b42e9c3cc71a19de.css" type="text/css"/>
+</head>
+
+<body>
+  <p class='extra'>&nbsp;</p>
+  <div class="header">
+    DuckDuckGo
+  </div>
+  <p class='extra'>&nbsp;</p>
+
+  <form action="/lite/" method="post">
+      <input class='query' type="text" size="40" name="q" value="best pizza recipe">
+      <input class='submit' type="submit" value="Search">
+      
+      
+      
+      
+
+      <div class="filters">
+        <select class="submit" name="kl">
+          
+            <option value="" >All Regions</option>
+          
+            <option value="ar-es" >Argentina</option>
+          
+            <option value="au-en" >Australia</option>
+          
+            <option value="at-de" >Austria</option>
+          
+            <option value="be-fr" >Belgium (fr)</option>
+          
+            <option value="be-nl" >Belgium (nl)</option>
+          
+            <option value="br-pt" >Brazil</option>
+          
+            <option value="bg-bg" >Bulgaria</option>
+          
+            <option value="ca-en" >Canada (en)</option>
+          
+            <option value="ca-fr" >Canada (fr)</option>
+          
+            <option value="ct-ca" >Catalonia</option>
+          
+            <option value="cl-es" >Chile</option>
+          
+            <option value="cn-zh" >China</option>
+          
+            <option value="co-es" >Colombia</option>
+          
+            <option value="hr-hr" >Croatia</option>
+          
+            <option value="cz-cs" >Czech Republic</option>
+          
+            <option value="dk-da" >Denmark</option>
+          
+            <option value="ee-et" >Estonia</option>
+          
+            <option value="fi-fi" >Finland</option>
+          
+            <option value="fr-fr" >France</option>
+          
+            <option value="de-de" >Germany</option>
+          
+            <option value="gr-el" >Greece</option>
+          
+            <option value="hk-tzh" >Hong Kong</option>
+          
+            <option value="hu-hu" >Hungary</option>
+          
+            <option value="is-is" >Iceland</option>
+          
+            <option value="in-en" >India (en)</option>
+          
+            <option value="id-en" >Indonesia (en)</option>
+          
+            <option value="ie-en" >Ireland</option>
+          
+            <option value="il-en" >Israel (en)</option>
+          
+            <option value="it-it" >Italy</option>
+          
+            <option value="jp-jp" >Japan</option>
+          
+            <option value="kr-kr" >Korea</option>
+          
+            <option value="lv-lv" >Latvia</option>
+          
+            <option value="lt-lt" >Lithuania</option>
+          
+            <option value="my-en" >Malaysia (en)</option>
+          
+            <option value="mx-es" >Mexico</option>
+          
+            <option value="nl-nl" >Netherlands</option>
+          
+            <option value="nz-en" >New Zealand</option>
+          
+            <option value="no-no" >Norway</option>
+          
+            <option value="pk-en" >Pakistan (en)</option>
+          
+            <option value="pe-es" >Peru</option>
+          
+            <option value="ph-en" >Philippines (en)</option>
+          
+            <option value="pl-pl" >Poland</option>
+          
+            <option value="pt-pt" >Portugal</option>
+          
+            <option value="ro-ro" >Romania</option>
+          
+            <option value="ru-ru" >Russia</option>
+          
+            <option value="xa-ar" >Saudi Arabia</option>
+          
+            <option value="sg-en" >Singapore</option>
+          
+            <option value="sk-sk" >Slovakia</option>
+          
+            <option value="sl-sl" >Slovenia</option>
+          
+            <option value="za-en" >South Africa</option>
+          
+            <option value="es-ca" >Spain (ca)</option>
+          
+            <option value="es-es" >Spain (es)</option>
+          
+            <option value="se-sv" >Sweden</option>
+          
+            <option value="ch-de" >Switzerland (de)</option>
+          
+            <option value="ch-fr" >Switzerland (fr)</option>
+          
+            <option value="tw-tzh" >Taiwan</option>
+          
+            <option value="th-en" >Thailand (en)</option>
+          
+            <option value="tr-tr" >Turkey</option>
+          
+            <option value="us-en" >US (English)</option>
+          
+            <option value="us-es" >US (Spanish)</option>
+          
+            <option value="ua-uk" >Ukraine</option>
+          
+            <option value="uk-en" >United Kingdom</option>
+          
+            <option value="vn-en" >Vietnam (en)</option>
+          
+        </select>
+
+        <select class="submit" name="df">
+          
+            <option value="" selected>Any Time</option>
+          
+            <option value="d" >Past Day</option>
+          
+            <option value="w" >Past Week</option>
+          
+            <option value="m" >Past Month</option>
+          
+            <option value="y" >Past Year</option>
+          
+        </select>
+      </div>
+  </form>
+
+  
+    <p class="extra">&nbsp;</p>
+    <table border="0">
+      <tr>
+        <td>
+          
+        </td>
+        <td>
+          
+            <!-- Next Page Button Sub-template -->
+<form class="next_form" action="/lite/" method="post">
+    <input type="submit" class='navbutton' value="Next Page &gt;">
+    <input type="hidden" name="q" value="best pizza recipe">
+    <input type="hidden" name="s" value="10">
+    <input type="hidden" name="nextParams" value="">
+    <input type="hidden" name="v" value="l">
+    <input type="hidden" name="o" value="json">
+    <input type="hidden" name="dc" value="12">
+    <input type="hidden" name="api" value="d.js">
+    <input type="hidden" name="vqd" value="4-73199546964023577393069429159456868822">
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    
+    
+    
+      <input name="kl" value="wt-wt" type="hidden">
+    
+    
+    
+    
+</form>
+          
+        </td>
+      </tr>
+    </table>
+  
+
+  
+
+  <p class='extra'>&nbsp;</p>
+
+  <table border="0">
+    
+  </table>
+
+  <table border="0">
+    
+      
+      <!-- Web results are present -->
+      
+        
+          
+
+            <tr class="result-sponsored">
+              
+                <!-- Sponsored result with counter -->
+                <td valign="top">
+                  
+                    1.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://duckduckgo.com/y.js?ad_domain=itsonly.recipes&amp;ad_provider=bingv7aa&amp;ad_type=txad&amp;click_metadata=llmGMjSKRZ54wIDgE8vvUsZRUZXo3F_ZSqODKBn4pgi55I81lq6B2xm6I1P9Sz%2D4adGRJxbpe8xnqJ1scjxg3eDrts2x_tQ9BitM7ySeulVHinKnMsORCi8lcIhyURVOC%2DLeulsM_X2imoJddrC3fx3Wp_23KAn9YHQI5qIOziw.zLlEHK_6WMXCiK7X7fOVHg&amp;rut=54f86022bf9d0f2f32051e0d5946484a7601b9144014dd73a52c323970bf5281&amp;u3=https%3A%2F%2Fwww.bing.com%2Faclick%3Fld%3De8niZEh6mP3zMPFZ27bdIWizVUCUyeSJW27vNasniocEsjaFliXpitoadGPD97_uQiqrWJ4L5Sk8LPsMNAXGc5ZHm4GD75%2D2iuEpNIpCExkluZ1HATYyAVWlLkcUNOZ3TtOyWaFFdZSakUPLJ2mHwWFYbOLUTigtiUj4ZLcFFX5TIe54UvGfcA1Ib_YxbJeTEc_vng4qkrfK8GVsUF_hyEPWs_yMY%26u%3DaHR0cHMlM2ElMmYlMmZpdHNvbmx5LnJlY2lwZXMlMmZzZWFyY2glMmZob21lbWFkZS1waXp6YSUzZm1zY2xraWQlM2RiMWJmYzc3NTc0NmQxMmJiMGJlOGFlZDcwMzVkOWYxMQ%26rlid%3Db1bfc775746d12bb0be8aed7035d9f11&amp;vqd=4-198568338691710476895458975521491842324&amp;iurl=%7B1%7DIG%3DCB412CA6D4534DA485C2D35346EB45A0%26CID%3D3BAC942A032B68AC2309832402EF6923%26ID%3DDevEx%2C5045.1" class='result-link'>Homemade Pizza - Easy Step-by-Step Recipe</a>
+                  (Sponsored link - <a
+                    href="https://duckduckgo.com/duckduckgo-help-pages/company/ads-by-microsoft-on-duckduckgo-private-search/"
+                    rel="nofollow" class="result-link">more info</a>)
+                </td>
+                
+            </tr>
+
+            
+              <tr class="result-sponsored">
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td class='result-snippet'>
+                  Find Homemade <b>Pizza</b> <b>recipes</b> in an easy-to-print format. Explore a wide range of <b>recipes</b> and easily find meal ideas for any day of the week.
+                </td>
+              </tr>
+            
+
+            
+              <tr class="result-sponsored">
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>itsonly.recipes</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+          
+
+          
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    2.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://anitalianinmykitchen.com/best-pizza-dough/" class='result-link'>Best Pizza Dough - An Italian in my Kitchen</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    <b>Best</b> <b>Pizza</b> Dough, this basic <b>Pizza</b> Dough <b>Recipe</b> is the only <b>pizza</b> <b>recipe</b> you will ever need. Make it by hand or in your stand up mixer.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>anitalianinmykitchen.com/best-pizza-dough/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2024-06-14T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    3.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.foodandwine.com/homemade-pizza-6409848" class='result-link'>27 Phenomenal Pizza Recipes - Food &amp; Wine</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Keep homemade <b>pizza</b> making fresh with a variety of pro <b>pizza</b> <b>recipes</b>, from classic Margherita to cacio e pepe <b>pizza</b>, tavern-style <b>pizza</b>, breakfast <b>pizza</b>, and more.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.foodandwine.com/homemade-pizza-6409848</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-04-29T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    4.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.foodnetwork.com/recipes/photos/top-pizza-recipes" class='result-link'>32 Best Pizza Recipes &amp; Ideas | Food Network</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Find your favorite <b>pizza</b> style, from classic cheese to Detroit-style, with these homemade <b>recipes</b>. Learn how to make <b>pizza</b> dough, sauce, toppings and more with tips and photos.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.foodnetwork.com/recipes/photos/top-pizza-recipes</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2024-02-15T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    5.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.acouplecooks.com/homemade-pizza/" class='result-link'>The Best Homemade Pizza (Really.) - A Couple Cooks</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Here&#x27;s the only homemade <b>pizza</b> <b>recipe</b> you need! Learn how to make the <b>best</b> <b>pizza</b> dough, sauce, and toppings.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.acouplecooks.com/homemade-pizza/</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    6.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.kingarthurbaking.com/blog/2025/08/07/homemade-pizza-recipes" class='result-link'>16 pizza recipes to turn your home into a pizzeria</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    You could order delivery, or you could bake your own homemade <b>pizzas</b> for dinner. From artisan Neapolitan-style <b>pizza</b> to weeknight-friendly pies that come together in under an hour, a <b>recipe</b> for every baker.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.kingarthurbaking.com/blog/2025/08/07/homemade-pizza-recipes</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-08-07T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    7.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://tastesbetterfromscratch.com/perfect-pizza-crust/" class='result-link'>BEST Pizza Dough Recipe - Tastes Better From Scratch</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    This homemade <b>pizza</b> dough <b>recipe</b> is so easy and made with just pantry ingredients. It&#x27;s a classic <b>recipe</b> everyone loves and anyone can make!
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>tastesbetterfromscratch.com/perfect-pizza-crust/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-03-26T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    8.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.allrecipes.com/gallery/best-pizza-recipes-of-all-time/" class='result-link'>Best Pizza Recipes of All Time</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Find our <b>best</b> <b>pizza</b> <b>recipes</b> including Detroit-style <b>pizza</b>, Margherita <b>pizza</b>, Chicago-style <b>pizza</b>, Brooklyn-style <b>pizza</b>, grilled <b>pizza</b>, and more.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.allrecipes.com/gallery/best-pizza-recipes-of-all-time/</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    9.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.tasteofhome.com/collection/easy-pizza-recipes/" class='result-link'>47 Homemade Pizza Recipes That Are Faster Than Delivery</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    When you&#x27;re craving pizza—and you want it your way—skip the delivery order and make one of these homemade <b>pizza</b> <b>recipes</b> instead.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.tasteofhome.com/collection/easy-pizza-recipes/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2025-03-17T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    10.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://www.simplyrecipes.com/recipes/homemade_pizza/" class='result-link'>Homemade Pizza &amp; Pizza Dough Recipe - Simply Recipes</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Make perfect <b>pizza</b> at home with this classic homemade <b>pizza</b> <b>recipe</b>, including a <b>pizza</b> dough <b>recipe</b>, topping suggestions, and step-by-step instructions with photos.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>www.simplyrecipes.com/recipes/homemade_pizza/</span>
+                  
+                    &nbsp;&nbsp;&nbsp;
+                    <span class='timestamp'>2026-02-16T00:00:00.0000000</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+        
+            <tr>
+              
+                <td valign="top">
+                  
+                    11.&nbsp;
+                  
+                </td>
+                <td>
+                  <a rel="nofollow" href="https://cooking.nytimes.com/68861692-nyt-cooking/807163-best-pizza-recipes" class='result-link'>Our Best Pizza Recipes - NYT Cooking</a>
+                </td>
+                
+            </tr>
+
+            
+              
+                <!-- Only show abstract separately if there's a click URL (not EOF) -->
+                <tr>
+                  <td>&nbsp;&nbsp;&nbsp;</td>
+                  <td class='result-snippet'>
+                    Editors&#x27; Collection Our <b>Best</b> <b>Pizza</b> <b>Recipes</b> Easy dough, delicious toppings, elegant dinner.
+                  </td>
+                </tr>
+              
+            
+
+            
+              <tr>
+                <td>&nbsp;&nbsp;&nbsp;</td>
+                <td>
+                  <span class='link-text'>cooking.nytimes.com/68861692-nyt-cooking/807163-best-pizza-recipes</span>
+                  
+                </td>
+              </tr>
+            
+
+            <tr>
+              <td>&nbsp;</td>
+              <td>&nbsp;</td>
+            </tr>
+
+        
+      
+    
+
+    
+      
+      <tr>
+        <td colspan=2>
+          
+          
+            <!-- Next Page Button Sub-template -->
+<form class="next_form" action="/lite/" method="post">
+    <input type="submit" class='navbutton' value="Next Page &gt;">
+    <input type="hidden" name="q" value="best pizza recipe">
+    <input type="hidden" name="s" value="10">
+    <input type="hidden" name="nextParams" value="">
+    <input type="hidden" name="v" value="l">
+    <input type="hidden" name="o" value="json">
+    <input type="hidden" name="dc" value="12">
+    <input type="hidden" name="api" value="d.js">
+    <input type="hidden" name="vqd" value="4-73199546964023577393069429159456868822">
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    
+    
+    
+      <input name="kl" value="wt-wt" type="hidden">
+    
+    
+    
+    
+</form>
+          
+          
+        </td>
+      </tr>
+    
+  </table>
+
+  <p class='extra'>&nbsp;</p>
+
+  <form action="/lite/" method="post">
+      <input class='query' type="text" size="40" name="q" value="best pizza recipe" >
+      <input class='submit' type="submit" value="Search">
+      
+      
+      
+      
+      
+        <input name="kl" value="wt-wt" type="hidden">
+      
+  </form>
+
+  <p class='extra'>&nbsp;</p>
+
+  
+    <img src="//duckduckgo.com/t/sl_l"/>
+  
+  <div id='end-spacer'>&nbsp;</div>
+
+</body>
+</html>

--- a/src/Netclaw.Search.Tests/Fixtures/searxng-akka-dotnet.json
+++ b/src/Netclaw.Search.Tests/Fixtures/searxng-akka-dotnet.json
@@ -1,0 +1,36 @@
+{
+  "query": "akka.net dotnet",
+  "number_of_results": 3,
+  "results": [
+    {
+      "url": "https://github.com/akkadotnet/akka.net",
+      "title": "akkadotnet/akka.net: Akka.NET - concurrent, distributed systems",
+      "content": "Akka.NET is a .NET port of the popular Akka framework for building highly concurrent, distributed, and fault-tolerant event-driven applications.",
+      "engine": "google",
+      "parsed_url": ["https", "github.com", "/akkadotnet/akka.net", "", "", ""],
+      "positions": [1],
+      "score": 9.0,
+      "category": "general"
+    },
+    {
+      "url": "https://getakka.net/",
+      "title": "Akka.NET | Akka.NET",
+      "content": "Akka.NET is a professional-grade port of the popular Java/Scala framework Akka distributed actor framework to .NET.",
+      "engine": "duckduckgo",
+      "parsed_url": ["https", "getakka.net", "/", "", "", ""],
+      "positions": [2],
+      "score": 8.0,
+      "category": "general"
+    },
+    {
+      "url": "https://petabridge.com/blog/intro-to-akka-net/",
+      "title": "Introduction to Akka.NET | Petabridge",
+      "content": "Learn how to build concurrent and distributed applications using Akka.NET, the .NET implementation of the actor model.",
+      "engine": "google",
+      "parsed_url": ["https", "petabridge.com", "/blog/intro-to-akka-net/", "", "", ""],
+      "positions": [3],
+      "score": 7.0,
+      "category": "general"
+    }
+  ]
+}

--- a/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
+++ b/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Netclaw.Search/Netclaw.Search.csproj"/>
+    <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Fixtures/**/*.html" />
+    <EmbeddedResource Include="Fixtures/**/*.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Search.Tests/SearXngBackendTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendTests.cs
@@ -1,0 +1,92 @@
+using Netclaw.Search;
+using Xunit;
+
+namespace Netclaw.Search.Tests;
+
+public class SearXngBackendTests
+{
+    [Fact]
+    public void ParseResults_extracts_results_from_fixture()
+    {
+        var json = LoadFixture("searxng-akka-dotnet.json");
+        var results = SearXngBackend.ParseResults(json, 30);
+
+        Assert.Equal(3, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_extracts_titles_and_urls()
+    {
+        var json = LoadFixture("searxng-akka-dotnet.json");
+        var results = SearXngBackend.ParseResults(json, 30);
+
+        var first = results[0];
+        Assert.Contains("akka.net", first.Url);
+        Assert.Contains("akkadotnet", first.Title.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ParseResults_extracts_content_as_snippet()
+    {
+        var json = LoadFixture("searxng-akka-dotnet.json");
+        var results = SearXngBackend.ParseResults(json, 30);
+
+        var first = results[0];
+        Assert.NotEmpty(first.Snippet);
+        Assert.Contains("Akka", first.Snippet, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ParseResults_respects_max_results()
+    {
+        var json = LoadFixture("searxng-akka-dotnet.json");
+        var results = SearXngBackend.ParseResults(json, 2);
+
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public void ParseResults_returns_empty_for_missing_results_array()
+    {
+        var json = """{"query":"test","number_of_results":0}""";
+        var results = SearXngBackend.ParseResults(json, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ParseResults_returns_empty_for_empty_results()
+    {
+        var json = """{"query":"test","number_of_results":0,"results":[]}""";
+        var results = SearXngBackend.ParseResults(json, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ParseResults_skips_entries_missing_url()
+    {
+        var json = """
+        {
+          "results": [
+            {"title": "No URL", "content": "Missing url field"},
+            {"title": "Has URL", "url": "https://example.com", "content": "Valid"}
+          ]
+        }
+        """;
+        var results = SearXngBackend.ParseResults(json, 10);
+
+        Assert.Single(results);
+        Assert.Equal("https://example.com", results[0].Url);
+    }
+
+    private static string LoadFixture(string filename)
+    {
+        var assembly = typeof(SearXngBackendTests).Assembly;
+        var resourceName = $"Netclaw.Search.Tests.Fixtures.{filename}";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Netclaw.Search/BraveSearchBackend.cs
+++ b/src/Netclaw.Search/BraveSearchBackend.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Netclaw.Search;
+
+/// <summary>
+/// Search backend using the Brave Search API.
+/// Authenticates via X-Subscription-Token header.
+/// </summary>
+public sealed class BraveSearchBackend : ISearchBackend
+{
+    private const string BaseUrl = "https://api.search.brave.com/res/v1/web/search";
+
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public BraveSearchBackend(string apiKey, HttpClient? httpClient = null)
+    {
+        _apiKey = apiKey;
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public async Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
+    {
+        try
+        {
+            var url = $"{BaseUrl}?q={Uri.EscapeDataString(query)}&count={maxResults}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("X-Subscription-Token", _apiKey);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+            using var response = await _httpClient.SendAsync(request, ct);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                return new SearchBackendResult.Error(
+                    "Brave Search API authentication failed. Check your API key in secrets.json (Search.BraveApiKey).");
+
+            if (response.StatusCode == (HttpStatusCode)429)
+                return new SearchBackendResult.Error(
+                    "Brave Search API rate limit exceeded. Wait before retrying or upgrade your plan.");
+
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var results = ParseResults(json, maxResults);
+            return new SearchBackendResult.Success(results);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SearchBackendResult.Error($"Brave Search request failed: {ex.Message}");
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new SearchBackendResult.Error("Brave Search request timed out.");
+        }
+    }
+
+    internal static List<SearchResult> ParseResults(string json, int maxResults)
+    {
+        var results = new List<SearchResult>();
+
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("web", out var web))
+            return results;
+
+        if (!web.TryGetProperty("results", out var resultsArray))
+            return results;
+
+        foreach (var item in resultsArray.EnumerateArray())
+        {
+            if (results.Count >= maxResults)
+                break;
+
+            var title = item.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+            var url = item.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+            var description = item.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
+
+            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(title))
+                continue;
+
+            results.Add(new SearchResult(title, url, description));
+        }
+
+        return results;
+    }
+}

--- a/src/Netclaw.Search/BraveSearchBackend.cs
+++ b/src/Netclaw.Search/BraveSearchBackend.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Netclaw.Search;
 
@@ -8,7 +9,7 @@ namespace Netclaw.Search;
 /// Search backend using the Brave Search API.
 /// Authenticates via X-Subscription-Token header.
 /// </summary>
-public sealed class BraveSearchBackend : ISearchBackend
+public sealed partial class BraveSearchBackend : ISearchBackend
 {
     private const string BaseUrl = "https://api.search.brave.com/res/v1/web/search";
 
@@ -81,9 +82,28 @@ public sealed class BraveSearchBackend : ISearchBackend
             if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(title))
                 continue;
 
-            results.Add(new SearchResult(title, url, description));
+            results.Add(new SearchResult(
+                StripHtml(title),
+                url,
+                StripHtml(description)));
         }
 
         return results;
     }
+
+    /// <summary>
+    /// Brave Search API returns HTML markup (e.g. &lt;strong&gt;) and entities in
+    /// titles and descriptions. Strip tags and decode for clean LLM consumption.
+    /// </summary>
+    internal static string StripHtml(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        var noTags = HtmlTagRegex().Replace(input, "");
+        return WebUtility.HtmlDecode(noTags);
+    }
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex HtmlTagRegex();
 }

--- a/src/Netclaw.Search/DuckDuckGoBackend.cs
+++ b/src/Netclaw.Search/DuckDuckGoBackend.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using HtmlAgilityPack;
+
+namespace Netclaw.Search;
+
+/// <summary>
+/// Search backend that scrapes DuckDuckGo Lite HTML results.
+/// Uses randomized user-agent headers and rate limiting to reduce bot detection.
+/// </summary>
+public sealed class DuckDuckGoBackend : ISearchBackend
+{
+    private const string DdgLiteUrl = "https://lite.duckduckgo.com/lite/";
+
+    private static readonly string[] UserAgents =
+    [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+    ];
+
+    private static readonly string[] AcceptLanguages =
+    [
+        "en-US,en;q=0.9",
+        "en-US,en;q=0.9,es;q=0.8",
+        "en-GB,en;q=0.9,en-US;q=0.8",
+        "en-US,en;q=0.5",
+        "en-CA,en;q=0.9,en-US;q=0.8",
+    ];
+
+    private readonly HttpClient _httpClient;
+    private readonly Random _random = new();
+
+    private static readonly object RateLimitLock = new();
+    private static DateTimeOffset _lastRequestTime = DateTimeOffset.MinValue;
+
+    public DuckDuckGoBackend(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public async Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
+    {
+        await MaybeDelayAsync(ct);
+
+        try
+        {
+            var html = await FetchSearchResultsAsync(query, ct);
+
+            if (html.Contains("anomaly-modal", StringComparison.OrdinalIgnoreCase))
+                return new SearchBackendResult.Error(
+                    "Search blocked by DuckDuckGo bot detection (CAPTCHA). " +
+                    "Configure Brave Search or SearXNG as an alternative backend in your search config.");
+
+            var results = ParseResults(html, maxResults);
+            return new SearchBackendResult.Success(results);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SearchBackendResult.Error($"DuckDuckGo search request failed: {ex.Message}");
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new SearchBackendResult.Error("DuckDuckGo search request timed out.");
+        }
+    }
+
+    private async Task<string> FetchSearchResultsAsync(string query, CancellationToken ct)
+    {
+        var url = $"{DdgLiteUrl}?q={Uri.EscapeDataString(query)}";
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        request.Headers.UserAgent.ParseAdd(UserAgents[_random.Next(UserAgents.Length)]);
+        request.Headers.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        request.Headers.AcceptLanguage.ParseAdd(AcceptLanguages[_random.Next(AcceptLanguages.Length)]);
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "identity");
+        request.Headers.Connection.Add("keep-alive");
+        request.Headers.TryAddWithoutValidation("Upgrade-Insecure-Requests", "1");
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-Dest", "document");
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-Mode", "navigate");
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "none");
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-User", "?1");
+        request.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue { MaxAge = TimeSpan.Zero };
+        if (_random.Next(2) == 0)
+            request.Headers.TryAddWithoutValidation("DNT", "1");
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    private async Task MaybeDelayAsync(CancellationToken ct)
+    {
+        TimeSpan delay;
+        lock (RateLimitLock)
+        {
+            var minGap = TimeSpan.FromMilliseconds(500 + _random.Next(1500));
+            var elapsed = DateTimeOffset.UtcNow - _lastRequestTime;
+            if (elapsed >= minGap)
+            {
+                _lastRequestTime = DateTimeOffset.UtcNow;
+                return;
+            }
+            delay = minGap - elapsed;
+            _lastRequestTime = DateTimeOffset.UtcNow + delay;
+        }
+        await Task.Delay(delay, ct);
+    }
+
+    /// <summary>
+    /// Parse DuckDuckGo Lite HTML into search results.
+    /// Each result is a group of table rows: result-link anchor, result-snippet td, link-text span.
+    /// </summary>
+    internal static List<SearchResult> ParseResults(string html, int maxResults)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var results = new List<SearchResult>();
+
+        var links = doc.DocumentNode.SelectNodes("//a[@class='result-link']");
+        if (links is null)
+            return results;
+
+        foreach (var link in links)
+        {
+            if (results.Count >= maxResults)
+                break;
+
+            var rawUrl = WebUtility.HtmlDecode(link.GetAttributeValue("href", ""));
+            var url = CleanDuckDuckGoUrl(rawUrl);
+            var title = WebUtility.HtmlDecode(link.InnerText).Trim();
+
+            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(title))
+                continue;
+
+            var parentTr = link.Ancestors("tr").FirstOrDefault();
+            var snippetTr = parentTr?.NextSibling;
+            while (snippetTr is { NodeType: not HtmlNodeType.Element })
+                snippetTr = snippetTr.NextSibling;
+
+            var snippetTd = snippetTr?.SelectSingleNode(".//td[@class='result-snippet']");
+            var snippet = snippetTd is not null
+                ? WebUtility.HtmlDecode(snippetTd.InnerText).Trim()
+                : "";
+
+            results.Add(new SearchResult(title, url, snippet));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// DDG Lite wraps result URLs in a redirect: //duckduckgo.com/l/?uddg=ENCODED_URL&amp;...
+    /// Extract the real destination URL.
+    /// </summary>
+    internal static string CleanDuckDuckGoUrl(string rawUrl)
+    {
+        if (rawUrl.Contains("duckduckgo.com/l/?uddg=", StringComparison.Ordinal))
+        {
+            var uddgIndex = rawUrl.IndexOf("uddg=", StringComparison.Ordinal);
+            if (uddgIndex >= 0)
+            {
+                var encoded = rawUrl[(uddgIndex + 5)..];
+                var ampIndex = encoded.IndexOf('&');
+                if (ampIndex >= 0)
+                    encoded = encoded[..ampIndex];
+                var decoded = Uri.UnescapeDataString(encoded);
+                if (!string.IsNullOrEmpty(decoded))
+                    return decoded;
+            }
+        }
+        return rawUrl;
+    }
+}

--- a/src/Netclaw.Search/ISearchBackend.cs
+++ b/src/Netclaw.Search/ISearchBackend.cs
@@ -1,0 +1,18 @@
+namespace Netclaw.Search;
+
+/// <summary>
+/// Abstraction for web search providers. Implementations handle the
+/// transport-specific details (HTML scraping, JSON APIs) and return
+/// a uniform result type.
+/// </summary>
+public interface ISearchBackend
+{
+    /// <summary>
+    /// Execute a web search query and return structured results.
+    /// </summary>
+    /// <param name="query">The search query string.</param>
+    /// <param name="maxResults">Maximum number of results to return.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Success with results, or Error with a human-readable message.</returns>
+    Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct);
+}

--- a/src/Netclaw.Search/Netclaw.Search.csproj
+++ b/src/Netclaw.Search/Netclaw.Search.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Search.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Netclaw.Search/SearXngBackend.cs
+++ b/src/Netclaw.Search/SearXngBackend.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Netclaw.Search;
+
+/// <summary>
+/// Search backend using a self-hosted SearXNG instance.
+/// Requires the instance to have JSON format enabled in settings.yml.
+/// </summary>
+public sealed class SearXngBackend : ISearchBackend
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _endpoint;
+
+    public SearXngBackend(string endpoint, HttpClient? httpClient = null)
+    {
+        _endpoint = endpoint.TrimEnd('/');
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public async Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
+    {
+        try
+        {
+            var url = $"{_endpoint}/search?q={Uri.EscapeDataString(query)}&format=json";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            using var response = await _httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+
+            var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
+            var body = await response.Content.ReadAsStringAsync(ct);
+
+            // Detect HTML response — means JSON format is not enabled
+            if (contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase)
+                || body.TrimStart().StartsWith('<'))
+            {
+                return new SearchBackendResult.Error(
+                    "SearXNG returned HTML instead of JSON. Enable JSON format in your SearXNG settings.yml: " +
+                    "search.formats should include 'json'.");
+            }
+
+            var results = ParseResults(body, maxResults);
+            return new SearchBackendResult.Success(results);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SearchBackendResult.Error($"SearXNG endpoint unreachable ({_endpoint}): {ex.Message}");
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new SearchBackendResult.Error($"SearXNG request timed out ({_endpoint}).");
+        }
+    }
+
+    internal static List<SearchResult> ParseResults(string json, int maxResults)
+    {
+        var results = new List<SearchResult>();
+
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("results", out var resultsArray))
+            return results;
+
+        foreach (var item in resultsArray.EnumerateArray())
+        {
+            if (results.Count >= maxResults)
+                break;
+
+            var title = item.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+            var url = item.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+            var content = item.TryGetProperty("content", out var c) ? c.GetString() ?? "" : "";
+
+            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(title))
+                continue;
+
+            results.Add(new SearchResult(title, url, content));
+        }
+
+        return results;
+    }
+}

--- a/src/Netclaw.Search/SearchBackendResult.cs
+++ b/src/Netclaw.Search/SearchBackendResult.cs
@@ -1,0 +1,13 @@
+namespace Netclaw.Search;
+
+/// <summary>
+/// Discriminated result from a search backend operation.
+/// Either a successful list of results or an error with a human-readable message.
+/// </summary>
+public abstract record SearchBackendResult
+{
+    private SearchBackendResult() { }
+
+    public sealed record Success(IReadOnlyList<SearchResult> Results) : SearchBackendResult;
+    public sealed record Error(string Message) : SearchBackendResult;
+}

--- a/src/Netclaw.Search/SearchResult.cs
+++ b/src/Netclaw.Search/SearchResult.cs
@@ -1,0 +1,6 @@
+namespace Netclaw.Search;
+
+/// <summary>
+/// A single web search result returned by any search backend.
+/// </summary>
+public sealed record SearchResult(string Title, string Url, string Snippet);


### PR DESCRIPTION
## Summary
- Adds `ISearchBackend` abstraction in new `Netclaw.Search` project with three implementations: DuckDuckGo (migrated), Brave Search (REST API), and SearXNG (self-hosted)
- Refactors `WebSearchTool` from monolithic DDG client to thin delegate over `ISearchBackend` — same tool name, same arguments, swappable backend
- Adds search provider selection step to the init wizard (before Exposure) with DuckDuckGo as default, Brave Search (API key → secrets.json), and SearXNG (endpoint URL)
- Brave Search responses have HTML tags stripped and entities decoded for clean LLM consumption
- Config split: `netclaw.json` gets `Search.Backend` + `Search.SearXngEndpoint`, `secrets.json` gets `Search.BraveApiKey`

## Test plan
- [x] All 120 tests pass (23 new: 8 Brave, 8 DDG, 7 SearXNG, 3 wizard config writing)
- [x] `dotnet slopwatch analyze` — zero violations
- [x] Brave Search API tested with real API key (HTML stripping verified)
- [x] Wizard step ordering: Provider → ChatServices → ACL → **Search** → Exposure → Identity → HealthCheck
- [x] DuckDuckGo default omits Search section from config (zero-config path preserved)