### PR TITLE
Retry Brave Search 429 responses with Retry-After backoff

### DIFF
--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http.Headers;
 using Netclaw.Search;
 using Xunit;
 
@@ -97,6 +99,81 @@ public class BraveSearchBackendTests
         Assert.Equal("https://example.com", results[0].Url);
     }
 
+    [Fact]
+    public async Task SearchAsync_retries_on_429_then_succeeds()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var rateLimitResponse = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        rateLimitResponse.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+        handler.Enqueue(rateLimitResponse);
+        handler.Enqueue(CreateSuccessResponse());
+
+        var backend = new BraveSearchBackend("test-key", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 10, CancellationToken.None);
+
+        Assert.IsType<SearchBackendResult.Success>(result);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_error_after_max_retries_on_429()
+    {
+        var handler = new FakeHttpMessageHandler();
+        for (var i = 0; i < 3; i++)
+        {
+            var r = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            r.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+            handler.Enqueue(r);
+        }
+
+        var backend = new BraveSearchBackend("test-key", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 10, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("rate limit", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(3, handler.RequestCount);
+    }
+
+    [Fact]
+    public void ParseRetryAfter_returns_delta_from_header()
+    {
+        var header = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+        var delay = BraveSearchBackend.ParseRetryAfter(header, 0, TimeProvider.System);
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
+    }
+
+    [Fact]
+    public void ParseRetryAfter_returns_remaining_time_from_date_header()
+    {
+        var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var future = now.AddSeconds(45);
+        var header = new RetryConditionHeaderValue(future);
+        var fakeTime = new FixedTimeProvider(now);
+
+        var delay = BraveSearchBackend.ParseRetryAfter(header, 0, fakeTime);
+
+        Assert.Equal(TimeSpan.FromSeconds(45), delay);
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(1, 10)]
+    [InlineData(2, 20)]
+    public void ParseRetryAfter_falls_back_to_exponential_backoff_when_header_absent(int attempt, int expectedSeconds)
+    {
+        var delay = BraveSearchBackend.ParseRetryAfter(null, attempt, TimeProvider.System);
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    private static HttpResponseMessage CreateSuccessResponse()
+    {
+        const string json = """{"web":{"results":[{"title":"Test Result","url":"https://example.com","description":"A test result"}]}}""";
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+    }
+
     private static string LoadFixture(string filename)
     {
         var assembly = typeof(BraveSearchBackendTests).Assembly;
@@ -105,5 +182,26 @@ public class BraveSearchBackendTests
             ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public int RequestCount { get; private set; }
+
+        public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("No more responses queued.");
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/src/Netclaw.Search/BraveSearchBackend.cs
+++ b/src/Netclaw.Search/BraveSearchBackend.cs
@@ -12,50 +12,88 @@ namespace Netclaw.Search;
 public sealed partial class BraveSearchBackend : ISearchBackend
 {
     private const string BaseUrl = "https://api.search.brave.com/res/v1/web/search";
+    private const int MaxRetries = 3;
 
     private readonly HttpClient _httpClient;
     private readonly string _apiKey;
+    private readonly TimeProvider _timeProvider;
 
-    public BraveSearchBackend(string apiKey, HttpClient? httpClient = null)
+    public BraveSearchBackend(string apiKey, HttpClient? httpClient = null, TimeProvider? timeProvider = null)
     {
         _apiKey = apiKey;
         _httpClient = httpClient ?? new HttpClient();
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
     {
-        try
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
         {
-            var url = $"{BaseUrl}?q={Uri.EscapeDataString(query)}&count={maxResults}";
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.TryAddWithoutValidation("X-Subscription-Token", _apiKey);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+            try
+            {
+                var url = $"{BaseUrl}?q={Uri.EscapeDataString(query)}&count={maxResults}";
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.TryAddWithoutValidation("X-Subscription-Token", _apiKey);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
 
-            using var response = await _httpClient.SendAsync(request, ct);
+                using var response = await _httpClient.SendAsync(request, ct);
 
-            if (response.StatusCode == HttpStatusCode.Unauthorized)
-                return new SearchBackendResult.Error(
-                    "Brave Search API authentication failed. Check your API key in secrets.json (Search.BraveApiKey).");
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    return new SearchBackendResult.Error(
+                        "Brave Search API authentication failed. Check your API key in secrets.json (Search.BraveApiKey).");
 
-            if (response.StatusCode == (HttpStatusCode)429)
-                return new SearchBackendResult.Error(
-                    "Brave Search API rate limit exceeded. Wait before retrying or upgrade your plan.");
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    if (attempt == MaxRetries - 1)
+                        break;
 
-            response.EnsureSuccessStatusCode();
+                    var delay = ParseRetryAfter(response.Headers.RetryAfter, attempt, _timeProvider);
+                    await Task.Delay(delay, ct);
+                    continue;
+                }
 
-            var json = await response.Content.ReadAsStringAsync(ct);
-            var results = ParseResults(json, maxResults);
-            return new SearchBackendResult.Success(results);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync(ct);
+                var results = ParseResults(json, maxResults);
+                return new SearchBackendResult.Success(results);
+            }
+            catch (HttpRequestException ex)
+            {
+                return new SearchBackendResult.Error($"Brave Search request failed: {ex.Message}");
+            }
+            catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+            {
+                return new SearchBackendResult.Error("Brave Search request timed out.");
+            }
         }
-        catch (HttpRequestException ex)
+
+        return new SearchBackendResult.Error(
+            "Brave Search API rate limit exceeded. Wait before retrying or upgrade your plan.");
+    }
+
+    /// <summary>
+    /// Parses the Retry-After response header into a wait duration.
+    /// Falls back to exponential backoff (5s, 10s, 20s) when the header is absent or in the past.
+    /// </summary>
+    internal static TimeSpan ParseRetryAfter(RetryConditionHeaderValue? retryAfter, int attempt, TimeProvider timeProvider)
+    {
+        if (retryAfter is not null)
         {
-            return new SearchBackendResult.Error($"Brave Search request failed: {ex.Message}");
+            if (retryAfter.Delta.HasValue)
+                return retryAfter.Delta.Value;
+
+            if (retryAfter.Date.HasValue)
+            {
+                var remaining = retryAfter.Date.Value - timeProvider.GetUtcNow();
+                if (remaining > TimeSpan.Zero)
+                    return remaining;
+            }
         }
-        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return new SearchBackendResult.Error("Brave Search request timed out.");
-        }
+
+        // Exponential backoff: 5s, 10s, 20s
+        return TimeSpan.FromSeconds(5 * Math.Pow(2, attempt));
     }
 
     internal static List<SearchResult> ParseResults(string json, int maxResults)


### PR DESCRIPTION
## Summary

- BraveSearchBackend now retries up to 3 times on HTTP 429 (Too Many Requests) instead of immediately giving up
- Reads the `Retry-After` response header (delta seconds or HTTP date) to determine wait time; falls back to exponential backoff (5s → 10s → 20s) when the header is absent
- Injects `TimeProvider` for testable date calculations, consistent with `DuckDuckGoBackend`

## Test plan

- [x] `SearchAsync_retries_on_429_then_succeeds` — queues 429 then 200, verifies success and exactly 2 requests made
- [x] `SearchAsync_returns_error_after_max_retries_on_429` — queues 3× 429, verifies error message and exactly 3 requests
- [x] `ParseRetryAfter_returns_delta_from_header` — integer-seconds `Retry-After` header is honored
- [x] `ParseRetryAfter_returns_remaining_time_from_date_header` — HTTP-date `Retry-After` uses `FixedTimeProvider` for determinism
- [x] `ParseRetryAfter_falls_back_to_exponential_backoff_when_header_absent` — [Theory] over attempts 0/1/2 → 5/10/20s
- [x] All 30 existing tests continue to pass
- [x] `dotnet slopwatch analyze` — 0 violations

Closes #113