### PR TITLE
Wire startup capability auto-detection for multimodal models

### DIFF
--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -155,6 +155,21 @@ static void ConfigureDaemonServices(
     var models = configuration.GetSection("Models")
         .Get<ModelSelection>() ?? new ModelSelection();
 
+    // Auto-detect model capabilities when not manually specified in config.
+    // Uses the OpenRouter public catalog as an oracle — works for models from
+    // any provider since OpenRouter indexes most publicly available models.
+    var inputModalities = models.Main.InputModalities;
+    var outputModalities = models.Main.OutputModalities;
+    if (inputModalities is null || outputModalities is null)
+    {
+        var detected = ResolveStartupCapabilities(models.Main.ModelId);
+        if (detected is not null)
+        {
+            inputModalities ??= detected.InputModalities;
+            outputModalities ??= detected.OutputModalities;
+        }
+    }
+
     // Session config: bind defaults from config section, overlay model-derived values
     var sessionConfig = configuration.GetSection("Session").Get<SessionConfig>() ?? new SessionConfig();
     services.AddSingleton(sessionConfig with
@@ -162,8 +177,8 @@ static void ConfigureDaemonServices(
         ModelId = models.Main.ModelId,
         ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
         CompactionModelId = models.Compaction?.ModelId,
-        InputModalities = models.Main.InputModalities ?? ModelModality.Text,
-        OutputModalities = models.Main.OutputModalities ?? ModelModality.Text,
+        InputModalities = inputModalities ?? ModelModality.Text,
+        OutputModalities = outputModalities ?? ModelModality.Text,
     });
 
     // Tools (auto-bound, no required properties)
@@ -311,6 +326,45 @@ static ISearchBackend? CreateSearchBackend(SearchConfig config)
         default:
             Console.Error.WriteLine($"warn: Unknown search backend '{backend}'. Falling back to DuckDuckGo.");
             return new DuckDuckGoBackend();
+    }
+}
+
+/// <summary>
+/// One-time capability detection at startup. Creates temporary HTTP resources
+/// to query the OpenRouter public catalog before the DI container is built.
+/// Returns null if detection fails (caller falls back to text-only).
+/// </summary>
+static ResolvedModelCapabilities? ResolveStartupCapabilities(string modelId)
+{
+    try
+    {
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+        var resolver = new OpenRouterOracleResolver(
+            httpClient, loggerFactory.CreateLogger<OpenRouterOracleResolver>());
+
+        var result = resolver.ResolveAsync(modelId, CancellationToken.None)
+            .GetAwaiter().GetResult();
+
+        if (result is not null)
+        {
+            Console.Error.WriteLine(
+                $"info: Auto-detected model capabilities for {modelId}: " +
+                $"input={result.InputModalities}, output={result.OutputModalities}");
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                $"info: Model {modelId} not found in OpenRouter catalog; defaulting to text-only");
+        }
+
+        return result;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine(
+            $"warn: Failed to auto-detect model capabilities for {modelId}: {ex.Message}");
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary

- The capability resolver chain (OpenRouter oracle -> HuggingFace -> text-only default) was registered in DI but never called at startup to populate `SessionConfig.InputModalities`
- When `ModelReference.InputModalities` was null (the default), the system always fell back to text-only, causing the modality gate in `LlmSessionActor` to strip images even for vision-capable models like Qwen3.5-35B-A3B
- Now queries the OpenRouter public catalog at startup when modalities aren't manually specified, so models correctly report their actual capabilities

## Test plan

- [x] All 18 capability resolver tests pass (OpenRouterOracle, ModelIdNormalizer, CompositeCapability)
- [x] All 6 modality gate + capability actor tests pass
- [x] Build succeeds with zero warnings
- [ ] Manual verification: configure a multimodal model (e.g. `qwen/qwen3.5-35b-a3b` on OpenRouter), send an image via Slack, confirm it passes through to the LLM instead of being stripped