### PR TITLE
Harden Slack session recovery and fix image media persistence

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -135,7 +135,9 @@ Tuning parameters for LLM session behavior.
     "SnapshotInterval": 20,
     "KeepRecentToolResults": 3,
     "MaxToolIterationsPerTurn": 10,
-    "SidecarLlmTimeoutSeconds": 90
+    "SidecarLlmTimeoutSeconds": 90,
+    "TurnLlmTimeoutSeconds": 180,
+    "ToolExecutionTimeoutSeconds": 90
   }
 }
 ```
@@ -147,6 +149,8 @@ Tuning parameters for LLM session behavior.
 | `KeepRecentToolResults` | int | `3` | Recent tool call/result pairs kept in full during compaction. |
 | `MaxToolIterationsPerTurn` | int | `10` | Max tool execution rounds per turn before forcing a text response. |
 | `SidecarLlmTimeoutSeconds` | int | `90` | Timeout for sidecar LLM calls (title generation, observer summaries, memory extraction). |
+| `TurnLlmTimeoutSeconds` | int | `180` | Timeout for the primary per-turn LLM streaming call before forcing an error/recovery path. |
+| `ToolExecutionTimeoutSeconds` | int | `90` | Timeout for one tool-execution batch before failing the turn safely. |
 
 ### Tools
 
@@ -316,7 +320,9 @@ export NETCLAW_Session__MaxToolIterationsPerTurn="5"
     "CompactionThreshold": 0.75,
     "SnapshotInterval": 20,
     "KeepRecentToolResults": 3,
-    "MaxToolIterationsPerTurn": 10
+    "MaxToolIterationsPerTurn": 10,
+    "TurnLlmTimeoutSeconds": 180,
+    "ToolExecutionTimeoutSeconds": 90
   },
   "Tools": {
     "ShellTimeoutSeconds": 60,

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -36,14 +36,19 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     private readonly ImageCapturingChatClient _chatClient = new();
     private readonly RecordingReplyClient _replyClient = new();
     private readonly FakeSlackFileHandler _httpHandler = new();
+    private readonly NetclawPaths _paths = new(Path.Combine(
+        Path.GetTempPath(),
+        $"netclaw-slack-file-tests-{Guid.NewGuid():N}"));
 
     public SlackFileFlowIntegrationTests(ITestOutputHelper output) : base(output: output)
     {
+        _paths.EnsureDirectoriesExist();
     }
 
     protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
+        services.AddSingleton(_paths);
         services.AddSingleton(new SessionConfig
         {
             ModelId = "fake-model",
@@ -131,7 +136,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         // Verify: file was persisted to session media directory
         var sessionId = new SessionId("D1/1000.1");
-        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId);
+        var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId, _paths.SessionsDirectory);
         var mediaDir = Path.Combine(sessionDir, "media");
         Assert.True(Directory.Exists(mediaDir),
             $"Expected session media directory to exist: {mediaDir}");
@@ -204,7 +209,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var sessionId = new SessionId("C_TEST/2000.1");
         var mediaDir = Path.Combine(
-            SessionDirectoryHelper.GetSessionDirectory(sessionId), "media");
+            SessionDirectoryHelper.GetSessionDirectory(sessionId, _paths.SessionsDirectory), "media");
         Assert.True(Directory.Exists(mediaDir),
             $"Expected session media directory: {mediaDir}");
         Assert.True(Directory.GetFiles(mediaDir).Length > 0,
@@ -270,7 +275,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var sessionId = new SessionId("D2/3000.1");
         var mediaDir = Path.Combine(
-            SessionDirectoryHelper.GetSessionDirectory(sessionId), "media");
+            SessionDirectoryHelper.GetSessionDirectory(sessionId, _paths.SessionsDirectory), "media");
         Assert.True(Directory.Exists(mediaDir),
             $"Expected session media directory: {mediaDir}");
         Assert.True(Directory.GetFiles(mediaDir).Length > 0,

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    private readonly HangingStreamingChatClient _chatClient = new();
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
+        services.AddSingleton(new SessionConfig
+        {
+            ModelId = "watchdog-test-model",
+            ContextWindowTokens = 128_000,
+            SnapshotInterval = 5,
+            TitleGenerationInterval = 0,
+            TurnLlmTimeoutSeconds = 1,
+            ToolExecutionTimeoutSeconds = 1,
+            SidecarLlmTimeoutSeconds = 1
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Watchdog_times_out_stuck_streaming_call_and_session_recovers_for_follow_up_turn()
+    {
+        var sessionId = new SessionId("watchdog/session-1");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("watchdog-subscriber");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        subscriber.ExpectMsg<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        var firstError = subscriber.ExpectMsg<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("timeout", firstError.Message, StringComparison.OrdinalIgnoreCase);
+        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        var secondError = subscriber.ExpectMsg<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("timeout", secondError.Message, StringComparison.OrdinalIgnoreCase);
+        subscriber.ExpectMsg<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.True(_chatClient.CallCount >= 2);
+    }
+
+    private sealed class HangingStreamingChatClient : IChatClient
+    {
+        private int _callCount;
+
+        public int CallCount => _callCount;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromException<ChatResponse>(new NotSupportedException("Streaming path only in this test."));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _callCount);
+            return NeverCompletesAsync(CancellationToken.None);
+        }
+
+        private static async IAsyncEnumerable<ChatResponseUpdate> NeverCompletesAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await gate.Task;
+            yield break;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -92,6 +92,8 @@ public sealed class MaterializedSession : IAsyncDisposable
 /// </summary>
 public sealed class SessionPipeline
 {
+    private const int SessionOutputBufferSize = 2048;
+
     private readonly ActorSystem _system;
     private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
     private readonly ISessionLifecycleObserver? _lifecycleObserver;
@@ -131,16 +133,16 @@ public sealed class SessionPipeline
         // When a materializer is provided, the subscriber actor is a child of the
         // owning actor — stopped automatically on passivation.
         var (subscriber, responseSource) = materializer is not null
-            ? Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
+            ? Source.ActorRef<SessionOutput>(SessionOutputBufferSize, OverflowStrategy.DropHead)
                 .PreMaterialize(materializer)
-            : Source.ActorRef<SessionOutput>(256, OverflowStrategy.DropHead)
+            : Source.ActorRef<SessionOutput>(SessionOutputBufferSize, OverflowStrategy.DropHead)
                 .PreMaterialize(_system);
 
         // Inbound: ChannelInput → SendUserMessage → session manager (direct Tell)
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options))
             .Via(killSwitch.Flow<SendUserMessage>())
-            .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd)));
+            .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd, ActorRefs.NoSender)));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source
         // When a lifecycle observer is registered, tap the stream so every output
@@ -167,7 +169,7 @@ public sealed class SessionPipeline
             SessionId = sessionId,
             Subscriber = subscriber,
             Filter = options.Filter
-        });
+        }, ActorRefs.NoSender);
 
         return new MaterializedSession(
             inputSink,

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -6,6 +6,7 @@ using Akka.Streams.Dsl;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Channels;
 
@@ -97,15 +98,18 @@ public sealed class SessionPipeline
     private readonly ActorSystem _system;
     private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
     private readonly ISessionLifecycleObserver? _lifecycleObserver;
+    private readonly NetclawPaths? _paths;
 
     public SessionPipeline(
         ActorSystem system,
         IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
-        ISessionLifecycleObserver? lifecycleObserver = null)
+        ISessionLifecycleObserver? lifecycleObserver = null,
+        NetclawPaths? paths = null)
     {
         _system = system;
         _sessionManagerProvider = sessionManagerProvider;
         _lifecycleObserver = lifecycleObserver;
+        _paths = paths;
     }
 
     /// <summary>
@@ -140,7 +144,7 @@ public sealed class SessionPipeline
 
         // Inbound: ChannelInput → SendUserMessage → session manager (direct Tell)
         var inputSink = Flow.Create<ChannelInput>()
-            .Select(input => MapToCommand(input, sessionId, options))
+            .Select(input => MapToCommand(input, sessionId, options, _paths))
             .Via(killSwitch.Flow<SendUserMessage>())
             .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd, ActorRefs.NoSender)));
 
@@ -178,7 +182,10 @@ public sealed class SessionPipeline
     }
 
     private static SendUserMessage MapToCommand(
-        ChannelInput input, SessionId sessionId, SessionPipelineOptions options)
+        ChannelInput input,
+        SessionId sessionId,
+        SessionPipelineOptions options,
+        NetclawPaths? paths)
     {
         var textParts = input.Contents.OfType<TextContent>().Select(t => t.Text);
         var content = string.Join("\n", textParts);
@@ -188,7 +195,9 @@ public sealed class SessionPipeline
         var dataContents = input.Contents.OfType<DataContent>().ToList();
         if (dataContents.Count > 0)
         {
-            var sessionDir = SessionDirectoryHelper.GetSessionDirectory(sessionId);
+            var sessionDir = paths is not null
+                ? SessionDirectoryHelper.GetSessionDirectory(sessionId, paths.SessionsDirectory)
+                : SessionDirectoryHelper.GetSessionDirectory(sessionId);
             var mediaDir = Path.Combine(sessionDir, "media");
             Directory.CreateDirectory(mediaDir);
 

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -50,6 +50,17 @@ internal sealed record ToolExecutionFailed
 }
 
 /// <summary>
+/// Internal watchdog timeout used to force stuck Processing operations to fail
+/// and return the session actor to Ready state.
+/// </summary>
+internal sealed record ProcessingWatchdogExpired
+{
+    public required long OperationId { get; init; }
+
+    public required string OperationName { get; init; }
+}
+
+/// <summary>
 /// Internal trigger to begin the compaction sequence.
 /// Sent to self after a turn completes when usage exceeds the threshold.
 /// </summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -28,7 +28,7 @@ namespace Netclaw.Actors.Sessions;
 /// - Processing: buffers incoming messages while LLM call is in flight
 /// - Compacting: runs tiered context compaction when usage exceeds threshold
 /// </summary>
-public sealed class LlmSessionActor : ReceivePersistentActor
+public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 {
     private readonly SessionId _sessionId;
     private readonly IChatClient _chatClient;
@@ -65,6 +65,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
 
+    // Processing watchdog state (non-persistent)
+    private static readonly object ProcessingWatchdogTimerKey = new();
+    private long _processingOperationId;
+    private string? _processingOperationName;
+
     // Persistent state (immutable — replaced on each event)
     private SessionState _state = SessionState.Empty;
 
@@ -72,6 +77,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     private bool _systemPromptRecovered;
 
     public override string PersistenceId { get; }
+    public ITimerScheduler Timers { get; set; } = null!;
 
     public LlmSessionActor(
         string entityId,
@@ -175,6 +181,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             Context.Stop(Self);
         });
 
+        Command<ProcessingWatchdogExpired>(_ => { });
+
         Command<SendUserMessage>(cmd =>
         {
             _log.Info("Received user message");
@@ -244,6 +252,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
         Command<LlmResponseReceived>(msg =>
         {
+            StopProcessingWatchdog();
+
             var response = msg.Response;
             var lastMessage = response.Messages[^1];
 
@@ -289,6 +299,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
         Command<LlmResponseDeltaReceived>(msg =>
         {
+            RefreshProcessingWatchdogIfActive();
+
             switch (msg.Content)
             {
                 case TextContent text when !string.IsNullOrEmpty(text.Text):
@@ -311,6 +323,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
         Command<ToolExecutionCompleted>(msg =>
         {
+            StopProcessingWatchdog();
+
             // Add tool results to history and log each result
             foreach (var result in msg.ToolResults)
             {
@@ -368,50 +382,41 @@ public sealed class LlmSessionActor : ReceivePersistentActor
 
         Command<ToolExecutionFailed>(msg =>
         {
+            StopProcessingWatchdog();
             _log.Error(msg.Cause, "Tool execution failed");
 
             const string errorMessage = "I encountered an error executing a tool. Please try again.";
-            _state = _state.AddErrorReply(errorMessage);
-
-            EmitOutput(new ErrorOutput
-            {
-                SessionId = _sessionId,
-                Message = errorMessage,
-                Cause = msg.Cause
-            });
-            EmitOutput(new TurnCompleted
-            {
-                SessionId = _sessionId,
-                TurnNumber = _state.TurnCount
-            });
-
-            _buffer.Clear();
-            Become(Ready);
+            FailCurrentTurn(errorMessage, msg.Cause);
         });
 
         Command<LlmCallFailed>(msg =>
         {
+            StopProcessingWatchdog();
             _log.Error(msg.Cause, "LLM call failed");
 
             var errorMessage = IsContextOverflowError(msg.Cause)
                 ? $"Context window exceeded after compaction — the session has too many tools or a large system prompt for the {_config.ModelId} context window ({_config.ContextWindowTokens} tokens). Try reducing tools or increasing the model's context window."
                 : "I encountered an error processing your message. Please try again.";
-            _state = _state.AddErrorReply(errorMessage);
+            FailCurrentTurn(errorMessage, msg.Cause);
+        });
 
-            EmitOutput(new ErrorOutput
-            {
-                SessionId = _sessionId,
-                Message = errorMessage,
-                Cause = msg.Cause
-            });
-            EmitOutput(new TurnCompleted
-            {
-                SessionId = _sessionId,
-                TurnNumber = _state.TurnCount
-            });
+        Command<ProcessingWatchdogExpired>(msg =>
+        {
+            if (!IsCurrentWatchdog(msg))
+                return;
 
-            _buffer.Clear();
-            Become(Ready);
+            _log.Error("Processing watchdog expired for operation {OperationName} (opId={OperationId})",
+                msg.OperationName, msg.OperationId);
+
+            var timeout = msg.OperationName is "tool-execution"
+                ? TimeSpan.FromSeconds(Math.Max(1, _config.ToolExecutionTimeoutSeconds))
+                : TimeSpan.FromSeconds(Math.Max(1, _config.TurnLlmTimeoutSeconds));
+
+            var timeoutCause = new TimeoutException(
+                $"Session processing operation '{msg.OperationName}' exceeded watchdog timeout of {timeout.TotalSeconds:F0}s");
+
+            StopProcessingWatchdog();
+            FailCurrentTurn("I encountered a timeout while processing your message. Please try again.", timeoutCause);
         });
     }
 
@@ -429,6 +434,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             _buffer.Add(cmd);
             TryReplyAck();
         });
+
+        Command<ProcessingWatchdogExpired>(_ => { });
 
         CommandAsync<CompactionTriggered>(async msg =>
         {
@@ -804,6 +811,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var maxInlineToolResultChars = _config.MaxInlineToolResultChars;
         var toolExecutionTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.ToolExecutionTimeoutSeconds));
 
+        StartProcessingWatchdog("tool-execution", toolExecutionTimeout);
+
         // Capture subscriber snapshot for subagent activity notifications.
         // These are emitted directly from the tool execution thread via Tell(),
         // which is thread-safe. The snapshot ensures we don't read _subscribers
@@ -1115,6 +1124,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 Tools = _availableTools.ToList()
             };
         }
+
+        StartProcessingWatchdog("llm-call", timeout);
 
         _ = InvokeLlmAsync(client, messages, options, self, timeout);
     }
@@ -1633,6 +1644,67 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             ContextWindowTokens = contextWindow,
             UsagePercent = usagePercent
         }, OutputFilter.Usage);
+    }
+
+    private void StartProcessingWatchdog(string operationName, TimeSpan timeout)
+    {
+        _processingOperationId++;
+        _processingOperationName = operationName;
+
+        Timers.StartSingleTimer(
+            ProcessingWatchdogTimerKey,
+            new ProcessingWatchdogExpired
+            {
+                OperationId = _processingOperationId,
+                OperationName = operationName
+            },
+            timeout);
+    }
+
+    private void RefreshProcessingWatchdogIfActive()
+    {
+        if (_processingOperationName is not "llm-call")
+            return;
+
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.TurnLlmTimeoutSeconds));
+        Timers.StartSingleTimer(
+            ProcessingWatchdogTimerKey,
+            new ProcessingWatchdogExpired
+            {
+                OperationId = _processingOperationId,
+                OperationName = _processingOperationName
+            },
+            timeout);
+    }
+
+    private bool IsCurrentWatchdog(ProcessingWatchdogExpired msg)
+        => msg.OperationId == _processingOperationId
+           && string.Equals(msg.OperationName, _processingOperationName, StringComparison.Ordinal);
+
+    private void StopProcessingWatchdog()
+    {
+        Timers.Cancel(ProcessingWatchdogTimerKey);
+        _processingOperationName = null;
+    }
+
+    private void FailCurrentTurn(string errorMessage, Exception cause)
+    {
+        _state = _state.AddErrorReply(errorMessage);
+
+        EmitOutput(new ErrorOutput
+        {
+            SessionId = _sessionId,
+            Message = errorMessage,
+            Cause = cause
+        });
+        EmitOutput(new TurnCompleted
+        {
+            SessionId = _sessionId,
+            TurnNumber = _state.TurnCount
+        });
+
+        _buffer.Clear();
+        Become(Ready);
     }
 
     private void EmitOutput(SessionOutput output, OutputFilter requiredFlag = OutputFilter.None)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -802,6 +802,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var tp = _timeProvider;
         var sessionDir = GetSessionDirectory();
         var maxInlineToolResultChars = _config.MaxInlineToolResultChars;
+        var toolExecutionTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.ToolExecutionTimeoutSeconds));
 
         // Capture subscriber snapshot for subagent activity notifications.
         // These are emitted directly from the tool execution thread via Tell(),
@@ -819,7 +820,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             logActor?.Tell(output);
         };
 
-        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, sessionDir, maxInlineToolResultChars, self, emitSubAgentOutput);
+        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput);
     }
 
     private void HandleTextResponse(
@@ -1104,6 +1105,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         InjectDynamicContextLayers(messages);
         var self = Self;
         var client = _chatClient;
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.TurnLlmTimeoutSeconds));
 
         ChatOptions? options = null;
         if (!forceNoTools && _availableTools.Count > 0)
@@ -1114,7 +1116,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             };
         }
 
-        _ = InvokeLlmAsync(client, messages, options, self);
+        _ = InvokeLlmAsync(client, messages, options, self, timeout);
     }
 
     /// <summary>
@@ -1154,12 +1156,26 @@ public sealed class LlmSessionActor : ReceivePersistentActor
     }
 
     private static async Task InvokeLlmAsync(
-        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, IActorRef self)
+        IChatClient client,
+        List<AiChatMessage> messages,
+        ChatOptions? options,
+        IActorRef self,
+        TimeSpan timeout)
     {
         try
         {
-            var response = await InvokeStreamingResponseAsync(client, messages, options, self);
+            using var cts = new CancellationTokenSource(timeout);
+            var response = await InvokeStreamingResponseAsync(client, messages, options, self, cts.Token);
             self.Tell(response);
+        }
+        catch (OperationCanceledException ex)
+        {
+            self.Tell(new LlmCallFailed
+            {
+                Cause = new TimeoutException(
+                    $"LLM call exceeded timeout of {timeout.TotalSeconds:F0}s",
+                    ex)
+            });
         }
         catch (Exception ex)
         {
@@ -1171,7 +1187,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         IChatClient client,
         List<AiChatMessage> messages,
         ChatOptions? options,
-        IActorRef self)
+        IActorRef self,
+        CancellationToken cancellationToken)
     {
         var contents = new List<AIContent>();
         var updates = new List<ChatResponseUpdate>();
@@ -1182,7 +1199,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         var textDeltaCount = 0;
         var thinkingDeltaCount = 0;
 
-        await foreach (var update in client.GetStreamingResponseAsync(messages, options))
+        await foreach (var update in client.GetStreamingResponseAsync(messages, options, cancellationToken))
         {
             updates.Add(update);
 
@@ -1276,11 +1293,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         TimeProvider timeProvider,
         string sessionDir,
         int maxInlineToolResultChars,
+        TimeSpan timeout,
         IActorRef self,
         Action<SubAgentOutput> emitSubAgentOutput)
     {
         try
         {
+            using var cts = new CancellationTokenSource(timeout);
+
             // Execute all tool calls in parallel — each is independent
             var tasks = toolCalls.Select(tc => ExecuteSingleToolAsync(
                 executor,
@@ -1290,7 +1310,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
                 timeProvider,
                 sessionDir,
                 maxInlineToolResultChars,
-                emitSubAgentOutput));
+                emitSubAgentOutput,
+                cts.Token));
             var results = await Task.WhenAll(tasks);
 
             var fileAttachments = results.SelectMany(r => r.FileAttachments).ToList();
@@ -1298,6 +1319,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor
             {
                 ToolResults = results.Select(r => r.Message).ToList(),
                 FileAttachments = fileAttachments
+            });
+        }
+        catch (OperationCanceledException ex)
+        {
+            self.Tell(new ToolExecutionFailed
+            {
+                Cause = new TimeoutException(
+                    $"Tool execution exceeded timeout of {timeout.TotalSeconds:F0}s",
+                    ex)
             });
         }
         catch (Exception ex)
@@ -1314,7 +1344,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         TimeProvider timeProvider,
         string sessionDir,
         int maxInlineToolResultChars,
-        Action<SubAgentOutput> emitSubAgentOutput)
+        Action<SubAgentOutput> emitSubAgentOutput,
+        CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
         string resultText;
@@ -1339,7 +1370,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         };
         try
         {
-            resultText = await executor.ExecuteAsync(tc, context);
+            resultText = await executor.ExecuteAsync(tc, context, ct);
             sw.Stop();
 
             auditLogger?.Log(new ToolAuditEntry

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -32,6 +32,11 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
     private int _pipelineGeneration;
     private bool _isReinitializing;
     private static readonly object ReinitializeTimerKey = new();
+    private static readonly TimeSpan InboundProcessingTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan QueueWriteTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan FileDownloadTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ContentScanTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
 
     public IStash Stash { get; set; } = null!;
     public ITimerScheduler Timers { get; set; } = null!;
@@ -129,6 +134,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
     private async Task HandleInboundAsync(SlackThreadInbound message)
     {
+        using var inboundCts = new CancellationTokenSource(InboundProcessingTimeout);
+
         try
         {
             if (!string.IsNullOrWhiteSpace(message.Text))
@@ -136,7 +143,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 PromptInjectionResult detection;
                 try
                 {
-                    detection = await _promptInjectionDetector.DetectAsync(message.Text, "slack");
+                    detection = await _promptInjectionDetector.DetectAsync(message.Text, "slack", inboundCts.Token);
                 }
                 catch (Exception ex)
                 {
@@ -176,12 +183,16 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
                     try
                     {
-                        var bytes = await DownloadSlackFileAsync(file);
+                        using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(inboundCts.Token);
+                        downloadCts.CancelAfter(FileDownloadTimeout);
+                        var bytes = await DownloadSlackFileAsync(file, downloadCts.Token);
                         if (bytes.Length == 0)
                             continue;
 
+                        using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(inboundCts.Token);
+                        scanCts.CancelAfter(ContentScanTimeout);
                         var scanResult = await _dependencies.ContentScanner.ScanAsync(
-                            bytes, file.Name, file.MimeType);
+                            bytes, file.Name, file.MimeType, scanCts.Token);
 
                         if (!scanResult.IsAllowed)
                         {
@@ -192,6 +203,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
                         contents.Add(new DataContent(bytes.ToArray(), file.MimeType));
                         _log.Info("Downloaded and scanned Slack file: {Name} ({Size} bytes)", file.Name, bytes.Length);
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        _log.Warning(ex, "Timed out while processing Slack file {Name}, skipping", file.Name);
                     }
                     catch (Exception ex)
                     {
@@ -206,7 +221,6 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 return;
             }
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             var writer = _inputQueue;
             if (writer is null)
             {
@@ -214,36 +228,55 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 return;
             }
 
-            await writer.WriteAsync(new ChannelInput
+            try
             {
-                SenderId = message.SenderId,
-                ChannelId = _channelId.Value,
-                Contents = contents,
-                ReceivedAt = message.ReceivedAt
-            }, cts.Token);
+                using var queueWriteCts = CancellationTokenSource.CreateLinkedTokenSource(inboundCts.Token);
+                queueWriteCts.CancelAfter(QueueWriteTimeout);
+
+                await writer.WriteAsync(new ChannelInput
+                {
+                    SenderId = message.SenderId,
+                    ChannelId = _channelId.Value,
+                    Contents = contents,
+                    ReceivedAt = message.ReceivedAt
+                }, queueWriteCts.Token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _log.Warning(ex, "Timed out enqueueing Slack message for session {0}", _sessionId.Value);
+                Self.Tell(new ReinitializePipeline("input queue write timeout"));
+                return;
+            }
+            catch (ChannelClosedException ex)
+            {
+                _log.Warning(ex, "Slack thread input queue closed for session {0}", _sessionId.Value);
+                Self.Tell(new ReinitializePipeline("input queue write failed"));
+                return;
+            }
 
             _log.Debug("Accepted inbound Slack message for session queue");
             ChannelTelemetry.RecordSlackMessageEnqueued();
         }
+        catch (OperationCanceledException ex)
+        {
+            _log.Warning(ex, "Inbound Slack processing timed out for session {0}", _sessionId.Value);
+        }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
-
-            if (ex is ChannelClosedException or OperationCanceledException)
-                Self.Tell(new ReinitializePipeline("input queue write failed"));
         }
     }
 
-    private async Task<ReadOnlyMemory<byte>> DownloadSlackFileAsync(SlackFileReference file)
+    private async Task<ReadOnlyMemory<byte>> DownloadSlackFileAsync(SlackFileReference file, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, file.UrlPrivateDownload);
         if (_dependencies.Options.BotToken is { Value: { Length: > 0 } token })
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 
-        using var response = await _dependencies.HttpClient!.SendAsync(request);
+        using var response = await _dependencies.HttpClient!.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
 
-        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var bytes = await response.Content.ReadAsByteArrayAsync(ct);
         return bytes;
     }
 
@@ -259,11 +292,16 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         // children and are stopped automatically when this actor passivates.
         _materializer = Context.Materializer(namePrefix: "slack-thread");
 
-        var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
-        {
-            ChannelType = "slack",
-            Filter = OutputFilter.Text | OutputFilter.Files
-        }, materializer: _materializer);
+        using var initCts = new CancellationTokenSource(PipelineInitTimeout);
+        var materialized = await _dependencies.Pipeline.CreateAsync(
+            _sessionId,
+            new SessionPipelineOptions
+            {
+                ChannelType = "slack",
+                Filter = OutputFilter.Text | OutputFilter.Files
+            },
+            materializer: _materializer,
+            cancellationToken: initCts.Token);
 
         var inputQueue = Source.Channel<ChannelInput>(512, true)
             .ToMaterialized(materialized.Input, Keep.Left)

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Streams;
@@ -11,7 +13,7 @@ using Netclaw.Security;
 
 namespace Netclaw.Channels.Slack;
 
-internal sealed class SlackThreadBindingActor : ReceiveActor
+internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStash, IWithTimers
 {
     private readonly SessionId _sessionId;
     private readonly SlackChannelId _channelId;
@@ -26,7 +28,13 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
 
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
-    private ISourceQueueWithComplete<ChannelInput>? _inputQueue;
+    private ChannelWriter<ChannelInput>? _inputQueue;
+    private int _pipelineGeneration;
+    private bool _isReinitializing;
+    private static readonly object ReinitializeTimerKey = new();
+
+    public IStash Stash { get; set; } = null!;
+    public ITimerScheduler Timers { get; set; } = null!;
 
     public SlackThreadBindingActor(
         SessionId sessionId,
@@ -45,13 +53,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
             .WithContext("SlackChannelId", _channelId)
             .WithContext("SlackThreadTs", _threadTs);
 
-        ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
-        ReceiveAsync<ThreadOutput>(HandleOutputAsync);
-        Receive<ReceiveTimeout>(_ =>
-        {
-            _log.Info("Slack thread idle for 1 hour, passivating");
-            Context.Stop(Self);
-        });
+        Initializing();
 
         Context.SetReceiveTimeout(TimeSpan.FromHours(1));
     }
@@ -63,106 +65,173 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         SlackGatewayDependencies dependencies) =>
         Props.Create(() => new SlackThreadBindingActor(sessionId, channelId, threadTs, dependencies));
 
+    protected override void PreStart()
+    {
+        Self.Tell(InitializePipeline.Instance);
+        base.PreStart();
+    }
+
     protected override void PostStop()
     {
-        _inputQueue?.Complete();
+        _inputQueue?.TryComplete();
         _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _materializer?.Dispose();
         base.PostStop();
     }
 
+    private void Initializing()
+    {
+        ReceiveAsync<InitializePipeline>(async _ =>
+        {
+            try
+            {
+                await EnsureInitializedAsync();
+                Become(Active);
+                Stash.UnstashAll();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to initialize Slack thread pipeline; stopping actor");
+                Context.Stop(Self);
+            }
+        });
+
+        ReceiveAny(msg =>
+        {
+            if (msg is not InitializePipeline)
+                Stash.Stash();
+        });
+    }
+
+    private void Active()
+    {
+        ReceiveAsync<SlackThreadInbound>(HandleInboundAsync);
+        ReceiveAsync<ThreadOutput>(HandleOutputAsync);
+        Receive<OutputStreamTerminated>(msg =>
+        {
+            if (msg.Generation != _pipelineGeneration)
+                return;
+
+            var reason = msg.Cause is null
+                ? "completed"
+                : $"faulted: {msg.Cause.Message}";
+
+            _log.Warning("Slack output stream terminated ({Reason}); reinitializing pipeline", reason);
+            Self.Tell(new ReinitializePipeline(reason));
+        });
+        ReceiveAsync<ReinitializePipeline>(async msg => await ReinitializePipelineAsync(msg.Reason));
+        Receive<ReceiveTimeout>(_ =>
+        {
+            _log.Info("Slack thread idle for 1 hour, passivating");
+            Context.Stop(Self);
+        });
+    }
+
     private async Task HandleInboundAsync(SlackThreadInbound message)
     {
-        if (!string.IsNullOrWhiteSpace(message.Text))
+        try
         {
-            var detection = await _promptInjectionDetector.DetectAsync(message.Text, "slack");
-            if (detection.Risk == PromptInjectionRisk.High)
+            if (!string.IsNullOrWhiteSpace(message.Text))
             {
-                var reason = string.IsNullOrWhiteSpace(detection.Message)
-                    ? "High-risk prompt injection pattern detected"
-                    : detection.Message;
-
-                _log.Warning("Blocked Slack message due to prompt injection risk: {Reason}", reason);
-                ChannelTelemetry.RecordSlackEventDropped("prompt_injection_high");
-                await SafePostAsync(":warning: Message blocked by prompt-injection policy.");
-                return;
-            }
-        }
-
-        await EnsureInitializedAsync();
-
-        // Build content list: text + downloaded file attachments
-        var contents = new List<AIContent>();
-        if (!string.IsNullOrEmpty(message.Text))
-            contents.Add(new TextContent(message.Text));
-
-        // Download and scan file attachments
-        if (message.Files is { Count: > 0 } && _dependencies.HttpClient is not null)
-        {
-            foreach (var file in message.Files)
-            {
-                // Only process image MIME types for now
-                if (!file.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-                {
-                    _log.Debug("Skipping non-image file attachment: {Name} ({MimeType})", file.Name, file.MimeType);
-                    continue;
-                }
-
+                PromptInjectionResult detection;
                 try
                 {
-                    var bytes = await DownloadSlackFileAsync(file);
-                    if (bytes.Length == 0)
-                        continue;
-
-                    var scanResult = await _dependencies.ContentScanner.ScanAsync(
-                        bytes, file.Name, file.MimeType);
-
-                    if (!scanResult.IsAllowed)
-                    {
-                        _log.Warning("Content scan rejected file {Name}: {Message}",
-                            file.Name, scanResult.Message ?? scanResult.Error?.ToString());
-                        continue;
-                    }
-
-                    contents.Add(new DataContent(bytes.ToArray(), file.MimeType));
-                    _log.Info("Downloaded and scanned Slack file: {Name} ({Size} bytes)", file.Name, bytes.Length);
+                    detection = await _promptInjectionDetector.DetectAsync(message.Text, "slack");
                 }
                 catch (Exception ex)
                 {
-                    _log.Warning(ex, "Failed to download Slack file {Name}, skipping", file.Name);
+                    _log.Warning(ex, "Prompt injection detector failed; allowing message through");
+                    detection = PromptInjectionResult.Safe();
+                }
+
+                if (detection.Risk == PromptInjectionRisk.High)
+                {
+                    var reason = string.IsNullOrWhiteSpace(detection.Message)
+                        ? "High-risk prompt injection pattern detected"
+                        : detection.Message;
+
+                    _log.Warning("Blocked Slack message due to prompt injection risk: {Reason}", reason);
+                    ChannelTelemetry.RecordSlackEventDropped("prompt_injection_high");
+                    await SafePostAsync(":warning: Message blocked by prompt-injection policy.");
+                    return;
                 }
             }
-        }
 
-        if (contents.Count == 0)
-        {
-            _log.Debug("No content to enqueue after file processing");
-            return;
-        }
+            // Build content list: text + downloaded file attachments
+            var contents = new List<AIContent>();
+            if (!string.IsNullOrEmpty(message.Text))
+                contents.Add(new TextContent(message.Text));
 
-        var result = await _inputQueue!.OfferAsync(new ChannelInput
-        {
-            SenderId = message.SenderId,
-            ChannelId = _channelId.Value,
-            Contents = contents,
-            ReceivedAt = message.ReceivedAt
-        });
+            // Download and scan file attachments
+            if (message.Files is { Count: > 0 } && _dependencies.HttpClient is not null)
+            {
+                foreach (var file in message.Files)
+                {
+                    // Only process image MIME types for now
+                    if (!file.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _log.Debug("Skipping non-image file attachment: {Name} ({MimeType})", file.Name, file.MimeType);
+                        continue;
+                    }
 
-        if (result is QueueOfferResult.QueueClosed)
-        {
-            _log.Warning("Slack thread queue closed for session {0}", _sessionId.Value);
-            Context.Stop(Self);
-            return;
-        }
+                    try
+                    {
+                        var bytes = await DownloadSlackFileAsync(file);
+                        if (bytes.Length == 0)
+                            continue;
 
-        if (result is QueueOfferResult.Enqueued)
-        {
+                        var scanResult = await _dependencies.ContentScanner.ScanAsync(
+                            bytes, file.Name, file.MimeType);
+
+                        if (!scanResult.IsAllowed)
+                        {
+                            _log.Warning("Content scan rejected file {Name}: {Message}",
+                                file.Name, scanResult.Message ?? scanResult.Error?.ToString());
+                            continue;
+                        }
+
+                        contents.Add(new DataContent(bytes.ToArray(), file.MimeType));
+                        _log.Info("Downloaded and scanned Slack file: {Name} ({Size} bytes)", file.Name, bytes.Length);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Warning(ex, "Failed to download Slack file {Name}, skipping", file.Name);
+                    }
+                }
+            }
+
+            if (contents.Count == 0)
+            {
+                _log.Debug("No content to enqueue after file processing");
+                return;
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var writer = _inputQueue;
+            if (writer is null)
+            {
+                _log.Warning("Slack thread input queue is not initialized; dropping inbound message");
+                return;
+            }
+
+            await writer.WriteAsync(new ChannelInput
+            {
+                SenderId = message.SenderId,
+                ChannelId = _channelId.Value,
+                Contents = contents,
+                ReceivedAt = message.ReceivedAt
+            }, cts.Token);
+
             _log.Debug("Accepted inbound Slack message for session queue");
             ChannelTelemetry.RecordSlackMessageEnqueued();
         }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
 
-        if (result is QueueOfferResult.Failure failure)
-            _log.Error(failure.Cause, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
+            if (ex is ChannelClosedException or OperationCanceledException)
+                Self.Tell(new ReinitializePipeline("input queue write failed"));
+        }
     }
 
     private async Task<ReadOnlyMemory<byte>> DownloadSlackFileAsync(SlackFileReference file)
@@ -193,21 +262,71 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
         var materialized = await _dependencies.Pipeline.CreateAsync(_sessionId, new SessionPipelineOptions
         {
             ChannelType = "slack",
-            Filter = OutputFilter.Full
+            Filter = OutputFilter.Text | OutputFilter.Files
         }, materializer: _materializer);
 
-        var inputQueue = Source.Queue<ChannelInput>(32, OverflowStrategy.Backpressure)
+        var inputQueue = Source.Channel<ChannelInput>(512, true)
             .ToMaterialized(materialized.Input, Keep.Left)
             .Run(_materializer);
 
-        materialized.Output
-            .To(Sink.ForEach<SessionOutput>(output => self.Tell(new ThreadOutput(output))))
+        var generation = ++_pipelineGeneration;
+        var outputCompletion = materialized.Output
+            .ToMaterialized(
+                Sink.ForEach<SessionOutput>(output => self.Tell(new ThreadOutput(output))),
+                Keep.Right)
             .Run(_materializer);
+
+        _ = outputCompletion.ContinueWith(t =>
+            {
+                var cause = t.IsFaulted ? t.Exception?.GetBaseException() : null;
+                self.Tell(new OutputStreamTerminated(generation, cause));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
         _session = materialized;
         _inputQueue = inputQueue;
 
         _log.Info("Slack thread binding pipeline initialized");
+    }
+
+    private async Task ReinitializePipelineAsync(string reason)
+    {
+        if (_isReinitializing)
+            return;
+
+        _isReinitializing = true;
+        try
+        {
+            _log.Warning("Reinitializing Slack thread pipeline: {Reason}", reason);
+
+            _inputQueue?.TryComplete();
+            _inputQueue = null;
+
+            if (_session is not null)
+            {
+                await _session.DisposeAsync();
+                _session = null;
+            }
+
+            _materializer?.Dispose();
+            _materializer = null;
+
+            await EnsureInitializedAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Slack thread pipeline reinitialization failed; scheduling retry");
+            Timers.StartSingleTimer(
+                ReinitializeTimerKey,
+                new ReinitializePipeline("retry after failed reinit"),
+                TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            _isReinitializing = false;
+        }
     }
 
     private async Task HandleOutputAsync(ThreadOutput threadOutput)
@@ -304,4 +423,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor
     }
 
     private sealed record ThreadOutput(SessionOutput Output);
+    private sealed record OutputStreamTerminated(int Generation, Exception? Cause);
+    private sealed record ReinitializePipeline(string Reason);
+    private sealed record InitializePipeline
+    {
+        public static InitializePipeline Instance { get; } = new();
+    }
 }

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -96,6 +96,20 @@ public sealed record SessionConfig
     public int SidecarLlmTimeoutSeconds { get; init; } = 90;
 
     /// <summary>
+    /// Timeout in seconds for the primary per-turn LLM streaming call.
+    /// Prevents sessions from remaining stuck in Processing forever when a
+    /// provider stream stalls under network/backpressure failure modes.
+    /// </summary>
+    public int TurnLlmTimeoutSeconds { get; init; } = 180;
+
+    /// <summary>
+    /// Timeout in seconds for one tool-execution batch (all tool calls emitted
+    /// by a single assistant response). Prevents indefinite hangs when one or
+    /// more tools block forever.
+    /// </summary>
+    public int ToolExecutionTimeoutSeconds { get; init; } = 90;
+
+    /// <summary>
     /// How long a session can be idle before passivating.
     /// The actor saves a snapshot and stops itself; re-creation by
     /// <c>GenericChildPerEntityParent</c> on next message recovers state from journal.


### PR DESCRIPTION
## Summary
- Replace Slack thread ingress queueing with `Source.Channel` + bounded write cancellation, and refactor `SlackThreadBindingActor` into an init/active state machine with pipeline reinitialization on stream termination.
- Add LLM session processing watchdogs (turn + tool batch timeouts) so stuck processing paths fail safely and return sessions to `Ready`.
- Fix Slack image regression in daemon mode by aligning media persistence path usage in `SessionPipeline` with daemon session directories (`~/.netclaw/sessions/*`) instead of temp directories.
- Increase stream buffering where needed and remove command-ack dead-letter noise by using `NoSender` for stream-driven session manager tells.
- Add regression coverage for watchdog timeout recovery and update Slack file flow integration tests for daemon session paths.

## Validation
- `dotnet test --nologo`
- `dotnet slopwatch analyze`
- Live deploy to `sys76-3` with soak monitoring
- Verified Slack ingress/reply counters move in runtime status
- Verified image attachments are downloaded/scanned and now visible to the model after path fix
- Filed upstream Akka.NET issue for Source.Queue cancellation support: https://github.com/akkadotnet/akka.net/issues/8081