### PR TITLE
Fix agent stalls from empty post-tool LLM responses

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -83,7 +83,7 @@ public class ToolExecutionIntegrationTests : TestKit
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        }, TimeSpan.FromSeconds(3));
+        }, TimeSpan.FromSeconds(10));
         subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -138,7 +138,7 @@ public class ToolExecutionIntegrationTests : TestKit
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        }, TimeSpan.FromSeconds(3));
+        }, TimeSpan.FromSeconds(10));
         subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -178,7 +178,7 @@ public class ToolExecutionIntegrationTests : TestKit
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        }, TimeSpan.FromSeconds(3));
+        }, TimeSpan.FromSeconds(10));
         subscriber.ExpectMsg<SessionJoined>(); // Drain subscriber notification
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
@@ -220,7 +220,7 @@ public class ToolExecutionIntegrationTests : TestKit
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = OutputFilter.Full
-        }, TimeSpan.FromSeconds(3));
+        }, TimeSpan.FromSeconds(10));
         subscriber.ExpectMsg<SessionJoined>();
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -59,6 +59,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     // Tool iteration counter (reset per turn, incremented on each ToolExecutionCompleted)
     private int _toolIterationCount;
 
+    // Whether we already sent a post-tool empty-response nudge in this tool chain
+    private bool _postToolNudgeSent;
+
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
 
@@ -178,6 +181,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             _logActor?.Tell(cmd);
 
             _toolIterationCount = 0;
+            _postToolNudgeSent = false;
             PrepareDiscoveredToolsForNewTurn();
 
             // Modality gate: strip unsupported media references
@@ -261,6 +265,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                     "Your previous response was empty. If you need MCP capabilities, call search_tools(\"servers\") to pick a server "
                     + "(for example browser, memory, or email), then call search_tools(\"<intent>\", server: \"<server_name>\") to load tools. "
                     + "MCP tools are not directly callable until loaded via search_tools.");
+                FireLlmCall();
+                return;
+            }
+
+            // Guard: if the LLM did tool work but produced an empty final response, nudge it
+            // to continue working or answer the user.
+            if (!hasText && _toolIterationCount > 0 && !_postToolNudgeSent)
+            {
+                _log.Debug("LLM produced empty response after {ToolIterations} tool iteration(s) — nudging",
+                    _toolIterationCount);
+                _postToolNudgeSent = true;
+                _state = _state.AddSystemNudge(
+                    "You received tool results but did not respond. "
+                    + "Continue working or answer the user's question.");
                 FireLlmCall();
                 return;
             }
@@ -728,6 +746,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         List<FunctionCallContent> toolCalls,
         UsageDetails? usage)
     {
+        // Model produced tool calls — reset post-tool nudge so it can fire again
+        // if the model stalls later in the chain.
+        _postToolNudgeSent = false;
+
         // Add assistant message (with tool calls) to history
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);
         _state = _state with { History = _state.History.Add(assistantMsg) };


### PR DESCRIPTION
## Summary

- Adds a post-tool empty response nudge to `LlmSessionActor` that detects when the LLM completes tool iterations but produces an empty final response (no text, no tool calls), and re-fires the LLM call with a system nudge asking it to continue or respond
- Uses a `_postToolNudgeSent` flag to prevent tight empty→nudge→empty loops, resetting the flag on successful tool calls so the model can be nudged again if it stalls later in a long chain
- Parallels the existing iteration-0 nudge (MCP tool discovery) but targets iteration > 0 (post-tool stall)

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 524 passed, 0 failed
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual verification: trigger a session where the LLM does tool work then produces an empty response; confirm the nudge fires and the model recovers