### PR TITLE
Prepare release notes and version metadata for 0.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>See RELEASE_NOTES.md</PackageReleaseNotes>
+    <PackageReleaseNotes>Netclaw v0.1.0 — Initial Release. Actor-based session engine on Slack Socket Mode with SQLite persistence, extractive context compaction, MCP tool integration with OAuth 2.1, multi-provider LLM support (OpenRouter/Ollama), file-based memory, binary distribution feed with auto-update, secrets protection with encryption at rest, and a full init wizard and doctor CLI.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,122 @@
-#### 1.0.0 April 10th 2025 ####
+#### 0.1.0 2026-03-04 ####
 
-Example release notes
+Netclaw v0.1.0 — Initial Release
+
+Netclaw is an always-on autonomous operations agent for homelab infrastructure.
+It runs as a single .NET 10 process, communicates through Slack, persists
+session state across restarts, and executes tasks autonomously on your behalf.
+
+**Core Agent & Session**
+
+* Actor-based session engine: each Slack thread (`{channelId}/{threadTs}`)
+  is an isolated, persistent session actor backed by SQLite journal and
+  snapshot storage
+* Tiered context compaction with extractive reducer — long threads are
+  compacted without losing conversation context
+* Adaptive compaction, context overflow detection, and session observability
+* Session resume: conversation history is replayed on reconnect
+* Session browsing and resume support in the TUI
+* Max tool iterations circuit breaker and parallel tool execution
+* Fixed agent stalls caused by empty post-tool LLM responses
+
+**Slack Integration**
+
+* Slack Socket Mode adapter with layered channel actor hierarchy
+* Slack DM support with `MentionRequiredInDm` option and auto-enable when
+  user IDs are configured
+* Slack file flow (attach and receive files in conversation)
+* Config wizard integration for Slack auth and channel name resolution
+* Auto-link bare URLs in Slack Block Converter output
+* Secure Slack defaults with default-deny ACL
+
+**LLM Provider Support**
+
+* Multi-provider configuration system via `Netclaw.Configuration`
+* OpenRouter as primary provider via `Microsoft.Extensions.AI`
+* Provider plugin architecture with resilience pipeline
+* CLI model selection and provider management
+* Ollama support with `OllamaCapabilityResolver` for provider-first
+  capability detection
+* Startup capability auto-detection for multimodal models
+* Model capabilities surfaced in status endpoint
+
+**MCP Tool Integration**
+
+* MCP tool integration with dynamic discovery and per-turn reset
+* MCP OAuth 2.1 Authorization Code + PKCE authentication
+* MCP connectivity checks, schema sanitization, and headless UX improvements
+* File-backed progressive MCP tool discovery
+* Browser MCP onboarding and context safeguards
+
+**Built-in Tools**
+
+* Web search and web fetch with session-scoped file output
+* Multimodal image pipeline with modality gating and file output
+* Headless prompt (`-p`) mode for scripted/non-interactive use
+
+**Memory & Context**
+
+* File-based memory fallback (unified memory provider M1)
+* SubAgentActor with Memorizer MCP-backed memory tools
+* Unified context discovery: skills, memory, and observational context layers
+* Identity file system (SOUL, AGENTS.md, environment inventory) loaded as
+  context layers at session start
+
+**Skills System**
+
+* System skills feed infrastructure with signed manifest and binary
+  distribution
+* Skill triggers metadata and execution stance for agent autonomy control
+* Built-in skill nudges for proactive memory and diagnostics
+
+**Binary Distribution & Auto-Update**
+
+* Binary distribution feed with signed release manifest
+* Auto-update system: agent checks for and applies new releases
+
+**Configuration & Init Wizard**
+
+* Procedural init wizard covering provider config, model selection, Slack
+  auth, and DM configuration
+* Search provider abstraction with init wizard integration
+* Daemon restart on config file change (no manual restart required)
+* `appsettings.Local.json` support for machine-specific overrides
+
+**CLI & TUI**
+
+* TUI with multi-line text input, paste debounce, status bar, crash logging,
+  and tool call timers
+* Daemon + thin client architecture over SignalR with streaming and typed
+  session recovery
+* CLI model selection, runtime env var customization, and provider management
+* Detailed status endpoint exposing build version, commit hash, build
+  timestamp, and uptime (corrected to reflect soft restarts)
+* Doctor command with autofix flow and domain-split diagnostics
+* Fixed README Quick Start to reflect actual setup steps
+
+**Observability & Telemetry**
+
+* OTLP logs and metrics with typed daemon telemetry configuration
+* Session logging: user prompts, richer transcripts, and sortable filenames
+* Per-session disk logging with console framework noise suppression
+
+**Security**
+
+* Secrets protection: encryption at rest using `Microsoft.AspNetCore.DataProtection`
+* Tool deny-list to block access to protected Netclaw paths
+* Hardened accidental secret leak guardrails across shell tool output
+* `ToolPathPolicy` command validation with Windows compatibility
+* Default-deny ACL with explicit channel/sender/data grants
+
+**Stability Fixes**
+
+* Fixed daemon CWD anchored to user-owned temp directory at startup
+  (resolves permission issues on Linux/macOS)
+* Fixed `DaemonClient` reconnect race condition
+* Fixed `JoinSession` race condition with deterministic `Ask<SessionJoined>` pattern
+* Fixed OpenRouter streaming and provider endpoint resolution
+* Fixed compaction losing conversation context
+
+**Legal**
+
+* Project re-licensed to AGPLv3 with Commons Clause restriction


### PR DESCRIPTION
## Summary

- Updates `RELEASE_NOTES.md` with the full v0.1.0 initial release notes covering all user-facing changes since the project was bootstrapped
- Updates `Directory.Build.props` `PackageReleaseNotes` with a concise release summary
- `VersionPrefix` is already `0.1.0` — no version bump needed

## Release Notes Coverage

The notes document the complete initial release of Netclaw, organized by area:
- Core actor/session engine with SQLite persistence
- Slack Socket Mode integration and DM support
- Multi-provider LLM support (OpenRouter, Ollama) with capability auto-detection
- MCP tool integration with OAuth 2.1 and dynamic discovery
- File-based memory and unified context discovery
- Binary distribution feed and auto-update system
- Secrets protection with encryption at rest
- Init wizard, doctor CLI, and TUI
- Security hardening and stability fixes
- AGPLv3 + Commons Clause re-licensing

## Test plan

- [ ] Confirm `RELEASE_NOTES.md` parses correctly (version `0.1.0`, date `2026-03-04`)
- [ ] Confirm `Directory.Build.props` `VersionPrefix` remains `0.1.0`
- [ ] Merge, sync dev, tag `0.1.0`, push tag to trigger CI/CD release