### PR TITLE
Add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: Test-${{matrix.os}}
     runs-on: ${{matrix.os}}
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -62,6 +63,7 @@ jobs:
   slopwatch:
     name: Slopwatch
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -13,6 +13,7 @@ jobs:
 
     name: publish-nuget
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes` to every CI job that was missing one to prevent runaway runs from consuming the Actions quota
- `pr_validation`: `test` → 30 min, `slopwatch` → 10 min
- `publish_nuget`: `publish-nuget` → 20 min
- `publish_skills`: `publish` → 10 min
- `smoke_sandbox` already had `timeout-minutes: 45` — left unchanged

## Test plan
- [ ] Verify PR validation workflow triggers and completes within the new limits
- [ ] Confirm no legitimate jobs are cut short by the new timeouts