### PR TITLE
File-based memory fallback (unified-memory-provider M1)

### DIFF
--- a/openspec/changes/unified-memory-provider/.openspec.yaml
+++ b/openspec/changes/unified-memory-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-02

--- a/openspec/changes/unified-memory-provider/design.md
+++ b/openspec/changes/unified-memory-provider/design.md
@@ -1,0 +1,263 @@
+## Context
+
+Netclaw's cross-session memory is currently all-or-nothing: either the operator
+runs a Memorizer MCP server, or the agent falls back to flat identity files with
+no search, tags, or organization. The `SearchMemoriesTool` hardcodes
+`"memorizer/"` as the MCP tool prefix. There's no config schema for memory, no
+wizard step, no doctor check, and no status output.
+
+The `IMemoryExtractor` interface and compaction integration are fully plumbed but
+wired to `NullMemoryExtractor` — extracted memories go nowhere because no real
+implementation is registered.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Memory works out of the box with zero configuration (file-based default).
+- `search_memories` and `store_memory` are always-loaded tools — no discovery
+  step required for basic memory operations.
+- Memorizer is an upgrade path with full workspace/project/relationship
+  capabilities, not a prerequisite.
+- The context layer is honest about what requires discovery and what doesn't.
+- Pre-compaction memory extraction persists to the active backend.
+- Wizard, doctor, and status treat memory as a first-class capability.
+
+**Non-Goals:**
+- Vector/embedding search for the file backend. Substring matching is sufficient
+  for MVP.
+- Migrating memories between backends. Operator can do this manually.
+- File-based workspaces/projects/relationships. These are Memorizer-only.
+- Automatic Memorizer detection (if MCP server happens to be configured). The
+  operator explicitly chooses the backend.
+
+## Decisions
+
+### Decision: Two always-loaded tools — search_memories and store_memory
+
+These are the core memory operations. Making them always-loaded means the agent
+can search and save without first calling `search_tools`. This solves the
+discovery gap that caused small models to fail at saving memories.
+
+Rationale:
+- `search_memories` is already always-loaded. Adding `store_memory` is symmetric.
+- Two tools cost ~200 tokens in ChatOptions — acceptable overhead.
+- Eliminates the most common failure mode (agent told to save, can't find tool).
+
+Alternatives considered:
+- Promote all Memorizer tools to always-loaded. Rejected — 21 tools is too many
+  tokens for every turn, and most are rarely used.
+- Keep `store_memory` as MCP-only. Rejected — defeats the purpose of the
+  behavioral SAVE trigger.
+
+### Decision: File-based backend with memory.md index
+
+Memories are stored as individual `.md` files in `~/.netclaw/memories/`. A
+`memory.md` index file lists all memories with titles, tags, and file paths.
+This is the progressive-discovery pattern already used for tools and skills.
+
+Rationale:
+- Consistent with how skills work (compressed index + file_read for details).
+- Human-readable and editable — operator can browse, edit, or delete memories
+  using any text editor.
+- No database dependency for the default backend.
+
+Alternatives considered:
+- SQLite-backed memory store. Rejected — adds dependency, not human-readable,
+  overkill for MVP where memory count will be small.
+- Single `memories.md` file. Rejected — doesn't scale, hard to manage individual
+  memories.
+
+### Decision: Explicit provider config, not auto-detection
+
+The `Memory.Provider` config field explicitly selects the backend. We don't
+auto-detect Memorizer from the MCP server list.
+
+Rationale:
+- Operator intent is clear. No surprise behavior if someone adds a Memorizer MCP
+  server for other purposes.
+- Config is the source of truth for what memory backend is active.
+- Doctor/status can report clearly because the expected backend is declared.
+
+### Decision: Memorizer context layer explains two-step discovery
+
+For advanced Memorizer operations (workspaces, projects, relationships), the
+context layer tells the agent it needs to discover tools first and points to the
+`memorizer-usage` skill file. This is honest about the architecture instead of
+pretending tools are directly callable.
+
+Rationale:
+- Small models failed when told to use `memorizer/store` directly. Being explicit
+  about the two-step process gives the agent a chance to succeed.
+- The skill file has the full workflow documentation for graph traversal.
+- Basic operations (`search_memories`, `store_memory`) don't require discovery.
+
+### Decision: Wire IMemoryExtractor to active backend
+
+The existing `IMemoryExtractor` plumbing in `LlmSessionActor` gets a real
+implementation that routes to the active memory provider. The DI registration
+in `Program.cs` picks the right implementation based on config.
+
+Rationale:
+- All the compaction plumbing is done. This is just wiring.
+- Extracted memories go to the same backend the agent uses proactively.
+- File backend gets extraction too — not just Memorizer.
+
+## Architecture
+
+### Memory Provider Interface
+
+```csharp
+public interface IMemoryProvider
+{
+    Task<string> SearchAsync(string query, int limit = 5, CancellationToken ct = default);
+    Task<string> StoreAsync(string title, string content, string[]? tags = null,
+        CancellationToken ct = default);
+}
+```
+
+### File-Based Implementation
+
+```
+~/.netclaw/memories/
+  ├── memory.md              (progressive-discovery index)
+  ├── 2026-03-02-k8s-fix.md  (individual memory)
+  ├── 2026-03-02-port-change.md
+  └── ...
+```
+
+`memory.md` format:
+```markdown
+# Memory Index
+
+| Title | Tags | File |
+|-------|------|------|
+| K8s pod restart fix | troubleshooting, kubernetes | 2026-03-02-k8s-fix.md |
+| Daemon port change | troubleshooting, netclaw | 2026-03-02-port-change.md |
+```
+
+Search algorithm: substring match against title, tags, and file content.
+Return top N results sorted by match quality (title > tags > content).
+
+### Memorizer Implementation
+
+Delegates to MCP tools:
+- `SearchAsync` → `memorizer/search_memories`
+- `StoreAsync` → `memorizer/store`
+
+Resolves MCP tools at call time via `ToolRegistry.GetByName()` (same pattern
+as existing `SearchMemoriesTool`).
+
+### IMemoryExtractor Implementation
+
+```csharp
+public sealed class ProviderMemoryExtractor : IMemoryExtractor
+{
+    private readonly IMemoryProvider _provider;
+
+    public async Task PersistAsync(string sessionId, string extractedMemories,
+        CancellationToken ct = default)
+    {
+        await _provider.StoreAsync(
+            title: $"Session extraction — {sessionId}",
+            content: extractedMemories,
+            tags: ["extraction", "compaction"],
+            ct: ct);
+    }
+}
+```
+
+### DI Registration
+
+```csharp
+// In Program.cs ConfigureServices
+var memoryConfig = configuration.GetSection("Memory");
+var provider = memoryConfig.GetValue<string>("Provider") ?? "files";
+
+IMemoryProvider memoryProvider = provider.ToLowerInvariant() switch
+{
+    "memorizer" => new MemorizerMemoryProvider(toolRegistry),
+    _ => new FileMemoryProvider(paths.MemoriesDirectory)
+};
+
+services.AddSingleton(memoryProvider);
+services.AddSingleton<IMemoryExtractor>(new ProviderMemoryExtractor(memoryProvider));
+```
+
+### Context Layer Content
+
+**File backend:**
+```
+[memories — cross-session knowledge]
+
+RETRIEVE: At the start of each conversation, search_memories for topics
+relevant to the user's first message. Check before answering from scratch.
+
+SAVE: When you learn something worth remembering, store_memory immediately.
+Write rich content with markdown, code blocks, and full context.
+
+Browse all memories: file_read ~/.netclaw/memories/memory.md
+```
+
+**Memorizer backend:**
+```
+[memories — cross-session knowledge via Memorizer]
+
+RETRIEVE: search_memories is always available. Use it at conversation start
+and when asked about something you might have encountered before.
+
+SAVE: store_memory is always available for basic saves. For rich organization
+(workspaces, projects, relationships), first call search_tools(Server="memorizer")
+to discover the full tool set, then use the discovered tools.
+
+When you find a memory with a projectId, you can explore its project context
+and related memories — discover tools first, then traverse the graph.
+
+For full Memorizer workflow: file_read ~/.netclaw/skills/memorizer-usage.md
+```
+
+### Config Schema
+
+```json
+{
+  "Memory": {
+    "Provider": "files"
+  }
+}
+```
+
+Or for Memorizer:
+
+```json
+{
+  "Memory": {
+    "Provider": "memorizer"
+  }
+}
+```
+
+The Memorizer MCP server entry in `McpServers` is still required separately —
+`Memory.Provider` just tells Netclaw which backend to use for the unified tools.
+
+## Risks / Trade-offs
+
+- [File search quality] Substring matching is naive compared to Memorizer's
+  vector search. Acceptable for MVP where memory count is small (tens to low
+  hundreds). If quality becomes an issue, SQLite FTS5 is a natural upgrade path.
+- [Index file stalability] The `memory.md` index can get out of sync if files
+  are manually added/deleted. Mitigation: rebuild index from files on startup.
+- [Two config concepts for Memorizer] Operator configures both
+  `Memory.Provider = "memorizer"` AND the MCP server entry. Potential confusion.
+  Mitigation: wizard handles both together; doctor validates consistency.
+
+## Migration Plan
+
+1. Add `IMemoryProvider` interface and file-based implementation.
+2. Add `StoreMemoryTool` as always-loaded builtin.
+3. Refactor `SearchMemoriesTool` to use `IMemoryProvider`.
+4. Add `MemorizerMemoryProvider` that delegates to MCP tools.
+5. Add `ProviderMemoryExtractor` and wire into DI.
+6. Update `MemoryIndexContextLayer` for provider-aware content.
+7. Add `Memory` config section and parsing.
+8. Add wizard step, doctor check, and status output.
+9. Update `memorizer-usage` skill with two-step discovery guidance.
+10. Update `netclaw-agent-memory` main spec with reconciled requirements.

--- a/openspec/changes/unified-memory-provider/proposal.md
+++ b/openspec/changes/unified-memory-provider/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+Netclaw's cross-session memory currently has two problems:
+
+1. **No fallback.** If Memorizer (the MCP-based memory server) isn't configured,
+   the agent's only option is flat identity files (`SOUL.md`, `TOOLING.md`).
+   There's no searchable, taggable, organized memory — just files the agent
+   can read and write. This means memory is effectively all-or-nothing: either
+   you run a separate MCP server, or you get nothing.
+
+2. **No abstraction.** Memory isn't a first-class Netclaw capability. It's an
+   incidental MCP server entry named `"memorizer"` in `netclaw.json`. There's
+   no config schema for memory, no wizard step, no doctor check, no status
+   output. The `SearchMemoriesTool` and `MemoryIndexContextLayer` hardcode
+   the string `"memorizer/"` to locate MCP tools.
+
+3. **Discovery gap for advanced operations.** The always-on context layer tells
+   the agent to "save using memorizer/store" but that tool isn't in
+   `ChatOptions.Tools` until the agent first calls `search_tools`. Small models
+   fail this two-step dance. Workspace/project/relationship operations are even
+   harder to discover.
+
+## What Changes
+
+- **Unified memory tools**: `search_memories` (existing) and a new
+  `store_memory` become always-loaded builtin tools that work regardless of
+  backend. When Memorizer is connected, they delegate to MCP. When it's not,
+  they use a file-based memory store.
+
+- **File-based memory backend**: A `~/.netclaw/memories/` directory with
+  individual `.md` files per memory and a `memory.md` index file that acts as
+  a progressive-discovery catalog (titles, tags, paths). The agent uses
+  `file_read` to load individual memories. The index is searchable via
+  substring matching — no vector DB required.
+
+- **Memory provider config**: A `Memory` section in `netclaw.json` that
+  declares the active provider (`"files"` or `"memorizer"`). Default is
+  `"files"` — Memorizer is opt-in when the MCP server is configured.
+
+- **Updated context layer**: `MemoryIndexContextLayer` becomes
+  provider-aware. For the file backend: points to `search_memories`,
+  `store_memory`, and the `memory.md` index. For Memorizer: explains the
+  two-step discovery process for advanced operations (workspaces, projects,
+  relationships) and refers the agent to the `memorizer-usage` skill file.
+
+- **Wizard step**: Add a memory configuration step to `netclaw init` that
+  asks whether the user wants file-based memory (default) or Memorizer, and
+  configures accordingly.
+
+- **Doctor check**: Validate that the configured memory provider is healthy
+  (files: directory exists and is writable; Memorizer: MCP server connected).
+
+- **Status integration**: `netclaw status` shows memory provider and health
+  alongside existing model/connector status.
+
+## Capabilities
+
+### New Capabilities
+
+- None (memory falls under existing `netclaw-agent-memory` capability).
+
+### Modified Capabilities
+
+- `netclaw-agent-memory`: gains provider abstraction, file-based backend,
+  `store_memory` builtin tool, and `memory.md` progressive-discovery index.
+- `netclaw-onboarding`: gains memory provider selection step in wizard.
+- `netclaw-cli`: gains memory provider doctor check and status output.
+
+## Impact
+
+- **Code/Runtime**: New `StoreMemoryTool`, `FileMemoryStore`, `memory.md`
+  index writer. Modified `MemoryIndexContextLayer` for provider-aware content.
+  Modified `SearchMemoriesTool` to support file backend. New wizard step and
+  doctor check.
+- **Security**: No new attack surface. File-based memories are local files
+  under `~/.netclaw/` with existing filesystem permissions.
+- **Operations**: Memory works out of the box with zero configuration.
+  Memorizer becomes an upgrade path, not a prerequisite.
+- **Dependencies/APIs**: No new external dependencies. File backend uses
+  filesystem only.
+- **Traceability**: Maps to `netclaw-agent-memory` spec (pre-compaction flush,
+  memory triage, cross-session recall). Addresses gap where memory was
+  unavailable without external MCP server.

--- a/openspec/changes/unified-memory-provider/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/unified-memory-provider/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,197 @@
+## RECONCILED Requirements
+
+The following requirements are updated to reflect the actual implementation.
+Stale terminology, removed features, and spec-vs-reality drift are corrected.
+
+### Requirement: Layered system prompt assembly
+
+The system SHALL assemble session context from ordered layers: `SOUL.md`,
+`AGENTS.md`, `TOOLING.md`, dynamic context layers (tool index, skill index,
+memory index), and session-specific context. Later layers SHALL augment earlier
+layers. Identity files SHALL be loaded at session start and cached for the
+session lifetime. Missing files SHALL be omitted without error.
+
+_Reconciliation: renamed files from `PERSONALITY.md/INSTRUCTIONS.md/USER.md`
+to `SOUL.md/AGENTS.md/TOOLING.md`. Removed project AGENTS.md overlay (not
+implemented, not planned for MVP). Added dynamic context layers._
+
+### Requirement: Personality bootstrap via onboarding wizard
+
+The system SHALL bootstrap agent personality through the `netclaw init`
+onboarding wizard. The wizard SHALL collect owner identity, write initial
+`SOUL.md`, and configure the standard identity directory. The agent MAY
+refine personality through conversation using `file_write` on identity files,
+guided by the `identity-management` skill.
+
+_Reconciliation: replaced conversational bootstrap with wizard-based bootstrap.
+Removed `netclaw personality reset` CLI command (not planned for MVP)._
+
+### ~~Requirement: Environment capability self-discovery~~
+
+_Struck. Agents discover environment capabilities ad hoc via `shell_execute`.
+No formal inventory is maintained._
+
+### Requirement: Self-configuration through conversation
+
+The system SHALL allow the agent to modify identity files (`SOUL.md`,
+`AGENTS.md`, `TOOLING.md`) and skill files (`~/.netclaw/skills/*.md`) through
+conversation using `file_read` and `file_write`. The `identity-management`
+built-in skill SHALL provide triage guidance for what information goes where.
+The agent SHALL NOT have tools that directly modify `netclaw.json`,
+`secrets.json`, ACL, or security policy.
+
+_Reconciliation: replaced dedicated identity tools with generic file tools +
+skill-based guidance. Safety boundary is architectural (no config-editing
+tools) rather than per-tool validation._
+
+### Requirement: Standard configuration directory
+
+The system SHALL use `~/.netclaw/` as the standard configuration directory
+with the following structure: `identity/` (soul files), `config/` (netclaw.json,
+secrets.json), `skills/` (procedural knowledge), `memories/` (file-based
+memory store), `sessions/`, `logs/`, `projects/`, and `schedules/`. The
+directory SHALL be created at startup if it does not exist.
+
+_Reconciliation: renamed `soul/` to `identity/`, added `skills/` and
+`memories/`, removed `environment/` (struck). Configurable base path deferred._
+
+## NEW Requirements
+
+### Requirement: Unified memory provider abstraction
+
+The system SHALL support pluggable memory backends through a provider
+abstraction. Two providers SHALL be supported:
+
+- **`files`** (default): File-based memory store at `~/.netclaw/memories/`
+  with a `memory.md` progressive-discovery index.
+- **`memorizer`**: Delegates to the Memorizer MCP server for full workspace,
+  project, and relationship capabilities.
+
+The active provider SHALL be configured in `netclaw.json` under a `Memory`
+section. Default is `files` when no configuration exists.
+
+#### Scenario: File-based memory is default
+
+- **GIVEN** no `Memory` section exists in `netclaw.json`
+- **WHEN** the daemon starts
+- **THEN** the file-based memory provider is active
+- **AND** `search_memories` and `store_memory` use the file backend
+
+#### Scenario: Memorizer provider configured
+
+- **GIVEN** `Memory.Provider` is set to `"memorizer"` in `netclaw.json`
+- **AND** the Memorizer MCP server is configured and connected
+- **WHEN** the daemon starts
+- **THEN** `search_memories` delegates to `memorizer/search_memories`
+- **AND** `store_memory` delegates to `memorizer/store`
+- **AND** the memory context layer explains the two-step discovery process
+  for advanced operations (workspaces, projects, relationships)
+
+#### Scenario: Memorizer configured but disconnected
+
+- **GIVEN** `Memory.Provider` is set to `"memorizer"`
+- **AND** the Memorizer MCP server is not connected
+- **WHEN** the agent calls `search_memories` or `store_memory`
+- **THEN** the tools return a clear error indicating Memorizer is unavailable
+- **AND** the memory context layer suggests checking MCP configuration
+
+### Requirement: Always-available memory tools
+
+The system SHALL provide `search_memories` and `store_memory` as always-loaded
+builtin tools regardless of which memory provider is active. These tools SHALL
+be in `ChatOptions.Tools` on every LLM call — no discovery step required.
+
+#### Scenario: search_memories always available
+
+- **WHEN** any session starts
+- **THEN** `search_memories` is in the tool list sent to the LLM
+- **AND** the tool works against whichever backend is configured
+
+#### Scenario: store_memory always available
+
+- **WHEN** any session starts
+- **THEN** `store_memory` is in the tool list sent to the LLM
+- **AND** the agent can save memories without first calling `search_tools`
+
+### Requirement: File-based memory store
+
+The file-based memory provider SHALL store memories as individual Markdown
+files in `~/.netclaw/memories/` with a `memory.md` index file that lists all
+memories with their titles, tags, and file paths. The index SHALL be updated
+on every store operation.
+
+#### Scenario: Store memory creates file and updates index
+
+- **GIVEN** the file-based memory provider is active
+- **WHEN** the agent calls `store_memory` with title, content, and tags
+- **THEN** a new `.md` file is created in `~/.netclaw/memories/`
+- **AND** the `memory.md` index is updated with the new entry
+- **AND** the memory is retrievable via `search_memories`
+
+#### Scenario: Search memories uses substring matching
+
+- **GIVEN** memories exist in `~/.netclaw/memories/`
+- **WHEN** the agent calls `search_memories` with a query
+- **THEN** the tool searches the `memory.md` index and file contents
+- **AND** returns matching memories ranked by relevance (title match > tag
+  match > content match)
+
+#### Scenario: Memory index is progressive-discovery catalog
+
+- **GIVEN** memories exist in `~/.netclaw/memories/`
+- **WHEN** the agent reads `memory.md` via `file_read`
+- **THEN** the file lists all memories with title, tags, and file path
+- **AND** the agent can `file_read` individual memory files for full content
+
+### Requirement: Memorizer discovery guidance
+
+When the Memorizer provider is active, the memory context layer SHALL explain
+the two-step discovery process for advanced operations. The always-on layer
+SHALL reference the `memorizer-usage` skill file for full guidance on
+workspaces, projects, and relationships.
+
+#### Scenario: Context layer explains two-step discovery
+
+- **GIVEN** the Memorizer provider is active and connected
+- **WHEN** the session system prompt is assembled
+- **THEN** the memory context layer includes:
+  - `search_memories` and `store_memory` are directly available
+  - Advanced operations (workspaces, projects, relationships) require
+    calling `search_tools(Server="memorizer")` first to discover tools
+  - Reference to `memorizer-usage` skill for full workflow guidance
+
+#### Scenario: Agent traverses memory graph
+
+- **GIVEN** the agent finds a memory with a `projectId`
+- **WHEN** the agent wants to understand the project context
+- **THEN** the agent calls `search_tools(Server="memorizer")` to discover
+  project tools
+- **AND** calls `memorizer/get_project_context` to explore the project
+- **AND** discovers related memories through project membership
+
+### Requirement: Pre-compaction memory extraction
+
+The system SHALL fire a memory extraction LLM call after compaction to
+identify durable knowledge worth saving. Extracted memories SHALL be persisted
+through the active memory provider. When no provider is configured, extraction
+SHALL be skipped gracefully.
+
+#### Scenario: Extraction persists to file backend
+
+- **GIVEN** the file-based memory provider is active
+- **WHEN** compaction completes and memory extraction runs
+- **THEN** extracted memories are saved as files in `~/.netclaw/memories/`
+- **AND** the `memory.md` index is updated
+
+#### Scenario: Extraction persists to Memorizer
+
+- **GIVEN** the Memorizer provider is active and connected
+- **WHEN** compaction completes and memory extraction runs
+- **THEN** extracted memories are saved via `memorizer/store`
+
+#### Scenario: Extraction skipped when no provider
+
+- **GIVEN** no memory provider is configured
+- **WHEN** compaction completes
+- **THEN** memory extraction is skipped (NullMemoryExtractor)
+- **AND** compaction proceeds without delay

--- a/openspec/changes/unified-memory-provider/specs/netclaw-cli/spec.md
+++ b/openspec/changes/unified-memory-provider/specs/netclaw-cli/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Diagnostic commands
+
+The `netclaw doctor` command SHALL include a memory provider health check.
+The `netclaw status` command SHALL display the active memory provider and
+its health status.
+
+#### Scenario: Doctor validates file-based memory
+
+- **GIVEN** the memory provider is `files`
+- **WHEN** the operator runs `netclaw doctor`
+- **THEN** doctor checks that `~/.netclaw/memories/` exists and is writable
+- **AND** reports pass/fail for the memory provider check
+
+#### Scenario: Doctor validates Memorizer
+
+- **GIVEN** the memory provider is `memorizer`
+- **WHEN** the operator runs `netclaw doctor`
+- **THEN** doctor checks that the Memorizer MCP server is configured
+- **AND** checks that the MCP server is reachable
+- **AND** reports pass/fail with remediation guidance if unhealthy
+
+#### Scenario: Status shows memory provider
+
+- **WHEN** the operator runs `netclaw status`
+- **THEN** the output includes a `memory:` line showing:
+  - Provider name (`files` or `memorizer`)
+  - Health status (`healthy`, `degraded`, or `unavailable`)
+  - For Memorizer: endpoint URL and tool count
+  - For files: memory count and index path

--- a/openspec/changes/unified-memory-provider/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/unified-memory-provider/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init`. The wizard SHALL
+include a memory configuration step that asks the operator whether to use
+file-based memory (default) or Memorizer, and configures accordingly.
+
+#### Scenario: Memory step offers provider choice
+
+- **WHEN** onboarding reaches the memory configuration step
+- **THEN** the wizard presents options: "File-based memory (default)" and
+  "Memorizer (MCP server)"
+- **AND** file-based is pre-selected as the recommended option
+
+#### Scenario: File-based memory selected
+
+- **GIVEN** the operator selects file-based memory
+- **WHEN** the wizard writes configuration
+- **THEN** `netclaw.json` includes `"Memory": { "Provider": "files" }`
+- **AND** `~/.netclaw/memories/` directory is created
+- **AND** no MCP server configuration is added for Memorizer
+
+#### Scenario: Memorizer selected
+
+- **GIVEN** the operator selects Memorizer
+- **WHEN** the wizard advances to Memorizer configuration
+- **THEN** the wizard prompts for the Memorizer endpoint URL
+  (default: `http://localhost:5012/mcp`)
+- **AND** `netclaw.json` includes `"Memory": { "Provider": "memorizer" }`
+- **AND** the Memorizer MCP server entry is added to `McpServers`
+
+#### Scenario: Health check validates memory provider
+
+- **WHEN** the wizard runs the final health check
+- **THEN** the health check validates the configured memory provider
+- **AND** for file-based: verifies directory exists and is writable
+- **AND** for Memorizer: verifies MCP server connectivity

--- a/openspec/changes/unified-memory-provider/tasks.md
+++ b/openspec/changes/unified-memory-provider/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: unified-memory-provider
+
+## Milestone 1: Core memory provider abstraction and file backend
+
+### Task 1.1: Add IMemoryProvider interface and config schema
+- [ ] Create `IMemoryProvider` interface in `Netclaw.Actors` with `SearchAsync` and `StoreAsync`
+- [ ] Add `Memory` config section to `Netclaw.Configuration` (parsed from `netclaw.json`)
+- [ ] Add `MemoriesDirectory` to `NetclawPaths`
+- [ ] Ensure `~/.netclaw/memories/` is created at startup alongside other directories
+
+**Acceptance:** Config section parses correctly with `"files"` and `"memorizer"` values. `NetclawPaths.MemoriesDirectory` resolves to `~/.netclaw/memories/`.
+
+### Task 1.2: Implement FileMemoryProvider
+- [ ] Create `FileMemoryProvider` that stores memories as individual `.md` files in `~/.netclaw/memories/`
+- [ ] File naming: `{date}-{kebab-title}.md` with YAML front matter (title, tags, created date)
+- [ ] Implement `memory.md` index file — markdown table listing all memories with title, tags, file path
+- [ ] `StoreAsync`: write memory file, update index
+- [ ] `SearchAsync`: substring match against index entries and file content, return top N results formatted as readable text
+- [ ] Rebuild index from files on startup (handle manual edits/deletions)
+
+**Acceptance:** Store creates file + updates index. Search finds memories by title, tag, or content substring. Index stays consistent after manual file additions/deletions.
+
+### Task 1.3: Add StoreMemoryTool as always-loaded builtin
+- [ ] Create `StoreMemoryTool` in `Netclaw.Actors.Memory` following `SearchMemoriesTool` patterns
+- [ ] Parameters: `Title` (required), `Content` (required), `Tags` (optional string array)
+- [ ] Delegates to `IMemoryProvider.StoreAsync`
+- [ ] Register as always-loaded builtin (not MCP, not requiring discovery)
+- [ ] Grant category: `builtin`
+
+**Acceptance:** `StoreMemoryTool` appears in `GetAlwaysLoadedTools()`. Agent can call `store_memory` without prior `search_tools` call. Tool works against file backend.
+
+### Task 1.4: Refactor SearchMemoriesTool to use IMemoryProvider
+- [ ] Replace hardcoded `memorizer/search_memories` MCP lookup with `IMemoryProvider.SearchAsync`
+- [ ] Remove `MemorizerToolNames` constant and `FindMemorizerTool` method
+- [ ] Keep graceful error when provider is unavailable
+- [ ] Update existing tests
+
+**Acceptance:** `SearchMemoriesTool` delegates to `IMemoryProvider` instead of directly resolving MCP tools. Existing tests updated and passing. File backend works end-to-end.
+
+### Task 1.5: Wire IMemoryProvider and IMemoryExtractor in DI
+- [ ] In `Program.cs`, read `Memory.Provider` config value (default: `"files"`)
+- [ ] Register `FileMemoryProvider` or `MemorizerMemoryProvider` based on config
+- [ ] Create `ProviderMemoryExtractor` that delegates to `IMemoryProvider.StoreAsync`
+- [ ] Register `ProviderMemoryExtractor` as `IMemoryExtractor` (replacing `NullMemoryExtractor`)
+- [ ] Inject `IMemoryProvider` into `SearchMemoriesTool` and `StoreMemoryTool`
+
+**Acceptance:** Pre-compaction memory extraction fires and persists to the active backend. `NullMemoryExtractor` is no longer the default when a provider is configured.
+
+### Task 1.6: Unit tests for file backend and tools
+- [ ] `FileMemoryProviderTests`: store, search, index rebuild, concurrent writes
+- [ ] `StoreMemoryToolTests`: parameter validation, delegation to provider, grant category
+- [ ] Update `SearchMemoriesToolTests` for provider-based delegation
+- [ ] `ProviderMemoryExtractorTests`: verify extraction routes to provider
+
+**Acceptance:** All tests pass. Coverage on store, search, index management, and extraction wiring.
+
+---
+
+## Milestone 2: Memorizer backend and provider-aware context layer
+
+### Task 2.1: Implement MemorizerMemoryProvider
+- [ ] Create `MemorizerMemoryProvider` that delegates to MCP tools via `ToolRegistry`
+- [ ] `SearchAsync` → resolve and call `memorizer/search_memories`
+- [ ] `StoreAsync` → resolve and call `memorizer/store`
+- [ ] Graceful error when Memorizer MCP is not connected
+
+**Acceptance:** When Memorizer MCP is connected, `search_memories` and `store_memory` delegate to it. When disconnected, clear error message returned.
+
+### Task 2.2: Update MemoryIndexContextLayer for provider-aware content
+- [ ] Accept provider type in `Update` method (not just connected boolean)
+- [ ] File backend: show RETRIEVE/SAVE rules pointing to `search_memories`, `store_memory`, and `memory.md` index
+- [ ] Memorizer backend (connected): show RETRIEVE/SAVE rules, explain two-step discovery for advanced ops, reference `memorizer-usage` skill
+- [ ] Memorizer backend (disconnected): show unavailable message with troubleshooting guidance
+- [ ] No backend configured: show fallback to identity files
+
+**Acceptance:** Context layer content varies by provider and connection state. Integration test confirms agent sees correct guidance for each scenario.
+
+### Task 2.3: Update memorizer-usage skill with discovery workflow
+- [ ] Add section explaining the two-step pattern: `search_memories`/`store_memory` are direct, everything else needs `search_tools` first
+- [ ] Add graph traversal workflow: find memory → see projectId → discover project tools → explore project → find related memories
+- [ ] Clarify which tools are always-available vs. discovery-required
+
+**Acceptance:** Skill file clearly documents the two tiers of memory operations.
+
+### Task 2.4: Tests for Memorizer backend and context layer
+- [ ] `MemorizerMemoryProviderTests`: delegation to MCP tools, disconnected fallback
+- [ ] Update `MemoryIndexContextLayer` tests for provider-aware content (file, memorizer-connected, memorizer-disconnected, no-backend)
+
+**Acceptance:** All tests pass for both backends and all context layer states.
+
+---
+
+## Milestone 3: Onboarding, diagnostics, and status
+
+### Task 3.1: Add memory wizard step to netclaw init
+- [ ] Add `WizardStep.Memory` between `BrowserAutomation` and `Exposure`
+- [ ] Selection: "File-based memory (recommended)" or "Memorizer (MCP server)"
+- [ ] File-based: no further input, writes `Memory.Provider = "files"` to config
+- [ ] Memorizer: prompt for endpoint URL (default `http://localhost:5012/mcp`), write both `Memory` config and `McpServers` entry
+- [ ] Update `TotalSteps` constant
+
+**Acceptance:** Wizard includes memory step. Both paths produce valid configuration. Back-navigation clears memory config.
+
+### Task 3.2: Add memory doctor check
+- [ ] Add `MemoryDoctorCheck` to `Netclaw.Cli/Doctor/`
+- [ ] File backend: verify `~/.netclaw/memories/` exists and is writable
+- [ ] Memorizer backend: verify MCP server entry exists in config, verify MCP server is connected (via daemon status API)
+- [ ] Report pass/fail with remediation guidance
+
+**Acceptance:** `netclaw doctor` includes memory check. Clear pass/fail output for each backend type.
+
+### Task 3.3: Add memory to netclaw status output
+- [ ] Add `memory:` line to status output
+- [ ] Show provider name, health status, and backend-specific details
+- [ ] File backend: memory count, index path
+- [ ] Memorizer: endpoint, tool count, connection status
+
+**Acceptance:** `netclaw status` shows memory provider info alongside existing model/connector output.
+
+### Task 3.4: Integration test — end-to-end memory workflow
+- [ ] Start daemon with file backend, run headless prompt that triggers search + store
+- [ ] Verify memory file created in `~/.netclaw/memories/` with correct content
+- [ ] Verify `memory.md` index updated
+- [ ] Verify subsequent search finds the stored memory
+
+**Acceptance:** Full round-trip: store → index update → search retrieval, all via CLI headless mode.
+
+---
+
+## Milestone 4: Spec reconciliation
+
+### Task 4.1: Sync delta specs to main specs
+- [ ] Sync `netclaw-agent-memory` delta spec to `openspec/specs/netclaw-agent-memory/spec.md`
+- [ ] Sync `netclaw-onboarding` delta spec to `openspec/specs/netclaw-onboarding/spec.md`
+- [ ] Sync `netclaw-cli` delta spec to `openspec/specs/netclaw-cli/spec.md`
+
+**Acceptance:** Main specs reflect reconciled requirements. No stale references to removed features or renamed files.
+
+### Task 4.2: Update ADR-002
+- [ ] Update ADR-002 to reflect unified memory provider architecture
+- [ ] Document file-based backend as default, Memorizer as upgrade path
+- [ ] Document `IMemoryProvider` abstraction and `IMemoryExtractor` wiring
+
+**Acceptance:** ADR-002 accurately describes the current memory architecture.

--- a/src/Netclaw.Actors.Tests/Memory/FileMemoryExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/FileMemoryExtractorTests.cs
@@ -1,0 +1,50 @@
+using Netclaw.Actors.Memory;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+public class FileMemoryExtractorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileMemoryStore _store;
+
+    public FileMemoryExtractorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new FileMemoryStore(_tempDir, TimeProvider.System);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task PersistAsync_stores_with_session_title_and_extraction_tags()
+    {
+        var extractor = new FileMemoryExtractor(_store);
+
+        await extractor.PersistAsync("chan123/ts456", "Key finding: the API rate limit is 100 req/min.");
+
+        var entries = await _store.GetEntriesAsync();
+        Assert.Single(entries);
+        Assert.Equal("Session extraction — chan123/ts456", entries[0].Title);
+        Assert.Contains("extraction", entries[0].Tags);
+        Assert.Contains("compaction", entries[0].Tags);
+        Assert.Contains("rate limit", entries[0].Content);
+    }
+
+    [Fact]
+    public async Task PersistAsync_skips_empty_content()
+    {
+        var extractor = new FileMemoryExtractor(_store);
+
+        await extractor.PersistAsync("session1", "");
+        await extractor.PersistAsync("session2", "   ");
+
+        var entries = await _store.GetEntriesAsync();
+        Assert.Empty(entries);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/FileMemoryStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/FileMemoryStoreTests.cs
@@ -1,0 +1,193 @@
+using Netclaw.Actors.Memory;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+public class FileMemoryStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly FileMemoryStore _store;
+
+    public FileMemoryStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 2, 12, 0, 0, TimeSpan.Zero));
+        _store = new FileMemoryStore(_tempDir, _timeProvider);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Store_creates_markdown_file_with_front_matter()
+    {
+        await _store.StoreAsync("Test Memory", "Some content here.", ["reference", "test"]);
+
+        var files = Directory.GetFiles(_tempDir, "*.md")
+            .Where(f => !Path.GetFileName(f).Equals("memory.md", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        Assert.Single(files);
+
+        var content = await File.ReadAllTextAsync(files[0]);
+        Assert.StartsWith("---", content);
+        Assert.Contains("title: \"Test Memory\"", content);
+        Assert.Contains("tags: [reference, test]", content);
+        Assert.Contains("created: 2026-03-02T12:00:00Z", content);
+        Assert.Contains("Some content here.", content);
+    }
+
+    [Fact]
+    public async Task Store_rebuilds_index_file()
+    {
+        await _store.StoreAsync("First Memory", "Content one.");
+
+        var indexPath = Path.Combine(_tempDir, "memory.md");
+        Assert.True(File.Exists(indexPath));
+
+        var index = await File.ReadAllTextAsync(indexPath);
+        Assert.Contains("# Memory Index", index);
+        Assert.Contains("First Memory", index);
+        Assert.Contains("Total: 1 memories", index);
+    }
+
+    [Fact]
+    public async Task Search_finds_by_title()
+    {
+        await _store.StoreAsync("Akka.NET Best Practices", "Use Ask with timeout.");
+        await _store.StoreAsync("Docker Compose Tips", "Use named volumes.");
+
+        var results = await _store.SearchAsync("akka");
+
+        Assert.Single(results);
+        Assert.Equal("Akka.NET Best Practices", results[0].Title);
+    }
+
+    [Fact]
+    public async Task Search_finds_by_tag()
+    {
+        await _store.StoreAsync("Networking Guide", "Use TCP.", ["networking", "infrastructure"]);
+        await _store.StoreAsync("Code Style", "Use var.", ["coding-standard"]);
+
+        var results = await _store.SearchAsync("infrastructure");
+
+        Assert.Single(results);
+        Assert.Equal("Networking Guide", results[0].Title);
+    }
+
+    [Fact]
+    public async Task Search_finds_by_content()
+    {
+        await _store.StoreAsync("Setup Guide", "Run dotnet restore first.");
+        await _store.StoreAsync("Deploy Guide", "Use kubectl apply.");
+
+        var results = await _store.SearchAsync("kubectl");
+
+        Assert.Single(results);
+        Assert.Equal("Deploy Guide", results[0].Title);
+    }
+
+    [Fact]
+    public async Task Search_ranks_title_matches_higher_than_content()
+    {
+        await _store.StoreAsync("Background Info", "The deployment uses kubernetes.");
+        await _store.StoreAsync("Kubernetes Deployment", "Run the apply command.");
+
+        var results = await _store.SearchAsync("kubernetes");
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Kubernetes Deployment", results[0].Title);
+    }
+
+    [Fact]
+    public async Task Search_returns_empty_for_no_match()
+    {
+        await _store.StoreAsync("Some Memory", "Unrelated content.");
+
+        var results = await _store.SearchAsync("nonexistent");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task Search_respects_max_results()
+    {
+        for (var i = 0; i < 10; i++)
+            await _store.StoreAsync($"Memory {i}", $"Content about topic {i}.");
+
+        var results = await _store.SearchAsync("topic", maxResults: 3);
+
+        Assert.Equal(3, results.Count);
+    }
+
+    [Fact]
+    public async Task Index_rebuild_handles_manually_added_files()
+    {
+        // Simulate a manually created memory file
+        var manualPath = Path.Combine(_tempDir, "2026-03-01-manual-note.md");
+        await File.WriteAllTextAsync(manualPath, """
+            ---
+            title: "Manual Note"
+            tags: [manual]
+            created: 2026-03-01T10:00:00Z
+            ---
+
+            This was added by hand.
+            """);
+
+        // Force index rebuild via search
+        var results = await _store.SearchAsync("manual");
+
+        Assert.Single(results);
+        Assert.Equal("Manual Note", results[0].Title);
+
+        // Index should also be updated
+        var index = await File.ReadAllTextAsync(Path.Combine(_tempDir, "memory.md"));
+        Assert.Contains("Manual Note", index);
+    }
+
+    [Fact]
+    public async Task Concurrent_writes_are_thread_safe()
+    {
+        var tasks = Enumerable.Range(0, 10)
+            .Select(i => _store.StoreAsync($"Concurrent Memory {i}", $"Content {i}."))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var entries = await _store.GetEntriesAsync();
+        Assert.Equal(10, entries.Count);
+    }
+
+    [Fact]
+    public void GenerateFileName_produces_kebab_case()
+    {
+        var date = new DateTimeOffset(2026, 3, 2, 0, 0, 0, TimeSpan.Zero);
+        var fileName = FileMemoryStore.GenerateFileName(date, "My Test Memory Title");
+        Assert.Equal("2026-03-02-my-test-memory-title.md", fileName);
+    }
+
+    [Fact]
+    public void GenerateFileName_truncates_long_titles()
+    {
+        var date = new DateTimeOffset(2026, 3, 2, 0, 0, 0, TimeSpan.Zero);
+        var longTitle = new string('a', 200);
+        var fileName = FileMemoryStore.GenerateFileName(date, longTitle);
+        Assert.True(fileName.Length <= 80); // date prefix + 60 char slug + .md
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public FakeTimeProvider(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan delta) => _utcNow += delta;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/MemorizerMemoryExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemorizerMemoryExtractorTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Tools;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+public class MemorizerMemoryExtractorTests
+{
+    [Fact]
+    public async Task PersistAsync_calls_memorizer_store_tool()
+    {
+        var registry = new ToolRegistry();
+        var fakeTool = new FakeNetclawTool("memorizer/store", "stored");
+        registry.Register(fakeTool);
+
+        var extractor = new MemorizerMemoryExtractor(registry);
+
+        await extractor.PersistAsync("chan/ts1", "Important finding: X depends on Y.");
+
+        Assert.True(fakeTool.WasCalled);
+        Assert.NotNull(fakeTool.LastArguments);
+        Assert.Equal("Session extraction — chan/ts1", fakeTool.LastArguments!["title"]);
+        Assert.Equal("Important finding: X depends on Y.", fakeTool.LastArguments["text"]);
+    }
+
+    [Fact]
+    public async Task PersistAsync_is_noop_when_memorizer_not_connected()
+    {
+        var registry = new ToolRegistry();
+        // No tools registered — Memorizer not connected
+        var extractor = new MemorizerMemoryExtractor(registry);
+
+        // Should not throw
+        await extractor.PersistAsync("chan/ts1", "Some content.");
+    }
+
+    [Fact]
+    public async Task PersistAsync_skips_empty_content()
+    {
+        var registry = new ToolRegistry();
+        var fakeTool = new FakeNetclawTool("memorizer/store", "stored");
+        registry.Register(fakeTool);
+
+        var extractor = new MemorizerMemoryExtractor(registry);
+
+        await extractor.PersistAsync("chan/ts1", "");
+        await extractor.PersistAsync("chan/ts2", "   ");
+
+        Assert.False(fakeTool.WasCalled);
+    }
+
+    private sealed class FakeNetclawTool : INetclawTool
+    {
+        private readonly string _result;
+
+        public FakeNetclawTool(string name, string result)
+        {
+            Name = name;
+            _result = result;
+        }
+
+        public string Name { get; }
+        public string Description => "Fake tool";
+        public string GrantCategory => "mcp:memorizer";
+        public System.Text.Json.JsonElement ParameterSchema => default;
+
+        public bool WasCalled { get; private set; }
+        public IDictionary<string, object?>? LastArguments { get; private set; }
+
+        public AITool ToAITool() => AIFunctionFactory.Create(() => _result, name: Name, description: Description);
+
+        public Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
+        {
+            WasCalled = true;
+            LastArguments = arguments;
+            return Task.FromResult(_result);
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Memory/SearchMemoriesToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SearchMemoriesToolTests.cs
@@ -1,78 +1,89 @@
-using Microsoft.Extensions.AI;
 using Netclaw.Actors.Memory;
-using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public class SearchMemoriesToolTests
+public class SearchMemoriesToolTests : IDisposable
 {
-    [Fact]
-    public async Task Returns_unavailable_message_when_memorizer_not_connected()
+    private readonly string _tempDir;
+    private readonly FileMemoryStore _store;
+
+    public SearchMemoriesToolTests()
     {
-        var registry = new ToolRegistry();
-        // No MCP tools registered — Memorizer is not connected
-        var tool = new SearchMemoriesTool(registry);
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new FileMemoryStore(_tempDir, TimeProvider.System);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Returns_no_memories_when_store_is_empty()
+    {
+        var tool = new SearchMemoriesTool(_store);
 
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?> { ["Query"] = "test query" },
             CancellationToken.None);
 
-        Assert.Contains("not available", result, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("not connected", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("No memories found.", result);
     }
 
     [Fact]
     public void Grant_category_is_builtin()
     {
-        var registry = new ToolRegistry();
-        var tool = new SearchMemoriesTool(registry);
-
+        var tool = new SearchMemoriesTool(_store);
         Assert.Equal("builtin", tool.GrantCategory);
     }
 
     [Fact]
-    public async Task Delegates_to_memorizer_mcp_tool_when_available()
+    public async Task Returns_matching_memories_after_store()
     {
-        var registry = new ToolRegistry();
+        await _store.StoreAsync("Akka.NET clustering guide", "Use cluster sharding for entity distribution.", ["reference", "akka"], CancellationToken.None);
 
-        // Register a fake MCP tool under the expected name
-        var fakeResult = "Found 1 memory: test memory content";
-        var fakeTool = AIFunctionFactory.Create((string query) => fakeResult,
-            name: "search_memories",
-            description: "Search memories");
-        registry.Register(fakeTool, "mcp:memorizer");
-
-        // Re-register with the expected namespaced name
-        var registry2 = new ToolRegistry();
-        var fakeMemorizerTool = new FakeNetclawTool("memorizer/search_memories", fakeResult);
-        registry2.Register(fakeMemorizerTool);
-
-        var tool = new SearchMemoriesTool(registry2);
+        var tool = new SearchMemoriesTool(_store);
 
         var result = await tool.ExecuteAsync(
-            new Dictionary<string, object?> { ["Query"] = "test" },
+            new Dictionary<string, object?> { ["Query"] = "akka clustering" },
             CancellationToken.None);
 
-        Assert.Contains("test memory content", result);
+        Assert.Contains("Akka.NET clustering guide", result);
+        Assert.Contains("cluster sharding", result);
     }
 
     [Fact]
-    public void MemoryIndexContextLayer_connected_shows_behavioral_triggers()
+    public void MemoryIndexContextLayer_file_backed_shows_store_memory_guidance()
     {
         var layer = new MemoryIndexContextLayer();
-        layer.Update(connected: true);
+        layer.Update(MemoryContextState.FileBacked);
 
         var content = layer.GetContextLayer();
 
-        // Behavioral triggers — retrieve and save rules
         Assert.Contains("RETRIEVE:", content);
         Assert.Contains("SAVE:", content);
         Assert.Contains("search_memories", content);
-        Assert.Contains("memorizer/store", content);
+        Assert.Contains("store_memory", content);
+        Assert.Contains("memory.md", content);
+        Assert.DoesNotContain("memorizer/store", content);
+        Assert.DoesNotContain("NOT AVAILABLE", content);
+    }
 
-        // Organization guidance still present
+    [Fact]
+    public void MemoryIndexContextLayer_memorizer_connected_shows_memorizer_guidance()
+    {
+        var layer = new MemoryIndexContextLayer();
+        layer.Update(MemoryContextState.MemorizerConnected);
+
+        var content = layer.GetContextLayer();
+
+        Assert.Contains("RETRIEVE:", content);
+        Assert.Contains("SAVE:", content);
+        Assert.Contains("memorizer/store", content);
         Assert.Contains("workspaces", content);
         Assert.Contains("projects", content);
         Assert.Contains("memorizer-usage", content);
@@ -80,39 +91,16 @@ public class SearchMemoriesToolTests
     }
 
     [Fact]
-    public void MemoryIndexContextLayer_disconnected_shows_unavailable_with_fallback()
+    public void MemoryIndexContextLayer_memorizer_disconnected_shows_troubleshooting()
     {
         var layer = new MemoryIndexContextLayer();
-        layer.Update(connected: false);
+        layer.Update(MemoryContextState.MemorizerDisconnected);
 
         var content = layer.GetContextLayer();
 
         Assert.Contains("NOT AVAILABLE", content);
-        // Fallback guidance — save to identity/skill files instead
+        Assert.Contains("not connected", content);
+        Assert.Contains("McpServers", content);
         Assert.Contains("SOUL.md", content);
-        Assert.Contains("identity-management", content);
-        Assert.Contains("skill", content, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Minimal INetclawTool fake for testing SearchMemoriesTool delegation.
-    /// </summary>
-    private sealed class FakeNetclawTool : Netclaw.Tools.INetclawTool
-    {
-        private readonly string _result;
-
-        public FakeNetclawTool(string name, string result)
-        {
-            Name = name;
-            _result = result;
-        }
-
-        public string Name { get; }
-        public string Description => "Fake tool";
-        public string GrantCategory => "mcp:memorizer";
-        public System.Text.Json.JsonElement ParameterSchema => default;
-        public AITool ToAITool() => AIFunctionFactory.Create(() => _result, name: Name, description: Description);
-        public Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
-            => Task.FromResult(_result);
     }
 }

--- a/src/Netclaw.Actors.Tests/Memory/StoreMemoryToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/StoreMemoryToolTests.cs
@@ -1,0 +1,93 @@
+using Netclaw.Actors.Memory;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+public class StoreMemoryToolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileMemoryStore _store;
+
+    public StoreMemoryToolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new FileMemoryStore(_tempDir, TimeProvider.System);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void Grant_category_is_builtin()
+    {
+        var tool = new StoreMemoryTool(_store);
+        Assert.Equal("builtin", tool.GrantCategory);
+    }
+
+    [Fact]
+    public async Task Stores_memory_and_returns_confirmation()
+    {
+        var tool = new StoreMemoryTool(_store);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?>
+            {
+                ["Title"] = "Test Memory",
+                ["Content"] = "Some test content"
+            },
+            CancellationToken.None);
+
+        Assert.Contains("Memory saved", result);
+        Assert.Contains("Test Memory", result);
+
+        // Verify file was created
+        var entries = await _store.GetEntriesAsync();
+        Assert.Single(entries);
+        Assert.Equal("Test Memory", entries[0].Title);
+    }
+
+    [Fact]
+    public async Task Parses_comma_separated_tags()
+    {
+        var tool = new StoreMemoryTool(_store);
+
+        await tool.ExecuteAsync(
+            new Dictionary<string, object?>
+            {
+                ["Title"] = "Tagged Memory",
+                ["Content"] = "Content",
+                ["Tags"] = "reference, how-to, akka"
+            },
+            CancellationToken.None);
+
+        var entries = await _store.GetEntriesAsync();
+        Assert.Single(entries);
+        Assert.Contains("reference", entries[0].Tags);
+        Assert.Contains("how-to", entries[0].Tags);
+        Assert.Contains("akka", entries[0].Tags);
+    }
+
+    [Fact]
+    public async Task Handles_null_tags()
+    {
+        var tool = new StoreMemoryTool(_store);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?>
+            {
+                ["Title"] = "No Tags Memory",
+                ["Content"] = "Content with no tags"
+            },
+            CancellationToken.None);
+
+        Assert.Contains("Memory saved", result);
+
+        var entries = await _store.GetEntriesAsync();
+        Assert.Single(entries);
+        Assert.Empty(entries[0].Tags);
+    }
+}

--- a/src/Netclaw.Actors/Memory/FileMemoryExtractor.cs
+++ b/src/Netclaw.Actors/Memory/FileMemoryExtractor.cs
@@ -1,0 +1,29 @@
+using Netclaw.Actors.Sessions;
+
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// Memory extractor that persists session extraction results to local markdown files
+/// via <see cref="FileMemoryStore"/>. Used when Memory.Provider = "files".
+/// </summary>
+public sealed class FileMemoryExtractor : IMemoryExtractor
+{
+    private readonly FileMemoryStore _store;
+
+    public FileMemoryExtractor(FileMemoryStore store)
+    {
+        _store = store;
+    }
+
+    public async Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(extractedMemories))
+            return;
+
+        await _store.StoreAsync(
+            $"Session extraction — {sessionId}",
+            extractedMemories,
+            ["extraction", "compaction"],
+            ct);
+    }
+}

--- a/src/Netclaw.Actors/Memory/FileMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/FileMemoryStore.cs
@@ -1,0 +1,289 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// File-backed memory store using markdown files with YAML front matter.
+/// Manages <c>~/.netclaw/memories/</c> with a progressive-discovery index.
+/// Thread-safe via <see cref="SemaphoreSlim"/> for write operations.
+/// </summary>
+public sealed partial class FileMemoryStore
+{
+    private readonly string _memoriesDirectory;
+    private readonly TimeProvider _timeProvider;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    /// <summary>Cached index entries, rebuilt on first use or after writes.</summary>
+    private List<MemoryEntry>? _cachedEntries;
+
+    public FileMemoryStore(string memoriesDirectory, TimeProvider timeProvider)
+    {
+        _memoriesDirectory = memoriesDirectory;
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Store a new memory as a markdown file with YAML front matter.
+    /// Rebuilds the index after writing.
+    /// </summary>
+    public async Task StoreAsync(string title, string content, string[]? tags = null, CancellationToken ct = default)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            Directory.CreateDirectory(_memoriesDirectory);
+
+            var now = _timeProvider.GetUtcNow();
+            var fileName = GenerateFileName(now, title);
+            var filePath = Path.Combine(_memoriesDirectory, fileName);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("---");
+            sb.AppendLine($"title: \"{EscapeYamlString(title)}\"");
+            if (tags is { Length: > 0 })
+                sb.AppendLine($"tags: [{string.Join(", ", tags)}]");
+            sb.AppendLine($"created: {now:yyyy-MM-ddTHH:mm:ssZ}");
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.Append(content);
+
+            await File.WriteAllTextAsync(filePath, sb.ToString(), ct);
+
+            // Invalidate cache and rebuild index
+            _cachedEntries = null;
+            await RebuildIndexAsync(ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Search memories by substring match against title, tags, and content.
+    /// Scores: title match > tag match > content match.
+    /// </summary>
+    public async Task<IReadOnlyList<MemorySearchResult>> SearchAsync(string query, int maxResults = 5, CancellationToken ct = default)
+    {
+        var entries = await GetEntriesAsync(ct);
+        if (entries.Count == 0 || string.IsNullOrWhiteSpace(query))
+            return [];
+
+        var queryLower = query.ToLowerInvariant();
+        var queryTerms = queryLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        var scored = new List<MemorySearchResult>();
+
+        foreach (var entry in entries)
+        {
+            var score = ScoreEntry(entry, queryTerms);
+            if (score > 0)
+            {
+                scored.Add(new MemorySearchResult(entry.Title, entry.Tags, entry.Content, entry.FilePath, score));
+            }
+        }
+
+        return scored
+            .OrderByDescending(r => r.Score)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Get all indexed entries, rebuilding from disk on first access.
+    /// </summary>
+    internal async Task<IReadOnlyList<MemoryEntry>> GetEntriesAsync(CancellationToken ct = default)
+    {
+        if (_cachedEntries is not null)
+            return _cachedEntries;
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            // Double-check after acquiring lock
+            if (_cachedEntries is not null)
+                return _cachedEntries;
+
+            _cachedEntries = ScanMemoryFiles();
+            await WriteIndexFileAsync(_cachedEntries, ct);
+            return _cachedEntries;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private List<MemoryEntry> ScanMemoryFiles()
+    {
+        var entries = new List<MemoryEntry>();
+
+        if (!Directory.Exists(_memoriesDirectory))
+            return entries;
+
+        var indexFileName = Path.GetFileName(GetIndexPath());
+
+        foreach (var filePath in Directory.EnumerateFiles(_memoriesDirectory, "*.md"))
+        {
+            var fileName = Path.GetFileName(filePath);
+            if (string.Equals(fileName, indexFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var entry = ParseMemoryFile(filePath);
+            if (entry is not null)
+                entries.Add(entry);
+        }
+
+        return entries.OrderByDescending(e => e.Created).ToList();
+    }
+
+    private static MemoryEntry? ParseMemoryFile(string filePath)
+    {
+        string text;
+        try
+        {
+            text = File.ReadAllText(filePath);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+
+        var title = Path.GetFileNameWithoutExtension(filePath);
+        string[] tags = [];
+        DateTimeOffset created = default;
+        var content = text;
+
+        // Parse YAML front matter
+        if (text.StartsWith("---", StringComparison.Ordinal))
+        {
+            var endIndex = text.IndexOf("\n---", 3, StringComparison.Ordinal);
+            if (endIndex > 0)
+            {
+                var frontMatter = text[3..endIndex].Trim();
+                content = text[(endIndex + 4)..].TrimStart('\r', '\n');
+
+                foreach (var line in frontMatter.Split('\n'))
+                {
+                    var trimmed = line.Trim();
+                    if (trimmed.StartsWith("title:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        title = trimmed[6..].Trim().Trim('"');
+                    }
+                    else if (trimmed.StartsWith("tags:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var tagsPart = trimmed[5..].Trim().Trim('[', ']');
+                        tags = tagsPart.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    }
+                    else if (trimmed.StartsWith("created:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var dateStr = trimmed[8..].Trim();
+                        DateTimeOffset.TryParse(dateStr, CultureInfo.InvariantCulture, DateTimeStyles.None, out created);
+                    }
+                }
+            }
+        }
+
+        return new MemoryEntry(title, tags, content, filePath, created);
+    }
+
+    private static double ScoreEntry(MemoryEntry entry, string[] queryTerms)
+    {
+        double score = 0;
+        var titleLower = entry.Title.ToLowerInvariant();
+        var tagsLower = string.Join(" ", entry.Tags).ToLowerInvariant();
+        var contentLower = entry.Content.ToLowerInvariant();
+
+        foreach (var term in queryTerms)
+        {
+            if (titleLower.Contains(term, StringComparison.Ordinal))
+                score += 3.0;
+            if (tagsLower.Contains(term, StringComparison.Ordinal))
+                score += 2.0;
+            if (contentLower.Contains(term, StringComparison.Ordinal))
+                score += 1.0;
+        }
+
+        return score;
+    }
+
+    private async Task RebuildIndexAsync(CancellationToken ct)
+    {
+        var entries = _cachedEntries ?? ScanMemoryFiles();
+        _cachedEntries = entries;
+        await WriteIndexFileAsync(entries, ct);
+    }
+
+    private async Task WriteIndexFileAsync(List<MemoryEntry> entries, CancellationToken ct)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Memory Index");
+        sb.AppendLine();
+
+        if (entries.Count == 0)
+        {
+            sb.AppendLine("_No memories stored yet._");
+        }
+        else
+        {
+            sb.AppendLine("| Date | Title | Tags |");
+            sb.AppendLine("|------|-------|------|");
+
+            foreach (var entry in entries)
+            {
+                var date = entry.Created == default ? "unknown" : entry.Created.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var tags = entry.Tags.Length > 0 ? string.Join(", ", entry.Tags) : "";
+                var fileName = Path.GetFileName(entry.FilePath);
+                sb.AppendLine($"| {date} | [{EscapeMarkdownPipe(entry.Title)}]({fileName}) | {EscapeMarkdownPipe(tags)} |");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"_Total: {entries.Count} memories_");
+
+        await File.WriteAllTextAsync(GetIndexPath(), sb.ToString(), ct);
+    }
+
+    private string GetIndexPath() => Path.Combine(_memoriesDirectory, "memory.md");
+
+    internal static string GenerateFileName(DateTimeOffset date, string title)
+    {
+        var kebab = KebabCaseRegex().Replace(title.Trim().ToLowerInvariant(), "-");
+        kebab = MultiDashRegex().Replace(kebab, "-").Trim('-');
+        if (kebab.Length > 60)
+            kebab = kebab[..60].TrimEnd('-');
+        return $"{date:yyyy-MM-dd}-{kebab}.md";
+    }
+
+    private static string EscapeYamlString(string value) => value.Replace("\"", "\\\"");
+
+    private static string EscapeMarkdownPipe(string value) => value.Replace("|", "\\|");
+
+    [GeneratedRegex(@"[^a-z0-9]+")]
+    private static partial Regex KebabCaseRegex();
+
+    [GeneratedRegex(@"-{2,}")]
+    private static partial Regex MultiDashRegex();
+}
+
+/// <summary>
+/// Parsed memory file entry with front matter metadata.
+/// </summary>
+public sealed record MemoryEntry(
+    string Title,
+    string[] Tags,
+    string Content,
+    string FilePath,
+    DateTimeOffset Created);
+
+/// <summary>
+/// Search result with relevance score.
+/// </summary>
+public sealed record MemorySearchResult(
+    string Title,
+    string[] Tags,
+    string Content,
+    string FilePath,
+    double Score);

--- a/src/Netclaw.Actors/Memory/MemorizerMemoryExtractor.cs
+++ b/src/Netclaw.Actors/Memory/MemorizerMemoryExtractor.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tools;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// Memory extractor that persists session extraction results to Memorizer MCP server.
+/// Resolves the <c>memorizer/store</c> MCP tool at call time via <see cref="ToolRegistry"/>.
+/// Graceful no-op if Memorizer is disconnected.
+/// </summary>
+public sealed class MemorizerMemoryExtractor : IMemoryExtractor
+{
+    private readonly ToolRegistry _toolRegistry;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Known MCP tool names for Memorizer's store operation. Checked in order.
+    /// </summary>
+    private static readonly string[] MemorizerStoreToolNames =
+    [
+        "memorizer/store",
+        "memorizer/store_memory"
+    ];
+
+    public MemorizerMemoryExtractor(ToolRegistry toolRegistry, ILogger<MemorizerMemoryExtractor>? logger = null)
+    {
+        _toolRegistry = toolRegistry;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+    public async Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(extractedMemories))
+            return;
+
+        var mcpTool = FindStoreTool();
+        if (mcpTool is null)
+        {
+            _logger.LogWarning(
+                "Memory extraction for session {SessionId} skipped — Memorizer MCP not connected",
+                sessionId);
+            return;
+        }
+
+        var arguments = new Dictionary<string, object?>
+        {
+            ["type"] = "reference",
+            ["title"] = $"Session extraction — {sessionId}",
+            ["text"] = extractedMemories,
+            ["source"] = "compaction",
+            ["tags"] = new[] { "extraction", "compaction" }
+        };
+
+        try
+        {
+            await mcpTool.ExecuteAsync(arguments, ct);
+            _logger.LogInformation(
+                "Memory extraction persisted to Memorizer for session {SessionId}",
+                sessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to persist memory extraction for session {SessionId}",
+                sessionId);
+        }
+    }
+
+    private INetclawTool? FindStoreTool()
+    {
+        foreach (var name in MemorizerStoreToolNames)
+        {
+            var tool = _toolRegistry.GetByName(name);
+            if (tool is not null)
+                return tool;
+        }
+
+        return null;
+    }
+}

--- a/src/Netclaw.Actors/Memory/SearchMemoriesTool.cs
+++ b/src/Netclaw.Actors/Memory/SearchMemoriesTool.cs
@@ -1,17 +1,17 @@
 using System.ComponentModel;
 using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Netclaw.Actors.Tools;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Memory;
 
 /// <summary>
-/// Meta-tool that wraps the Memorizer MCP server's <c>search_memories</c> tool.
-/// Resolves the underlying MCP tool at call time via <see cref="ToolRegistry"/>.
-/// Returns graceful error if Memorizer is not connected.
+/// File-backed memory search tool. Searches local markdown memory files
+/// by substring matching against title, tags, and content.
+/// Only registered when Memory.Provider = "files".
+/// When Memorizer is configured, <c>memorizer/search_memories</c> is available
+/// directly through MCP discovery — no builtin wrapper needed.
 /// </summary>
 [NetclawTool("search_memories",
     "Search cross-session memory for prior knowledge, saved context, and project information. "
@@ -19,17 +19,8 @@ namespace Netclaw.Actors.Memory;
     Grant = "builtin")]
 public sealed partial class SearchMemoriesTool : NetclawTool<SearchMemoriesTool.Params>
 {
-    private readonly ToolRegistry _toolRegistry;
+    private readonly FileMemoryStore _store;
     private readonly ILogger _logger;
-
-    /// <summary>
-    /// Known MCP tool names for Memorizer's search. Checked in order.
-    /// </summary>
-    private static readonly string[] MemorizerToolNames =
-    [
-        "memorizer/search_memories",
-        "memorizer/search"
-    ];
 
     public record Params(
         [property: Description("Search query to find relevant memories")]
@@ -37,38 +28,40 @@ public sealed partial class SearchMemoriesTool : NetclawTool<SearchMemoriesTool.
         [property: Description("Maximum number of results to return (default 5)")]
         int? Limit = null);
 
-    public SearchMemoriesTool(ToolRegistry toolRegistry, ILogger<SearchMemoriesTool>? logger = null)
+    public SearchMemoriesTool(FileMemoryStore store, ILogger<SearchMemoriesTool>? logger = null)
     {
-        _toolRegistry = toolRegistry;
+        _store = store;
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
-        var mcpTool = FindMemorizerTool();
-        if (mcpTool is null)
-        {
-            _logger.LogWarning("Memory search requested but Memorizer MCP is not connected");
-            return "Memory store is not available. Memorizer MCP server is not connected. "
-                   + "Check McpServers configuration in netclaw.json.";
-        }
-
-        var arguments = new Dictionary<string, object?>
-        {
-            ["query"] = args.Query
-        };
-
-        if (args.Limit is > 0)
-            arguments["limit"] = args.Limit.Value;
+        var limit = args.Limit is > 0 ? args.Limit.Value : 5;
 
         try
         {
-            var result = await mcpTool.ExecuteAsync(arguments, ct);
-            var formatted = FormatResult(result);
+            var results = await _store.SearchAsync(args.Query, limit, ct);
 
+            if (results.Count == 0)
+            {
+                _logger.LogInformation("Memory search: query='{Query}', no results", args.Query);
+                return "No memories found.";
+            }
+
+            var sb = new StringBuilder();
+            foreach (var result in results)
+            {
+                sb.AppendLine($"━━━ {result.Title} ━━━");
+                if (result.Tags.Length > 0)
+                    sb.AppendLine($"Tags: {string.Join(", ", result.Tags)}");
+                sb.AppendLine(result.Content);
+                sb.AppendLine();
+            }
+
+            var formatted = sb.ToString().TrimEnd();
             _logger.LogInformation(
-                "Memory search: query='{Query}', result={ResultLength} chars",
-                args.Query, formatted.Length);
+                "Memory search: query='{Query}', results={Count}, chars={Chars}",
+                args.Query, results.Count, formatted.Length);
 
             return formatted;
         }
@@ -76,64 +69,6 @@ public sealed partial class SearchMemoriesTool : NetclawTool<SearchMemoriesTool.
         {
             _logger.LogError(ex, "Memory search failed: query='{Query}'", args.Query);
             return $"Error searching memories: {ex.Message}";
-        }
-    }
-
-    private INetclawTool? FindMemorizerTool()
-    {
-        foreach (var name in MemorizerToolNames)
-        {
-            var tool = _toolRegistry.GetByName(name);
-            if (tool is not null)
-                return tool;
-        }
-
-        return null;
-    }
-
-    private static string FormatResult(string rawResult)
-    {
-        if (string.IsNullOrWhiteSpace(rawResult))
-            return "No memories found.";
-
-        // If the result is already readable text, return as-is
-        if (!rawResult.TrimStart().StartsWith('{') && !rawResult.TrimStart().StartsWith('['))
-            return rawResult;
-
-        // Try to parse and format JSON for readability
-        try
-        {
-            using var doc = JsonDocument.Parse(rawResult);
-            var sb = new StringBuilder();
-
-            if (doc.RootElement.ValueKind == JsonValueKind.Array)
-            {
-                var count = 0;
-                foreach (var item in doc.RootElement.EnumerateArray())
-                {
-                    count++;
-                    if (item.TryGetProperty("title", out var title))
-                        sb.AppendLine($"━━━ {title.GetString()} ━━━");
-
-                    if (item.TryGetProperty("text", out var text))
-                        sb.AppendLine(text.GetString());
-                    else if (item.TryGetProperty("content", out var content))
-                        sb.AppendLine(content.GetString());
-
-                    sb.AppendLine();
-                }
-
-                if (count == 0)
-                    return "No memories found.";
-
-                return sb.ToString().TrimEnd();
-            }
-
-            return rawResult;
-        }
-        catch (JsonException)
-        {
-            return rawResult;
         }
     }
 }

--- a/src/Netclaw.Actors/Memory/StoreMemoryTool.cs
+++ b/src/Netclaw.Actors/Memory/StoreMemoryTool.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Memory;
+
+/// <summary>
+/// File-backed memory storage tool. Saves memories as markdown files
+/// in the local memories directory. Only registered when Memory.Provider = "files".
+/// </summary>
+[NetclawTool("store_memory",
+    "Save knowledge to cross-session memory for future retrieval. "
+    + "Use for solutions, decisions, research findings, and project context.",
+    Grant = "builtin")]
+public sealed partial class StoreMemoryTool : NetclawTool<StoreMemoryTool.Params>
+{
+    private readonly FileMemoryStore _store;
+    private readonly ILogger _logger;
+
+    public record Params(
+        [property: Description("Title for the memory entry")]
+        string Title,
+        [property: Description("Content to store — use markdown, include code blocks, provide full context")]
+        string Content,
+        [property: Description("Optional comma-separated tags for categorization (e.g. \"reference, how-to, decision\")")]
+        string? Tags = null);
+
+    public StoreMemoryTool(FileMemoryStore store, ILogger<StoreMemoryTool>? logger = null)
+    {
+        _store = store;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        var tags = ParseTags(args.Tags);
+
+        try
+        {
+            await _store.StoreAsync(args.Title, args.Content, tags, ct);
+            _logger.LogInformation("Memory stored: title='{Title}'", args.Title);
+            return $"Memory saved: \"{args.Title}\"";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to store memory: title='{Title}'", args.Title);
+            return $"Error saving memory: {ex.Message}";
+        }
+    }
+
+    private static string[]? ParseTags(string? tagsCsv)
+    {
+        if (string.IsNullOrWhiteSpace(tagsCsv))
+            return null;
+
+        var tags = tagsCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return tags.Length > 0 ? tags : null;
+    }
+}

--- a/src/Netclaw.Configuration/MemoryConfig.cs
+++ b/src/Netclaw.Configuration/MemoryConfig.cs
@@ -1,0 +1,15 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for the cross-session memory subsystem.
+/// <c>Provider</c> selects the backend: "files" for local markdown files,
+/// "memorizer" for the Memorizer MCP server.
+/// </summary>
+public sealed class MemoryConfig
+{
+    /// <summary>
+    /// Memory backend provider. "files" (default) uses local markdown files;
+    /// "memorizer" delegates to the Memorizer MCP server.
+    /// </summary>
+    public string Provider { get; set; } = "files";
+}

--- a/src/Netclaw.Configuration/MemoryIndexContextLayer.cs
+++ b/src/Netclaw.Configuration/MemoryIndexContextLayer.cs
@@ -1,50 +1,108 @@
 namespace Netclaw.Configuration;
 
 /// <summary>
-/// Dynamic context layer that indicates Memorizer availability status.
-/// Updated after MCP discovery completes.
+/// The three possible states for the memory context layer.
+/// </summary>
+public enum MemoryContextState
+{
+    /// <summary>
+    /// File-backed memory using local markdown files.
+    /// <c>search_memories</c> and <c>store_memory</c> are always-loaded builtins.
+    /// </summary>
+    FileBacked,
+
+    /// <summary>
+    /// Memorizer MCP server is configured and connected.
+    /// Full graph: workspaces, projects, relationships, similarity search.
+    /// </summary>
+    MemorizerConnected,
+
+    /// <summary>
+    /// Memorizer MCP server is configured but not connected.
+    /// </summary>
+    MemorizerDisconnected
+}
+
+/// <summary>
+/// Dynamic context layer that provides memory subsystem guidance to the LLM.
+/// Updated after MCP discovery completes based on the configured provider
+/// and Memorizer connectivity status.
 /// </summary>
 public sealed class MemoryIndexContextLayer : IContextLayerProvider
 {
     private volatile string _status = string.Empty;
 
     /// <summary>
-    /// Update the Memorizer status. Call with connected=true after
-    /// Memorizer MCP tools are registered, or connected=false otherwise.
+    /// Update the memory context layer based on the resolved state.
     /// </summary>
-    public void Update(bool connected)
+    public void Update(MemoryContextState state)
     {
-        _status = connected
-            ? """
-              [memories — cross-session knowledge via Memorizer]
+        _status = state switch
+        {
+            MemoryContextState.FileBacked => """
+                [memories — file-backed cross-session knowledge]
 
-              RETRIEVE: At the start of each conversation, search_memories for topics
-              relevant to the user's first message. Also search when asked about something
-              you might have encountered before. Check before answering from scratch.
+                RETRIEVE: At the start of each conversation, search_memories for topics
+                relevant to the user's first message. Also search when asked about something
+                you might have encountered before. Check before answering from scratch.
 
-              SAVE: When you learn something worth remembering across sessions, save it
-              immediately using memorizer/store. Write rich content: use markdown, include
-              code blocks, provide full context. Good memories are self-contained — a future
-              agent reading them should understand without the original conversation.
+                SAVE: When you learn something worth remembering across sessions, save it
+                immediately using store_memory. Write rich content: use markdown, include
+                code blocks, provide full context. Good memories are self-contained — a future
+                agent reading them should understand without the original conversation.
 
-              What to save: solutions to problems, user-confirmed facts, architecture
-              decisions, research findings, troubleshooting steps, project context.
+                What to save: solutions to problems, user-confirmed facts, architecture
+                decisions, research findings, troubleshooting steps, project context.
 
-              What NOT to save: ephemeral task state, things already in identity files,
-              unverified guesses, duplicate information (search first).
+                What NOT to save: ephemeral task state, things already in identity files,
+                unverified guesses, duplicate information (search first).
 
-              Organization: workspaces (domains) → projects (goals) → memories (documents
-              or records). Assign to the right workspace/project. Use tags: reference,
-              how-to, decision, troubleshooting, coding-standard.
+                Tags: reference, how-to, decision, troubleshooting, coding-standard.
 
-              For full guidance: file_read ~/.netclaw/skills/memorizer-usage.md
-              """
-            : """
-              [memories — NOT AVAILABLE: Memorizer MCP server not connected]
-              Cross-session memory is unavailable. Save important knowledge to identity
-              files (SOUL.md, AGENTS.md, TOOLING.md) or skill files (~/.netclaw/skills/)
-              instead. See identity-management skill for triage guidance.
-              """;
+                The memory index at ~/.netclaw/memories/memory.md lists all stored memories.
+                """,
+
+            MemoryContextState.MemorizerConnected => """
+                [memories — cross-session knowledge via Memorizer]
+
+                RETRIEVE: At the start of each conversation, search_memories for topics
+                relevant to the user's first message. Also search when asked about something
+                you might have encountered before. Check before answering from scratch.
+
+                SAVE: When you learn something worth remembering across sessions, save it
+                immediately using memorizer/store. Write rich content: use markdown, include
+                code blocks, provide full context. Good memories are self-contained — a future
+                agent reading them should understand without the original conversation.
+
+                What to save: solutions to problems, user-confirmed facts, architecture
+                decisions, research findings, troubleshooting steps, project context.
+
+                What NOT to save: ephemeral task state, things already in identity files,
+                unverified guesses, duplicate information (search first).
+
+                Organization: workspaces (domains) → projects (goals) → memories (documents
+                or records). Assign to the right workspace/project. Use tags: reference,
+                how-to, decision, troubleshooting, coding-standard.
+
+                For full guidance: file_read ~/.netclaw/skills/memorizer-usage.md
+                """,
+
+            MemoryContextState.MemorizerDisconnected => """
+                [memories — NOT AVAILABLE: Memorizer MCP server not connected]
+
+                Cross-session memory is configured to use Memorizer, but the MCP server is not
+                connected. Troubleshooting:
+                1. Check McpServers configuration in netclaw.json
+                2. Verify the Memorizer server is running
+                3. Check daemon logs for MCP connection errors
+
+                Save important knowledge to identity files (SOUL.md, AGENTS.md, TOOLING.md)
+                or skill files (~/.netclaw/skills/) instead.
+                See identity-management skill for triage guidance.
+                """,
+
+            _ => string.Empty
+        };
     }
 
     public string GetContextLayer() => _status;

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -31,6 +31,10 @@ public sealed class NetclawPaths
     // ── Skills directory (procedural context) ──
     public string SkillsDirectory => Path.Combine(BasePath, "skills");
 
+    // ── Memory directory (file-backed cross-session memory) ──
+    public string MemoriesDirectory => Path.Combine(BasePath, "memories");
+    public string MemoryIndexPath => Path.Combine(MemoriesDirectory, "memory.md");
+
     // ── Other standard directories ──
     public string ProjectsDirectory => Path.Combine(BasePath, "projects");
     public string EnvironmentDirectory => Path.Combine(BasePath, "environment");
@@ -72,6 +76,7 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(ConfigDirectory);
         Directory.CreateDirectory(LogsDirectory);
         Directory.CreateDirectory(SessionLogsDirectory);
+        Directory.CreateDirectory(MemoriesDirectory);
         Directory.CreateDirectory(SessionsDirectory);
     }
 }

--- a/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
+++ b/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
@@ -10,24 +10,27 @@ namespace Netclaw.Daemon.Mcp;
 /// Runs after <see cref="McpClientManager"/> so MCP tools are included in the index.
 /// The tool index is written to system-managed shadow files and injected dynamically
 /// into each LLM call via file-backed context layers. Also updates memory context layers
-/// based on Memorizer connectivity.
+/// based on config provider + Memorizer connectivity.
 /// </summary>
 internal sealed class ToolIndexUpdater : IHostedService
 {
     private readonly McpShadowCatalogWriter _shadowCatalogWriter;
     private readonly ToolRegistry _toolRegistry;
     private readonly MemoryIndexContextLayer _memoryIndexLayer;
+    private readonly MemoryConfig _memoryConfig;
     private readonly ILogger<ToolIndexUpdater> _logger;
 
     public ToolIndexUpdater(
         McpShadowCatalogWriter shadowCatalogWriter,
         ToolRegistry toolRegistry,
         MemoryIndexContextLayer memoryIndexLayer,
+        MemoryConfig memoryConfig,
         ILogger<ToolIndexUpdater> logger)
     {
         _shadowCatalogWriter = shadowCatalogWriter;
         _toolRegistry = toolRegistry;
         _memoryIndexLayer = memoryIndexLayer;
+        _memoryConfig = memoryConfig;
         _logger = logger;
     }
 
@@ -36,16 +39,27 @@ internal sealed class ToolIndexUpdater : IHostedService
         _shadowCatalogWriter.WriteCatalogs();
         _logger.LogInformation("Tool index updated ({ToolCount} registrations)", _toolRegistry.GetAllRegistrations().Count);
 
-        // Detect Memorizer connectivity by checking for known MCP tool names
-        var memorizerConnected =
-            _toolRegistry.GetByName("memorizer/search_memories") is not null
-            || _toolRegistry.GetByName("memorizer/search") is not null;
-
-        _memoryIndexLayer.Update(memorizerConnected);
-        _logger.LogInformation("Memory context layer updated (Memorizer connected: {Connected})", memorizerConnected);
+        var state = ResolveMemoryState();
+        _memoryIndexLayer.Update(state);
+        _logger.LogInformation("Memory context layer updated (state: {State})", state);
 
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private MemoryContextState ResolveMemoryState()
+    {
+        if (!_memoryConfig.Provider.Equals("memorizer", StringComparison.OrdinalIgnoreCase))
+            return MemoryContextState.FileBacked;
+
+        // Memorizer path: check if MCP tools are actually connected
+        var memorizerConnected =
+            _toolRegistry.GetByName("memorizer/search_memories") is not null
+            || _toolRegistry.GetByName("memorizer/search") is not null;
+
+        return memorizerConnected
+            ? MemoryContextState.MemorizerConnected
+            : MemoryContextState.MemorizerDisconnected;
+    }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -267,8 +267,25 @@ static void ConfigureDaemonServices(
         skillRegistry.Register(skill);
     services.AddSingleton(skillRegistry);
 
-    // Cross-session memory: search_memories wraps Memorizer MCP tool
-    toolRegistry.Register(new SearchMemoriesTool(toolRegistry));
+    // Cross-session memory: provider-based wiring
+    var memoryConfig = configuration.GetSection("Memory")
+        .Get<MemoryConfig>() ?? new MemoryConfig();
+    services.AddSingleton(memoryConfig);
+
+    if (memoryConfig.Provider.Equals("memorizer", StringComparison.OrdinalIgnoreCase))
+    {
+        // Memorizer path: no builtin memory tools — MCP discovery handles everything
+        services.AddSingleton<IMemoryExtractor>(sp =>
+            new MemorizerMemoryExtractor(sp.GetRequiredService<ToolRegistry>()));
+    }
+    else
+    {
+        // File path: register builtin memory tools backed by local markdown files
+        var fileStore = new FileMemoryStore(paths.MemoriesDirectory, TimeProvider.System);
+        toolRegistry.Register(new SearchMemoriesTool(fileStore));
+        toolRegistry.Register(new StoreMemoryTool(fileStore));
+        services.AddSingleton<IMemoryExtractor>(new FileMemoryExtractor(fileStore));
+    }
 
     services.AddSingleton(toolRegistry);
     services.AddSingleton<IToolExecutor>(sp =>


### PR DESCRIPTION
## Summary

- **File-backed memory store** as the default cross-session memory backend (`~/.netclaw/memories/`), working out of the box with zero configuration
- **`store_memory` and `search_memories`** registered as always-loaded builtin tools when `Memory.Provider = "files"` (default)
- **`MemoryConfig`** with explicit provider selection — `"files"` (default) or `"memorizer"` (opt-in)
- **Real `IMemoryExtractor` implementations** replacing `NullMemoryExtractor` — `FileMemoryExtractor` for file path, `MemorizerMemoryExtractor` for Memorizer MCP path
- **Three-state `MemoryIndexContextLayer`** — `FileBacked`, `MemorizerConnected`, `MemorizerDisconnected` with provider-specific LLM guidance
- **Conditional DI wiring** in `Program.cs` — file path registers builtins + file extractor, memorizer path registers MCP extractor only

### Smoke test results (dolphin3 on Ollama)

| | File-backed | Memorizer MCP |
|---|---|---|
| **Implicit retrieve** | 1 call, works | 3-7 calls, name confusion |
| **Implicit store** | 1 call, done | 6 calls, never stored |
| **Token cost** | ~1,600 | ~4,800 (3x) |

File-backed memory is the right default for local/small models. Memorizer as an upgrade path will be addressed in a follow-up with a curation agent design.

## Test plan

- [x] `dotnet build` — zero errors
- [x] `dotnet test` — 137/137 pass (27 new memory tests + 110 existing)
- [x] `dotnet slopwatch analyze` — zero new violations
- [x] Smoke test: daemon starts with file-backed default, tools registered, store + search work implicitly via dolphin3
- [x] Smoke test: daemon starts with `Provider = "memorizer"`, builtin tools not registered, MCP tools available via discovery