### PR TITLE
Harden accidental secret leak guardrails across tools

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -180,4 +180,62 @@ public class AttachFileToolTests : IDisposable
         Assert.Contains("Error", result);
         Assert.Empty(context.FileAttachments);
     }
+
+    [Fact]
+    public async Task Prefix_collision_path_is_rejected()
+    {
+        var outsideDir = _tempDir + "-outside";
+        Directory.CreateDirectory(outsideDir);
+        var outsideFile = Path.Combine(outsideDir, "secret.txt");
+        await File.WriteAllTextAsync(outsideFile, "sensitive");
+
+        var context = new ToolExecutionContext("test-session", _tempDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = outsideFile
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("session directory", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(context.FileAttachments);
+    }
+
+    [Fact]
+    public async Task Symlink_to_outside_file_is_rejected()
+    {
+        var outsideFile = Path.Combine(Path.GetTempPath(), $"netclaw-outside-{Guid.NewGuid():N}.txt");
+        var symlinkPath = Path.Combine(_tempDir, "linked.txt");
+
+        await File.WriteAllTextAsync(outsideFile, "sensitive data");
+
+        try
+        {
+            File.CreateSymbolicLink(symlinkPath, outsideFile);
+
+            var context = new ToolExecutionContext("test-session", _tempDir);
+            var args = new Dictionary<string, object?>
+            {
+                ["Path"] = symlinkPath
+            };
+
+            var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+            Assert.Contains("Error", result);
+            Assert.Contains("session directory", result, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(context.FileAttachments);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return;
+        }
+        finally
+        {
+            if (File.Exists(symlinkPath))
+                File.Delete(symlinkPath);
+            if (File.Exists(outsideFile))
+                File.Delete(outsideFile);
+        }
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -135,4 +135,15 @@ public class ShellToolTests
         Assert.Contains("protected file path", result);
         Assert.Contains("Access denied", result);
     }
+
+    [Fact]
+    public async Task Execute_redacts_secret_like_output()
+    {
+        var args = new Dictionary<string, object?> { ["Command"] = "echo API_KEY=secret123" };
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("API_KEY=***REDACTED***", result);
+        Assert.DoesNotContain("secret123", result);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -146,4 +146,22 @@ public class ShellToolTests
         Assert.Contains("API_KEY=***REDACTED***", result);
         Assert.DoesNotContain("secret123", result);
     }
+
+    [Fact]
+    public async Task High_risk_glob_on_netclaw_config_is_blocked()
+    {
+        var secretsPath = "/home/user/.netclaw/config/secrets.json";
+        var policy = new ToolPathPolicy([secretsPath]);
+        var tool = new ShellTool(new ToolConfig(), policy);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["Command"] = "cat ~/.netclaw/config/*.json"
+        };
+
+        var result = await tool.ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Contains("protected file path", result);
+        Assert.Contains("Access denied", result);
+    }
 }

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -28,22 +28,53 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         if (string.IsNullOrWhiteSpace(context.SessionDirectory))
             return Task.FromResult("Error: No session directory available.");
 
-        // Canonicalize both paths to prevent traversal attacks
-        var sessionDir = Path.GetFullPath(context.SessionDirectory);
-        var filePath = Path.GetFullPath(args.Path);
+        var sessionDir = NormalizeDirectoryPath(context.SessionDirectory);
+        var requestedPath = Path.GetFullPath(args.Path);
 
-        if (!filePath.StartsWith(sessionDir, StringComparison.OrdinalIgnoreCase))
+        if (!IsPathWithinDirectory(requestedPath, sessionDir))
             return Task.FromResult($"Error: File path must be within the session directory ({sessionDir}).");
 
-        if (!File.Exists(filePath))
-            return Task.FromResult($"Error: File not found: {filePath}");
+        if (!File.Exists(requestedPath))
+            return Task.FromResult($"Error: File not found: {requestedPath}");
 
-        var rawFilename = args.DisplayName ?? Path.GetFileName(filePath);
+        var resolvedPath = ResolveFinalPath(requestedPath);
+        if (!IsPathWithinDirectory(resolvedPath, sessionDir))
+            return Task.FromResult($"Error: File path must be within the session directory ({sessionDir}).");
+
+        var rawFilename = args.DisplayName ?? Path.GetFileName(resolvedPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
-        var mimeType = GuessMimeType(filePath);
+        var mimeType = GuessMimeType(resolvedPath);
 
-        context.AddFileAttachment(filePath, sanitizedFilename, mimeType);
-        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {filePath}");
+        context.AddFileAttachment(resolvedPath, sanitizedFilename, mimeType);
+        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {resolvedPath}");
+    }
+
+    private static string NormalizeDirectoryPath(string directoryPath)
+    {
+        return Path.GetFullPath(directoryPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static bool IsPathWithinDirectory(string path, string directory)
+    {
+        var fullPath = Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (!fullPath.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (fullPath.Length == directory.Length)
+            return true;
+
+        var boundary = fullPath[directory.Length];
+        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
+    }
+
+    private static string ResolveFinalPath(string path)
+    {
+        var fileInfo = new FileInfo(path);
+        var target = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
+        return target is null ? fileInfo.FullName : target.FullName;
     }
 
     private static string GuessMimeType(string path)

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -116,7 +116,8 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
                 result.Append(errorBuilder);
             }
 
-            var output = TruncateOutput(result.ToString(), _config.MaxOutputChars);
+            var sanitized = SecretOutputRedactor.Redact(result.ToString());
+            var output = TruncateOutput(sanitized, _config.MaxOutputChars);
             return $"Exit code: {process.ExitCode}{Environment.NewLine}{output}";
         }
     }

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -34,7 +34,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         if (string.IsNullOrWhiteSpace(args.Command))
             return "Error: 'command' parameter is required.";
 
-        if (_pathPolicy?.CommandReferencesDeniedPath(args.Command) == true)
+        if (_pathPolicy?.CommandReferencesDeniedPath(args.Command, args.WorkingDirectory) == true)
             return "Error: Command references a protected file path. Access denied by security policy.";
 
         var isWindows = OperatingSystem.IsWindows();

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -69,7 +69,12 @@ public sealed class McpCommandTests : IDisposable
         Assert.True(secrets.RootElement.TryGetProperty("McpServers", out var mcpSecrets));
         Assert.True(mcpSecrets.TryGetProperty("myserver", out var serverSecrets));
         Assert.True(serverSecrets.TryGetProperty("EnvironmentVariables", out var envVars));
-        Assert.Equal("secret123", envVars.GetProperty("API_KEY").GetString());
+        var encrypted = envVars.GetProperty("API_KEY").GetString();
+        Assert.StartsWith("ENC:", encrypted);
+
+        // Loader should transparently decrypt encrypted values
+        var loaded = McpCommand.LoadMcpServers(_paths);
+        Assert.Equal("secret123", loaded["myserver"].EnvironmentVariables?["API_KEY"]);
     }
 
     [Fact]
@@ -84,7 +89,12 @@ public sealed class McpCommandTests : IDisposable
         Assert.True(secrets.RootElement.TryGetProperty("McpServers", out var mcpSecrets));
         Assert.True(mcpSecrets.TryGetProperty("myapi", out var serverSecrets));
         Assert.True(serverSecrets.TryGetProperty("Headers", out var headers));
-        Assert.Equal("Bearer tok-123", headers.GetProperty("Authorization").GetString());
+        var encrypted = headers.GetProperty("Authorization").GetString();
+        Assert.StartsWith("ENC:", encrypted);
+
+        // Loader should transparently decrypt encrypted values
+        var loaded = McpCommand.LoadMcpServers(_paths);
+        Assert.Equal("Bearer tok-123", loaded["myapi"].Headers?["Authorization"]);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -95,7 +95,12 @@ public sealed class ProviderCommandTests : IDisposable
         var secrets = ReadConfigFile(_paths.SecretsPath);
         Assert.True(secrets.RootElement.TryGetProperty("Providers", out var secretProviders));
         Assert.True(secretProviders.TryGetProperty("my-openrouter", out var secretEntry));
-        Assert.Equal("sk-or-test-123", secretEntry.GetProperty("ApiKey").GetString());
+        var encrypted = secretEntry.GetProperty("ApiKey").GetString();
+        Assert.StartsWith("ENC:", encrypted);
+
+        // Verify provider loader decrypts back to usable plaintext
+        var loaded = ProviderCommand.LoadProviders(_paths);
+        Assert.Equal("sk-or-test-123", loaded["my-openrouter"].ApiKey?.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
 
 namespace Netclaw.Cli.Config;
 
@@ -89,5 +91,23 @@ internal static class ConfigFileHelper
         if (dir is not null)
             Directory.CreateDirectory(dir);
         File.WriteAllText(path, JsonSerializer.Serialize(data, JsonOptions));
+    }
+
+    /// <summary>
+    /// Serialize and write secrets.json using hardened permissions and encryption-at-rest.
+    /// </summary>
+    internal static void WriteSecretsFile(Configuration.NetclawPaths paths, Dictionary<string, object> data)
+    {
+        var protector = SecretsProtection.CreateProtector(paths);
+        SecretsFileWriter.Write(paths.SecretsPath, data, options: JsonOptions, protector: protector);
+    }
+
+    internal static string DecryptIfEncrypted(Configuration.NetclawPaths paths, string? value)
+    {
+        if (string.IsNullOrEmpty(value) || !ISecretsProtector.IsEncrypted(value))
+            return value ?? string.Empty;
+
+        var protector = SecretsProtection.CreateProtector(paths);
+        return protector.Unprotect(value);
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -202,7 +202,7 @@ internal static class McpCommand
                 serverSecrets["Headers"] = headers;
 
             secretMcp[name] = JsonSerializer.SerializeToElement(serverSecrets);
-            WriteConfigFile(paths.SecretsPath, secrets);
+            WriteSecretsFile(paths, secrets);
         }
 
         writer.WriteLine($"Added MCP server '{name}' ({transport})");
@@ -418,7 +418,7 @@ internal static class McpCommand
         var secretMcp = GetSectionOrNull(secrets, "McpServers");
         if (secretMcp?.Remove(name) == true)
         {
-            WriteConfigFile(paths.SecretsPath, secrets);
+            WriteSecretsFile(paths, secrets);
             removed = true;
         }
 
@@ -555,6 +555,9 @@ internal static class McpCommand
     private static void WriteConfigFile(string path, Dictionary<string, object> data)
         => ConfigFileHelper.WriteConfigFile(path, data);
 
+    private static void WriteSecretsFile(NetclawPaths paths, Dictionary<string, object> data)
+        => ConfigFileHelper.WriteSecretsFile(paths, data);
+
     internal static Dictionary<string, McpServerEntry> LoadMcpServers(NetclawPaths paths)
     {
         // Merge netclaw.json and secrets.json McpServers sections
@@ -589,14 +592,20 @@ internal static class McpCommand
                 {
                     entry.EnvironmentVariables ??= new Dictionary<string, string>();
                     foreach (var ev in envVars.EnumerateObject())
-                        entry.EnvironmentVariables[ev.Name] = ev.Value.GetString() ?? "";
+                    {
+                        var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, ev.Value.GetString());
+                        entry.EnvironmentVariables[ev.Name] = decrypted;
+                    }
                 }
 
                 if (prop.Value.TryGetProperty("Headers", out var hdrs))
                 {
                     entry.Headers ??= new Dictionary<string, string>();
                     foreach (var h in hdrs.EnumerateObject())
-                        entry.Headers[h.Name] = h.Value.GetString() ?? "";
+                    {
+                        var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, h.Value.GetString());
+                        entry.Headers[h.Name] = decrypted;
+                    }
                 }
             }
         }

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -143,7 +143,7 @@ internal static class ProviderCommand
             {
                 ["ApiKey"] = apiKey
             };
-            ConfigFileHelper.WriteConfigFile(paths.SecretsPath, secrets);
+            ConfigFileHelper.WriteSecretsFile(paths, secrets);
         }
 
         writer.WriteLine($"Added provider '{name}' ({type})");
@@ -184,7 +184,7 @@ internal static class ProviderCommand
         var secretProviders = ConfigFileHelper.GetSectionOrNull(secrets, "Providers");
         if (secretProviders?.Remove(name) == true)
         {
-            ConfigFileHelper.WriteConfigFile(paths.SecretsPath, secrets);
+            ConfigFileHelper.WriteSecretsFile(paths, secrets);
             removed = true;
         }
 
@@ -240,7 +240,10 @@ internal static class ProviderCommand
                     continue;
 
                 if (prop.Value.TryGetProperty("ApiKey", out var apiKey))
-                    entry.ApiKey = new SensitiveString(apiKey.GetString() ?? "");
+                {
+                    var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, apiKey.GetString());
+                    entry.ApiKey = new SensitiveString(decrypted);
+                }
             }
         }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -380,7 +380,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 {
                     ["ApiKey"] = FixApiKey
                 };
-                ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+                ConfigFileHelper.WriteSecretsFile(_paths, secrets);
             }
 
             if (FixEndpoint is not null && DetailProvider.Entry is not null
@@ -456,7 +456,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
         var secretProviders = ConfigFileHelper.GetSectionOrNull(secrets, "Providers");
         if (secretProviders?.Remove(RemoveProviderName) == true)
-            ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+            ConfigFileHelper.WriteSecretsFile(_paths, secrets);
 
         StatusMessage.Value = $"Removed provider '{RemoveProviderName}'. Restart daemon for changes to take effect.";
         RemoveProviderName = null;
@@ -683,7 +683,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             {
                 ["ApiKey"] = NewApiKey
             };
-            ConfigFileHelper.WriteConfigFile(_paths.SecretsPath, secrets);
+            ConfigFileHelper.WriteSecretsFile(_paths, secrets);
         }
     }
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -268,7 +268,7 @@ static void ConfigureDaemonServices(
     var searchBackend = CreateSearchBackend(searchConfig);
 
     // Tool path deny-list: prevent agent tools from accessing secrets
-    var toolPathPolicy = new ToolPathPolicy([paths.SecretsPath]);
+    var toolPathPolicy = new ToolPathPolicy([paths.SecretsPath, paths.KeysDirectory]);
     services.AddSingleton(toolPathPolicy);
 
     var toolRegistry = new ToolRegistry();

--- a/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
+++ b/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed class SecretOutputRedactorTests
+{
+    [Fact]
+    public void Redact_masks_json_secret_values()
+    {
+        const string input = "{\"apiKey\": \"sk-or-test-123\", \"safe\": \"ok\"}";
+
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Contains("\"apiKey\": \"***REDACTED***\"", redacted);
+        Assert.Contains("\"safe\": \"ok\"", redacted);
+        Assert.DoesNotContain("sk-or-test-123", redacted);
+    }
+
+    [Fact]
+    public void Redact_masks_env_style_secrets()
+    {
+        const string input = "API_KEY=secret123\nNORMAL=value";
+
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Contains("API_KEY=***REDACTED***", redacted);
+        Assert.Contains("NORMAL=value", redacted);
+        Assert.DoesNotContain("secret123", redacted);
+    }
+
+    [Fact]
+    public void Redact_masks_authorization_header()
+    {
+        const string input = "Authorization: Bearer abcdefghijklmnop";
+
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Equal("Authorization: Bearer ***REDACTED***", redacted);
+    }
+}

--- a/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
@@ -75,4 +75,37 @@ public sealed class ToolPathPolicyTests
         Assert.True(policy.IsDenied("/path/b"));
         Assert.False(policy.IsDenied("/path/c"));
     }
+
+    [Fact]
+    public void IsDenied_blocks_children_of_denied_directory()
+    {
+        var policy = new ToolPathPolicy(["/home/user/.netclaw/keys"]);
+        Assert.True(policy.IsDenied("/home/user/.netclaw/keys/keyring.xml"));
+    }
+
+    [Fact]
+    public void IsDenied_does_not_match_prefix_without_path_boundary()
+    {
+        var policy = new ToolPathPolicy(["/home/user/.netclaw/keys"]);
+        Assert.False(policy.IsDenied("/home/user/.netclaw/keys-backup/data.txt"));
+    }
+
+    [Fact]
+    public void CommandReferencesDeniedPath_detects_home_shorthand()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var policy = new ToolPathPolicy([Path.Combine(home, ".netclaw", "config", "secrets.json")]);
+
+        Assert.True(policy.CommandReferencesDeniedPath("cat ~/.netclaw/config/secrets.json"));
+        Assert.True(policy.CommandReferencesDeniedPath("cat $HOME/.netclaw/config/secrets.json"));
+    }
+
+    [Fact]
+    public void CommandReferencesDeniedPath_detects_keys_directory_access()
+    {
+        var policy = new ToolPathPolicy(["/home/user/.netclaw/keys"]);
+
+        Assert.True(policy.CommandReferencesDeniedPath("ls ~/.netclaw/keys"));
+        Assert.True(policy.CommandReferencesDeniedPath("tar czf /tmp/k.tgz ~/.netclaw/keys"));
+    }
 }

--- a/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ToolPathPolicyTests.cs
@@ -108,4 +108,21 @@ public sealed class ToolPathPolicyTests
         Assert.True(policy.CommandReferencesDeniedPath("ls ~/.netclaw/keys"));
         Assert.True(policy.CommandReferencesDeniedPath("tar czf /tmp/k.tgz ~/.netclaw/keys"));
     }
+
+    [Fact]
+    public void CommandReferencesDeniedPath_detects_high_risk_glob_in_config_directory()
+    {
+        var policy = new ToolPathPolicy(["/home/user/.netclaw/config/secrets.json"]);
+
+        Assert.True(policy.CommandReferencesDeniedPath("cat ~/.netclaw/config/*.json"));
+        Assert.True(policy.CommandReferencesDeniedPath("jq . ~/.netclaw/config/*.json"));
+    }
+
+    [Fact]
+    public void CommandReferencesDeniedPath_detects_high_risk_archive_of_config_directory()
+    {
+        var policy = new ToolPathPolicy(["/home/user/.netclaw/config/secrets.json"]);
+
+        Assert.True(policy.CommandReferencesDeniedPath("tar czf /tmp/netclaw-config.tgz ~/.netclaw/config"));
+    }
 }

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -1,0 +1,45 @@
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Redacts common secret-bearing patterns from tool output before returning text to the LLM.
+/// This is defense-in-depth for accidental leakage; not a replacement for access controls.
+/// </summary>
+public static partial class SecretOutputRedactor
+{
+    private const string Redacted = "***REDACTED***";
+
+    public static string Redact(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+            return output;
+
+        var sanitized = output;
+
+        sanitized = JsonSecretValueRegex().Replace(sanitized, m =>
+            $"\"{m.Groups[1].Value}\": \"{Redacted}\"");
+
+        sanitized = EnvSecretValueRegex().Replace(sanitized, m =>
+            $"{m.Groups[1].Value}={Redacted}");
+
+        sanitized = HeaderSecretValueRegex().Replace(sanitized, m =>
+            $"{m.Groups[1].Value}{Redacted}");
+
+        sanitized = ProviderTokenRegex().Replace(sanitized, Redacted);
+
+        return sanitized;
+    }
+
+    [GeneratedRegex("\"((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token)[^\"]*)\"\\s*:\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase)]
+    private static partial Regex JsonSecretValueRegex();
+
+    [GeneratedRegex("\\b((?:api[_-]?key|token|secret|password|authorization)[A-Z0-9_-]*)=([^\\s]+)", RegexOptions.IgnoreCase)]
+    private static partial Regex EnvSecretValueRegex();
+
+    [GeneratedRegex("(Authorization\\s*:\\s*Bearer\\s+)(\\S+)", RegexOptions.IgnoreCase)]
+    private static partial Regex HeaderSecretValueRegex();
+
+    [GeneratedRegex("\\b(sk-[A-Za-z0-9_-]{8,}|xox[baprs]-[A-Za-z0-9-]{8,}|ghp_[A-Za-z0-9]{20,})\\b")]
+    private static partial Regex ProviderTokenRegex();
+}

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -8,6 +8,12 @@ public sealed class ToolPathPolicy
 {
     private readonly HashSet<string> _deniedPaths;
     private readonly HashSet<string> _commandIndicators;
+    private static readonly HashSet<string> HighRiskVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cat", "less", "more", "head", "tail", "grep", "rg", "find", "jq", "awk", "sed", "strings", "xxd", "hexdump",
+        "cp", "mv", "tar", "zip", "unzip", "scp", "rsync", "curl", "wget", "nc", "ncat",
+        "python", "python3", "node", "ruby", "perl", "php"
+    };
 
     public ToolPathPolicy(IEnumerable<string> deniedPaths)
     {
@@ -58,6 +64,7 @@ public sealed class ToolPathPolicy
         if (string.IsNullOrWhiteSpace(command))
             return false;
 
+        var tokens = Tokenize(command).ToList();
         var slashCommand = command.Replace('\\', '/');
         foreach (var indicator in _commandIndicators)
         {
@@ -65,7 +72,7 @@ public sealed class ToolPathPolicy
                 return true;
         }
 
-        foreach (var token in Tokenize(command))
+        foreach (var token in tokens)
         {
             if (!LooksLikePath(token))
                 continue;
@@ -85,7 +92,34 @@ public sealed class ToolPathPolicy
             }
         }
 
+        if (ContainsProtectedPathHint(slashCommand) && ContainsHighRiskVerb(tokens))
+            return true;
+
         return false;
+    }
+
+    private static bool ContainsProtectedPathHint(string slashCommand)
+    {
+        return slashCommand.Contains(".netclaw/config", StringComparison.OrdinalIgnoreCase)
+            || slashCommand.Contains(".netclaw/keys", StringComparison.OrdinalIgnoreCase)
+            || slashCommand.Contains("secrets.json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsHighRiskVerb(IEnumerable<string> tokens)
+    {
+        foreach (var token in tokens)
+        {
+            var verb = TrimShellPunctuation(token);
+            if (HighRiskVerbs.Contains(verb))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string TrimShellPunctuation(string token)
+    {
+        return token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');
     }
 
     private bool IsDeniedNormalized(string candidate)

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -7,20 +7,29 @@ namespace Netclaw.Security;
 public sealed class ToolPathPolicy
 {
     private readonly HashSet<string> _deniedPaths;
-    // Keep both raw and normalized forms for command substring matching.
-    // On Windows, Path.GetFullPath("/home/user/...") normalizes to "D:\home\user\...",
-    // but the command string may contain the original Unix-style path.
-    private readonly HashSet<string> _deniedPathStrings;
+    private readonly HashSet<string> _commandIndicators;
 
     public ToolPathPolicy(IEnumerable<string> deniedPaths)
     {
         var paths = deniedPaths.ToList();
-        _deniedPaths = new HashSet<string>(
-            paths.Select(NormalizePath),
-            StringComparer.OrdinalIgnoreCase);
-        _deniedPathStrings = new HashSet<string>(
-            paths.Concat(paths.Select(NormalizePath)),
-            StringComparer.OrdinalIgnoreCase);
+        var normalizedPaths = paths.Select(NormalizePath).ToList();
+
+        _deniedPaths = new HashSet<string>(normalizedPaths, StringComparer.OrdinalIgnoreCase);
+        _commandIndicators = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in paths.Concat(normalizedPaths))
+        {
+            var slashPath = path.Replace('\\', '/');
+            _commandIndicators.Add(slashPath);
+
+            var netclawSegmentIdx = slashPath.IndexOf("/.netclaw/", StringComparison.OrdinalIgnoreCase);
+            if (netclawSegmentIdx >= 0)
+                _commandIndicators.Add(slashPath[(netclawSegmentIdx + 1)..]);
+
+            var fileName = Path.GetFileName(path);
+            if (!string.IsNullOrWhiteSpace(fileName) && fileName.Contains('.', StringComparison.Ordinal))
+                _commandIndicators.Add(fileName);
+        }
     }
 
     /// <summary>
@@ -32,8 +41,11 @@ public sealed class ToolPathPolicy
         if (string.IsNullOrWhiteSpace(path))
             return false;
 
-        var normalized = NormalizePath(path);
-        return _deniedPaths.Contains(normalized);
+        if (TryNormalizePath(path, null, out var normalized) && IsDeniedNormalized(normalized))
+            return true;
+
+        return TryResolveSymlinkTarget(path, out var resolvedTarget)
+            && IsDeniedNormalized(resolvedTarget);
     }
 
     /// <summary>
@@ -41,18 +53,197 @@ public sealed class ToolPathPolicy
     /// Checks both the original path strings and their normalized forms.
     /// This is a defense-in-depth heuristic — not bulletproof against obfuscation.
     /// </summary>
-    public bool CommandReferencesDeniedPath(string command)
+    public bool CommandReferencesDeniedPath(string command, string? workingDirectory = null)
     {
         if (string.IsNullOrWhiteSpace(command))
             return false;
 
-        foreach (var deniedPath in _deniedPathStrings)
+        var slashCommand = command.Replace('\\', '/');
+        foreach (var indicator in _commandIndicators)
         {
-            if (command.Contains(deniedPath, StringComparison.OrdinalIgnoreCase))
+            if (slashCommand.Contains(indicator, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        foreach (var token in Tokenize(command))
+        {
+            if (!LooksLikePath(token))
+                continue;
+
+            var expanded = ExpandHomeAndEnv(token);
+            if (TryNormalizePath(expanded, workingDirectory, out var normalized)
+                && IsDeniedNormalized(normalized))
+            {
+                return true;
+            }
+
+            if (expanded.Contains("secrets.json", StringComparison.OrdinalIgnoreCase)
+                || expanded.Contains(".netclaw/keys", StringComparison.OrdinalIgnoreCase)
+                || expanded.Contains(".netclaw\\keys", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool IsDeniedNormalized(string candidate)
+    {
+        foreach (var denied in _deniedPaths)
+        {
+            if (IsSamePathOrChild(candidate, denied))
                 return true;
         }
 
         return false;
+    }
+
+    private static bool IsSamePathOrChild(string candidate, string denied)
+    {
+        if (!candidate.StartsWith(denied, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (candidate.Length == denied.Length)
+            return true;
+
+        var boundary = candidate[denied.Length];
+        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
+    }
+
+    private static bool TryNormalizePath(string rawPath, string? workingDirectory, out string normalized)
+    {
+        normalized = string.Empty;
+
+        try
+        {
+            var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
+                ? workingDirectory
+                : Environment.CurrentDirectory;
+
+            normalized = Path.IsPathRooted(rawPath)
+                ? NormalizePath(rawPath)
+                : NormalizePath(Path.Combine(baseDir, rawPath));
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryResolveSymlinkTarget(string path, out string normalizedTarget)
+    {
+        normalizedTarget = string.Empty;
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                var target = new FileInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+                if (target is null)
+                    return false;
+
+                normalizedTarget = NormalizePath(target.FullName);
+                return true;
+            }
+
+            if (Directory.Exists(path))
+            {
+                var target = new DirectoryInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+                if (target is null)
+                    return false;
+
+                normalizedTarget = NormalizePath(target.FullName);
+                return true;
+            }
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> Tokenize(string command)
+    {
+        var current = new System.Text.StringBuilder();
+        char? quote = null;
+
+        foreach (var ch in command)
+        {
+            if (quote is null && (ch == '\'' || ch == '"'))
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (quote is not null && ch == quote)
+            {
+                quote = null;
+                continue;
+            }
+
+            if (quote is null && char.IsWhiteSpace(ch))
+            {
+                if (current.Length > 0)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                }
+
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+            yield return current.ToString();
+    }
+
+    private static bool LooksLikePath(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return false;
+
+        if (token.StartsWith("-", StringComparison.Ordinal))
+            return false;
+
+        return token.Contains('/')
+            || token.Contains('\\')
+            || token.StartsWith(".", StringComparison.Ordinal)
+            || token.StartsWith("~", StringComparison.Ordinal)
+            || token.Contains(':')
+            || token.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ExpandHomeAndEnv(string token)
+    {
+        var expanded = token;
+
+        if (expanded.StartsWith("~", StringComparison.Ordinal))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrWhiteSpace(home))
+            {
+                expanded = expanded.Length == 1
+                    ? home
+                    : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
+            }
+        }
+
+        var homeEnv = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(homeEnv))
+        {
+            expanded = expanded.Replace("$HOME", homeEnv, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("${HOME}", homeEnv, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("%USERPROFILE%", homeEnv, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return expanded;
     }
 
     private static string NormalizePath(string path)


### PR DESCRIPTION
## Summary
- strengthen `ToolPathPolicy` and shell command checks to better block protected path access patterns (including high-risk command + protected-path combinations)
- redact secret-like values from `shell_execute` output before returning responses to the model
- harden `attach_file` path validation with boundary-aware containment and symlink target checks, and route CLI secret writes/reads through encrypted secret handling paths

## Validation
- dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~ShellToolTests"
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~AttachFileToolTests"
- dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~ProviderCommandTests|FullyQualifiedName~McpCommandTests|FullyQualifiedName~ProviderManagerViewModelTests"
- dotnet slopwatch analyze