### PR TITLE
Surface build version, commit hash, and build timestamp in daemon status

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+  <!--
+    Capture the UTC build timestamp at evaluation time and embed it as an
+    AssemblyMetadata attribute. The git commit hash is already embedded by
+    Microsoft.SourceLink.GitHub in AssemblyInformationalVersion as
+    "{VersionPrefix}+{full-sha}", so no separate action is needed for it.
+  -->
+  <PropertyGroup>
+    <BuildTimestamp>$([System.DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))</BuildTimestamp>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BuildTimestamp</_Parameter1>
+      <_Parameter2>$(BuildTimestamp)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/openspec/changes/auto-update-feed-infra/.openspec.yaml
+++ b/openspec/changes/auto-update-feed-infra/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/auto-update-feed-infra/proposal.md
+++ b/openspec/changes/auto-update-feed-infra/proposal.md
@@ -1,0 +1,76 @@
+> **Status: PROPOSED** — infrastructure commitments (hosting, CI publishing) not yet finalized.
+> Implementation is blocked until the feed hosting backend is confirmed.
+
+## Why
+
+Netclaw ships two long-running components (CLI and daemon) that users install
+directly. Without a stable, operator-controlled update endpoint, any repository
+move or hosting change would silently break auto-update for every installed
+instance. A thin managed feed in front of GitHub Releases gives us a stable
+surface to evolve independently of where the repository lives.
+
+## What Changes
+
+- **New**: Cloudflare Worker at a stable URL (e.g.
+  `https://netclaw.stannardlabs.com/releases/stable.json`) that proxies GitHub
+  Releases API and returns a versioned manifest in our own schema
+- **New**: Manifest schema with separate `cli` and `daemon` download entries per
+  platform so the two components can version independently
+- **New**: Release pipeline step that triggers the Worker cache flush (or
+  equivalent) when a new GitHub Release is published
+- **New**: `netclaw update` command — checks feed, downloads platform binary,
+  self-replaces CLI executable using shell/PowerShell trampoline script
+- **New**: `netclaw daemon update` command — stops daemon gracefully, replaces
+  daemon binary, signals restart; requires daemon to be reachable via SignalR
+- **New**: Background update check on `netclaw status` and `netclaw --version`
+  with a non-blocking 3-second timeout; prints a nudge line if a newer version
+  is available
+- **Modified**: `netclaw status` response includes current daemon version/commit
+  alongside any available update version (already partially landed on this branch)
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-update-feed`: Managed feed infrastructure — the Cloudflare Worker,
+  manifest schema, cache/invalidation strategy, and release pipeline sync.
+  Covers the server side of auto-update; the client-side update commands are
+  part of `netclaw-cli`.
+
+### Modified Capabilities
+
+- `netclaw-cli`: Add `update` and `daemon update` commands, background update
+  nudge, and version display in `netclaw status` and `--version` output.
+
+## Impact
+
+**Infrastructure (not yet committed)**
+- Cloudflare Worker account and routing under `stannardlabs.com`
+- GitHub personal access token (or GitHub App) for the Worker to call GitHub
+  Releases API without anonymous rate limits
+- Worker KV or Cache API for short-lived caching of the GitHub response
+  (suggested TTL: 5 minutes) to avoid hammering GitHub on every daemon restart
+
+**Release pipeline**
+- GitHub Actions workflow addition: on `release` event, dispatch a Worker cache
+  flush via Cloudflare API so the new manifest is live within seconds
+- Binary asset naming convention must be locked in before the Worker can map
+  them: `netclaw-{version}-{os}-{arch}.tar.gz` / `.zip` and
+  `netclawd-{version}-{os}-{arch}.tar.gz` / `.zip`
+
+**Client code (Netclaw.Cli)**
+- New `UpdateService` — HTTP GET to feed URL, manifest deserialization, semver
+  comparison (strip `+metadata` before comparing, same approach as freshdesk-cli)
+- Platform detection: `RuntimeInformation.OSDescription` + `RuntimeInformation.ProcessArchitecture`
+- Binary self-replace: shell script trampoline on Unix, PowerShell on Windows
+  (sleep 2s → mv backup → mv new → chmod → verify `--version`)
+- Feed URL should be a compile-time constant (not user-configurable in MVP)
+  so users cannot accidentally point at a malicious feed
+
+**Security**
+- SHA-256 checksum verification before replacing any binary (checksums published
+  alongside assets in GitHub Release, surfaced in manifest)
+- Daemon binary replacement requires daemon to be stopped first; no in-process
+  hot-swap
+- Manifest served over HTTPS only; Worker enforces HTTPS redirect
+- No auto-apply without explicit user confirmation (except `--force` flag)

--- a/src/Netclaw.Cli/Daemon/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonRuntimeStatus.cs
@@ -12,6 +12,8 @@ public static class DaemonRuntimeStatus
     {
         public string Overall { get; init; } = "unknown";
 
+        public required Build Build { get; init; }
+
         public required Process Process { get; init; }
 
         public required List<Connector> Connectors { get; init; }
@@ -19,6 +21,15 @@ public static class DaemonRuntimeStatus
         public required Persistence Persistence { get; init; }
 
         public required Telemetry Telemetry { get; init; }
+    }
+
+    public sealed class Build : IWireType
+    {
+        public required string Version { get; init; }
+
+        public required string CommitHash { get; init; }
+
+        public required string BuildTimestamp { get; init; }
     }
 
     public sealed class Process : IWireType

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -682,6 +682,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration 
 static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoint)
 {
     Console.WriteLine($"overall: {status.Overall}");
+    Console.WriteLine($"version: {status.Build.Version} (commit {status.Build.CommitHash}, built {status.Build.BuildTimestamp})");
     Console.WriteLine($"daemon: PID {status.Process.Pid}, uptime {FormatUptime(status.Process.UptimeSeconds)}, endpoint {endpoint}");
     Console.WriteLine($"persistence: {status.Persistence.Provider}");
     Console.WriteLine($"telemetry: {(status.Telemetry.Enabled ? "enabled" : "disabled")}" +

--- a/src/Netclaw.Daemon/BuildInfo.cs
+++ b/src/Netclaw.Daemon/BuildInfo.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+
+namespace Netclaw.Daemon;
+
+/// <summary>
+/// Exposes build-time information embedded at compile time.
+/// The commit hash comes from <see cref="AssemblyInformationalVersionAttribute"/>
+/// which Microsoft.SourceLink.GitHub populates as "{version}+{full-sha}".
+/// The build timestamp comes from an <see cref="AssemblyMetadataAttribute"/> written
+/// by Directory.Build.targets at evaluation time.
+/// </summary>
+internal static class BuildInfo
+{
+    private static readonly Assembly Assembly = typeof(BuildInfo).Assembly;
+
+    /// <summary>
+    /// Semver version prefix from Directory.Build.props (e.g. "0.1.0").
+    /// </summary>
+    public static string Version { get; } =
+        Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+
+    /// <summary>
+    /// Short git commit hash (first 7 chars of the SHA embedded by SourceLink),
+    /// or "unknown" if the assembly was built outside a git repository.
+    /// </summary>
+    public static string CommitHash { get; } = ResolveCommitHash();
+
+    /// <summary>
+    /// UTC build timestamp in ISO-8601 format captured at MSBuild evaluation time,
+    /// or "unknown" if not available.
+    /// </summary>
+    public static string BuildTimestamp { get; } =
+        Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+                .FirstOrDefault(a => a.Key == "BuildTimestamp")?.Value ?? "unknown";
+
+    private static string ResolveCommitHash()
+    {
+        var informational = Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (informational is null)
+            return "unknown";
+
+        var plusIndex = informational.IndexOf('+');
+        if (plusIndex < 0 || plusIndex + 1 >= informational.Length)
+            return "unknown";
+
+        var fullSha = informational[(plusIndex + 1)..];
+        return fullSha.Length >= 7 ? fullSha[..7] : fullSha;
+    }
+}

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatus.cs
@@ -12,6 +12,8 @@ public static class DaemonRuntimeStatus
     {
         public string Overall { get; init; } = "unknown";
 
+        public required Build Build { get; init; }
+
         public required Process Process { get; init; }
 
         public required List<Connector> Connectors { get; init; }
@@ -19,6 +21,15 @@ public static class DaemonRuntimeStatus
         public required Persistence Persistence { get; init; }
 
         public required Telemetry Telemetry { get; init; }
+    }
+
+    public sealed class Build : IWireType
+    {
+        public required string Version { get; init; }
+
+        public required string CommitHash { get; init; }
+
+        public required string BuildTimestamp { get; init; }
     }
 
     public sealed class Process : IWireType

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -30,6 +30,12 @@ public sealed class DaemonRuntimeStatusService(
         return new DaemonRuntimeStatus.Response
         {
             Overall = overall,
+            Build = new DaemonRuntimeStatus.Build
+            {
+                Version = BuildInfo.Version,
+                CommitHash = BuildInfo.CommitHash,
+                BuildTimestamp = BuildInfo.BuildTimestamp
+            },
             Process = new DaemonRuntimeStatus.Process
             {
                 Pid = process.Id,


### PR DESCRIPTION
## Summary

- Embeds `BuildTimestamp` as an `AssemblyMetadata` attribute at MSBuild evaluation time via a new `Directory.Build.targets` at the repo root; git commit hash is already captured by `Microsoft.SourceLink.GitHub` in `AssemblyInformationalVersion`
- Adds `BuildInfo` static class in `Netclaw.Daemon` that reads version from `AssemblyName`, short commit hash parsed from `InformationalVersion` (`+sha`), and `BuildTimestamp` from `AssemblyMetadata`
- Extends `DaemonRuntimeStatus.Response` with a required `Build` section (`Version`, `CommitHash`, `BuildTimestamp`) in both daemon and CLI wire types
- Renders a version line in `netclaw status` text output: `version: 0.1.0 (commit abc1234, built 2026-03-01T14:02:46Z)`
- Adds proposed OpenSpec change `auto-update-feed-infra` capturing the managed feed architecture (Cloudflare Worker proxying GitHub Releases), manifest schema, release pipeline sync, and update command design — left in PROPOSED status pending infrastructure decisions

## Test plan

- [ ] `dotnet build` passes with 0 warnings for both `Netclaw.Daemon` and `Netclaw.Cli`
- [ ] `Netclaw.Daemon.Tests` all pass (54 tests)
- [ ] Verify `obj/.../Netclaw.Daemon.AssemblyInfo.cs` contains `AssemblyMetadataAttribute("BuildTimestamp", ...)` and `AssemblyInformationalVersionAttribute` with `+{sha}` suffix
- [ ] `netclaw status` text output includes `version:` line with version, commit hash, and build timestamp
- [ ] `netclaw status --json` output includes `build` object with `version`, `commitHash`, and `buildTimestamp` fields