### PR TITLE
Fix daemon status uptime to reflect soft restarts

### DIFF
--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -161,7 +161,10 @@ public sealed partial class DaemonManager
                     Message: "Daemon is not running (PID file pointed to a different process).");
             }
 
-            var uptime = _timeProvider.GetUtcNow() - new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+            // Prefer PID file timestamp (reflects soft restarts), fall back to process start time
+            TryReadPidFile(out _, out var pidFileStartedAt);
+            var startedAt = pidFileStartedAt ?? new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+            var uptime = _timeProvider.GetUtcNow() - startedAt;
             return new DaemonStatus(IsRunning: true, Pid: pid,
                 Message: $"Daemon running (PID {pid}, uptime {FormatUptime(uptime)}).");
         }
@@ -396,12 +399,24 @@ public sealed partial class DaemonManager
 
     private bool TryReadPid(out int pid)
     {
+        return TryReadPidFile(out pid, out _);
+    }
+
+    private bool TryReadPidFile(out int pid, out DateTimeOffset? startedAt)
+    {
         pid = 0;
+        startedAt = null;
         if (!File.Exists(_paths.PidFilePath))
             return false;
 
-        var content = File.ReadAllText(_paths.PidFilePath).Trim();
-        return int.TryParse(content, out pid);
+        var lines = File.ReadAllLines(_paths.PidFilePath);
+        if (lines.Length == 0 || !int.TryParse(lines[0].Trim(), out pid))
+            return false;
+
+        if (lines.Length > 1 && DateTimeOffset.TryParse(lines[1].Trim(), System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var ts))
+            startedAt = ts;
+
+        return true;
     }
 
     private void CleanupPidFile()

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -16,12 +16,13 @@ public sealed class DaemonRuntimeStatusService(
     SessionConfig sessionConfig,
     ModelSelection modelSelection)
 {
+    private readonly DateTimeOffset _startedAt = timeProvider.GetUtcNow();
+
     public async Task<DaemonRuntimeStatus.Response> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         var process = Process.GetCurrentProcess();
-        var startedAt = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
         var now = timeProvider.GetUtcNow();
-        var uptime = now - startedAt;
+        var uptime = now - _startedAt;
 
         var connectors = new List<DaemonRuntimeStatus.Connector>
         {
@@ -42,7 +43,7 @@ public sealed class DaemonRuntimeStatusService(
             Process = new DaemonRuntimeStatus.Process
             {
                 Pid = process.Id,
-                StartedAtUtc = startedAt,
+                StartedAtUtc = _startedAt,
                 UptimeSeconds = (long)uptime.TotalSeconds
             },
             Connectors = connectors,

--- a/src/Netclaw.Daemon/Services/PidFileService.cs
+++ b/src/Netclaw.Daemon/Services/PidFileService.cs
@@ -12,12 +12,14 @@ public sealed class PidFileService : IHostedService
 {
     private readonly NetclawPaths _paths;
     private readonly DaemonRestartSignal _restartSignal;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<PidFileService> _logger;
 
-    public PidFileService(NetclawPaths paths, DaemonRestartSignal restartSignal, ILogger<PidFileService> logger)
+    public PidFileService(NetclawPaths paths, DaemonRestartSignal restartSignal, TimeProvider timeProvider, ILogger<PidFileService> logger)
     {
         _paths = paths;
         _restartSignal = restartSignal;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -26,7 +28,8 @@ public sealed class PidFileService : IHostedService
         _paths.EnsureDirectoriesExist();
 
         var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        File.WriteAllText(_paths.PidFilePath, pid);
+        var startedAt = _timeProvider.GetUtcNow().ToString("o", CultureInfo.InvariantCulture);
+        File.WriteAllText(_paths.PidFilePath, $"{pid}\n{startedAt}");
         _logger.LogDebug("Wrote daemon PID file: {PidFilePath} -> {Pid}", _paths.PidFilePath, pid);
 
         return Task.CompletedTask;


### PR DESCRIPTION
## Summary

- PID file now writes `{pid}\n{iso8601_utc_timestamp}` so the CLI can compute uptime from the logical start time, not the OS process start time
- CLI (`DaemonManager.GetStatus`) reads the timestamp from the PID file, falling back to `Process.StartTime` for backward compatibility with old single-line PID files
- Daemon HTTP endpoint (`DaemonRuntimeStatusService`) captures `timeProvider.GetUtcNow()` at construction instead of using `Process.StartTime` — since it's a singleton scoped to each `RunDaemonAsync` iteration, a config hot-reload creates a fresh instance with a reset timestamp

## Test plan

- [x] `dotnet build` — zero warnings, zero errors
- [x] `dotnet test` — all 513 tests pass
- [x] `dotnet slopwatch analyze` — no violations
- [ ] Manual: start daemon, check `daemon status` uptime, edit config, verify uptime resets after soft restart
- [ ] Manual: verify `netclaw status` HTTP endpoint shows reset `StartedAtUtc` and `UptimeSeconds`