### PR TITLE
Fix daemon startup console noise from capability detection

### DIFF
--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -340,7 +340,7 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(string modelId, Log
     try
     {
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-        using var loggerFactory = LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(logLevel));
+        using var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(logLevel));
         var logger = loggerFactory.CreateLogger("Netclaw.Startup");
         var resolver = new OpenRouterOracleResolver(
             httpClient, loggerFactory.CreateLogger<OpenRouterOracleResolver>());


### PR DESCRIPTION
## Summary

- Removed `.AddConsole()` from the temporary `LoggerFactory` in `ResolveStartupCapabilities()`, which was bypassing the daemon's main logging configuration and leaking capability detection messages to the terminal after `daemon start`.

## Root Cause

`ResolveStartupCapabilities()` creates a short-lived `LoggerFactory` to pass loggers to `OpenRouterOracleResolver`. This factory was configured with `.AddConsole()`, completely independent of the daemon's primary logging pipeline (which disables console output by default via `ConfigureNetclawLogging`). Since the daemon inherits the CLI's stdout, the log messages appeared in the user's terminal.

## Test plan

- [ ] Run `dotnet run --project src/Netclaw.Cli -- daemon start` and verify only "Daemon started (PID X)." appears — no capability detection log messages
- [ ] Verify `~/.netclaw/logs/daemon-*.log` still contains normal daemon operation logs
- [ ] Verify `/api/health/status` endpoint still reports detected model capabilities correctly