### PR TITLE
Add no-sudo user-space Node fallback for browser MCP setup

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -694,7 +694,9 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.True(config.RootElement.TryGetProperty("McpServers", out var mcpServers));
         Assert.True(mcpServers.TryGetProperty("browser_chrome_devtools", out var browserEntry));
         Assert.Equal("stdio", browserEntry.GetProperty("Transport").GetString());
-        Assert.Equal("npx", browserEntry.GetProperty("Command").GetString());
+        var command = browserEntry.GetProperty("Command").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(command));
+        Assert.EndsWith("npx", command, StringComparison.OrdinalIgnoreCase);
 
         var args = browserEntry.GetProperty("Arguments");
         Assert.Contains(args.EnumerateArray().Select(a => a.GetString()), a => a == "chrome-devtools-mcp@latest");

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Netclaw.Cli.Mcp;
 
@@ -87,6 +88,9 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
 
     private static async Task<bool> HasNodeRuntimeAsync(CancellationToken ct)
     {
+        if (BrowserAutomationRuntimeDetector.HasNodeRuntime())
+            return true;
+
         var hasNode = await CommandExistsAsync("node", ct);
         var hasNpx = await CommandExistsAsync("npx", ct);
         return hasNode && hasNpx;
@@ -130,7 +134,74 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
             return (true, ok, command);
         }
 
+        var userSpace = await TryInstallNodeJsUserSpaceAsync(ct);
+        if (userSpace.Attempted)
+            return userSpace;
+
         return (false, false, GetDefaultManualInstallCommand());
+    }
+
+    private static async Task<(bool Attempted, bool Succeeded, string? ManualCommand)> TryInstallNodeJsUserSpaceAsync(CancellationToken ct)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+            return (false, false, null);
+
+        var platformToken = BrowserAutomationRuntimeDetector.GetNodeArchivePlatformToken();
+        var toolsRoot = BrowserAutomationRuntimeDetector.GetUserToolsRoot();
+        var installRoot = Path.Combine(toolsRoot, "node");
+        var downloadsRoot = Path.Combine(toolsRoot, "downloads");
+
+        Directory.CreateDirectory(toolsRoot);
+        Directory.CreateDirectory(downloadsRoot);
+
+        const string latestBaseUrl = "https://nodejs.org/dist/latest-v20.x/";
+        var archivePattern = $"node-v[0-9]+\\.[0-9]+\\.[0-9]+-{Regex.Escape(platformToken)}\\.tar\\.xz";
+
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+            var listing = await http.GetStringAsync(latestBaseUrl, ct);
+            var match = Regex.Match(listing, archivePattern, RegexOptions.IgnoreCase);
+            if (!match.Success)
+            {
+                return (true, false,
+                    "Could not resolve a Node.js archive for this platform from https://nodejs.org/dist/latest-v20.x/");
+            }
+
+            var archiveName = match.Value;
+            var archivePath = Path.Combine(downloadsRoot, archiveName);
+
+            await using (var remote = await http.GetStreamAsync(latestBaseUrl + archiveName, ct))
+            await using (var local = File.Create(archivePath))
+            {
+                await remote.CopyToAsync(local, ct);
+            }
+
+            if (Directory.Exists(installRoot))
+                Directory.Delete(installRoot, recursive: true);
+
+            var extractedRootName = archiveName.Replace(".tar.xz", string.Empty, StringComparison.OrdinalIgnoreCase);
+            var extractedPath = Path.Combine(toolsRoot, extractedRootName);
+            if (Directory.Exists(extractedPath))
+                Directory.Delete(extractedPath, recursive: true);
+
+            var extracted = await RunCommandAsync(
+                "tar",
+                $"-xJf \"{archivePath}\" -C \"{toolsRoot}\"",
+                TimeSpan.FromMinutes(2),
+                ct);
+
+            if (!extracted || !Directory.Exists(extractedPath))
+                return (true, false, "tar -xJf <node-archive>.tar.xz -C ~/.netclaw/tools");
+
+            Directory.Move(extractedPath, installRoot);
+            return (true, true, null);
+        }
+        catch
+        {
+            return (true, false,
+                "Install Node.js LTS in user space from https://nodejs.org/dist/latest-v20.x/ and ensure node+npx are available");
+        }
     }
 
     private static string GetDefaultManualInstallCommand()

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationMcpProfiles.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationMcpProfiles.cs
@@ -9,6 +9,9 @@ internal static class BrowserAutomationMcpProfiles
 
     public static (string Name, McpServerEntry Entry) Create(string backend)
     {
+        var npxCommand = BrowserAutomationRuntimeDetector.GetPreferredNpxCommand();
+        var env = BrowserAutomationRuntimeDetector.BuildMcpEnvironmentOverlay(npxCommand);
+
         return backend switch
         {
             PlaywrightBackend => ("browser_playwright", new McpServerEntry
@@ -16,7 +19,8 @@ internal static class BrowserAutomationMcpProfiles
                 Transport = "stdio",
                 Enabled = true,
                 GrantCategory = "browser_automation",
-                Command = "npx",
+                Command = npxCommand,
+                EnvironmentVariables = env,
                 Arguments =
                 [
                     "-y",
@@ -34,7 +38,8 @@ internal static class BrowserAutomationMcpProfiles
                 Transport = "stdio",
                 Enabled = true,
                 GrantCategory = "browser_automation",
-                Command = "npx",
+                Command = npxCommand,
+                EnvironmentVariables = env,
                 Arguments =
                 [
                     "-y",

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Netclaw.Cli.Mcp;
 
 internal sealed record ChromeDetectionResult(
@@ -7,6 +9,8 @@ internal sealed record ChromeDetectionResult(
 
 internal static class BrowserAutomationRuntimeDetector
 {
+    private const string ToolsDirectoryName = ".netclaw/tools";
+
     private static readonly string[] ChromeCommandCandidates =
     [
         "google-chrome",
@@ -60,7 +64,83 @@ internal static class BrowserAutomationRuntimeDetector
     }
 
     public static bool HasNodeRuntime()
-        => ResolveCommandPath("node") is not null && ResolveCommandPath("npx") is not null;
+    {
+        var bundled = GetBundledNodeBinDirectory();
+        if (bundled is not null
+            && File.Exists(Path.Combine(bundled, "node"))
+            && File.Exists(Path.Combine(bundled, "npx")))
+        {
+            return true;
+        }
+
+        return ResolveCommandPath("node") is not null && ResolveCommandPath("npx") is not null;
+    }
+
+    public static string GetPreferredNpxCommand()
+    {
+        var bundled = GetBundledNodeBinDirectory();
+        if (bundled is not null)
+        {
+            var candidate = Path.Combine(bundled, "npx");
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return ResolveCommandPath("npx") ?? "npx";
+    }
+
+    public static Dictionary<string, string>? BuildMcpEnvironmentOverlay(string commandPath)
+    {
+        if (!Path.IsPathRooted(commandPath))
+            return null;
+
+        var commandDir = Path.GetDirectoryName(commandPath);
+        if (string.IsNullOrWhiteSpace(commandDir))
+            return null;
+
+        var existingPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var combinedPath = string.IsNullOrWhiteSpace(existingPath)
+            ? commandDir
+            : $"{commandDir}{separator}{existingPath}";
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PATH"] = combinedPath
+        };
+    }
+
+    public static string GetUserToolsRoot()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ToolsDirectoryName);
+    }
+
+    public static string? GetBundledNodeBinDirectory()
+    {
+        var toolsRoot = GetUserToolsRoot();
+        var nodeRoot = Path.Combine(toolsRoot, "node");
+        if (!Directory.Exists(nodeRoot))
+            return null;
+
+        var bin = OperatingSystem.IsWindows()
+            ? Path.Combine(nodeRoot)
+            : Path.Combine(nodeRoot, "bin");
+
+        return Directory.Exists(bin) ? bin : null;
+    }
+
+    public static string GetNodeArchivePlatformToken()
+    {
+        var os = OperatingSystem.IsMacOS() ? "darwin" : "linux";
+        var arch = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.Arm64 => "arm64",
+            _ => "x64"
+        };
+
+        return $"{os}-{arch}";
+    }
 
     private static string? ResolveCommandPath(string command)
     {

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -916,6 +916,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 ["Transport"] = entry.Transport,
                 ["Command"] = entry.Command,
                 ["Arguments"] = entry.Arguments,
+                ["EnvironmentVariables"] = entry.EnvironmentVariables,
                 ["Enabled"] = entry.Enabled,
                 ["GrantCategory"] = entry.GrantCategory
             };


### PR DESCRIPTION
## Summary
- Add a no-sudo fallback installer for browser automation prerequisites that downloads and installs Node.js LTS into `~/.netclaw/tools/node` when package-manager installs are unavailable.
- Teach browser MCP profile generation to prefer discovered/bundled `npx` command paths and inject a PATH overlay so spawned MCP processes can resolve `node` correctly.
- Extend runtime detection to discover bundled user-space Node installs and expose preferred command/environment helpers.
- Persist MCP environment variables from init wizard profile generation so user-space runtime paths survive daemon restarts.
- Update init wizard browser profile tests to accept either PATH `npx` or absolute user-space `npx` command paths.

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --nologo`
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --nologo`
- `dotnet slopwatch analyze`