### PR TITLE
Fix stale crash log detection and add --version CLI command

### DIFF
--- a/src/Netclaw.Cli/Doctor/SqliteProvisioningDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SqliteProvisioningDoctorCheck.cs
@@ -45,6 +45,14 @@ public sealed class SqliteProvisioningDoctorCheck(NetclawPaths paths) : IDoctorC
                 "No SQLite provisioning failure found in the latest daemon crash log."));
         }
 
+        // If the daemon was restarted after the crash, the crash log is stale.
+        if (IsCrashLogStale(latestCrash, paths.PidFilePath))
+        {
+            return Task.FromResult(DoctorCheckResult.Pass(
+                CheckName,
+                $"SQLite crash detected ({latestCrash.Name}) but daemon has been restarted since."));
+        }
+
         var occurredAt = TryParseCrashTimestamp(latestCrash.Name)
             ?.ToString("u", CultureInfo.InvariantCulture)
             ?? latestCrash.LastWriteTimeUtc.ToString("u", CultureInfo.InvariantCulture);
@@ -90,6 +98,16 @@ public sealed class SqliteProvisioningDoctorCheck(NetclawPaths paths) : IDoctorC
             || crashText.Contains("SQLitePCL", StringComparison.Ordinal)
             || crashText.Contains("e_sqlite3", StringComparison.Ordinal)
             || crashText.Contains("SchemaMigrator.MigrateAsync", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns true if the PID file was written after the crash log, meaning the daemon
+    /// was restarted since the crash and the crash log is stale.
+    /// </summary>
+    private static bool IsCrashLogStale(FileInfo crashLog, string pidFilePath)
+    {
+        var pidFile = new FileInfo(pidFilePath);
+        return pidFile.Exists && pidFile.LastWriteTimeUtc > crashLog.LastWriteTimeUtc;
     }
 
     private static DateTimeOffset? TryParseCrashTimestamp(string fileName)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -42,6 +42,12 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    if (mode is "version" or "--version" or "-V")
+    {
+        Console.WriteLine($"netclaw {BuildInfo.Version} (commit {BuildInfo.CommitHash}, built {BuildInfo.BuildTimestamp})");
+        return;
+    }
+
     if (mode is "-p" or "--prompt")
     {
         headlessPrompt = args.Length > 1
@@ -519,6 +525,7 @@ static void WriteGeneralHelp()
     Console.WriteLine("  secrets                  Manage encrypted secrets (set key/value pairs)");
     Console.WriteLine("  init                     First-run setup wizard");
     Console.WriteLine("  update                   Check for and install updates");
+    Console.WriteLine("  version, --version       Show CLI version");
     Console.WriteLine("  config                   Configuration management (planned)");
     Console.WriteLine();
     Console.WriteLine("Run `netclaw <command> --help` for details on any command.");


### PR DESCRIPTION
## Summary
- **Fix stale crash log in doctor**: `SqliteProvisioningDoctorCheck` now compares the crash log timestamp against the PID file timestamp. If the daemon was restarted after the crash (PID file is newer), the check returns Pass instead of a false Error.
- **Add `--version` CLI command**: `netclaw version`, `netclaw --version`, and `netclaw -V` print the CLI binary version using `BuildInfo` — no running daemon required.

## Test plan
- [ ] `dotnet build src/Netclaw.Cli/` compiles cleanly
- [ ] `netclaw --version` / `netclaw version` / `netclaw -V` all print version string
- [ ] `netclaw doctor` with a stale crash log + running daemon shows Pass
- [ ] `netclaw doctor` with a crash log and no PID file still shows Error
- [ ] `dotnet slopwatch analyze` passes with no new violations