### PR TITLE
Log user prompts in SessionLogActor

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -171,6 +171,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         Command<SendUserMessage>(cmd =>
         {
             _log.Info("Received user message");
+            _logActor?.Tell(cmd);
 
             _toolIterationCount = 0;
 

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -26,6 +26,7 @@ public sealed class SessionLogActor : ReceiveActor
         _sessionId = sessionId;
         _logDirectory = logDirectory;
 
+        Receive<SendUserMessage>(OnUserMessage);
         Receive<SessionOutput>(OnOutput);
     }
 
@@ -54,6 +55,23 @@ public sealed class SessionLogActor : ReceiveActor
         catch (Exception ex)
         {
             _log.Debug(ex, "Failed to dispose session log writer for {SessionId}", _sessionId.Value);
+        }
+    }
+
+    private void OnUserMessage(SendUserMessage msg)
+    {
+        if (_writer is null) return;
+
+        try
+        {
+            var mediaNote = msg.MediaReferences.Count > 0
+                ? $" (+{msg.MediaReferences.Count} media)"
+                : string.Empty;
+            _writer.WriteLine($"[{DateTimeOffset.UtcNow:o}] User: {Truncate(msg.Content, 200)}{mediaNote}");
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to write user message log entry for {SessionId}", _sessionId.Value);
         }
     }
 


### PR DESCRIPTION
## Summary

- Forward `SendUserMessage` to `SessionLogActor` so user prompts appear in session log files alongside assistant output
- Adds `Receive<SendUserMessage>` handler to `SessionLogActor` that formats timestamped user entries with media reference counts

Previously session logs only showed the assistant side of the conversation, making them incomplete for debugging and replay.

## Test plan
- [x] All 508 tests pass
- [x] Build: 0 warnings, 0 errors
- [ ] Manual: start a session, verify `~/.netclaw/logs/sessions/{id}.log` contains `User:` lines interleaved with `Assistant:` lines