### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.2</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.1.2 — Daemon startup and diagnostics hardening. Includes SQLite native library self-extract for single-file daemon builds and improved doctor handling for encrypted or corrupted Slack secrets.</PackageReleaseNotes>
+    <VersionPrefix>0.1.3</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.1.3 — CLI, diagnostics, and reliability fixes. Adds --version CLI command, fixes stale crash log false positives in doctor, fixes session title generation timeouts with thinking models, and corrects the binary update manifest endpoint.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 0.1.3 2026-03-04 ####
+
+Netclaw v0.1.3 — OpenAI OAuth, CLI, Diagnostics, and Reliability Fixes
+
+* Added OpenAI OAuth device flow authentication (RFC 8628) — operators can now authenticate with OpenAI interactively via browser instead of managing API keys manually. Available in the Provider Manager TUI, Init Wizard, and via `netclaw provider add <name> openai --auth oauth-device` from the CLI. OAuth tokens are stored encrypted at rest.
+* Added `netclaw --version`, `netclaw version`, and `netclaw -V` commands to print the CLI binary version without a running daemon.
+* Fixed false-positive doctor errors caused by stale crash logs when the daemon has since been restarted — `SqliteProvisioningDoctorCheck` now compares crash log timestamps against the PID file before reporting an error.
+* Fixed session title generation failures with thinking models (e.g. `qwen3.5:9b`) by increasing the generation timeout from 10s to 30s and routing failures through the daemon log instead of silently discarding them. ([#84](https://github.com/Aaronontheweb/netclaw/issues/84))
+* Fixed auto-update checks producing false "up to date" results by pointing the binary update manifest at `https://releases.netclaw.dev/manifest.json`.
+
 #### 0.1.2 2026-03-04 ####
 
 Netclaw v0.1.2 — Daemon Startup and Diagnostics Hardening


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` to `0.1.3` in `Directory.Build.props`
- Update `RELEASE_NOTES.md` with all changes since 0.1.2

## Changes in this release

- Added OpenAI OAuth device flow authentication (RFC 8628) — browser-based auth for OpenAI, no API key management required (#125)
- Added `netclaw --version`, `netclaw version`, and `netclaw -V` CLI commands (#132)
- Fixed false-positive doctor errors from stale crash logs — `SqliteProvisioningDoctorCheck` now validates crash log timestamps against the PID file (#132)
- Fixed session title generation failures with thinking models by increasing timeout from 10s to 30s and routing failures through daemon log (#130, fixes #84)
- Fixed auto-update checks pointing at the wrong manifest endpoint (#131)

## Test plan

- [x] `dotnet build Netclaw.slnx --configuration Release` — 0 errors, 0 warnings
- [ ] Merge and tag `0.1.3` — CI/CD will create the GitHub Release automatically