### PR TITLE
Replace LLM summarization compaction with extractive reducer

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -90,13 +90,13 @@ public class CompactionIntegrationTests : TestKit
         subscriber.ExpectMsg<UsageOutput>(TimeSpan.FromSeconds(3));
         subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
 
-        // Then: compaction output (summarization happened)
+        // Then: compaction output (extractive — no LLM summarization)
         var compaction = subscriber.ExpectMsg<CompactionOutput>(TimeSpan.FromSeconds(5));
-        Assert.True(compaction.Summarized);
+        Assert.False(compaction.Summarized);
         Assert.True(compaction.MessagesAfter < compaction.MessagesBefore);
 
-        // LLM was called: 1 for the turn + 2 for compaction (extraction + summarization)
-        // (Memory extraction may or may not fire depending on timing, but summarization always does)
+        // 2 LLM calls: 1 for the turn + 1 for memory extraction (no summarization call).
+        // Memory extraction fires because FakeMemoryExtractor is registered (not NullMemoryExtractor).
         Assert.True(_fakeChatClient.CallCount >= 2);
     }
 
@@ -358,9 +358,9 @@ public class CompactionIntegrationTests : TestKit
         subscriber.ExpectMsg<UsageOutput>(TimeSpan.FromSeconds(3));
         subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
 
-        // Compaction
+        // Compaction (extractive — no LLM summarization)
         var compaction = subscriber.ExpectMsg<CompactionOutput>(TimeSpan.FromSeconds(5));
-        Assert.True(compaction.Summarized);
+        Assert.False(compaction.Summarized);
 
         // Verify post-compaction by sending another message (low usage to avoid re-compaction)
         _fakeChatClient.UsageOverride = new UsageDetails

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionPromptBuilderTests.cs
@@ -5,99 +5,11 @@ using Xunit;
 namespace Netclaw.Actors.Tests.Sessions;
 
 /// <summary>
-/// Tests for <see cref="CompactionPromptBuilder"/> structured prompt generation.
+/// Tests for <see cref="CompactionPromptBuilder"/> memory extraction prompt generation.
+/// Summarization prompts were removed when compaction switched to extractive reduction.
 /// </summary>
 public class CompactionPromptBuilderTests
 {
-    [Fact]
-    public void BuildSummarizationSystemPrompt_contains_key_sections()
-    {
-        var prompt = CompactionPromptBuilder.BuildSummarizationSystemPrompt();
-
-        Assert.Contains("compaction agent", prompt);
-        Assert.Contains("Goal", prompt);
-        Assert.Contains("Key Facts", prompt);
-        Assert.Contains("past tense", prompt);
-    }
-
-    [Fact]
-    public void BuildSummarizationUserPrompt_skips_system_messages()
-    {
-        var history = new List<SerializableChatMessage>
-        {
-            new() { Role = ChatRole.System, Content = "You are helpful." },
-            new() { Role = ChatRole.User, Content = "Hello" },
-            new() { Role = ChatRole.Assistant, Content = "Hi there!" }
-        };
-
-        var prompt = CompactionPromptBuilder.BuildSummarizationUserPrompt(history);
-
-        Assert.DoesNotContain("You are helpful", prompt);
-        Assert.Contains("Hello", prompt);
-        Assert.Contains("Hi there!", prompt);
-    }
-
-    [Fact]
-    public void BuildSummarizationUserPrompt_includes_tool_call_arguments()
-    {
-        var history = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Assistant,
-                Content = string.Empty,
-                ToolCalls =
-                {
-                    new SerializableToolCall
-                    {
-                        CallId = "call-1",
-                        Name = "web_search",
-                        ArgumentsJson = """{"query": "freshdesk ticket 579"}"""
-                    }
-                }
-            },
-            new()
-            {
-                Role = ChatRole.Tool,
-                Content = "Found 3 results",
-                ToolCallId = "call-1",
-                Name = "web_search"
-            }
-        };
-
-        var prompt = CompactionPromptBuilder.BuildSummarizationUserPrompt(history);
-
-        Assert.Contains("""[Called tool: web_search({"query": "freshdesk ticket 579"})]""", prompt);
-        Assert.Contains("Found 3 results", prompt);
-    }
-
-    [Fact]
-    public void BuildSummarizationUserPrompt_tool_call_with_no_args_omits_parens()
-    {
-        var history = new List<SerializableChatMessage>
-        {
-            new()
-            {
-                Role = ChatRole.Assistant,
-                Content = string.Empty,
-                ToolCalls =
-                {
-                    new SerializableToolCall
-                    {
-                        CallId = "call-1",
-                        Name = "list_files",
-                        ArgumentsJson = ""
-                    }
-                }
-            }
-        };
-
-        var prompt = CompactionPromptBuilder.BuildSummarizationUserPrompt(history);
-
-        Assert.Contains("[Called tool: list_files]", prompt);
-        Assert.DoesNotContain("()", prompt);
-    }
-
     [Fact]
     public void BuildMemoryExtractionSystemPrompt_contains_required_sections()
     {
@@ -138,10 +50,10 @@ public class CompactionPromptBuilderTests
     }
 
     [Fact]
-    public void BuildSummarizationUserPrompt_empty_history_returns_header_only()
+    public void BuildMemoryExtractionUserPrompt_empty_history_returns_header_only()
     {
-        var prompt = CompactionPromptBuilder.BuildSummarizationUserPrompt([]);
+        var prompt = CompactionPromptBuilder.BuildMemoryExtractionUserPrompt([]);
 
-        Assert.Contains("Summarize the following", prompt);
+        Assert.Contains("Extract durable memories", prompt);
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/ExtractiveSessionReducerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ExtractiveSessionReducerTests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Sessions;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Unit tests for <see cref="ExtractiveSessionReducer"/>.
+/// Verifies system prompt preservation, last-N retention, tool message handling,
+/// and edge cases (empty, zero-keep, negative-keep, at-limit no-op).
+/// </summary>
+public class ExtractiveSessionReducerTests
+{
+    [Fact]
+    public async Task System_prompt_is_always_preserved()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 2);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are helpful."),
+            new(ChatRole.User, "Hello"),
+            new(ChatRole.Assistant, "Hi there!"),
+            new(ChatRole.User, "How are you?"),
+            new(ChatRole.Assistant, "I'm good!")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Equal(3, result.Count); // system + 2 kept
+        Assert.Equal(ChatRole.System, result[0].Role);
+        Assert.Equal("You are helpful.", result[0].Text);
+    }
+
+    [Fact]
+    public async Task Keeps_last_N_non_system_messages()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 2);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "First"),
+            new(ChatRole.Assistant, "Reply 1"),
+            new(ChatRole.User, "Second"),
+            new(ChatRole.Assistant, "Reply 2")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Second", result[1].Text);
+        Assert.Equal("Reply 2", result[2].Text);
+    }
+
+    [Fact]
+    public async Task Tool_messages_kept_within_window()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 4);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "Old message"),
+            new(ChatRole.Assistant, "Old reply"),
+            // These 4 should be kept:
+            new(ChatRole.User, "Search for X"),
+            new(ChatRole.Assistant, [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = "X" })]),
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", "Found X")]),
+            new(ChatRole.Assistant, "Here's what I found about X.")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Equal(5, result.Count); // system + 4 kept
+        Assert.Equal(ChatRole.System, result[0].Role);
+        Assert.Equal("Search for X", result[1].Text);
+        Assert.Equal(ChatRole.Tool, result[3].Role);
+        Assert.Equal("Here's what I found about X.", result[4].Text);
+    }
+
+    [Fact]
+    public async Task Empty_history_returns_empty()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 5);
+        var messages = new List<ChatMessage>();
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Keep_zero_preserves_only_system_prompt()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 0);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "Hello"),
+            new(ChatRole.Assistant, "Hi!")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(ChatRole.System, result[0].Role);
+    }
+
+    [Fact]
+    public async Task Negative_keep_treated_as_zero()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: -5);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "Hello"),
+            new(ChatRole.Assistant, "Hi!")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(ChatRole.System, result[0].Role);
+    }
+
+    [Fact]
+    public async Task At_limit_returns_original_messages()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 4);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "Hello"),
+            new(ChatRole.Assistant, "Hi!"),
+            new(ChatRole.User, "Bye"),
+            new(ChatRole.Assistant, "Goodbye!")
+        };
+
+        var result = await reducer.ReduceAsync(messages, CancellationToken.None);
+
+        // At limit — no reduction needed, returns original reference
+        Assert.Same(messages, result);
+    }
+
+    [Fact]
+    public async Task Over_limit_returns_original_messages()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 10);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "System prompt"),
+            new(ChatRole.User, "Hello"),
+            new(ChatRole.Assistant, "Hi!")
+        };
+
+        var result = await reducer.ReduceAsync(messages, CancellationToken.None);
+
+        // Under limit — no reduction needed, returns original reference
+        Assert.Same(messages, result);
+    }
+
+    [Fact]
+    public async Task No_system_prompt_keeps_last_N()
+    {
+        var reducer = new ExtractiveSessionReducer(keepRecentMessages: 2);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "First"),
+            new(ChatRole.Assistant, "Reply 1"),
+            new(ChatRole.User, "Second"),
+            new(ChatRole.Assistant, "Reply 2")
+        };
+
+        var result = (await reducer.ReduceAsync(messages, CancellationToken.None)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Second", result[0].Text);
+        Assert.Equal("Reply 2", result[1].Text);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -53,13 +53,13 @@ public class ModalityGateTextOnlyTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("modality-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -77,14 +77,14 @@ public class ModalityGateTextOnlyTests : TestKit
         }, TimeSpan.FromSeconds(5));
 
         // Should receive the "images removed" acknowledgement
-        var ack = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        var ack = await subscriber.ExpectMsgAsync<TextOutput>();
         Assert.Contains("Images removed", ack.Text);
 
         // The LLM should still be called with the text content
-        var textOutput = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        var textOutput = await subscriber.ExpectMsgAsync<TextOutput>();
         Assert.Contains("fake", textOutput.Text, StringComparison.OrdinalIgnoreCase);
 
-        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>();
 
         // LLM was called (text was sent through despite images being stripped)
         Assert.Equal(1, _fakeChatClient.CallCount);
@@ -97,13 +97,13 @@ public class ModalityGateTextOnlyTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("modality-image-only-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -121,14 +121,14 @@ public class ModalityGateTextOnlyTests : TestKit
         }, TimeSpan.FromSeconds(5));
 
         // Should receive the "images removed" acknowledgement first
-        var stripped = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        var stripped = await subscriber.ExpectMsgAsync<TextOutput>();
         Assert.Contains("Images removed", stripped.Text);
 
         // Then the "only images" explanation
-        var explanation = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        var explanation = await subscriber.ExpectMsgAsync<TextOutput>();
         Assert.Contains("only images", explanation.Text, StringComparison.OrdinalIgnoreCase);
 
-        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>();
 
         // LLM was NOT called
         Assert.Equal(0, _fakeChatClient.CallCount);
@@ -173,13 +173,13 @@ public class ModalityGateVisionTests : TestKit
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
         var subscriber = CreateTestProbe("vision-sub");
 
-        sessionManager.Tell(new JoinSession
+        await sessionManager.Ask<SessionJoined>(new JoinSession
         {
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        });
-        subscriber.ExpectMsg<SessionJoined>();
+        }, TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -197,11 +197,11 @@ public class ModalityGateVisionTests : TestKit
         }, TimeSpan.FromSeconds(5));
 
         // Should NOT receive an "images removed" acknowledgement — go straight to LLM response
-        var textOutput = subscriber.ExpectMsg<TextOutput>(TimeSpan.FromSeconds(3));
+        var textOutput = await subscriber.ExpectMsgAsync<TextOutput>();
         Assert.Contains("fake", textOutput.Text, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Images removed", textOutput.Text);
 
-        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>();
 
         // LLM was called
         Assert.Equal(1, _fakeChatClient.CallCount);

--- a/src/Netclaw.Actors/Sessions/CompactionPromptBuilder.cs
+++ b/src/Netclaw.Actors/Sessions/CompactionPromptBuilder.cs
@@ -3,96 +3,12 @@ using Netclaw.Actors.Protocol;
 namespace Netclaw.Actors.Sessions;
 
 /// <summary>
-/// Builds structured prompts for the compaction summarization LLM call.
-/// The compaction LLM produces a context summary; recent messages are preserved
-/// verbatim by the caller based on a fixed config value.
+/// Builds structured prompts for pre-compaction memory extraction.
+/// Summarization prompts were removed when compaction switched from
+/// LLM-based abstractive summarization to deterministic extractive reduction.
 /// </summary>
 public static class CompactionPromptBuilder
 {
-    /// <summary>
-    /// Builds the system prompt for the compaction summarization call.
-    /// </summary>
-    public static string BuildSummarizationSystemPrompt()
-    {
-        return """
-            You are a conversation compaction agent. Your job is to produce a context
-            summary of a conversation that will be injected as background context for
-            the assistant to continue working.
-
-            Write the summary in past tense — this is historical context, not
-            instructions. Use phrases like "The user was working on..." or
-            "We investigated..." rather than imperatives like "Do X" or "Continue Y".
-
-            Include these sections as relevant (omit empty ones):
-
-            **Goal**: What the user is working on — the high-level objective.
-
-            **Completed**: What has been accomplished so far.
-
-            **Decisions**: Key decisions made during the conversation and their rationale.
-
-            **Key Facts**: Names, file paths, URLs, configuration values, identifiers,
-            or other specifics needed to continue the work.
-
-            **Tool Findings**: Essential outcomes from tool calls — not full outputs,
-            just the conclusions that matter.
-
-            **Open Items**: Pending questions, next steps, or unresolved issues.
-
-            Keep the summary concise but complete. Prioritize information that the
-            assistant would need to continue the conversation without the user having
-            to repeat themselves.
-            """;
-    }
-
-    /// <summary>
-    /// Builds the user prompt containing the conversation history to summarize.
-    /// </summary>
-    public static string BuildSummarizationUserPrompt(
-        IReadOnlyList<SerializableChatMessage> history)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Summarize the following conversation into the structured format described above.");
-        sb.AppendLine();
-        sb.AppendLine("---");
-        sb.AppendLine();
-
-        foreach (var msg in history)
-        {
-            // Skip system prompt — it's preserved separately
-            if (msg.Role == ChatRole.System)
-                continue;
-
-            var roleLabel = msg.Role switch
-            {
-                ChatRole.User => "User",
-                ChatRole.Assistant => "Assistant",
-                ChatRole.Tool => $"Tool ({msg.Name ?? "unknown"})",
-                _ => msg.Role.ToString()
-            };
-
-            sb.AppendLine($"**{roleLabel}:**");
-
-            if (msg.ToolCalls.Count > 0)
-            {
-                foreach (var tc in msg.ToolCalls)
-                {
-                    var args = !string.IsNullOrEmpty(tc.ArgumentsJson) ? $"({tc.ArgumentsJson})" : "";
-                    sb.AppendLine($"[Called tool: {tc.Name}{args}]");
-                }
-            }
-
-            if (!string.IsNullOrEmpty(msg.Content))
-            {
-                sb.AppendLine(msg.Content);
-            }
-
-            sb.AppendLine();
-        }
-
-        return sb.ToString();
-    }
-
     /// <summary>
     /// Builds the system prompt for pre-compaction memory extraction.
     /// </summary>

--- a/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
+++ b/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Deterministic extractive chat reducer that keeps the system prompt and the
+/// last N non-system messages, dropping everything else. Tool call and tool
+/// result messages within the window are preserved (unlike MEAI's
+/// <c>MessageCountingChatReducer</c> which drops them silently).
+///
+/// This reducer is synchronous (<see cref="Task.FromResult{TResult}"/>) and
+/// cannot fail — safe to call with <c>.GetAwaiter().GetResult()</c> inside an
+/// Akka actor (no <c>SynchronizationContext</c>).
+/// </summary>
+public sealed class ExtractiveSessionReducer : IChatReducer
+{
+    private readonly int _keepRecentMessages;
+
+    public ExtractiveSessionReducer(int keepRecentMessages)
+    {
+        _keepRecentMessages = Math.Max(0, keepRecentMessages);
+    }
+
+    public Task<IEnumerable<ChatMessage>> ReduceAsync(
+        IEnumerable<ChatMessage> messages,
+        CancellationToken cancellationToken)
+    {
+        var list = messages as IList<ChatMessage> ?? messages.ToList();
+
+        var hasSystemPrompt = list.Count > 0 && list[0].Role == ChatRole.System;
+        var systemOffset = hasSystemPrompt ? 1 : 0;
+        var nonSystemCount = list.Count - systemOffset;
+        var keepCount = Math.Min(_keepRecentMessages, nonSystemCount);
+
+        // Nothing to reduce — return as-is
+        if (keepCount >= nonSystemCount)
+        {
+            return Task.FromResult(messages);
+        }
+
+        var result = new List<ChatMessage>(keepCount + systemOffset);
+
+        if (hasSystemPrompt)
+            result.Add(list[0]);
+
+        // Keep last N non-system messages (tool calls and results included)
+        var startIndex = list.Count - keepCount;
+        for (var i = startIndex; i < list.Count; i++)
+        {
+            result.Add(list[i]);
+        }
+
+        return Task.FromResult<IEnumerable<ChatMessage>>(result);
+    }
+}

--- a/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
+++ b/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
@@ -9,8 +9,8 @@ namespace Netclaw.Actors.Sessions;
 /// <c>MessageCountingChatReducer</c> which drops them silently).
 ///
 /// This reducer is synchronous (<see cref="Task.FromResult{TResult}"/>) and
-/// cannot fail — safe to call with <c>.GetAwaiter().GetResult()</c> inside an
-/// Akka actor (no <c>SynchronizationContext</c>).
+/// cannot fail. The actor calls it via <c>await</c> inside a
+/// <c>CommandAsync</c> handler, so async reducers are also supported.
 /// </summary>
 public sealed class ExtractiveSessionReducer : IChatReducer
 {

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -68,15 +68,6 @@ internal sealed record MemoryExtractionCompleted
 }
 
 /// <summary>
-/// Internal message completing the summarization LLM call.
-/// Contains the structured summary to persist in <see cref="Protocol.SessionCompacted"/>.
-/// </summary>
-internal sealed record SummarizationCompleted
-{
-    public required string Summary { get; init; }
-}
-
-/// <summary>
 /// Internal message when a compaction step (extraction or summarization) fails.
 /// </summary>
 internal sealed record CompactionFailed

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -395,7 +395,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             TryReplyAck();
         });
 
-        Command<CompactionTriggered>(msg =>
+        CommandAsync<CompactionTriggered>(async msg =>
         {
             var messagesBefore = _state.History.Count;
 
@@ -408,15 +408,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 _log.Info("Phase 1: Cleared {ClearedCount} old tool result(s)", clearedCount);
             }
 
-            // Phase 2: Extractive reduction via IChatReducer (no LLM call).
+            // Phase 2: Extractive reduction via IChatReducer (no LLM call for the
+            // default ExtractiveSessionReducer, but async reducers are supported).
             // Convert to MEAI ChatMessage without sessionDir (skip media file I/O —
             // the reducer only needs message structure, not media bytes).
-            // GetAwaiter().GetResult() is safe: ExtractiveSessionReducer is synchronous
-            // and Akka actors have no SynchronizationContext. A future async reducer
-            // would need PipeTo instead.
             var meaiMessages = ChatMessageConverter.ToAiMessages(_state.History);
-            var reduced = _chatReducer.ReduceAsync(meaiMessages, CancellationToken.None)
-                .GetAwaiter().GetResult();
+            var reduced = await _chatReducer.ReduceAsync(meaiMessages, CancellationToken.None);
 
             // Map reduced result back to original SerializableChatMessage objects.
             // The extractive reducer preserves order and only trims from the beginning,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -38,6 +38,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     private readonly IToolExecutor? _toolExecutor;
     private readonly IToolAuditLogger? _auditLogger;
     private readonly IMemoryExtractor _memoryExtractor;
+    private readonly IChatReducer _chatReducer;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
 
@@ -71,6 +72,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         IToolAuditLogger? auditLogger = null,
         ToolRegistry? toolRegistry = null,
         IMemoryExtractor? memoryExtractor = null,
+        IChatReducer? chatReducer = null,
         TimeProvider? timeProvider = null,
         IReadOnlyList<IContextLayerProvider>? contextLayers = null)
     {
@@ -85,6 +87,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         _toolExecutor = toolExecutor;
         _auditLogger = auditLogger;
         _memoryExtractor = memoryExtractor ?? NullMemoryExtractor.Instance;
+        _chatReducer = chatReducer ?? new ExtractiveSessionReducer(config.KeepRecentMessages);
         _timeProvider = timeProvider ?? TimeProvider.System;
         PersistenceId = $"session-{entityId}";
 
@@ -405,50 +408,43 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 _log.Info("Phase 1: Cleared {ClearedCount} old tool result(s)", clearedCount);
             }
 
-            // Phase 2: Fire memory extraction + summarization LLM calls
-            _log.Info("Phase 2: Starting summarization (history={HistoryCount} messages)", _state.History.Count);
-            FireMemoryExtractionCall(messagesBefore, clearedCount > 0);
-        });
+            // Phase 2: Extractive reduction via IChatReducer (no LLM call).
+            // Convert to MEAI ChatMessage without sessionDir (skip media file I/O —
+            // the reducer only needs message structure, not media bytes).
+            // GetAwaiter().GetResult() is safe: ExtractiveSessionReducer is synchronous
+            // and Akka actors have no SynchronizationContext. A future async reducer
+            // would need PipeTo instead.
+            var meaiMessages = ChatMessageConverter.ToAiMessages(_state.History);
+            var reduced = _chatReducer.ReduceAsync(meaiMessages, CancellationToken.None)
+                .GetAwaiter().GetResult();
 
-        Command<MemoryExtractionCompleted>(msg =>
-        {
-            // Persist extracted memories externally
-            var self = Self;
-            var extractor = _memoryExtractor;
-            var sessionId = _sessionId.Value;
-            _ = PersistMemoriesAsync(extractor, sessionId, msg.ExtractedMemories, self);
-        });
+            // Map reduced result back to original SerializableChatMessage objects.
+            // The extractive reducer preserves order and only trims from the beginning,
+            // so we count non-system messages in the result and take that many from the
+            // tail of the original history. This avoids lossy ChatMessage→SerializableChatMessage
+            // round-trip conversion (which would lose media references).
+            var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage>
+                ?? reduced.ToList();
+            var keptNonSystemCount = reducedList
+                .Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
 
-        Command<SummarizationCompleted>(msg =>
-        {
-            var messagesBefore = _state.History.Count;
-
-            // Build compacted history: User(context-summary) + preserved recent messages
-            var compactedMessages = new List<SerializableChatMessage>();
-
-            // 1. Summary as User message with context-summary tags
-            compactedMessages.Add(new SerializableChatMessage
-            {
-                Role = Protocol.ChatRole.User,
-                Content = $"<context-summary>\n{msg.Summary}\n</context-summary>"
-            });
-
-            // 2. Preserve last N non-system messages verbatim
-            var systemPromptOffset = _state.History.Count > 0
+            var systemOffset = _state.History.Count > 0
                 && _state.History[0].Role == Protocol.ChatRole.System ? 1 : 0;
-            var nonSystemCount = _state.History.Count - systemPromptOffset;
-            var keepCount = Math.Min(_config.KeepRecentMessages, nonSystemCount);
-            var startIndex = _state.History.Count - keepCount;
+            var startIndex = _state.History.Count - keptNonSystemCount;
 
-            for (var i = startIndex; i < _state.History.Count; i++)
+            var compactedMessages = new List<SerializableChatMessage>();
+            for (var i = Math.Max(systemOffset, startIndex); i < _state.History.Count; i++)
             {
                 compactedMessages.Add(_state.History[i]);
             }
 
+            _log.Info("Phase 2: Extractive reduction (history={HistoryCount} → {KeptCount} messages)",
+                _state.History.Count, compactedMessages.Count + systemOffset);
+
             var compactedEvent = new SessionCompacted
             {
                 SessionId = _sessionId,
-                Summary = msg.Summary,
+                Summary = string.Empty, // Extractive — no LLM summary
                 CompactedMessages = compactedMessages,
                 TurnCountBefore = _state.TurnCount,
                 CompactedAtMs = NowMs()
@@ -467,22 +463,49 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                     SessionId = _sessionId,
                     MessagesBefore = messagesBefore,
                     MessagesAfter = _state.History.Count,
-                    ToolResultsCleared = true,
-                    Summarized = true
+                    ToolResultsCleared = clearedCount > 0,
+                    Summarized = false // Extractive, not summarized
                 });
 
                 _log.Info("Compaction complete (before={MessagesBefore}, after={MessagesAfter})",
                     messagesBefore, _state.History.Count);
 
-                DrainBufferOrReady();
+                // Memory extraction is optional and best-effort.
+                // If no extractor is configured, skip the async LLM call and drain immediately.
+                if (_memoryExtractor is NullMemoryExtractor)
+                {
+                    DrainBufferOrReady();
+                }
+                else
+                {
+                    InvokeMemoryExtractionAsync();
+                }
             });
+        });
+
+        Command<MemoryExtractionCompleted>(msg =>
+        {
+            // Persist extracted memories externally (fire-and-forget)
+            var self = Self;
+            var extractor = _memoryExtractor;
+            var sessionId = _sessionId.Value;
+            _ = PersistMemoriesAsync(extractor, sessionId, msg.ExtractedMemories, self);
+
+            DrainBufferOrReady();
         });
 
         Command<CompactionFailed>(msg =>
         {
-            _log.Warning(msg.Cause, "Compaction failed, continuing without compaction");
+            _log.Warning(msg.Cause, "Compaction failed");
 
-            // Compaction is best-effort — if it fails, drain buffer and continue
+            EmitOutput(new ErrorOutput
+            {
+                SessionId = _sessionId,
+                Message = "Context compaction encountered an error. The session will continue.",
+                Cause = msg.Cause
+            });
+
+            // Compaction is best-effort — drain buffer and continue
             DrainBufferOrReady();
         });
     }
@@ -507,56 +530,39 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         }
     }
 
-    private void FireMemoryExtractionCall(int messagesBefore, bool toolResultsCleared)
+    /// <summary>
+    /// Fire an async memory extraction LLM call with a 30-second timeout.
+    /// Results come back as <see cref="MemoryExtractionCompleted"/> or
+    /// <see cref="CompactionFailed"/> if the call fails or times out.
+    /// </summary>
+    private void InvokeMemoryExtractionAsync()
     {
         var history = _state.History;
         var self = Self;
         var client = _compactionClient;
 
-        _ = InvokeCompactionSequenceAsync(client, history, self, messagesBefore, toolResultsCleared);
+        _ = InvokeMemoryExtractionCoreAsync(client, history, self);
     }
 
-    private static async Task InvokeCompactionSequenceAsync(
+    private static async Task InvokeMemoryExtractionCoreAsync(
         IChatClient client,
         IReadOnlyList<SerializableChatMessage> history,
-        IActorRef self,
-        int messagesBefore,
-        bool toolResultsCleared)
+        IActorRef self)
     {
         try
         {
-            // Step 1: Memory extraction (optional — if it fails, we still summarize)
-            try
-            {
-                var extractionMessages = new List<AiChatMessage>
-                {
-                    new(Microsoft.Extensions.AI.ChatRole.System,
-                        CompactionPromptBuilder.BuildMemoryExtractionSystemPrompt()),
-                    new(Microsoft.Extensions.AI.ChatRole.User,
-                        CompactionPromptBuilder.BuildMemoryExtractionUserPrompt(history))
-                };
-                var extractionResponse = await client.GetResponseAsync(extractionMessages);
-                var extractedText = extractionResponse.Messages[^1].Text ?? string.Empty;
-                self.Tell(new MemoryExtractionCompleted { ExtractedMemories = extractedText });
-            }
-            catch (Exception ex)
-            {
-                // Memory extraction is best-effort — log and continue to summarization
-                Trace.TraceWarning("Memory extraction failed during compaction: {0}", ex.Message);
-            }
-
-            // Step 2: Summarization
-            var summaryMessages = new List<AiChatMessage>
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var extractionMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,
-                    CompactionPromptBuilder.BuildSummarizationSystemPrompt()),
+                    CompactionPromptBuilder.BuildMemoryExtractionSystemPrompt()),
                 new(Microsoft.Extensions.AI.ChatRole.User,
-                    CompactionPromptBuilder.BuildSummarizationUserPrompt(history))
+                    CompactionPromptBuilder.BuildMemoryExtractionUserPrompt(history))
             };
-            var summaryResponse = await client.GetResponseAsync(summaryMessages);
-            var summaryText = summaryResponse.Messages[^1].Text ?? string.Empty;
-
-            self.Tell(new SummarizationCompleted { Summary = summaryText });
+            var extractionResponse = await client.GetResponseAsync(extractionMessages,
+                cancellationToken: cts.Token);
+            var extractedText = extractionResponse.Messages[^1].Text ?? string.Empty;
+            self.Tell(new MemoryExtractionCompleted { ExtractedMemories = extractedText });
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
@@ -173,14 +175,17 @@ static void ConfigureDaemonServices(
 
     // Session config: bind defaults from config section, overlay model-derived values
     var sessionConfig = configuration.GetSection("Session").Get<SessionConfig>() ?? new SessionConfig();
-    services.AddSingleton(sessionConfig with
+    var resolvedSessionConfig = sessionConfig with
     {
         ModelId = models.Main.ModelId,
         ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
         CompactionModelId = models.Compaction?.ModelId,
         InputModalities = inputModalities ?? ModelModality.Text,
         OutputModalities = outputModalities ?? ModelModality.Text,
-    });
+    };
+    services.AddSingleton(resolvedSessionConfig);
+    services.AddSingleton<IChatReducer>(
+        new ExtractiveSessionReducer(resolvedSessionConfig.KeepRecentMessages));
 
     // Tools (auto-bound, no required properties)
     var toolConfig = configuration.GetSection("Tools")


### PR DESCRIPTION
## Summary

- Replace Phase 2 (LLM summarization) of context compaction with a deterministic `ExtractiveSessionReducer` implementing `IChatReducer` from MEAI Abstractions 10.3.0. Keeps system prompt + last N non-system messages (tool call/result messages preserved within window).
- Fix silent session death: `CompactionFailed` now emits `ErrorOutput` instead of silently draining the buffer.
- Decouple memory extraction: optional async LLM call with 30s timeout, only fires when a real `IMemoryExtractor` is configured (skipped for `NullMemoryExtractor`).

### Root cause

In tool-heavy sessions, the summarization prompt (which serialized the entire conversation including full tool call argument JSON) exceeded the model's context window. The LLM call failed, `CompactionFailed` called `DrainBufferOrReady()` with no error output, and the session appeared dead to the user.

### What changed

| File | Change |
|------|--------|
| `ExtractiveSessionReducer.cs` | New `IChatReducer` impl — synchronous, deterministic, cannot fail |
| `LlmSessionActor.cs` | Rewritten `Compacting` behavior, deleted `InvokeCompactionSequenceAsync` |
| `LlmMessages.cs` | Deleted `SummarizationCompleted` record |
| `CompactionPromptBuilder.cs` | Removed summarization prompts, kept memory extraction |
| `Program.cs` | Register `IChatReducer` in DI |
| Tests | 8 new reducer unit tests, updated integration + prompt builder tests |

Wire compatibility preserved: `SessionCompacted.Summary` set to empty string, `CompactedMessages` contract unchanged.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --filter "Compaction|Extractive|CompactionPromptBuilder"` — 27/27 pass
- [x] `dotnet test` — 477/477 pass (full suite)
- [x] `dotnet slopwatch analyze` — 0 violations