### PR TITLE
Replay recent history on session resume

### DIFF
--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -1,6 +1,16 @@
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
+/// Lightweight DTO for a chat message carried on the wire (role + content only).
+/// Used to replay recent history when resuming a session.
+/// </summary>
+public sealed record ChatMessageDto
+{
+    public required string Role { get; init; }
+    public required string Content { get; init; }
+}
+
+/// <summary>
 /// Wire-safe DTO for session output. Flattens the discriminated union
 /// (<see cref="SessionOutput"/>) into a single serializable type for
 /// SignalR transport.
@@ -50,6 +60,7 @@ public sealed record SessionOutputDto
     // Session Joined
     public string? Title { get; init; }
     public int? TurnCount { get; init; }
+    public List<ChatMessageDto>? RecentMessages { get; init; }
 
     // File Output
     public string? FilePath { get; init; }

--- a/src/Netclaw.Actors/Protocol/SessionSubscription.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSubscription.cs
@@ -89,4 +89,10 @@ public sealed record SessionJoined : SessionOutput
     /// Number of turns completed so far.
     /// </summary>
     public int TurnCount { get; init; }
+
+    /// <summary>
+    /// Recent user/assistant messages for display on resume.
+    /// Null for brand-new sessions. Populated from persisted history.
+    /// </summary>
+    public IReadOnlyList<ChatMessageDto>? RecentMessages { get; init; }
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
@@ -803,7 +804,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             {
                 SessionId = _sessionId,
                 Title = _state.Title,
-                TurnCount = _state.TurnCount
+                TurnCount = _state.TurnCount,
+                RecentMessages = ExtractRecentMessages(_state.History)
             };
 
             cmd.Subscriber.Tell(joined);
@@ -875,6 +877,60 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     /// Naive token estimation: total character count / 4.
     /// Includes the system prompt (if present) plus all compacted messages.
     /// </summary>
+    /// <summary>
+    /// Extracts the last N user/assistant text messages for session resume display.
+    /// Skips system prompts, tool messages, and assistant messages that are tool-call-only
+    /// (no visible text). Truncates long content to keep the DTO payload reasonable.
+    /// </summary>
+    private static IReadOnlyList<ChatMessageDto>? ExtractRecentMessages(
+        ImmutableList<SerializableChatMessage> history, int maxMessages = 20)
+    {
+        if (history.Count == 0)
+            return null;
+
+        const int maxContentLength = 2000;
+
+        var candidates = new List<ChatMessageDto>();
+        for (var i = 0; i < history.Count; i++)
+        {
+            var msg = history[i];
+
+            // Only include user and assistant messages
+            if (msg.Role is not (Protocol.ChatRole.User or Protocol.ChatRole.Assistant))
+                continue;
+
+            // Skip assistant messages that are tool-call-only (no visible text)
+            if (msg.Role == Protocol.ChatRole.Assistant
+                && string.IsNullOrWhiteSpace(msg.Content)
+                && msg.ToolCalls.Count > 0)
+                continue;
+
+            // Skip system nudges injected as user messages
+            if (msg.Role == Protocol.ChatRole.User
+                && msg.Content.StartsWith("[system:", StringComparison.Ordinal))
+                continue;
+
+            var content = msg.Content;
+            if (content.Length > maxContentLength)
+                content = string.Concat(content.AsSpan(0, maxContentLength - 3), "...");
+
+            candidates.Add(new ChatMessageDto
+            {
+                Role = msg.Role == Protocol.ChatRole.User ? "user" : "assistant",
+                Content = content
+            });
+        }
+
+        if (candidates.Count == 0)
+            return null;
+
+        // Take the last N messages
+        if (candidates.Count > maxMessages)
+            candidates = candidates.GetRange(candidates.Count - maxMessages, maxMessages);
+
+        return candidates;
+    }
+
     private static int EstimateTokens(
         List<SerializableChatMessage> messages,
         SerializableChatMessage? systemPrompt)

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -82,4 +82,57 @@ public sealed class DaemonClientMappingTests
         Assert.Contains("Unknown output type", error.Message);
         Assert.Equal("signalr/test", error.SessionId.Value);
     }
+
+    [Fact]
+    public void FromDto_maps_session_joined_with_recent_messages()
+    {
+        var dto = new SessionOutputDto
+        {
+            Type = "session_joined",
+            SessionId = "signalr/test",
+            TimestampMs = 100,
+            Title = "Test Chat",
+            TurnCount = 3,
+            RecentMessages =
+            [
+                new ChatMessageDto { Role = "user", Content = "Hello" },
+                new ChatMessageDto { Role = "assistant", Content = "Hi there!" }
+            ]
+        };
+
+        var output = DaemonClient.FromDto(dto);
+
+        var joined = Assert.IsType<SessionJoined>(output);
+        Assert.Equal("signalr/test", joined.SessionId.Value);
+        Assert.Equal("Test Chat", joined.Title);
+        Assert.Equal(3, joined.TurnCount);
+        Assert.NotNull(joined.RecentMessages);
+        Assert.Equal(2, joined.RecentMessages.Count);
+        Assert.Equal("user", joined.RecentMessages[0].Role);
+        Assert.Equal("Hello", joined.RecentMessages[0].Content);
+        Assert.Equal("assistant", joined.RecentMessages[1].Role);
+        Assert.Equal("Hi there!", joined.RecentMessages[1].Content);
+    }
+
+    [Fact]
+    public void FromDto_maps_session_joined_without_recent_messages()
+    {
+        var dto = new SessionOutputDto
+        {
+            Type = "session_joined",
+            SessionId = "signalr/test",
+            TimestampMs = 100,
+            Title = null,
+            TurnCount = 0,
+            RecentMessages = null
+        };
+
+        var output = DaemonClient.FromDto(dto);
+
+        var joined = Assert.IsType<SessionJoined>(output);
+        Assert.Equal("signalr/test", joined.SessionId.Value);
+        Assert.Null(joined.Title);
+        Assert.Equal(0, joined.TurnCount);
+        Assert.Null(joined.RecentMessages);
+    }
 }

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -465,7 +465,8 @@ public sealed class DaemonClient : IAsyncDisposable
                 SessionId = sessionId,
                 TimestampMs = dto.TimestampMs,
                 Title = dto.Title,
-                TurnCount = dto.TurnCount ?? 0
+                TurnCount = dto.TurnCount ?? 0,
+                RecentMessages = dto.RecentMessages
             },
             _ => new ErrorOutput
             {

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -191,7 +191,22 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 _chatHistory.AppendLine(
                     $"System: Session started. {(msg.Title is not null ? $"Title: {msg.Title}" : sessionState)}",
                     Color.BrightBlack);
+
+                // Replay recent conversation history so the user has context
+                if (msg.RecentMessages is { Count: > 0 })
+                {
+                    _chatHistory.AppendLine("");
+                    _chatHistory.AppendLine("--- Previous conversation ---", Color.BrightBlack);
+                    foreach (var historic in msg.RecentMessages)
+                    {
+                        var label = historic.Role == "user" ? "You" : "Netclaw";
+                        _chatHistory.AppendLine($"{label}: {historic.Content}", Color.BrightBlack);
+                    }
+                    _chatHistory.AppendLine("--- End of history ---", Color.BrightBlack);
+                }
+
                 _chatHistory.AppendLine("");
+                _chatHistory.ScrollToBottom();
                 break;
 
             case TextOutput msg:

--- a/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionOutputMapper.cs
@@ -127,7 +127,12 @@ public static class SessionOutputMapper
             SessionId = msg.SessionId.Value,
             TimestampMs = msg.TimestampMs,
             Title = msg.Title,
-            TurnCount = msg.TurnCount
+            TurnCount = msg.TurnCount,
+            RecentMessages = msg.RecentMessages?.Select(m => new ChatMessageDto
+            {
+                Role = m.Role,
+                Content = m.Content
+            }).ToList()
         },
 
         _ => new SessionOutputDto


### PR DESCRIPTION
## Summary

- Extends `SessionJoined` to carry the last 20 user/assistant messages from persisted history
- TUI renders replayed messages in gray with `--- Previous conversation ---` / `--- End of history ---` separators when resuming a session
- Filters out system prompts, tool messages, tool-call-only assistant messages, and system nudges; truncates long content at 2000 chars
- Wires `RecentMessages` through the full actor → SessionOutputMapper → SignalR DTO → DaemonClient → ChatPage pipeline

## Test plan

- [x] `dotnet build` — compiles across all layers
- [x] `dotnet test` — all 515 tests pass including 2 new mapping tests
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] Manual: run daemon, create a session with a few turns, browse sessions, resume — should see gray historical messages before "Session started"