### PR TITLE
Fix session title generation timeout and logging

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -612,18 +612,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var history = _state.History;
         var self = Self;
         var client = _compactionClient;
+        var log = _log;
 
-        _ = GenerateTitleAsync(client, history, self);
+        _ = GenerateTitleAsync(client, history, self, log);
     }
 
     private static async Task GenerateTitleAsync(
         IChatClient client,
         IReadOnlyList<SerializableChatMessage> history,
-        IActorRef self)
+        IActorRef self,
+        ILoggingAdapter log)
     {
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var messages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.User,
@@ -631,12 +633,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             };
             var response = await client.GetResponseAsync(messages, cancellationToken: cts.Token);
             var title = response.Messages[^1].Text ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                log.Warning("Sidecar title generation returned null/whitespace text");
+                return;
+            }
+
             self.Tell(new TitleGenerationCompleted { Title = title });
         }
         catch (Exception ex)
         {
             // Title generation is best-effort — log and move on
-            Trace.TraceWarning("Sidecar title generation failed: {0}", ex.Message);
+            log.Warning("Sidecar title generation failed: {0}", ex.Message);
         }
     }
 


### PR DESCRIPTION
## Summary
- Increase `GenerateTitleAsync` timeout from 10s to 30s to accommodate thinking models (e.g. `qwen3.5:9b`) that need extended reasoning time before producing text
- Replace `Trace.TraceWarning` with Akka `ILoggingAdapter` so title generation failures appear in `daemon.log` instead of being silently swallowed
- Add guard against null/whitespace model responses to prevent blank titles from being persisted

## Test plan
- [x] `dotnet build` — compiles cleanly
- [x] `dotnet test` — all 608 tests pass
- [x] `dotnet slopwatch analyze` — no new violations
- [ ] Manual: run daemon, send a message, verify title appears in `daemon.log` and SQLite

Fixes #84