### PR TITLE
Fix binary update manifest endpoint

### DIFF
--- a/src/Netclaw.Configuration/Feeds/FeedConstants.cs
+++ b/src/Netclaw.Configuration/Feeds/FeedConstants.cs
@@ -2,13 +2,12 @@ namespace Netclaw.Configuration.Feeds;
 
 /// <summary>
 /// Compile-time constants for the Netclaw feed infrastructure.
-/// Feed URLs are not user-configurable in MVP — they point to the
-/// project-owned CDN at feeds.netclaw.dev.
+/// Feed URLs are not user-configurable in MVP.
 /// </summary>
 public static class FeedConstants
 {
     /// <summary>
-    /// Base URL for the Netclaw feeds CDN (Cloudflare Pages).
+    /// Base URL for the system skills feed (Cloudflare Pages).
     /// </summary>
     public const string FeedBaseUrl = "https://feeds.netclaw.dev";
 
@@ -20,9 +19,9 @@ public static class FeedConstants
 
     /// <summary>
     /// URL for the binary releases manifest.
+    /// Binary assets are hosted on the dedicated releases domain, not the skills feed domain.
     /// </summary>
-    public const string BinaryManifestUrl =
-        $"{FeedBaseUrl}/releases/manifest.json";
+    public const string BinaryManifestUrl = "https://releases.netclaw.dev/manifest.json";
 
     /// <summary>
     /// HTTP timeout for feed manifest and skill downloads.

--- a/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
@@ -132,6 +132,21 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CheckForUpdateAsync_UsesDedicatedReleasesManifestEndpoint()
+    {
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = new FakeHttpHandler();
+        handler.AddJsonResponse("https://releases.netclaw.dev/manifest.json", manifest);
+
+        using var httpClient = new HttpClient(handler);
+        var result = await UpdateCheckService.CheckForUpdateAsync(
+            httpClient, "0.1.0");
+
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal("0.2.0", result.LatestVersion);
+    }
+
+    [Fact]
     public void EvaluateManifest_MatchesAssetsByRid()
     {
         var manifest = new BinaryFeedManifest


### PR DESCRIPTION
## Summary
- Point binary update checks at `https://releases.netclaw.dev/manifest.json` instead of the skills feed host.
- Prevent false "up to date" results when the updater receives the feeds site index HTML.
- Add a regression test that verifies update checks succeed when the dedicated releases manifest endpoint is available.

## Validation
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj`
- `dotnet slopwatch analyze`