### PR TITLE
Add proactive Slack messaging via send_slack_message LLM tool

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -5,6 +5,7 @@ using Akka.Hosting.TestKit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tests.Channels.TestHelpers;
 using Netclaw.Channels.Slack;
 using Netclaw.Security;
 using Xunit;
@@ -264,12 +265,4 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         }
     }
 
-    private sealed class NoopReplyClient : ISlackReplyClient
-    {
-        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-
-        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -1,0 +1,531 @@
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Slack;
+using Netclaw.Channels.Slack.Tools;
+using Netclaw.Security;
+using SlackNet;
+using SlackNet.WebApi;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+#region SendSlackMessageTool Tests
+
+public sealed class SendSlackMessageToolTests
+{
+    private static readonly SlackChannelOptions DefaultOptions = new()
+    {
+        AllowDirectMessages = true,
+        AllowedUserIds = ["U1", "U2"],
+        AllowedChannelIds = ["C1", "C2"]
+    };
+
+    [Fact]
+    public async Task Rejects_when_both_channel_and_user_provided()
+    {
+        var tool = CreateTool();
+        var result = await ExecuteAsync(tool, "hello", channelId: "C1", userId: "U1");
+        Assert.Contains("exactly one", result);
+    }
+
+    [Fact]
+    public async Task Rejects_when_neither_provided()
+    {
+        var tool = CreateTool();
+        var result = await ExecuteAsync(tool, "hello");
+        Assert.Contains("exactly one", result);
+    }
+
+    [Fact]
+    public async Task Rejects_disallowed_user()
+    {
+        var tool = CreateTool();
+        var result = await ExecuteAsync(tool, "hello", userId: "UBAD");
+        Assert.Contains("not in the allowed users list", result);
+    }
+
+    [Fact]
+    public async Task Rejects_disallowed_channel()
+    {
+        var tool = CreateTool();
+        var result = await ExecuteAsync(tool, "hello", channelId: "CBAD");
+        Assert.Contains("not in the allowed channels list", result);
+    }
+
+    [Fact]
+    public async Task Allows_default_channel()
+    {
+        var fake = new FakeSlackOutboundClient();
+        var gateway = new FakeGatewayActor();
+        var tool = CreateTool(
+            outbound: fake,
+            gatewayAccessor: () => gateway,
+            defaultChannelIdAccessor: () => new SlackChannelId("CDEFAULT"));
+
+        var result = await ExecuteAsync(tool, "hello", channelId: "CDEFAULT");
+        Assert.Contains("Message sent", result);
+    }
+
+    [Fact]
+    public async Task Rejects_DM_when_AllowDirectMessages_false()
+    {
+        var options = new SlackChannelOptions
+        {
+            AllowDirectMessages = false,
+            AllowedUserIds = ["U1"]
+        };
+        var tool = CreateTool(options: options);
+        var result = await ExecuteAsync(tool, "hello", userId: "U1");
+        Assert.Contains("Direct messages are disabled", result);
+    }
+
+    [Fact]
+    public async Task Returns_error_when_gateway_disconnected()
+    {
+        var tool = CreateTool(gatewayAccessor: () => null);
+        var result = await ExecuteAsync(tool, "hello", channelId: "C1");
+        Assert.Contains("gateway is not connected", result);
+    }
+
+    [Fact]
+    public async Task Returns_error_on_Slack_API_failure()
+    {
+        var fake = new FakeSlackOutboundClient { ShouldThrow = true };
+        var tool = CreateTool(outbound: fake);
+        var result = await ExecuteAsync(tool, "hello", channelId: "C1");
+        Assert.Contains("Failed to post message to Slack", result);
+    }
+
+    [Fact]
+    public async Task Returns_error_on_DM_open_failure()
+    {
+        var fake = new FakeSlackOutboundClient { ShouldThrow = true };
+        var tool = CreateTool(outbound: fake);
+        var result = await ExecuteAsync(tool, "hello", userId: "U1");
+        Assert.Contains("Failed to open DM channel", result);
+    }
+
+    [Fact]
+    public async Task Successful_channel_message()
+    {
+        var fake = new FakeSlackOutboundClient();
+        var gateway = new FakeGatewayActor();
+        var tool = CreateTool(outbound: fake, gatewayAccessor: () => gateway);
+
+        var result = await ExecuteAsync(tool, "hello world", channelId: "C1");
+
+        Assert.Contains("Message sent to channel C1", result);
+        Assert.Contains("C1/", result);
+        Assert.Single(fake.PostedThreads);
+        Assert.Equal("C1", fake.PostedThreads[0].ChannelId.Value);
+    }
+
+    [Fact]
+    public async Task Successful_DM()
+    {
+        var fake = new FakeSlackOutboundClient();
+        var gateway = new FakeGatewayActor();
+        var tool = CreateTool(outbound: fake, gatewayAccessor: () => gateway);
+
+        var result = await ExecuteAsync(tool, "hello user", userId: "U1");
+
+        Assert.Contains("Message sent to user U1", result);
+        Assert.Single(fake.OpenedDms);
+        Assert.Equal("U1", fake.OpenedDms[0].Value);
+    }
+
+    private static Task<string> ExecuteAsync(SendSlackMessageTool tool, string message,
+        string? channelId = null, string? userId = null)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["Message"] = message
+        };
+        if (channelId is not null) args["ChannelId"] = channelId;
+        if (userId is not null) args["UserId"] = userId;
+        return tool.ExecuteAsync(args, CancellationToken.None);
+    }
+
+    private static SendSlackMessageTool CreateTool(
+        FakeSlackOutboundClient? outbound = null,
+        SlackChannelOptions? options = null,
+        Func<SlackChannelId?>? defaultChannelIdAccessor = null,
+        Func<IActorRef?>? gatewayAccessor = null)
+    {
+        return new SendSlackMessageTool(
+            outbound ?? new FakeSlackOutboundClient(),
+            new NoopReplyClient(),
+            options ?? DefaultOptions,
+            defaultChannelIdAccessor ?? (() => null),
+            gatewayAccessor ?? (() => new FakeGatewayActor()));
+    }
+
+    private sealed class NoopReplyClient : ISlackReplyClient
+    {
+        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class FakeSlackOutboundClient : ISlackOutboundClient
+    {
+        public bool ShouldThrow { get; init; }
+        public List<SlackUserId> OpenedDms { get; } = [];
+        public List<(SlackChannelId ChannelId, string Text)> PostedThreads { get; } = [];
+
+        public Task<SlackChannelId> OpenDmChannelAsync(SlackUserId userId, CancellationToken ct = default)
+        {
+            if (ShouldThrow) throw new InvalidOperationException("Slack API error");
+            OpenedDms.Add(userId);
+            return Task.FromResult(new SlackChannelId($"D{userId.Value}"));
+        }
+
+        public Task<SlackNewThread> PostNewThreadAsync(SlackChannelId channelId, string text, CancellationToken ct = default)
+        {
+            if (ShouldThrow) throw new InvalidOperationException("Slack API error");
+            PostedThreads.Add((channelId, text));
+            return Task.FromResult(new SlackNewThread(channelId, new SlackThreadTs("1234567890.000001")));
+        }
+    }
+
+    /// <summary>
+    /// Minimal fake that satisfies IActorRef for Ask pattern without an actor system.
+    /// Immediately responds with ProactiveThreadAck.
+    /// </summary>
+    private sealed class FakeGatewayActor : MinimalActorRef
+    {
+        public override ActorPath Path { get; } =
+            new RootActorPath(Address.AllSystems) / "fake-gateway";
+
+        public override IActorRefProvider Provider =>
+            throw new NotSupportedException("Not needed for tool tests");
+
+        protected override void TellInternal(object message, IActorRef sender)
+        {
+            if (message is StartProactiveThread spt)
+            {
+                sender.Tell(new ProactiveThreadAck(spt.SessionId));
+            }
+        }
+    }
+}
+
+#endregion
+
+#region LookupSlackUserTool Tests
+
+public sealed class LookupSlackUserToolTests
+{
+    [Fact]
+    public async Task Matches_by_real_name()
+    {
+        var tool = CreateTool(CreateUsers());
+        var result = await ExecuteAsync(tool, "Alice");
+        Assert.Contains("U1", result);
+        Assert.Contains("Alice Smith", result);
+    }
+
+    [Fact]
+    public async Task Matches_by_display_name()
+    {
+        var tool = CreateTool(CreateUsers());
+        var result = await ExecuteAsync(tool, "bobby");
+        Assert.Contains("U2", result);
+    }
+
+    [Fact]
+    public async Task Matches_by_email()
+    {
+        var tool = CreateTool(CreateUsers());
+        var result = await ExecuteAsync(tool, "alice@example.com");
+        Assert.Contains("U1", result);
+    }
+
+    [Fact]
+    public async Task Returns_no_matches()
+    {
+        var tool = CreateTool(CreateUsers());
+        var result = await ExecuteAsync(tool, "nonexistent");
+        Assert.Contains("No matching users found", result);
+    }
+
+    [Fact]
+    public async Task Filters_to_allowed_users()
+    {
+        var options = new SlackChannelOptions { AllowedUserIds = ["U1"] };
+        var tool = CreateTool(CreateUsers(), options);
+        var result = await ExecuteAsync(tool, "Bob");
+        Assert.Contains("No matching users found", result);
+    }
+
+    [Fact]
+    public async Task Caches_on_second_call()
+    {
+        var fakeApi = new FakeSlackUsersApi(CreateUsers());
+        var tool = new LookupSlackUserTool(fakeApi, new SlackChannelOptions(), TimeProvider.System);
+
+        await ExecuteAsync(tool, "Alice");
+        await ExecuteAsync(tool, "Bob");
+
+        Assert.Equal(1, fakeApi.CallCount);
+    }
+
+    [Fact]
+    public async Task Refreshes_after_TTL()
+    {
+        var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var fakeApi = new FakeSlackUsersApi(CreateUsers());
+        var tool = new LookupSlackUserTool(fakeApi, new SlackChannelOptions(), fakeTime);
+
+        await ExecuteAsync(tool, "Alice");
+        Assert.Equal(1, fakeApi.CallCount);
+
+        // Advance past the 5-minute cache TTL
+        fakeTime.Advance(TimeSpan.FromMinutes(6));
+
+        await ExecuteAsync(tool, "Alice");
+        Assert.Equal(2, fakeApi.CallCount);
+    }
+
+    private static Task<string> ExecuteAsync(LookupSlackUserTool tool, string query)
+    {
+        var args = new Dictionary<string, object?> { ["Query"] = query };
+        return tool.ExecuteAsync(args, CancellationToken.None);
+    }
+
+    private static List<User> CreateUsers()
+    {
+        return
+        [
+            new User
+            {
+                Id = "U1", Name = "alice", RealName = "Alice Smith",
+                Profile = new UserProfile { DisplayName = "alice_s", Email = "alice@example.com" }
+            },
+            new User
+            {
+                Id = "U2", Name = "bob", RealName = "Bob Jones",
+                Profile = new UserProfile { DisplayName = "bobby", Email = "bob@example.com" }
+            },
+            // Bot user — should be filtered
+            new User
+            {
+                Id = "UBOT", Name = "bot", RealName = "Bot User", IsBot = true,
+                Profile = new UserProfile { DisplayName = "bot" }
+            }
+        ];
+    }
+
+    private static LookupSlackUserTool CreateTool(
+        List<User> users,
+        SlackChannelOptions? options = null)
+    {
+        var fakeApi = new FakeSlackUsersApi(users);
+        return new LookupSlackUserTool(fakeApi, options ?? new SlackChannelOptions(), TimeProvider.System);
+    }
+
+    /// <summary>
+    /// Minimal fake implementing only Users.List for the lookup tool.
+    /// All other members throw.
+    /// </summary>
+    internal sealed class FakeSlackUsersApi : IUsersApi
+    {
+        private readonly List<User> _users;
+        public int CallCount { get; private set; }
+
+        public FakeSlackUsersApi(List<User> users) => _users = users;
+
+        public Task<UserListResponse> List(string? cursor = null, bool includeLocale = false, int limit = 0,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new UserListResponse
+            {
+                Members = _users,
+                ResponseMetadata = new ResponseMetadata { NextCursor = null }
+            });
+        }
+
+        public Task<ConversationListResponse> Conversations(bool excludeArchived = false, int limit = 0,
+            IEnumerable<ConversationType>? types = null, string? teamId = null, string? userId = null,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task DeletePhoto(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Presence> GetPresence(string userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IdentityResponse> Identity(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User> Info(string userId, bool includeLocale = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User> LookupByEmail(string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> LookupDiscoverableContact(string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task SetPhoto(byte[] image, string contentType, string? fileName = null, int? cropW = null, int? cropX = null, int? cropY = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task SetPhoto(Stream image, string contentType, string? fileName = null, int? cropW = null, int? cropX = null, int? cropY = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task SetPresence(Presence presence, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task SetPresence(RequestPresence presence, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}
+
+#endregion
+
+#region SlackProactiveThreadActorTests (TestKit)
+
+public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    protected override Config? Config =>
+        ConfigurationFactory.ParseString("akka.test.default-timeout = 5s");
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void Routes_proactive_thread_to_thread_actor()
+    {
+        var sink = CreateTestProbe("proactive-thread-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(
+            SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps),
+            "proactive-route-test");
+
+        var sessionId = new SessionId("C1/100.1");
+        conversation.Tell(new StartProactiveThread(
+            new SlackChannelId("C1"),
+            new SlackThreadTs("100.1"),
+            sessionId));
+
+        sink.ExpectMsg<StartProactiveThread>(msg =>
+            Assert.Equal("C1/100.1", msg.SessionId.Value));
+    }
+
+    [Fact]
+    public void Reuses_existing_conversation_thread_for_proactive()
+    {
+        var sink = CreateTestProbe("reuse-conversation-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(
+            SlackConversationActor.CreateProps(new SlackChannelId("C1"), deps),
+            "proactive-reuse-test");
+
+        // First: mention starts a thread
+        conversation.Tell(CreateAppMention("C1:200", "C1", "200.1", "<@UBOT> start"));
+        var first = sink.ExpectMsg<SlackThreadInbound>();
+        Assert.Equal("C1/200.1", first.SessionId.Value);
+
+        // Second: proactive thread with the same thread ts reuses the existing actor
+        conversation.Tell(new StartProactiveThread(
+            new SlackChannelId("C1"),
+            new SlackThreadTs("200.1"),
+            new SessionId("C1/200.1")));
+
+        sink.ExpectMsg<StartProactiveThread>(msg =>
+            Assert.Equal("C1/200.1", msg.SessionId.Value));
+    }
+
+    [Fact]
+    public void ProactiveThreadAck_flows_back_through_gateway()
+    {
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) =>
+                Props.Create(() => new AckActor()));
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "ack-flow-gateway");
+
+        var sessionId = new SessionId("C1/300.1");
+        gateway.Tell(new StartProactiveThread(
+            new SlackChannelId("C1"),
+            new SlackThreadTs("300.1"),
+            sessionId));
+
+        // The ack should flow back to us (the sender) through Forward chain
+        ExpectMsg<ProactiveThreadAck>(ack =>
+            Assert.Equal("C1/300.1", ack.SessionId.Value));
+    }
+
+    private static SlackGatewayDependencies CreateDependencies(
+        Func<SlackChannelId, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
+        Func<SessionId, SlackChannelId, SlackThreadTs, SlackGatewayDependencies, Props>? threadPropsFactory = null)
+    {
+        return new SlackGatewayDependencies(
+            Pipeline: null!,
+            ActorSystem: null!,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                MentionOnly = true,
+                AllowDirectMessages = true,
+                AllowedChannelIds = ["C1"]
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: new NoopReplyClient(),
+            ContentScanner: new NullContentScanner(),
+            ConversationPropsFactory: conversationPropsFactory,
+            ThreadPropsFactory: threadPropsFactory);
+    }
+
+    private static SlackInboundMessage CreateAppMention(
+        string eventId,
+        string channelId,
+        string eventTs,
+        string text)
+    {
+        return new SlackInboundMessage(
+            Kind: SlackInboundKind.AppMention,
+            EventId: new SlackEventId(eventId),
+            ChannelId: new SlackChannelId(channelId),
+            ThreadTs: null,
+            EventTs: new SlackEventTs(eventTs),
+            UserId: new SlackUserId("U1"),
+            BotId: null,
+            Text: text,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: false);
+    }
+
+    private sealed class ForwardActor : ReceiveActor
+    {
+        public ForwardActor(IActorRef target)
+        {
+            ReceiveAny(msg => target.Tell(msg));
+        }
+    }
+
+    /// <summary>
+    /// Actor that simulates SlackThreadBindingActor's proactive ack behavior.
+    /// </summary>
+    private sealed class AckActor : ReceiveActor
+    {
+        public AckActor()
+        {
+            Receive<StartProactiveThread>(msg =>
+                Sender.Tell(new ProactiveThreadAck(msg.SessionId)));
+        }
+    }
+
+    private sealed class NoopReplyClient : ISlackReplyClient
+    {
+        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}
+
+#endregion

--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tests.Channels.TestHelpers;
 using Netclaw.Channels.Slack;
 using Netclaw.Channels.Slack.Tools;
 using Netclaw.Security;
@@ -161,19 +162,9 @@ public sealed class SendSlackMessageToolTests
     {
         return new SendSlackMessageTool(
             outbound ?? new FakeSlackOutboundClient(),
-            new NoopReplyClient(),
             options ?? DefaultOptions,
             defaultChannelIdAccessor ?? (() => null),
             gatewayAccessor ?? (() => new FakeGatewayActor()));
-    }
-
-    private sealed class NoopReplyClient : ISlackReplyClient
-    {
-        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-
-        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
     }
 
     private sealed class FakeSlackOutboundClient : ISlackOutboundClient
@@ -255,6 +246,21 @@ public sealed class LookupSlackUserToolTests
     {
         var tool = CreateTool(CreateUsers());
         var result = await ExecuteAsync(tool, "nonexistent");
+        Assert.Contains("No matching users found", result);
+    }
+
+    [Fact]
+    public async Task Filters_deleted_users()
+    {
+        var users = CreateUsers();
+        users.Add(new User
+        {
+            Id = "UDEL", Name = "deleted", RealName = "Deleted Person", Deleted = true,
+            Profile = new UserProfile { DisplayName = "deleted" }
+        });
+
+        var tool = CreateTool(users);
+        var result = await ExecuteAsync(tool, "Deleted");
         Assert.Contains("No matching users found", result);
     }
 
@@ -437,6 +443,48 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
     }
 
     [Fact]
+    public void StartProactiveThread_rejected_for_disallowed_channel()
+    {
+        var sink = CreateTestProbe("disallowed-channel-sink");
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(
+            SlackConversationActor.CreateProps(new SlackChannelId("CBAD"), deps),
+            "proactive-disallowed-test");
+
+        conversation.Tell(new StartProactiveThread(
+            new SlackChannelId("CBAD"),
+            new SlackThreadTs("400.1"),
+            new SessionId("CBAD/400.1")));
+
+        // Message should be silently dropped — no thread actor created
+        sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public void StartProactiveThread_allows_dm_channel_not_in_allow_list()
+    {
+        var sink = CreateTestProbe("dm-bypass-sink");
+        // AllowedChannelIds = ["C1"] — "DU1" is NOT in the list
+        var deps = CreateDependencies(
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(
+            SlackConversationActor.CreateProps(new SlackChannelId("DU1"), deps),
+            "proactive-dm-bypass-test");
+
+        conversation.Tell(new StartProactiveThread(
+            new SlackChannelId("DU1"),
+            new SlackThreadTs("500.1"),
+            new SessionId("DU1/500.1")));
+
+        // DM channels bypass the channel ACL check — should be forwarded
+        sink.ExpectMsg<StartProactiveThread>(msg =>
+            Assert.Equal("DU1/500.1", msg.SessionId.Value));
+    }
+
+    [Fact]
     public void ProactiveThreadAck_flows_back_through_gateway()
     {
         var deps = CreateDependencies(
@@ -518,14 +566,6 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
         }
     }
 
-    private sealed class NoopReplyClient : ISlackReplyClient
-    {
-        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-
-        public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-    }
 }
 
 #endregion

--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -458,7 +458,32 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
             new SlackThreadTs("400.1"),
             new SessionId("CBAD/400.1")));
 
-        // Message should be silently dropped — no thread actor created
+        ExpectMsg<Status.Failure>(failure =>
+            Assert.Contains("allowed channels", failure.Cause.Message, StringComparison.OrdinalIgnoreCase));
+
+        // Message should be rejected before thread actor creation.
+        sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public void StartProactiveThread_rejected_when_dm_disabled()
+    {
+        var sink = CreateTestProbe("dm-disabled-sink");
+        var deps = CreateDependencies(
+            allowDirectMessages: false,
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var conversation = Sys.ActorOf(
+            SlackConversationActor.CreateProps(new SlackChannelId("DU1"), deps),
+            "proactive-dm-disabled-test");
+
+        conversation.Tell(new StartProactiveThread(
+            new SlackChannelId("DU1"),
+            new SlackThreadTs("510.1"),
+            new SessionId("DU1/510.1")));
+
+        ExpectMsg<Status.Failure>(failure =>
+            Assert.Contains("Direct messages are disabled", failure.Cause.Message, StringComparison.OrdinalIgnoreCase));
         sink.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
     }
 
@@ -505,6 +530,7 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
     }
 
     private static SlackGatewayDependencies CreateDependencies(
+        bool allowDirectMessages = true,
         Func<SlackChannelId, SlackGatewayDependencies, Props>? conversationPropsFactory = null,
         Func<SessionId, SlackChannelId, SlackThreadTs, SlackGatewayDependencies, Props>? threadPropsFactory = null)
     {
@@ -515,7 +541,7 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
             Options: new SlackChannelOptions
             {
                 MentionOnly = true,
-                AllowDirectMessages = true,
+                AllowDirectMessages = allowDirectMessages,
                 AllowedChannelIds = ["C1"]
             },
             BotUserId: new SlackUserId("UBOT"),

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/NoopReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/NoopReplyClient.cs
@@ -1,0 +1,12 @@
+using Netclaw.Channels.Slack;
+
+namespace Netclaw.Actors.Tests.Channels.TestHelpers;
+
+internal sealed class NoopReplyClient : ISlackReplyClient
+{
+    public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task UploadFileToThreadAsync(SlackChannelId channelId, SlackThreadTs threadTs, string filePath, string? filename = null, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -9,17 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Hosting.TestKit"/>
-    <PackageReference Include="Akka.Persistence.Hosting"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
-    <PackageReference Include="xunit.runner.visualstudio"/>
+    <PackageReference Include="Akka.Hosting.TestKit" />
+    <PackageReference Include="Akka.Persistence.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj"/>
+    <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj" />
     <ProjectReference Include="../Netclaw.Channels/Netclaw.Channels.csproj" />
-    <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj"/>
+    <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Channels/Netclaw.Channels.csproj
+++ b/src/Netclaw.Channels/Netclaw.Channels.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Netclaw.Actors.Tests" />
+    <InternalsVisibleTo Include="netclawd" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
     <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
     <ProjectReference Include="..\Netclaw.Security\Netclaw.Security.csproj" />
+    <ProjectReference Include="..\Netclaw.Tools.Generators\Netclaw.Tools.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Channels/Slack/ISlackOutboundClient.cs
+++ b/src/Netclaw.Channels/Slack/ISlackOutboundClient.cs
@@ -1,0 +1,19 @@
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Result of posting a new top-level message to a Slack channel.
+/// </summary>
+public readonly record struct SlackNewThread(SlackChannelId ChannelId, SlackThreadTs ThreadTs);
+
+/// <summary>
+/// Thin abstraction over the Slack API for proactive outbound operations:
+/// opening DM channels and posting new threads.
+/// </summary>
+public interface ISlackOutboundClient
+{
+    /// <summary>Open a DM channel with a user. Returns the DM channel ID.</summary>
+    Task<SlackChannelId> OpenDmChannelAsync(SlackUserId userId, CancellationToken ct = default);
+
+    /// <summary>Post a new top-level message to a channel. Returns the thread root ts.</summary>
+    Task<SlackNewThread> PostNewThreadAsync(SlackChannelId channelId, string text, CancellationToken ct = default);
+}

--- a/src/Netclaw.Channels/Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels/Slack/SlackAclPolicy.cs
@@ -1,0 +1,35 @@
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Shared ACL checks for Slack channel and user authorization.
+/// Used by both <see cref="SlackConversationActor"/> (inbound) and
+/// <see cref="Tools.SendSlackMessageTool"/> (outbound/proactive).
+/// </summary>
+public static class SlackAclPolicy
+{
+    /// <summary>
+    /// Returns true if <paramref name="channelId"/> is the default channel
+    /// or appears in <see cref="SlackChannelOptions.AllowedChannelIds"/>.
+    /// </summary>
+    public static bool IsAllowedChannel(
+        SlackChannelId channelId,
+        SlackChannelOptions options,
+        SlackChannelId? defaultChannelId)
+    {
+        if (defaultChannelId is not null && channelId == defaultChannelId.Value)
+            return true;
+
+        return options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns true if the user is permitted. An empty allow-list means all users are allowed.
+    /// </summary>
+    public static bool IsAllowedUser(SlackUserId userId, SlackChannelOptions options)
+    {
+        if (options.AllowedUserIds.Length == 0)
+            return true;
+
+        return options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -59,6 +59,12 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
 
     public string DisplayName => "Slack";
 
+    /// <summary>
+    /// The gateway actor ref, exposed so that proactive tools can send
+    /// <see cref="StartProactiveThread"/> messages to wire up the actor hierarchy.
+    /// </summary>
+    internal IActorRef? Gateway => _gateway;
+
     public ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default)
     {
         if (!_options.Enabled)

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -65,6 +65,12 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     /// </summary>
     internal IActorRef? Gateway => _gateway;
 
+    /// <summary>
+    /// The resolved default channel ID, available after <see cref="StartAsync"/> completes.
+    /// Exposed for proactive tools that need runtime-resolved channel IDs for ACL checks.
+    /// </summary>
+    internal SlackChannelId? DefaultChannelId => _defaultChannelId;
+
     public ValueTask<ChannelHealth> GetHealthAsync(CancellationToken cancellationToken = default)
     {
         if (!_options.Enabled)

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -111,10 +111,20 @@ public sealed class SlackConversationActor : ReceiveActor
             // Defense-in-depth: validate channel ACL even though the tool already checked.
             // DM channels (D-prefixed) skip this — they were validated via user ACL + AllowDirectMessages.
             var isDmChannel = message.ChannelId.Value.StartsWith("D", StringComparison.Ordinal);
+            if (isDmChannel && !_dependencies.Options.AllowDirectMessages)
+            {
+                var reason = "Direct messages are disabled by Slack channel configuration.";
+                _log.Warning("Rejected proactive DM thread for channel {0}: {1}", message.ChannelId, reason);
+                Sender.Tell(new Status.Failure(new InvalidOperationException(reason)));
+                return;
+            }
+
             if (!isDmChannel && !SlackAclPolicy.IsAllowedChannel(
                     message.ChannelId, _dependencies.Options, _dependencies.DefaultChannelId))
             {
                 _log.Warning("Rejected proactive thread for disallowed channel {0}", message.ChannelId);
+                Sender.Tell(new Status.Failure(new InvalidOperationException(
+                    $"Channel {message.ChannelId.Value} is not in the allowed channels list.")));
                 return;
             }
 

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -105,6 +105,19 @@ public sealed class SlackConversationActor : ReceiveActor
                 ReceivedAt: _dependencies.TimeProvider.GetUtcNow(),
                 Files: message.Files));
         });
+
+        Receive<StartProactiveThread>(message =>
+        {
+            var threadActorName = Uri.EscapeDataString(message.ThreadTs.Value);
+            var existingThread = Context.Child(threadActorName);
+
+            var thread = existingThread.IsNobody()
+                ? Context.ActorOf(CreateThreadProps(message.ChannelId, message.ThreadTs), threadActorName)
+                : existingThread;
+
+            _log.Debug("Routing proactive thread setup to thread actor {0}", message.ThreadTs);
+            thread.Forward(message);
+        });
     }
 
     public static Props CreateProps(SlackChannelId conversationId, SlackGatewayDependencies dependencies) =>

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -108,6 +108,16 @@ public sealed class SlackConversationActor : ReceiveActor
 
         Receive<StartProactiveThread>(message =>
         {
+            // Defense-in-depth: validate channel ACL even though the tool already checked.
+            // DM channels (D-prefixed) skip this — they were validated via user ACL + AllowDirectMessages.
+            var isDmChannel = message.ChannelId.Value.StartsWith("D", StringComparison.Ordinal);
+            if (!isDmChannel && !SlackAclPolicy.IsAllowedChannel(
+                    message.ChannelId, _dependencies.Options, _dependencies.DefaultChannelId))
+            {
+                _log.Warning("Rejected proactive thread for disallowed channel {0}", message.ChannelId);
+                return;
+            }
+
             var threadActorName = Uri.EscapeDataString(message.ThreadTs.Value);
             var existingThread = Context.Child(threadActorName);
 
@@ -128,13 +138,8 @@ public sealed class SlackConversationActor : ReceiveActor
         if (message.IsDirectMessage)
             return _dependencies.Options.AllowDirectMessages;
 
-        var matchesDefaultChannel = _dependencies.DefaultChannelId is not null
-            && message.ChannelId == _dependencies.DefaultChannelId.Value;
-
-        var matchesAllowedChannel = _dependencies.Options.AllowedChannelIds
-            .Contains(message.ChannelId.Value, StringComparer.Ordinal);
-
-        return matchesDefaultChannel || matchesAllowedChannel;
+        return SlackAclPolicy.IsAllowedChannel(
+            message.ChannelId, _dependencies.Options, _dependencies.DefaultChannelId);
     }
 
     private bool IsBotMessage(SlackInboundMessage message)
@@ -151,13 +156,10 @@ public sealed class SlackConversationActor : ReceiveActor
 
     private bool IsAllowedUser(SlackInboundMessage message)
     {
-        if (_dependencies.Options.AllowedUserIds.Length == 0)
-            return true;
-
         if (message.UserId is not { } userId)
             return false;
 
-        return _dependencies.Options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
+        return SlackAclPolicy.IsAllowedUser(userId, _dependencies.Options);
     }
 
     private bool ContainsBotMention(string text)

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -44,6 +44,18 @@ public sealed class SlackGatewayActor : ReceiveActor
             ChannelTelemetry.RecordSlackEventRouted(message.Kind.ToString());
             conversation.Forward(message);
         });
+
+        Receive<StartProactiveThread>(message =>
+        {
+            var actorName = Uri.EscapeDataString(message.ChannelId.Value);
+            var conversationProps = _dependencies.ConversationPropsFactory?.Invoke(message.ChannelId, _dependencies)
+                ?? SlackConversationActor.CreateProps(message.ChannelId, _dependencies);
+            var conversation = Context.Child(actorName)
+                .GetOrElse(() => Context.ActorOf(conversationProps, actorName));
+
+            _log.Debug("Routing proactive thread to conversation {0}", message.ChannelId);
+            conversation.Forward(message);
+        });
     }
 
     public static Props CreateProps(SlackGatewayDependencies dependencies) =>

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -42,3 +42,13 @@ public sealed record SlackPostMessage(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
     string Text);
+
+/// <summary>
+/// Sent to the gateway to wire up the actor hierarchy for a proactively-created thread.
+/// The Slack message has already been posted; this creates the session pipeline so
+/// user replies route back to a live session.
+/// </summary>
+public sealed record StartProactiveThread(
+    SlackChannelId ChannelId,
+    SlackThreadTs ThreadTs,
+    SessionId SessionId);

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -52,3 +52,9 @@ public sealed record StartProactiveThread(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
     SessionId SessionId);
+
+/// <summary>
+/// Acknowledgement that the proactive thread's session pipeline was initialized.
+/// Returned by <see cref="SlackThreadBindingActor"/> in response to <see cref="StartProactiveThread"/>.
+/// </summary>
+public sealed record ProactiveThreadAck(SessionId SessionId);

--- a/src/Netclaw.Channels/Slack/SlackOutboundClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackOutboundClient.cs
@@ -1,0 +1,27 @@
+using SlackNet;
+using SlackNet.WebApi;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed class SlackOutboundClient(ISlackApiClient slackApiClient) : ISlackOutboundClient
+{
+    public async Task<SlackChannelId> OpenDmChannelAsync(SlackUserId userId, CancellationToken ct = default)
+    {
+        var channelId = await slackApiClient.Conversations.Open(new[] { userId.Value }, ct);
+        return new SlackChannelId(channelId);
+    }
+
+    public async Task<SlackNewThread> PostNewThreadAsync(SlackChannelId channelId, string text, CancellationToken ct = default)
+    {
+        var blocks = SlackBlockConverter.Convert(text);
+        var response = await slackApiClient.Chat.PostMessage(new Message
+        {
+            Channel = channelId.Value,
+            Text = text,
+            Blocks = blocks
+        }, ct);
+
+        var threadTs = new SlackThreadTs(response.Ts);
+        return new SlackNewThread(channelId, threadTs);
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -78,6 +78,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         await EnsureInitializedAsync();
         // No inbound message to enqueue — the initial message was already posted to Slack.
         // The session pipeline is now live and ready for user replies.
+        Sender.Tell(new ProactiveThreadAck(message.SessionId));
     }
 
     private async Task HandleInboundAsync(SlackThreadInbound message)

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -46,6 +46,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
             .WithContext("SlackThreadTs", _threadTs);
 
         ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
+        ReceiveAsync<StartProactiveThread>(HandleProactiveThreadAsync);
         ReceiveAsync<ThreadOutput>(HandleOutputAsync);
         Receive<ReceiveTimeout>(_ =>
         {
@@ -69,6 +70,14 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _materializer?.Dispose();
         base.PostStop();
+    }
+
+    private async Task HandleProactiveThreadAsync(StartProactiveThread message)
+    {
+        _log.Info("Initializing proactive thread pipeline for session {0}", message.SessionId.Value);
+        await EnsureInitializedAsync();
+        // No inbound message to enqueue — the initial message was already posted to Slack.
+        // The session pipeline is now live and ready for user replies.
     }
 
     private async Task HandleInboundAsync(SlackThreadInbound message)

--- a/src/Netclaw.Channels/Slack/Tools/LookupSlackUserTool.cs
+++ b/src/Netclaw.Channels/Slack/Tools/LookupSlackUserTool.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text;
 using Netclaw.Tools;
-using SlackNet;
 using SlackNet.WebApi;
 
 namespace Netclaw.Channels.Slack.Tools;
@@ -13,25 +12,28 @@ namespace Netclaw.Channels.Slack.Tools;
 [NetclawTool("lookup_slack_user",
     "Look up a Slack user by name, display name, or email. " +
     "Returns their user ID for use with send_slack_message.",
-    Grant = "slack")]
-public sealed partial class LookupSlackUserTool : NetclawTool<LookupSlackUserTool.Params>
+    Grant = "builtin")]
+public sealed partial class LookupSlackUserTool : NetclawTool<LookupSlackUserTool.Params>, IChannelTool
 {
-    private readonly ISlackApiClient _slackApiClient;
+    private readonly IUsersApi _usersApi;
     private readonly SlackChannelOptions _options;
+    private readonly TimeProvider _timeProvider;
 
     // Simple in-memory cache: cleared after a short TTL to avoid stale data
     private List<CachedUser>? _cachedUsers;
     private DateTimeOffset _cacheExpiry;
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
 
     public record Params(
         [property: Description("Name, display name, or email to search for")]
         string Query);
 
-    public LookupSlackUserTool(ISlackApiClient slackApiClient, SlackChannelOptions options)
+    public LookupSlackUserTool(IUsersApi usersApi, SlackChannelOptions options, TimeProvider timeProvider)
     {
-        _slackApiClient = slackApiClient;
+        _usersApi = usersApi;
         _options = options;
+        _timeProvider = timeProvider;
     }
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
@@ -73,43 +75,56 @@ public sealed partial class LookupSlackUserTool : NetclawTool<LookupSlackUserToo
 
     private async Task<List<CachedUser>> GetUsersAsync(CancellationToken ct)
     {
-        if (_cachedUsers is not null && DateTimeOffset.UtcNow < _cacheExpiry)
-            return _cachedUsers;
+        // Fast path: cache hit without lock
+        if (_cachedUsers is { } cached && _timeProvider.GetUtcNow() < _cacheExpiry)
+            return cached;
 
-        var allUsers = new List<CachedUser>();
-        string? cursor = null;
-
-        do
+        await _cacheLock.WaitAsync(ct);
+        try
         {
-            var response = await _slackApiClient.Users.List(cursor: cursor, cancellationToken: ct);
-            foreach (var user in response.Members)
+            // Double-check after acquiring lock
+            if (_cachedUsers is { } rechecked && _timeProvider.GetUtcNow() < _cacheExpiry)
+                return rechecked;
+
+            var allUsers = new List<CachedUser>();
+            string? cursor = null;
+
+            do
             {
-                if (user.IsBot || user.Deleted)
-                    continue;
+                var response = await _usersApi.List(cursor: cursor, cancellationToken: ct);
+                foreach (var user in response.Members)
+                {
+                    if (user.IsBot || user.Deleted)
+                        continue;
 
-                // Filter to allowed users if the allow-list is non-empty
-                if (_options.AllowedUserIds.Length > 0
-                    && !_options.AllowedUserIds.Contains(user.Id, StringComparer.Ordinal))
-                    continue;
+                    // Filter to allowed users if the allow-list is non-empty
+                    if (_options.AllowedUserIds.Length > 0
+                        && !_options.AllowedUserIds.Contains(user.Id, StringComparer.Ordinal))
+                        continue;
 
-                allUsers.Add(new CachedUser(
-                    Id: user.Id,
-                    Name: user.Name ?? string.Empty,
-                    RealName: user.RealName ?? string.Empty,
-                    DisplayName: user.Profile?.DisplayName ?? string.Empty,
-                    Email: user.Profile?.Email ?? string.Empty));
-            }
+                    allUsers.Add(new CachedUser(
+                        Id: user.Id,
+                        Name: user.Name ?? string.Empty,
+                        RealName: user.RealName ?? string.Empty,
+                        DisplayName: user.Profile?.DisplayName ?? string.Empty,
+                        Email: user.Profile?.Email ?? string.Empty));
+                }
 
-            cursor = response.ResponseMetadata?.NextCursor;
-        } while (!string.IsNullOrWhiteSpace(cursor));
+                cursor = response.ResponseMetadata?.NextCursor;
+            } while (!string.IsNullOrWhiteSpace(cursor));
 
-        _cachedUsers = allUsers;
-        _cacheExpiry = DateTimeOffset.UtcNow + CacheTtl;
+            _cachedUsers = allUsers;
+            _cacheExpiry = _timeProvider.GetUtcNow() + CacheTtl;
 
-        return allUsers;
+            return allUsers;
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
     }
 
-    private sealed record CachedUser(
+    internal sealed record CachedUser(
         string Id,
         string Name,
         string RealName,

--- a/src/Netclaw.Channels/Slack/Tools/LookupSlackUserTool.cs
+++ b/src/Netclaw.Channels/Slack/Tools/LookupSlackUserTool.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using System.Text;
+using Netclaw.Tools;
+using SlackNet;
+using SlackNet.WebApi;
+
+namespace Netclaw.Channels.Slack.Tools;
+
+/// <summary>
+/// LLM tool that looks up Slack users by name, display name, or email.
+/// Returns user IDs suitable for use with <see cref="SendSlackMessageTool"/>.
+/// </summary>
+[NetclawTool("lookup_slack_user",
+    "Look up a Slack user by name, display name, or email. " +
+    "Returns their user ID for use with send_slack_message.",
+    Grant = "slack")]
+public sealed partial class LookupSlackUserTool : NetclawTool<LookupSlackUserTool.Params>
+{
+    private readonly ISlackApiClient _slackApiClient;
+    private readonly SlackChannelOptions _options;
+
+    // Simple in-memory cache: cleared after a short TTL to avoid stale data
+    private List<CachedUser>? _cachedUsers;
+    private DateTimeOffset _cacheExpiry;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    public record Params(
+        [property: Description("Name, display name, or email to search for")]
+        string Query);
+
+    public LookupSlackUserTool(ISlackApiClient slackApiClient, SlackChannelOptions options)
+    {
+        _slackApiClient = slackApiClient;
+        _options = options;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Query))
+            return "Error: 'query' parameter is required.";
+
+        var users = await GetUsersAsync(ct);
+        var query = args.Query.Trim();
+
+        var matches = users
+            .Where(u => MatchesQuery(u, query))
+            .Take(10)
+            .ToList();
+
+        if (matches.Count == 0)
+            return "No matching users found.";
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Found {matches.Count} matching user(s):");
+        foreach (var user in matches)
+        {
+            sb.Append($"  {user.Id} ({user.RealName})");
+            if (!string.IsNullOrWhiteSpace(user.Email))
+                sb.Append($" — {user.Email}");
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static bool MatchesQuery(CachedUser user, string query)
+    {
+        return user.RealName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || user.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || user.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || user.Email.Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<List<CachedUser>> GetUsersAsync(CancellationToken ct)
+    {
+        if (_cachedUsers is not null && DateTimeOffset.UtcNow < _cacheExpiry)
+            return _cachedUsers;
+
+        var allUsers = new List<CachedUser>();
+        string? cursor = null;
+
+        do
+        {
+            var response = await _slackApiClient.Users.List(cursor: cursor, cancellationToken: ct);
+            foreach (var user in response.Members)
+            {
+                if (user.IsBot || user.Deleted)
+                    continue;
+
+                // Filter to allowed users if the allow-list is non-empty
+                if (_options.AllowedUserIds.Length > 0
+                    && !_options.AllowedUserIds.Contains(user.Id, StringComparer.Ordinal))
+                    continue;
+
+                allUsers.Add(new CachedUser(
+                    Id: user.Id,
+                    Name: user.Name ?? string.Empty,
+                    RealName: user.RealName ?? string.Empty,
+                    DisplayName: user.Profile?.DisplayName ?? string.Empty,
+                    Email: user.Profile?.Email ?? string.Empty));
+            }
+
+            cursor = response.ResponseMetadata?.NextCursor;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        _cachedUsers = allUsers;
+        _cacheExpiry = DateTimeOffset.UtcNow + CacheTtl;
+
+        return allUsers;
+    }
+
+    private sealed record CachedUser(
+        string Id,
+        string Name,
+        string RealName,
+        string DisplayName,
+        string Email);
+}

--- a/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
+++ b/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
@@ -18,7 +18,6 @@ namespace Netclaw.Channels.Slack.Tools;
 public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageTool.Params>, IChannelTool
 {
     private readonly ISlackOutboundClient _outboundClient;
-    private readonly ISlackReplyClient _replyClient;
     private readonly SlackChannelOptions _options;
     private readonly Func<SlackChannelId?> _defaultChannelIdAccessor;
     private readonly Func<IActorRef?> _gatewayAccessor;
@@ -29,28 +28,21 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
         [property: Description("Slack channel ID (C...) to post to. Mutually exclusive with user_id.")]
         string? ChannelId = null,
         [property: Description("Slack user ID (U...) to DM. Mutually exclusive with channel_id.")]
-        string? UserId = null,
-        [property: Description("Comma-separated absolute file paths to attach to the thread. Files must be within the session directory.")]
-        string? FilePaths = null);
+        string? UserId = null);
 
     public SendSlackMessageTool(
         ISlackOutboundClient outboundClient,
-        ISlackReplyClient replyClient,
         SlackChannelOptions options,
         Func<SlackChannelId?> defaultChannelIdAccessor,
         Func<IActorRef?> gatewayAccessor)
     {
         _outboundClient = outboundClient;
-        _replyClient = replyClient;
         _options = options;
         _defaultChannelIdAccessor = defaultChannelIdAccessor;
         _gatewayAccessor = gatewayAccessor;
     }
 
-    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
-        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
-
-    protected override async Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Message))
             return "Error: 'message' parameter is required.";
@@ -74,7 +66,7 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
 
             var userId = new SlackUserId(args.UserId!);
 
-            if (!IsAllowedUser(userId))
+            if (!SlackAclPolicy.IsAllowedUser(userId, _options))
                 return $"Error: User {userId.Value} is not in the allowed users list.";
 
             try
@@ -90,7 +82,7 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
         {
             targetChannelId = new SlackChannelId(args.ChannelId!);
 
-            if (!IsAllowedChannel(targetChannelId))
+            if (!SlackAclPolicy.IsAllowedChannel(targetChannelId, _options, _defaultChannelIdAccessor()))
                 return $"Error: Channel {targetChannelId.Value} is not in the allowed channels list.";
         }
 
@@ -110,7 +102,7 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
         {
             await gateway.Ask<ProactiveThreadAck>(
                 new StartProactiveThread(result.ChannelId, result.ThreadTs, sessionId),
-                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(30),
                 ct);
         }
         catch (Exception)
@@ -121,97 +113,7 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
                    $"Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
         }
 
-        // Upload file attachments after the thread is established
-        var fileErrors = await UploadFilesAsync(args.FilePaths, context, result.ChannelId, result.ThreadTs, ct);
-
         var successTarget = hasUser ? $"user {args.UserId}" : $"channel {args.ChannelId}";
-        var response = $"Message sent to {successTarget}. Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
-
-        if (fileErrors.Count > 0)
-            response += $" File upload errors: {string.Join("; ", fileErrors)}";
-
-        return response;
-    }
-
-    private async Task<List<string>> UploadFilesAsync(
-        string? filePathsCsv,
-        ToolExecutionContext context,
-        SlackChannelId channelId,
-        SlackThreadTs threadTs,
-        CancellationToken ct)
-    {
-        var errors = new List<string>();
-
-        if (string.IsNullOrWhiteSpace(filePathsCsv))
-            return errors;
-
-        var sessionDir = context.SessionDirectory;
-        var paths = filePathsCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        foreach (var rawPath in paths)
-        {
-            var fullPath = Path.GetFullPath(rawPath);
-
-            // Validate file is within session directory (if available)
-            if (!string.IsNullOrWhiteSpace(sessionDir) && !IsPathWithinDirectory(fullPath, sessionDir))
-            {
-                errors.Add($"{rawPath}: path must be within the session directory");
-                continue;
-            }
-
-            if (!File.Exists(fullPath))
-            {
-                errors.Add($"{rawPath}: file not found");
-                continue;
-            }
-
-            try
-            {
-                await _replyClient.UploadFileToThreadAsync(channelId, threadTs, fullPath, Path.GetFileName(fullPath), ct);
-            }
-            catch (Exception ex)
-            {
-                errors.Add($"{rawPath}: {ex.Message}");
-            }
-        }
-
-        return errors;
-    }
-
-    private static bool IsPathWithinDirectory(string path, string directory)
-    {
-        var fullPath = Path.GetFullPath(path)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var normalizedDir = Path.GetFullPath(directory)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (!fullPath.StartsWith(normalizedDir, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (fullPath.Length == normalizedDir.Length)
-            return true;
-
-        var boundary = fullPath[normalizedDir.Length];
-        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
-    }
-
-    private bool IsAllowedUser(SlackUserId userId)
-    {
-        if (_options.AllowedUserIds.Length == 0)
-            return true;
-
-        return _options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
-    }
-
-    private bool IsAllowedChannel(SlackChannelId channelId)
-    {
-        var defaultChannelId = _defaultChannelIdAccessor();
-        var matchesDefault = defaultChannelId is not null
-            && channelId == defaultChannelId.Value;
-
-        var matchesAllowed = _options.AllowedChannelIds
-            .Contains(channelId.Value, StringComparer.Ordinal);
-
-        return matchesDefault || matchesAllowed;
+        return $"Message sent to {successTarget}. Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
     }
 }

--- a/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
+++ b/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel;
+using Akka.Actor;
+using Netclaw.Actors.Protocol;
+using Netclaw.Tools;
+
+namespace Netclaw.Channels.Slack.Tools;
+
+/// <summary>
+/// LLM tool that sends a proactive message to a Slack channel or DMs a user,
+/// creating a new conversation thread. The new thread is wired into the actor
+/// hierarchy so user replies route back to a live session.
+/// </summary>
+[NetclawTool("send_slack_message",
+    "Send a message to a Slack channel or DM a user, creating a new conversation thread. " +
+    "Use this to proactively notify users or start discussions. " +
+    "Provide exactly one of channel_id or user_id.",
+    Grant = "slack")]
+public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageTool.Params>
+{
+    private readonly ISlackOutboundClient _outboundClient;
+    private readonly SlackChannelOptions _options;
+    private readonly SlackChannelId? _defaultChannelId;
+    private readonly Func<IActorRef?> _gatewayAccessor;
+
+    public record Params(
+        [property: Description("The message text to send")]
+        string Message,
+        [property: Description("Slack channel ID (C...) to post to. Mutually exclusive with user_id.")]
+        string? ChannelId = null,
+        [property: Description("Slack user ID (U...) to DM. Mutually exclusive with channel_id.")]
+        string? UserId = null);
+
+    public SendSlackMessageTool(
+        ISlackOutboundClient outboundClient,
+        SlackChannelOptions options,
+        SlackChannelId? defaultChannelId,
+        Func<IActorRef?> gatewayAccessor)
+    {
+        _outboundClient = outboundClient;
+        _options = options;
+        _defaultChannelId = defaultChannelId;
+        _gatewayAccessor = gatewayAccessor;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Message))
+            return "Error: 'message' parameter is required.";
+
+        var hasChannel = !string.IsNullOrWhiteSpace(args.ChannelId);
+        var hasUser = !string.IsNullOrWhiteSpace(args.UserId);
+
+        if (hasChannel == hasUser) // both set or neither set
+            return "Error: Provide exactly one of 'channel_id' or 'user_id'.";
+
+        var gateway = _gatewayAccessor();
+        if (gateway is null)
+            return "Error: Slack gateway is not connected.";
+
+        SlackChannelId targetChannelId;
+
+        if (hasUser)
+        {
+            var userId = new SlackUserId(args.UserId!);
+
+            if (!IsAllowedUser(userId))
+                return $"Error: User {userId.Value} is not in the allowed users list.";
+
+            targetChannelId = await _outboundClient.OpenDmChannelAsync(userId, ct);
+        }
+        else
+        {
+            targetChannelId = new SlackChannelId(args.ChannelId!);
+
+            if (!IsAllowedChannel(targetChannelId))
+                return $"Error: Channel {targetChannelId.Value} is not in the allowed channels list.";
+        }
+
+        var result = await _outboundClient.PostNewThreadAsync(targetChannelId, args.Message, ct);
+
+        var sessionId = new SessionId($"{result.ChannelId.Value}/{result.ThreadTs.Value}");
+        gateway.Tell(new StartProactiveThread(result.ChannelId, result.ThreadTs, sessionId));
+
+        var target = hasUser ? $"user {args.UserId}" : $"channel {args.ChannelId}";
+        return $"Message sent to {target}. Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
+    }
+
+    private bool IsAllowedUser(SlackUserId userId)
+    {
+        if (_options.AllowedUserIds.Length == 0)
+            return true;
+
+        return _options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
+    }
+
+    private bool IsAllowedChannel(SlackChannelId channelId)
+    {
+        var matchesDefault = _defaultChannelId is not null
+            && channelId == _defaultChannelId.Value;
+
+        var matchesAllowed = _options.AllowedChannelIds
+            .Contains(channelId.Value, StringComparer.Ordinal);
+
+        return matchesDefault || matchesAllowed;
+    }
+}

--- a/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
+++ b/src/Netclaw.Channels/Slack/Tools/SendSlackMessageTool.cs
@@ -14,12 +14,13 @@ namespace Netclaw.Channels.Slack.Tools;
     "Send a message to a Slack channel or DM a user, creating a new conversation thread. " +
     "Use this to proactively notify users or start discussions. " +
     "Provide exactly one of channel_id or user_id.",
-    Grant = "slack")]
-public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageTool.Params>
+    Grant = "builtin")]
+public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageTool.Params>, IChannelTool
 {
     private readonly ISlackOutboundClient _outboundClient;
+    private readonly ISlackReplyClient _replyClient;
     private readonly SlackChannelOptions _options;
-    private readonly SlackChannelId? _defaultChannelId;
+    private readonly Func<SlackChannelId?> _defaultChannelIdAccessor;
     private readonly Func<IActorRef?> _gatewayAccessor;
 
     public record Params(
@@ -28,21 +29,28 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
         [property: Description("Slack channel ID (C...) to post to. Mutually exclusive with user_id.")]
         string? ChannelId = null,
         [property: Description("Slack user ID (U...) to DM. Mutually exclusive with channel_id.")]
-        string? UserId = null);
+        string? UserId = null,
+        [property: Description("Comma-separated absolute file paths to attach to the thread. Files must be within the session directory.")]
+        string? FilePaths = null);
 
     public SendSlackMessageTool(
         ISlackOutboundClient outboundClient,
+        ISlackReplyClient replyClient,
         SlackChannelOptions options,
-        SlackChannelId? defaultChannelId,
+        Func<SlackChannelId?> defaultChannelIdAccessor,
         Func<IActorRef?> gatewayAccessor)
     {
         _outboundClient = outboundClient;
+        _replyClient = replyClient;
         _options = options;
-        _defaultChannelId = defaultChannelId;
+        _defaultChannelIdAccessor = defaultChannelIdAccessor;
         _gatewayAccessor = gatewayAccessor;
     }
 
-    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
+
+    protected override async Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(args.Message))
             return "Error: 'message' parameter is required.";
@@ -61,12 +69,22 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
 
         if (hasUser)
         {
+            if (!_options.AllowDirectMessages)
+                return "Error: Direct messages are disabled. Enable AllowDirectMessages in Slack configuration to send DMs.";
+
             var userId = new SlackUserId(args.UserId!);
 
             if (!IsAllowedUser(userId))
                 return $"Error: User {userId.Value} is not in the allowed users list.";
 
-            targetChannelId = await _outboundClient.OpenDmChannelAsync(userId, ct);
+            try
+            {
+                targetChannelId = await _outboundClient.OpenDmChannelAsync(userId, ct);
+            }
+            catch (Exception ex)
+            {
+                return $"Error: Failed to open DM channel: {ex.Message}";
+            }
         }
         else
         {
@@ -76,13 +94,105 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
                 return $"Error: Channel {targetChannelId.Value} is not in the allowed channels list.";
         }
 
-        var result = await _outboundClient.PostNewThreadAsync(targetChannelId, args.Message, ct);
+        SlackNewThread result;
+        try
+        {
+            result = await _outboundClient.PostNewThreadAsync(targetChannelId, args.Message, ct);
+        }
+        catch (Exception ex)
+        {
+            return $"Error: Failed to post message to Slack: {ex.Message}";
+        }
 
         var sessionId = new SessionId($"{result.ChannelId.Value}/{result.ThreadTs.Value}");
-        gateway.Tell(new StartProactiveThread(result.ChannelId, result.ThreadTs, sessionId));
 
-        var target = hasUser ? $"user {args.UserId}" : $"channel {args.ChannelId}";
-        return $"Message sent to {target}. Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
+        try
+        {
+            await gateway.Ask<ProactiveThreadAck>(
+                new StartProactiveThread(result.ChannelId, result.ThreadTs, sessionId),
+                TimeSpan.FromSeconds(10),
+                ct);
+        }
+        catch (Exception)
+        {
+            // Message was already posted to Slack; the pipeline just didn't initialize
+            var target = hasUser ? $"user {args.UserId}" : $"channel {args.ChannelId}";
+            return $"Message sent to {target} but session pipeline failed to initialize. " +
+                   $"Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
+        }
+
+        // Upload file attachments after the thread is established
+        var fileErrors = await UploadFilesAsync(args.FilePaths, context, result.ChannelId, result.ThreadTs, ct);
+
+        var successTarget = hasUser ? $"user {args.UserId}" : $"channel {args.ChannelId}";
+        var response = $"Message sent to {successTarget}. Thread: {result.ChannelId.Value}/{result.ThreadTs.Value}";
+
+        if (fileErrors.Count > 0)
+            response += $" File upload errors: {string.Join("; ", fileErrors)}";
+
+        return response;
+    }
+
+    private async Task<List<string>> UploadFilesAsync(
+        string? filePathsCsv,
+        ToolExecutionContext context,
+        SlackChannelId channelId,
+        SlackThreadTs threadTs,
+        CancellationToken ct)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(filePathsCsv))
+            return errors;
+
+        var sessionDir = context.SessionDirectory;
+        var paths = filePathsCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var rawPath in paths)
+        {
+            var fullPath = Path.GetFullPath(rawPath);
+
+            // Validate file is within session directory (if available)
+            if (!string.IsNullOrWhiteSpace(sessionDir) && !IsPathWithinDirectory(fullPath, sessionDir))
+            {
+                errors.Add($"{rawPath}: path must be within the session directory");
+                continue;
+            }
+
+            if (!File.Exists(fullPath))
+            {
+                errors.Add($"{rawPath}: file not found");
+                continue;
+            }
+
+            try
+            {
+                await _replyClient.UploadFileToThreadAsync(channelId, threadTs, fullPath, Path.GetFileName(fullPath), ct);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"{rawPath}: {ex.Message}");
+            }
+        }
+
+        return errors;
+    }
+
+    private static bool IsPathWithinDirectory(string path, string directory)
+    {
+        var fullPath = Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedDir = Path.GetFullPath(directory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (!fullPath.StartsWith(normalizedDir, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (fullPath.Length == normalizedDir.Length)
+            return true;
+
+        var boundary = fullPath[normalizedDir.Length];
+        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
     }
 
     private bool IsAllowedUser(SlackUserId userId)
@@ -95,8 +205,9 @@ public sealed partial class SendSlackMessageTool : NetclawTool<SendSlackMessageT
 
     private bool IsAllowedChannel(SlackChannelId channelId)
     {
-        var matchesDefault = _defaultChannelId is not null
-            && channelId == _defaultChannelId.Value;
+        var defaultChannelId = _defaultChannelIdAccessor();
+        var matchesDefault = defaultChannelId is not null
+            && channelId == defaultChannelId.Value;
 
         var matchesAllowed = _options.AllowedChannelIds
             .Contains(channelId.Value, StringComparer.Ordinal);

--- a/src/Netclaw.Daemon/Configuration/ChannelToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/ChannelToolRegistration.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Actors.Tools;
+using Netclaw.Channels.Slack.Tools;
+
+namespace Netclaw.Daemon.Configuration;
+
+/// <summary>
+/// Registers channel-specific LLM tools with the <see cref="ToolRegistry"/>
+/// after the DI container is built. Channel tools are only present in DI
+/// when their channel adapter is enabled.
+/// </summary>
+internal static class ChannelToolRegistration
+{
+    public static void RegisterChannelTools(IServiceProvider services)
+    {
+        var registry = services.GetRequiredService<ToolRegistry>();
+
+        // Slack tools — only present when Slack adapter is enabled
+        var sendTool = services.GetService<SendSlackMessageTool>();
+        if (sendTool is not null)
+            registry.Register(sendTool);
+
+        var lookupTool = services.GetService<LookupSlackUserTool>();
+        if (lookupTool is not null)
+            registry.Register(lookupTool);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/ChannelToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/ChannelToolRegistration.cs
@@ -1,13 +1,14 @@
 using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Actors.Tools;
-using Netclaw.Channels.Slack.Tools;
+using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Configuration;
 
 /// <summary>
 /// Registers channel-specific LLM tools with the <see cref="ToolRegistry"/>
-/// after the DI container is built. Channel tools are only present in DI
-/// when their channel adapter is enabled.
+/// after the DI container is built. Channel tools are discovered dynamically
+/// via the <see cref="IChannelTool"/> marker interface — only tools whose
+/// channel adapter is enabled will be present in DI.
 /// </summary>
 internal static class ChannelToolRegistration
 {
@@ -15,13 +16,9 @@ internal static class ChannelToolRegistration
     {
         var registry = services.GetRequiredService<ToolRegistry>();
 
-        // Slack tools — only present when Slack adapter is enabled
-        var sendTool = services.GetService<SendSlackMessageTool>();
-        if (sendTool is not null)
-            registry.Register(sendTool);
-
-        var lookupTool = services.GetService<LookupSlackUserTool>();
-        if (lookupTool is not null)
-            registry.Register(lookupTool);
+        foreach (var tool in services.GetServices<IChannelTool>())
+        {
+            registry.Register(tool);
+        }
     }
 }

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -1,5 +1,6 @@
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
+using Netclaw.Channels.Slack.Tools;
 using SlackNet.Events;
 using SlackNet.Extensions.DependencyInjection;
 
@@ -25,6 +26,7 @@ public static class SlackChannelRegistrationExtensions
 
         services.AddHttpClient("slack-files");
         services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
+        services.AddSingleton<ISlackOutboundClient, SlackOutboundClient>();
         services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
         services.AddSingleton<IChannel>(sp =>
             sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
@@ -42,7 +44,36 @@ public static class SlackChannelRegistrationExtensions
             c.RegisterEventHandler<AppMention, SlackChannel>();
         });
 
+        // Channel-specific LLM tools: registered as INetclawTool singletons.
+        // The gateway actor ref is resolved lazily via SlackChannel since it's
+        // not available until StartAsync completes.
+        services.AddSingleton<SendSlackMessageTool>(sp =>
+        {
+            var outbound = sp.GetRequiredService<ISlackOutboundClient>();
+            var channel = sp.GetRequiredService<SlackChannel>();
+            return new SendSlackMessageTool(
+                outbound,
+                slackOptions,
+                ResolveDefaultChannelId(slackOptions),
+                () => channel.Gateway);
+        });
+
+        services.AddSingleton<LookupSlackUserTool>(sp =>
+        {
+            var slackApi = sp.GetRequiredService<SlackNet.ISlackApiClient>();
+            return new LookupSlackUserTool(slackApi, slackOptions);
+        });
+
         services.AddSingleton<IHostedService>(sp =>
             (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
+    }
+
+    private static SlackChannelId? ResolveDefaultChannelId(SlackChannelOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.DefaultChannelId))
+            return new SlackChannelId(options.DefaultChannelId);
+        // Channel name resolution happens at runtime in SlackChannel.StartAsync;
+        // for tool ACL we only use the configured ID.
+        return null;
     }
 }

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -1,6 +1,7 @@
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
 using Netclaw.Channels.Slack.Tools;
+using Netclaw.Tools;
 using SlackNet.Events;
 using SlackNet.Extensions.DependencyInjection;
 
@@ -45,35 +46,31 @@ public static class SlackChannelRegistrationExtensions
         });
 
         // Channel-specific LLM tools: registered as INetclawTool singletons.
-        // The gateway actor ref is resolved lazily via SlackChannel since it's
-        // not available until StartAsync completes.
+        // The gateway actor ref and default channel ID are resolved lazily via
+        // SlackChannel since they're not available until StartAsync completes.
         services.AddSingleton<SendSlackMessageTool>(sp =>
         {
             var outbound = sp.GetRequiredService<ISlackOutboundClient>();
+            var replyClient = sp.GetRequiredService<ISlackReplyClient>();
             var channel = sp.GetRequiredService<SlackChannel>();
             return new SendSlackMessageTool(
                 outbound,
+                replyClient,
                 slackOptions,
-                ResolveDefaultChannelId(slackOptions),
+                () => channel.DefaultChannelId,
                 () => channel.Gateway);
         });
+        services.AddSingleton<IChannelTool>(sp => sp.GetRequiredService<SendSlackMessageTool>());
 
         services.AddSingleton<LookupSlackUserTool>(sp =>
         {
             var slackApi = sp.GetRequiredService<SlackNet.ISlackApiClient>();
-            return new LookupSlackUserTool(slackApi, slackOptions);
+            var timeProvider = sp.GetRequiredService<TimeProvider>();
+            return new LookupSlackUserTool(slackApi.Users, slackOptions, timeProvider);
         });
+        services.AddSingleton<IChannelTool>(sp => sp.GetRequiredService<LookupSlackUserTool>());
 
         services.AddSingleton<IHostedService>(sp =>
             (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
-    }
-
-    private static SlackChannelId? ResolveDefaultChannelId(SlackChannelOptions options)
-    {
-        if (!string.IsNullOrWhiteSpace(options.DefaultChannelId))
-            return new SlackChannelId(options.DefaultChannelId);
-        // Channel name resolution happens at runtime in SlackChannel.StartAsync;
-        // for tool ACL we only use the configured ID.
-        return null;
     }
 }

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -51,11 +51,9 @@ public static class SlackChannelRegistrationExtensions
         services.AddSingleton<SendSlackMessageTool>(sp =>
         {
             var outbound = sp.GetRequiredService<ISlackOutboundClient>();
-            var replyClient = sp.GetRequiredService<ISlackReplyClient>();
             var channel = sp.GetRequiredService<SlackChannel>();
             return new SendSlackMessageTool(
                 outbound,
-                replyClient,
                 slackOptions,
                 () => channel.DefaultChannelId,
                 () => channel.Gateway);

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -136,6 +136,9 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         return Results.Ok(new { status = status.ToString() });
     });
 
+    // Register channel-specific tools after DI is built (tools need resolved services).
+    ChannelToolRegistration.RegisterChannelTools(app.Services);
+
     await app.RunAsync();
 }
 

--- a/src/Netclaw.Tools.Abstractions/INetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/INetclawTool.cs
@@ -4,6 +4,12 @@ using Microsoft.Extensions.AI;
 namespace Netclaw.Tools;
 
 /// <summary>
+/// Marker interface for tools provided by a channel adapter (e.g. Slack, Teams).
+/// Channel tools are discovered and registered dynamically at startup.
+/// </summary>
+public interface IChannelTool : INetclawTool;
+
+/// <summary>
 /// A self-contained tool definition: schema, metadata, and execution in one type.
 /// </summary>
 public interface INetclawTool


### PR DESCRIPTION
## Summary

- Adds `send_slack_message` and `lookup_slack_user` LLM tools so the agent can initiate Slack conversations (DMs and channel threads) proactively
- Introduces `ISlackOutboundClient` / `SlackOutboundClient` as a thin Slack API wrapper for outbound operations
- Adds `StartProactiveThread` message that routes through Gateway → Conversation → ThreadBinding to wire up the session pipeline for reply routing
- Introduces channel-specific tool registration pattern: tools only exist when their channel adapter is enabled

## What works today

- LLM can call `send_slack_message(user_id: "U...", message: "...")` to DM a user
- LLM can call `send_slack_message(channel_id: "C...", message: "...")` to post a new thread
- LLM can call `lookup_slack_user(query: "Aaron")` to resolve names → user IDs
- ACL enforcement on outbound: same `AllowedUserIds` / `AllowedChannelIds` as inbound
- New thread is wired into actor hierarchy so user replies route to a live session
- Tools only register when Slack adapter is enabled (conditional DI)

## Known issues (planned follow-up commits)

1. **`"slack"` grant category is a dead letter** — no session config grants it; works today via `GetAlwaysLoadedTools()` but fragile
2. **`DefaultChannelId` resolution incomplete** — tool only sees static config, not runtime-resolved channel name
3. **No error handling on Slack API failures** — exceptions propagate instead of returning error strings
4. **`LookupSlackUserTool` cache not thread-safe** — singleton with unsynchronized instance fields
5. **`TimeProvider` not used in cache** — violates quality bar for time virtualization
6. **No tests** — actor hierarchy routing, ACL logic, and error cases all uncovered
7. **`StartProactiveThread` is fire-and-forget** — no confirmation that pipeline initialized
8. **Channel tool registration is hand-wired** — no discovery mechanism for future adapters
9. **DM ACL asymmetry** — tool doesn't check `AllowDirectMessages`; can DM users who can't reply
10. **No file attachment support** — planned in design but not implemented

## Test plan

- [x] Fix all 10 known issues in follow-up commits
- [x] Add actor hierarchy tests for `StartProactiveThread` routing
- [x] Add tool ACL tests (allowed/denied users and channels)
- [x] Add error handling tests (Slack API failures, gateway disconnected)
- [ ] `dotnet build` clean
- [ ] `dotnet test` all pass
- [ ] `dotnet slopwatch analyze` no new violations