### PR TITLE
Anchor daemon process CWD to user-owned temp directory

### DIFF
--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -41,6 +41,14 @@ catch (Exception ex)
 
 static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSignal)
 {
+    // Anchor process CWD to a user-owned temp directory.
+    // Without this, the daemon runs from its install location (e.g. /usr/local/bin),
+    // which means shell commands, relative file paths, and stdio MCP child processes
+    // (Playwright screenshots, etc.) all default to a potentially privileged directory.
+    var netclawTempDir = Path.Combine(Path.GetTempPath(), "netclaw");
+    Directory.CreateDirectory(netclawTempDir);
+    Environment.CurrentDirectory = netclawTempDir;
+
     var builder = WebApplication.CreateBuilder(args);
 
     // Use port 5199 to avoid conflicts with Aspire (5000) and other defaults


### PR DESCRIPTION
## Summary

- Sets `Environment.CurrentDirectory` to `$TMPDIR/netclaw/` at daemon startup, before the host is built
- Without this, the daemon inherits its launch directory (e.g. `/usr/local/bin` when installed as a system service), causing shell commands, relative file paths, and stdio MCP child processes to operate in a potentially privileged or unintended location
- Covers all file I/O surfaces at once: `shell_execute`, `file_read`/`file_write` with relative paths, and stdio MCP child processes (e.g. Playwright screenshots) which inherit the daemon CWD

## Test plan

- [ ] Verify daemon starts cleanly and `$TMPDIR/netclaw/` is created
- [ ] Confirm `shell_execute` with no `WorkingDirectory` runs in `$TMPDIR/netclaw/`
- [ ] Confirm relative paths in `file_write`/`file_read` resolve under `$TMPDIR/netclaw/`
- [ ] Verify stdio MCP server processes (e.g. Playwright) inherit the anchored CWD