### PR TITLE
Add live Slack flow counters and OTLP reliability runbook updates

### DIFF
--- a/docs/runbooks/behavior-debugging.md
+++ b/docs/runbooks/behavior-debugging.md
@@ -104,7 +104,28 @@ Current instrumentation emits:
 
 Export target can be LocalTelemetry (or any OTLP collector).
 
+If exporting to Seq through `otlphttp`, use Seq's OTLP ingest path as the
+exporter endpoint base:
+
+```yaml
+exporters:
+  otlphttp/seq:
+    endpoint: https://<seq-host>/ingest/otlp
+```
+
+Using the root URL (for example `https://<seq-host>/`) causes 404s when the
+collector appends `/v1/logs` or `/v1/traces`.
+
 This gives per-turn causality and timing without heavy log spelunking.
+
+You can also inspect the daemon's in-memory Slack flow counters directly:
+
+```bash
+netclaw status
+```
+
+Look for `slack counters:` and compare `recv/routed/enqueued/replied` to detect
+where messages are being dropped.
 
 ## OTLP Query Cheat Sheet
 

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -134,7 +134,8 @@ Tuning parameters for LLM session behavior.
     "CompactionThreshold": 0.75,
     "SnapshotInterval": 20,
     "KeepRecentToolResults": 3,
-    "MaxToolIterationsPerTurn": 10
+    "MaxToolIterationsPerTurn": 10,
+    "SidecarLlmTimeoutSeconds": 90
   }
 }
 ```
@@ -145,6 +146,7 @@ Tuning parameters for LLM session behavior.
 | `SnapshotInterval` | int | `20` | Number of turns between persistence snapshots. |
 | `KeepRecentToolResults` | int | `3` | Recent tool call/result pairs kept in full during compaction. |
 | `MaxToolIterationsPerTurn` | int | `10` | Max tool execution rounds per turn before forcing a text response. |
+| `SidecarLlmTimeoutSeconds` | int | `90` | Timeout for sidecar LLM calls (title generation, observer summaries, memory extraction). |
 
 ### Tools
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -613,19 +613,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var self = Self;
         var client = _compactionClient;
         var log = _log;
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds));
 
-        _ = GenerateTitleAsync(client, history, self, log);
+        _ = GenerateTitleAsync(client, history, self, log, timeout);
     }
 
     private static async Task GenerateTitleAsync(
         IChatClient client,
         IReadOnlyList<SerializableChatMessage> history,
         IActorRef self,
-        ILoggingAdapter log)
+        ILoggingAdapter log,
+        TimeSpan timeout)
     {
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = new CancellationTokenSource(timeout);
             var messages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.User,
@@ -667,7 +669,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds));
+            using var cts = new CancellationTokenSource(timeout);
             var observerMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,
@@ -706,18 +709,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var history = _state.History;
         var self = Self;
         var client = _compactionClient;
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds));
 
-        _ = InvokeMemoryExtractionCoreAsync(client, history, self);
+        _ = InvokeMemoryExtractionCoreAsync(client, history, self, timeout);
     }
 
     private static async Task InvokeMemoryExtractionCoreAsync(
         IChatClient client,
         IReadOnlyList<SerializableChatMessage> history,
-        IActorRef self)
+        IActorRef self,
+        TimeSpan timeout)
     {
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = new CancellationTokenSource(timeout);
             var extractionMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,

--- a/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using System.Threading;
 
 namespace Netclaw.Channels.Telemetry;
 
@@ -29,27 +30,75 @@ public static class ChannelTelemetry
     private static readonly Histogram<double> SlackReplyDurationMs =
         Meter.CreateHistogram<double>("netclaw.slack.reply.duration.ms", unit: "ms");
 
+    private static long _slackEventsReceivedTotal;
+    private static long _slackEventsDroppedTotal;
+    private static long _slackEventsRoutedTotal;
+    private static long _slackMessagesEnqueuedTotal;
+    private static long _slackRepliesPostedTotal;
+    private static long _slackRepliesFailedTotal;
+
+    public sealed record Snapshot(
+        long SlackEventsReceived,
+        long SlackEventsDropped,
+        long SlackEventsRouted,
+        long SlackMessagesEnqueued,
+        long SlackRepliesPosted,
+        long SlackRepliesFailed);
+
     public static void RecordSlackEventReceived(string kind)
-        => SlackEventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    {
+        Interlocked.Increment(ref _slackEventsReceivedTotal);
+        SlackEventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    }
 
     public static void RecordSlackEventDropped(string reason)
-        => SlackEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    {
+        Interlocked.Increment(ref _slackEventsDroppedTotal);
+        SlackEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    }
 
     public static void RecordSlackEventRouted(string kind)
-        => SlackEventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    {
+        Interlocked.Increment(ref _slackEventsRoutedTotal);
+        SlackEventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    }
 
     public static void RecordSlackMessageEnqueued()
-        => SlackMessagesEnqueued.Add(1);
+    {
+        Interlocked.Increment(ref _slackMessagesEnqueuedTotal);
+        SlackMessagesEnqueued.Add(1);
+    }
 
     public static void RecordSlackReplyPosted(double durationMs)
     {
+        Interlocked.Increment(ref _slackRepliesPostedTotal);
         SlackRepliesPosted.Add(1);
         SlackReplyDurationMs.Record(durationMs);
     }
 
     public static void RecordSlackReplyFailed(double durationMs)
     {
+        Interlocked.Increment(ref _slackRepliesFailedTotal);
         SlackRepliesFailed.Add(1);
         SlackReplyDurationMs.Record(durationMs);
+    }
+
+    public static Snapshot GetSnapshot()
+        => new(
+            SlackEventsReceived: Interlocked.Read(ref _slackEventsReceivedTotal),
+            SlackEventsDropped: Interlocked.Read(ref _slackEventsDroppedTotal),
+            SlackEventsRouted: Interlocked.Read(ref _slackEventsRoutedTotal),
+            SlackMessagesEnqueued: Interlocked.Read(ref _slackMessagesEnqueuedTotal),
+            SlackRepliesPosted: Interlocked.Read(ref _slackRepliesPostedTotal),
+            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal));
+
+    internal static void ResetForTests()
+    {
+        Interlocked.Exchange(ref _slackEventsReceivedTotal, 0);
+        Interlocked.Exchange(ref _slackEventsDroppedTotal, 0);
+        Interlocked.Exchange(ref _slackEventsRoutedTotal, 0);
+        Interlocked.Exchange(ref _slackMessagesEnqueuedTotal, 0);
+        Interlocked.Exchange(ref _slackRepliesPostedTotal, 0);
+        Interlocked.Exchange(ref _slackRepliesFailedTotal, 0);
     }
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -790,6 +790,12 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
                           ? $" ({status.Telemetry.OtlpEndpoint})"
                           : string.Empty));
 
+    if (status.Telemetry.SlackCounters is { } counters)
+    {
+        Console.WriteLine(
+            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} reply_failed={counters.RepliesFailed}");
+    }
+
     if (status.Model is { } model)
     {
         Console.WriteLine($"model: {model.ModelId} (provider: {model.Provider}, context: {model.ContextWindow:N0} tokens)");

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -68,6 +68,23 @@ public static class DaemonRuntimeStatus
         public bool Enabled { get; init; }
 
         public string? OtlpEndpoint { get; init; }
+
+        public SlackCounters? SlackCounters { get; init; }
+    }
+
+    public sealed class SlackCounters : IWireType
+    {
+        public long EventsReceived { get; init; }
+
+        public long EventsDropped { get; init; }
+
+        public long EventsRouted { get; init; }
+
+        public long MessagesEnqueued { get; init; }
+
+        public long RepliesPosted { get; init; }
+
+        public long RepliesFailed { get; init; }
     }
 
     public sealed class Model : IWireType

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -89,6 +89,13 @@ public sealed record SessionConfig
     public int TitleGenerationInterval { get; init; } = 10;
 
     /// <summary>
+    /// Timeout in seconds for sidecar LLM calls (title generation, observer
+    /// summaries, and memory extraction). Increase this when running slower
+    /// models to reduce false timeout failures during background tasks.
+    /// </summary>
+    public int SidecarLlmTimeoutSeconds { get; init; } = 90;
+
+    /// <summary>
     /// How long a session can be idle before passivating.
     /// The actor saves a snapshot and stops itself; re-creation by
     /// <c>GenericChildPerEntityParent</c> on next message recovers state from journal.

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -4,6 +4,7 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Tools;
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
+using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
@@ -217,5 +218,39 @@ public sealed class DaemonRuntimeStatusServiceTests : IDisposable
         Assert.NotNull(status.Memory);
         Assert.Equal("memorizer", status.Memory.Provider);
         Assert.Equal("unavailable", status.Memory.Status);
+    }
+
+    [Fact]
+    public async Task StatusIncludesSlackCountersSnapshot()
+    {
+        var before = ChannelTelemetry.GetSnapshot();
+
+        ChannelTelemetry.RecordSlackEventReceived("message");
+        ChannelTelemetry.RecordSlackEventDropped("channel_not_allowed");
+        ChannelTelemetry.RecordSlackEventRouted("message");
+        ChannelTelemetry.RecordSlackMessageEnqueued();
+        ChannelTelemetry.RecordSlackReplyPosted(42);
+        ChannelTelemetry.RecordSlackReplyFailed(77);
+
+        var service = new DaemonRuntimeStatusService(
+            TimeProvider.System,
+            channels: Array.Empty<IChannel>(),
+            slackOptions: new SlackChannelOptions { Enabled = false },
+            persistenceOptions: new DaemonPersistenceOptions(),
+            telemetryOptions: Options.Create(new TelemetryOptions()),
+            sessionConfig: DefaultSessionConfig,
+            modelSelection: DefaultModelSelection,
+            memoryConfig: DefaultMemoryConfig,
+            paths: CreatePaths());
+
+        var status = await service.GetStatusAsync();
+
+        Assert.NotNull(status.Telemetry.SlackCounters);
+        Assert.True(status.Telemetry.SlackCounters!.EventsReceived >= before.SlackEventsReceived + 1);
+        Assert.True(status.Telemetry.SlackCounters.EventsDropped >= before.SlackEventsDropped + 1);
+        Assert.True(status.Telemetry.SlackCounters.EventsRouted >= before.SlackEventsRouted + 1);
+        Assert.True(status.Telemetry.SlackCounters.MessagesEnqueued >= before.SlackMessagesEnqueued + 1);
+        Assert.True(status.Telemetry.SlackCounters.RepliesPosted >= before.SlackRepliesPosted + 1);
+        Assert.True(status.Telemetry.SlackCounters.RepliesFailed >= before.SlackRepliesFailed + 1);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/SchemaMigratorTests.cs
@@ -144,11 +144,11 @@ public sealed class SchemaMigratorTests : IDisposable
                 }
                 catch (IOException) when (attempt < 5)
                 {
-                    Thread.Sleep(50);
+                    SqliteConnection.ClearAllPools();
                 }
                 catch (UnauthorizedAccessException) when (attempt < 5)
                 {
-                    Thread.Sleep(50);
+                    SqliteConnection.ClearAllPools();
                 }
             }
         }

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Netclaw.Actors.Memory;
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
+using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Feeds;
 using Netclaw.Daemon.Configuration;
@@ -63,7 +64,8 @@ internal sealed class DaemonRuntimeStatusService(
             Telemetry = new DaemonRuntimeStatus.Telemetry
             {
                 Enabled = telemetryOptions.Value.Enabled,
-                OtlpEndpoint = telemetryOptions.Value.Otlp.Endpoint
+                OtlpEndpoint = telemetryOptions.Value.Otlp.Endpoint,
+                SlackCounters = BuildSlackCounters()
             },
             Model = new DaemonRuntimeStatus.Model
             {
@@ -75,6 +77,20 @@ internal sealed class DaemonRuntimeStatusService(
             },
             Update = BuildUpdateStatus(),
             Memory = await BuildMemoryStatusAsync(cancellationToken)
+        };
+    }
+
+    private static DaemonRuntimeStatus.SlackCounters BuildSlackCounters()
+    {
+        var snapshot = ChannelTelemetry.GetSnapshot();
+        return new DaemonRuntimeStatus.SlackCounters
+        {
+            EventsReceived = snapshot.SlackEventsReceived,
+            EventsDropped = snapshot.SlackEventsDropped,
+            EventsRouted = snapshot.SlackEventsRouted,
+            MessagesEnqueued = snapshot.SlackMessagesEnqueued,
+            RepliesPosted = snapshot.SlackRepliesPosted,
+            RepliesFailed = snapshot.SlackRepliesFailed
         };
     }
 


### PR DESCRIPTION
## Summary
- Expose live Slack flow counters (`recv/routed/dropped/enqueued/replied/reply_failed`) through daemon runtime status so operators can quickly localize where messages are being lost.
- Surface those counters in `netclaw status` and add daemon tests covering telemetry snapshot wiring.
- Add `Session.SidecarLlmTimeoutSeconds` (default 90s) and route sidecar title/observer/memory extraction calls through the configurable timeout to reduce spurious 30s timeout failures on slower models.
- Update debugging/config docs with OTLP + Seq ingest-path guidance and status-counter troubleshooting guidance.
- Remove `Thread.Sleep` from schema migrator test cleanup retries to keep Slopwatch clean.

## Validation
- `dotnet test --nologo`
- `dotnet slopwatch analyze`
- Published binaries and deployed directly to `sys76-3` for live validation
- Enabled daemon telemetry on host (`Telemetry:Enabled=true`, `Telemetry:Otlp:Endpoint=http://127.0.0.1:4317`)
- Fixed collector Seq exporter endpoint to `/ingest/otlp` and verified collector receives logs/metrics without Seq 404 export errors
- Verified remote `netclaw status` now shows `slack counters` line from live runtime