### PR TITLE
Adaptive compaction, context overflow detection, and session observability

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -50,7 +50,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
             InputModalities = ModelModality.Text | ModelModality.Image,
-            OutputModalities = ModelModality.Text
+            OutputModalities = ModelModality.Text,
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -40,7 +40,8 @@ public class CompactionIntegrationTests : TestKit
             CompactionThreshold = 0.75, // 750 tokens triggers compaction
             SnapshotInterval = 5,
             KeepRecentToolResults = 1,
-            KeepRecentMessages = 0
+            KeepRecentMessages = 0,
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -35,7 +35,8 @@ public class LlmSessionIntegrationTests : TestKit
         {
             ModelId = "fake-model",
             ContextWindowTokens = 128_000,
-            SnapshotInterval = 5
+            SnapshotInterval = 5,
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -37,7 +37,8 @@ public class MaxToolIterationTests : TestKit
             ModelId = "fake-model",
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
-            MaxToolIterationsPerTurn = 3 // Low limit for testing
+            MaxToolIterationsPerTurn = 3, // Low limit for testing
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant with tools."));

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -31,7 +31,8 @@ public class ModalityGateTextOnlyTests : TestKit
         {
             ModelId = "text-only-model",
             ContextWindowTokens = 128_000,
-            InputModalities = ModelModality.Text // no Image flag
+            InputModalities = ModelModality.Text, // no Image flag
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
@@ -151,7 +152,8 @@ public class ModalityGateVisionTests : TestKit
         {
             ModelId = "vision-model",
             ContextWindowTokens = 128_000,
-            InputModalities = ModelModality.Text | ModelModality.Image // supports vision
+            InputModalities = ModelModality.Text | ModelModality.Image, // supports vision
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -36,7 +36,8 @@ public class ToolExecutionIntegrationTests : TestKit
         {
             ModelId = "fake-model",
             ContextWindowTokens = 128_000,
-            SnapshotInterval = 5
+            SnapshotInterval = 5,
+            TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant with tools."));

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -94,13 +94,16 @@ public sealed class SessionPipeline
 {
     private readonly ActorSystem _system;
     private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
+    private readonly ISessionLifecycleObserver? _lifecycleObserver;
 
     public SessionPipeline(
         ActorSystem system,
-        IRequiredActor<SessionManagerActorKey> sessionManagerProvider)
+        IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
+        ISessionLifecycleObserver? lifecycleObserver = null)
     {
         _system = system;
         _sessionManagerProvider = sessionManagerProvider;
+        _lifecycleObserver = lifecycleObserver;
     }
 
     /// <summary>
@@ -140,8 +143,23 @@ public sealed class SessionPipeline
             .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd)));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source
+        // When a lifecycle observer is registered, tap the stream so every output
+        // is reported regardless of which channel materializes the session.
         var outputSource = responseSource
             .Via(killSwitch.Flow<SessionOutput>());
+
+        if (_lifecycleObserver is not null)
+        {
+            var observer = _lifecycleObserver;
+            outputSource = outputSource.Select(output =>
+            {
+                observer.OnOutput(output);
+                return output;
+            });
+        }
+
+        // Notify observer of session creation
+        _lifecycleObserver?.OnSessionCreated(sessionId, options.ChannelType);
 
         // Join the session — subscriber starts receiving output
         sessionManager.Tell(new JoinSession

--- a/src/Netclaw.Actors/Channels/ISessionLifecycleObserver.cs
+++ b/src/Netclaw.Actors/Channels/ISessionLifecycleObserver.cs
@@ -1,0 +1,23 @@
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Observer for session lifecycle events. Implemented by infrastructure services
+/// (e.g. session catalog) that need to track all sessions regardless of channel type.
+/// Injected into <see cref="SessionPipeline"/> via DI — every materialized session
+/// automatically reports creation and output events.
+/// </summary>
+public interface ISessionLifecycleObserver
+{
+    /// <summary>
+    /// Called when a new session is created (or re-materialized).
+    /// </summary>
+    void OnSessionCreated(SessionId sessionId, string channelType);
+
+    /// <summary>
+    /// Called for every <see cref="SessionOutput"/> emitted by the session.
+    /// Implementations must be fast — this runs synchronously in the Akka.Streams pipeline.
+    /// </summary>
+    void OnOutput(SessionOutput output);
+}

--- a/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
@@ -8,11 +8,22 @@ public static class SessionDirectoryHelper
 {
     /// <summary>
     /// Computes the session directory path under the OS temp directory.
+    /// Prefer the overload that accepts a base path for daemon-mode sessions.
     /// </summary>
     public static string GetSessionDirectory(SessionId sessionId)
     {
         var sanitized = SanitizeSessionId(sessionId.Value);
         return Path.Combine(Path.GetTempPath(), "netclaw-sessions", sanitized);
+    }
+
+    /// <summary>
+    /// Computes the session directory path under the given base directory
+    /// (e.g. <c>~/.netclaw/sessions/</c>).
+    /// </summary>
+    public static string GetSessionDirectory(SessionId sessionId, string basePath)
+    {
+        var sanitized = SanitizeSessionId(sessionId.Value);
+        return Path.Combine(basePath, sanitized);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -182,4 +182,21 @@ public sealed record CompactionOutput : SessionOutput
 
     /// <summary>Whether summarization was applied (Phase 2).</summary>
     public bool Summarized { get; init; }
+
+    /// <summary>
+    /// The configured context window budget in tokens.
+    /// </summary>
+    public int ContextWindowTokens { get; init; }
+
+    /// <summary>
+    /// The input token count that triggered compaction (<see cref="Sessions.SessionConfig.CompactionTokenLimit"/>).
+    /// </summary>
+    public long PreCompactionInputTokens { get; init; }
+
+    /// <summary>
+    /// The effective keep count used after adaptive reduction.
+    /// May be less than the configured <see cref="Sessions.SessionConfig.KeepRecentMessages"/>
+    /// if the post-compaction estimate still exceeded the budget.
+    /// </summary>
+    public int KeepCountUsed { get; init; }
 }

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -44,6 +44,8 @@ public sealed record SessionOutputDto
     // Compaction
     public int? MessagesBefore { get; init; }
     public int? MessagesAfter { get; init; }
+    public long? PreCompactionInputTokens { get; init; }
+    public int? KeepCountUsed { get; init; }
 
     // Session Joined
     public string? Title { get; init; }

--- a/src/Netclaw.Actors/Sessions/CompactionPromptBuilder.cs
+++ b/src/Netclaw.Actors/Sessions/CompactionPromptBuilder.cs
@@ -10,6 +10,51 @@ namespace Netclaw.Actors.Sessions;
 public static class CompactionPromptBuilder
 {
     /// <summary>
+    /// Builds the user prompt for session title generation.
+    /// Includes the last few messages for context.
+    /// </summary>
+    public static string BuildTitleGenerationPrompt(
+        IReadOnlyList<SerializableChatMessage> history,
+        int maxMessages = 6)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("Generate a short title (8 words or fewer) for this conversation. Reply with only the title — no quotes, no punctuation, no explanation.");
+        sb.AppendLine();
+
+        var startIndex = 0;
+        for (var i = 0; i < history.Count; i++)
+        {
+            if (history[i].Role == ChatRole.System)
+            {
+                startIndex = i + 1;
+                break;
+            }
+        }
+
+        var nonSystemMessages = history.Count - startIndex;
+        if (nonSystemMessages > maxMessages)
+            startIndex = history.Count - maxMessages;
+
+        for (var i = startIndex; i < history.Count; i++)
+        {
+            var msg = history[i];
+            if (msg.Role == ChatRole.System) continue;
+
+            var roleLabel = msg.Role switch
+            {
+                ChatRole.User => "User",
+                ChatRole.Assistant => "Assistant",
+                _ => msg.Role.ToString()
+            };
+
+            if (!string.IsNullOrEmpty(msg.Content))
+                sb.AppendLine($"**{roleLabel}:** {msg.Content}");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Builds the system prompt for pre-compaction memory extraction.
     /// </summary>
     public static string BuildMemoryExtractionSystemPrompt()

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -74,3 +74,11 @@ internal sealed record CompactionFailed
 {
     public required Exception Cause { get; init; }
 }
+
+/// <summary>
+/// Internal message completing a sidecar title generation LLM call.
+/// </summary>
+internal sealed record TitleGenerationCompleted
+{
+    public required string Title { get; init; }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -38,9 +38,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     private readonly IToolExecutor? _toolExecutor;
     private readonly IToolAuditLogger? _auditLogger;
     private readonly IMemoryExtractor _memoryExtractor;
-    private readonly IChatReducer _chatReducer;
     private readonly TimeProvider _timeProvider;
     private readonly string? _sessionsBasePath;
+    private readonly string? _sessionLogsBasePath;
     private readonly ILoggingAdapter _log;
 
     // Transient state (not persisted)
@@ -55,6 +55,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     // Tool iteration counter (reset per turn, incremented on each ToolExecutionCompleted)
     private int _toolIterationCount;
+
+    // Child actor for per-session log file (created when session logs directory is configured)
+    private IActorRef? _logActor;
 
     // Persistent state (immutable — replaced on each event)
     private SessionState _state = SessionState.Empty;
@@ -73,7 +76,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         IToolAuditLogger? auditLogger = null,
         ToolRegistry? toolRegistry = null,
         IMemoryExtractor? memoryExtractor = null,
-        IChatReducer? chatReducer = null,
         TimeProvider? timeProvider = null,
         IReadOnlyList<IContextLayerProvider>? contextLayers = null,
         NetclawPaths? paths = null)
@@ -89,9 +91,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         _toolExecutor = toolExecutor;
         _auditLogger = auditLogger;
         _memoryExtractor = memoryExtractor ?? NullMemoryExtractor.Instance;
-        _chatReducer = chatReducer ?? new ExtractiveSessionReducer(config.KeepRecentMessages);
         _timeProvider = timeProvider ?? TimeProvider.System;
         _sessionsBasePath = paths?.SessionsDirectory;
+        _sessionLogsBasePath = paths?.SessionLogsDirectory;
         PersistenceId = $"session-{entityId}";
 
         // Enrich logger with session context — all log messages automatically include SessionId
@@ -136,6 +138,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             }
 
             Become(Ready);
+
+            if (_sessionLogsBasePath is not null)
+            {
+                _logActor = Context.ActorOf(
+                    SessionLogActor.CreateProps(_sessionId, _sessionLogsBasePath),
+                    "session-log");
+            }
         });
     }
 
@@ -587,9 +596,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             var title = response.Messages[^1].Text ?? string.Empty;
             self.Tell(new TitleGenerationCompleted { Title = title });
         }
-        catch
+        catch (Exception ex)
         {
-            // Title generation is best-effort — don't disrupt the session
+            // Title generation is best-effort — log and move on
+            Trace.TraceWarning("Sidecar title generation failed: {0}", ex.Message);
         }
     }
 
@@ -872,7 +882,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         if (systemPrompt is not null)
             totalChars += systemPrompt.Content?.Length ?? 0;
         foreach (var msg in messages)
+        {
             totalChars += msg.Content?.Length ?? 0;
+            foreach (var tc in msg.ToolCalls)
+                totalChars += tc.ArgumentsJson?.Length ?? 0;
+        }
         return totalChars / 4;
     }
 
@@ -1284,6 +1298,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 subscriber.Tell(output);
             }
         }
+
+        _logActor?.Tell(output);
     }
 
     private void TryReplyAck()

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -549,6 +549,51 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     }
 
     /// <summary>
+    /// Fire a sidecar LLM call to generate a short session title.
+    /// Best-effort — failures are silently ignored.
+    /// </summary>
+    private void MaybeGenerateTitle()
+    {
+        var interval = _config.TitleGenerationInterval;
+        if (interval <= 0)
+            return;
+
+        // Generate on turn 1, then refresh every N turns
+        var turn = _state.TurnCount;
+        if (turn != 1 && turn % interval != 0)
+            return;
+
+        var history = _state.History;
+        var self = Self;
+        var client = _compactionClient;
+
+        _ = GenerateTitleAsync(client, history, self);
+    }
+
+    private static async Task GenerateTitleAsync(
+        IChatClient client,
+        IReadOnlyList<SerializableChatMessage> history,
+        IActorRef self)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var messages = new List<AiChatMessage>
+            {
+                new(Microsoft.Extensions.AI.ChatRole.User,
+                    CompactionPromptBuilder.BuildTitleGenerationPrompt(history))
+            };
+            var response = await client.GetResponseAsync(messages, cancellationToken: cts.Token);
+            var title = response.Messages[^1].Text ?? string.Empty;
+            self.Tell(new TitleGenerationCompleted { Title = title });
+        }
+        catch
+        {
+            // Title generation is best-effort — don't disrupt the session
+        }
+    }
+
+    /// <summary>
     /// Fire an async memory extraction LLM call with a 30-second timeout.
     /// Results come back as <see cref="MemoryExtractionCompleted"/> or
     /// <see cref="CompactionFailed"/> if the call fails or times out.
@@ -686,6 +731,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
             EmitResponseOutputs(lastMessage, usage, includeText: true, includeThinking: true);
             MaybeSnapshot();
+            MaybeGenerateTitle();
 
             // Check if compaction should trigger
             if (ShouldCompact())
@@ -723,6 +769,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private void CommandSubscriptionMessages()
     {
+        // Title generation result — can arrive in any behavior, always safe to apply
+        Command<TitleGenerationCompleted>(msg =>
+        {
+            var title = msg.Title.Trim();
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                _log.Info("Title generated: {Title}", title);
+                SetTitle(title);
+            }
+        });
+
         Command<JoinSession>(cmd =>
         {
             _subscribers[cmd.Subscriber] = cmd.Filter;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -40,6 +40,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     private readonly IMemoryExtractor _memoryExtractor;
     private readonly IChatReducer _chatReducer;
     private readonly TimeProvider _timeProvider;
+    private readonly string? _sessionsBasePath;
     private readonly ILoggingAdapter _log;
 
     // Transient state (not persisted)
@@ -74,7 +75,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         IMemoryExtractor? memoryExtractor = null,
         IChatReducer? chatReducer = null,
         TimeProvider? timeProvider = null,
-        IReadOnlyList<IContextLayerProvider>? contextLayers = null)
+        IReadOnlyList<IContextLayerProvider>? contextLayers = null,
+        NetclawPaths? paths = null)
     {
         _sessionId = new SessionId(entityId);
         _chatClient = clientProvider.GetClient(ModelRole.Main);
@@ -89,6 +91,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         _memoryExtractor = memoryExtractor ?? NullMemoryExtractor.Instance;
         _chatReducer = chatReducer ?? new ExtractiveSessionReducer(config.KeepRecentMessages);
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _sessionsBasePath = paths?.SessionsDirectory;
         PersistenceId = $"session-{entityId}";
 
         // Enrich logger with session context — all log messages automatically include SessionId
@@ -360,7 +363,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         {
             _log.Error(msg.Cause, "LLM call failed");
 
-            const string errorMessage = "I encountered an error processing your message. Please try again.";
+            var errorMessage = IsContextOverflowError(msg.Cause)
+                ? $"Context window exceeded after compaction — the session has too many tools or a large system prompt for the {_config.ModelId} context window ({_config.ContextWindowTokens} tokens). Try reducing tools or increasing the model's context window."
+                : "I encountered an error processing your message. Please try again.";
             _state = _state.AddErrorReply(errorMessage);
 
             EmitOutput(new ErrorOutput
@@ -398,6 +403,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         CommandAsync<CompactionTriggered>(async msg =>
         {
             var messagesBefore = _state.History.Count;
+            var preCompactionInputTokens = _lastInputTokenCount;
 
             // Phase 1: Clear old tool results
             var (newState, clearedCount) = _state.ClearOldToolResults(_config.KeepRecentToolResults);
@@ -408,35 +414,47 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 _log.Info("Phase 1: Cleared {ClearedCount} old tool result(s)", clearedCount);
             }
 
-            // Phase 2: Extractive reduction via IChatReducer (no LLM call for the
-            // default ExtractiveSessionReducer, but async reducers are supported).
-            // Convert to MEAI ChatMessage without sessionDir (skip media file I/O —
-            // the reducer only needs message structure, not media bytes).
-            var meaiMessages = ChatMessageConverter.ToAiMessages(_state.History);
-            var reduced = await _chatReducer.ReduceAsync(meaiMessages, CancellationToken.None);
-
-            // Map reduced result back to original SerializableChatMessage objects.
-            // The extractive reducer preserves order and only trims from the beginning,
-            // so we count non-system messages in the result and take that many from the
-            // tail of the original history. This avoids lossy ChatMessage→SerializableChatMessage
-            // round-trip conversion (which would lose media references).
-            var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage>
-                ?? reduced.ToList();
-            var keptNonSystemCount = reducedList
-                .Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
-
+            // Phase 2: Extractive reduction with adaptive keep count.
+            // Start with the configured keep count, then halve if estimated tokens
+            // still exceed 50% of the context window (minimum 2 messages).
             var systemOffset = _state.History.Count > 0
                 && _state.History[0].Role == Protocol.ChatRole.System ? 1 : 0;
-            var startIndex = _state.History.Count - keptNonSystemCount;
+            var effectiveKeepCount = _config.KeepRecentMessages;
+            List<SerializableChatMessage> compactedMessages;
 
-            var compactedMessages = new List<SerializableChatMessage>();
-            for (var i = Math.Max(systemOffset, startIndex); i < _state.History.Count; i++)
+            while (true)
             {
-                compactedMessages.Add(_state.History[i]);
+                var reducer = new ExtractiveSessionReducer(effectiveKeepCount);
+                var meaiMessages = ChatMessageConverter.ToAiMessages(_state.History);
+                var reduced = await reducer.ReduceAsync(meaiMessages, CancellationToken.None);
+
+                var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage>
+                    ?? reduced.ToList();
+                var keptNonSystemCount = reducedList
+                    .Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
+
+                var startIndex = _state.History.Count - keptNonSystemCount;
+                compactedMessages = new List<SerializableChatMessage>();
+                for (var i = Math.Max(systemOffset, startIndex); i < _state.History.Count; i++)
+                {
+                    compactedMessages.Add(_state.History[i]);
+                }
+
+                // Estimate remaining token cost (naive chars/4 heuristic)
+                var estimatedTokens = EstimateTokens(compactedMessages, systemOffset > 0 ? _state.History[0] : null);
+                var budgetHalf = _config.ContextWindowTokens / 2;
+
+                if (estimatedTokens <= budgetHalf || effectiveKeepCount <= 2)
+                    break;
+
+                var newKeepCount = Math.Max(2, effectiveKeepCount / 2);
+                _log.Info("Adaptive compaction: estimated {EstimatedTokens} tokens > {Budget} budget half, reducing keep count {OldKeep} → {NewKeep}",
+                    estimatedTokens, budgetHalf, effectiveKeepCount, newKeepCount);
+                effectiveKeepCount = newKeepCount;
             }
 
-            _log.Info("Phase 2: Extractive reduction (history={HistoryCount} → {KeptCount} messages)",
-                _state.History.Count, compactedMessages.Count + systemOffset);
+            _log.Info("Phase 2: Extractive reduction (history={HistoryCount} → {KeptCount} messages, keepCount={KeepCount})",
+                _state.History.Count, compactedMessages.Count + systemOffset, effectiveKeepCount);
 
             var compactedEvent = new SessionCompacted
             {
@@ -461,7 +479,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                     MessagesBefore = messagesBefore,
                     MessagesAfter = _state.History.Count,
                     ToolResultsCleared = clearedCount > 0,
-                    Summarized = false // Extractive, not summarized
+                    Summarized = false, // Extractive, not summarized
+                    ContextWindowTokens = _config.ContextWindowTokens,
+                    PreCompactionInputTokens = preCompactionInputTokens,
+                    KeepCountUsed = effectiveKeepCount
                 });
 
                 _log.Info("Compaction complete (before={MessagesBefore}, after={MessagesAfter})",
@@ -622,7 +643,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var sessionId = _sessionId;
         var auditLogger = _auditLogger;
         var tp = _timeProvider;
-        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, self);
+        var sessionDir = GetSessionDirectory();
+        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, sessionDir, self);
     }
 
     private void HandleTextResponse(
@@ -762,6 +784,46 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     // ── Helpers ──
 
+    /// <summary>
+    /// Detect context-length overflow errors from LLM providers.
+    /// Ollama: "context length exceeded", OpenAI-compatible: "maximum context length".
+    /// </summary>
+    private static bool IsContextOverflowError(Exception? ex)
+    {
+        if (ex is null) return false;
+        var message = ex.Message;
+        // Walk inner exceptions too — provider SDKs often wrap
+        while (ex.InnerException is not null)
+        {
+            ex = ex.InnerException;
+            message = string.Concat(message, " ", ex.Message);
+        }
+        return message.Contains("context length", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("maximum context", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("context_length_exceeded", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Naive token estimation: total character count / 4.
+    /// Includes the system prompt (if present) plus all compacted messages.
+    /// </summary>
+    private static int EstimateTokens(
+        List<SerializableChatMessage> messages,
+        SerializableChatMessage? systemPrompt)
+    {
+        var totalChars = 0;
+        if (systemPrompt is not null)
+            totalChars += systemPrompt.Content?.Length ?? 0;
+        foreach (var msg in messages)
+            totalChars += msg.Content?.Length ?? 0;
+        return totalChars / 4;
+    }
+
+    private string GetSessionDirectory() =>
+        _sessionsBasePath is not null
+            ? SessionDirectoryHelper.GetSessionDirectory(_sessionId, _sessionsBasePath)
+            : SessionDirectoryHelper.GetSessionDirectory(_sessionId);
+
     private long NowMs() => _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
     private void SetSystemPrompt()
@@ -789,7 +851,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
     private void FireLlmCall(bool forceNoTools = false)
     {
-        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(_sessionId);
+        var sessionDir = GetSessionDirectory();
         var messages = ChatMessageConverter.ToAiMessages(_state.History, sessionDir);
 
         // Inject dynamic context layers (e.g. tool index) as transient system messages.
@@ -967,12 +1029,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         SessionId sessionId,
         IToolAuditLogger? auditLogger,
         TimeProvider timeProvider,
+        string sessionDir,
         IActorRef self)
     {
         try
         {
             // Execute all tool calls in parallel — each is independent
-            var tasks = toolCalls.Select(tc => ExecuteSingleToolAsync(executor, tc, sessionId, auditLogger, timeProvider));
+            var tasks = toolCalls.Select(tc => ExecuteSingleToolAsync(executor, tc, sessionId, auditLogger, timeProvider, sessionDir));
             var results = await Task.WhenAll(tasks);
 
             var fileAttachments = results.SelectMany(r => r.FileAttachments).ToList();
@@ -993,11 +1056,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         FunctionCallContent tc,
         SessionId sessionId,
         IToolAuditLogger? auditLogger,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        string sessionDir)
     {
         var sw = Stopwatch.StartNew();
         string resultText;
-        var context = CreateExecutionContext(sessionId);
+        var context = new Netclaw.Tools.ToolExecutionContext(sessionId.Value, sessionDir);
         try
         {
             resultText = await executor.ExecuteAsync(tc, context);
@@ -1173,11 +1237,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         Sender.Tell(CommandAck.For(_sessionId));
     }
 
-    private static Netclaw.Tools.ToolExecutionContext CreateExecutionContext(SessionId sessionId)
-    {
-        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId);
-        return new Netclaw.Tools.ToolExecutionContext(sessionId.Value, sessionDir);
-    }
+
 
     internal void SetTitle(string title)
     {

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -1,0 +1,94 @@
+using Akka.Actor;
+using Akka.Event;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Per-session child actor that owns the log file lifecycle.
+/// Created by <see cref="LlmSessionActor"/> when a session logs directory is configured.
+/// Not persistent — log files are best-effort observability.
+/// The actor opens the log file in <see cref="PreStart"/> and disposes it in <see cref="PostStop"/>,
+/// ensuring the file handle is properly released when the session actor passivates.
+/// </summary>
+public sealed class SessionLogActor : ReceiveActor
+{
+    private readonly SessionId _sessionId;
+    private readonly string _logDirectory;
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private StreamWriter? _writer;
+
+    public static Props CreateProps(SessionId sessionId, string logDirectory) =>
+        Props.Create(() => new SessionLogActor(sessionId, logDirectory));
+
+    public SessionLogActor(SessionId sessionId, string logDirectory)
+    {
+        _sessionId = sessionId;
+        _logDirectory = logDirectory;
+
+        Receive<SessionOutput>(OnOutput);
+    }
+
+    protected override void PreStart()
+    {
+        try
+        {
+            var sanitized = SessionDirectoryHelper.SanitizeSessionId(_sessionId.Value);
+            var logPath = Path.Combine(_logDirectory, $"{sanitized}.log");
+            Directory.CreateDirectory(_logDirectory);
+            _writer = new StreamWriter(logPath, append: true) { AutoFlush = true };
+            _writer.WriteLine($"[{DateTimeOffset.UtcNow:o}] Session log started: {_sessionId.Value}");
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to open session log file for {SessionId}", _sessionId.Value);
+        }
+    }
+
+    protected override void PostStop()
+    {
+        try
+        {
+            _writer?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to dispose session log writer for {SessionId}", _sessionId.Value);
+        }
+    }
+
+    private void OnOutput(SessionOutput output)
+    {
+        if (_writer is null) return;
+
+        try
+        {
+            var line = output switch
+            {
+                TextOutput text => $"Assistant: {Truncate(text.Text, 200)}",
+                ToolCallOutput toolCall => $"Tool call: {toolCall.ToolName} (call={toolCall.CallId})",
+                ToolResultOutput toolResult => $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {Truncate(toolResult.Result, 200)}",
+                TurnCompleted tc => $"Turn {tc.TurnNumber} completed",
+                SessionTitleOutput title => $"Title set: {title.Title}",
+                CompactionOutput compaction =>
+                    $"Compaction: {compaction.MessagesBefore} → {compaction.MessagesAfter} messages " +
+                    $"(keep={compaction.KeepCountUsed}, context={compaction.PreCompactionInputTokens}/{compaction.ContextWindowTokens} tokens)",
+                ErrorOutput error => $"Error: {error.Message}",
+                FileOutput file => $"File: {file.FileName} ({file.MimeType})",
+                _ => null
+            };
+
+            if (line is not null)
+            {
+                _writer.WriteLine($"[{DateTimeOffset.UtcNow:o}] {line}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to write session log entry for {SessionId}", _sessionId.Value);
+        }
+    }
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
+}

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -386,7 +386,10 @@ public sealed class DaemonClient : IAsyncDisposable
                 SessionId = sessionId,
                 TimestampMs = dto.TimestampMs,
                 MessagesBefore = dto.MessagesBefore ?? 0,
-                MessagesAfter = dto.MessagesAfter ?? 0
+                MessagesAfter = dto.MessagesAfter ?? 0,
+                ContextWindowTokens = dto.ContextWindowTokens ?? 0,
+                PreCompactionInputTokens = dto.PreCompactionInputTokens ?? 0,
+                KeepCountUsed = dto.KeepCountUsed ?? 0
             },
             "session_joined" => new SessionJoined
             {

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Nodes;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, error) = DoctorJsonConfigReader.TryReadConfig(paths);
+        if (error is not null)
+            return Task.FromResult(error);
+
+        if (root is null)
+            return Task.FromResult(DoctorCheckResult.Pass("Context Window", "No config file to check."));
+
+        var models = root["Models"] as JsonObject;
+        var main = models?["Main"] as JsonObject;
+
+        if (main is null)
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Context Window",
+                "No Models.Main section in config. Using default context window (32,768 tokens).",
+                "Add a Models.Main section with ContextWindow to netclaw.json."));
+        }
+
+        var contextWindow = main["ContextWindow"];
+        if (contextWindow is null)
+        {
+            var modelId = main["ModelId"]?.GetValue<string>() ?? "unknown";
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Context Window",
+                $"No explicit context window configured for {modelId}. Using default 32,768 tokens.",
+                "Set Models.Main.ContextWindow in netclaw.json to match your model's actual context window."));
+        }
+
+        if (contextWindow.GetValue<int>() is var cw and > 0)
+        {
+            return Task.FromResult(DoctorCheckResult.Pass(
+                "Context Window",
+                $"Context window explicitly set to {cw:N0} tokens."));
+        }
+
+        return Task.FromResult(DoctorCheckResult.Error(
+            "Context Window",
+            "Models.Main.ContextWindow must be a positive integer.",
+            "Set Models.Main.ContextWindow to the model's context window size in tokens."));
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -14,5 +14,6 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SlackAuthDoctorCheck>();
         services.AddSingleton<IDoctorCheck, McpServersDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, ContextWindowDoctorCheck>();
     }
 }

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -205,8 +205,8 @@ public sealed class HeadlessChannel : IChannel
                 break;
 
             case CompactionOutput msg:
-                Console.WriteLine($"[compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages");
-                Log(log, $"COMPACTION: before={msg.MessagesBefore} after={msg.MessagesAfter} tool_results_cleared={msg.ToolResultsCleared} summarized={msg.Summarized}");
+                Console.WriteLine($"[compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages (keep={msg.KeepCountUsed}, context={msg.PreCompactionInputTokens}/{msg.ContextWindowTokens} tokens)");
+                Log(log, $"COMPACTION: before={msg.MessagesBefore} after={msg.MessagesAfter} tool_results_cleared={msg.ToolResultsCleared} summarized={msg.Summarized} context_window={msg.ContextWindowTokens} input_tokens={msg.PreCompactionInputTokens} keep_count={msg.KeepCountUsed}");
                 break;
         }
     }

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -294,7 +294,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
 
             case CompactionOutput msg:
                 _chatHistory.AppendLine(
-                    $"  [compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages",
+                    $"  [compaction] {msg.MessagesBefore} \u2192 {msg.MessagesAfter} messages (keep={msg.KeepCountUsed}, {msg.PreCompactionInputTokens}/{msg.ContextWindowTokens} tokens)",
                     Color.Yellow);
                 break;
         }

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -33,7 +33,9 @@ public sealed class NetclawPaths
     public string NetclawConfigPath => Path.Combine(ConfigDirectory, "netclaw.json");
     public string SecretsPath => Path.Combine(ConfigDirectory, "secrets.json");
     public string LogsDirectory => Path.Combine(BasePath, "logs");
+    public string SessionLogsDirectory => Path.Combine(LogsDirectory, "sessions");
     public string DaemonLogPath => Path.Combine(LogsDirectory, "daemon.log");
+    public string SessionsDirectory => Path.Combine(BasePath, "sessions");
     public string PidFilePath => Path.Combine(BasePath, "netclaw.pid");
     public string SqliteDbPath => Path.Combine(BasePath, "netclaw.db");
 
@@ -59,5 +61,7 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(SchedulesDirectory);
         Directory.CreateDirectory(ConfigDirectory);
         Directory.CreateDirectory(LogsDirectory);
+        Directory.CreateDirectory(SessionLogsDirectory);
+        Directory.CreateDirectory(SessionsDirectory);
     }
 }

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -62,6 +62,12 @@ public sealed record SessionConfig
     public int KeepRecentMessages { get; init; } = 6;
 
     /// <summary>
+    /// Turn interval for sidecar title generation. Title is always generated
+    /// on turn 1, then refreshed every N turns. Set to 0 to disable.
+    /// </summary>
+    public int TitleGenerationInterval { get; init; } = 10;
+
+    /// <summary>
     /// How long a session can be idle before passivating.
     /// The actor saves a snapshot and stops itself; re-creation by
     /// <c>GenericChildPerEntityParent</c> on next message recovers state from journal.

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 
@@ -7,10 +8,10 @@ namespace Netclaw.Daemon.Gateway;
 
 /// <summary>
 /// Singleton service maintaining the <c>sessions</c> table in the SQLite database.
-/// Provides write methods called from <see cref="SessionRegistry"/> and output
-/// subscribers, plus read methods for the <c>GET /api/sessions</c> endpoint.
+/// Implements <see cref="ISessionLifecycleObserver"/> so <see cref="SessionPipeline"/>
+/// automatically reports all session events regardless of channel type.
 /// </summary>
-public sealed class SessionCatalogService
+public sealed class SessionCatalogService : ISessionLifecycleObserver
 {
     private readonly string _connectionString;
     private readonly NetclawPaths _paths;
@@ -35,10 +36,8 @@ public sealed class SessionCatalogService
         _logger = logger;
     }
 
-    /// <summary>
-    /// Record a new session in the catalog. Called when a session is created.
-    /// </summary>
-    public void RecordSessionCreated(SessionId sessionId, string channel)
+    /// <inheritdoc />
+    public void OnSessionCreated(SessionId sessionId, string channelType)
     {
         var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         var persistenceId = $"session-{sessionId.Value}";
@@ -58,7 +57,7 @@ public sealed class SessionCatalogService
                     last_activity = $now
                 """;
             cmd.Parameters.AddWithValue("$pid", persistenceId);
-            cmd.Parameters.AddWithValue("$channel", channel);
+            cmd.Parameters.AddWithValue("$channel", channelType);
             cmd.Parameters.AddWithValue("$now", nowMs);
             cmd.ExecuteNonQuery();
 
@@ -67,7 +66,7 @@ public sealed class SessionCatalogService
             Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
             var writer = new StreamWriter(logPath, append: true) { AutoFlush = true };
             _logWriters[persistenceId] = writer;
-            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] Session created: {sessionId.Value} channel={channel}");
+            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] Session created: {sessionId.Value} channel={channelType}");
 
             // Update log_path in DB
             using var updateCmd = conn.CreateCommand();
@@ -82,10 +81,8 @@ public sealed class SessionCatalogService
         }
     }
 
-    /// <summary>
-    /// Process a session output event — updates the catalog and writes to the session log.
-    /// </summary>
-    public void HandleOutput(SessionOutput output)
+    /// <inheritdoc />
+    public void OnOutput(SessionOutput output)
     {
         var persistenceId = $"session-{output.SessionId.Value}";
 
@@ -105,6 +102,20 @@ public sealed class SessionCatalogService
                             """;
                     });
                     LogToSession(persistenceId, $"Turn {tc.TurnNumber} completed");
+                    break;
+
+                case UsageOutput usage when usage.InputTokens.HasValue:
+                    UpdateSession(persistenceId, cmd =>
+                    {
+                        cmd.CommandText =
+                            """
+                            UPDATE sessions SET
+                                last_input_tokens = $tokens,
+                                last_activity = $now
+                            WHERE persistence_id = $pid
+                            """;
+                        cmd.Parameters.AddWithValue("$tokens", usage.InputTokens.Value);
+                    });
                     break;
 
                 case SessionTitleOutput title:
@@ -169,7 +180,7 @@ public sealed class SessionCatalogService
             cmd.CommandText =
                 """
                 SELECT persistence_id, channel, title, description, status, turn_count,
-                       created_at, last_activity, log_path
+                       created_at, last_activity, log_path, last_input_tokens
                 FROM sessions
                 ORDER BY last_activity DESC
                 LIMIT $limit
@@ -189,7 +200,8 @@ public sealed class SessionCatalogService
                     TurnCount = reader.GetInt32(5),
                     CreatedAt = reader.GetInt64(6),
                     LastActivity = reader.GetInt64(7),
-                    LogPath = reader.IsDBNull(8) ? null : reader.GetString(8)
+                    LogPath = reader.IsDBNull(8) ? null : reader.GetString(8),
+                    LastInputTokens = reader.IsDBNull(9) ? null : reader.GetInt64(9)
                 });
             }
         }
@@ -267,4 +279,5 @@ public sealed class SessionCatalogEntry
     public required long CreatedAt { get; init; }
     public required long LastActivity { get; init; }
     public string? LogPath { get; init; }
+    public long? LastInputTokens { get; init; }
 }

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -1,0 +1,270 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Gateway;
+
+/// <summary>
+/// Singleton service maintaining the <c>sessions</c> table in the SQLite database.
+/// Provides write methods called from <see cref="SessionRegistry"/> and output
+/// subscribers, plus read methods for the <c>GET /api/sessions</c> endpoint.
+/// </summary>
+public sealed class SessionCatalogService
+{
+    private readonly string _connectionString;
+    private readonly NetclawPaths _paths;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<SessionCatalogService> _logger;
+
+    // Per-session log writers (created on session start, flushed on each write)
+    private readonly Dictionary<string, StreamWriter> _logWriters = new();
+
+    public SessionCatalogService(
+        NetclawPaths paths,
+        TimeProvider timeProvider,
+        ILogger<SessionCatalogService> logger)
+    {
+        _paths = paths;
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = paths.SqliteDbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Record a new session in the catalog. Called when a session is created.
+    /// </summary>
+    public void RecordSessionCreated(SessionId sessionId, string channel)
+    {
+        var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        var persistenceId = $"session-{sessionId.Value}";
+
+        try
+        {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                """
+                INSERT INTO sessions (persistence_id, channel, created_at, last_activity, status, turn_count)
+                VALUES ($pid, $channel, $now, $now, 'active', 0)
+                ON CONFLICT(persistence_id) DO UPDATE SET
+                    status = 'active',
+                    last_activity = $now
+                """;
+            cmd.Parameters.AddWithValue("$pid", persistenceId);
+            cmd.Parameters.AddWithValue("$channel", channel);
+            cmd.Parameters.AddWithValue("$now", nowMs);
+            cmd.ExecuteNonQuery();
+
+            // Set up per-session log file
+            var logPath = GetSessionLogPath(sessionId);
+            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+            var writer = new StreamWriter(logPath, append: true) { AutoFlush = true };
+            _logWriters[persistenceId] = writer;
+            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] Session created: {sessionId.Value} channel={channel}");
+
+            // Update log_path in DB
+            using var updateCmd = conn.CreateCommand();
+            updateCmd.CommandText = "UPDATE sessions SET log_path = $path WHERE persistence_id = $pid";
+            updateCmd.Parameters.AddWithValue("$path", logPath);
+            updateCmd.Parameters.AddWithValue("$pid", persistenceId);
+            updateCmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to record session creation for {SessionId}", sessionId.Value);
+        }
+    }
+
+    /// <summary>
+    /// Process a session output event — updates the catalog and writes to the session log.
+    /// </summary>
+    public void HandleOutput(SessionOutput output)
+    {
+        var persistenceId = $"session-{output.SessionId.Value}";
+
+        try
+        {
+            switch (output)
+            {
+                case TurnCompleted tc:
+                    UpdateSession(persistenceId, cmd =>
+                    {
+                        cmd.CommandText =
+                            """
+                            UPDATE sessions SET
+                                turn_count = turn_count + 1,
+                                last_activity = $now
+                            WHERE persistence_id = $pid
+                            """;
+                    });
+                    LogToSession(persistenceId, $"Turn {tc.TurnNumber} completed");
+                    break;
+
+                case SessionTitleOutput title:
+                    UpdateSession(persistenceId, cmd =>
+                    {
+                        cmd.CommandText =
+                            """
+                            UPDATE sessions SET
+                                title = $title,
+                                last_activity = $now
+                            WHERE persistence_id = $pid
+                            """;
+                        cmd.Parameters.AddWithValue("$title", title.Title);
+                    });
+                    LogToSession(persistenceId, $"Title set: {title.Title}");
+                    break;
+
+                case CompactionOutput compaction:
+                    LogToSession(persistenceId,
+                        $"Compaction: {compaction.MessagesBefore} → {compaction.MessagesAfter} messages " +
+                        $"(keep={compaction.KeepCountUsed}, context={compaction.PreCompactionInputTokens}/{compaction.ContextWindowTokens} tokens)");
+                    UpdateLastActivity(persistenceId);
+                    break;
+
+                case ErrorOutput error:
+                    LogToSession(persistenceId, $"Error: {error.Message}");
+                    UpdateLastActivity(persistenceId);
+                    break;
+
+                case TextOutput text:
+                    LogToSession(persistenceId, $"Assistant: {Truncate(text.Text, 200)}");
+                    break;
+
+                case ToolCallOutput toolCall:
+                    LogToSession(persistenceId, $"Tool call: {toolCall.ToolName} (call={toolCall.CallId})");
+                    break;
+
+                case ToolResultOutput toolResult:
+                    LogToSession(persistenceId, $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {Truncate(toolResult.Result, 200)}");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to handle output for session {SessionId}", output.SessionId.Value);
+        }
+    }
+
+    /// <summary>
+    /// List recent sessions, ordered by last activity descending.
+    /// </summary>
+    public List<SessionCatalogEntry> ListRecent(int limit = 50)
+    {
+        var entries = new List<SessionCatalogEntry>();
+
+        try
+        {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                """
+                SELECT persistence_id, channel, title, description, status, turn_count,
+                       created_at, last_activity, log_path
+                FROM sessions
+                ORDER BY last_activity DESC
+                LIMIT $limit
+                """;
+            cmd.Parameters.AddWithValue("$limit", limit);
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                entries.Add(new SessionCatalogEntry
+                {
+                    PersistenceId = reader.GetString(0),
+                    Channel = reader.GetString(1),
+                    Title = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    Description = reader.IsDBNull(3) ? null : reader.GetString(3),
+                    Status = reader.GetString(4),
+                    TurnCount = reader.GetInt32(5),
+                    CreatedAt = reader.GetInt64(6),
+                    LastActivity = reader.GetInt64(7),
+                    LogPath = reader.IsDBNull(8) ? null : reader.GetString(8)
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to list sessions");
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Flush and close all open session log writers.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var writer in _logWriters.Values)
+        {
+            try { writer.Dispose(); } catch { /* best effort */ }
+        }
+        _logWriters.Clear();
+    }
+
+    private void UpdateSession(string persistenceId, Action<SqliteCommand> configure)
+    {
+        var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+
+        using var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+
+        using var cmd = conn.CreateCommand();
+        configure(cmd);
+        cmd.Parameters.AddWithValue("$pid", persistenceId);
+        cmd.Parameters.AddWithValue("$now", nowMs);
+        cmd.ExecuteNonQuery();
+    }
+
+    private void UpdateLastActivity(string persistenceId)
+    {
+        UpdateSession(persistenceId, cmd =>
+        {
+            cmd.CommandText = "UPDATE sessions SET last_activity = $now WHERE persistence_id = $pid";
+        });
+    }
+
+    private void LogToSession(string persistenceId, string message)
+    {
+        if (_logWriters.TryGetValue(persistenceId, out var writer))
+        {
+            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] {message}");
+        }
+    }
+
+    private string GetSessionLogPath(SessionId sessionId)
+    {
+        var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
+        return Path.Combine(_paths.SessionLogsDirectory, $"{sanitized}.log");
+    }
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
+}
+
+/// <summary>
+/// DTO for session catalog entries returned by <c>GET /api/sessions</c>.
+/// </summary>
+public sealed class SessionCatalogEntry
+{
+    public required string PersistenceId { get; init; }
+    public required string Channel { get; init; }
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public required string Status { get; init; }
+    public required int TurnCount { get; init; }
+    public required long CreatedAt { get; init; }
+    public required long LastActivity { get; init; }
+    public string? LogPath { get; init; }
+}

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -10,6 +10,9 @@ namespace Netclaw.Daemon.Gateway;
 /// Singleton service maintaining the <c>sessions</c> table in the SQLite database.
 /// Implements <see cref="ISessionLifecycleObserver"/> so <see cref="SessionPipeline"/>
 /// automatically reports all session events regardless of channel type.
+///
+/// Per-session log file I/O is handled by <see cref="Netclaw.Actors.Sessions.SessionLogActor"/>
+/// (a child of each session actor), not this service.
 /// </summary>
 public sealed class SessionCatalogService : ISessionLifecycleObserver
 {
@@ -17,9 +20,6 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
     private readonly NetclawPaths _paths;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<SessionCatalogService> _logger;
-
-    // Per-session log writers (created on session start, flushed on each write)
-    private readonly Dictionary<string, StreamWriter> _logWriters = new();
 
     public SessionCatalogService(
         NetclawPaths paths,
@@ -44,36 +44,29 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
 
         try
         {
+            // Compute expected log path deterministically — the child SessionLogActor
+            // independently creates the file at this same path.
+            var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
+            var logPath = Path.Combine(_paths.SessionLogsDirectory, $"{sanitized}.log");
+
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();
 
             using var cmd = conn.CreateCommand();
             cmd.CommandText =
                 """
-                INSERT INTO sessions (persistence_id, channel, created_at, last_activity, status, turn_count)
-                VALUES ($pid, $channel, $now, $now, 'active', 0)
+                INSERT INTO sessions (persistence_id, channel, created_at, last_activity, status, turn_count, log_path)
+                VALUES ($pid, $channel, $now, $now, 'active', 0, $path)
                 ON CONFLICT(persistence_id) DO UPDATE SET
                     status = 'active',
-                    last_activity = $now
+                    last_activity = $now,
+                    log_path = $path
                 """;
             cmd.Parameters.AddWithValue("$pid", persistenceId);
             cmd.Parameters.AddWithValue("$channel", channelType);
             cmd.Parameters.AddWithValue("$now", nowMs);
+            cmd.Parameters.AddWithValue("$path", logPath);
             cmd.ExecuteNonQuery();
-
-            // Set up per-session log file
-            var logPath = GetSessionLogPath(sessionId);
-            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
-            var writer = new StreamWriter(logPath, append: true) { AutoFlush = true };
-            _logWriters[persistenceId] = writer;
-            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] Session created: {sessionId.Value} channel={channelType}");
-
-            // Update log_path in DB
-            using var updateCmd = conn.CreateCommand();
-            updateCmd.CommandText = "UPDATE sessions SET log_path = $path WHERE persistence_id = $pid";
-            updateCmd.Parameters.AddWithValue("$path", logPath);
-            updateCmd.Parameters.AddWithValue("$pid", persistenceId);
-            updateCmd.ExecuteNonQuery();
         }
         catch (Exception ex)
         {
@@ -90,7 +83,7 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
         {
             switch (output)
             {
-                case TurnCompleted tc:
+                case TurnCompleted:
                     UpdateSession(persistenceId, cmd =>
                     {
                         cmd.CommandText =
@@ -101,7 +94,6 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
                             WHERE persistence_id = $pid
                             """;
                     });
-                    LogToSession(persistenceId, $"Turn {tc.TurnNumber} completed");
                     break;
 
                 case UsageOutput usage when usage.InputTokens.HasValue:
@@ -130,31 +122,11 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
                             """;
                         cmd.Parameters.AddWithValue("$title", title.Title);
                     });
-                    LogToSession(persistenceId, $"Title set: {title.Title}");
                     break;
 
-                case CompactionOutput compaction:
-                    LogToSession(persistenceId,
-                        $"Compaction: {compaction.MessagesBefore} → {compaction.MessagesAfter} messages " +
-                        $"(keep={compaction.KeepCountUsed}, context={compaction.PreCompactionInputTokens}/{compaction.ContextWindowTokens} tokens)");
+                case CompactionOutput:
+                case ErrorOutput:
                     UpdateLastActivity(persistenceId);
-                    break;
-
-                case ErrorOutput error:
-                    LogToSession(persistenceId, $"Error: {error.Message}");
-                    UpdateLastActivity(persistenceId);
-                    break;
-
-                case TextOutput text:
-                    LogToSession(persistenceId, $"Assistant: {Truncate(text.Text, 200)}");
-                    break;
-
-                case ToolCallOutput toolCall:
-                    LogToSession(persistenceId, $"Tool call: {toolCall.ToolName} (call={toolCall.CallId})");
-                    break;
-
-                case ToolResultOutput toolResult:
-                    LogToSession(persistenceId, $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {Truncate(toolResult.Result, 200)}");
                     break;
             }
         }
@@ -213,18 +185,6 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
         return entries;
     }
 
-    /// <summary>
-    /// Flush and close all open session log writers.
-    /// </summary>
-    public void Dispose()
-    {
-        foreach (var writer in _logWriters.Values)
-        {
-            try { writer.Dispose(); } catch { /* best effort */ }
-        }
-        _logWriters.Clear();
-    }
-
     private void UpdateSession(string persistenceId, Action<SqliteCommand> configure)
     {
         var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
@@ -246,23 +206,6 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
             cmd.CommandText = "UPDATE sessions SET last_activity = $now WHERE persistence_id = $pid";
         });
     }
-
-    private void LogToSession(string persistenceId, string message)
-    {
-        if (_logWriters.TryGetValue(persistenceId, out var writer))
-        {
-            writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] {message}");
-        }
-    }
-
-    private string GetSessionLogPath(SessionId sessionId)
-    {
-        var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
-        return Path.Combine(_paths.SessionLogsDirectory, $"{sanitized}.log");
-    }
-
-    private static string Truncate(string text, int maxLength) =>
-        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
 }
 
 /// <summary>

--- a/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
@@ -115,7 +115,10 @@ public static class SessionOutputMapper
             SessionId = msg.SessionId.Value,
             TimestampMs = msg.TimestampMs,
             MessagesBefore = msg.MessagesBefore,
-            MessagesAfter = msg.MessagesAfter
+            MessagesAfter = msg.MessagesAfter,
+            ContextWindowTokens = msg.ContextWindowTokens,
+            PreCompactionInputTokens = msg.PreCompactionInputTokens,
+            KeepCountUsed = msg.KeepCountUsed
         },
 
         SessionJoined msg => new SessionOutputDto

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -22,7 +22,6 @@ public sealed class SessionRegistry
     private readonly ActorSystem _system;
     private readonly TimeProvider _timeProvider;
     private readonly IHubContext<SessionHub, ISessionHubClient> _hubContext;
-    private readonly SessionCatalogService _catalog;
     private readonly ILogger<SessionRegistry> _logger;
 
     // sessionId → session state
@@ -35,14 +34,12 @@ public sealed class SessionRegistry
         ActorSystem system,
         TimeProvider timeProvider,
         IHubContext<SessionHub, ISessionHubClient> hubContext,
-        SessionCatalogService catalog,
         ILogger<SessionRegistry> logger)
     {
         _pipeline = pipeline;
         _system = system;
         _timeProvider = timeProvider;
         _hubContext = hubContext;
-        _catalog = catalog;
         _logger = logger;
     }
 
@@ -57,7 +54,6 @@ public sealed class SessionRegistry
         var sessionId = new SessionId($"signalr/{Guid.NewGuid():N}");
 
         await MaterializeAndBindSessionAsync(sessionId, callerConnectionId, channelType);
-        _catalog.RecordSessionCreated(sessionId, channelType);
 
         return sessionId.Value;
     }
@@ -220,9 +216,6 @@ public sealed class SessionRegistry
 
     private void PublishOutput(SessionId sessionId, SessionOutput output)
     {
-        // Record to session catalog (log file + DB) regardless of connection state
-        _catalog.HandleOutput(output);
-
         if (!_sessions.ContainsKey(sessionId))
             return;
 

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -22,6 +22,7 @@ public sealed class SessionRegistry
     private readonly ActorSystem _system;
     private readonly TimeProvider _timeProvider;
     private readonly IHubContext<SessionHub, ISessionHubClient> _hubContext;
+    private readonly SessionCatalogService _catalog;
     private readonly ILogger<SessionRegistry> _logger;
 
     // sessionId → session state
@@ -34,12 +35,14 @@ public sealed class SessionRegistry
         ActorSystem system,
         TimeProvider timeProvider,
         IHubContext<SessionHub, ISessionHubClient> hubContext,
+        SessionCatalogService catalog,
         ILogger<SessionRegistry> logger)
     {
         _pipeline = pipeline;
         _system = system;
         _timeProvider = timeProvider;
         _hubContext = hubContext;
+        _catalog = catalog;
         _logger = logger;
     }
 
@@ -54,6 +57,7 @@ public sealed class SessionRegistry
         var sessionId = new SessionId($"signalr/{Guid.NewGuid():N}");
 
         await MaterializeAndBindSessionAsync(sessionId, callerConnectionId, channelType);
+        _catalog.RecordSessionCreated(sessionId, channelType);
 
         return sessionId.Value;
     }
@@ -216,6 +220,9 @@ public sealed class SessionRegistry
 
     private void PublishOutput(SessionId sessionId, SessionOutput output)
     {
+        // Record to session catalog (log file + DB) regardless of connection state
+        _catalog.HandleOutput(output);
+
         if (!_sessions.ContainsKey(sessionId))
             return;
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -54,6 +54,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     // SignalR for remote clients (CLI thin client, Blazor ops console)
     builder.Services.AddSignalR();
     builder.Services.AddSingleton<SessionCatalogService>();
+    builder.Services.AddSingleton<ISessionLifecycleObserver>(sp => sp.GetRequiredService<SessionCatalogService>());
     builder.Services.AddSingleton<SessionRegistry>();
     builder.Services.AddSingleton<DaemonRuntimeStatusService>();
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -189,8 +189,6 @@ static void ConfigureDaemonServices(
         OutputModalities = outputModalities ?? ModelModality.Text,
     };
     services.AddSingleton(resolvedSessionConfig);
-    services.AddSingleton<IChatReducer>(
-        new ExtractiveSessionReducer(resolvedSessionConfig.KeepRecentMessages));
 
     // Tools (auto-bound, no required properties)
     var toolConfig = configuration.GetSection("Tools")

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -53,6 +53,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // SignalR for remote clients (CLI thin client, Blazor ops console)
     builder.Services.AddSignalR();
+    builder.Services.AddSingleton<SessionCatalogService>();
     builder.Services.AddSingleton<SessionRegistry>();
     builder.Services.AddSingleton<DaemonRuntimeStatusService>();
 
@@ -63,6 +64,8 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     app.MapGet("/api/health/ready", () => Results.Ok("healthy"));
     app.MapGet("/api/health/status", async (DaemonRuntimeStatusService statusService, CancellationToken cancellationToken) =>
         Results.Ok(await statusService.GetStatusAsync(cancellationToken)));
+    app.MapGet("/api/sessions", (SessionCatalogService catalog) =>
+        Results.Ok(catalog.ListRecent(limit: 50)));
 
     await app.RunAsync();
 }

--- a/src/Netclaw.Daemon/migrations/sqlite/003_sessions_table.sql
+++ b/src/Netclaw.Daemon/migrations/sqlite/003_sessions_table.sql
@@ -1,0 +1,18 @@
+-- Session catalog: tracks active and historical sessions for observability.
+-- Used by SessionCatalogService for the GET /api/sessions endpoint and per-session logging.
+
+CREATE TABLE IF NOT EXISTS sessions (
+    persistence_id  TEXT NOT NULL PRIMARY KEY,
+    channel         TEXT NOT NULL,
+    created_at      INTEGER NOT NULL,
+    last_activity   INTEGER NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active',
+    turn_count      INTEGER NOT NULL DEFAULT 0,
+    title           TEXT,
+    description     TEXT,
+    log_path        TEXT,
+    metadata        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions (status);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions (last_activity);

--- a/src/Netclaw.Daemon/migrations/sqlite/003_sessions_table.sql
+++ b/src/Netclaw.Daemon/migrations/sqlite/003_sessions_table.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     turn_count      INTEGER NOT NULL DEFAULT 0,
     title           TEXT,
     description     TEXT,
+    last_input_tokens INTEGER,
     log_path        TEXT,
     metadata        TEXT
 );


### PR DESCRIPTION
## Summary

- **Adaptive compaction**: After extractive reduction, estimates remaining token cost (chars/4 heuristic) and halves the keep count if it exceeds 50% of the context window, down to a minimum of 2 messages. Addresses the root cause where compaction was ineffective because tool JSON schemas + system prompt consumed most of the budget.
- **Compaction diagnostics**: Enriches `CompactionOutput` with `ContextWindowTokens`, `PreCompactionInputTokens`, and `KeepCountUsed` fields across all layers (protocol, DTO, mapper, TUI, headless).
- **Context overflow error detection**: `LlmCallFailed` handler now detects context-length errors from Ollama/OpenAI and emits a descriptive message with model ID and context window size instead of a generic error.
- **Doctor check**: New `ContextWindowDoctorCheck` warns when `Models.Main.ContextWindow` is unset (relying on 32K default).
- **Session observability** (closes #78): Sessions table (`003_sessions_table.sql`), `SessionCatalogService` with per-session log files, `GET /api/sessions` endpoint, and session working directories moved from `/tmp/` to `~/.netclaw/sessions/`.

## Test plan
- [x] All 120 existing tests pass (including compaction integration tests)
- [x] Slopwatch: 0 violations
- [ ] Manual: start a session with `qwen3:30b`, use tools until compaction fires, verify `CompactionOutput` includes new diagnostic fields
- [ ] Manual: verify `003_sessions_table.sql` applies on daemon startup (`sqlite3 ~/.netclaw/netclaw.db ".tables"`)
- [ ] Manual: hit `GET /api/sessions` and verify response
- [ ] Manual: check `~/.netclaw/logs/sessions/` for per-session log file
- [ ] Manual: verify session working directory is under `~/.netclaw/sessions/` not `/tmp/`