### PR TITLE
Add OpenAI OAuth device flow authentication (RFC 8628)

### DIFF
--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -153,6 +153,42 @@ public sealed class ModelCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Discover_OAuthProvider_UsesOAuthAccessToken()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["OAuthAccessToken"] = "oauth-access-token"
+                }
+            }
+        });
+
+        var exitCode = await ModelCommand.RunAsync(
+            ["model", "discover", "my-openai"],
+            _paths, _fakeProbe, output: _output);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("oauth-access-token", _fakeProbe.LastApiKey);
+    }
+
+    [Fact]
     public async Task Discover_NonexistentProvider_ReturnsError()
     {
         var exitCode = await ModelCommand.RunAsync(
@@ -241,6 +277,12 @@ public sealed class ModelCommandTests : IDisposable
     private void WriteConfig(Dictionary<string, object> data)
     {
         File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private void WriteSecrets(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.SecretsPath,
             JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
     }
 

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Netclaw.Cli.Provider;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Provider;
@@ -101,6 +102,31 @@ public sealed class ProviderCommandTests : IDisposable
         // Verify provider loader decrypts back to usable plaintext
         var loaded = ProviderCommand.LoadProviders(_paths);
         Assert.Equal("sk-or-test-123", loaded["my-openrouter"].ApiKey?.Value);
+    }
+
+    [Fact]
+    public async Task Add_WithAuthApiKeyFlag_SucceedsForApiKeyProvider()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "add", "my-openai", "openai", "--auth", "api-key", "--api-key", "sk-openai-test-123"],
+            _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+
+        var config = ReadConfigFile(_paths.NetclawConfigPath);
+        var provider = config.RootElement.GetProperty("Providers").GetProperty("my-openai");
+        Assert.Equal("ApiKey", provider.GetProperty("AuthMethod").GetString());
+    }
+
+    [Fact]
+    public async Task Add_WithUnknownAuthMethod_ReturnsError()
+    {
+        var exitCode = await ProviderCommand.RunAsync(
+            ["provider", "add", "my-openai", "openai", "--auth", "bogus-auth"],
+            _paths, output: _output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown auth method", _output.ToString());
     }
 
     [Fact]
@@ -211,6 +237,45 @@ public sealed class ProviderCommandTests : IDisposable
         Assert.True(providers.ContainsKey("my-anthropic"));
         Assert.Equal("anthropic", providers["my-anthropic"].Type);
         Assert.Equal("sk-ant-test", providers["my-anthropic"].ApiKey?.Value);
+    }
+
+    [Fact]
+    public void LoadProviders_DecryptsEncryptedOAuthTokenExpiry()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        var protector = SecretsProtection.CreateProtector(_paths);
+        var expiry = DateTimeOffset.Parse("2026-03-05T00:00:00+00:00").ToString("o");
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["OAuthAccessToken"] = protector.Protect("oauth-access-token"),
+                    ["OAuthTokenExpiry"] = protector.Protect(expiry)
+                }
+            }
+        });
+
+        var providers = ProviderCommand.LoadProviders(_paths);
+
+        Assert.True(providers.ContainsKey("my-openai"));
+        Assert.NotNull(providers["my-openai"].OAuthTokenExpiry);
+        Assert.Equal(DateTimeOffset.Parse(expiry), providers["my-openai"].OAuthTokenExpiry!.Value);
     }
 
     private void WriteConfig(Dictionary<string, object> data)

--- a/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
@@ -40,12 +40,18 @@ public sealed class FakeProviderProbe : IProviderProbe
     /// </summary>
     public string? LastProviderType { get; private set; }
 
+    /// <summary>
+    /// The credential value passed in the last call.
+    /// </summary>
+    public string? LastApiKey { get; private set; }
+
     public Task<ProviderProbeResult> ProbeAsync(
         string providerType, string? endpoint, string? apiKey,
         CancellationToken ct = default)
     {
         ProbeCallCount++;
         LastProviderType = providerType;
+        LastApiKey = apiKey;
         ProbedTypes.Add(providerType);
 
         var result = TypeResults.TryGetValue(providerType, out var typeResult)

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -69,6 +69,43 @@ public sealed class ModelManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task StartAssignment_OAuthProvider_UsesOAuthAccessTokenForDiscovery()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["OAuthAccessToken"] = "oauth-access-token"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("oauth-access-token", _fakeProbe.LastApiKey);
+    }
+
+    [Fact]
     public void StartAssignment_MultipleProviders_GoesToSelectProvider()
     {
         WriteConfig(new Dictionary<string, object>
@@ -194,6 +231,12 @@ public sealed class ModelManagerViewModelTests : IDisposable
     private void WriteConfig(Dictionary<string, object> data)
     {
         File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private void WriteSecrets(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.SecretsPath,
             JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Providers.OAuth;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui;
@@ -134,6 +135,41 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         Assert.Contains("openrouter", _fakeProbe.ProbedTypes);
         Assert.Contains("ollama", _fakeProbe.ProbedTypes);
         Assert.Equal(2, _fakeProbe.ProbeCallCount);
+    }
+
+    [Fact]
+    public async Task EagerProbe_UsesOAuthAccessTokenWhenApiKeyMissing()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai",
+                    ["Endpoint"] = "https://api.openai.com",
+                    ["AuthMethod"] = "OAuthDevice"
+                }
+            }
+        });
+
+        WriteSecrets(new Dictionary<string, object>
+        {
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openai"] = new Dictionary<string, object>
+                {
+                    ["OAuthAccessToken"] = "oauth-access-token"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        Assert.Equal("openai", _fakeProbe.LastProviderType);
+        Assert.Equal("oauth-access-token", _fakeProbe.LastApiKey);
     }
 
     [Fact]
@@ -410,6 +446,35 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task ConfirmAdd_OAuth_TokensPersistOnlyOnSave()
+    {
+        using var vm = CreateViewModel();
+        vm.NewProviderName = "my-openai";
+        vm.NewProviderType = "openai";
+        vm.NewAuthMethod = AuthMethod.OAuthDevice;
+        vm.NewEndpoint = "https://api.openai.com";
+        vm.OAuthResult = new OAuthDeviceFlowResult(
+            new SensitiveString("oauth-access-token"),
+            new SensitiveString("oauth-refresh-token"),
+            DateTimeOffset.UtcNow.AddHours(1));
+
+        Assert.False(File.Exists(_paths.SecretsPath));
+
+        vm.ConfirmAdd();
+        await vm.EagerProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(File.Exists(_paths.SecretsPath));
+
+        var secrets = JsonDocument.Parse(File.ReadAllText(_paths.SecretsPath));
+        var provider = secrets.RootElement
+            .GetProperty("Providers")
+            .GetProperty("my-openai");
+
+        Assert.StartsWith("ENC:", provider.GetProperty("OAuthAccessToken").GetString());
+        Assert.StartsWith("ENC:", provider.GetProperty("OAuthRefreshToken").GetString());
+    }
+
+    [Fact]
     public async Task RemoveProvider_ReferencedByModelRole_IsRejected()
     {
         WriteConfig(new Dictionary<string, object>
@@ -517,6 +582,12 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     private void WriteConfig(Dictionary<string, object> data)
     {
         File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private void WriteSecrets(Dictionary<string, object> data)
+    {
+        File.WriteAllText(_paths.SecretsPath,
             JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
     }
 }

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -183,7 +183,7 @@ internal static class ModelCommand
         var result = await probe.ProbeAsync(
             entry.Type,
             string.IsNullOrWhiteSpace(entry.Endpoint) ? null : entry.Endpoint,
-            entry.ApiKey?.Value,
+            entry.ApiKey?.Value ?? entry.OAuthAccessToken?.Value,
             CancellationToken.None);
 
         if (!result.Success)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -16,6 +16,7 @@ using Netclaw.Cli.Tui;
 using Netclaw.Cli.Update;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
 using Netclaw.Configuration.Secrets;
 using Termina.Diagnostics;
 using Termina.Hosting;
@@ -96,6 +97,11 @@ static async Task RunAsync(string[] args)
 
             // Provider descriptors (includes IProviderProbe via registry)
             builder.Services.AddProviderDescriptors();
+            builder.Services.AddHttpClient("OAuthDeviceFlow");
+            builder.Services.AddSingleton(sp =>
+                new OAuthDeviceFlowService(
+                    sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                    sp.GetService<TimeProvider>()));
             builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
 
             // Init wizard + chat page dependencies (daemon lifecycle + SignalR)
@@ -321,6 +327,11 @@ static async Task RunAsync(string[] args)
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
             builder.Services.AddProviderDescriptors();
+            builder.Services.AddHttpClient("OAuthDeviceFlow");
+            builder.Services.AddSingleton(sp =>
+                new OAuthDeviceFlowService(
+                    sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                    sp.GetService<TimeProvider>()));
             builder.Logging.ClearProviders();
             builder.Logging.SetMinimumLevel(LogLevel.Warning);
 

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -98,10 +98,31 @@ internal static class ProviderCommand
             }
         }
 
-        // Handle --auth oauth-device explicitly
-        if (string.Equals(authFlag, "oauth-device", StringComparison.OrdinalIgnoreCase))
+        AuthMethod? requestedAuthMethod = null;
+        if (authFlag is not null)
         {
-            if (!descriptor.SupportedAuthMethods.Contains(AuthMethod.OAuthDevice))
+            if (string.Equals(authFlag, "oauth-device", StringComparison.OrdinalIgnoreCase))
+            {
+                requestedAuthMethod = AuthMethod.OAuthDevice;
+            }
+            else if (string.Equals(authFlag, "api-key", StringComparison.OrdinalIgnoreCase))
+            {
+                requestedAuthMethod = AuthMethod.ApiKey;
+            }
+            else
+            {
+                writer.WriteLine($"Error: Unknown auth method '{authFlag}'.");
+                writer.WriteLine("Auth methods: api-key, oauth-device");
+                return 1;
+            }
+        }
+
+        var supportedAuth = descriptor.SupportedAuthMethods;
+
+        // Handle --auth oauth-device explicitly
+        if (requestedAuthMethod == AuthMethod.OAuthDevice)
+        {
+            if (!supportedAuth.Contains(AuthMethod.OAuthDevice))
             {
                 writer.WriteLine($"Error: Provider '{type}' does not support OAuth device flow.");
                 return 1;
@@ -110,7 +131,13 @@ internal static class ProviderCommand
             return RunOAuthDeviceFlow(name, type, endpoint, descriptor, paths, writer);
         }
 
-        var supportedAuth = descriptor.SupportedAuthMethods;
+        if (requestedAuthMethod == AuthMethod.ApiKey && !supportedAuth.Contains(AuthMethod.ApiKey))
+        {
+            writer.WriteLine($"Error: Provider '{type}' does not support API key auth.");
+            return 1;
+        }
+
+        var forceApiKey = requestedAuthMethod == AuthMethod.ApiKey;
         var authMethod = AuthMethod.None;
 
         if (supportedAuth.Contains(AuthMethod.ApiKey) && apiKey is not null)
@@ -121,7 +148,7 @@ internal static class ProviderCommand
             && !supportedAuth.Contains(AuthMethod.None))
         {
             // OAuth-capable providers without --api-key: guide user to TUI or --auth
-            if (supportedAuth.Contains(AuthMethod.OAuthDevice))
+            if (supportedAuth.Contains(AuthMethod.OAuthDevice) && !forceApiKey)
             {
                 WriteProviderGuidance(descriptor, writer);
                 writer.WriteLine();
@@ -363,8 +390,8 @@ internal static class ProviderCommand
 
                 if (prop.Value.TryGetProperty("OAuthTokenExpiry", out var tokenExpiry))
                 {
-                    var expiryStr = tokenExpiry.GetString();
-                    if (expiryStr is not null && DateTimeOffset.TryParse(expiryStr, out var parsed))
+                    var expiryStr = ConfigFileHelper.DecryptIfEncrypted(paths, tokenExpiry.GetString());
+                    if (!string.IsNullOrWhiteSpace(expiryStr) && DateTimeOffset.TryParse(expiryStr, out var parsed))
                         entry.OAuthTokenExpiry = parsed;
                 }
             }

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
+using Netclaw.Configuration.Secrets;
 
 namespace Netclaw.Cli.Provider;
 
@@ -51,12 +53,13 @@ internal static class ProviderCommand
 
     private static int RunAdd(string[] args, NetclawPaths paths, ProviderDescriptorRegistry registry, TextWriter writer)
     {
-        // Parse: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]
+        // Parse: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>] [--auth <method>]
         if (args.Length < 4)
         {
-            writer.WriteLine("Usage: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>]");
+            writer.WriteLine("Usage: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>] [--auth <method>]");
             writer.WriteLine();
             writer.WriteLine("Types: " + string.Join(", ", registry.KnownTypeKeys));
+            writer.WriteLine("Auth methods: api-key, oauth-device");
             return 1;
         }
 
@@ -72,6 +75,7 @@ internal static class ProviderCommand
 
         string? apiKey = null;
         string? endpoint = null;
+        string? authFlag = null;
 
         for (var i = 4; i < args.Length; i++)
         {
@@ -86,6 +90,24 @@ internal static class ProviderCommand
                 endpoint = args[++i];
                 continue;
             }
+
+            if (args[i] is "--auth" && i + 1 < args.Length)
+            {
+                authFlag = args[++i];
+                continue;
+            }
+        }
+
+        // Handle --auth oauth-device explicitly
+        if (string.Equals(authFlag, "oauth-device", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!descriptor.SupportedAuthMethods.Contains(AuthMethod.OAuthDevice))
+            {
+                writer.WriteLine($"Error: Provider '{type}' does not support OAuth device flow.");
+                return 1;
+            }
+
+            return RunOAuthDeviceFlow(name, type, endpoint, descriptor, paths, writer);
         }
 
         var supportedAuth = descriptor.SupportedAuthMethods;
@@ -98,12 +120,13 @@ internal static class ProviderCommand
         else if (supportedAuth.Contains(AuthMethod.ApiKey) && apiKey is null
             && !supportedAuth.Contains(AuthMethod.None))
         {
-            // OAuth-capable providers without --api-key: guide user to TUI
+            // OAuth-capable providers without --api-key: guide user to TUI or --auth
             if (supportedAuth.Contains(AuthMethod.OAuthDevice))
             {
                 WriteProviderGuidance(descriptor, writer);
                 writer.WriteLine();
-                writer.WriteLine("Tip: Use `netclaw provider` (TUI) for OAuth device flow setup,");
+                writer.WriteLine("Tip: Use `netclaw provider` (TUI) for interactive OAuth setup,");
+                writer.WriteLine("     or pass --auth oauth-device for CLI device flow,");
                 writer.WriteLine("     or pass --api-key to use an API key instead.");
                 return 1;
             }
@@ -135,7 +158,7 @@ internal static class ProviderCommand
         providers[name] = providerEntry;
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);
 
-        // Write secret to secrets.json
+        // Write secret to secrets.json via SecretsFileWriter for encryption-at-rest
         if (!string.IsNullOrWhiteSpace(apiKey))
         {
             var secretProviders = ConfigFileHelper.GetOrCreateSection(secrets, "Providers");
@@ -150,6 +173,87 @@ internal static class ProviderCommand
         WriteProviderGuidance(descriptor, writer);
         writer.WriteLine();
         return 0;
+    }
+
+    private static int RunOAuthDeviceFlow(
+        string name, string type, string? endpoint,
+        IProviderDescriptor descriptor, NetclawPaths paths, TextWriter writer)
+    {
+        if (descriptor.OAuthDeviceEndpoint is null || descriptor.OAuthTokenEndpoint is null
+            || descriptor.OAuthDefaultClientId is null)
+        {
+            writer.WriteLine($"Error: Provider '{type}' missing OAuth endpoint configuration.");
+            return 1;
+        }
+
+        endpoint ??= descriptor.DefaultEndpoint;
+
+        var config = new OAuthDeviceFlowConfig(
+            descriptor.OAuthDeviceEndpoint,
+            descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId);
+
+        using var httpClient = new HttpClient();
+        var service = new OAuthDeviceFlowService(httpClient);
+
+        try
+        {
+            // Start device authorization
+            writer.WriteLine("Starting OAuth device authorization...");
+            var deviceAuth = service.StartDeviceAuthorizationAsync(config).GetAwaiter().GetResult();
+
+            writer.WriteLine();
+            writer.WriteLine($"  Visit:      {deviceAuth.VerificationUri}");
+            writer.WriteLine($"  Enter code: {deviceAuth.UserCode}");
+            writer.WriteLine();
+            writer.Write("Waiting for authorization...");
+
+            // Poll for token
+            var result = service.PollForTokenAsync(config, deviceAuth,
+                state =>
+                {
+                    if (state == DeviceFlowState.Polling)
+                        writer.Write(".");
+                }).GetAwaiter().GetResult();
+
+            writer.WriteLine();
+            writer.WriteLine("Authorization successful!");
+
+            // Write config to netclaw.json
+            var (configDict, _) = ConfigFileHelper.LoadConfigFiles(paths);
+            var providers = ConfigFileHelper.GetOrCreateSection(configDict, "Providers");
+            providers[name] = new Dictionary<string, object>
+            {
+                ["Type"] = type,
+                ["Endpoint"] = endpoint,
+                ["AuthMethod"] = AuthMethod.OAuthDevice.ToString()
+            };
+            ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, configDict);
+
+            // Persist tokens to secrets.json with encryption
+            OAuthTokenPersistence.PersistTokens(paths, name, result, SecretsProtection.CreateProtector(paths));
+
+            writer.WriteLine($"Added provider '{name}' ({type}) with OAuth authentication.");
+            return 0;
+        }
+        catch (OAuthDeviceFlowDeniedException)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Error: Authorization was denied.");
+            return 1;
+        }
+        catch (OAuthDeviceFlowExpiredException)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Error: Authorization code expired. Please try again.");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
     }
 
     private static int RunRemove(string[] args, NetclawPaths paths, TextWriter writer)
@@ -244,6 +348,25 @@ internal static class ProviderCommand
                     var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, apiKey.GetString());
                     entry.ApiKey = new SensitiveString(decrypted);
                 }
+
+                if (prop.Value.TryGetProperty("OAuthAccessToken", out var oauthToken))
+                {
+                    var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, oauthToken.GetString());
+                    entry.OAuthAccessToken = new SensitiveString(decrypted);
+                }
+
+                if (prop.Value.TryGetProperty("OAuthRefreshToken", out var refreshToken))
+                {
+                    var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, refreshToken.GetString());
+                    entry.OAuthRefreshToken = new SensitiveString(decrypted);
+                }
+
+                if (prop.Value.TryGetProperty("OAuthTokenExpiry", out var tokenExpiry))
+                {
+                    var expiryStr = tokenExpiry.GetString();
+                    if (expiryStr is not null && DateTimeOffset.TryParse(expiryStr, out var parsed))
+                        entry.OAuthTokenExpiry = parsed;
+                }
             }
         }
 
@@ -307,12 +430,14 @@ internal static class ProviderCommand
         writer.WriteLine("Options for 'add':");
         writer.WriteLine("  --api-key <key>       API key (or prompted interactively)");
         writer.WriteLine("  --endpoint <url>      Custom endpoint URL");
+        writer.WriteLine("  --auth <method>       Auth method: api-key, oauth-device");
         writer.WriteLine();
         writer.WriteLine("Provider types: " + string.Join(", ", registry.KnownTypeKeys));
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://big-gpu:11434");
         writer.WriteLine("  netclaw provider add my-anthropic anthropic --api-key sk-ant-...");
+        writer.WriteLine("  netclaw provider add my-openai openai --auth oauth-device");
         writer.WriteLine("  netclaw provider remove my-ollama");
         return 0;
     }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -1,5 +1,6 @@
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
 using Netclaw.Cli.Mcp;
 using R3;
 using Termina.Extensions;
@@ -176,6 +177,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             // evaluation, blanking the screen.
             if (step == WizardStep.Provider && _providerSubStep == 3)
                 return BuildValidationSubStep();
+            if (step == WizardStep.Provider && _providerSubStep == 5)
+                return BuildOAuthDeviceFlowSubStep();
             if (step == WizardStep.Memory && _memorySubStep == 2)
                 return BuildMemorizerValidationSubStep();
 
@@ -224,6 +227,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Validating connection and discovering available models...",
                 WizardStep.Provider when _providerSubStep == 4 =>
                     "  Select the model to use for conversations.",
+                WizardStep.Provider when _providerSubStep == 5 =>
+                    "  Complete the authorization in your browser.",
                 WizardStep.ChatServices when _chatServicesSubStep == 0 =>
                     "  Enable Slack to connect Netclaw as a Slack bot.",
                 WizardStep.ChatServices when _chatServicesSubStep == 3 =>
@@ -314,6 +319,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             2 => BuildCredentialInputSubStep(),
             3 => BuildValidationSubStep(),
             4 => BuildModelSelectionSubStep(),
+            5 => BuildOAuthDeviceFlowSubStep(),
             _ => Layouts.Empty()
         };
     }
@@ -363,7 +369,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Select(m => m switch
             {
                 AuthMethod.ApiKey => "API Key",
-                AuthMethod.OAuthDevice => "OAuth Device Flow (coming soon)",
+                AuthMethod.OAuthDevice => "OAuth Device Flow (recommended)",
                 _ => m.ToString()
             })
             .ToList();
@@ -380,10 +386,20 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             {
                 if (selected.Count > 0)
                 {
-                    ViewModel.SelectedAuthMethod = selected[0].StartsWith("API", StringComparison.Ordinal)
+                    var method = selected[0].StartsWith("API", StringComparison.Ordinal)
                         ? AuthMethod.ApiKey
                         : AuthMethod.OAuthDevice;
-                    SetProviderSubStep(2);
+                    ViewModel.SelectedAuthMethod = method;
+
+                    if (method == AuthMethod.OAuthDevice)
+                    {
+                        SetProviderSubStep(5);
+                        ViewModel.StartOAuthFlow();
+                    }
+                    else
+                    {
+                        SetProviderSubStep(2);
+                    }
                 }
             })
             .DisposeWith(_stepSubs);
@@ -592,6 +608,72 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .WithBorderColor(Color.Gray)
                 .WithContent(_manualModelInput)
                 .Height(3));
+    }
+
+    private ILayoutNode BuildOAuthDeviceFlowSubStep()
+    {
+        var children = Layouts.Vertical();
+        var providerType = ViewModel.SelectedProviderType ?? "unknown";
+        var flowState = ViewModel.OAuthFlowState.Value;
+
+        children.WithChild(new TextNode($"  OAuth Device Flow for {providerType}")
+            .WithForeground(Color.White).Bold());
+        children.WithChild(new TextNode("").Height(1));
+
+        switch (flowState)
+        {
+            case DeviceFlowState.NotStarted:
+                children.WithChild(new TextNode("  Starting device authorization...")
+                    .WithForeground(Color.Yellow));
+                break;
+
+            case DeviceFlowState.WaitingForUser:
+            case DeviceFlowState.Polling:
+            {
+                var elapsed = ViewModel.ProbeElapsedSeconds.Value;
+                var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+
+                if (ViewModel.OAuthVerificationUri is not null)
+                {
+                    children.WithChild(new TextNode($"  Visit: {ViewModel.OAuthVerificationUri}")
+                        .WithForeground(Color.Cyan));
+                    children.WithChild(new TextNode("").Height(1));
+                }
+
+                if (ViewModel.OAuthUserCode is not null)
+                {
+                    children.WithChild(new TextNode($"  Enter code: {ViewModel.OAuthUserCode}")
+                        .WithForeground(Color.White).Bold());
+                    children.WithChild(new TextNode("").Height(1));
+                }
+
+                children.WithChild(new TextNode($"  {frame} Waiting for authorization...")
+                    .WithForeground(Color.Yellow));
+                break;
+            }
+
+            case DeviceFlowState.Succeeded:
+                children.WithChild(new TextNode("  \u2713 Authorization successful!")
+                    .WithForeground(Color.Green));
+                break;
+
+            case DeviceFlowState.Denied:
+            case DeviceFlowState.Expired:
+            case DeviceFlowState.Error:
+                children.WithChild(new TextNode($"  \u2717 {ViewModel.OAuthErrorMessage ?? "Authorization failed."}")
+                    .WithForeground(Color.Red));
+                children.WithChild(new TextNode("").Height(1));
+                children.WithChild(new TextNode("  Press [Esc] to go back and try again.")
+                    .WithForeground(Color.BrightBlack));
+                break;
+
+            case DeviceFlowState.Cancelled:
+                children.WithChild(new TextNode("  Authorization cancelled.")
+                    .WithForeground(Color.Yellow));
+                break;
+        }
+
+        return children;
     }
 
     private ILayoutNode BuildChatServicesStep()
@@ -1363,6 +1445,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         {
             if (_providerSubStep == 2)
                 ViewModel.ClearFromProvider();
+            if (_providerSubStep == 5)
+            {
+                // Going back from OAuth device flow — cancel flow and go to auth selection
+                ViewModel.CancelOAuthFlow();
+                SetProviderSubStep(1);
+                return true;
+            }
             if (_providerSubStep == 4)
             {
                 // Going back from model selection to validation — re-probe or skip to credentials
@@ -1636,12 +1725,32 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             })
             .DisposeWith(Subscriptions);
 
-        // Animate spinner on validation sub-step every second
+        // Animate spinner on validation sub-step and OAuth device flow sub-step every second
         ViewModel.ProbeElapsedSeconds
             .Subscribe(_ =>
             {
-                if (ViewModel.CurrentStep.Value == WizardStep.Provider && _providerSubStep == 3)
+                if (ViewModel.CurrentStep.Value == WizardStep.Provider
+                    && (_providerSubStep == 3 || _providerSubStep == 5))
                     _stepContentNode?.Invalidate();
+            })
+            .DisposeWith(Subscriptions);
+
+        // OAuth device flow state changed — invalidate to show progress, auto-advance on success
+        ViewModel.OAuthFlowState
+            .Subscribe(state =>
+            {
+                if (ViewModel.CurrentStep.Value != WizardStep.Provider || _providerSubStep != 5)
+                    return;
+
+                _stepContentNode?.Invalidate();
+                _helpTextNode?.Invalidate();
+
+                // Auto-advance to validation sub-step on success
+                if (state == DeviceFlowState.Succeeded)
+                {
+                    SetProviderSubStep(3);
+                    ViewModel.StartProbe();
+                }
             })
             .DisposeWith(Subscriptions);
 

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -5,6 +5,8 @@ using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Mcp;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
+using Netclaw.Configuration.Secrets;
 using R3;
 using Termina.Input;
 using Termina.Reactive;
@@ -41,6 +43,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
     private readonly ProviderDescriptorRegistry _registry;
     private readonly ISlackProbe _slackProbe;
     private readonly IBrowserAutomationBootstrapper _browserBootstrapper;
+    private readonly OAuthDeviceFlowService? _oauthService;
+    private CancellationTokenSource? _oauthCts;
 
     /// <summary>
     /// The provider descriptor registry. Exposed for use by the page.
@@ -91,6 +95,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public AuthMethod SelectedAuthMethod { get; set; } = AuthMethod.None;
     public string? ApiKeyInput { get; set; }
     public string? EndpointInput { get; set; }
+
+    // ── Step 1 (continued): OAuth device flow ──
+    public ReactiveProperty<DeviceFlowState> OAuthFlowState { get; } = new(DeviceFlowState.NotStarted);
+    public string? OAuthUserCode { get; set; }
+    public string? OAuthVerificationUri { get; set; }
+    public string? OAuthErrorMessage { get; set; }
+    internal OAuthDeviceFlowResult? OAuthResult { get; set; }
+    internal Task? OAuthFlowCompletion { get; private set; }
 
     // ── Step 1 (continued): Model selection ──
     public string? SelectedModelId { get; set; }
@@ -148,9 +160,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         NetclawPaths paths,
         ProviderDescriptorRegistry registry,
         ISlackProbe slackProbe,
+        OAuthDeviceFlowService? oauthService = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
-        : this(paths, registry, registry, slackProbe, null, daemonManager, daemonEndpoint)
+        : this(paths, registry, registry, slackProbe, null, oauthService, daemonManager, daemonEndpoint)
     {
     }
 
@@ -163,6 +176,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         IProviderProbe probe,
         ISlackProbe slackProbe,
         IBrowserAutomationBootstrapper? browserBootstrapper = null,
+        OAuthDeviceFlowService? oauthService = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
     {
@@ -171,6 +185,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _registry = registry;
         _slackProbe = slackProbe;
         _browserBootstrapper = browserBootstrapper ?? new BrowserAutomationBootstrapper();
+        _oauthService = oauthService;
         _daemonManager = daemonManager;
         _daemonEndpoint = daemonEndpoint ?? "http://127.0.0.1:5199";
     }
@@ -399,9 +414,105 @@ public partial class InitWizardViewModel : ReactiveViewModel
         }
     }
 
+    /// <summary>
+    /// Start the OAuth device flow. Called by the page when the user selects OAuth.
+    /// </summary>
+    public void StartOAuthFlow()
+    {
+        OAuthFlowCompletion = StartOAuthDeviceFlowAsync();
+    }
+
+    /// <summary>
+    /// Start the OAuth device flow for the selected provider.
+    /// On success, sets ApiKeyInput to the access token and starts the probe.
+    /// </summary>
+    internal async Task StartOAuthDeviceFlowAsync()
+    {
+        if (_oauthService is null || SelectedProviderType is null)
+        {
+            OAuthErrorMessage = "OAuth service not available.";
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            RequestRedraw();
+            return;
+        }
+
+        var descriptor = _registry.Get(SelectedProviderType);
+        if (descriptor.OAuthDeviceEndpoint is null || descriptor.OAuthTokenEndpoint is null
+            || descriptor.OAuthDefaultClientId is null)
+        {
+            OAuthErrorMessage = "Provider does not support OAuth device flow.";
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            RequestRedraw();
+            return;
+        }
+
+        _oauthCts = new CancellationTokenSource();
+        var ct = _oauthCts.Token;
+
+        var config = new OAuthDeviceFlowConfig(
+            descriptor.OAuthDeviceEndpoint,
+            descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId);
+
+        try
+        {
+            var deviceAuth = await _oauthService.StartDeviceAuthorizationAsync(config, ct);
+            OAuthUserCode = deviceAuth.UserCode;
+            OAuthVerificationUri = deviceAuth.VerificationUri;
+            OAuthFlowState.Value = DeviceFlowState.WaitingForUser;
+            RequestRedraw();
+
+            var result = await _oauthService.PollForTokenAsync(config, deviceAuth,
+                state =>
+                {
+                    OAuthFlowState.Value = state;
+                    RequestRedraw();
+                }, ct);
+
+            OAuthResult = result;
+            ApiKeyInput = result.AccessToken.Value;
+            OAuthFlowState.Value = DeviceFlowState.Succeeded;
+            RequestRedraw();
+        }
+        catch (OAuthDeviceFlowDeniedException)
+        {
+            OAuthErrorMessage = "Authorization was denied.";
+            OAuthFlowState.Value = DeviceFlowState.Denied;
+            RequestRedraw();
+        }
+        catch (OAuthDeviceFlowExpiredException)
+        {
+            OAuthErrorMessage = "The authorization code expired. Please try again.";
+            OAuthFlowState.Value = DeviceFlowState.Expired;
+            RequestRedraw();
+        }
+        catch (OperationCanceledException)
+        {
+            OAuthFlowState.Value = DeviceFlowState.Cancelled;
+            RequestRedraw();
+        }
+        catch (Exception ex)
+        {
+            OAuthErrorMessage = ex.Message;
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            RequestRedraw();
+        }
+    }
+
+    internal void CancelOAuthFlow()
+    {
+        if (_oauthCts is not null)
+        {
+            _oauthCts.Cancel();
+            _oauthCts.Dispose();
+            _oauthCts = null;
+        }
+    }
+
     internal void ClearFromProvider()
     {
         CancelProbe();
+        CancelOAuthFlow();
         SelectedAuthMethod = AuthMethod.None;
         ApiKeyInput = null;
         EndpointInput = null;
@@ -409,6 +520,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
         ProbeElapsedSeconds.Value = 0;
         SelectedModelId = null;
         DiscoveredModels.Clear();
+        OAuthFlowState.Value = DeviceFlowState.NotStarted;
+        OAuthUserCode = null;
+        OAuthVerificationUri = null;
+        OAuthErrorMessage = null;
+        OAuthResult = null;
     }
 
     private static IReadOnlyList<string> ParseChannelNames(string? input)
@@ -826,15 +942,34 @@ public partial class InitWizardViewModel : ReactiveViewModel
         // Build secrets.json (sensitive values)
         var secrets = new Dictionary<string, object>();
 
-        if (!string.IsNullOrWhiteSpace(ApiKeyInput) && !string.IsNullOrWhiteSpace(SelectedProviderType))
+        if (!string.IsNullOrWhiteSpace(SelectedProviderType))
         {
-            secrets["Providers"] = new Dictionary<string, object>
+            if (OAuthResult is not null)
             {
-                [SelectedProviderType.ToLowerInvariant()] = new Dictionary<string, object>
+                var providerSecrets = new Dictionary<string, object>
                 {
-                    ["ApiKey"] = ApiKeyInput
-                }
-            };
+                    ["OAuthAccessToken"] = OAuthResult.AccessToken.Value
+                };
+                if (OAuthResult.RefreshToken is not null)
+                    providerSecrets["OAuthRefreshToken"] = OAuthResult.RefreshToken.Value;
+                if (OAuthResult.ExpiresAt.HasValue)
+                    providerSecrets["OAuthTokenExpiry"] = OAuthResult.ExpiresAt.Value.ToString("o");
+
+                secrets["Providers"] = new Dictionary<string, object>
+                {
+                    [SelectedProviderType.ToLowerInvariant()] = providerSecrets
+                };
+            }
+            else if (!string.IsNullOrWhiteSpace(ApiKeyInput))
+            {
+                secrets["Providers"] = new Dictionary<string, object>
+                {
+                    [SelectedProviderType.ToLowerInvariant()] = new Dictionary<string, object>
+                    {
+                        ["ApiKey"] = ApiKeyInput
+                    }
+                };
+            }
         }
 
         if (SlackEnabled)
@@ -973,6 +1108,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public override void Dispose()
     {
         CancelProbe();
+        CancelOAuthFlow();
         CurrentStep.Dispose();
         StatusMessage.Dispose();
         IsHealthCheckRunning.Dispose();
@@ -983,6 +1119,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         IsMemorizerProbing.Dispose();
         MemorizerProbeResult.Dispose();
         HealthCheckResultVersion.Dispose();
+        OAuthFlowState.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -292,7 +292,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         var result = await _probe.ProbeAsync(
             provider.Entry.Type,
             string.IsNullOrWhiteSpace(provider.Entry.Endpoint) ? null : provider.Entry.Endpoint,
-            provider.Entry.ApiKey?.Value,
+            provider.Entry.ApiKey?.Value ?? provider.Entry.OAuthAccessToken?.Value,
             ct);
 
         CancelProbe();

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -1,5 +1,6 @@
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
 using R3;
 using Termina.Extensions;
 using Termina.Input;
@@ -75,6 +76,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                 ProviderManagerState.List => BuildProviderListView(),
                 ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
                 ProviderManagerState.AddCredentials => BuildCredentialsView(),
+                ProviderManagerState.AddOAuthDeviceFlow => BuildOAuthDeviceFlowView(),
                 ProviderManagerState.AddValidating => BuildValidatingView(),
                 ProviderManagerState.AddComplete => BuildAddCompleteView(),
                 ProviderManagerState.Details => BuildDetailsView(),
@@ -118,6 +120,8 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                         " [Enter] Confirm  [Esc] Cancel  [Ctrl+Q] Quit",
                     ProviderManagerState.AddComplete =>
                         " [Enter] Save  [Esc] Cancel  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddOAuthDeviceFlow =>
+                        " [Esc] Cancel  [Ctrl+Q] Quit",
                     _ =>
                         " [\u2191/\u2193] Navigate  [Enter] Next  [Esc] Back  [Ctrl+Q] Quit"
                 };
@@ -213,7 +217,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .Select(m => m switch
             {
                 AuthMethod.ApiKey => "API Key",
-                AuthMethod.OAuthDevice => "OAuth Device Flow (coming soon)",
+                AuthMethod.OAuthDevice => "OAuth Device Flow (recommended)",
                 _ => m.ToString()
             })
             .ToList();
@@ -315,6 +319,72 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             children.WithChild(new TextNode("").Height(1));
             children.WithChild(new TextNode($"  {descriptor.DisplayName} runs locally. No authentication required.")
                 .WithForeground(Color.Gray));
+        }
+
+        return children;
+    }
+
+    private ILayoutNode BuildOAuthDeviceFlowView()
+    {
+        var children = Layouts.Vertical();
+        var providerType = ViewModel.NewProviderType ?? "unknown";
+        var flowState = ViewModel.OAuthFlowState.Value;
+
+        children.WithChild(new TextNode($"  OAuth Device Flow for {providerType}")
+            .WithForeground(Color.White).Bold());
+        children.WithChild(new TextNode("").Height(1));
+
+        switch (flowState)
+        {
+            case DeviceFlowState.NotStarted:
+                children.WithChild(new TextNode("  Starting device authorization...")
+                    .WithForeground(Color.Yellow));
+                break;
+
+            case DeviceFlowState.WaitingForUser:
+            case DeviceFlowState.Polling:
+            {
+                var elapsed = ViewModel.ProbeElapsedSeconds.Value;
+                var frame = SpinnerFrames[elapsed % SpinnerFrames.Length];
+
+                if (ViewModel.OAuthVerificationUri is not null)
+                {
+                    children.WithChild(new TextNode($"  Visit: {ViewModel.OAuthVerificationUri}")
+                        .WithForeground(Color.Cyan));
+                    children.WithChild(new TextNode("").Height(1));
+                }
+
+                if (ViewModel.OAuthUserCode is not null)
+                {
+                    children.WithChild(new TextNode($"  Enter code: {ViewModel.OAuthUserCode}")
+                        .WithForeground(Color.White).Bold());
+                    children.WithChild(new TextNode("").Height(1));
+                }
+
+                children.WithChild(new TextNode($"  {frame} Waiting for authorization...")
+                    .WithForeground(Color.Yellow));
+                break;
+            }
+
+            case DeviceFlowState.Succeeded:
+                children.WithChild(new TextNode("  \u2714 Authorization successful!")
+                    .WithForeground(Color.Green));
+                break;
+
+            case DeviceFlowState.Denied:
+            case DeviceFlowState.Expired:
+            case DeviceFlowState.Error:
+                children.WithChild(new TextNode($"  \u2718 {ViewModel.OAuthErrorMessage ?? "Authorization failed."}")
+                    .WithForeground(Color.Red));
+                children.WithChild(new TextNode("").Height(1));
+                children.WithChild(new TextNode("  Press [Esc] to go back and try again.")
+                    .WithForeground(Color.Gray));
+                break;
+
+            case DeviceFlowState.Cancelled:
+                children.WithChild(new TextNode("  Authorization cancelled.")
+                    .WithForeground(Color.Yellow));
+                break;
         }
 
         return children;

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
+using Netclaw.Configuration.Secrets;
 using R3;
 using Termina.Input;
 using Termina.Reactive;
@@ -17,6 +19,7 @@ public enum ProviderManagerState
     List,
     AddSelectAuth,
     AddCredentials,
+    AddOAuthDeviceFlow,
     AddValidating,
     AddComplete,
     Details,
@@ -61,7 +64,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     private readonly NetclawPaths _paths;
     private readonly ProviderDescriptorRegistry _registry;
     private readonly IProviderProbe _probe;
+    private readonly OAuthDeviceFlowService? _oauthService;
     private CancellationTokenSource? _probeCts;
+    private CancellationTokenSource? _oauthCts;
 
     public ReactiveProperty<ProviderManagerState> CurrentState { get; } = new(ProviderManagerState.Loading);
     public ReactiveProperty<string> StatusMessage { get; } = new("");
@@ -97,6 +102,18 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public string? NewApiKey { get; set; }
     public string? NewEndpoint { get; set; }
 
+    // ── OAuth device flow state ──
+    public ReactiveProperty<DeviceFlowState> OAuthFlowState { get; } = new(DeviceFlowState.NotStarted);
+    public string? OAuthUserCode { get; set; }
+    public string? OAuthVerificationUri { get; set; }
+    public string? OAuthErrorMessage { get; set; }
+    internal OAuthDeviceFlowResult? OAuthResult { get; set; }
+
+    /// <summary>
+    /// Completes when the OAuth device flow finishes. Used for testing.
+    /// </summary>
+    internal Task? OAuthFlowCompletion { get; private set; }
+
     // ── Fix flow state ──
     public string? FixApiKey { get; set; }
     public string? FixEndpoint { get; set; }
@@ -120,16 +137,19 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     /// </summary>
     public ProviderDescriptorRegistry Registry => _registry;
 
-    public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry)
-        : this(paths, registry, registry)
+    public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry,
+        OAuthDeviceFlowService? oauthService = null)
+        : this(paths, registry, registry, oauthService)
     {
     }
 
-    public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry, IProviderProbe probe)
+    public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry, IProviderProbe probe,
+        OAuthDeviceFlowService? oauthService = null)
     {
         _paths = paths;
         _registry = registry;
         _probe = probe;
+        _oauthService = oauthService;
     }
 
     public override void OnActivated()
@@ -326,11 +346,20 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     }
 
     /// <summary>
-    /// Select auth method and advance to credential input.
+    /// Select auth method and advance to credential input or OAuth device flow.
     /// </summary>
     public void SelectAuthMethod(AuthMethod method)
     {
         NewAuthMethod = method;
+
+        if (method == AuthMethod.OAuthDevice)
+        {
+            CurrentState.Value = ProviderManagerState.AddOAuthDeviceFlow;
+            NotifyStateChanged();
+            OAuthFlowCompletion = StartOAuthDeviceFlowAsync();
+            return;
+        }
+
         CurrentState.Value = ProviderManagerState.AddCredentials;
         NotifyStateChanged();
     }
@@ -501,6 +530,90 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         NotifyStateChanged();
     }
 
+    /// <summary>
+    /// Run the OAuth device flow: start device authorization, display user code,
+    /// poll for token, persist tokens on success, then transition to probe validation.
+    /// </summary>
+    internal async Task StartOAuthDeviceFlowAsync()
+    {
+        if (_oauthService is null || NewProviderType is null)
+        {
+            OAuthErrorMessage = "OAuth service not available.";
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            NotifyStateChanged();
+            return;
+        }
+
+        var descriptor = _registry.Get(NewProviderType);
+        if (descriptor.OAuthDeviceEndpoint is null || descriptor.OAuthTokenEndpoint is null
+            || descriptor.OAuthDefaultClientId is null)
+        {
+            OAuthErrorMessage = "Provider does not support OAuth device flow.";
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            NotifyStateChanged();
+            return;
+        }
+
+        _oauthCts = new CancellationTokenSource();
+        var ct = _oauthCts.Token;
+
+        var config = new OAuthDeviceFlowConfig(
+            descriptor.OAuthDeviceEndpoint,
+            descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId);
+
+        try
+        {
+            // Step 1: Start device authorization
+            var deviceAuth = await _oauthService.StartDeviceAuthorizationAsync(config, ct);
+            OAuthUserCode = deviceAuth.UserCode;
+            OAuthVerificationUri = deviceAuth.VerificationUri;
+            OAuthFlowState.Value = DeviceFlowState.WaitingForUser;
+            NotifyStateChanged();
+
+            // Step 2: Poll for token
+            var result = await _oauthService.PollForTokenAsync(config, deviceAuth,
+                state =>
+                {
+                    OAuthFlowState.Value = state;
+                    NotifyStateChanged();
+                }, ct);
+
+            // Step 3: Persist tokens
+            OAuthResult = result;
+            OAuthTokenPersistence.PersistTokens(_paths, NewProviderName!, result, SecretsProtection.CreateProtector(_paths));
+
+            // Step 4: Transition to probe validation using the OAuth token
+            NewApiKey = result.AccessToken.Value;
+            CurrentState.Value = ProviderManagerState.AddValidating;
+            NotifyStateChanged();
+            StartProbe();
+        }
+        catch (OAuthDeviceFlowDeniedException)
+        {
+            OAuthErrorMessage = "Authorization was denied.";
+            OAuthFlowState.Value = DeviceFlowState.Denied;
+            NotifyStateChanged();
+        }
+        catch (OAuthDeviceFlowExpiredException)
+        {
+            OAuthErrorMessage = "The authorization code expired. Please try again.";
+            OAuthFlowState.Value = DeviceFlowState.Expired;
+            NotifyStateChanged();
+        }
+        catch (OperationCanceledException)
+        {
+            OAuthFlowState.Value = DeviceFlowState.Cancelled;
+            NotifyStateChanged();
+        }
+        catch (Exception ex)
+        {
+            OAuthErrorMessage = ex.Message;
+            OAuthFlowState.Value = DeviceFlowState.Error;
+            NotifyStateChanged();
+        }
+    }
+
     public void GoBackToList()
     {
         CancelProbe();
@@ -522,6 +635,11 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         {
             case ProviderManagerState.AddSelectAuth:
                 GoBackToList();
+                break;
+            case ProviderManagerState.AddOAuthDeviceFlow:
+                CancelOAuthFlow();
+                CurrentState.Value = ProviderManagerState.AddSelectAuth;
+                NotifyStateChanged();
                 break;
             case ProviderManagerState.AddCredentials:
                 var descriptor = _registry.Get(NewProviderType ?? "");
@@ -676,7 +794,13 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         providers[NewProviderName!] = providerEntry;
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
 
-        if (!string.IsNullOrWhiteSpace(NewApiKey))
+        // Write secrets via SecretsFileWriter for encryption-at-rest
+        if (OAuthResult is not null)
+        {
+            // OAuth flow: tokens already persisted by StartOAuthDeviceFlowAsync
+            // Just ensure AuthMethod is recorded correctly
+        }
+        else if (!string.IsNullOrWhiteSpace(NewApiKey))
         {
             var secretProviders = ConfigFileHelper.GetOrCreateSection(secrets, "Providers");
             secretProviders[NewProviderName!] = new Dictionary<string, object>
@@ -712,6 +836,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     private void ClearAddState()
     {
         CancelProbe();
+        CancelOAuthFlow();
         NewProviderName = null;
         NewProviderType = null;
         NewAuthMethod = AuthMethod.None;
@@ -720,6 +845,21 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         IsFixFlow = false;
+        OAuthFlowState.Value = DeviceFlowState.NotStarted;
+        OAuthUserCode = null;
+        OAuthVerificationUri = null;
+        OAuthErrorMessage = null;
+        OAuthResult = null;
+    }
+
+    private void CancelOAuthFlow()
+    {
+        if (_oauthCts is not null)
+        {
+            _oauthCts.Cancel();
+            _oauthCts.Dispose();
+            _oauthCts = null;
+        }
     }
 
     private void NotifyStateChanged()
@@ -740,6 +880,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public override void Dispose()
     {
         CancelProbe();
+        CancelOAuthFlow();
         CurrentState.Dispose();
         StatusMessage.Dispose();
         IsProbing.Dispose();
@@ -748,6 +889,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         IsEagerProbing.Dispose();
         EagerProbeElapsedSeconds.Dispose();
         StateVersion.Dispose();
+        OAuthFlowState.Dispose();
         base.Dispose();
     }
 }

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -241,7 +241,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 var result = await _probe.ProbeAsync(
                     item.ProviderType,
                     item.Entry?.Endpoint,
-                    item.Entry?.ApiKey?.Value,
+                    GetProbeCredential(item.Entry),
                     CancellationToken.None);
 
                 item.ProbeResult = result;
@@ -429,7 +429,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         // Set up probe using fix credentials
         NewProviderType = type;
         NewEndpoint = FixEndpoint;
-        NewApiKey = FixApiKey ?? DetailProvider.Entry?.ApiKey?.Value;
+        NewApiKey = FixApiKey
+            ?? DetailProvider.Entry?.ApiKey?.Value
+            ?? DetailProvider.Entry?.OAuthAccessToken?.Value;
         IsFixFlow = true;
 
         CurrentState.Value = ProviderManagerState.AddValidating;
@@ -514,7 +516,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             var result = await _probe.ProbeAsync(
                 item.ProviderType,
                 item.Entry?.Endpoint,
-                item.Entry?.ApiKey?.Value,
+                GetProbeCredential(item.Entry),
                 CancellationToken.None);
 
             item.ProbeResult = result;
@@ -579,9 +581,8 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                     NotifyStateChanged();
                 }, ct);
 
-            // Step 3: Persist tokens
+            // Step 3: Keep tokens in-memory until provider is confirmed
             OAuthResult = result;
-            OAuthTokenPersistence.PersistTokens(_paths, NewProviderName!, result, SecretsProtection.CreateProtector(_paths));
 
             // Step 4: Transition to probe validation using the OAuth token
             NewApiKey = result.AccessToken.Value;
@@ -797,8 +798,12 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         // Write secrets via SecretsFileWriter for encryption-at-rest
         if (OAuthResult is not null)
         {
-            // OAuth flow: tokens already persisted by StartOAuthDeviceFlowAsync
-            // Just ensure AuthMethod is recorded correctly
+            // OAuth flow: persist tokens only after user confirms add
+            OAuthTokenPersistence.PersistTokens(
+                _paths,
+                NewProviderName!,
+                OAuthResult,
+                SecretsProtection.CreateProtector(_paths));
         }
         else if (!string.IsNullOrWhiteSpace(NewApiKey))
         {
@@ -812,6 +817,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     }
 
     // ── Helpers ──
+
+    private static string? GetProbeCredential(ProviderEntry? entry)
+        => entry?.ApiKey?.Value ?? entry?.OAuthAccessToken?.Value;
 
     private string GenerateProviderName(string type)
     {

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
@@ -63,7 +63,7 @@ public class OAuthDeviceFlowServiceTests
             UserCode: "UC-TEST",
             VerificationUri: "https://auth.example.com/verify",
             ExpiresIn: 30,
-            Interval: 1); // minimum interval per RFC is 5, but our code clamps to max(interval, 5)
+            Interval: 1); // test-friendly interval; code clamps to max(interval, 1)
 
         var states = new List<DeviceFlowState>();
         var result = await service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Configuration.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+public class OAuthDeviceFlowServiceTests
+{
+    private static readonly OAuthDeviceFlowConfig TestConfig = new(
+        "https://auth.example.com/device",
+        "https://auth.example.com/token",
+        "test-client-id");
+
+    [Fact]
+    public async Task StartDeviceAuthorization_ReturnsDeviceAuthResponse()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                device_code = "dc-123",
+                user_code = "USER-CODE",
+                verification_uri = "https://auth.example.com/verify",
+                expires_in = 300,
+                interval = 5
+            }));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.StartDeviceAuthorizationAsync(TestConfig);
+
+        Assert.Equal("dc-123", result.DeviceCode);
+        Assert.Equal("USER-CODE", result.UserCode);
+        Assert.Equal("https://auth.example.com/verify", result.VerificationUri);
+        Assert.Equal(300, result.ExpiresIn);
+        Assert.Equal(5, result.Interval);
+    }
+
+    [Fact]
+    public async Task PollForToken_PendingThenSuccess_ReturnsToken()
+    {
+        var callCount = 0;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            callCount++;
+            if (callCount <= 2)
+                return JsonResponse(new { error = "authorization_pending" }, HttpStatusCode.BadRequest);
+
+            return JsonResponse(new
+            {
+                access_token = "at-secret",
+                refresh_token = "rt-secret",
+                expires_in = 3600
+            });
+        });
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+
+        // Use a very short interval device auth to keep the test fast
+        var deviceAuth = new DeviceAuthorizationResponse(
+            DeviceCode: "dc-test",
+            UserCode: "UC-TEST",
+            VerificationUri: "https://auth.example.com/verify",
+            ExpiresIn: 30,
+            Interval: 1); // minimum interval per RFC is 5, but our code clamps to max(interval, 5)
+
+        var states = new List<DeviceFlowState>();
+        var result = await service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+
+        Assert.Equal("at-secret", result.AccessToken.Value);
+        Assert.NotNull(result.RefreshToken);
+        Assert.Equal("rt-secret", result.RefreshToken!.Value);
+        Assert.NotNull(result.ExpiresAt);
+        Assert.Contains(DeviceFlowState.WaitingForUser, states);
+        Assert.Contains(DeviceFlowState.Succeeded, states);
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task PollForToken_SlowDown_IncreasesInterval()
+    {
+        var callCount = 0;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            callCount++;
+            if (callCount == 1)
+                return JsonResponse(new { error = "slow_down" }, HttpStatusCode.BadRequest);
+
+            return JsonResponse(new { access_token = "token", expires_in = 3600 });
+        });
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
+
+        var result = await service.PollForTokenAsync(TestConfig, deviceAuth);
+
+        Assert.Equal("token", result.AccessToken.Value);
+        Assert.True(callCount >= 2);
+    }
+
+    [Fact]
+    public async Task PollForToken_AccessDenied_ThrowsDeniedException()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "access_denied" }, HttpStatusCode.BadRequest));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
+
+        await Assert.ThrowsAsync<OAuthDeviceFlowDeniedException>(
+            () => service.PollForTokenAsync(TestConfig, deviceAuth));
+    }
+
+    [Fact]
+    public async Task PollForToken_ExpiredToken_ThrowsExpiredException()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "expired_token" }, HttpStatusCode.BadRequest));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
+
+        await Assert.ThrowsAsync<OAuthDeviceFlowExpiredException>(
+            () => service.PollForTokenAsync(TestConfig, deviceAuth));
+    }
+
+    [Fact]
+    public async Task PollForToken_Cancellation_ThrowsOperationCanceled()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "authorization_pending" }, HttpStatusCode.BadRequest));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task RefreshToken_Success_ReturnsNewToken()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                refresh_token = "new-rt",
+                expires_in = 3600
+            }));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.example.com/token",
+            "client-id",
+            "old-refresh-token");
+
+        Assert.NotNull(result);
+        Assert.Equal("new-at", result!.AccessToken.Value);
+        Assert.NotNull(result.RefreshToken);
+        Assert.Equal("new-rt", result.RefreshToken!.Value);
+    }
+
+    [Fact]
+    public async Task RefreshToken_InvalidGrant_ReturnsNull()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "invalid_grant" }, HttpStatusCode.BadRequest));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.example.com/token",
+            "client-id",
+            "expired-refresh-token");
+
+        Assert.Null(result);
+    }
+
+    // ── Helpers ──
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var json = JsonSerializer.Serialize(body);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Configuration/Providers/Descriptors/AnthropicDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/AnthropicDescriptor.cs
@@ -19,6 +19,9 @@ public sealed class AnthropicDescriptor : IProviderDescriptor
     public string ModelListingPath => "/v1/models";
     public CredentialInputMode CredentialMode => CredentialInputMode.ApiKey;
     public string? ApiKeyGuidanceUrl => "https://console.anthropic.com/settings/keys";
+    public string? OAuthDeviceEndpoint => null;
+    public string? OAuthTokenEndpoint => null;
+    public string? OAuthDefaultClientId => null;
 
     public Task<ProviderProbeResult> ProbeAsync(
         ProviderEntry entry, CancellationToken ct = default)

--- a/src/Netclaw.Configuration/Providers/Descriptors/OllamaDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OllamaDescriptor.cs
@@ -24,6 +24,9 @@ public sealed class OllamaDescriptor : IProviderDescriptor
     public string ModelListingPath => "/api/tags";
     public CredentialInputMode CredentialMode => CredentialInputMode.EndpointOnly;
     public string? ApiKeyGuidanceUrl => null;
+    public string? OAuthDeviceEndpoint => null;
+    public string? OAuthTokenEndpoint => null;
+    public string? OAuthDefaultClientId => null;
 
     public Task<ProviderProbeResult> ProbeAsync(
         ProviderEntry entry, CancellationToken ct = default)

--- a/src/Netclaw.Configuration/Providers/Descriptors/OpenAiDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OpenAiDescriptor.cs
@@ -21,13 +21,16 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
     public string ModelListingPath => "/v1/models";
     public CredentialInputMode CredentialMode => CredentialInputMode.ApiKey;
     public string? ApiKeyGuidanceUrl => "https://platform.openai.com/api-keys";
+    public string? OAuthDeviceEndpoint => "https://auth.openai.com/codex/device";
+    public string? OAuthTokenEndpoint => "https://auth.openai.com/oauth/token";
+    public string? OAuthDefaultClientId => "app_EMoamEEZ73f0CkXaXp7hrann";
 
     public Task<ProviderProbeResult> ProbeAsync(
         ProviderEntry entry, CancellationToken ct = default)
     {
-        var apiKey = entry.ApiKey?.Value;
-        if (string.IsNullOrWhiteSpace(apiKey))
-            return Task.FromResult(new ProviderProbeResult(false, "API key is required for OpenAI.", []));
+        var bearerToken = entry.ApiKey?.Value ?? entry.OAuthAccessToken?.Value;
+        if (string.IsNullOrWhiteSpace(bearerToken))
+            return Task.FromResult(new ProviderProbeResult(false, "API key or OAuth token is required for OpenAI.", []));
 
         return ProbeHelpers.ExecuteProbeAsync(
             _httpClient,
@@ -35,7 +38,7 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
             DefaultEndpoint,
             ModelListingPath,
             entry.Endpoint,
-            request => request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey),
+            request => request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken),
             ProbeHelpers.ParseOpenAiStyleModels,
             ct);
     }

--- a/src/Netclaw.Configuration/Providers/Descriptors/OpenRouterDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OpenRouterDescriptor.cs
@@ -21,6 +21,9 @@ public sealed class OpenRouterDescriptor : IProviderDescriptor
     public string ModelListingPath => "/models";
     public CredentialInputMode CredentialMode => CredentialInputMode.ApiKey;
     public string? ApiKeyGuidanceUrl => "https://openrouter.ai/keys";
+    public string? OAuthDeviceEndpoint => null;
+    public string? OAuthTokenEndpoint => null;
+    public string? OAuthDefaultClientId => null;
 
     public Task<ProviderProbeResult> ProbeAsync(
         ProviderEntry entry, CancellationToken ct = default)

--- a/src/Netclaw.Configuration/Providers/IProviderDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/IProviderDescriptor.cs
@@ -35,6 +35,24 @@ public interface IProviderDescriptor
     string? ApiKeyGuidanceUrl { get; }
 
     /// <summary>
+    /// RFC 8628 device authorization endpoint URL.
+    /// Null for providers that don't support OAuth device flow.
+    /// </summary>
+    string? OAuthDeviceEndpoint { get; }
+
+    /// <summary>
+    /// OAuth token endpoint URL (for token exchange and refresh).
+    /// Null for providers that don't support OAuth.
+    /// </summary>
+    string? OAuthTokenEndpoint { get; }
+
+    /// <summary>
+    /// Default OAuth client_id for this provider. Operators can override in config.
+    /// Null for providers that don't support OAuth.
+    /// </summary>
+    string? OAuthDefaultClientId { get; }
+
+    /// <summary>
     /// Validate credentials and discover available models.
     /// </summary>
     Task<ProviderProbeResult> ProbeAsync(

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowExceptions.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowExceptions.cs
@@ -1,0 +1,23 @@
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// Thrown when the user denies the device authorization request.
+/// </summary>
+public sealed class OAuthDeviceFlowDeniedException : Exception
+{
+    public OAuthDeviceFlowDeniedException()
+        : base("The user denied the device authorization request.")
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when the device code expires before the user completes authorization.
+/// </summary>
+public sealed class OAuthDeviceFlowExpiredException : Exception
+{
+    public OAuthDeviceFlowExpiredException()
+        : base("The device code has expired. Please start the authorization flow again.")
+    {
+    }
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
@@ -1,0 +1,228 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// Configuration for an RFC 8628 device authorization grant flow.
+/// </summary>
+public sealed record OAuthDeviceFlowConfig(
+    string DeviceAuthorizationEndpoint,
+    string TokenEndpoint,
+    string ClientId,
+    string? Scope = null);
+
+/// <summary>
+/// Response from the device authorization endpoint (RFC 8628 §3.2).
+/// </summary>
+public sealed record DeviceAuthorizationResponse(
+    [property: JsonPropertyName("device_code")] string DeviceCode,
+    [property: JsonPropertyName("user_code")] string UserCode,
+    [property: JsonPropertyName("verification_uri")] string VerificationUri,
+    [property: JsonPropertyName("expires_in")] int ExpiresIn,
+    [property: JsonPropertyName("interval")] int Interval);
+
+/// <summary>
+/// Successful token result from the OAuth device flow.
+/// </summary>
+public sealed record OAuthDeviceFlowResult(
+    SensitiveString AccessToken,
+    SensitiveString? RefreshToken,
+    DateTimeOffset? ExpiresAt);
+
+/// <summary>
+/// Observable state of the device flow polling loop.
+/// </summary>
+public enum DeviceFlowState
+{
+    NotStarted,
+    WaitingForUser,
+    Polling,
+    Succeeded,
+    Denied,
+    Expired,
+    Cancelled,
+    Error
+}
+
+/// <summary>
+/// Generic RFC 8628 device authorization grant implementation.
+/// Parameterized by provider endpoints so it can be reused across providers.
+/// </summary>
+public sealed class OAuthDeviceFlowService
+{
+    private readonly HttpClient _httpClient;
+    private readonly TimeProvider _timeProvider;
+
+    public OAuthDeviceFlowService(HttpClient httpClient, TimeProvider? timeProvider = null)
+    {
+        _httpClient = httpClient;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// POST to the device authorization endpoint to get a user code and verification URI.
+    /// </summary>
+    public async Task<DeviceAuthorizationResponse> StartDeviceAuthorizationAsync(
+        OAuthDeviceFlowConfig config, CancellationToken ct = default)
+    {
+        var content = new FormUrlEncodedContent(BuildDeviceAuthParams(config));
+        var response = await _httpClient.PostAsync(config.DeviceAuthorizationEndpoint, content, ct);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<DeviceAuthorizationResponse>(ct);
+        return result ?? throw new InvalidOperationException("Empty device authorization response.");
+    }
+
+    /// <summary>
+    /// Poll the token endpoint until the user authorizes, denies, or the code expires.
+    /// </summary>
+    public async Task<OAuthDeviceFlowResult> PollForTokenAsync(
+        OAuthDeviceFlowConfig config,
+        DeviceAuthorizationResponse deviceAuth,
+        Action<DeviceFlowState>? onStateChanged = null,
+        CancellationToken ct = default)
+    {
+        var interval = Math.Max(deviceAuth.Interval, 1);
+        var deadline = _timeProvider.GetUtcNow().AddSeconds(deviceAuth.ExpiresIn);
+
+        onStateChanged?.Invoke(DeviceFlowState.WaitingForUser);
+
+        while (_timeProvider.GetUtcNow() < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            await Task.Delay(TimeSpan.FromSeconds(interval), _timeProvider, ct);
+
+            onStateChanged?.Invoke(DeviceFlowState.Polling);
+
+            var tokenParams = new Dictionary<string, string>
+            {
+                ["grant_type"] = "urn:ietf:params:oauth:grant-type:device_code",
+                ["device_code"] = deviceAuth.DeviceCode,
+                ["client_id"] = config.ClientId
+            };
+
+            var response = await _httpClient.PostAsync(
+                config.TokenEndpoint,
+                new FormUrlEncodedContent(tokenParams),
+                ct);
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = ParseTokenResponse(root);
+                onStateChanged?.Invoke(DeviceFlowState.Succeeded);
+                return result;
+            }
+
+            var error = root.TryGetProperty("error", out var errProp)
+                ? errProp.GetString() : null;
+
+            switch (error)
+            {
+                case "authorization_pending":
+                    // Keep polling
+                    continue;
+
+                case "slow_down":
+                    // RFC 8628 §3.5: increase interval by 5 seconds
+                    interval += 5;
+                    continue;
+
+                case "access_denied":
+                    onStateChanged?.Invoke(DeviceFlowState.Denied);
+                    throw new OAuthDeviceFlowDeniedException();
+
+                case "expired_token":
+                    onStateChanged?.Invoke(DeviceFlowState.Expired);
+                    throw new OAuthDeviceFlowExpiredException();
+
+                default:
+                    var description = root.TryGetProperty("error_description", out var descProp)
+                        ? descProp.GetString() : error;
+                    onStateChanged?.Invoke(DeviceFlowState.Error);
+                    throw new InvalidOperationException(
+                        $"OAuth device flow error: {description ?? "unknown error"}");
+            }
+        }
+
+        onStateChanged?.Invoke(DeviceFlowState.Expired);
+        throw new OAuthDeviceFlowExpiredException();
+    }
+
+    /// <summary>
+    /// Exchange a refresh token for a new access token.
+    /// Returns null if the refresh token is invalid or revoked.
+    /// </summary>
+    public async Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default)
+    {
+        var tokenParams = new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["client_id"] = clientId,
+            ["refresh_token"] = refreshToken
+        };
+
+        var response = await _httpClient.PostAsync(
+            tokenEndpoint,
+            new FormUrlEncodedContent(tokenParams),
+            ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorJson = await response.Content.ReadAsStringAsync(ct);
+            using var errorDoc = JsonDocument.Parse(errorJson);
+            var error = errorDoc.RootElement.TryGetProperty("error", out var errProp)
+                ? errProp.GetString() : null;
+
+            if (error == "invalid_grant")
+                return null;
+
+            response.EnsureSuccessStatusCode(); // throw for other errors
+        }
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return ParseTokenResponse(doc.RootElement);
+    }
+
+    private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
+    {
+        var accessToken = root.GetProperty("access_token").GetString()
+            ?? throw new InvalidOperationException("Missing access_token in response.");
+
+        string? refreshToken = root.TryGetProperty("refresh_token", out var refreshProp)
+            ? refreshProp.GetString() : null;
+
+        DateTimeOffset? expiresAt = root.TryGetProperty("expires_in", out var expiresProp)
+            ? _timeProvider.GetUtcNow().AddSeconds(expiresProp.GetInt32())
+            : null;
+
+        return new OAuthDeviceFlowResult(
+            new SensitiveString(accessToken),
+            refreshToken is not null ? new SensitiveString(refreshToken) : null,
+            expiresAt);
+    }
+
+    private static List<KeyValuePair<string, string>> BuildDeviceAuthParams(OAuthDeviceFlowConfig config)
+    {
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("client_id", config.ClientId)
+        };
+
+        if (config.Scope is not null)
+            parameters.Add(new("scope", config.Scope));
+
+        return parameters;
+    }
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthTokenPersistence.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Configuration.Secrets;
+
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// Helpers for persisting and loading OAuth tokens to/from secrets.json.
+/// Uses <see cref="SecretsFileWriter"/> for encrypted writes and
+/// config-binding-compatible field names matching <see cref="ProviderEntry"/>.
+/// </summary>
+public static class OAuthTokenPersistence
+{
+    /// <summary>
+    /// Persist OAuth tokens to secrets.json for the given provider name.
+    /// Merges into existing secrets content, preserving other providers' entries.
+    /// </summary>
+    public static void PersistTokens(
+        NetclawPaths paths,
+        string providerName,
+        OAuthDeviceFlowResult result,
+        ISecretsProtector? protector = null)
+    {
+        paths.EnsureDirectoriesExist();
+
+        // Load existing secrets as a JSON object tree to preserve other entries
+        var existingJson = File.Exists(paths.SecretsPath)
+            ? File.ReadAllText(paths.SecretsPath)
+            : "{}";
+
+        var root = JsonNode.Parse(existingJson)?.AsObject() ?? new JsonObject();
+        var providers = root["Providers"]?.AsObject() ?? new JsonObject();
+        root["Providers"] = providers;
+
+        var providerNode = providers[providerName]?.AsObject() ?? new JsonObject();
+        providers[providerName] = providerNode;
+
+        providerNode["OAuthAccessToken"] = result.AccessToken.Value;
+
+        if (result.RefreshToken is not null)
+            providerNode["OAuthRefreshToken"] = result.RefreshToken.Value;
+
+        if (result.ExpiresAt.HasValue)
+            providerNode["OAuthTokenExpiry"] = result.ExpiresAt.Value.ToString("o");
+
+        var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        SecretsFileWriter.Write(paths.SecretsPath, json, protector);
+    }
+
+    /// <summary>
+    /// Load OAuth tokens from secrets.json for the given provider name.
+    /// Returns null if no OAuth tokens are stored for this provider.
+    /// Transparent decryption happens via <see cref="SensitiveStringTypeConverter"/>.
+    /// </summary>
+    public static OAuthDeviceFlowResult? LoadTokens(NetclawPaths paths, string providerName)
+    {
+        if (!File.Exists(paths.SecretsPath))
+            return null;
+
+        var json = File.ReadAllText(paths.SecretsPath);
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("Providers", out var providers))
+            return null;
+
+        if (!providers.TryGetProperty(providerName, out var provider))
+            return null;
+
+        if (!provider.TryGetProperty("OAuthAccessToken", out var accessTokenProp))
+            return null;
+
+        var accessTokenStr = accessTokenProp.GetString();
+        if (string.IsNullOrWhiteSpace(accessTokenStr))
+            return null;
+
+        // Transparent decrypt via SensitiveStringTypeConverter.Protector
+        var protector = SensitiveStringTypeConverter.Protector;
+        if (protector is not null && ISecretsProtector.IsEncrypted(accessTokenStr))
+            accessTokenStr = protector.Unprotect(accessTokenStr);
+
+        string? refreshTokenStr = null;
+        if (provider.TryGetProperty("OAuthRefreshToken", out var refreshProp))
+        {
+            refreshTokenStr = refreshProp.GetString();
+            if (protector is not null && refreshTokenStr is not null && ISecretsProtector.IsEncrypted(refreshTokenStr))
+                refreshTokenStr = protector.Unprotect(refreshTokenStr);
+        }
+
+        DateTimeOffset? expiresAt = null;
+        if (provider.TryGetProperty("OAuthTokenExpiry", out var expiryProp))
+        {
+            var expiryStr = expiryProp.GetString();
+            if (expiryStr is not null && DateTimeOffset.TryParse(expiryStr, out var parsed))
+                expiresAt = parsed;
+        }
+
+        return new OAuthDeviceFlowResult(
+            new SensitiveString(accessTokenStr),
+            refreshTokenStr is not null ? new SensitiveString(refreshTokenStr) : null,
+            expiresAt);
+    }
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthTokenPersistence.cs
@@ -90,6 +90,9 @@ public static class OAuthTokenPersistence
         if (provider.TryGetProperty("OAuthTokenExpiry", out var expiryProp))
         {
             var expiryStr = expiryProp.GetString();
+            if (protector is not null && expiryStr is not null && ISecretsProtector.IsEncrypted(expiryStr))
+                expiryStr = protector.Unprotect(expiryStr);
+
             if (expiryStr is not null && DateTimeOffset.TryParse(expiryStr, out var parsed))
                 expiresAt = parsed;
         }

--- a/src/Netclaw.Daemon/Providers/LlmProviderServiceExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/LlmProviderServiceExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
 using Netclaw.Configuration.Providers.Descriptors;
+using Netclaw.Configuration.Providers.OAuth;
 using Netclaw.Daemon.Configuration;
 
 namespace Netclaw.Daemon.Providers;
@@ -22,6 +23,13 @@ public static class LlmProviderServiceExtensions
     {
         // Register descriptors (shared with CLI)
         services.AddProviderDescriptors();
+
+        // OAuth device flow service (for future auto-refresh)
+        services.AddHttpClient("OAuthDeviceFlow");
+        services.AddSingleton(sp =>
+            new OAuthDeviceFlowService(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                sp.GetService<TimeProvider>()));
 
         // Register daemon-specific plugins
         services.AddSingleton<OllamaProviderPlugin>();

--- a/src/Netclaw.Daemon/Providers/ProviderPluginBase.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderPluginBase.cs
@@ -26,6 +26,9 @@ public abstract class ProviderPluginBase<TDescriptor> : ILlmProviderPlugin
     public string ModelListingPath => Descriptor.ModelListingPath;
     public CredentialInputMode CredentialMode => Descriptor.CredentialMode;
     public string? ApiKeyGuidanceUrl => Descriptor.ApiKeyGuidanceUrl;
+    public string? OAuthDeviceEndpoint => Descriptor.OAuthDeviceEndpoint;
+    public string? OAuthTokenEndpoint => Descriptor.OAuthTokenEndpoint;
+    public string? OAuthDefaultClientId => Descriptor.OAuthDefaultClientId;
 
     public Task<ProviderProbeResult> ProbeAsync(ProviderEntry entry, CancellationToken ct = default)
         => Descriptor.ProbeAsync(entry, ct);


### PR DESCRIPTION
## Summary

- Implements RFC 8628 device authorization grant for OpenAI, enabling operators to authenticate interactively via browser instead of manually managing API keys
- Generic `OAuthDeviceFlowService` is reusable for future providers (e.g., Anthropic)
- Adds OAuth endpoint metadata to `IProviderDescriptor` interface with OpenAI-specific endpoints (`auth.openai.com`)
- Wires device flow into Provider Manager TUI, Init Wizard TUI, and CLI (`--auth oauth-device` flag)
- Persists tokens via `SecretsFileWriter` with encryption-at-rest (`ENC:` prefix)
- Migrates existing secrets writes to `SecretsFileWriter` for consistency
- 8 unit tests covering happy path, error cases, cancellation, and token refresh

## Changes

| Area | Files |
|------|-------|
| Core service | `OAuthDeviceFlowService.cs`, `OAuthDeviceFlowExceptions.cs`, `OAuthTokenPersistence.cs` |
| Descriptor metadata | `IProviderDescriptor.cs`, all 4 descriptors, `ProviderPluginBase.cs` |
| Provider Manager TUI | `ProviderManagerViewModel.cs`, `ProviderManagerPage.cs` |
| Init Wizard TUI | `InitWizardViewModel.cs`, `InitWizardPage.cs` |
| CLI | `ProviderCommand.cs` (new `--auth oauth-device` flag) |
| Daemon DI | `LlmProviderServiceExtensions.cs` |
| Tests | `OAuthDeviceFlowServiceTests.cs` (8 tests) |

## Known tradeoffs

- **No runtime auto-refresh (MVP)**: If an OAuth token expires during a long daemon session, API calls fail until re-auth. Acceptable for homelab MVP.
- **Codex CLI client_id**: Uses OpenAI's Codex CLI client_id as default. Configurable via descriptor if revoked.

## Test plan

- [x] `dotnet build Netclaw.slnx` — 0 errors, 0 warnings
- [x] `dotnet test Netclaw.slnx` — 631 tests passed, 0 failed
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual: `netclaw provider` TUI → OpenAI → OAuth Device Flow → verify code + URL → complete in browser
- [ ] Manual: `netclaw provider add my-openai openai --auth oauth-device` → CLI flow
- [ ] Manual: verify tokens persisted encrypted in `~/.netclaw/config/secrets.json`
- [ ] Manual: restart daemon → verify OpenAI connects with OAuth token
- [ ] Manual: API key fallback still works