### PR TITLE
Add OllamaCapabilityResolver for provider-first capability detection

### DIFF
--- a/src/Netclaw.Configuration/Providers/Descriptors/OllamaDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OllamaDescriptor.cs
@@ -8,6 +8,8 @@ namespace Netclaw.Configuration.Providers.Descriptors;
 /// </summary>
 public sealed class OllamaDescriptor : IProviderDescriptor
 {
+    public const string DefaultEndpointValue = "http://localhost:11434";
+
     private readonly HttpClient _httpClient;
 
     public OllamaDescriptor(HttpClient httpClient)
@@ -18,7 +20,7 @@ public sealed class OllamaDescriptor : IProviderDescriptor
     public string TypeKey => "ollama";
     public string DisplayName => "Ollama";
     public IReadOnlyList<AuthMethod> SupportedAuthMethods => [AuthMethod.None];
-    public string DefaultEndpoint => "http://localhost:11434";
+    public string DefaultEndpoint => DefaultEndpointValue;
     public string ModelListingPath => "/api/tags";
     public CredentialInputMode CredentialMode => CredentialInputMode.EndpointOnly;
     public string? ApiKeyGuidanceUrl => null;

--- a/src/Netclaw.Daemon.Tests/Providers/OllamaCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OllamaCapabilityResolverTests.cs
@@ -1,0 +1,120 @@
+using Netclaw.Configuration;
+using Netclaw.Daemon.Providers;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class OllamaCapabilityResolverTests
+{
+    [Fact]
+    public void ParseShowResponse_Qwen35_ContextWindow()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "general.architecture": "qwen35",
+            "qwen35.context_length": 262144,
+            "qwen35.embedding_length": 3072
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "qwen3.5:9b");
+
+        Assert.NotNull(result);
+        Assert.Equal(262_144, result.ContextWindowTokens);
+        Assert.Equal("qwen3.5:9b", result.ModelId);
+    }
+
+    [Fact]
+    public void ParseShowResponse_VisionModel()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "general.architecture": "llava",
+            "llava.context_length": 4096,
+            "llava.vision.block_count": 23
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "llava:13b");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+        Assert.Equal(4096, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void ParseShowResponse_TextOnly()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "general.architecture": "qwen35",
+            "qwen35.context_length": 131072
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "qwen3.5:30b");
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void ParseShowResponse_MissingModelInfo_ReturnsNull()
+    {
+        const string json = """
+        {
+          "license": "apache-2.0",
+          "modelfile": "FROM qwen3.5:9b"
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "qwen3.5:9b");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseShowResponse_MissingContextLength()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "general.architecture": "qwen35",
+            "qwen35.embedding_length": 3072
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "qwen3.5:9b");
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+    }
+
+    [Fact]
+    public void ParseShowResponse_MissingArchitecture()
+    {
+        const string json = """
+        {
+          "model_info": {
+            "some.other.key": 42
+          }
+        }
+        """;
+
+        var result = OllamaCapabilityResolver.ParseShowResponse(json, "mystery-model");
+
+        Assert.NotNull(result);
+        Assert.Null(result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -207,14 +207,27 @@ static void ConfigureDaemonServices(
     services.AddSingleton(models);
 
     // Auto-detect model capabilities when not manually specified in config.
-    // Uses the OpenRouter public catalog as an oracle — works for models from
-    // any provider since OpenRouter indexes most publicly available models.
+    // Provider-first resolution: query the hosting provider (e.g. Ollama /api/show)
+    // before falling back to external oracles (OpenRouter, HuggingFace).
+    var providers = configuration.GetSection("Providers")
+        .Get<Dictionary<string, ProviderEntry>>()
+        ?? new() { ["local-ollama"] = new ProviderEntry() };
+    var mainProviderType = providers.TryGetValue(models.Main.Provider, out var mainProvider)
+        ? mainProvider.Type
+        : null;
+    var ollamaEndpoint = mainProviderType?.Equals("ollama", StringComparison.OrdinalIgnoreCase) == true
+        ? (string.IsNullOrWhiteSpace(mainProvider!.Endpoint)
+            ? Netclaw.Configuration.Providers.Descriptors.OllamaDescriptor.DefaultEndpointValue
+            : mainProvider.Endpoint)
+        : null;
+
     var inputModalities = models.Main.InputModalities;
     var outputModalities = models.Main.OutputModalities;
     int? contextWindow = models.Main.ContextWindow;
     if (inputModalities is null || outputModalities is null || contextWindow is null)
     {
-        var detected = ResolveStartupCapabilities(models.Main.ModelId, daemonLogLevel);
+        var detected = ResolveStartupCapabilities(
+            models.Main.ModelId, daemonLogLevel, mainProviderType, ollamaEndpoint);
         if (detected is not null)
         {
             inputModalities ??= detected.InputModalities;
@@ -329,16 +342,32 @@ static void ConfigureDaemonServices(
     services.AddSingleton<SchemaMigrationHostedService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SchemaMigrationHostedService>());
 
-    // Model capability resolution chain: OpenRouter oracle → HuggingFace → text-only default
+    // Model capability resolution chain: [Ollama →] OpenRouter oracle → HuggingFace → text-only default
+    // When the main provider is Ollama, query it first — it knows the true context window
+    // for locally hosted models that may not be indexed by external oracles.
     services.AddHttpClient<OpenRouterOracleResolver>();
     services.AddHttpClient<HuggingFaceCapabilityResolver>();
+    if (ollamaEndpoint is not null)
+    {
+        services.AddHttpClient(nameof(OllamaCapabilityResolver));
+        services.AddSingleton(sp =>
+            new OllamaCapabilityResolver(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(OllamaCapabilityResolver)),
+                sp.GetRequiredService<ILogger<OllamaCapabilityResolver>>(),
+                ollamaEndpoint));
+    }
     services.AddSingleton<IModelCapabilityResolver>(sp =>
-        new CompositeCapabilityResolver(
-            [
-                sp.GetRequiredService<OpenRouterOracleResolver>(),
-                sp.GetRequiredService<HuggingFaceCapabilityResolver>(),
-            ],
-            sp.GetRequiredService<ILogger<CompositeCapabilityResolver>>()));
+    {
+        var resolvers = new List<IModelCapabilityResolver>();
+        if (ollamaEndpoint is not null)
+            resolvers.Add(sp.GetRequiredService<OllamaCapabilityResolver>());
+        resolvers.Add(sp.GetRequiredService<OpenRouterOracleResolver>());
+        resolvers.Add(sp.GetRequiredService<HuggingFaceCapabilityResolver>());
+
+        return new CompositeCapabilityResolver(
+            resolvers,
+            sp.GetRequiredService<ILogger<CompositeCapabilityResolver>>());
+    });
 
     // Akka.NET actor system
     services.AddAkka("netclaw", (akkaBuilder, sp) =>
@@ -426,18 +455,39 @@ static ISearchBackend? CreateSearchBackend(SearchConfig config)
 
 /// <summary>
 /// One-time capability detection at startup. Creates temporary HTTP resources
-/// to query the OpenRouter public catalog before the DI container is built.
+/// to query the hosting provider (Ollama) or OpenRouter public catalog before
+/// the DI container is built.
 /// Returns null if detection fails (caller falls back to text-only).
 /// </summary>
-static ResolvedModelCapabilities? ResolveStartupCapabilities(string modelId, LogLevel logLevel)
+static ResolvedModelCapabilities? ResolveStartupCapabilities(
+    string modelId, LogLevel logLevel, string? providerType, string? ollamaEndpoint)
 {
     try
     {
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
         using var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(logLevel));
         var logger = loggerFactory.CreateLogger("Netclaw.Startup");
-        // Build a minimal registry for the resolver (pre-DI bootstrap).
-        // Only the OpenRouter descriptor is needed for capability detection.
+
+        // Provider-first: try Ollama /api/show when running against an Ollama backend
+        if (providerType?.Equals("ollama", StringComparison.OrdinalIgnoreCase) == true
+            && ollamaEndpoint is not null)
+        {
+            var ollamaResolver = new OllamaCapabilityResolver(
+                httpClient, loggerFactory.CreateLogger<OllamaCapabilityResolver>(), ollamaEndpoint);
+            var ollamaResult = ollamaResolver.ResolveAsync(modelId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+
+            if (ollamaResult is not null)
+            {
+                logger.LogInformation(
+                    "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
+                    modelId, ollamaResult.InputModalities, ollamaResult.OutputModalities,
+                    ollamaResult.ContextWindowTokens?.ToString() ?? "unknown");
+                return ollamaResult;
+            }
+        }
+
+        // Fallback: OpenRouter public catalog (works for models from any provider)
         var openRouterDescriptor = new Netclaw.Configuration.Providers.Descriptors.OpenRouterDescriptor(httpClient);
         var registry = new ProviderDescriptorRegistry([openRouterDescriptor]);
         var resolver = new OpenRouterOracleResolver(
@@ -456,7 +506,7 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(string modelId, Log
         else
         {
             logger.LogInformation(
-                "Model {ModelId} not found in OpenRouter catalog; defaulting to text-only",
+                "Model {ModelId} not found in capability oracles; defaulting to text-only",
                 modelId);
         }
 

--- a/src/Netclaw.Daemon/Providers/OllamaCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/OllamaCapabilityResolver.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Providers;
+
+/// <summary>
+/// Resolves model capabilities by querying the Ollama <c>POST /api/show</c>
+/// endpoint. Extracts context window and vision support from the
+/// <c>model_info</c> object, which uses architecture-prefixed flat keys
+/// (e.g. <c>"qwen35.context_length"</c>).
+/// </summary>
+public sealed class OllamaCapabilityResolver : IModelCapabilityResolver
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OllamaCapabilityResolver> _logger;
+    private readonly string _endpoint;
+
+    public OllamaCapabilityResolver(
+        HttpClient httpClient,
+        ILogger<OllamaCapabilityResolver> logger,
+        string endpoint)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _endpoint = endpoint.TrimEnd('/');
+    }
+
+    public async Task<ResolvedModelCapabilities?> ResolveAsync(
+        string modelId, CancellationToken ct = default)
+    {
+        try
+        {
+            var requestBody = JsonSerializer.Serialize(new { name = modelId });
+            using var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+            using var response = await _httpClient.PostAsync($"{_endpoint}/api/show", content, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "Ollama /api/show returned {Status} for model {ModelId}",
+                    response.StatusCode, modelId);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            return ParseShowResponse(json, modelId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex,
+                "Ollama capability detection failed for {ModelId}", modelId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses the Ollama <c>/api/show</c> JSON response to extract model
+    /// capabilities. Architecture-prefixed keys in <c>model_info</c> are
+    /// used to determine context window and vision support.
+    /// </summary>
+    internal static ResolvedModelCapabilities? ParseShowResponse(string json, string modelId)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("model_info", out var modelInfo))
+            return null;
+
+        // Read the architecture prefix (e.g. "qwen35", "llava")
+        string? arch = null;
+        if (modelInfo.TryGetProperty("general.architecture", out var archProp))
+            arch = archProp.GetString();
+
+        int? contextWindow = null;
+        var inputModalities = ModelModality.Text;
+
+        if (arch is not null)
+        {
+            // Context window: "{arch}.context_length"
+            if (modelInfo.TryGetProperty($"{arch}.context_length", out var ctxProp) &&
+                ctxProp.ValueKind == JsonValueKind.Number)
+            {
+                contextWindow = ctxProp.GetInt32();
+            }
+
+            // Vision: "{arch}.vision.block_count" > 0 means image input
+            if (modelInfo.TryGetProperty($"{arch}.vision.block_count", out var visionProp) &&
+                visionProp.ValueKind == JsonValueKind.Number &&
+                visionProp.GetInt32() > 0)
+            {
+                inputModalities = ModelModality.Text | ModelModality.Image;
+            }
+        }
+
+        // Ollama only serves text generators — output is always text
+        return new ResolvedModelCapabilities(modelId, inputModalities, ModelModality.Text, contextWindow);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `OllamaCapabilityResolver` that queries `POST /api/show` to extract context window and vision support from `model_info` arch-prefixed keys
- Updates capability resolution chain to **Ollama → OpenRouter → HuggingFace** when the main provider is Ollama
- Fixes detection for models like `qwen3.5:9b` (256k context) that aren't indexed on external catalogs

## Test plan
- [x] 6 new `ParseShowResponse` unit tests (context window, vision, text-only, missing model_info, missing context_length, missing architecture)
- [x] Full test suite passes (227 tests)
- [x] `dotnet slopwatch analyze` — 0 new violations
- [ ] Manual: restart daemon with `qwen3.5:9b` → logs should show `context_window=262144`