### PR TITLE
Fix sessions upgrade regression and harden browser MCP onboarding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.3</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.1.3 — CLI, diagnostics, and reliability fixes. Adds --version CLI command, fixes stale crash log false positives in doctor, fixes session title generation timeouts with thinking models, and corrects the binary update manifest endpoint.</PackageReleaseNotes>
+    <VersionPrefix>0.1.4</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.1.4 — upgrade and browser reliability hardening. Fixes legacy sessions schema migration regressions in published single-file daemon binaries, preserves historical sessions on upgrade, and disables Chrome DevTools onboarding when Chrome is missing while improving browser MCP diagnostics.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 0.1.4 2026-03-04 ####
+
+Netclaw v0.1.4 — Upgrade Safety and Browser Automation Reliability
+
+* Fixed a `netclaw sessions` regression on upgraded deployments by adding legacy sessions-table compatibility migration logic and resilient catalog reads for pre-0.1.4 schemas.
+* Fixed SQLite migration discovery in published single-file daemon binaries by embedding migration SQL assets and falling back to embedded resources when filesystem migrations are absent.
+* Added regression tests covering legacy sessions schema upgrade and session catalog compatibility behavior.
+* Changed browser automation onboarding defaults to Playwright MCP and disabled Chrome DevTools selection when a local Chrome executable is not detected.
+* Improved MCP doctor diagnostics to report explicit browser runtime prerequisites (Node.js runtime and Chrome executable) for `browser_chrome_devtools`.
+
 #### 0.1.3 2026-03-04 ####
 
 Netclaw v0.1.3 — OpenAI OAuth, CLI, Diagnostics, and Reliability Fixes

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -664,6 +664,13 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
+    public void BrowserAutomation_DefaultBackend_IsPlaywright()
+    {
+        using var vm = CreateViewModel();
+        Assert.Equal(BrowserAutomationMcpProfiles.PlaywrightBackend, vm.SelectedBrowserAutomationBackend);
+    }
+
+    [Fact]
     public async Task HealthCheck_BrowserAutomationChrome_WritesMcpProfile()
     {
         var browserBootstrapper = new FakeBrowserAutomationBootstrapper

--- a/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
@@ -82,6 +82,26 @@ public sealed class McpServersDoctorCheck(NetclawPaths paths) : IDoctorCheck
 
         foreach (var (name, entry) in validServers)
         {
+            if (entry.Enabled && name.Equals("browser_chrome_devtools", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!BrowserAutomationRuntimeDetector.HasNodeRuntime())
+                {
+                    enabledCount++;
+                    failedCount++;
+                    statusMessages.Add($"{name}: unreachable — Node.js runtime (node+npx) not found");
+                    continue;
+                }
+
+                var chrome = BrowserAutomationRuntimeDetector.DetectChrome();
+                if (!chrome.IsInstalled)
+                {
+                    enabledCount++;
+                    failedCount++;
+                    statusMessages.Add($"{name}: unreachable — local Chrome executable not found");
+                    continue;
+                }
+            }
+
             // Use full entry (with secrets merged) if available
             var probeEntry = fullServers.TryGetValue(name, out var full) ? full : entry;
             var probe = await McpCommand.ProbeServerAsync(name, probeEntry, cancellationToken);

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
@@ -27,6 +27,18 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
 
         if (await HasNodeRuntimeAsync(ct))
         {
+            if (backend == BrowserAutomationMcpProfiles.ChromeDevToolsBackend)
+            {
+                var chrome = BrowserAutomationRuntimeDetector.DetectChrome();
+                if (!chrome.IsInstalled)
+                {
+                    return new BrowserAutomationBootstrapResult(
+                        Success: false,
+                        NeedsManualAction: false,
+                        Message: "Chrome DevTools MCP requires a local Chrome executable, but none was found.");
+                }
+            }
+
             return new BrowserAutomationBootstrapResult(
                 Success: true,
                 NeedsManualAction: false,
@@ -36,6 +48,18 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
         var install = await TryInstallNodeJsAsync(ct);
         if (install.Succeeded && await HasNodeRuntimeAsync(ct))
         {
+            if (backend == BrowserAutomationMcpProfiles.ChromeDevToolsBackend)
+            {
+                var chrome = BrowserAutomationRuntimeDetector.DetectChrome();
+                if (!chrome.IsInstalled)
+                {
+                    return new BrowserAutomationBootstrapResult(
+                        Success: false,
+                        NeedsManualAction: false,
+                        Message: "Node.js installed, but Chrome DevTools MCP still needs a local Chrome executable.");
+                }
+            }
+
             return new BrowserAutomationBootstrapResult(
                 Success: true,
                 NeedsManualAction: false,

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
@@ -1,0 +1,90 @@
+namespace Netclaw.Cli.Mcp;
+
+internal sealed record ChromeDetectionResult(
+    bool IsInstalled,
+    string? ExecutablePath,
+    string? Reason);
+
+internal static class BrowserAutomationRuntimeDetector
+{
+    private static readonly string[] ChromeCommandCandidates =
+    [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "chrome"
+    ];
+
+    private static readonly string[] LinuxPathCandidates =
+    [
+        "/opt/google/chrome/chrome",
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser"
+    ];
+
+    private static readonly string[] MacPathCandidates =
+    [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    ];
+
+    public static ChromeDetectionResult DetectChrome()
+    {
+        var envPath = Environment.GetEnvironmentVariable("CHROME_PATH");
+        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+        {
+            return new ChromeDetectionResult(true, envPath, null);
+        }
+
+        foreach (var command in ChromeCommandCandidates)
+        {
+            var resolved = ResolveCommandPath(command);
+            if (resolved is not null)
+                return new ChromeDetectionResult(true, resolved, null);
+        }
+
+        var platformPaths = OperatingSystem.IsMacOS() ? MacPathCandidates : LinuxPathCandidates;
+        foreach (var path in platformPaths)
+        {
+            if (File.Exists(path))
+                return new ChromeDetectionResult(true, path, null);
+        }
+
+        return new ChromeDetectionResult(
+            false,
+            null,
+            "local Chrome executable not found");
+    }
+
+    public static bool HasNodeRuntime()
+        => ResolveCommandPath("node") is not null && ResolveCommandPath("npx") is not null;
+
+    private static string? ResolveCommandPath(string command)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(pathVar))
+            return null;
+
+        foreach (var segment in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.IsNullOrWhiteSpace(segment))
+                continue;
+
+            var candidate = Path.Combine(segment, command);
+            if (File.Exists(candidate))
+                return candidate;
+
+            if (OperatingSystem.IsWindows())
+            {
+                var candidateExe = candidate + ".exe";
+                if (File.Exists(candidateExe))
+                    return candidateExe;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -250,7 +250,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.BrowserAutomation when _browserAutomationSubStep == 0 =>
                     "  Optional. Enable this to let the agent delegate browser steering via MCP tools.",
                 WizardStep.BrowserAutomation when _browserAutomationSubStep == 1 =>
-                    "  Chrome DevTools MCP enables full browser automation. Playwright MCP supports broader cross-browser workflows with stricter output flags.",
+                    "  Playwright MCP is the default no-sudo path. Chrome DevTools is enabled only when a local Chrome executable is detected.",
                 WizardStep.Memory when _memorySubStep == 0 =>
                     "  Cross-session memory lets the agent retain knowledge between conversations.",
                 WizardStep.Memory when _memorySubStep == 1 =>
@@ -1067,8 +1067,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private ILayoutNode BuildBrowserAutomationBackendSubStep()
     {
+        var chromeLabel = ViewModel.IsChromeDevToolsAvailable
+            ? "Chrome DevTools MCP"
+            : $"Chrome DevTools MCP (disabled - {ViewModel.ChromeDevToolsUnavailableReason})";
+
         _browserAutomationBackendList = Layouts.SelectionList(
-                "Chrome DevTools MCP (recommended)",
+                chromeLabel,
                 "Playwright MCP")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
@@ -1081,6 +1085,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             {
                 if (selected.Count == 0)
                     return;
+
+                if (selected[0].StartsWith("Chrome DevTools", StringComparison.Ordinal)
+                    && !ViewModel.IsChromeDevToolsAvailable)
+                {
+                    ViewModel.StatusMessage.Value =
+                        "Chrome DevTools is disabled: local Chrome executable not found. Choose Playwright MCP.";
+                    return;
+                }
 
                 ViewModel.SelectedBrowserAutomationBackend =
                     selected[0].StartsWith("Playwright", StringComparison.Ordinal)

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -127,7 +127,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     // ── Step 5: Browser automation ──
     public bool BrowserAutomationEnabled { get; set; }
-    public string SelectedBrowserAutomationBackend { get; set; } = BrowserAutomationMcpProfiles.ChromeDevToolsBackend;
+    public string SelectedBrowserAutomationBackend { get; set; } = BrowserAutomationMcpProfiles.PlaywrightBackend;
+    public bool IsChromeDevToolsAvailable { get; }
+    public string ChromeDevToolsUnavailableReason { get; }
 
     // ── Step 6: Memory ──
     public string SelectedMemoryBackend { get; set; } = "files";
@@ -188,6 +190,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _oauthService = oauthService;
         _daemonManager = daemonManager;
         _daemonEndpoint = daemonEndpoint ?? "http://127.0.0.1:5199";
+
+        var chromeDetection = BrowserAutomationRuntimeDetector.DetectChrome();
+        IsChromeDevToolsAvailable = chromeDetection.IsInstalled;
+        ChromeDevToolsUnavailableReason =
+            chromeDetection.Reason ?? "local Chrome executable not found";
     }
 
     public override void OnActivated()

--- a/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Gateway;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class SchemaMigratorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public SchemaMigratorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-schema-migrator-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    [Fact]
+    public async Task MigrateAsync_legacy_sessions_schema_is_upgraded_and_data_preserved()
+    {
+        var connString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _paths.SqliteDbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+
+        await using (var conn = new SqliteConnection(connString))
+        {
+            await conn.OpenAsync();
+
+            await using var create = conn.CreateCommand();
+            create.CommandText =
+                """
+                CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY,
+                    last_activity INTEGER NOT NULL,
+                    message_count INTEGER DEFAULT 0,
+                    created INTEGER DEFAULT 0,
+                    display_name TEXT DEFAULT 'Unknown Session'
+                );
+                INSERT INTO sessions(session_id, last_activity, message_count, created, display_name)
+                VALUES ('D123/1772671231.713319', 1772671231713, 4, 1772671200000, 'Legacy Session');
+                """;
+            await create.ExecuteNonQueryAsync();
+        }
+
+        var migrator = new SchemaMigrator(_paths, NullLogger<SchemaMigrator>.Instance);
+        await migrator.MigrateAsync(_paths.SqliteDbPath, CancellationToken.None);
+
+        await using var verifyConn = new SqliteConnection(connString);
+        await verifyConn.OpenAsync();
+
+        await using (var columnsCmd = verifyConn.CreateCommand())
+        {
+            columnsCmd.CommandText = "PRAGMA table_info(sessions)";
+            await using var reader = await columnsCmd.ExecuteReaderAsync();
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (await reader.ReadAsync())
+                columns.Add(reader.GetString(1));
+
+            Assert.Contains("persistence_id", columns);
+            Assert.DoesNotContain("session_id", columns);
+        }
+
+        await using (var rowCmd = verifyConn.CreateCommand())
+        {
+            rowCmd.CommandText =
+                "SELECT persistence_id, channel, turn_count, title FROM sessions WHERE persistence_id = 'session-D123/1772671231.713319'";
+            await using var reader = await rowCmd.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("session-D123/1772671231.713319", reader.GetString(0));
+            Assert.Equal("slack", reader.GetString(1));
+            Assert.Equal(4, reader.GetInt32(2));
+            Assert.Equal("Legacy Session", reader.GetString(3));
+        }
+
+        await using (var schemaCmd = verifyConn.CreateCommand())
+        {
+            schemaCmd.CommandText = "SELECT COUNT(*) FROM schema_version";
+            var appliedCount = (long)(await schemaCmd.ExecuteScalarAsync() ?? 0L);
+            Assert.True(appliedCount >= 3);
+        }
+    }
+
+    [Fact]
+    public void SessionCatalogService_lists_legacy_sessions_when_schema_not_yet_upgraded()
+    {
+        var connString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _paths.SqliteDbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+
+        using (var conn = new SqliteConnection(connString))
+        {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                """
+                CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY,
+                    last_activity INTEGER NOT NULL,
+                    message_count INTEGER DEFAULT 0,
+                    created INTEGER DEFAULT 0,
+                    display_name TEXT DEFAULT 'Unknown Session'
+                );
+                INSERT INTO sessions(session_id, last_activity, message_count, created, display_name)
+                VALUES ('signalr/abc123', 1772671231713, 2, 1772671200000, 'SignalR Session');
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        var service = new SessionCatalogService(
+            _paths,
+            TimeProvider.System,
+            NullLogger<SessionCatalogService>.Instance);
+
+        var sessions = service.ListRecent();
+
+        var entry = Assert.Single(sessions);
+        Assert.Equal("session-signalr/abc123", entry.PersistenceId);
+        Assert.Equal("signalr", entry.Channel);
+        Assert.Equal("SignalR Session", entry.Title);
+        Assert.Equal(2, entry.TurnCount);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
@@ -131,7 +131,26 @@ public sealed class SchemaMigratorTests : IDisposable
 
     public void Dispose()
     {
+        SqliteConnection.ClearAllPools();
+
         if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
+        {
+            for (var attempt = 1; attempt <= 5; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(_tempDir, recursive: true);
+                    break;
+                }
+                catch (IOException) when (attempt < 5)
+                {
+                    Thread.Sleep(50);
+                }
+                catch (UnauthorizedAccessException) when (attempt < 5)
+                {
+                    Thread.Sleep(50);
+                }
+            }
+        }
     }
 }

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -16,6 +16,13 @@ namespace Netclaw.Daemon.Gateway;
 /// </summary>
 public sealed class SessionCatalogService : ISessionLifecycleObserver
 {
+    private enum SessionsSchemaMode
+    {
+        Missing,
+        Legacy,
+        Current
+    }
+
     private readonly string _connectionString;
     private readonly NetclawPaths _paths;
     private readonly TimeProvider _timeProvider;
@@ -52,20 +59,39 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();
 
+            var schemaMode = DetectSchemaMode(conn);
+            if (schemaMode is SessionsSchemaMode.Missing)
+                return;
+
             using var cmd = conn.CreateCommand();
-            cmd.CommandText =
-                """
-                INSERT INTO sessions (persistence_id, channel, created_at, last_activity, status, turn_count, log_path)
-                VALUES ($pid, $channel, $now, $now, 'active', 0, $path)
-                ON CONFLICT(persistence_id) DO UPDATE SET
-                    status = 'active',
-                    last_activity = $now,
-                    log_path = $path
-                """;
-            cmd.Parameters.AddWithValue("$pid", persistenceId);
-            cmd.Parameters.AddWithValue("$channel", channelType);
+            if (schemaMode is SessionsSchemaMode.Current)
+            {
+                cmd.CommandText =
+                    """
+                    INSERT INTO sessions (persistence_id, channel, created_at, last_activity, status, turn_count, log_path)
+                    VALUES ($pid, $channel, $now, $now, 'active', 0, $path)
+                    ON CONFLICT(persistence_id) DO UPDATE SET
+                        status = 'active',
+                        last_activity = $now,
+                        log_path = $path
+                    """;
+                cmd.Parameters.AddWithValue("$pid", persistenceId);
+                cmd.Parameters.AddWithValue("$channel", channelType);
+                cmd.Parameters.AddWithValue("$path", logPath);
+            }
+            else
+            {
+                cmd.CommandText =
+                    """
+                    INSERT INTO sessions (session_id, last_activity, message_count, created, display_name)
+                    VALUES ($sid, $now, 0, $now, 'Session')
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        last_activity = $now
+                    """;
+                cmd.Parameters.AddWithValue("$sid", sessionId.Value);
+            }
+
             cmd.Parameters.AddWithValue("$now", nowMs);
-            cmd.Parameters.AddWithValue("$path", logPath);
             cmd.ExecuteNonQuery();
         }
         catch (Exception ex)
@@ -81,52 +107,102 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
 
         try
         {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            var schemaMode = DetectSchemaMode(conn);
+            if (schemaMode is SessionsSchemaMode.Missing)
+                return;
+
             switch (output)
             {
                 case TurnCompleted:
-                    UpdateSession(persistenceId, cmd =>
+                    if (schemaMode is SessionsSchemaMode.Current)
                     {
-                        cmd.CommandText =
-                            """
-                            UPDATE sessions SET
-                                turn_count = turn_count + 1,
-                                last_activity = $now
-                            WHERE persistence_id = $pid
-                            """;
-                    });
+                        UpdateSession(conn, persistenceId, schemaMode, cmd =>
+                        {
+                            cmd.CommandText =
+                                """
+                                UPDATE sessions SET
+                                    turn_count = turn_count + 1,
+                                    last_activity = $now
+                                WHERE persistence_id = $pid
+                                """;
+                        });
+                    }
+                    else
+                    {
+                        UpdateSession(conn, output.SessionId.Value, schemaMode, cmd =>
+                        {
+                            cmd.CommandText =
+                                """
+                                UPDATE sessions SET
+                                    message_count = COALESCE(message_count, 0) + 1,
+                                    last_activity = $now
+                                WHERE session_id = $sid
+                                """;
+                        });
+                    }
+
                     break;
 
                 case UsageOutput usage when usage.InputTokens.HasValue:
-                    UpdateSession(persistenceId, cmd =>
+                    if (schemaMode is SessionsSchemaMode.Current)
                     {
-                        cmd.CommandText =
-                            """
-                            UPDATE sessions SET
-                                last_input_tokens = $tokens,
-                                last_activity = $now
-                            WHERE persistence_id = $pid
-                            """;
-                        cmd.Parameters.AddWithValue("$tokens", usage.InputTokens.Value);
-                    });
+                        UpdateSession(conn, persistenceId, schemaMode, cmd =>
+                        {
+                            cmd.CommandText =
+                                """
+                                UPDATE sessions SET
+                                    last_input_tokens = $tokens,
+                                    last_activity = $now
+                                WHERE persistence_id = $pid
+                                """;
+                            cmd.Parameters.AddWithValue("$tokens", usage.InputTokens.Value);
+                        });
+                    }
+                    else
+                    {
+                        UpdateLastActivity(conn, output.SessionId.Value, schemaMode);
+                    }
+
                     break;
 
                 case SessionTitleOutput title:
-                    UpdateSession(persistenceId, cmd =>
+                    if (schemaMode is SessionsSchemaMode.Current)
                     {
-                        cmd.CommandText =
-                            """
-                            UPDATE sessions SET
-                                title = $title,
-                                last_activity = $now
-                            WHERE persistence_id = $pid
-                            """;
-                        cmd.Parameters.AddWithValue("$title", title.Title);
-                    });
+                        UpdateSession(conn, persistenceId, schemaMode, cmd =>
+                        {
+                            cmd.CommandText =
+                                """
+                                UPDATE sessions SET
+                                    title = $title,
+                                    last_activity = $now
+                                WHERE persistence_id = $pid
+                                """;
+                            cmd.Parameters.AddWithValue("$title", title.Title);
+                        });
+                    }
+                    else
+                    {
+                        UpdateSession(conn, output.SessionId.Value, schemaMode, cmd =>
+                        {
+                            cmd.CommandText =
+                                """
+                                UPDATE sessions SET
+                                    display_name = $title,
+                                    last_activity = $now
+                                WHERE session_id = $sid
+                                """;
+                            cmd.Parameters.AddWithValue("$title", title.Title);
+                        });
+                    }
+
                     break;
 
                 case CompactionOutput:
                 case ErrorOutput:
-                    UpdateLastActivity(persistenceId);
+                    UpdateLastActivity(conn, output.SessionId.Value, schemaMode);
                     break;
             }
         }
@@ -148,11 +224,23 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();
 
+            var schemaMode = DetectSchemaMode(conn);
+            if (schemaMode is SessionsSchemaMode.Missing)
+                return entries;
+
             using var cmd = conn.CreateCommand();
-            cmd.CommandText =
+            cmd.CommandText = schemaMode is SessionsSchemaMode.Current
+                ?
                 """
                 SELECT persistence_id, channel, title, description, status, turn_count,
                        created_at, last_activity, log_path, last_input_tokens
+                FROM sessions
+                ORDER BY last_activity DESC
+                LIMIT $limit
+                """
+                :
+                """
+                SELECT session_id, display_name, message_count, created, last_activity
                 FROM sessions
                 ORDER BY last_activity DESC
                 LIMIT $limit
@@ -162,19 +250,39 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
             {
-                entries.Add(new SessionCatalogEntry
+                if (schemaMode is SessionsSchemaMode.Current)
                 {
-                    PersistenceId = reader.GetString(0),
-                    Channel = reader.GetString(1),
-                    Title = reader.IsDBNull(2) ? null : reader.GetString(2),
-                    Description = reader.IsDBNull(3) ? null : reader.GetString(3),
-                    Status = reader.GetString(4),
-                    TurnCount = reader.GetInt32(5),
-                    CreatedAt = reader.GetInt64(6),
-                    LastActivity = reader.GetInt64(7),
-                    LogPath = reader.IsDBNull(8) ? null : reader.GetString(8),
-                    LastInputTokens = reader.IsDBNull(9) ? null : reader.GetInt64(9)
-                });
+                    entries.Add(new SessionCatalogEntry
+                    {
+                        PersistenceId = reader.GetString(0),
+                        Channel = reader.GetString(1),
+                        Title = reader.IsDBNull(2) ? null : reader.GetString(2),
+                        Description = reader.IsDBNull(3) ? null : reader.GetString(3),
+                        Status = reader.GetString(4),
+                        TurnCount = reader.GetInt32(5),
+                        CreatedAt = reader.GetInt64(6),
+                        LastActivity = reader.GetInt64(7),
+                        LogPath = reader.IsDBNull(8) ? null : reader.GetString(8),
+                        LastInputTokens = reader.IsDBNull(9) ? null : reader.GetInt64(9)
+                    });
+                }
+                else
+                {
+                    var sessionId = reader.GetString(0);
+                    entries.Add(new SessionCatalogEntry
+                    {
+                        PersistenceId = $"session-{sessionId}",
+                        Channel = InferChannelFromSessionId(sessionId),
+                        Title = reader.IsDBNull(1) ? null : reader.GetString(1),
+                        Description = null,
+                        Status = "active",
+                        TurnCount = reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+                        CreatedAt = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                        LastActivity = reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                        LogPath = null,
+                        LastInputTokens = null
+                    });
+                }
             }
         }
         catch (Exception ex)
@@ -185,26 +293,76 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
         return entries;
     }
 
-    private void UpdateSession(string persistenceId, Action<SqliteCommand> configure)
+    private void UpdateSession(
+        SqliteConnection conn,
+        string sessionKey,
+        SessionsSchemaMode schemaMode,
+        Action<SqliteCommand> configure)
     {
         var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
-        using var conn = new SqliteConnection(_connectionString);
-        conn.Open();
-
         using var cmd = conn.CreateCommand();
         configure(cmd);
-        cmd.Parameters.AddWithValue("$pid", persistenceId);
+        if (schemaMode is SessionsSchemaMode.Current)
+            cmd.Parameters.AddWithValue("$pid", sessionKey.StartsWith("session-", StringComparison.Ordinal) ? sessionKey : $"session-{sessionKey}");
+        else
+            cmd.Parameters.AddWithValue("$sid", sessionKey.StartsWith("session-", StringComparison.Ordinal) ? sessionKey["session-".Length..] : sessionKey);
+
         cmd.Parameters.AddWithValue("$now", nowMs);
         cmd.ExecuteNonQuery();
     }
 
-    private void UpdateLastActivity(string persistenceId)
+    private void UpdateLastActivity(SqliteConnection conn, string sessionId, SessionsSchemaMode schemaMode)
     {
-        UpdateSession(persistenceId, cmd =>
+        UpdateSession(conn, sessionId, schemaMode, cmd =>
         {
-            cmd.CommandText = "UPDATE sessions SET last_activity = $now WHERE persistence_id = $pid";
+            cmd.CommandText = schemaMode is SessionsSchemaMode.Current
+                ? "UPDATE sessions SET last_activity = $now WHERE persistence_id = $pid"
+                : "UPDATE sessions SET last_activity = $now WHERE session_id = $sid";
         });
+    }
+
+    private static SessionsSchemaMode DetectSchemaMode(SqliteConnection conn)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(sessions)";
+
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            if (!reader.IsDBNull(1))
+                columns.Add(reader.GetString(1));
+        }
+
+        if (columns.Count == 0)
+            return SessionsSchemaMode.Missing;
+
+        if (columns.Contains("persistence_id"))
+            return SessionsSchemaMode.Current;
+
+        if (columns.Contains("session_id"))
+            return SessionsSchemaMode.Legacy;
+
+        return SessionsSchemaMode.Missing;
+    }
+
+    private static string InferChannelFromSessionId(string sessionId)
+    {
+        if (sessionId.StartsWith("signalr/", StringComparison.Ordinal))
+            return "signalr";
+
+        if (sessionId.StartsWith("headless/", StringComparison.Ordinal))
+            return "headless";
+
+        if (sessionId.StartsWith("console/", StringComparison.Ordinal))
+            return "console";
+
+        if (sessionId.StartsWith("C", StringComparison.Ordinal)
+            || sessionId.StartsWith("D", StringComparison.Ordinal))
+            return "slack";
+
+        return "unknown";
     }
 }
 

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -33,6 +33,7 @@
     <None Update="migrations\sqlite\**\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <EmbeddedResource Include="migrations\sqlite\**\*.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Daemon/Services/SchemaMigrator.cs
+++ b/src/Netclaw.Daemon/Services/SchemaMigrator.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
+using System.Reflection;
 
 namespace Netclaw.Daemon.Services;
 
@@ -30,9 +31,16 @@ public sealed class SchemaMigrator
         await conn.OpenAsync(cancellationToken);
 
         await EnsureSchemaVersionTableAsync(conn, cancellationToken);
+        await EnsureLegacySessionsTableCompatibilityAsync(conn, cancellationToken);
 
         var applied = await ReadAppliedVersionsAsync(conn, cancellationToken);
         var migrations = DiscoverMigrations();
+
+        if (migrations.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No SQLite migrations were discovered. Ensure migration assets are included in the published binary.");
+        }
 
         foreach (var migration in migrations)
         {
@@ -63,6 +71,119 @@ public sealed class SchemaMigrator
         }
 
         _logger.LogInformation("SQLite schema migration complete ({Count} migration files discovered)", migrations.Count);
+    }
+
+    private async Task EnsureLegacySessionsTableCompatibilityAsync(
+        SqliteConnection conn,
+        CancellationToken cancellationToken)
+    {
+        var columns = await ReadTableColumnsAsync(conn, "sessions", cancellationToken);
+        if (columns.Count == 0)
+            return;
+
+        var hasCurrentSchema = columns.Contains("persistence_id");
+        var hasLegacySchema = columns.Contains("session_id");
+
+        if (hasCurrentSchema || !hasLegacySchema)
+            return;
+
+        _logger.LogWarning(
+            "Detected legacy sessions schema (session_id/message_count/display_name). Migrating to current schema.");
+
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(cancellationToken);
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText =
+                "ALTER TABLE sessions RENAME TO sessions_legacy";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText =
+                """
+                CREATE TABLE sessions (
+                    persistence_id  TEXT NOT NULL PRIMARY KEY,
+                    channel         TEXT NOT NULL,
+                    created_at      INTEGER NOT NULL,
+                    last_activity   INTEGER NOT NULL,
+                    status          TEXT NOT NULL DEFAULT 'active',
+                    turn_count      INTEGER NOT NULL DEFAULT 0,
+                    title           TEXT,
+                    description     TEXT,
+                    last_input_tokens INTEGER,
+                    log_path        TEXT,
+                    metadata        TEXT
+                );
+                """;
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText =
+                """
+                INSERT INTO sessions (
+                    persistence_id,
+                    channel,
+                    created_at,
+                    last_activity,
+                    status,
+                    turn_count,
+                    title,
+                    description,
+                    last_input_tokens,
+                    log_path,
+                    metadata)
+                SELECT
+                    'session-' || session_id,
+                    CASE
+                        WHEN session_id LIKE 'signalr/%' THEN 'signalr'
+                        WHEN session_id LIKE 'headless/%' THEN 'headless'
+                        WHEN session_id LIKE 'console/%' THEN 'console'
+                        WHEN session_id LIKE 'C%/%' OR session_id LIKE 'D%/%' THEN 'slack'
+                        ELSE 'unknown'
+                    END,
+                    COALESCE(created, last_activity, 0),
+                    COALESCE(last_activity, created, 0),
+                    'active',
+                    COALESCE(message_count, 0),
+                    NULLIF(display_name, ''),
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL
+                FROM sessions_legacy;
+                """;
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText = "DROP TABLE sessions_legacy";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText = "CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions (status);";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.Transaction = tx;
+            cmd.CommandText = "CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions (last_activity);";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await tx.CommitAsync(cancellationToken);
     }
 
     private static async Task EnsureSchemaVersionTableAsync(SqliteConnection conn, CancellationToken cancellationToken)
@@ -96,20 +217,81 @@ public sealed class SchemaMigrator
     private static List<SqlMigration> DiscoverMigrations()
     {
         var migrationRoot = Path.Combine(AppContext.BaseDirectory, "migrations", "sqlite");
-        if (!Directory.Exists(migrationRoot))
-            return [];
+        if (Directory.Exists(migrationRoot))
+        {
+            return Directory.GetFiles(migrationRoot, "*.sql", SearchOption.TopDirectoryOnly)
+                .Select(path => new
+                {
+                    Path = path,
+                    Name = Path.GetFileName(path),
+                    Version = ParseVersion(Path.GetFileName(path))
+                })
+                .Where(x => x.Version is not null)
+                .OrderBy(x => x.Version)
+                .Select(x => new SqlMigration(x.Version!.Value, x.Name, File.ReadAllText(x.Path)))
+                .ToList();
+        }
 
-        return Directory.GetFiles(migrationRoot, "*.sql", SearchOption.TopDirectoryOnly)
+        var marker = ".migrations.sqlite.";
+        var assembly = typeof(SchemaMigrator).Assembly;
+
+        return assembly.GetManifestResourceNames()
+            .Where(name => name.EndsWith(".sql", StringComparison.OrdinalIgnoreCase)
+                           && name.Contains(marker, StringComparison.OrdinalIgnoreCase))
             .Select(path => new
             {
-                Path = path,
-                Name = Path.GetFileName(path),
-                Version = ParseVersion(Path.GetFileName(path))
+                ResourceName = path,
+                Name = ExtractMigrationName(path, marker)
+            })
+            .Where(x => x.Name is not null)
+            .Select(x => new
+            {
+                x.ResourceName,
+                Name = x.Name!,
+                Version = ParseVersion(x.Name!)
             })
             .Where(x => x.Version is not null)
             .OrderBy(x => x.Version)
-            .Select(x => new SqlMigration(x.Version!.Value, x.Name, File.ReadAllText(x.Path)))
+            .Select(x => new SqlMigration(
+                x.Version!.Value,
+                x.Name,
+                ReadEmbeddedResourceText(assembly, x.ResourceName)))
             .ToList();
+    }
+
+    private static async Task<HashSet<string>> ReadTableColumnsAsync(
+        SqliteConnection conn,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"PRAGMA table_info({tableName})";
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            if (!reader.IsDBNull(1))
+                columns.Add(reader.GetString(1));
+        }
+
+        return columns;
+    }
+
+    private static string? ExtractMigrationName(string resourceName, string marker)
+    {
+        var idx = resourceName.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            return null;
+
+        return resourceName[(idx + marker.Length)..];
+    }
+
+    private static string ReadEmbeddedResourceText(Assembly assembly, string resourceName)
+    {
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded migration resource not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 
     private static int? ParseVersion(string fileName)


### PR DESCRIPTION
## Summary
- Fix `netclaw sessions` regressions after upgrades by hardening SQLite migration discovery for single-file publishes, adding legacy `sessions` schema conversion, and adding runtime compatibility reads for pre-upgrade catalog tables.
- Add regression tests for legacy sessions schema migration and session catalog compatibility behavior.
- Improve browser onboarding reliability: default init backend to Playwright, disable Chrome DevTools selection when Chrome is missing, and add explicit MCP doctor diagnostics for missing Node/Chrome runtime prerequisites.
- Bump version metadata to `0.1.4` and add release notes entry for upgrade + browser reliability work.

## Validation
- `dotnet test --nologo`
- `dotnet slopwatch analyze`
- Published fresh binaries and deployed directly to `sys76-3` for live validation
- Verified `GET /api/sessions` returned historical session records post-upgrade
- Verified remote `schema_version` now includes migrations 1-3 and `sessions` table schema is current
- Verified `netclaw doctor` emits explicit browser MCP runtime failure reason when Node/Chrome prerequisites are missing