### PR TITLE
Prepare 0.1.2 release and harden Slack token diagnostics

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.1.1 — Release feed hardening and installer fixes. Removes NuGet publish from release automation, aligns installers to releases.netclaw.dev, and publishes signed manifest/install artifacts directly to the release host.</PackageReleaseNotes>
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.1.2 — Daemon startup and diagnostics hardening. Includes SQLite native library self-extract for single-file daemon builds and improved doctor handling for encrypted or corrupted Slack secrets.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 0.1.2 2026-03-04 ####
+
+Netclaw v0.1.2 — Daemon Startup and Diagnostics Hardening
+
+* Fixed Linux single-file daemon SQLite startup failures by enabling native library self-extract for `netclawd` publishes.
+* Added a dedicated `SQLite Provisioning` doctor check to surface daemon crash-log evidence when SQLite initialization fails.
+* Improved Slack doctor token handling to decrypt encrypted secrets before probe and report corrupted encrypted token errors clearly.
+* Added regression coverage for SQLite provisioning diagnostics and encrypted Slack token failure handling.
+
 #### 0.1.1 2026-03-04 ####
 
 Netclaw v0.1.1 — Release Feed and Installer Fixes

--- a/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SlackAuthDoctorCheckTests.cs
@@ -115,6 +115,33 @@ public sealed class SlackAuthDoctorCheckTests
         Assert.Equal("xoxb-valid-token", probe.LastBotToken);
     }
 
+    [Fact]
+    public async Task ReturnsError_WhenEncryptedBotTokenCannotBeDecrypted()
+    {
+        var (paths, _) = CreateTempPaths();
+        WriteConfig(paths, slackEnabled: true);
+
+        var secrets = new Dictionary<string, object>
+        {
+            ["Slack"] = new Dictionary<string, object>
+            {
+                ["BotToken"] = "ENC:corrupted-token"
+            }
+        };
+
+        File.WriteAllText(paths.SecretsPath,
+            JsonSerializer.Serialize(secrets, new JsonSerializerOptions { WriteIndented = true }));
+
+        var probe = new FakeSlackProbe();
+        var check = new SlackAuthDoctorCheck(paths, probe);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("could not be decrypted", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.Remediation);
+        Assert.Equal(0, probe.ProbeCallCount);
+    }
+
     private static (NetclawPaths paths, string basePath) CreateTempPaths()
     {
         var basePath = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));

--- a/src/Netclaw.Cli/Doctor/SlackAuthDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SlackAuthDoctorCheck.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Netclaw.Channels.Slack;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
 
 namespace Netclaw.Cli.Doctor;
 
@@ -19,7 +20,14 @@ public sealed class SlackAuthDoctorCheck(NetclawPaths paths, ISlackProbe slackPr
             return DoctorCheckResult.Pass(CheckName, "Slack is disabled.");
 
         // Read bot token from secrets.json
-        var botToken = ReadBotToken(paths);
+        var (botToken, tokenReadError) = ReadBotToken(paths);
+        if (!string.IsNullOrWhiteSpace(tokenReadError))
+        {
+            return DoctorCheckResult.Error(CheckName,
+                tokenReadError,
+                "Ensure ~/.netclaw/keys exists for this user, then re-enter Slack tokens via `netclaw init`.");
+        }
+
         if (string.IsNullOrWhiteSpace(botToken))
         {
             return DoctorCheckResult.Error(CheckName,
@@ -35,23 +43,34 @@ public sealed class SlackAuthDoctorCheck(NetclawPaths paths, ISlackProbe slackPr
             "Check your Slack app's Bot User OAuth Token and scopes.");
     }
 
-    private static string? ReadBotToken(NetclawPaths paths)
+    private static (string? Token, string? Error) ReadBotToken(NetclawPaths paths)
     {
         if (!File.Exists(paths.SecretsPath))
-            return null;
+            return (null, null);
 
         try
         {
             var secrets = JsonNode.Parse(File.ReadAllText(paths.SecretsPath)) as JsonObject;
             var raw = secrets?["Slack"]?["BotToken"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(raw))
-                return null;
+                return (null, null);
 
-            return ConfigFileHelper.DecryptIfEncrypted(paths, raw);
+            if (!ISecretsProtector.IsEncrypted(raw))
+                return (raw, null);
+
+            try
+            {
+                return (ConfigFileHelper.DecryptIfEncrypted(paths, raw), null);
+            }
+            catch (Exception ex)
+            {
+                return (null,
+                    $"Slack bot token is present but could not be decrypted: {ex.Message}");
+            }
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            return (null, $"Failed reading Slack bot token from secrets.json: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- bump release metadata to 0.1.2 in `Directory.Build.props` and `RELEASE_NOTES.md`
- improve `SlackAuthDoctorCheck` to distinguish missing token from encrypted token decryption failures
- add regression coverage for corrupted encrypted Slack bot token handling

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj`
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj`
- `dotnet slopwatch analyze`