### PR TITLE
Add MentionRequiredInDm option and auto-enable DMs when user IDs are set

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -189,6 +189,7 @@ Slack Socket Mode channel configuration.
 | `DefaultChannelName` | string? | `null` | Optional channel name resolved to channel ID at startup. |
 | `MentionOnly` | bool | `true` | If true, plain `message` events are ignored unless the bot is mentioned. |
 | `AllowDirectMessages` | bool | `false` | If true, DM messages do not require mention. |
+| `MentionRequiredInDm` | bool | `false` | If true, DM messages also require a bot mention. Only applies when `AllowDirectMessages` is true. |
 | `AllowedChannelIds` | string[] | `[]` | Allow-list of Slack channel IDs. Empty means no channels are allowed. |
 | `AllowedUserIds` | string[] | `[]` | Optional allow-list of Slack user IDs. Empty means all users in allowed channels/DM policy are accepted. |
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
@@ -14,6 +14,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -29,6 +30,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: true);
 
@@ -44,6 +46,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: true,
             containsBotMention: false);
 
@@ -61,6 +64,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -76,6 +80,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -91,10 +96,43 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
         Assert.Equal(SlackRoutingDecision.Ignore, decision);
+    }
+
+    [Fact]
+    public void DirectMessage_Ignored_WhenMentionRequired_AndNoMention()
+    {
+        var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            mentionRequiredInDm: true,
+            threadExists: false,
+            containsBotMention: false);
+
+        Assert.Equal(SlackRoutingDecision.Ignore, decision);
+    }
+
+    [Fact]
+    public void DirectMessage_Processed_WhenMentionRequired_AndMentionPresent()
+    {
+        var message = CreateMessage(text: "<@U1> hey", threadTs: null, isDirectMessage: true);
+
+        var decision = SlackRoutingPolicy.Evaluate(
+            message,
+            mentionOnly: true,
+            allowDirectMessages: true,
+            mentionRequiredInDm: true,
+            threadExists: false,
+            containsBotMention: true);
+
+        Assert.Equal(SlackRoutingDecision.StartOrContinue, decision);
     }
 
     [Fact]
@@ -110,6 +148,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: true,
             containsBotMention: false);
 
@@ -129,6 +168,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: true);
 
@@ -148,6 +188,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: false,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -167,6 +208,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: false,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -186,6 +228,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: true,
             allowDirectMessages: true,
+            mentionRequiredInDm: false,
             threadExists: true,
             containsBotMention: false);
 
@@ -202,6 +245,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: false,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -217,6 +261,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: false,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 
@@ -232,6 +277,7 @@ public class SlackRoutingPolicyTests
             message,
             mentionOnly: false,
             allowDirectMessages: false,
+            mentionRequiredInDm: false,
             threadExists: false,
             containsBotMention: false);
 

--- a/src/Netclaw.Actors.Tests/Configuration/SlackChannelOptionsDefaultsTests.cs
+++ b/src/Netclaw.Actors.Tests/Configuration/SlackChannelOptionsDefaultsTests.cs
@@ -19,6 +19,7 @@ public sealed class SlackChannelOptionsDefaultsTests
         Assert.True(options.SocketMode);
         Assert.True(options.MentionOnly);
         Assert.False(options.AllowDirectMessages);
+        Assert.False(options.MentionRequiredInDm);
         Assert.Empty(options.AllowedChannelIds);
         Assert.Empty(options.AllowedUserIds);
     }
@@ -42,6 +43,7 @@ public sealed class SlackChannelOptionsDefaultsTests
         Assert.Equal("openclaw", options.DefaultChannelName);
         Assert.True(options.MentionOnly);
         Assert.False(options.AllowDirectMessages);
+        Assert.False(options.MentionRequiredInDm);
         Assert.Empty(options.AllowedChannelIds);
         Assert.Empty(options.AllowedUserIds);
     }

--- a/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannelOptions.cs
@@ -20,6 +20,13 @@ public sealed class SlackChannelOptions
 
     public bool AllowDirectMessages { get; init; }
 
+    /// <summary>
+    /// If true, DMs require a bot mention just like channel messages.
+    /// Default is false — DMs are processed without requiring a mention.
+    /// Only applies when <see cref="AllowDirectMessages"/> is true.
+    /// </summary>
+    public bool MentionRequiredInDm { get; init; } = false;
+
     public string[] AllowedChannelIds { get; init; } = [];
 
     public string[] AllowedUserIds { get; init; } = [];

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -59,6 +59,7 @@ public sealed class SlackConversationActor : ReceiveActor
                 message,
                 _dependencies.Options.MentionOnly,
                 _dependencies.Options.AllowDirectMessages,
+                _dependencies.Options.MentionRequiredInDm,
                 threadExists,
                 containsMention);
 

--- a/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
+++ b/src/Netclaw.Channels/Slack/SlackRoutingPolicy.cs
@@ -6,6 +6,7 @@ public static class SlackRoutingPolicy
         SlackInboundMessage message,
         bool mentionOnly,
         bool allowDirectMessages,
+        bool mentionRequiredInDm,
         bool threadExists,
         bool containsBotMention)
     {
@@ -35,7 +36,13 @@ public static class SlackRoutingPolicy
         }
 
         if (message.IsDirectMessage)
-            return allowDirectMessages ? SlackRoutingDecision.StartOrContinue : SlackRoutingDecision.Ignore;
+        {
+            if (!allowDirectMessages)
+                return SlackRoutingDecision.Ignore;
+            if (mentionRequiredInDm && !containsBotMention)
+                return SlackRoutingDecision.Ignore;
+            return SlackRoutingDecision.StartOrContinue;
+        }
 
         if (threadExists)
             return SlackRoutingDecision.ContinueOnly;

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -803,6 +803,31 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task HealthCheck_AutoEnablesDm_WhenUserIdsProvided()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+        vm.SlackAllowDirectMessages = false; // not explicitly enabled
+        vm.SlackAllowedUserIdsInput = "U001ABC";
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(vm.IsComplete.Value);
+
+        var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        Assert.True(config.RootElement.TryGetProperty("Slack", out var slack));
+        Assert.True(slack.GetProperty("AllowDirectMessages").GetBoolean());
+
+        var allowedUsers = slack.GetProperty("AllowedUserIds");
+        Assert.Equal(1, allowedUsers.GetArrayLength());
+        Assert.Equal("U001ABC", allowedUsers[0].GetString());
+    }
+
+    [Fact]
     public void WriteIdentityFiles_GeneratesAllThreeFiles()
     {
         using var vm = CreateViewModel();

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -657,12 +657,12 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 slackSection["DefaultChannelId"] = ids[0];
             }
 
-            if (SlackAllowDirectMessages)
+            var userIds = ParseUserIds(SlackAllowedUserIdsInput);
+            if (SlackAllowDirectMessages || userIds.Count > 0)
             {
                 slackSection["AllowDirectMessages"] = true;
             }
 
-            var userIds = ParseUserIds(SlackAllowedUserIdsInput);
             if (userIds.Count > 0)
             {
                 slackSection["AllowedUserIds"] = userIds.ToArray();

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -18,6 +18,7 @@
         "DefaultChannelName": { "type": ["string", "null"] },
         "MentionOnly": { "type": "boolean" },
         "AllowDirectMessages": { "type": "boolean" },
+        "MentionRequiredInDm": { "type": "boolean" },
         "AllowedChannelIds": {
           "type": "array",
           "items": { "type": "string" }


### PR DESCRIPTION
## Summary

- Adds `MentionRequiredInDm` (default `false`) to `SlackChannelOptions`, allowing DM mention requirements to be configured independently from channel mention behavior
- Wires the new flag through `SlackRoutingPolicy.Evaluate` and `SlackConversationActor`
- Updates the init wizard so that providing allowed user IDs in the Chat Services step automatically enables `AllowDirectMessages` in the written config — if you're explicitly allow-listing users, they should be able to DM without needing to separately toggle the flag
- Updates JSON schema, configuration spec, and all affected tests (18 routing policy tests + 2 defaults tests + 37 wizard tests all pass)

## Test plan

- [ ] `dotnet test src/Netclaw.Actors.Tests/ --filter "SlackRoutingPolicy|SlackChannelOptionsDefaults"` — 18 tests pass
- [ ] `dotnet test src/Netclaw.Cli.Tests/ --filter "InitWizardViewModel"` — 37 tests pass
- [ ] `dotnet slopwatch analyze` — 0 violations