### PR TITLE
Add scheduled reminders with one-shot, interval, and cron support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <!-- Nuget package versions -->
     <AkkaHostingVersion>1.5.60</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.60.1</AkkaPersistenceSqlHostingVersion>
-    <AkkaRemindersVersion>0.4.0</AkkaRemindersVersion>
+    <AkkaRemindersVersion>0.5.0</AkkaRemindersVersion>
     <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
   </PropertyGroup>
   <!-- App dependencies -->
@@ -15,6 +15,7 @@
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.Hosting" Version="$(AkkaPersistenceSqlHostingVersion)" />
     <PackageVersion Include="Aaron.Akka.Reminders" Version="$(AkkaRemindersVersion)" />
+    <PackageVersion Include="Aaron.Akka.Reminders.Sqlite" Version="$(AkkaRemindersVersion)" />
     <PackageVersion Include="Anthropic" Version="12.8.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
+    <PackageVersion Include="Cronos" Version="0.8.4" />
     <PackageVersion Include="Termina" Version="0.7.2" />
     <PackageVersion Include="Mime-Detective" Version="25.8.1" />
     <PackageVersion Include="Mime-Detective.Definitions.Condensed" Version="25.8.1" />

--- a/src/Netclaw.Actors.Tests/Reminders/CronScheduleHelperTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/CronScheduleHelperTests.cs
@@ -1,0 +1,82 @@
+using Netclaw.Actors.Reminders;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Reminders;
+
+public class CronScheduleHelperTests
+{
+    [Fact]
+    public void TryParse_valid_expression_returns_true()
+    {
+        Assert.True(CronScheduleHelper.TryParse("0 */6 * * *"));
+    }
+
+    [Fact]
+    public void TryParse_invalid_expression_returns_false()
+    {
+        Assert.False(CronScheduleHelper.TryParse("not a cron"));
+    }
+
+    [Fact]
+    public void TryParse_empty_string_returns_false()
+    {
+        Assert.False(CronScheduleHelper.TryParse(""));
+    }
+
+    [Theory]
+    [InlineData("* * * * *")]       // every minute
+    [InlineData("0 0 * * *")]       // daily at midnight
+    [InlineData("0 */6 * * *")]     // every 6 hours
+    [InlineData("30 8 * * 1-5")]    // weekdays at 8:30
+    public void TryParse_standard_expressions_return_true(string expr)
+    {
+        Assert.True(CronScheduleHelper.TryParse(expr));
+    }
+
+    [Fact]
+    public void GetNextOccurrence_returns_future_time()
+    {
+        var from = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var next = CronScheduleHelper.GetNextOccurrence("0 */6 * * *", from);
+
+        Assert.NotNull(next);
+        Assert.True(next > from);
+    }
+
+    [Fact]
+    public void GetNextOccurrence_every_minute_returns_next_minute()
+    {
+        var from = new DateTimeOffset(2026, 3, 5, 14, 30, 0, TimeSpan.Zero);
+        var next = CronScheduleHelper.GetNextOccurrence("* * * * *", from);
+
+        Assert.NotNull(next);
+        Assert.Equal(new DateTimeOffset(2026, 3, 5, 14, 31, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void GetNextOccurrence_daily_midnight_returns_next_day()
+    {
+        var from = new DateTimeOffset(2026, 3, 5, 0, 0, 1, TimeSpan.Zero);
+        var next = CronScheduleHelper.GetNextOccurrence("0 0 * * *", from);
+
+        Assert.NotNull(next);
+        Assert.Equal(new DateTimeOffset(2026, 3, 6, 0, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void GetNextOccurrence_with_TimeProvider_uses_current_time()
+    {
+        var fakeTime = new FakeTimeProvider(
+            new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
+
+        var next = CronScheduleHelper.GetNextOccurrence("0 */6 * * *", fakeTime);
+
+        Assert.NotNull(next);
+        Assert.Equal(new DateTimeOffset(2026, 6, 15, 18, 0, 0, TimeSpan.Zero), next);
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -15,6 +15,8 @@ namespace Netclaw.Actors.Tests.Reminders;
 
 public class ReminderManagerActorTests : TestKit
 {
+    private readonly string _basePath = Path.Combine(Path.GetTempPath(), $"netclaw-reminder-tests-{Guid.NewGuid():N}");
+
     public ReminderManagerActorTests(ITestOutputHelper output) : base(output: output) { }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
@@ -22,6 +24,10 @@ public class ReminderManagerActorTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore();
+
+        var paths = new NetclawPaths(_basePath);
+        paths.EnsureDirectoriesExist();
+        var definitionStore = new ReminderDefinitionStore(paths);
 
         // Wire local reminders with in-memory storage
         var sharedResolver = new TestShardRegionResolver();
@@ -45,7 +51,8 @@ public class ReminderManagerActorTests : TestKit
                 Props.Create(() => new ReminderManagerActor(
                     new ReminderConfig(),
                     pipeline,
-                    TimeProvider.System)),
+                    TimeProvider.System,
+                    definitionStore)),
                 "reminder-manager-test");
 
             registry.Register<ReminderManagerActorKey>(reminderManager);
@@ -64,20 +71,20 @@ public class ReminderManagerActorTests : TestKit
     {
         var manager = await GetManagerAsync();
 
-        var payload = CreatePayload("test-list", "once", "Check status");
+        var definition = CreateDefinition("test-list", "Check status");
 
-        var scheduled = await manager.Ask<ReminderScheduledResponse>(
-            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(5));
+        var scheduled = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition), TimeSpan.FromSeconds(5));
 
-        Assert.Equal("test-list", scheduled.Name);
+        Assert.Equal("test-list", scheduled.Title);
         Assert.NotNull(scheduled.NextFire);
 
         var list = await manager.Ask<ReminderListResponse>(
             new ListRemindersCommand(), TimeSpan.FromSeconds(5));
 
         Assert.Single(list.Reminders);
-        Assert.Equal("test-list", list.Reminders[0].Name);
-        Assert.Equal("Check status", list.Reminders[0].Prompt);
+        Assert.Equal("test-list", list.Reminders[0].Title);
+        Assert.Equal("Check status", list.Reminders[0].Instructions);
     }
 
     [Fact]
@@ -85,13 +92,13 @@ public class ReminderManagerActorTests : TestKit
     {
         var manager = await GetManagerAsync();
 
-        var payload = CreatePayload("test-cancel", "once", "Check it");
+        var definition = CreateDefinition("test-cancel", "Check it");
 
-        await manager.Ask<ReminderScheduledResponse>(
-            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(5));
+        await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition), TimeSpan.FromSeconds(5));
 
         var cancelled = await manager.Ask<ReminderCancelledResponse>(
-            new CancelReminderCommand(payload.Id), TimeSpan.FromSeconds(5));
+            new CancelReminderCommand(new ReminderId(definition.Id)), TimeSpan.FromSeconds(5));
 
         Assert.True(cancelled.Found);
     }
@@ -108,22 +115,26 @@ public class ReminderManagerActorTests : TestKit
         Assert.False(cancelled.Found);
     }
 
-    private static ReminderPayload CreatePayload(string name, string scheduleType, string prompt)
+    private static ReminderDefinition CreateDefinition(string name, string instructions)
     {
         var id = new ReminderId($"{name}-{Guid.NewGuid():N}"[..20]);
         var now = TimeProvider.System.GetUtcNow();
 
-        return new ReminderPayload
+        return new ReminderDefinition
         {
-            Id = id,
-            Name = name,
-            Prompt = prompt,
+            Id = id.Value,
+            Title = name,
+            Instructions = instructions,
+            NotifyInstructions = "Reply in-thread with concise status.",
             Schedule = new ReminderSchedule
             {
                 Type = ReminderScheduleType.OneShot,
                 FireAt = now.AddHours(1)
             },
-            CreatedAt = now
+            Enabled = true,
+            CreatedBy = "test",
+            CreatedAt = now,
+            UpdatedAt = now
         };
     }
 }

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -108,23 +108,10 @@ public class ReminderManagerActorTests : TestKit
         Assert.False(cancelled.Found);
     }
 
-    [Fact]
-    public async Task List_empty_returns_empty()
-    {
-        var manager = await GetManagerAsync();
-
-        var list = await manager.Ask<ReminderListResponse>(
-            new ListRemindersCommand(), TimeSpan.FromSeconds(5));
-
-        // May contain reminders from other tests if run in parallel,
-        // but at minimum should not throw.
-        Assert.NotNull(list.Reminders);
-    }
-
     private static ReminderPayload CreatePayload(string name, string scheduleType, string prompt)
     {
         var id = new ReminderId($"{name}-{Guid.NewGuid():N}"[..20]);
-        var now = DateTimeOffset.UtcNow;
+        var now = TimeProvider.System.GetUtcNow();
 
         return new ReminderPayload
         {

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -1,0 +1,142 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Akka.Reminders;
+using Akka.Reminders.Sharding;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Reminders;
+using Netclaw.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Reminders;
+
+public class ReminderManagerActorTests : TestKit
+{
+    public ReminderManagerActorTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore();
+
+        // Wire local reminders with in-memory storage
+        var sharedResolver = new TestShardRegionResolver();
+        builder.WithLocalReminders(reminders =>
+        {
+            reminders.WithInMemoryStorage();
+            reminders.WithResolver(_ => sharedResolver);
+        });
+
+        builder.StartActors((system, registry, _) =>
+        {
+            // Create a minimal SessionPipeline stub — manager needs it but
+            // we won't actually execute reminders in these tests.
+            registry.Register<SessionManagerActorKey>(system.DeadLetters);
+
+            var pipeline = new SessionPipeline(
+                system,
+                new RequiredActor<SessionManagerActorKey>(ActorRegistry.For(system)));
+
+            var reminderManager = system.ActorOf(
+                Props.Create(() => new ReminderManagerActor(
+                    new ReminderConfig(),
+                    pipeline,
+                    TimeProvider.System)),
+                "reminder-manager-test");
+
+            registry.Register<ReminderManagerActorKey>(reminderManager);
+            sharedResolver.RegisterShardRegion(ReminderManagerActor.ShardRegionName, reminderManager);
+        });
+    }
+
+    private async Task<IActorRef> GetManagerAsync()
+    {
+        var registry = ActorRegistry.For(Sys);
+        return registry.Get<ReminderManagerActorKey>();
+    }
+
+    [Fact]
+    public async Task Schedule_and_list_returns_reminder()
+    {
+        var manager = await GetManagerAsync();
+
+        var payload = CreatePayload("test-list", "once", "Check status");
+
+        var scheduled = await manager.Ask<ReminderScheduledResponse>(
+            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(5));
+
+        Assert.Equal("test-list", scheduled.Name);
+        Assert.NotNull(scheduled.NextFire);
+
+        var list = await manager.Ask<ReminderListResponse>(
+            new ListRemindersCommand(), TimeSpan.FromSeconds(5));
+
+        Assert.Single(list.Reminders);
+        Assert.Equal("test-list", list.Reminders[0].Name);
+        Assert.Equal("Check status", list.Reminders[0].Prompt);
+    }
+
+    [Fact]
+    public async Task Cancel_existing_reminder_returns_found()
+    {
+        var manager = await GetManagerAsync();
+
+        var payload = CreatePayload("test-cancel", "once", "Check it");
+
+        await manager.Ask<ReminderScheduledResponse>(
+            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(5));
+
+        var cancelled = await manager.Ask<ReminderCancelledResponse>(
+            new CancelReminderCommand(payload.Id), TimeSpan.FromSeconds(5));
+
+        Assert.True(cancelled.Found);
+    }
+
+    [Fact]
+    public async Task Cancel_nonexistent_returns_not_found()
+    {
+        var manager = await GetManagerAsync();
+
+        var cancelled = await manager.Ask<ReminderCancelledResponse>(
+            new CancelReminderCommand(new ReminderId("does-not-exist")),
+            TimeSpan.FromSeconds(5));
+
+        Assert.False(cancelled.Found);
+    }
+
+    [Fact]
+    public async Task List_empty_returns_empty()
+    {
+        var manager = await GetManagerAsync();
+
+        var list = await manager.Ask<ReminderListResponse>(
+            new ListRemindersCommand(), TimeSpan.FromSeconds(5));
+
+        // May contain reminders from other tests if run in parallel,
+        // but at minimum should not throw.
+        Assert.NotNull(list.Reminders);
+    }
+
+    private static ReminderPayload CreatePayload(string name, string scheduleType, string prompt)
+    {
+        var id = new ReminderId($"{name}-{Guid.NewGuid():N}"[..20]);
+        var now = DateTimeOffset.UtcNow;
+
+        return new ReminderPayload
+        {
+            Id = id,
+            Name = name,
+            Prompt = prompt,
+            Schedule = new ReminderSchedule
+            {
+                Type = ReminderScheduleType.OneShot,
+                FireAt = now.AddHours(1)
+            },
+            CreatedAt = now
+        };
+    }
+}

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -3,6 +3,7 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
 using Netclaw.Actors.Reminders;
+using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,7 +28,7 @@ public class SetReminderToolTests : TestKit
     public async Task Schedule_oneshot_relative_time_30m()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         _ = Task.Run(async () =>
         {
@@ -57,7 +58,7 @@ public class SetReminderToolTests : TestKit
     public async Task Schedule_interval_2h()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         _ = Task.Run(async () =>
         {
@@ -83,7 +84,7 @@ public class SetReminderToolTests : TestKit
     public async Task Schedule_cron_every_6_hours()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         _ = Task.Run(async () =>
         {
@@ -109,7 +110,7 @@ public class SetReminderToolTests : TestKit
     public async Task Rejects_invalid_cron_expression()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         var result = await tool.ExecuteAsync(new Dictionary<string, object?>
         {
@@ -128,7 +129,7 @@ public class SetReminderToolTests : TestKit
     public async Task Rejects_unknown_schedule_type()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         var result = await tool.ExecuteAsync(new Dictionary<string, object?>
         {
@@ -146,7 +147,7 @@ public class SetReminderToolTests : TestKit
     public async Task Rejects_interval_under_60_seconds()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
         var result = await tool.ExecuteAsync(new Dictionary<string, object?>
         {
@@ -164,7 +165,7 @@ public class SetReminderToolTests : TestKit
     public async Task Self_targeting_captures_session_id()
     {
         var probe = CreateTestProbe();
-        var tool = new SetReminderTool(probe, _timeProvider);
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
         var context = new ToolExecutionContext("C0123ABC/1234567890.123456", null);
 
         _ = Task.Run(async () =>

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -1,0 +1,196 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Netclaw.Actors.Reminders;
+using Netclaw.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Reminders;
+
+public class SetReminderToolTests : TestKit
+{
+    private readonly FakeTimeProvider _timeProvider = new(
+        new DateTimeOffset(2026, 3, 5, 12, 0, 0, TimeSpan.Zero));
+
+    public SetReminderToolTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore();
+    }
+
+    [Fact]
+    public async Task Schedule_oneshot_relative_time_30m()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        _ = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Name"] = "test-reminder",
+                ["Prompt"] = "Check the server",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "30m"
+            });
+            return result;
+        });
+
+        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal("Check the server", cmd.Payload.Prompt);
+        Assert.Equal(ReminderScheduleType.OneShot, cmd.Payload.Schedule.Type);
+
+        var expectedFire = _timeProvider.GetUtcNow().AddMinutes(30);
+        Assert.NotNull(cmd.Payload.Schedule.FireAt);
+        Assert.Equal(expectedFire, cmd.Payload.Schedule.FireAt.Value, TimeSpan.FromSeconds(1));
+
+        // Reply
+        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name, expectedFire));
+    }
+
+    [Fact]
+    public async Task Schedule_interval_2h()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        _ = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Name"] = "interval-check",
+                ["Prompt"] = "Run diagnostics",
+                ["ScheduleType"] = "interval",
+                ["Schedule"] = "2h"
+            });
+            return result;
+        });
+
+        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal(ReminderScheduleType.Interval, cmd.Payload.Schedule.Type);
+        Assert.Equal(TimeSpan.FromHours(2), cmd.Payload.Schedule.Interval);
+
+        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
+            _timeProvider.GetUtcNow().AddHours(2)));
+    }
+
+    [Fact]
+    public async Task Schedule_cron_every_6_hours()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        _ = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Name"] = "cron-check",
+                ["Prompt"] = "Periodic scan",
+                ["ScheduleType"] = "cron",
+                ["Schedule"] = "0 */6 * * *"
+            });
+            return result;
+        });
+
+        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal(ReminderScheduleType.Cron, cmd.Payload.Schedule.Type);
+        Assert.Equal("0 */6 * * *", cmd.Payload.Schedule.CronExpression);
+
+        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
+            new DateTimeOffset(2026, 3, 5, 18, 0, 0, TimeSpan.Zero)));
+    }
+
+    [Fact]
+    public async Task Rejects_invalid_cron_expression()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Name"] = "bad-cron",
+            ["Prompt"] = "Test",
+            ["ScheduleType"] = "cron",
+            ["Schedule"] = "not valid cron"
+        });
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Invalid cron expression", result);
+        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public async Task Rejects_unknown_schedule_type()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Name"] = "bad-type",
+            ["Prompt"] = "Test",
+            ["ScheduleType"] = "weekly",
+            ["Schedule"] = "1h"
+        });
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Unknown schedule type", result);
+    }
+
+    [Fact]
+    public async Task Rejects_interval_under_60_seconds()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Name"] = "too-fast",
+            ["Prompt"] = "Test",
+            ["ScheduleType"] = "interval",
+            ["Schedule"] = "10s"
+        });
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Minimum interval", result);
+    }
+
+    [Fact]
+    public async Task Self_targeting_captures_session_id()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider);
+        var context = new ToolExecutionContext("C0123ABC/1234567890.123456", null);
+
+        _ = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Name"] = "self-target",
+                ["Prompt"] = "Check weather",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "5m"
+            }, context);
+            return result;
+        });
+
+        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal("C0123ABC", cmd.Payload.ReportToChannel);
+        Assert.Equal("1234567890.123456", cmd.Payload.ReportToThreadTs);
+        Assert.NotNull(cmd.Payload.OriginatingSessionId);
+        Assert.Equal("C0123ABC/1234567890.123456", cmd.Payload.OriginatingSessionId.Value.Value);
+
+        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
+            _timeProvider.GetUtcNow().AddMinutes(5)));
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -30,7 +30,7 @@ public class SetReminderToolTests : TestKit
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
-        _ = Task.Run(async () =>
+        var execution = Task.Run(async () =>
         {
             var result = await tool.ExecuteAsync(new Dictionary<string, object?>
             {
@@ -42,16 +42,22 @@ public class SetReminderToolTests : TestKit
             return result;
         });
 
-        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
-        Assert.Equal("Check the server", cmd.Payload.Prompt);
-        Assert.Equal(ReminderScheduleType.OneShot, cmd.Payload.Schedule.Type);
+        var cmd = probe.ExpectMsg<SaveReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal("Check the server", cmd.Definition.Instructions);
+        Assert.Equal(ReminderScheduleType.OneShot, cmd.Definition.Schedule.Type);
 
         var expectedFire = _timeProvider.GetUtcNow().AddMinutes(30);
-        Assert.NotNull(cmd.Payload.Schedule.FireAt);
-        Assert.Equal(expectedFire, cmd.Payload.Schedule.FireAt.Value, TimeSpan.FromSeconds(1));
+        Assert.NotNull(cmd.Definition.Schedule.FireAt);
+        Assert.Equal(expectedFire, cmd.Definition.Schedule.FireAt.Value, TimeSpan.FromSeconds(1));
 
         // Reply
-        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name, expectedFire));
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: expectedFire));
+
+        await execution;
     }
 
     [Fact]
@@ -60,7 +66,7 @@ public class SetReminderToolTests : TestKit
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
-        _ = Task.Run(async () =>
+        var execution = Task.Run(async () =>
         {
             var result = await tool.ExecuteAsync(new Dictionary<string, object?>
             {
@@ -72,12 +78,17 @@ public class SetReminderToolTests : TestKit
             return result;
         });
 
-        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
-        Assert.Equal(ReminderScheduleType.Interval, cmd.Payload.Schedule.Type);
-        Assert.Equal(TimeSpan.FromHours(2), cmd.Payload.Schedule.Interval);
+        var cmd = probe.ExpectMsg<SaveReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal(ReminderScheduleType.Interval, cmd.Definition.Schedule.Type);
+        Assert.Equal(TimeSpan.FromHours(2), cmd.Definition.Schedule.Interval);
 
-        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
-            _timeProvider.GetUtcNow().AddHours(2)));
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: _timeProvider.GetUtcNow().AddHours(2)));
+
+        await execution;
     }
 
     [Fact]
@@ -86,7 +97,7 @@ public class SetReminderToolTests : TestKit
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
 
-        _ = Task.Run(async () =>
+        var execution = Task.Run(async () =>
         {
             var result = await tool.ExecuteAsync(new Dictionary<string, object?>
             {
@@ -98,12 +109,17 @@ public class SetReminderToolTests : TestKit
             return result;
         });
 
-        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
-        Assert.Equal(ReminderScheduleType.Cron, cmd.Payload.Schedule.Type);
-        Assert.Equal("0 */6 * * *", cmd.Payload.Schedule.CronExpression);
+        var cmd = probe.ExpectMsg<SaveReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal(ReminderScheduleType.Cron, cmd.Definition.Schedule.Type);
+        Assert.Equal("0 */6 * * *", cmd.Definition.Schedule.CronExpression);
 
-        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
-            new DateTimeOffset(2026, 3, 5, 18, 0, 0, TimeSpan.Zero)));
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: new DateTimeOffset(2026, 3, 5, 18, 0, 0, TimeSpan.Zero)));
+
+        await execution;
     }
 
     [Fact]
@@ -168,7 +184,7 @@ public class SetReminderToolTests : TestKit
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
         var context = new ToolExecutionContext("C0123ABC/1234567890.123456", null);
 
-        _ = Task.Run(async () =>
+        var execution = Task.Run(async () =>
         {
             var result = await tool.ExecuteAsync(new Dictionary<string, object?>
             {
@@ -180,14 +196,18 @@ public class SetReminderToolTests : TestKit
             return result;
         });
 
-        var cmd = probe.ExpectMsg<ScheduleReminderCommand>(TimeSpan.FromSeconds(5));
-        Assert.Equal("C0123ABC", cmd.Payload.ReportToChannel);
-        Assert.Equal("1234567890.123456", cmd.Payload.ReportToThreadTs);
-        Assert.NotNull(cmd.Payload.OriginatingSessionId);
-        Assert.Equal("C0123ABC/1234567890.123456", cmd.Payload.OriginatingSessionId.Value.Value);
+        var cmd = probe.ExpectMsg<SaveReminderCommand>(TimeSpan.FromSeconds(5));
+        Assert.Equal("C0123ABC", cmd.Definition.ReportToChannel);
+        Assert.Equal("1234567890.123456", cmd.Definition.ReportToThreadTs);
+        Assert.Equal("C0123ABC/1234567890.123456", cmd.Definition.SessionId);
 
-        probe.Reply(new ReminderScheduledResponse(cmd.Payload.Id, cmd.Payload.Name,
-            _timeProvider.GetUtcNow().AddMinutes(5)));
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: _timeProvider.GetUtcNow().AddMinutes(5)));
+
+        await execution;
     }
 
     private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/src/Netclaw.Actors/Hosting/ActorRegistryKeys.cs
+++ b/src/Netclaw.Actors/Hosting/ActorRegistryKeys.cs
@@ -10,3 +10,8 @@ public sealed class SessionManagerActorKey;
 /// Marker type for ActorRegistry lookup of the model capability cache actor.
 /// </summary>
 public sealed class ModelCapabilityActorKey;
+
+/// <summary>
+/// Marker type for ActorRegistry lookup of the reminder manager actor.
+/// </summary>
+public sealed class ReminderManagerActorKey;

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -1,6 +1,9 @@
 using Akka.Actor;
 using Akka.DependencyInjection;
 using Akka.Hosting;
+using Akka.Reminders;
+using Akka.Reminders.Sharding;
+using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Routing;
 using Netclaw.Actors.Sessions;
 
@@ -45,6 +48,38 @@ public static class NetclawAkkaHostingExtensions
     }
 
     /// <summary>
+    /// Registers the reminder manager as a singleton actor and wires
+    /// the local akka-reminders scheduler to deliver payloads to it.
+    /// Uses in-memory storage (reminders do not survive daemon restarts).
+    /// </summary>
+    public static AkkaConfigurationBuilder WithReminderManager(
+        this AkkaConfigurationBuilder builder)
+    {
+        // Shared resolver: created at configuration time, populated at actor startup.
+        // The scheduler starts first with an empty resolver; by the time any reminder
+        // actually fires, the ReminderManagerActor is registered as the shard region.
+        var sharedResolver = new TestShardRegionResolver();
+
+        return builder
+            .WithLocalReminders(reminders =>
+            {
+                reminders.WithInMemoryStorage();
+                reminders.WithResolver(_ => sharedResolver);
+            })
+            .StartActors((system, registry, resolver) =>
+            {
+                var reminderManager = system.ActorOf(
+                    resolver.Props<ReminderManagerActor>(),
+                    "reminder-manager");
+                registry.Register<ReminderManagerActorKey>(reminderManager);
+
+                // Register so akka-reminders delivers fired payloads to our manager
+                sharedResolver.RegisterShardRegion(
+                    ReminderManagerActor.ShardRegionName, reminderManager);
+            });
+    }
+
+    /// <summary>
     /// Convenience method that registers all Netclaw actor infrastructure.
     /// Requires <see cref="SessionConfig"/> and <see cref="Microsoft.Extensions.AI.IChatClient"/>
     /// to be registered in DI.
@@ -54,6 +89,7 @@ public static class NetclawAkkaHostingExtensions
     {
         return builder
             .WithModelCapabilityCache()
-            .WithSessionManager();
+            .WithSessionManager()
+            .WithReminderManager();
     }
 }

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -3,6 +3,8 @@ using Akka.DependencyInjection;
 using Akka.Hosting;
 using Akka.Reminders;
 using Akka.Reminders.Sharding;
+using Akka.Reminders.Sqlite;
+using Akka.Reminders.Sqlite.Configuration;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Routing;
 using Netclaw.Actors.Sessions;
@@ -11,6 +13,13 @@ namespace Netclaw.Actors.Hosting;
 
 public static class NetclawAkkaHostingExtensions
 {
+    public sealed record ReminderStorageOptions
+    {
+        public string? SqliteConnectionString { get; init; }
+        public string TableName { get; init; } = "scheduled_reminders";
+        public bool AutoInitialize { get; init; } = true;
+    }
+
     /// <summary>
     /// Registers the session manager as a <see cref="GenericChildPerEntityParent"/>
     /// that routes <see cref="Protocol.IWithSessionId"/> messages to per-session
@@ -49,11 +58,11 @@ public static class NetclawAkkaHostingExtensions
 
     /// <summary>
     /// Registers the reminder manager as a singleton actor and wires
-    /// the local akka-reminders scheduler to deliver payloads to it.
-    /// Uses in-memory storage (reminders do not survive daemon restarts).
+    /// the local Akka.Reminders scheduler to deliver payloads to it.
     /// </summary>
     public static AkkaConfigurationBuilder WithReminderManager(
-        this AkkaConfigurationBuilder builder)
+        this AkkaConfigurationBuilder builder,
+        ReminderStorageOptions? storageOptions = null)
     {
         // Shared resolver: created at configuration time, populated at actor startup.
         // The scheduler starts first with an empty resolver; by the time any reminder
@@ -63,7 +72,21 @@ public static class NetclawAkkaHostingExtensions
         return builder
             .WithLocalReminders(reminders =>
             {
-                reminders.WithInMemoryStorage();
+                if (!string.IsNullOrWhiteSpace(storageOptions?.SqliteConnectionString))
+                {
+                    reminders.WithStorage(system =>
+                        new SqliteReminderStorage(
+                            SqliteReminderStorageSettings.Create(
+                                connectionString: storageOptions.SqliteConnectionString,
+                                tableName: storageOptions.TableName,
+                                autoInitialize: storageOptions.AutoInitialize),
+                            system));
+                }
+                else
+                {
+                    reminders.WithInMemoryStorage();
+                }
+
                 reminders.WithResolver(_ => sharedResolver);
             })
             .StartActors((system, registry, resolver) =>
@@ -85,11 +108,12 @@ public static class NetclawAkkaHostingExtensions
     /// to be registered in DI.
     /// </summary>
     public static AkkaConfigurationBuilder WithNetclawActors(
-        this AkkaConfigurationBuilder builder)
+        this AkkaConfigurationBuilder builder,
+        ReminderStorageOptions? reminderStorageOptions = null)
     {
         return builder
             .WithModelCapabilityCache()
             .WithSessionManager()
-            .WithReminderManager();
+            .WithReminderManager(reminderStorageOptions);
     }
 }

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Akka.Cluster.Sharding" />
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Aaron.Akka.Reminders" />
+    <PackageReference Include="Cronos" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="ModelContextProtocol.Core" />

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Akka.Cluster.Sharding" />
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Aaron.Akka.Reminders" />
+    <PackageReference Include="Aaron.Akka.Reminders.Sqlite" />
     <PackageReference Include="Cronos" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using Akka.Actor;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// LLM tool for cancelling a scheduled reminder by its ID.
+/// </summary>
+[NetclawTool("cancel_reminder",
+    "Cancel a scheduled reminder by its ID. Use list_reminders to find reminder IDs.",
+    Grant = "scheduling")]
+public sealed partial class CancelReminderTool : NetclawTool<CancelReminderTool.Params>
+{
+    private readonly IActorRef _reminderManager;
+
+    public record Params(
+        [property: Description("The reminder ID to cancel (returned by set_reminder or list_reminders)")]
+        string ReminderId);
+
+    public CancelReminderTool(IActorRef reminderManager)
+    {
+        _reminderManager = reminderManager;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.ReminderId))
+            return "Error: 'reminderId' is required.";
+
+        var id = new ReminderId(args.ReminderId);
+        var response = await _reminderManager.Ask<ReminderCancelledResponse>(
+            new CancelReminderCommand(id), TimeSpan.FromSeconds(10), ct);
+
+        return response.Found
+            ? $"Reminder '{args.ReminderId}' cancelled."
+            : $"Reminder '{args.ReminderId}' not found.";
+    }
+}

--- a/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
@@ -5,10 +5,10 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
-/// LLM tool for cancelling a scheduled reminder by its ID.
+/// LLM tool for deleting a reminder by ID.
 /// </summary>
 [NetclawTool("cancel_reminder",
-    "Cancel a scheduled reminder by its ID. Use list_reminders to find reminder IDs.",
+    "Delete a reminder by its ID. Use list_reminders to find reminder IDs.",
     Grant = "scheduling")]
 public sealed partial class CancelReminderTool : NetclawTool<CancelReminderTool.Params>
 {
@@ -33,7 +33,7 @@ public sealed partial class CancelReminderTool : NetclawTool<CancelReminderTool.
             new CancelReminderCommand(id), TimeSpan.FromSeconds(10), ct);
 
         return response.Found
-            ? $"Reminder '{args.ReminderId}' cancelled."
+            ? $"Reminder '{args.ReminderId}' deleted."
             : $"Reminder '{args.ReminderId}' not found.";
     }
 }

--- a/src/Netclaw.Actors/Reminders/CronScheduleHelper.cs
+++ b/src/Netclaw.Actors/Reminders/CronScheduleHelper.cs
@@ -1,0 +1,47 @@
+using Cronos;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Wraps Cronos for cron expression parsing and next-occurrence computation.
+/// Uses <see cref="TimeProvider"/> for testable time.
+/// </summary>
+public static class CronScheduleHelper
+{
+    /// <summary>
+    /// Computes the next occurrence of the given cron expression after <paramref name="from"/>.
+    /// Returns null if the expression has no future occurrence.
+    /// </summary>
+    public static DateTimeOffset? GetNextOccurrence(string cronExpression, DateTimeOffset from)
+    {
+        var expression = CronExpression.Parse(cronExpression, CronFormat.Standard);
+        return expression.GetNextOccurrence(from, TimeZoneInfo.Utc);
+    }
+
+    /// <summary>
+    /// Computes the next occurrence using the given <see cref="TimeProvider"/> for current time.
+    /// </summary>
+    public static DateTimeOffset? GetNextOccurrence(string cronExpression, TimeProvider timeProvider)
+    {
+        return GetNextOccurrence(cronExpression, timeProvider.GetUtcNow());
+    }
+
+    /// <summary>
+    /// Validates whether the given string is a valid 5-field cron expression.
+    /// </summary>
+    public static bool TryParse(string expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        try
+        {
+            CronExpression.Parse(expression, CronFormat.Standard);
+            return true;
+        }
+        catch (CronFormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ListRemindersTool.cs
+++ b/src/Netclaw.Actors/Reminders/ListRemindersTool.cs
@@ -6,17 +6,17 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
-/// LLM tool for listing all active reminders.
+/// LLM tool for listing reminder definitions.
 /// </summary>
 [NetclawTool("list_reminders",
-    "List all scheduled reminders with their IDs, names, schedules, and next fire times.",
+    "List reminder definitions with IDs, schedules, status, and next fire times.",
     Grant = "scheduling")]
 public sealed partial class ListRemindersTool : NetclawTool<ListRemindersTool.Params>
 {
     private readonly IActorRef _reminderManager;
 
     public record Params(
-        [property: Description("Optional filter: 'active' (default) or 'all'")]
+        [property: Description("Optional filter: 'active' (default) or 'all'.")]
         string? Filter = null);
 
     public ListRemindersTool(IActorRef reminderManager)
@@ -26,34 +26,34 @@ public sealed partial class ListRemindersTool : NetclawTool<ListRemindersTool.Pa
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
+        var includeDisabled = string.Equals(args.Filter, "all", StringComparison.OrdinalIgnoreCase);
+
         var response = await _reminderManager.Ask<ReminderListResponse>(
-            new ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+            new ListRemindersCommand(includeDisabled), TimeSpan.FromSeconds(10), ct);
 
         if (response.Reminders.Count == 0)
-            return "No active reminders.";
+            return includeDisabled ? "No reminders found." : "No active reminders.";
 
         var sb = new StringBuilder();
-        sb.AppendLine($"Active reminders ({response.Reminders.Count}):");
+        sb.AppendLine($"Reminders ({response.Reminders.Count}):");
         sb.AppendLine();
 
         foreach (var r in response.Reminders)
         {
             var scheduleDesc = r.Schedule.Type switch
             {
-                ReminderScheduleType.OneShot => $"once at {r.NextFire:u}",
+                ReminderScheduleType.OneShot => $"once at {r.Schedule.FireAt:u}",
                 ReminderScheduleType.Interval => $"every {r.Schedule.Interval!.Value.TotalMinutes:F0}m",
                 ReminderScheduleType.Cron => $"cron '{r.Schedule.CronExpression}'",
                 _ => r.Schedule.OriginalExpression ?? "unknown"
             };
 
             sb.AppendLine($"  ID: {r.Id.Value}");
-            sb.AppendLine($"  Name: {r.Name}");
+            sb.AppendLine($"  Title: {r.Title}");
+            sb.AppendLine($"  Status: {(r.Enabled ? "active" : "disabled")}");
             sb.AppendLine($"  Schedule: {scheduleDesc}");
             if (r.NextFire is not null)
                 sb.AppendLine($"  Next fire: {r.NextFire:u}");
-            if (r.ReportToChannel is not null)
-                sb.AppendLine($"  Report to: {r.ReportToChannel}");
-            sb.AppendLine($"  Prompt: {(r.Prompt.Length > 100 ? r.Prompt[..100] + "..." : r.Prompt)}");
             sb.AppendLine();
         }
 

--- a/src/Netclaw.Actors/Reminders/ListRemindersTool.cs
+++ b/src/Netclaw.Actors/Reminders/ListRemindersTool.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Text;
+using Akka.Actor;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// LLM tool for listing all active reminders.
+/// </summary>
+[NetclawTool("list_reminders",
+    "List all scheduled reminders with their IDs, names, schedules, and next fire times.",
+    Grant = "scheduling")]
+public sealed partial class ListRemindersTool : NetclawTool<ListRemindersTool.Params>
+{
+    private readonly IActorRef _reminderManager;
+
+    public record Params(
+        [property: Description("Optional filter: 'active' (default) or 'all'")]
+        string? Filter = null);
+
+    public ListRemindersTool(IActorRef reminderManager)
+    {
+        _reminderManager = reminderManager;
+    }
+
+    protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
+    {
+        var response = await _reminderManager.Ask<ReminderListResponse>(
+            new ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+
+        if (response.Reminders.Count == 0)
+            return "No active reminders.";
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Active reminders ({response.Reminders.Count}):");
+        sb.AppendLine();
+
+        foreach (var r in response.Reminders)
+        {
+            var scheduleDesc = r.Schedule.Type switch
+            {
+                ReminderScheduleType.OneShot => $"once at {r.NextFire:u}",
+                ReminderScheduleType.Interval => $"every {r.Schedule.Interval!.Value.TotalMinutes:F0}m",
+                ReminderScheduleType.Cron => $"cron '{r.Schedule.CronExpression}'",
+                _ => r.Schedule.OriginalExpression ?? "unknown"
+            };
+
+            sb.AppendLine($"  ID: {r.Id.Value}");
+            sb.AppendLine($"  Name: {r.Name}");
+            sb.AppendLine($"  Schedule: {scheduleDesc}");
+            if (r.NextFire is not null)
+                sb.AppendLine($"  Next fire: {r.NextFire:u}");
+            if (r.ReportToChannel is not null)
+                sb.AppendLine($"  Report to: {r.ReportToChannel}");
+            sb.AppendLine($"  Prompt: {(r.Prompt.Length > 100 ? r.Prompt[..100] + "..." : r.Prompt)}");
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderDefinitionStore.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// File-backed reminder definition store.
+///
+/// Reminder schedules are durable in Akka.Reminders (SQLite), but the execution
+/// contract and mutable task content are sourced from these JSON files.
+/// Scheduled messages only carry a pointer (reminder ID).
+/// </summary>
+public sealed class ReminderDefinitionStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly string _directory;
+    private readonly object _sync = new();
+
+    public ReminderDefinitionStore(NetclawPaths paths)
+    {
+        _directory = paths.RemindersDirectory;
+        Directory.CreateDirectory(_directory);
+    }
+
+    public bool Exists(ReminderId id)
+    {
+        lock (_sync)
+            return File.Exists(GetPath(id));
+    }
+
+    public ReminderDefinition? Get(ReminderId id)
+    {
+        lock (_sync)
+        {
+            var path = GetPath(id);
+            if (!File.Exists(path))
+                return null;
+
+            return ReadDefinition(path);
+        }
+    }
+
+    public IReadOnlyList<ReminderDefinition> List()
+    {
+        lock (_sync)
+        {
+            var list = new List<ReminderDefinition>();
+            foreach (var file in Directory.EnumerateFiles(_directory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                var definition = ReadDefinition(file);
+                if (definition is not null)
+                    list.Add(definition);
+            }
+
+            return list;
+        }
+    }
+
+    public void Save(ReminderDefinition definition)
+    {
+        lock (_sync)
+        {
+            Directory.CreateDirectory(_directory);
+
+            var path = GetPath(new ReminderId(definition.Id));
+            var tempPath = $"{path}.tmp";
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(definition, JsonOptions));
+            File.Move(tempPath, path, overwrite: true);
+        }
+    }
+
+    public bool Delete(ReminderId id)
+    {
+        lock (_sync)
+        {
+            var path = GetPath(id);
+            if (!File.Exists(path))
+                return false;
+
+            File.Delete(path);
+            return true;
+        }
+    }
+
+    private string GetPath(ReminderId id)
+    {
+        var encoded = Uri.EscapeDataString(id.Value);
+        return Path.Combine(_directory, $"{encoded}.json");
+    }
+
+    private static ReminderDefinition? ReadDefinition(string path)
+    {
+        var text = File.ReadAllText(path);
+        var definition = JsonSerializer.Deserialize<ReminderDefinition>(text, JsonOptions);
+        if (definition is null || string.IsNullOrWhiteSpace(definition.Id))
+            return null;
+
+        return definition;
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -1,0 +1,173 @@
+using System.Text;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Short-lived child actor handling a single reminder execution.
+/// Creates a session pipeline, sends the prompt, collects output,
+/// and reports success/failure to parent <see cref="ReminderManagerActor"/>.
+/// </summary>
+internal sealed class ReminderExecutionActor : ReceiveActor
+{
+    private readonly ReminderPayload _payload;
+    private readonly SessionPipeline _pipeline;
+    private readonly ILoggingAdapter _log;
+
+    private readonly StringBuilder _buffer = new();
+    private bool _sawTextDelta;
+    private bool _completed;
+
+    private ActorMaterializer? _materializer;
+    private MaterializedSession? _session;
+
+    public static Props CreateProps(
+        ReminderPayload payload,
+        SessionPipeline pipeline,
+        ReminderConfig config,
+        TimeProvider timeProvider) =>
+        Props.Create(() => new ReminderExecutionActor(payload, pipeline, config));
+
+    private ReminderExecutionActor(
+        ReminderPayload payload,
+        SessionPipeline pipeline,
+        ReminderConfig config)
+    {
+        _payload = payload;
+        _pipeline = pipeline;
+        _log = Context.GetLogger();
+
+        // Set execution timeout
+        Context.SetReceiveTimeout(TimeSpan.FromSeconds(config.ExecutionTimeoutSeconds));
+
+        Receive<ExecutionOutput>(HandleOutput);
+        Receive<ExecutionStarted>(_ => { }); // ack
+        Receive<ReceiveTimeout>(_ =>
+        {
+            _log.Warning("Reminder execution timed out: '{0}'", _payload.Name);
+            ReportAndStop(false, "Execution timed out");
+        });
+    }
+
+    protected override void PreStart()
+    {
+        Self.Tell(new ExecutionStarted());
+        RunTask(InitializeAsync);
+    }
+
+    private async Task InitializeAsync()
+    {
+        try
+        {
+            // Determine session ID
+            var sessionId = _payload.OriginatingSessionId
+                ?? new SessionId($"reminder/{_payload.Id.Value}/{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
+
+            _log.Info("Starting reminder execution for '{0}' with session '{1}'",
+                _payload.Name, sessionId.Value);
+
+            _materializer = Context.Materializer(namePrefix: "reminder-exec");
+
+            var materialized = await _pipeline.CreateAsync(sessionId, new SessionPipelineOptions
+            {
+                ChannelType = "reminder",
+                Filter = OutputFilter.Text
+            }, materializer: _materializer);
+
+            var self = Self;
+
+            // Wire input queue
+            var inputQueue = Source.Queue<ChannelInput>(8, OverflowStrategy.Backpressure)
+                .ToMaterialized(materialized.Input, Keep.Left)
+                .Run(_materializer);
+
+            // Wire output sink
+            materialized.Output
+                .To(Sink.ForEach<SessionOutput>(output => self.Tell(new ExecutionOutput(output))))
+                .Run(_materializer);
+
+            _session = materialized;
+
+            // Send the prompt
+            await inputQueue.OfferAsync(new ChannelInput
+            {
+                SenderId = "reminder-system",
+                ChannelId = _payload.ReportToChannel,
+                Contents = [new TextContent(_payload.Prompt)],
+                ReceivedAt = DateTimeOffset.UtcNow
+            });
+
+            // Complete the input — single prompt, one turn
+            inputQueue.Complete();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to initialize reminder execution for '{0}'", _payload.Name);
+            ReportAndStop(false, ex.Message);
+        }
+    }
+
+    private void HandleOutput(ExecutionOutput wrapper)
+    {
+        switch (wrapper.Output)
+        {
+            case TextDeltaOutput delta:
+                _buffer.Append(delta.Delta);
+                _sawTextDelta = true;
+                break;
+
+            case TextOutput text:
+                if (!_sawTextDelta)
+                    _buffer.Append(text.Text);
+                break;
+
+            case TurnCompleted:
+                var result = _buffer.ToString().Trim();
+                _log.Info("Reminder '{0}' execution completed, output length: {1}",
+                    _payload.Name, result.Length);
+
+                if (string.IsNullOrWhiteSpace(result))
+                    result = $"(Reminder '{_payload.Name}' executed but produced no output)";
+
+                // Log the result; Slack posting would be handled by the session
+                // if the session targets a Slack channel
+                _log.Info("Reminder output for '{0}': {1}",
+                    _payload.Name, result.Length > 200 ? result[..200] + "..." : result);
+
+                ReportAndStop(true);
+                break;
+
+            case ErrorOutput err:
+                _log.Warning("Reminder '{0}' error output: {1}", _payload.Name, err.Message);
+                ReportAndStop(false, err.Message);
+                break;
+        }
+    }
+
+    private void ReportAndStop(bool success, string? errorMessage = null)
+    {
+        if (_completed)
+            return;
+
+        _completed = true;
+        Context.Parent.Tell(new ReminderExecutionCompleted(_payload.Id, success, errorMessage));
+        Context.Stop(Self);
+    }
+
+    protected override void PostStop()
+    {
+        _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _materializer?.Dispose();
+        base.PostStop();
+    }
+
+    private sealed record ExecutionStarted;
+    private sealed record ExecutionOutput(SessionOutput Output);
+}

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -19,6 +19,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 {
     private readonly ReminderPayload _payload;
     private readonly SessionPipeline _pipeline;
+    private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
 
     private readonly StringBuilder _buffer = new();
@@ -33,15 +34,17 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         SessionPipeline pipeline,
         ReminderConfig config,
         TimeProvider timeProvider) =>
-        Props.Create(() => new ReminderExecutionActor(payload, pipeline, config));
+        Props.Create(() => new ReminderExecutionActor(payload, pipeline, config, timeProvider));
 
     private ReminderExecutionActor(
         ReminderPayload payload,
         SessionPipeline pipeline,
-        ReminderConfig config)
+        ReminderConfig config,
+        TimeProvider timeProvider)
     {
         _payload = payload;
         _pipeline = pipeline;
+        _timeProvider = timeProvider;
         _log = Context.GetLogger();
 
         // Set execution timeout
@@ -68,7 +71,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         {
             // Determine session ID
             var sessionId = _payload.OriginatingSessionId
-                ?? new SessionId($"reminder/{_payload.Id.Value}/{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
+                ?? new SessionId($"reminder/{_payload.Id.Value}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
 
             _log.Info("Starting reminder execution for '{0}' with session '{1}'",
                 _payload.Name, sessionId.Value);
@@ -101,7 +104,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 SenderId = "reminder-system",
                 ChannelId = _payload.ReportToChannel,
                 Contents = [new TextContent(_payload.Prompt)],
-                ReceivedAt = DateTimeOffset.UtcNow
+                ReceivedAt = _timeProvider.GetUtcNow()
             });
 
             // Complete the input — single prompt, one turn
@@ -163,9 +166,15 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
     protected override void PostStop()
     {
-        _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        _materializer?.Dispose();
-        base.PostStop();
+        try
+        {
+            _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _materializer?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to dispose reminder execution resources for '{0}'", _payload.Name);
+        }
     }
 
     private sealed record ExecutionStarted;

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -12,12 +12,13 @@ namespace Netclaw.Actors.Reminders;
 
 /// <summary>
 /// Short-lived child actor handling a single reminder execution.
-/// Creates a session pipeline, sends the prompt, collects output,
-/// and reports success/failure to parent <see cref="ReminderManagerActor"/>.
+/// Creates a session pipeline, sends reminder instructions, collects output,
+/// and reports success/failure to <see cref="ReminderManagerActor"/>.
 /// </summary>
 internal sealed class ReminderExecutionActor : ReceiveActor
 {
-    private readonly ReminderPayload _payload;
+    private readonly Guid _executionId;
+    private readonly ReminderDefinition _definition;
     private readonly SessionPipeline _pipeline;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
@@ -30,31 +31,33 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private MaterializedSession? _session;
 
     public static Props CreateProps(
-        ReminderPayload payload,
+        Guid executionId,
+        ReminderDefinition definition,
         SessionPipeline pipeline,
         ReminderConfig config,
         TimeProvider timeProvider) =>
-        Props.Create(() => new ReminderExecutionActor(payload, pipeline, config, timeProvider));
+        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, timeProvider));
 
     private ReminderExecutionActor(
-        ReminderPayload payload,
+        Guid executionId,
+        ReminderDefinition definition,
         SessionPipeline pipeline,
         ReminderConfig config,
         TimeProvider timeProvider)
     {
-        _payload = payload;
+        _executionId = executionId;
+        _definition = definition;
         _pipeline = pipeline;
         _timeProvider = timeProvider;
         _log = Context.GetLogger();
 
-        // Set execution timeout
         Context.SetReceiveTimeout(TimeSpan.FromSeconds(config.ExecutionTimeoutSeconds));
 
         Receive<ExecutionOutput>(HandleOutput);
-        Receive<ExecutionStarted>(_ => { }); // ack
+        Receive<ExecutionStarted>(_ => { });
         Receive<ReceiveTimeout>(_ =>
         {
-            _log.Warning("Reminder execution timed out: '{0}'", _payload.Name);
+            _log.Warning("Reminder execution timed out: '{0}'", _definition.Title);
             ReportAndStop(false, "Execution timed out");
         });
     }
@@ -69,12 +72,12 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     {
         try
         {
-            // Determine session ID
-            var sessionId = _payload.OriginatingSessionId
-                ?? new SessionId($"reminder/{_payload.Id.Value}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
+            var sessionId = !string.IsNullOrWhiteSpace(_definition.SessionId)
+                ? new SessionId(_definition.SessionId)
+                : new SessionId($"reminder/{_definition.Id}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
 
             _log.Info("Starting reminder execution for '{0}' with session '{1}'",
-                _payload.Name, sessionId.Value);
+                _definition.Title, sessionId.Value);
 
             _materializer = Context.Materializer(namePrefix: "reminder-exec");
 
@@ -86,35 +89,41 @@ internal sealed class ReminderExecutionActor : ReceiveActor
 
             var self = Self;
 
-            // Wire input queue
             var inputQueue = Source.Queue<ChannelInput>(8, OverflowStrategy.Backpressure)
                 .ToMaterialized(materialized.Input, Keep.Left)
                 .Run(_materializer);
 
-            // Wire output sink
             materialized.Output
                 .To(Sink.ForEach<SessionOutput>(output => self.Tell(new ExecutionOutput(output))))
                 .Run(_materializer);
 
             _session = materialized;
 
-            // Send the prompt
+            var prompt = BuildPrompt(_definition);
+
             await inputQueue.OfferAsync(new ChannelInput
             {
                 SenderId = "reminder-system",
-                ChannelId = _payload.ReportToChannel,
-                Contents = [new TextContent(_payload.Prompt)],
+                ChannelId = _definition.ReportToChannel,
+                Contents = [new TextContent(prompt)],
                 ReceivedAt = _timeProvider.GetUtcNow()
             });
 
-            // Complete the input — single prompt, one turn
             inputQueue.Complete();
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to initialize reminder execution for '{0}'", _payload.Name);
+            _log.Error(ex, "Failed to initialize reminder execution for '{0}'", _definition.Title);
             ReportAndStop(false, ex.Message);
         }
+    }
+
+    private static string BuildPrompt(ReminderDefinition definition)
+    {
+        return
+            $"{definition.Instructions}\n\n" +
+            "Notification instructions:\n" +
+            definition.NotifyInstructions;
     }
 
     private void HandleOutput(ExecutionOutput wrapper)
@@ -134,21 +143,19 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             case TurnCompleted:
                 var result = _buffer.ToString().Trim();
                 _log.Info("Reminder '{0}' execution completed, output length: {1}",
-                    _payload.Name, result.Length);
+                    _definition.Title, result.Length);
 
                 if (string.IsNullOrWhiteSpace(result))
-                    result = $"(Reminder '{_payload.Name}' executed but produced no output)";
+                    result = $"(Reminder '{_definition.Title}' executed but produced no output)";
 
-                // Log the result; Slack posting would be handled by the session
-                // if the session targets a Slack channel
                 _log.Info("Reminder output for '{0}': {1}",
-                    _payload.Name, result.Length > 200 ? result[..200] + "..." : result);
+                    _definition.Title, result.Length > 200 ? result[..200] + "..." : result);
 
                 ReportAndStop(true);
                 break;
 
             case ErrorOutput err:
-                _log.Warning("Reminder '{0}' error output: {1}", _payload.Name, err.Message);
+                _log.Warning("Reminder '{0}' error output: {1}", _definition.Title, err.Message);
                 ReportAndStop(false, err.Message);
                 break;
         }
@@ -160,7 +167,11 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             return;
 
         _completed = true;
-        Context.Parent.Tell(new ReminderExecutionCompleted(_payload.Id, success, errorMessage));
+        Context.Parent.Tell(new ReminderExecutionCompleted(
+            _executionId,
+            new ReminderId(_definition.Id),
+            success,
+            errorMessage));
         Context.Stop(Self);
     }
 
@@ -173,7 +184,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         }
         catch (Exception ex)
         {
-            _log.Debug(ex, "Failed to dispose reminder execution resources for '{0}'", _payload.Name);
+            _log.Debug(ex, "Failed to dispose reminder execution resources for '{0}'", _definition.Title);
         }
     }
 

--- a/src/Netclaw.Actors/Reminders/ReminderIdGenerator.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderIdGenerator.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Actors.Reminders;
+
+internal static partial class ReminderIdGenerator
+{
+    [GeneratedRegex("[^a-z0-9\\-]", RegexOptions.Compiled)]
+    private static partial Regex InvalidChars();
+
+    public static ReminderId Generate(string title)
+    {
+        var slug = title.ToLowerInvariant().Trim()
+            .Replace(' ', '-')
+            .Replace('_', '-');
+
+        slug = InvalidChars().Replace(slug, string.Empty);
+        if (string.IsNullOrWhiteSpace(slug))
+            slug = "reminder";
+        if (slug.Length > 30)
+            slug = slug[..30];
+
+        var suffix = Guid.NewGuid().ToString("N")[..6];
+        return new ReminderId($"{slug}-{suffix}");
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -44,6 +44,7 @@ public sealed class ReminderManagerActor : ReceiveActor
         ReceiveAsync<ScheduleReminderCommand>(HandleScheduleAsync);
         ReceiveAsync<CancelReminderCommand>(HandleCancelAsync);
         ReceiveAsync<ListRemindersCommand>(HandleListAsync);
+        ReceiveAsync<GetReminderCommand>(HandleGetAsync);
         ReceiveAsync<ReminderPayload>(HandleReminderFiredAsync);
         Receive<ReminderExecutionCompleted>(HandleExecutionCompleted);
     }
@@ -161,6 +162,40 @@ public sealed class ReminderManagerActor : ReceiveActor
         {
             _log.Error(ex, "Error listing reminders");
             Sender.Tell(new ReminderListResponse([]));
+        }
+    }
+
+    private async Task HandleGetAsync(GetReminderCommand cmd)
+    {
+        try
+        {
+            var result = await _client!.ListRemindersAsync();
+            ReminderInfo? match = null;
+
+            if (result.ResponseCode == FetchRemindersResponseCode.Success)
+            {
+                foreach (var scheduled in result.Reminders)
+                {
+                    if (scheduled.Message is ReminderPayload payload && payload.Id.Value == cmd.Id.Value)
+                    {
+                        match = new ReminderInfo(
+                            payload.Id,
+                            payload.Name,
+                            payload.Prompt,
+                            payload.Schedule,
+                            scheduled.When,
+                            payload.ReportToChannel);
+                        break;
+                    }
+                }
+            }
+
+            Sender.Tell(new GetReminderResponse(match));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error getting reminder '{0}'", cmd.Id.Value);
+            Sender.Tell(new GetReminderResponse(null));
         }
     }
 

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -1,18 +1,18 @@
+using System.Text.RegularExpressions;
 using Akka.Actor;
 using Akka.Event;
-using Akka.Hosting;
 using Akka.Reminders;
 using Netclaw.Actors.Channels;
-using Netclaw.Actors.Hosting;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
-/// Singleton actor that mediates between akka-reminders and session execution.
-/// Handles scheduling, cancellation, listing, and reminder-fire delivery.
+/// Singleton actor that mediates between Akka.Reminders and reminder execution.
+/// Schedules durable timer entries and resolves execution behavior from
+/// file-backed reminder definitions.
 /// </summary>
-public sealed class ReminderManagerActor : ReceiveActor
+public sealed partial class ReminderManagerActor : ReceiveActor
 {
     public const string ShardRegionName = "netclaw-reminders";
     public const string EntityId = "manager";
@@ -20,33 +20,38 @@ public sealed class ReminderManagerActor : ReceiveActor
     private readonly ReminderConfig _config;
     private readonly SessionPipeline _pipeline;
     private readonly TimeProvider _timeProvider;
+    private readonly ReminderDefinitionStore _definitionStore;
     private readonly ILoggingAdapter _log;
 
     private IReminderClient? _client;
 
-    // Concurrency tracking
-    private readonly HashSet<ReminderId> _activeExecutions = new();
-    private readonly Queue<ReminderPayload> _deferredQueue = new();
-
-    // Failure tracking: consecutive failures per reminder
-    private readonly Dictionary<ReminderId, int> _failureCounts = new();
+    private readonly HashSet<Guid> _activeExecutionIds = [];
+    private readonly Queue<ReminderId> _deferredQueue = new();
+    private readonly Dictionary<ReminderId, int> _failureCounts = [];
 
     public ReminderManagerActor(
         ReminderConfig config,
         SessionPipeline pipeline,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ReminderDefinitionStore definitionStore)
     {
         _config = config;
         _pipeline = pipeline;
         _timeProvider = timeProvider;
+        _definitionStore = definitionStore;
         _log = Context.GetLogger();
 
-        ReceiveAsync<ScheduleReminderCommand>(HandleScheduleAsync);
+        ReceiveAsync<SaveReminderCommand>(HandleSaveAsync);
         ReceiveAsync<CancelReminderCommand>(HandleCancelAsync);
+        ReceiveAsync<DisableReminderCommand>(HandleDisableAsync);
+        ReceiveAsync<EnableReminderCommand>(HandleEnableAsync);
         ReceiveAsync<ListRemindersCommand>(HandleListAsync);
         ReceiveAsync<GetReminderCommand>(HandleGetAsync);
+
         ReceiveAsync<ReminderPayload>(HandleReminderFiredAsync);
-        Receive<ReminderExecutionCompleted>(HandleExecutionCompleted);
+        ReceiveAsync<ReminderExecutionCompleted>(HandleExecutionCompletedAsync);
+
+        ReceiveAsync<ReconcileReminders>(_ => HandleReconcileAsync());
     }
 
     protected override void PreStart()
@@ -54,194 +59,340 @@ public sealed class ReminderManagerActor : ReceiveActor
         var extension = ReminderClientExtension.Get(Context.System);
         _client = extension.CreateClient(new ReminderEntity(ShardRegionName, EntityId));
         _log.Info("ReminderManagerActor started");
+
+        Self.Tell(ReconcileReminders.Instance);
     }
 
-    private async Task HandleScheduleAsync(ScheduleReminderCommand cmd)
+    private async Task HandleSaveAsync(SaveReminderCommand cmd)
     {
-        var payload = cmd.Payload;
-        var key = new ReminderKey(payload.Id.Value);
+        var replyTo = Sender;
 
-        try
+        if (cmd.Definition is null)
         {
-            Akka.Reminders.ReminderProtocol.ReminderScheduled result;
-            DateTimeOffset? nextFire;
-
-            switch (payload.Schedule.Type)
-            {
-                case ReminderScheduleType.OneShot:
-                    nextFire = payload.Schedule.FireAt!.Value;
-                    result = await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
-                    break;
-
-                case ReminderScheduleType.Interval:
-                    nextFire = payload.Schedule.FireAt ?? _timeProvider.GetUtcNow().Add(payload.Schedule.Interval!.Value);
-                    result = await _client!.ScheduleRecurringReminderAsync(
-                        key, nextFire.Value, payload.Schedule.Interval!.Value, payload);
-                    break;
-
-                case ReminderScheduleType.Cron:
-                    nextFire = CronScheduleHelper.GetNextOccurrence(
-                        payload.Schedule.CronExpression!, _timeProvider);
-                    if (nextFire is null)
-                    {
-                        Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
-                        return;
-                    }
-                    result = await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
-                    break;
-
-                default:
-                    Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
-                    return;
-            }
-
-            if (result.ResponseCode == ReminderScheduleResponseCode.Success)
-            {
-                _log.Info("Scheduled reminder '{0}' ({1}), next fire: {2}",
-                    payload.Name, payload.Schedule.Type, nextFire);
-            }
-            else
-            {
-                _log.Warning("Failed to schedule reminder '{0}': {1}", payload.Name, result.Message);
-            }
-
-            Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, nextFire));
+            replyTo.Tell(new ReminderSavedResponse(
+                new ReminderId("unknown"),
+                "unknown",
+                Success: false,
+                NextFire: null,
+                Error: ReminderSaveError.Validation,
+                ErrorMessage: "Reminder definition is required."));
+            return;
         }
-        catch (Exception ex)
+
+        var title = cmd.Definition.Title?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(title))
         {
-            _log.Error(ex, "Error scheduling reminder '{0}'", payload.Name);
-            Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
+            replyTo.Tell(new ReminderSavedResponse(
+                new ReminderId(cmd.Definition.Id ?? "unknown"),
+                string.Empty,
+                Success: false,
+                NextFire: null,
+                Error: ReminderSaveError.Validation,
+                ErrorMessage: "Reminder title is required."));
+            return;
         }
+
+        var id = !string.IsNullOrWhiteSpace(cmd.Definition.Id)
+            ? new ReminderId(cmd.Definition.Id)
+            : ReminderIdGenerator.Generate(title);
+
+        var exists = _definitionStore.Exists(id);
+
+        switch (cmd.WriteMode)
+        {
+            case ReminderWriteMode.CreateOnly when exists:
+                replyTo.Tell(new ReminderSavedResponse(
+                    id,
+                    title,
+                    Success: false,
+                    NextFire: null,
+                    Error: ReminderSaveError.Conflict,
+                    ErrorMessage: $"Reminder '{id.Value}' already exists."));
+                return;
+
+            case ReminderWriteMode.Replace when !exists:
+                replyTo.Tell(new ReminderSavedResponse(
+                    id,
+                    title,
+                    Success: false,
+                    NextFire: null,
+                    Error: ReminderSaveError.NotFound,
+                    ErrorMessage: $"Reminder '{id.Value}' was not found."));
+                return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var normalized = cmd.Definition with
+        {
+            Id = id.Value,
+            Title = title,
+            CreatedBy = string.IsNullOrWhiteSpace(cmd.Definition.CreatedBy)
+                ? "system"
+                : cmd.Definition.CreatedBy
+        };
+
+        if (exists)
+        {
+            var existing = _definitionStore.Get(id);
+            normalized.CreatedAtMs = existing?.CreatedAtMs ?? (normalized.CreatedAtMs > 0 ? normalized.CreatedAtMs : now.ToUnixTimeMilliseconds());
+        }
+        else
+        {
+            normalized.CreatedAtMs = normalized.CreatedAtMs > 0 ? normalized.CreatedAtMs : now.ToUnixTimeMilliseconds();
+        }
+
+        normalized.UpdatedAtMs = now.ToUnixTimeMilliseconds();
+
+        if (exists)
+        {
+            await CancelScheduleOnlyAsync(id);
+            RemoveFromDeferredQueue(id);
+        }
+
+        DateTimeOffset? nextFire = null;
+        if (normalized.Enabled)
+        {
+            var scheduleResult = await ScheduleDefinitionAsync(
+                normalized,
+                rescheduleFromNow: exists || cmd.WriteMode is not ReminderWriteMode.CreateOnly);
+
+            if (!scheduleResult.IsSuccess)
+            {
+                replyTo.Tell(new ReminderSavedResponse(
+                    id,
+                    normalized.Title,
+                    Success: false,
+                    NextFire: null,
+                    Error: ReminderSaveError.Validation,
+                    ErrorMessage: scheduleResult.ErrorMessage));
+                return;
+            }
+
+            nextFire = scheduleResult.NextFire;
+        }
+        else
+        {
+            await CancelScheduleOnlyAsync(id);
+            RemoveFromDeferredQueue(id);
+        }
+
+        _definitionStore.Save(normalized);
+
+        _log.Info("Saved reminder '{0}' (enabled={1})", normalized.Id, normalized.Enabled);
+
+        replyTo.Tell(new ReminderSavedResponse(
+            id,
+            normalized.Title,
+            Success: true,
+            NextFire: nextFire));
     }
 
     private async Task HandleCancelAsync(CancelReminderCommand cmd)
     {
-        var key = new ReminderKey(cmd.Id.Value);
-        try
-        {
-            var result = await _client!.CancelReminderAsync(key);
-            var found = result.ResponseCode == ReminderCancelResponseCode.Success;
-            _failureCounts.Remove(cmd.Id);
-            _log.Info("Cancel reminder '{0}': {1}", cmd.Id.Value, found ? "found and cancelled" : "not found");
-            Sender.Tell(new ReminderCancelledResponse(cmd.Id, found));
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Error cancelling reminder '{0}'", cmd.Id.Value);
-            Sender.Tell(new ReminderCancelledResponse(cmd.Id, false));
-        }
+        var replyTo = Sender;
+        var deleted = _definitionStore.Delete(cmd.Id);
+        var scheduleCancelled = await CancelScheduleOnlyAsync(cmd.Id);
+
+        _failureCounts.Remove(cmd.Id);
+        RemoveFromDeferredQueue(cmd.Id);
+
+        var found = deleted || scheduleCancelled;
+        _log.Info("Delete reminder '{0}': {1}", cmd.Id.Value, found ? "deleted" : "not found");
+        replyTo.Tell(new ReminderCancelledResponse(cmd.Id, found));
     }
 
-    private async Task HandleListAsync(ListRemindersCommand _)
+    private async Task HandleDisableAsync(DisableReminderCommand cmd)
     {
+        var replyTo = Sender;
+        var response = await DisableReminderInternalAsync(cmd.Id);
+        replyTo.Tell(response);
+    }
+
+    private async Task HandleEnableAsync(EnableReminderCommand cmd)
+    {
+        var replyTo = Sender;
+        var response = await EnableReminderInternalAsync(cmd.Id);
+        replyTo.Tell(response);
+    }
+
+    private async Task<ReminderStateResponse> DisableReminderInternalAsync(ReminderId id)
+    {
+        var definition = _definitionStore.Get(id);
+        if (definition is null)
+            return new ReminderStateResponse(id, Found: false, Enabled: false, ErrorMessage: "Reminder not found.");
+
+        if (!definition.Enabled)
+            return new ReminderStateResponse(id, Found: true, Enabled: false);
+
+        definition = definition with
+        {
+            Enabled = false,
+            UpdatedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()
+        };
+
+        _definitionStore.Save(definition);
+        await CancelScheduleOnlyAsync(id);
+
+        _failureCounts.Remove(id);
+        RemoveFromDeferredQueue(id);
+
+        _log.Info("Disabled reminder '{0}'", id.Value);
+        return new ReminderStateResponse(id, Found: true, Enabled: false);
+    }
+
+    private async Task<ReminderStateResponse> EnableReminderInternalAsync(ReminderId id)
+    {
+        var definition = _definitionStore.Get(id);
+        if (definition is null)
+            return new ReminderStateResponse(id, Found: false, Enabled: false, ErrorMessage: "Reminder not found.");
+
+        definition = definition with
+        {
+            Enabled = true,
+            UpdatedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()
+        };
+
+        var scheduleResult = await ScheduleDefinitionAsync(definition, rescheduleFromNow: true);
+        if (!scheduleResult.IsSuccess)
+        {
+            definition = definition with
+            {
+                Enabled = false,
+                UpdatedAtMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds()
+            };
+            _definitionStore.Save(definition);
+
+            return new ReminderStateResponse(
+                id,
+                Found: true,
+                Enabled: false,
+                ErrorMessage: scheduleResult.ErrorMessage);
+        }
+
+        _definitionStore.Save(definition);
+        _log.Info("Enabled reminder '{0}'", id.Value);
+
+        return new ReminderStateResponse(
+            id,
+            Found: true,
+            Enabled: true,
+            NextFire: scheduleResult.NextFire);
+    }
+
+    private async Task HandleListAsync(ListRemindersCommand cmd)
+    {
+        var replyTo = Sender;
         try
         {
-            var result = await _client!.ListRemindersAsync();
-            var infos = new List<ReminderInfo>();
+            var definitions = _definitionStore.List();
+            var schedules = await ListScheduledRemindersAsync();
 
-            if (result.ResponseCode == FetchRemindersResponseCode.Success)
-            {
-                foreach (var scheduled in result.Reminders)
-                {
-                    if (scheduled.Message is ReminderPayload payload)
-                    {
-                        infos.Add(new ReminderInfo(
-                            payload.Id,
-                            payload.Name,
-                            payload.Prompt,
-                            payload.Schedule,
-                            scheduled.When,
-                            payload.ReportToChannel));
-                    }
-                }
-            }
+            var infos = definitions
+                .Where(d => cmd.IncludeDisabled || d.Enabled)
+                .OrderBy(d => d.Title, StringComparer.OrdinalIgnoreCase)
+                .Select(d => new ReminderInfo(
+                    Id: new ReminderId(d.Id),
+                    Title: d.Title,
+                    Instructions: d.Instructions,
+                    NotifyInstructions: d.NotifyInstructions,
+                    Schedule: d.Schedule,
+                    NextFire: schedules.GetValueOrDefault(d.Id),
+                    Enabled: d.Enabled,
+                    SessionId: d.SessionId,
+                    ReportToChannel: d.ReportToChannel,
+                    ReportToThreadTs: d.ReportToThreadTs,
+                    AgentDefinitionId: d.AgentDefinitionId))
+                .ToList();
 
-            Sender.Tell(new ReminderListResponse(infos));
+            replyTo.Tell(new ReminderListResponse(infos));
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Error listing reminders");
-            Sender.Tell(new ReminderListResponse([]));
+            replyTo.Tell(new ReminderListResponse([]));
         }
     }
 
     private async Task HandleGetAsync(GetReminderCommand cmd)
     {
+        var replyTo = Sender;
         try
         {
-            var result = await _client!.ListRemindersAsync();
-            ReminderInfo? match = null;
-
-            if (result.ResponseCode == FetchRemindersResponseCode.Success)
+            var definition = _definitionStore.Get(cmd.Id);
+            if (definition is null)
             {
-                foreach (var scheduled in result.Reminders)
-                {
-                    if (scheduled.Message is ReminderPayload payload && payload.Id.Value == cmd.Id.Value)
-                    {
-                        match = new ReminderInfo(
-                            payload.Id,
-                            payload.Name,
-                            payload.Prompt,
-                            payload.Schedule,
-                            scheduled.When,
-                            payload.ReportToChannel);
-                        break;
-                    }
-                }
+                replyTo.Tell(new GetReminderResponse(null));
+                return;
             }
 
-            Sender.Tell(new GetReminderResponse(match));
+            var schedules = await ListScheduledRemindersAsync();
+            var info = new ReminderInfo(
+                Id: cmd.Id,
+                Title: definition.Title,
+                Instructions: definition.Instructions,
+                NotifyInstructions: definition.NotifyInstructions,
+                Schedule: definition.Schedule,
+                NextFire: schedules.GetValueOrDefault(definition.Id),
+                Enabled: definition.Enabled,
+                SessionId: definition.SessionId,
+                ReportToChannel: definition.ReportToChannel,
+                ReportToThreadTs: definition.ReportToThreadTs,
+                AgentDefinitionId: definition.AgentDefinitionId);
+
+            replyTo.Tell(new GetReminderResponse(info));
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Error getting reminder '{0}'", cmd.Id.Value);
-            Sender.Tell(new GetReminderResponse(null));
+            replyTo.Tell(new GetReminderResponse(null));
         }
     }
 
     private async Task HandleReminderFiredAsync(ReminderPayload payload)
     {
-        _log.Info("Reminder fired: '{0}' (id={1})", payload.Name, payload.Id.Value);
+        var reminderId = payload.Id;
+        var definition = _definitionStore.Get(reminderId);
 
-        // For cron schedules, reschedule the next occurrence immediately
-        if (payload.Schedule.Type == ReminderScheduleType.Cron)
+        if (definition is null)
         {
-            var nextFire = CronScheduleHelper.GetNextOccurrence(
-                payload.Schedule.CronExpression!, _timeProvider);
-            if (nextFire is not null)
-            {
-                var key = new ReminderKey(payload.Id.Value);
-                await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
-                _log.Info("Rescheduled cron reminder '{0}', next fire: {1}", payload.Name, nextFire);
-            }
-        }
-
-        // Check concurrency limit
-        if (_activeExecutions.Count >= _config.MaxConcurrentExecutions)
-        {
-            _log.Info("Concurrency limit reached ({0}), deferring reminder '{1}'",
-                _config.MaxConcurrentExecutions, payload.Name);
-            _deferredQueue.Enqueue(payload);
+            _log.Error("Reminder fired for missing definition '{0}'. Cancelling orphaned schedule.", reminderId.Value);
+            await CancelScheduleOnlyAsync(reminderId);
             return;
         }
 
-        StartExecution(payload);
+        if (!definition.Enabled)
+        {
+            _log.Warning("Reminder '{0}' fired while disabled. Cancelling any lingering schedule.", reminderId.Value);
+            await CancelScheduleOnlyAsync(reminderId);
+            RemoveFromDeferredQueue(reminderId);
+            return;
+        }
+
+        // Cron reminders are implemented as recurring single-shot schedules.
+        if (definition.Schedule.Type == ReminderScheduleType.Cron)
+        {
+            var scheduleResult = await ScheduleDefinitionAsync(definition, rescheduleFromNow: true);
+            if (!scheduleResult.IsSuccess)
+            {
+                _log.Warning("Failed to reschedule cron reminder '{0}': {1}", reminderId.Value, scheduleResult.ErrorMessage);
+            }
+        }
+
+        if (_activeExecutionIds.Count >= _config.MaxConcurrentExecutions)
+        {
+            _log.Info("Concurrency limit reached ({0}), deferring reminder '{1}'",
+                _config.MaxConcurrentExecutions, reminderId.Value);
+            _deferredQueue.Enqueue(reminderId);
+            return;
+        }
+
+        StartExecution(definition);
     }
 
-    private void StartExecution(ReminderPayload payload)
+    private async Task HandleExecutionCompletedAsync(ReminderExecutionCompleted completed)
     {
-        _activeExecutions.Add(payload.Id);
-
-        var executionActor = Context.ActorOf(
-            ReminderExecutionActor.CreateProps(payload, _pipeline, _config, _timeProvider),
-            $"exec-{payload.Id.Value}-{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
-
-        _log.Info("Started execution actor for reminder '{0}': {1}", payload.Name, executionActor.Path);
-    }
-
-    private void HandleExecutionCompleted(ReminderExecutionCompleted completed)
-    {
-        _activeExecutions.Remove(completed.Id);
+        if (!_activeExecutionIds.Remove(completed.ExecutionId))
+            return;
 
         if (completed.Success)
         {
@@ -254,22 +405,249 @@ public sealed class ReminderManagerActor : ReceiveActor
             _failureCounts[completed.Id] = count;
 
             _log.Warning("Reminder '{0}' execution failed ({1}/{2}): {3}",
-                completed.Id.Value, count, _config.FailurePauseThreshold, completed.ErrorMessage);
+                completed.Id.Value,
+                count,
+                _config.FailurePauseThreshold,
+                completed.ErrorMessage);
 
             if (count >= _config.FailurePauseThreshold)
             {
-                _log.Warning("Reminder '{0}' hit failure threshold ({1}), auto-cancelling",
-                    completed.Id.Value, _config.FailurePauseThreshold);
-                Self.Tell(new CancelReminderCommand(completed.Id));
+                _log.Warning("Reminder '{0}' hit failure threshold ({1}), disabling",
+                    completed.Id.Value,
+                    _config.FailurePauseThreshold);
+
+                await DisableReminderInternalAsync(completed.Id);
                 _failureCounts.Remove(completed.Id);
             }
         }
 
-        // Process deferred queue
-        if (_deferredQueue.Count > 0 && _activeExecutions.Count < _config.MaxConcurrentExecutions)
+        await ProcessDeferredQueueAsync();
+    }
+
+    private async Task HandleReconcileAsync()
+    {
+        try
         {
-            var next = _deferredQueue.Dequeue();
-            StartExecution(next);
+            var scheduled = await ListScheduledRemindersAsync();
+            var definitions = _definitionStore.List();
+            var definitionsById = definitions.ToDictionary(d => d.Id, StringComparer.Ordinal);
+
+            var cancelledOrphans = 0;
+            foreach (var (id, _) in scheduled)
+            {
+                if (!definitionsById.TryGetValue(id, out var definition) || !definition.Enabled)
+                {
+                    await CancelScheduleOnlyAsync(new ReminderId(id));
+                    cancelledOrphans++;
+                }
+            }
+
+            var restoredSchedules = 0;
+            foreach (var definition in definitions.Where(d => d.Enabled))
+            {
+                if (scheduled.ContainsKey(definition.Id))
+                    continue;
+
+                var result = await ScheduleDefinitionAsync(definition, rescheduleFromNow: true);
+                if (result.IsSuccess)
+                    restoredSchedules++;
+            }
+
+            if (cancelledOrphans > 0 || restoredSchedules > 0)
+            {
+                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}",
+                    cancelledOrphans,
+                    restoredSchedules);
+            }
         }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Reminder reconcile failed");
+        }
+    }
+
+    private void StartExecution(ReminderDefinition definition)
+    {
+        var executionId = Guid.NewGuid();
+        _activeExecutionIds.Add(executionId);
+
+        var actorName = $"exec-{SanitizeActorName(definition.Id)}-{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}";
+        var executionActor = Context.ActorOf(
+            ReminderExecutionActor.CreateProps(
+                executionId,
+                definition,
+                _pipeline,
+                _config,
+                _timeProvider),
+            actorName);
+
+        _log.Info("Started execution actor for reminder '{0}': {1}", definition.Id, executionActor.Path);
+    }
+
+    private async Task ProcessDeferredQueueAsync()
+    {
+        while (_deferredQueue.Count > 0 && _activeExecutionIds.Count < _config.MaxConcurrentExecutions)
+        {
+            var nextId = _deferredQueue.Dequeue();
+            var definition = _definitionStore.Get(nextId);
+            if (definition is null || !definition.Enabled)
+                continue;
+
+            StartExecution(definition);
+        }
+    }
+
+    private void RemoveFromDeferredQueue(ReminderId id)
+    {
+        if (_deferredQueue.Count == 0)
+            return;
+
+        var keep = new Queue<ReminderId>();
+        while (_deferredQueue.Count > 0)
+        {
+            var item = _deferredQueue.Dequeue();
+            if (item != id)
+                keep.Enqueue(item);
+        }
+
+        while (keep.Count > 0)
+            _deferredQueue.Enqueue(keep.Dequeue());
+    }
+
+    private async Task<ScheduleAttempt> ScheduleDefinitionAsync(ReminderDefinition definition, bool rescheduleFromNow)
+    {
+        if (_client is null)
+            return ScheduleAttempt.Fail("Reminder client is not initialized.");
+
+        var id = new ReminderId(definition.Id);
+        var key = new ReminderKey(definition.Id);
+        var payload = new ReminderPayload { Id = id };
+        var now = _timeProvider.GetUtcNow();
+
+        try
+        {
+            switch (definition.Schedule.Type)
+            {
+                case ReminderScheduleType.OneShot:
+                {
+                    if (definition.Schedule.FireAt is null)
+                        return ScheduleAttempt.Fail("One-shot reminders require an absolute fire time.");
+
+                    var fireAt = definition.Schedule.FireAt.Value;
+                    if (fireAt <= now)
+                        return ScheduleAttempt.Fail("One-shot fire time is in the past.");
+
+                    var result = await _client.ScheduleSingleReminderAsync(key, fireAt, payload);
+                    return result.ResponseCode == ReminderScheduleResponseCode.Success
+                        ? ScheduleAttempt.Ok(fireAt)
+                        : ScheduleAttempt.Fail(result.Message ?? "Failed to schedule one-shot reminder.");
+                }
+
+                case ReminderScheduleType.Interval:
+                {
+                    if (definition.Schedule.Interval is null)
+                        return ScheduleAttempt.Fail("Interval reminders require an interval duration.");
+
+                    var interval = definition.Schedule.Interval.Value;
+                    var first = rescheduleFromNow
+                        ? now.Add(interval)
+                        : definition.Schedule.FireAt is { } explicitFirst && explicitFirst > now
+                            ? explicitFirst
+                            : now.Add(interval);
+
+                    definition.Schedule.FireAt = first;
+
+                    var result = await _client.ScheduleRecurringReminderAsync(key, first, interval, payload);
+                    return result.ResponseCode == ReminderScheduleResponseCode.Success
+                        ? ScheduleAttempt.Ok(first)
+                        : ScheduleAttempt.Fail(result.Message ?? "Failed to schedule interval reminder.");
+                }
+
+                case ReminderScheduleType.Cron:
+                {
+                    if (string.IsNullOrWhiteSpace(definition.Schedule.CronExpression))
+                        return ScheduleAttempt.Fail("Cron reminders require a cron expression.");
+
+                    var nextFire = CronScheduleHelper.GetNextOccurrence(definition.Schedule.CronExpression, _timeProvider);
+                    if (nextFire is null)
+                        return ScheduleAttempt.Fail("Cron schedule has no future occurrence.");
+
+                    var result = await _client.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
+                    return result.ResponseCode == ReminderScheduleResponseCode.Success
+                        ? ScheduleAttempt.Ok(nextFire)
+                        : ScheduleAttempt.Fail(result.Message ?? "Failed to schedule cron reminder.");
+                }
+
+                default:
+                    return ScheduleAttempt.Fail("Unknown schedule type.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error scheduling reminder '{0}'", definition.Id);
+            return ScheduleAttempt.Fail(ex.Message);
+        }
+    }
+
+    private async Task<Dictionary<string, DateTimeOffset?>> ListScheduledRemindersAsync()
+    {
+        var map = new Dictionary<string, DateTimeOffset?>(StringComparer.Ordinal);
+
+        if (_client is null)
+            return map;
+
+        var result = await _client.ListRemindersAsync();
+        if (result.ResponseCode != FetchRemindersResponseCode.Success)
+            return map;
+
+        foreach (var scheduled in result.Reminders)
+        {
+            if (scheduled.Message is ReminderPayload payload)
+                map[payload.Id.Value] = scheduled.When;
+            // Ignore unknown payload types
+        }
+
+        return map;
+    }
+
+    private async Task<bool> CancelScheduleOnlyAsync(ReminderId id)
+    {
+        if (_client is null)
+            return false;
+
+        try
+        {
+            var result = await _client.CancelReminderAsync(new ReminderKey(id.Value));
+            return result.ResponseCode == ReminderCancelResponseCode.Success;
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error cancelling reminder schedule '{0}'", id.Value);
+            return false;
+        }
+    }
+
+    [GeneratedRegex("[^a-zA-Z0-9_-]", RegexOptions.Compiled)]
+    private static partial Regex InvalidActorNameChars();
+
+    private static string SanitizeActorName(string raw)
+    {
+        var sanitized = InvalidActorNameChars().Replace(raw, "-");
+        if (string.IsNullOrWhiteSpace(sanitized))
+            return "reminder";
+        if (sanitized.Length > 60)
+            return sanitized[..60];
+        return sanitized;
+    }
+
+    private sealed record ScheduleAttempt(bool IsSuccess, DateTimeOffset? NextFire, string? ErrorMessage)
+    {
+        public static ScheduleAttempt Ok(DateTimeOffset? nextFire) => new(true, nextFire, null);
+        public static ScheduleAttempt Fail(string message) => new(false, null, message);
+    }
+
+    private sealed record ReconcileReminders
+    {
+        public static readonly ReconcileReminders Instance = new();
     }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -1,0 +1,240 @@
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Akka.Reminders;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Hosting;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Singleton actor that mediates between akka-reminders and session execution.
+/// Handles scheduling, cancellation, listing, and reminder-fire delivery.
+/// </summary>
+public sealed class ReminderManagerActor : ReceiveActor
+{
+    public const string ShardRegionName = "netclaw-reminders";
+    public const string EntityId = "manager";
+
+    private readonly ReminderConfig _config;
+    private readonly SessionPipeline _pipeline;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILoggingAdapter _log;
+
+    private IReminderClient? _client;
+
+    // Concurrency tracking
+    private readonly HashSet<ReminderId> _activeExecutions = new();
+    private readonly Queue<ReminderPayload> _deferredQueue = new();
+
+    // Failure tracking: consecutive failures per reminder
+    private readonly Dictionary<ReminderId, int> _failureCounts = new();
+
+    public ReminderManagerActor(
+        ReminderConfig config,
+        SessionPipeline pipeline,
+        TimeProvider timeProvider)
+    {
+        _config = config;
+        _pipeline = pipeline;
+        _timeProvider = timeProvider;
+        _log = Context.GetLogger();
+
+        ReceiveAsync<ScheduleReminderCommand>(HandleScheduleAsync);
+        ReceiveAsync<CancelReminderCommand>(HandleCancelAsync);
+        ReceiveAsync<ListRemindersCommand>(HandleListAsync);
+        ReceiveAsync<ReminderPayload>(HandleReminderFiredAsync);
+        Receive<ReminderExecutionCompleted>(HandleExecutionCompleted);
+    }
+
+    protected override void PreStart()
+    {
+        var extension = ReminderClientExtension.Get(Context.System);
+        _client = extension.CreateClient(new ReminderEntity(ShardRegionName, EntityId));
+        _log.Info("ReminderManagerActor started");
+    }
+
+    private async Task HandleScheduleAsync(ScheduleReminderCommand cmd)
+    {
+        var payload = cmd.Payload;
+        var key = new ReminderKey(payload.Id.Value);
+
+        try
+        {
+            Akka.Reminders.ReminderProtocol.ReminderScheduled result;
+            DateTimeOffset? nextFire;
+
+            switch (payload.Schedule.Type)
+            {
+                case ReminderScheduleType.OneShot:
+                    nextFire = payload.Schedule.FireAt!.Value;
+                    result = await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
+                    break;
+
+                case ReminderScheduleType.Interval:
+                    nextFire = payload.Schedule.FireAt ?? _timeProvider.GetUtcNow().Add(payload.Schedule.Interval!.Value);
+                    result = await _client!.ScheduleRecurringReminderAsync(
+                        key, nextFire.Value, payload.Schedule.Interval!.Value, payload);
+                    break;
+
+                case ReminderScheduleType.Cron:
+                    nextFire = CronScheduleHelper.GetNextOccurrence(
+                        payload.Schedule.CronExpression!, _timeProvider);
+                    if (nextFire is null)
+                    {
+                        Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
+                        return;
+                    }
+                    result = await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
+                    break;
+
+                default:
+                    Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
+                    return;
+            }
+
+            if (result.ResponseCode == ReminderScheduleResponseCode.Success)
+            {
+                _log.Info("Scheduled reminder '{0}' ({1}), next fire: {2}",
+                    payload.Name, payload.Schedule.Type, nextFire);
+            }
+            else
+            {
+                _log.Warning("Failed to schedule reminder '{0}': {1}", payload.Name, result.Message);
+            }
+
+            Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, nextFire));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error scheduling reminder '{0}'", payload.Name);
+            Sender.Tell(new ReminderScheduledResponse(payload.Id, payload.Name, null));
+        }
+    }
+
+    private async Task HandleCancelAsync(CancelReminderCommand cmd)
+    {
+        var key = new ReminderKey(cmd.Id.Value);
+        try
+        {
+            var result = await _client!.CancelReminderAsync(key);
+            var found = result.ResponseCode == ReminderCancelResponseCode.Success;
+            _failureCounts.Remove(cmd.Id);
+            _log.Info("Cancel reminder '{0}': {1}", cmd.Id.Value, found ? "found and cancelled" : "not found");
+            Sender.Tell(new ReminderCancelledResponse(cmd.Id, found));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error cancelling reminder '{0}'", cmd.Id.Value);
+            Sender.Tell(new ReminderCancelledResponse(cmd.Id, false));
+        }
+    }
+
+    private async Task HandleListAsync(ListRemindersCommand _)
+    {
+        try
+        {
+            var result = await _client!.ListRemindersAsync();
+            var infos = new List<ReminderInfo>();
+
+            if (result.ResponseCode == FetchRemindersResponseCode.Success)
+            {
+                foreach (var scheduled in result.Reminders)
+                {
+                    if (scheduled.Message is ReminderPayload payload)
+                    {
+                        infos.Add(new ReminderInfo(
+                            payload.Id,
+                            payload.Name,
+                            payload.Prompt,
+                            payload.Schedule,
+                            scheduled.When,
+                            payload.ReportToChannel));
+                    }
+                }
+            }
+
+            Sender.Tell(new ReminderListResponse(infos));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Error listing reminders");
+            Sender.Tell(new ReminderListResponse([]));
+        }
+    }
+
+    private async Task HandleReminderFiredAsync(ReminderPayload payload)
+    {
+        _log.Info("Reminder fired: '{0}' (id={1})", payload.Name, payload.Id.Value);
+
+        // For cron schedules, reschedule the next occurrence immediately
+        if (payload.Schedule.Type == ReminderScheduleType.Cron)
+        {
+            var nextFire = CronScheduleHelper.GetNextOccurrence(
+                payload.Schedule.CronExpression!, _timeProvider);
+            if (nextFire is not null)
+            {
+                var key = new ReminderKey(payload.Id.Value);
+                await _client!.ScheduleSingleReminderAsync(key, nextFire.Value, payload);
+                _log.Info("Rescheduled cron reminder '{0}', next fire: {1}", payload.Name, nextFire);
+            }
+        }
+
+        // Check concurrency limit
+        if (_activeExecutions.Count >= _config.MaxConcurrentExecutions)
+        {
+            _log.Info("Concurrency limit reached ({0}), deferring reminder '{1}'",
+                _config.MaxConcurrentExecutions, payload.Name);
+            _deferredQueue.Enqueue(payload);
+            return;
+        }
+
+        StartExecution(payload);
+    }
+
+    private void StartExecution(ReminderPayload payload)
+    {
+        _activeExecutions.Add(payload.Id);
+
+        var executionActor = Context.ActorOf(
+            ReminderExecutionActor.CreateProps(payload, _pipeline, _config, _timeProvider),
+            $"exec-{payload.Id.Value}-{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
+
+        _log.Info("Started execution actor for reminder '{0}': {1}", payload.Name, executionActor.Path);
+    }
+
+    private void HandleExecutionCompleted(ReminderExecutionCompleted completed)
+    {
+        _activeExecutions.Remove(completed.Id);
+
+        if (completed.Success)
+        {
+            _failureCounts.Remove(completed.Id);
+            _log.Info("Reminder '{0}' execution completed successfully", completed.Id.Value);
+        }
+        else
+        {
+            var count = _failureCounts.GetValueOrDefault(completed.Id) + 1;
+            _failureCounts[completed.Id] = count;
+
+            _log.Warning("Reminder '{0}' execution failed ({1}/{2}): {3}",
+                completed.Id.Value, count, _config.FailurePauseThreshold, completed.ErrorMessage);
+
+            if (count >= _config.FailurePauseThreshold)
+            {
+                _log.Warning("Reminder '{0}' hit failure threshold ({1}), auto-cancelling",
+                    completed.Id.Value, _config.FailurePauseThreshold);
+                Self.Tell(new CancelReminderCommand(completed.Id));
+                _failureCounts.Remove(completed.Id);
+            }
+        }
+
+        // Process deferred queue
+        if (_deferredQueue.Count > 0 && _activeExecutions.Count < _config.MaxConcurrentExecutions)
+        {
+            var next = _deferredQueue.Dequeue();
+            StartExecution(next);
+        }
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -1,0 +1,119 @@
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Strongly-typed reminder identity.
+/// </summary>
+public readonly record struct ReminderId(string Value)
+{
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// The type of schedule for a reminder.
+/// </summary>
+public enum ReminderScheduleType
+{
+    OneShot,
+    Interval,
+    Cron
+}
+
+/// <summary>
+/// Describes when and how a reminder fires.
+/// </summary>
+public sealed record ReminderSchedule
+{
+    public required ReminderScheduleType Type { get; init; }
+
+    /// <summary>
+    /// For OneShot: the absolute fire time.
+    /// For Interval/Cron: the first fire time.
+    /// </summary>
+    public DateTimeOffset? FireAt { get; init; }
+
+    /// <summary>
+    /// For Interval schedules: the repeat interval.
+    /// </summary>
+    public TimeSpan? Interval { get; init; }
+
+    /// <summary>
+    /// For Cron schedules: the cron expression.
+    /// </summary>
+    public string? CronExpression { get; init; }
+
+    /// <summary>
+    /// Original schedule string as provided by the user (e.g. "6h", "0 */6 * * *").
+    /// </summary>
+    public string? OriginalExpression { get; init; }
+}
+
+/// <summary>
+/// Payload stored with a reminder and delivered when it fires.
+/// This is the <c>message</c> object passed to akka-reminders.
+/// </summary>
+public sealed record ReminderPayload
+{
+    public required ReminderId Id { get; init; }
+    public required string Name { get; init; }
+    public required string Prompt { get; init; }
+    public required ReminderSchedule Schedule { get; init; }
+
+    /// <summary>
+    /// Slack channel to post results to. Null = log-only for autonomous reminders.
+    /// </summary>
+    public string? ReportToChannel { get; init; }
+
+    /// <summary>
+    /// Slack thread TS for self-targeting reminders. Null = create new thread.
+    /// </summary>
+    public string? ReportToThreadTs { get; init; }
+
+    /// <summary>
+    /// The session ID that created this reminder (for self-targeting).
+    /// </summary>
+    public SessionId? OriginatingSessionId { get; init; }
+
+    public string CreatedBy { get; init; } = "system";
+    public DateTimeOffset CreatedAt { get; init; }
+}
+
+// ── Commands ──
+
+public sealed record ScheduleReminderCommand(ReminderPayload Payload);
+public sealed record CancelReminderCommand(ReminderId Id);
+public sealed record ListRemindersCommand;
+
+// ── Responses ──
+
+public sealed record ReminderScheduledResponse(ReminderId Id, string Name, DateTimeOffset? NextFire);
+public sealed record ReminderCancelledResponse(ReminderId Id, bool Found);
+public sealed record ReminderListResponse(IReadOnlyList<ReminderInfo> Reminders);
+
+public sealed record ReminderInfo(
+    ReminderId Id,
+    string Name,
+    string Prompt,
+    ReminderSchedule Schedule,
+    DateTimeOffset? NextFire,
+    string? ReportToChannel);
+
+// ── Internal messages ──
+
+/// <summary>
+/// Sent by <see cref="ReminderExecutionActor"/> to parent when execution completes.
+/// </summary>
+internal sealed record ReminderExecutionCompleted(ReminderId Id, bool Success, string? ErrorMessage = null);
+
+/// <summary>
+/// REST API request body for creating a reminder.
+/// </summary>
+public sealed record CreateReminderRequest
+{
+    public required string Name { get; init; }
+    public required string Prompt { get; init; }
+    public required string ScheduleType { get; init; }
+    public required string Schedule { get; init; }
+    public string? ReportToChannel { get; init; }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -1,4 +1,4 @@
-using Netclaw.Actors.Protocol;
+using System.Text.Json.Serialization;
 using ProtoBuf;
 
 namespace Netclaw.Actors.Reminders;
@@ -35,8 +35,8 @@ public sealed class ReminderSchedule
 
     /// <summary>
     /// For OneShot: the absolute fire time.
-    /// For Interval/Cron: the first fire time.
-    /// Stored as milliseconds since Unix epoch for serialization.
+    /// For Interval: optional explicit first fire.
+    /// For Cron: not used.
     /// </summary>
     [ProtoMember(2)]
     public long? FireAtMs { get; set; }
@@ -49,8 +49,7 @@ public sealed class ReminderSchedule
     }
 
     /// <summary>
-    /// For Interval schedules: the repeat interval.
-    /// Stored as ticks for serialization.
+    /// For Interval schedules: repeat interval.
     /// </summary>
     [ProtoMember(3)]
     public long? IntervalTicks { get; set; }
@@ -63,94 +62,147 @@ public sealed class ReminderSchedule
     }
 
     /// <summary>
-    /// For Cron schedules: the cron expression.
+    /// For Cron schedules: cron expression.
     /// </summary>
     [ProtoMember(4)]
     public string? CronExpression { get; set; }
 
     /// <summary>
-    /// Original schedule string as provided by the user (e.g. "6h", "0 */6 * * *").
+    /// Original expression as entered by user (e.g. "6h", "0 */6 * * *").
     /// </summary>
     [ProtoMember(5)]
     public string? OriginalExpression { get; set; }
 }
 
 /// <summary>
-/// Payload stored with a reminder and delivered when it fires.
-/// This is the <c>message</c> object passed to akka-reminders.
+/// Canonical reminder definition persisted to disk.
+/// </summary>
+public sealed record ReminderDefinition
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public required ReminderSchedule Schedule { get; init; }
+    public required string Instructions { get; init; }
+    public required string NotifyInstructions { get; init; }
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Optional session to resume when running this reminder.
+    /// Useful for routing responses back to the originating Slack thread.
+    /// </summary>
+    public string? SessionId { get; init; }
+
+    public string? ReportToChannel { get; init; }
+    public string? ReportToThreadTs { get; init; }
+
+    /// <summary>
+    /// Deferred shadow field for selecting specialized agent behavior.
+    /// Tracked by issue #147.
+    /// </summary>
+    public string? AgentDefinitionId { get; init; }
+
+    public string CreatedBy { get; init; } = "system";
+    public long CreatedAtMs { get; set; }
+    public long UpdatedAtMs { get; set; }
+
+    [JsonIgnore]
+    public DateTimeOffset CreatedAt
+    {
+        get => DateTimeOffset.FromUnixTimeMilliseconds(CreatedAtMs);
+        set => CreatedAtMs = value.ToUnixTimeMilliseconds();
+    }
+
+    [JsonIgnore]
+    public DateTimeOffset UpdatedAt
+    {
+        get => DateTimeOffset.FromUnixTimeMilliseconds(UpdatedAtMs);
+        set => UpdatedAtMs = value.ToUnixTimeMilliseconds();
+    }
+}
+
+/// <summary>
+/// Message persisted inside Akka.Reminders. Intentionally lightweight: pointer to disk definition.
 /// </summary>
 [ProtoContract]
 public sealed class ReminderPayload
 {
     [ProtoMember(1)]
     public ReminderId Id { get; set; }
+}
 
-    [ProtoMember(2)]
-    public string Name { get; set; } = string.Empty;
+public enum ReminderWriteMode
+{
+    CreateOnly,
+    Replace,
+    Upsert
+}
 
-    [ProtoMember(3)]
-    public string Prompt { get; set; } = string.Empty;
-
-    [ProtoMember(4)]
-    public ReminderSchedule Schedule { get; set; } = new();
-
-    /// <summary>
-    /// Slack channel to post results to. Null = log-only for autonomous reminders.
-    /// </summary>
-    [ProtoMember(5)]
-    public string? ReportToChannel { get; set; }
-
-    /// <summary>
-    /// Slack thread TS for self-targeting reminders. Null = create new thread.
-    /// </summary>
-    [ProtoMember(6)]
-    public string? ReportToThreadTs { get; set; }
-
-    /// <summary>
-    /// The session ID that created this reminder (for self-targeting).
-    /// </summary>
-    [ProtoMember(7)]
-    public SessionId? OriginatingSessionId { get; set; }
-
-    [ProtoMember(8)]
-    public string CreatedBy { get; set; } = "system";
-
-    [ProtoMember(9)]
-    public long CreatedAtMs { get; set; }
-
-    [ProtoIgnore]
-    public DateTimeOffset CreatedAt
-    {
-        get => DateTimeOffset.FromUnixTimeMilliseconds(CreatedAtMs);
-        set => CreatedAtMs = value.ToUnixTimeMilliseconds();
-    }
+public enum ReminderSaveError
+{
+    None,
+    Conflict,
+    NotFound,
+    Validation,
+    Internal
 }
 
 // ── Commands ──
 
-public sealed record ScheduleReminderCommand(ReminderPayload Payload);
+public sealed record SaveReminderCommand(
+    ReminderDefinition Definition,
+    ReminderWriteMode WriteMode = ReminderWriteMode.CreateOnly);
+
+/// <summary>
+/// Permanently deletes a reminder definition and cancels any active schedule.
+/// </summary>
 public sealed record CancelReminderCommand(ReminderId Id);
-public sealed record ListRemindersCommand;
+public sealed record DisableReminderCommand(ReminderId Id);
+public sealed record EnableReminderCommand(ReminderId Id);
+public sealed record ListRemindersCommand(bool IncludeDisabled = true);
 public sealed record GetReminderCommand(ReminderId Id);
 
 // ── Responses ──
 
-public sealed record ReminderScheduledResponse(ReminderId Id, string Name, DateTimeOffset? NextFire);
+public sealed record ReminderSavedResponse(
+    ReminderId Id,
+    string Title,
+    bool Success,
+    DateTimeOffset? NextFire,
+    ReminderSaveError Error = ReminderSaveError.None,
+    string? ErrorMessage = null);
+
 public sealed record ReminderCancelledResponse(ReminderId Id, bool Found);
+
+public sealed record ReminderStateResponse(
+    ReminderId Id,
+    bool Found,
+    bool Enabled,
+    DateTimeOffset? NextFire = null,
+    string? ErrorMessage = null);
+
 public sealed record ReminderListResponse(IReadOnlyList<ReminderInfo> Reminders);
 public sealed record GetReminderResponse(ReminderInfo? Reminder);
 
 public sealed record ReminderInfo(
     ReminderId Id,
-    string Name,
-    string Prompt,
+    string Title,
+    string Instructions,
+    string NotifyInstructions,
     ReminderSchedule Schedule,
     DateTimeOffset? NextFire,
-    string? ReportToChannel);
+    bool Enabled,
+    string? SessionId,
+    string? ReportToChannel,
+    string? ReportToThreadTs,
+    string? AgentDefinitionId);
 
 // ── Internal messages ──
 
 /// <summary>
 /// Sent by <see cref="ReminderExecutionActor"/> to parent when execution completes.
 /// </summary>
-internal sealed record ReminderExecutionCompleted(ReminderId Id, bool Success, string? ErrorMessage = null);
+internal sealed record ReminderExecutionCompleted(
+    Guid ExecutionId,
+    ReminderId Id,
+    bool Success,
+    string? ErrorMessage = null);

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -1,11 +1,14 @@
 using Netclaw.Actors.Protocol;
+using ProtoBuf;
 
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
 /// Strongly-typed reminder identity.
 /// </summary>
-public readonly record struct ReminderId(string Value)
+[ProtoContract]
+public readonly record struct ReminderId(
+    [property: ProtoMember(1)] string Value)
 {
     public override string ToString() => Value;
 }
@@ -13,70 +16,114 @@ public readonly record struct ReminderId(string Value)
 /// <summary>
 /// The type of schedule for a reminder.
 /// </summary>
+[ProtoContract]
 public enum ReminderScheduleType
 {
-    OneShot,
-    Interval,
-    Cron
+    OneShot = 0,
+    Interval = 1,
+    Cron = 2
 }
 
 /// <summary>
 /// Describes when and how a reminder fires.
 /// </summary>
-public sealed record ReminderSchedule
+[ProtoContract]
+public sealed class ReminderSchedule
 {
-    public required ReminderScheduleType Type { get; init; }
+    [ProtoMember(1)]
+    public ReminderScheduleType Type { get; set; }
 
     /// <summary>
     /// For OneShot: the absolute fire time.
     /// For Interval/Cron: the first fire time.
+    /// Stored as milliseconds since Unix epoch for serialization.
     /// </summary>
-    public DateTimeOffset? FireAt { get; init; }
+    [ProtoMember(2)]
+    public long? FireAtMs { get; set; }
+
+    [ProtoIgnore]
+    public DateTimeOffset? FireAt
+    {
+        get => FireAtMs is not null ? DateTimeOffset.FromUnixTimeMilliseconds(FireAtMs.Value) : null;
+        set => FireAtMs = value?.ToUnixTimeMilliseconds();
+    }
 
     /// <summary>
     /// For Interval schedules: the repeat interval.
+    /// Stored as ticks for serialization.
     /// </summary>
-    public TimeSpan? Interval { get; init; }
+    [ProtoMember(3)]
+    public long? IntervalTicks { get; set; }
+
+    [ProtoIgnore]
+    public TimeSpan? Interval
+    {
+        get => IntervalTicks is not null ? TimeSpan.FromTicks(IntervalTicks.Value) : null;
+        set => IntervalTicks = value?.Ticks;
+    }
 
     /// <summary>
     /// For Cron schedules: the cron expression.
     /// </summary>
-    public string? CronExpression { get; init; }
+    [ProtoMember(4)]
+    public string? CronExpression { get; set; }
 
     /// <summary>
     /// Original schedule string as provided by the user (e.g. "6h", "0 */6 * * *").
     /// </summary>
-    public string? OriginalExpression { get; init; }
+    [ProtoMember(5)]
+    public string? OriginalExpression { get; set; }
 }
 
 /// <summary>
 /// Payload stored with a reminder and delivered when it fires.
 /// This is the <c>message</c> object passed to akka-reminders.
 /// </summary>
-public sealed record ReminderPayload
+[ProtoContract]
+public sealed class ReminderPayload
 {
-    public required ReminderId Id { get; init; }
-    public required string Name { get; init; }
-    public required string Prompt { get; init; }
-    public required ReminderSchedule Schedule { get; init; }
+    [ProtoMember(1)]
+    public ReminderId Id { get; set; }
+
+    [ProtoMember(2)]
+    public string Name { get; set; } = string.Empty;
+
+    [ProtoMember(3)]
+    public string Prompt { get; set; } = string.Empty;
+
+    [ProtoMember(4)]
+    public ReminderSchedule Schedule { get; set; } = new();
 
     /// <summary>
     /// Slack channel to post results to. Null = log-only for autonomous reminders.
     /// </summary>
-    public string? ReportToChannel { get; init; }
+    [ProtoMember(5)]
+    public string? ReportToChannel { get; set; }
 
     /// <summary>
     /// Slack thread TS for self-targeting reminders. Null = create new thread.
     /// </summary>
-    public string? ReportToThreadTs { get; init; }
+    [ProtoMember(6)]
+    public string? ReportToThreadTs { get; set; }
 
     /// <summary>
     /// The session ID that created this reminder (for self-targeting).
     /// </summary>
-    public SessionId? OriginatingSessionId { get; init; }
+    [ProtoMember(7)]
+    public SessionId? OriginatingSessionId { get; set; }
 
-    public string CreatedBy { get; init; } = "system";
-    public DateTimeOffset CreatedAt { get; init; }
+    [ProtoMember(8)]
+    public string CreatedBy { get; set; } = "system";
+
+    [ProtoMember(9)]
+    public long CreatedAtMs { get; set; }
+
+    [ProtoIgnore]
+    public DateTimeOffset CreatedAt
+    {
+        get => DateTimeOffset.FromUnixTimeMilliseconds(CreatedAtMs);
+        set => CreatedAtMs = value.ToUnixTimeMilliseconds();
+    }
 }
 
 // ── Commands ──
@@ -84,12 +131,14 @@ public sealed record ReminderPayload
 public sealed record ScheduleReminderCommand(ReminderPayload Payload);
 public sealed record CancelReminderCommand(ReminderId Id);
 public sealed record ListRemindersCommand;
+public sealed record GetReminderCommand(ReminderId Id);
 
 // ── Responses ──
 
 public sealed record ReminderScheduledResponse(ReminderId Id, string Name, DateTimeOffset? NextFire);
 public sealed record ReminderCancelledResponse(ReminderId Id, bool Found);
 public sealed record ReminderListResponse(IReadOnlyList<ReminderInfo> Reminders);
+public sealed record GetReminderResponse(ReminderInfo? Reminder);
 
 public sealed record ReminderInfo(
     ReminderId Id,
@@ -105,15 +154,3 @@ public sealed record ReminderInfo(
 /// Sent by <see cref="ReminderExecutionActor"/> to parent when execution completes.
 /// </summary>
 internal sealed record ReminderExecutionCompleted(ReminderId Id, bool Success, string? ErrorMessage = null);
-
-/// <summary>
-/// REST API request body for creating a reminder.
-/// </summary>
-public sealed record CreateReminderRequest
-{
-    public required string Name { get; init; }
-    public required string Prompt { get; init; }
-    public required string ScheduleType { get; init; }
-    public required string Schedule { get; init; }
-    public string? ReportToChannel { get; init; }
-}

--- a/src/Netclaw.Actors/Reminders/ReminderScheduleParser.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderScheduleParser.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Reminders;
+
+public static partial class ReminderScheduleParser
+{
+    [GeneratedRegex(
+        "^(?:every\\s+)?(\\d+)\\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex RelativeTimePattern();
+
+    public static (ReminderSchedule? Schedule, string? Error) Parse(
+        string scheduleType,
+        string scheduleValue,
+        TimeProvider timeProvider,
+        ReminderConfig config)
+    {
+        var type = scheduleType.ToLowerInvariant() switch
+        {
+            "once" or "one-shot" or "oneshot" => ReminderScheduleType.OneShot,
+            "interval" or "recurring" or "repeat" => ReminderScheduleType.Interval,
+            "cron" => ReminderScheduleType.Cron,
+            _ => (ReminderScheduleType?)null
+        };
+
+        if (type is null)
+            return (null, $"Unknown schedule type '{scheduleType}'. Use 'once', 'interval', or 'cron'.");
+
+        switch (type.Value)
+        {
+            case ReminderScheduleType.OneShot:
+            {
+                var fireAt = ParseTimeValue(scheduleValue, timeProvider);
+                if (fireAt is null)
+                {
+                    return (null,
+                        $"Cannot parse schedule '{scheduleValue}'. Use relative time (e.g. '30m', '2h') or ISO 8601 datetime.");
+                }
+
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.OneShot,
+                    FireAt = fireAt,
+                    OriginalExpression = scheduleValue
+                }, null);
+            }
+
+            case ReminderScheduleType.Interval:
+            {
+                var interval = ParseDuration(scheduleValue);
+                if (interval is null)
+                    return (null, $"Cannot parse interval '{scheduleValue}'. Use format like '30m', '2h', '1d'.");
+                if (interval.Value.TotalSeconds < config.MinIntervalSeconds)
+                    return (null, $"Minimum interval is {config.MinIntervalSeconds} seconds.");
+
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.Interval,
+                    Interval = interval,
+                    FireAt = timeProvider.GetUtcNow().Add(interval.Value),
+                    OriginalExpression = scheduleValue
+                }, null);
+            }
+
+            case ReminderScheduleType.Cron:
+            {
+                if (!CronScheduleHelper.TryParse(scheduleValue))
+                {
+                    return (null,
+                        $"Invalid cron expression '{scheduleValue}'. Use standard 5-field format (minute hour day month weekday).");
+                }
+
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.Cron,
+                    CronExpression = scheduleValue,
+                    OriginalExpression = scheduleValue
+                }, null);
+            }
+
+            default:
+                return (null, "Unknown schedule type.");
+        }
+    }
+
+    private static DateTimeOffset? ParseTimeValue(string value, TimeProvider timeProvider)
+    {
+        var duration = ParseDuration(value);
+        if (duration is not null)
+            return timeProvider.GetUtcNow().Add(duration.Value);
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal, out var parsed))
+            return parsed;
+
+        return null;
+    }
+
+    private static TimeSpan? ParseDuration(string value)
+    {
+        var match = RelativeTimePattern().Match(value.Trim());
+        if (!match.Success)
+            return null;
+
+        var amount = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        var unit = match.Groups[2].Value.ToLowerInvariant();
+
+        return unit switch
+        {
+            "s" or "sec" or "secs" or "second" or "seconds" => TimeSpan.FromSeconds(amount),
+            "m" or "min" or "mins" or "minute" or "minutes" => TimeSpan.FromMinutes(amount),
+            "h" or "hr" or "hrs" or "hour" or "hours" => TimeSpan.FromHours(amount),
+            "d" or "day" or "days" => TimeSpan.FromDays(amount),
+            _ => null
+        };
+    }
+}

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
-using System.Text.RegularExpressions;
 using Akka.Actor;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
@@ -12,31 +10,28 @@ namespace Netclaw.Actors.Reminders;
 /// LLM tool for scheduling reminders. Supports one-shot, interval, and cron schedules.
 /// </summary>
 [NetclawTool("set_reminder",
-    "Schedule a reminder that will execute a prompt at a specified time or on a recurring schedule. " +
-    "Supports: relative time ('30m', '2h', '1d'), ISO 8601 datetime, interval ('every 6h'), " +
-    "and cron expressions ('0 */6 * * *').",
+    "Schedule a reminder that will execute at a specific time or on a recurring schedule. " +
+    "Supports relative durations ('30m', '2h'), interval schedules ('every 6h'), and cron ('0 */6 * * *').",
     Grant = "scheduling")]
 public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params>
 {
-    private static readonly Regex RelativeTimePattern = new(
-        @"^(?:every\s+)?(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)$",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
     private readonly IActorRef _reminderManager;
     private readonly TimeProvider _timeProvider;
     private readonly ReminderConfig _config;
 
     public record Params(
-        [property: Description("A short name for this reminder (e.g. 'daily-standup', 'check-backups')")]
+        [property: Description("A short title for this reminder (e.g. 'daily-standup').")]
         string Name,
-        [property: Description("The prompt to execute when the reminder fires")]
+        [property: Description("Execution instructions for this reminder.")]
         string Prompt,
-        [property: Description("Schedule type: 'once' for one-shot, 'interval' for recurring interval, 'cron' for cron expression")]
+        [property: Description("Schedule type: 'once', 'interval', or 'cron'.")]
         string ScheduleType,
-        [property: Description("Schedule value: relative time ('30m', '2h'), ISO 8601 datetime, interval duration ('6h'), or cron expression ('0 */6 * * *')")]
+        [property: Description("Schedule value: relative time, ISO 8601 datetime, interval duration, or cron expression.")]
         string Schedule,
-        [property: Description("Optional Slack channel ID to post results to. Omit for self-targeting (posts back to current thread).")]
-        string? ReportToChannel = null);
+        [property: Description("Optional Slack channel ID for reporting. Omit for current-session targeting.")]
+        string? ReportToChannel = null,
+        [property: Description("Optional notify instructions describing how Netclaw should report results.")]
+        string? NotifyInstructions = null);
 
     public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider, ReminderConfig config)
     {
@@ -57,22 +52,26 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
         if (string.IsNullOrWhiteSpace(args.Schedule))
             return "Error: 'schedule' is required.";
 
-        var (schedule, error) = ParseSchedule(args.ScheduleType, args.Schedule);
+        var (schedule, error) = ReminderScheduleParser.Parse(
+            args.ScheduleType,
+            args.Schedule,
+            _timeProvider,
+            _config);
+
         if (schedule is null)
             return $"Error: {error}";
 
-        var id = GenerateId(args.Name);
+        var id = ReminderIdGenerator.Generate(args.Name);
         var now = _timeProvider.GetUtcNow();
 
-        // Determine self-targeting from context
-        SessionId? originatingSession = null;
+        string? sessionId = null;
         string? reportToChannel = args.ReportToChannel;
         string? reportToThreadTs = null;
 
         if (context.SessionId is not null && string.IsNullOrEmpty(reportToChannel))
         {
-            originatingSession = new SessionId(context.SessionId);
-            // Extract channel/thread from session ID (format: channelId/threadTs)
+            sessionId = context.SessionId;
+
             var parts = context.SessionId.Split('/');
             if (parts.Length >= 2)
             {
@@ -81,136 +80,44 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
             }
         }
 
-        var payload = new ReminderPayload
+        var notifyInstructions = args.NotifyInstructions;
+        if (string.IsNullOrWhiteSpace(notifyInstructions))
         {
-            Id = id,
-            Name = args.Name,
-            Prompt = args.Prompt,
+            notifyInstructions = reportToChannel is null
+                ? "Reply in the originating session thread with a concise result."
+                : $"Post the result to Slack channel {reportToChannel}.";
+        }
+
+        var definition = new ReminderDefinition
+        {
+            Id = id.Value,
+            Title = args.Name,
             Schedule = schedule,
+            Instructions = args.Prompt,
+            NotifyInstructions = notifyInstructions,
+            Enabled = true,
+            SessionId = sessionId,
             ReportToChannel = reportToChannel,
             ReportToThreadTs = reportToThreadTs,
-            OriginatingSessionId = originatingSession,
             CreatedBy = "llm-tool",
-            CreatedAt = now
+            CreatedAt = now,
+            UpdatedAt = now
         };
 
-        var response = await _reminderManager.Ask<ReminderScheduledResponse>(
-            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(10), ct);
+        var response = await _reminderManager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition, ReminderWriteMode.CreateOnly), TimeSpan.FromSeconds(10), ct);
 
-        if (response.NextFire is null)
-            return $"Failed to schedule reminder '{args.Name}'. The schedule may have no future occurrence.";
+        if (!response.Success)
+            return $"Failed to schedule reminder '{args.Name}': {response.ErrorMessage ?? "unknown error"}";
 
         var scheduleDesc = schedule.Type switch
         {
             ReminderScheduleType.OneShot => $"once at {response.NextFire:u}",
             ReminderScheduleType.Interval => $"every {schedule.Interval!.Value.TotalMinutes:F0}m, next: {response.NextFire:u}",
             ReminderScheduleType.Cron => $"cron '{schedule.CronExpression}', next: {response.NextFire:u}",
-            _ => response.NextFire.Value.ToString("u")
+            _ => response.NextFire?.ToString("u") ?? "scheduled"
         };
 
         return $"Reminder '{args.Name}' scheduled ({scheduleDesc}). ID: {id.Value}";
-    }
-
-    private (ReminderSchedule? schedule, string? error) ParseSchedule(string scheduleType, string scheduleValue)
-    {
-        var type = scheduleType.ToLowerInvariant() switch
-        {
-            "once" or "one-shot" or "oneshot" => ReminderScheduleType.OneShot,
-            "interval" or "recurring" or "repeat" => ReminderScheduleType.Interval,
-            "cron" => ReminderScheduleType.Cron,
-            _ => (ReminderScheduleType?)null
-        };
-
-        if (type is null)
-            return (null, $"Unknown schedule type '{scheduleType}'. Use 'once', 'interval', or 'cron'.");
-
-        switch (type.Value)
-        {
-            case ReminderScheduleType.OneShot:
-                var fireAt = ParseTimeValue(scheduleValue);
-                if (fireAt is null)
-                    return (null, $"Cannot parse schedule '{scheduleValue}'. Use relative time (e.g. '30m', '2h') or ISO 8601 datetime.");
-                return (new ReminderSchedule
-                {
-                    Type = ReminderScheduleType.OneShot,
-                    FireAt = fireAt,
-                    OriginalExpression = scheduleValue
-                }, null);
-
-            case ReminderScheduleType.Interval:
-                var interval = ParseDuration(scheduleValue);
-                if (interval is null)
-                    return (null, $"Cannot parse interval '{scheduleValue}'. Use format like '30m', '2h', '1d'.");
-                if (interval.Value.TotalSeconds < _config.MinIntervalSeconds)
-                    return (null, $"Minimum interval is {_config.MinIntervalSeconds} seconds.");
-                var firstFire = _timeProvider.GetUtcNow().Add(interval.Value);
-                return (new ReminderSchedule
-                {
-                    Type = ReminderScheduleType.Interval,
-                    Interval = interval,
-                    FireAt = firstFire,
-                    OriginalExpression = scheduleValue
-                }, null);
-
-            case ReminderScheduleType.Cron:
-                if (!CronScheduleHelper.TryParse(scheduleValue))
-                    return (null, $"Invalid cron expression '{scheduleValue}'. Use standard 5-field format (minute hour day month weekday).");
-                return (new ReminderSchedule
-                {
-                    Type = ReminderScheduleType.Cron,
-                    CronExpression = scheduleValue,
-                    OriginalExpression = scheduleValue
-                }, null);
-
-            default:
-                return (null, "Unknown schedule type.");
-        }
-    }
-
-    private DateTimeOffset? ParseTimeValue(string value)
-    {
-        // Try relative time first
-        var duration = ParseDuration(value);
-        if (duration is not null)
-            return _timeProvider.GetUtcNow().Add(duration.Value);
-
-        // Try ISO 8601
-        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal, out var parsed))
-            return parsed;
-
-        return null;
-    }
-
-    private static TimeSpan? ParseDuration(string value)
-    {
-        var match = RelativeTimePattern.Match(value.Trim());
-        if (!match.Success)
-            return null;
-
-        var amount = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
-        var unit = match.Groups[2].Value.ToLowerInvariant();
-
-        return unit switch
-        {
-            "s" or "sec" or "secs" or "second" or "seconds" => TimeSpan.FromSeconds(amount),
-            "m" or "min" or "mins" or "minute" or "minutes" => TimeSpan.FromMinutes(amount),
-            "h" or "hr" or "hrs" or "hour" or "hours" => TimeSpan.FromHours(amount),
-            "d" or "day" or "days" => TimeSpan.FromDays(amount),
-            _ => null
-        };
-    }
-
-    private static ReminderId GenerateId(string name)
-    {
-        var slug = name.ToLowerInvariant()
-            .Replace(' ', '-')
-            .Replace('_', '-');
-        // Keep only alphanumeric and hyphens
-        slug = Regex.Replace(slug, @"[^a-z0-9\-]", "");
-        if (slug.Length > 30)
-            slug = slug[..30];
-        var suffix = Guid.NewGuid().ToString("N")[..6];
-        return new ReminderId($"{slug}-{suffix}");
     }
 }

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Akka.Actor;
 using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Reminders;
@@ -23,6 +24,7 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
 
     private readonly IActorRef _reminderManager;
     private readonly TimeProvider _timeProvider;
+    private readonly ReminderConfig _config;
 
     public record Params(
         [property: Description("A short name for this reminder (e.g. 'daily-standup', 'check-backups')")]
@@ -36,10 +38,11 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
         [property: Description("Optional Slack channel ID to post results to. Omit for self-targeting (posts back to current thread).")]
         string? ReportToChannel = null);
 
-    public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider)
+    public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider, ReminderConfig config)
     {
         _reminderManager = reminderManager;
         _timeProvider = timeProvider;
+        _config = config;
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
@@ -138,8 +141,8 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
                 var interval = ParseDuration(scheduleValue);
                 if (interval is null)
                     return (null, $"Cannot parse interval '{scheduleValue}'. Use format like '30m', '2h', '1d'.");
-                if (interval.Value.TotalSeconds < 60)
-                    return (null, "Minimum interval is 60 seconds.");
+                if (interval.Value.TotalSeconds < _config.MinIntervalSeconds)
+                    return (null, $"Minimum interval is {_config.MinIntervalSeconds} seconds.");
                 var firstFire = _timeProvider.GetUtcNow().Add(interval.Value);
                 return (new ReminderSchedule
                 {

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -1,0 +1,213 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Akka.Actor;
+using Netclaw.Actors.Protocol;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// LLM tool for scheduling reminders. Supports one-shot, interval, and cron schedules.
+/// </summary>
+[NetclawTool("set_reminder",
+    "Schedule a reminder that will execute a prompt at a specified time or on a recurring schedule. " +
+    "Supports: relative time ('30m', '2h', '1d'), ISO 8601 datetime, interval ('every 6h'), " +
+    "and cron expressions ('0 */6 * * *').",
+    Grant = "scheduling")]
+public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params>
+{
+    private static readonly Regex RelativeTimePattern = new(
+        @"^(?:every\s+)?(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IActorRef _reminderManager;
+    private readonly TimeProvider _timeProvider;
+
+    public record Params(
+        [property: Description("A short name for this reminder (e.g. 'daily-standup', 'check-backups')")]
+        string Name,
+        [property: Description("The prompt to execute when the reminder fires")]
+        string Prompt,
+        [property: Description("Schedule type: 'once' for one-shot, 'interval' for recurring interval, 'cron' for cron expression")]
+        string ScheduleType,
+        [property: Description("Schedule value: relative time ('30m', '2h'), ISO 8601 datetime, interval duration ('6h'), or cron expression ('0 */6 * * *')")]
+        string Schedule,
+        [property: Description("Optional Slack channel ID to post results to. Omit for self-targeting (posts back to current thread).")]
+        string? ReportToChannel = null);
+
+    public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider)
+    {
+        _reminderManager = reminderManager;
+        _timeProvider = timeProvider;
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
+
+    protected override async Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Name))
+            return "Error: 'name' is required.";
+        if (string.IsNullOrWhiteSpace(args.Prompt))
+            return "Error: 'prompt' is required.";
+        if (string.IsNullOrWhiteSpace(args.Schedule))
+            return "Error: 'schedule' is required.";
+
+        var (schedule, error) = ParseSchedule(args.ScheduleType, args.Schedule);
+        if (schedule is null)
+            return $"Error: {error}";
+
+        var id = GenerateId(args.Name);
+        var now = _timeProvider.GetUtcNow();
+
+        // Determine self-targeting from context
+        SessionId? originatingSession = null;
+        string? reportToChannel = args.ReportToChannel;
+        string? reportToThreadTs = null;
+
+        if (context.SessionId is not null && string.IsNullOrEmpty(reportToChannel))
+        {
+            originatingSession = new SessionId(context.SessionId);
+            // Extract channel/thread from session ID (format: channelId/threadTs)
+            var parts = context.SessionId.Split('/');
+            if (parts.Length >= 2)
+            {
+                reportToChannel = parts[0];
+                reportToThreadTs = parts[1];
+            }
+        }
+
+        var payload = new ReminderPayload
+        {
+            Id = id,
+            Name = args.Name,
+            Prompt = args.Prompt,
+            Schedule = schedule,
+            ReportToChannel = reportToChannel,
+            ReportToThreadTs = reportToThreadTs,
+            OriginatingSessionId = originatingSession,
+            CreatedBy = "llm-tool",
+            CreatedAt = now
+        };
+
+        var response = await _reminderManager.Ask<ReminderScheduledResponse>(
+            new ScheduleReminderCommand(payload), TimeSpan.FromSeconds(10), ct);
+
+        if (response.NextFire is null)
+            return $"Failed to schedule reminder '{args.Name}'. The schedule may have no future occurrence.";
+
+        var scheduleDesc = schedule.Type switch
+        {
+            ReminderScheduleType.OneShot => $"once at {response.NextFire:u}",
+            ReminderScheduleType.Interval => $"every {schedule.Interval!.Value.TotalMinutes:F0}m, next: {response.NextFire:u}",
+            ReminderScheduleType.Cron => $"cron '{schedule.CronExpression}', next: {response.NextFire:u}",
+            _ => response.NextFire.Value.ToString("u")
+        };
+
+        return $"Reminder '{args.Name}' scheduled ({scheduleDesc}). ID: {id.Value}";
+    }
+
+    private (ReminderSchedule? schedule, string? error) ParseSchedule(string scheduleType, string scheduleValue)
+    {
+        var type = scheduleType.ToLowerInvariant() switch
+        {
+            "once" or "one-shot" or "oneshot" => ReminderScheduleType.OneShot,
+            "interval" or "recurring" or "repeat" => ReminderScheduleType.Interval,
+            "cron" => ReminderScheduleType.Cron,
+            _ => (ReminderScheduleType?)null
+        };
+
+        if (type is null)
+            return (null, $"Unknown schedule type '{scheduleType}'. Use 'once', 'interval', or 'cron'.");
+
+        switch (type.Value)
+        {
+            case ReminderScheduleType.OneShot:
+                var fireAt = ParseTimeValue(scheduleValue);
+                if (fireAt is null)
+                    return (null, $"Cannot parse schedule '{scheduleValue}'. Use relative time (e.g. '30m', '2h') or ISO 8601 datetime.");
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.OneShot,
+                    FireAt = fireAt,
+                    OriginalExpression = scheduleValue
+                }, null);
+
+            case ReminderScheduleType.Interval:
+                var interval = ParseDuration(scheduleValue);
+                if (interval is null)
+                    return (null, $"Cannot parse interval '{scheduleValue}'. Use format like '30m', '2h', '1d'.");
+                if (interval.Value.TotalSeconds < 60)
+                    return (null, "Minimum interval is 60 seconds.");
+                var firstFire = _timeProvider.GetUtcNow().Add(interval.Value);
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.Interval,
+                    Interval = interval,
+                    FireAt = firstFire,
+                    OriginalExpression = scheduleValue
+                }, null);
+
+            case ReminderScheduleType.Cron:
+                if (!CronScheduleHelper.TryParse(scheduleValue))
+                    return (null, $"Invalid cron expression '{scheduleValue}'. Use standard 5-field format (minute hour day month weekday).");
+                return (new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.Cron,
+                    CronExpression = scheduleValue,
+                    OriginalExpression = scheduleValue
+                }, null);
+
+            default:
+                return (null, "Unknown schedule type.");
+        }
+    }
+
+    private DateTimeOffset? ParseTimeValue(string value)
+    {
+        // Try relative time first
+        var duration = ParseDuration(value);
+        if (duration is not null)
+            return _timeProvider.GetUtcNow().Add(duration.Value);
+
+        // Try ISO 8601
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal, out var parsed))
+            return parsed;
+
+        return null;
+    }
+
+    private static TimeSpan? ParseDuration(string value)
+    {
+        var match = RelativeTimePattern.Match(value.Trim());
+        if (!match.Success)
+            return null;
+
+        var amount = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        var unit = match.Groups[2].Value.ToLowerInvariant();
+
+        return unit switch
+        {
+            "s" or "sec" or "secs" or "second" or "seconds" => TimeSpan.FromSeconds(amount),
+            "m" or "min" or "mins" or "minute" or "minutes" => TimeSpan.FromMinutes(amount),
+            "h" or "hr" or "hrs" or "hour" or "hours" => TimeSpan.FromHours(amount),
+            "d" or "day" or "days" => TimeSpan.FromDays(amount),
+            _ => null
+        };
+    }
+
+    private static ReminderId GenerateId(string name)
+    {
+        var slug = name.ToLowerInvariant()
+            .Replace(' ', '-')
+            .Replace('_', '-');
+        // Keep only alphanumeric and hyphens
+        slug = Regex.Replace(slug, @"[^a-z0-9\-]", "");
+        if (slug.Length > 30)
+            slug = slug[..30];
+        var suffix = Guid.NewGuid().ToString("N")[..6];
+        return new ReminderId($"{slug}-{suffix}");
+    }
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -1,5 +1,7 @@
+using Akka.Actor;
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
+using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Netclaw.Search;
 using Netclaw.Security;
@@ -29,6 +31,21 @@ public static class ToolRegistrationExtensions
         // Register search_tools meta-tool (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry));
 
+        return registry;
+    }
+
+    /// <summary>
+    /// Registers reminder tools (set, cancel, list) that communicate with the
+    /// <see cref="ReminderManagerActor"/> via Ask.
+    /// </summary>
+    public static ToolRegistry WithReminderTools(
+        this ToolRegistry registry,
+        IActorRef reminderManager,
+        TimeProvider timeProvider)
+    {
+        registry.Register(new SetReminderTool(reminderManager, timeProvider));
+        registry.Register(new CancelReminderTool(reminderManager));
+        registry.Register(new ListRemindersTool(reminderManager));
         return registry;
     }
 

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -41,9 +41,10 @@ public static class ToolRegistrationExtensions
     public static ToolRegistry WithReminderTools(
         this ToolRegistry registry,
         IActorRef reminderManager,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ReminderConfig config)
     {
-        registry.Register(new SetReminderTool(reminderManager, timeProvider));
+        registry.Register(new SetReminderTool(reminderManager, timeProvider, config));
         registry.Register(new CancelReminderTool(reminderManager));
         registry.Register(new ListRemindersTool(reminderManager));
         return registry;

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -388,6 +388,27 @@ static async Task RunAsync(string[] args)
     // ── Reminder management ──
     if (mode is "reminder")
     {
+        if (args.Length == 1)
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            builder.Services.AddHttpClient("ReminderApi", client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(10);
+            });
+
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-reminder-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+
+            builder.Services.AddTermina("/reminder", t =>
+                t.RegisterRoute<ReminderCreatePage, ReminderCreateViewModel>("/reminder"));
+
+            await builder.Build().RunAsync();
+            return;
+        }
+
         Environment.ExitCode = await ReminderCommand.RunAsync(args);
         return;
     }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -9,6 +9,7 @@ using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Mcp;
+using Netclaw.Cli.Reminder;
 using Netclaw.Cli.Secrets;
 using Netclaw.Cli.Model;
 using Netclaw.Cli.Provider;
@@ -384,6 +385,13 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    // ── Reminder management ──
+    if (mode is "reminder")
+    {
+        Environment.ExitCode = await ReminderCommand.RunAsync(args);
+        return;
+    }
+
     // ── Secrets management ──
     if (mode is "secrets")
     {
@@ -533,6 +541,7 @@ static void WriteGeneralHelp()
     Console.WriteLine("  mcp                      Manage MCP server profiles");
     Console.WriteLine("  provider                 Manage LLM providers (TUI) or use subcommands");
     Console.WriteLine("  model                    Manage model assignments (TUI) or use subcommands");
+    Console.WriteLine("  reminder                 Manage scheduled reminders (daemon-required)");
     Console.WriteLine("  secrets                  Manage encrypted secrets (set key/value pairs)");
     Console.WriteLine("  init                     First-run setup wizard");
     Console.WriteLine("  update                   Check for and install updates");

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -1,17 +1,20 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Actors.Reminders;
 
 namespace Netclaw.Cli.Reminder;
 
 /// <summary>
-/// Handles <c>netclaw reminder</c> CLI subcommands: list, create, cancel, show.
+/// Handles <c>netclaw reminder</c> CLI subcommands.
 /// All commands require the daemon to be running (HTTP to REST API).
 /// </summary>
 internal static class ReminderCommand
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
-        WriteIndented = true
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
     };
 
     public static async Task<int> RunAsync(string[] args)
@@ -33,7 +36,11 @@ internal static class ReminderCommand
         {
             "list" => await RunListAsync(client, baseUrl),
             "create" => await RunCreateAsync(client, baseUrl, args),
-            "cancel" => await RunCancelAsync(client, baseUrl, args),
+            "cancel" or "delete" => await RunDeleteAsync(client, baseUrl, args),
+            "disable" => await RunDisableAsync(client, baseUrl, args),
+            "enable" => await RunEnableAsync(client, baseUrl, args),
+            "import" => await RunImportAsync(client, baseUrl, args),
+            "validate" => RunValidate(args),
             "show" => await RunShowAsync(client, baseUrl, args),
             _ => WriteHelp()
         };
@@ -133,11 +140,11 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunCancelAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunDeleteAsync(HttpClient client, string baseUrl, string[] args)
     {
         if (args.Length < 3)
         {
-            Console.Error.WriteLine("Usage: netclaw reminder cancel <id>");
+            Console.Error.WriteLine("Usage: netclaw reminder delete <id>");
             return 1;
         }
 
@@ -167,6 +174,208 @@ internal static class ReminderCommand
         {
             Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
             return 1;
+        }
+    }
+
+    private static async Task<int> RunDisableAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder disable <id>");
+            return 1;
+        }
+
+        return await RunSimplePostByIdAsync(client, baseUrl, args[2], "disable");
+    }
+
+    private static async Task<int> RunEnableAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder enable <id>");
+            return 1;
+        }
+
+        return await RunSimplePostByIdAsync(client, baseUrl, args[2], "enable");
+    }
+
+    private static async Task<int> RunSimplePostByIdAsync(HttpClient client, string baseUrl, string id, string action)
+    {
+        try
+        {
+            var response = await client.PostAsync($"{baseUrl}/{id}/{action}", content: null);
+            var json = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+            if (response.IsSuccessStatusCode)
+            {
+                if (result.TryGetProperty("message", out var msg))
+                    Console.WriteLine(msg.GetString());
+                else
+                    Console.WriteLine(json);
+                return 0;
+            }
+
+            if (result.TryGetProperty("error", out var err))
+                Console.Error.WriteLine($"[FAIL] {err.GetString()}");
+            else
+                Console.Error.WriteLine($"[FAIL] {json}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunImportAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder import <file> [--replace|--upsert]");
+            return 1;
+        }
+
+        var filePath = args[2];
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"[FAIL] file not found: {filePath}");
+            return 1;
+        }
+
+        var mode = "create";
+        for (var i = 3; i < args.Length; i++)
+        {
+            if (args[i] == "--replace") mode = "replace";
+            if (args[i] == "--upsert") mode = "upsert";
+        }
+
+        ReminderDefinition? definition;
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            definition = JsonSerializer.Deserialize<ReminderDefinition>(json, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] invalid JSON: {ex.Message}");
+            return 1;
+        }
+
+        if (definition is null)
+        {
+            Console.Error.WriteLine("[FAIL] file does not contain a reminder definition.");
+            return 1;
+        }
+
+        var validation = ValidateDefinition(definition);
+        if (validation is not null)
+        {
+            Console.Error.WriteLine($"[FAIL] {validation}");
+            return 1;
+        }
+
+        try
+        {
+            var response = await client.PostAsJsonAsync($"{baseUrl}/import", new
+            {
+                definition,
+                writeMode = mode
+            }, JsonOptions);
+
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<JsonElement>(body);
+
+            if (response.IsSuccessStatusCode)
+            {
+                if (result.TryGetProperty("message", out var msg))
+                    Console.WriteLine(msg.GetString());
+                else
+                    Console.WriteLine(body);
+                return 0;
+            }
+
+            if (result.TryGetProperty("error", out var err))
+                Console.Error.WriteLine($"[FAIL] {err.GetString()}");
+            else
+                Console.Error.WriteLine($"[FAIL] {body}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static int RunValidate(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder validate <file>");
+            return 1;
+        }
+
+        var filePath = args[2];
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"[FAIL] file not found: {filePath}");
+            return 1;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            var definition = JsonSerializer.Deserialize<ReminderDefinition>(json, JsonOptions);
+            if (definition is null)
+            {
+                Console.Error.WriteLine("[FAIL] file does not contain a reminder definition.");
+                return 1;
+            }
+
+            var validationError = ValidateDefinition(definition);
+            if (validationError is not null)
+            {
+                Console.Error.WriteLine($"[FAIL] {validationError}");
+                return 1;
+            }
+
+            Console.WriteLine($"Reminder definition is valid: {definition.Id}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] invalid JSON: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string? ValidateDefinition(ReminderDefinition definition)
+    {
+        if (string.IsNullOrWhiteSpace(definition.Id))
+            return "Reminder id is required.";
+        if (string.IsNullOrWhiteSpace(definition.Title))
+            return "Reminder title is required.";
+        if (string.IsNullOrWhiteSpace(definition.Instructions))
+            return "Reminder instructions are required.";
+        if (string.IsNullOrWhiteSpace(definition.NotifyInstructions))
+            return "Reminder notifyInstructions is required.";
+        if (definition.Schedule is null)
+            return "Reminder schedule is required.";
+
+        switch (definition.Schedule.Type)
+        {
+            case ReminderScheduleType.OneShot when definition.Schedule.FireAt is null:
+                return "One-shot reminders require schedule.fireAtMs.";
+            case ReminderScheduleType.Interval when definition.Schedule.IntervalTicks is null:
+                return "Interval reminders require schedule.intervalTicks.";
+            case ReminderScheduleType.Cron when string.IsNullOrWhiteSpace(definition.Schedule.CronExpression):
+                return "Cron reminders require schedule.cronExpression.";
+            case ReminderScheduleType.Cron when !CronScheduleHelper.TryParse(definition.Schedule.CronExpression!):
+                return "Cron expression is invalid.";
+            default:
+                return null;
         }
     }
 
@@ -212,7 +421,11 @@ internal static class ReminderCommand
         Console.WriteLine("Subcommands:");
         Console.WriteLine("  list                                          List all active reminders");
         Console.WriteLine("  create <name> <type> <schedule> \"<prompt>\"    Create a reminder");
-        Console.WriteLine("  cancel <id>                                   Cancel a reminder");
+        Console.WriteLine("  delete <id>                                   Delete a reminder");
+        Console.WriteLine("  disable <id>                                  Disable a reminder");
+        Console.WriteLine("  enable <id>                                   Enable a reminder");
+        Console.WriteLine("  import <file> [--replace|--upsert]            Import one reminder file");
+        Console.WriteLine("  validate <file>                               Validate reminder file");
         Console.WriteLine("  show <id>                                     Show reminder details");
         Console.WriteLine();
         Console.WriteLine("Schedule types: once, interval, cron");

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -1,0 +1,224 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Netclaw.Cli.Reminder;
+
+/// <summary>
+/// Handles <c>netclaw reminder</c> CLI subcommands: list, create, cancel, show.
+/// All commands require the daemon to be running (HTTP to REST API).
+/// </summary>
+internal static class ReminderCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var subcommand = args.Length > 1 ? args[1] : "help";
+        if (subcommand is "help" or "-h" or "--help")
+        {
+            WriteHelp();
+            return 0;
+        }
+
+        var endpoint = Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
+            ?? "http://127.0.0.1:5199";
+        var baseUrl = $"{endpoint.TrimEnd('/')}/api/reminders";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+        return subcommand switch
+        {
+            "list" => await RunListAsync(client, baseUrl),
+            "create" => await RunCreateAsync(client, baseUrl, args),
+            "cancel" => await RunCancelAsync(client, baseUrl, args),
+            "show" => await RunShowAsync(client, baseUrl, args),
+            _ => WriteHelp()
+        };
+    }
+
+    private static async Task<int> RunListAsync(HttpClient client, string baseUrl)
+    {
+        try
+        {
+            var response = await client.GetAsync(baseUrl);
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[FAIL] daemon returned {(int)response.StatusCode}");
+                return 1;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var reminders = JsonSerializer.Deserialize<JsonElement>(json);
+
+            if (reminders.ValueKind == JsonValueKind.Array && reminders.GetArrayLength() == 0)
+            {
+                Console.WriteLine("No active reminders.");
+                return 0;
+            }
+
+            Console.WriteLine(JsonSerializer.Serialize(reminders, JsonOptions));
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            Console.Error.WriteLine("       fix: run `netclaw daemon start` and retry.");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunCreateAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        // netclaw reminder create <name> <scheduleType> <schedule> "<prompt>" [--channel <id>]
+        if (args.Length < 6)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder create <name> <scheduleType> <schedule> \"<prompt>\" [--channel <id>]");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("  scheduleType: once, interval, cron");
+            Console.Error.WriteLine("  schedule:     '30m', '2h', '0 */6 * * *', etc.");
+            return 1;
+        }
+
+        var name = args[2];
+        var scheduleType = args[3];
+        var schedule = args[4];
+        var prompt = args[5];
+        string? channel = null;
+
+        for (var i = 6; i < args.Length; i++)
+        {
+            if (args[i] is "--channel" && i + 1 < args.Length)
+            {
+                channel = args[++i];
+            }
+        }
+
+        var body = new
+        {
+            name,
+            prompt,
+            scheduleType,
+            schedule,
+            reportToChannel = channel
+        };
+
+        try
+        {
+            var response = await client.PostAsJsonAsync(baseUrl, body);
+            var json = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+            if (response.IsSuccessStatusCode)
+            {
+                if (result.TryGetProperty("message", out var msg))
+                    Console.WriteLine(msg.GetString());
+                else
+                    Console.WriteLine(json);
+                return 0;
+            }
+
+            if (result.TryGetProperty("error", out var err))
+                Console.Error.WriteLine($"[FAIL] {err.GetString()}");
+            else
+                Console.Error.WriteLine($"[FAIL] {json}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunCancelAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder cancel <id>");
+            return 1;
+        }
+
+        var id = args[2];
+        try
+        {
+            var response = await client.DeleteAsync($"{baseUrl}/{id}");
+            var json = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<JsonElement>(json);
+
+            if (response.IsSuccessStatusCode)
+            {
+                if (result.TryGetProperty("message", out var msg))
+                    Console.WriteLine(msg.GetString());
+                else
+                    Console.WriteLine(json);
+                return 0;
+            }
+
+            if (result.TryGetProperty("error", out var err))
+                Console.Error.WriteLine($"[FAIL] {err.GetString()}");
+            else
+                Console.Error.WriteLine($"[FAIL] {json}");
+            return response.StatusCode == System.Net.HttpStatusCode.NotFound ? 1 : 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunShowAsync(HttpClient client, string baseUrl, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder show <id>");
+            return 1;
+        }
+
+        var id = args[2];
+        try
+        {
+            var response = await client.GetAsync($"{baseUrl}/{id}");
+            var json = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = JsonSerializer.Deserialize<JsonElement>(json);
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return 0;
+            }
+
+            var err = JsonSerializer.Deserialize<JsonElement>(json);
+            if (err.TryGetProperty("error", out var errMsg))
+                Console.Error.WriteLine($"[FAIL] {errMsg.GetString()}");
+            else
+                Console.Error.WriteLine($"[FAIL] {json}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] unable to reach daemon: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw reminder <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  list                                          List all active reminders");
+        Console.WriteLine("  create <name> <type> <schedule> \"<prompt>\"    Create a reminder");
+        Console.WriteLine("  cancel <id>                                   Cancel a reminder");
+        Console.WriteLine("  show <id>                                     Show reminder details");
+        Console.WriteLine();
+        Console.WriteLine("Schedule types: once, interval, cron");
+        Console.WriteLine("Schedule examples: '30m', '2h', '1d', '0 */6 * * *'");
+        Console.WriteLine();
+        Console.WriteLine("Requires daemon to be running (netclaw daemon start).");
+        return 0;
+    }
+}

--- a/src/Netclaw.Cli/Tui/ReminderCreatePage.cs
+++ b/src/Netclaw.Cli/Tui/ReminderCreatePage.cs
@@ -1,0 +1,341 @@
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui;
+
+public sealed class ReminderCreatePage : ReactivePage<ReminderCreateViewModel>
+{
+    private DynamicLayoutNode? _contentNode;
+
+    private TextInputNode _titleInput = null!;
+    private SelectionListNode<string> _scheduleTypeList = null!;
+    private TextInputNode _scheduleInput = null!;
+    private TextAreaNode _instructionsInput = null!;
+    private TextAreaNode _notifyInput = null!;
+    private SelectionListNode<string> _confirmList = null!;
+    private SelectionListNode<string> _doneList = null!;
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+
+        _titleInput = new TextInputNode().WithPlaceholder("daily-standup");
+        _titleInput.Submitted
+            .Subscribe(ViewModel.SetTitle)
+            .DisposeWith(Subscriptions);
+
+        _scheduleTypeList = Layouts.SelectionList(new List<string> { "once", "interval", "cron" })
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+        _scheduleTypeList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                if (items.Count > 0)
+                    ViewModel.SetScheduleType(items[0]);
+            })
+            .DisposeWith(Subscriptions);
+
+        _scheduleInput = new TextInputNode().WithPlaceholder("30m / every 6h / 0 */6 * * *");
+        _scheduleInput.Submitted
+            .Subscribe(ViewModel.SetSchedule)
+            .DisposeWith(Subscriptions);
+
+        _instructionsInput = new TextAreaNode()
+            .WithPlaceholder("What Netclaw should do when this reminder fires...")
+            .WithMaxHeight(10)
+            .WithHistory(20);
+        _instructionsInput.Submitted
+            .Subscribe(ViewModel.SetInstructions)
+            .DisposeWith(Subscriptions);
+
+        _notifyInput = new TextAreaNode()
+            .WithPlaceholder("How Netclaw should notify you about results...")
+            .WithMaxHeight(8)
+            .WithHistory(20);
+        _notifyInput.Submitted
+            .Subscribe(ViewModel.SetNotifyInstructions)
+            .DisposeWith(Subscriptions);
+
+        _confirmList = Layouts.SelectionList(new List<string> { "Create reminder", "Back" })
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Green);
+        _confirmList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                if (items.Count == 0)
+                    return;
+
+                if (items[0] == "Create reminder")
+                    _ = ViewModel.SubmitAsync();
+                else
+                    ViewModel.GoBack();
+            })
+            .DisposeWith(Subscriptions);
+
+        _doneList = Layouts.SelectionList(new List<string> { "Create another", "Quit" })
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+        _doneList.SelectionConfirmed
+            .Subscribe(items =>
+            {
+                if (items.Count == 0)
+                    return;
+
+                if (items[0] == "Create another")
+                    ViewModel.Reset();
+                else
+                    ViewModel.RequestQuit();
+            })
+            .DisposeWith(Subscriptions);
+
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+
+        ViewModel.Input.OfType<IInputEvent, PasteEvent>()
+            .Subscribe(HandlePaste)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Reminder Builder")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(BuildInnerLayout())
+                    .Fill());
+    }
+
+    private ILayoutNode BuildInnerLayout()
+    {
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(BuildContent())
+            .WithChild(Layouts.Empty().Fill())
+            .WithChild(BuildStatusBar())
+            .WithChild(BuildKeyBindings());
+    }
+
+    private LayoutNode BuildContent()
+    {
+        _contentNode = new DynamicLayoutNode(() =>
+            ViewModel.CurrentState.Value switch
+            {
+                ReminderCreateState.Title => BuildTitle(),
+                ReminderCreateState.ScheduleType => BuildScheduleType(),
+                ReminderCreateState.Schedule => BuildSchedule(),
+                ReminderCreateState.Instructions => BuildInstructions(),
+                ReminderCreateState.NotifyInstructions => BuildNotifyInstructions(),
+                ReminderCreateState.Confirm => BuildConfirm(),
+                ReminderCreateState.Done => BuildDone(),
+                _ => Layouts.Empty()
+            });
+
+        ViewModel.StateVersion
+            .Subscribe(_ => _contentNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return _contentNode;
+    }
+
+    private LayoutNode BuildStatusBar()
+    {
+        return ViewModel.StatusMessage
+            .Select(msg => (ILayoutNode)new TextNode($"  {msg}").WithForeground(Color.Green))
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildKeyBindings()
+    {
+        return ViewModel.CurrentState
+            .Select(state =>
+            {
+                var text = state switch
+                {
+                    ReminderCreateState.Title => " [Enter] Next  [Esc] Quit  [Ctrl+Q] Quit",
+                    ReminderCreateState.ScheduleType => " [Up/Down] Select  [Enter] Next  [Esc] Back  [Ctrl+Q] Quit",
+                    ReminderCreateState.Schedule => " [Enter] Next  [Esc] Back  [Ctrl+Q] Quit",
+                    ReminderCreateState.Instructions => " [Ctrl+Enter] Newline  [Enter] Next  [Esc] Back  [Ctrl+Q] Quit",
+                    ReminderCreateState.NotifyInstructions => " [Ctrl+Enter] Newline  [Enter] Next  [Esc] Back  [Ctrl+Q] Quit",
+                    ReminderCreateState.Confirm => " [Up/Down] Select  [Enter] Confirm  [Esc] Back  [Ctrl+Q] Quit",
+                    ReminderCreateState.Done => " [Up/Down] Select  [Enter] Continue  [Esc] Quit  [Ctrl+Q] Quit",
+                    _ => " [Ctrl+Q] Quit"
+                };
+                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    private ILayoutNode BuildTitle()
+    {
+        _titleInput.OnFocused();
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 1 of 6: Reminder title").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("  Choose a short identifier for this reminder.").WithForeground(Color.Gray))
+            .WithChild(new PanelNode()
+                .WithTitle("Title")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_titleInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildScheduleType()
+    {
+        _scheduleTypeList.OnFocused();
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 2 of 6: Schedule type").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("  once: one-time, interval: repeating duration, cron: calendar expression.")
+                .WithForeground(Color.Gray))
+            .WithChild(_scheduleTypeList);
+    }
+
+    private ILayoutNode BuildSchedule()
+    {
+        _scheduleInput.OnFocused();
+        var hint = ViewModel.ScheduleType switch
+        {
+            "once" => "Example: 30m or 2026-03-05T18:00:00Z",
+            "interval" => "Example: 15m, 2h, every 1d",
+            "cron" => "Example: 0 */6 * * *",
+            _ => "Example: 30m"
+        };
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 3 of 6: Schedule value").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode($"  {hint}").WithForeground(Color.Gray))
+            .WithChild(new PanelNode()
+                .WithTitle("Schedule")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_scheduleInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildInstructions()
+    {
+        _instructionsInput.OnFocused();
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 4 of 6: Instructions").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("  Describe exactly what Netclaw should do.").WithForeground(Color.Gray))
+            .WithChild(new PanelNode()
+                .WithTitle("Instructions")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_instructionsInput)
+                .HeightAuto(min: 5, max: 12));
+    }
+
+    private ILayoutNode BuildNotifyInstructions()
+    {
+        _notifyInput.OnFocused();
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 5 of 6: Notify instructions").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode("  Explain how and when Netclaw should notify you.").WithForeground(Color.Gray))
+            .WithChild(new PanelNode()
+                .WithTitle("Notify Instructions")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_notifyInput)
+                .HeightAuto(min: 4, max: 10));
+    }
+
+    private ILayoutNode BuildConfirm()
+    {
+        _confirmList.OnFocused();
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Step 6 of 6: Review").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode($"  Title: {ViewModel.Title}").WithForeground(Color.White))
+            .WithChild(new TextNode($"  Type: {ViewModel.ScheduleType}").WithForeground(Color.White))
+            .WithChild(new TextNode($"  Schedule: {ViewModel.Schedule}").WithForeground(Color.White))
+            .WithChild(new TextNode("  Instructions:").WithForeground(Color.Gray))
+            .WithChild(new TextNode($"    {TrimForPreview(ViewModel.Instructions)}").WithForeground(Color.White))
+            .WithChild(new TextNode("  Notify Instructions:").WithForeground(Color.Gray))
+            .WithChild(new TextNode($"    {TrimForPreview(ViewModel.NotifyInstructions)}").WithForeground(Color.White))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(_confirmList);
+    }
+
+    private ILayoutNode BuildDone()
+    {
+        _doneList.OnFocused();
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Reminder created.").WithForeground(Color.Green).Bold())
+            .WithChild(new TextNode("  What do you want to do next?").WithForeground(Color.Gray))
+            .WithChild(_doneList);
+    }
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+
+        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.RequestQuit();
+            return;
+        }
+
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            ViewModel.GoBack();
+            return;
+        }
+
+        if (ViewModel.IsSubmitting.Value)
+            return;
+
+        switch (ViewModel.CurrentState.Value)
+        {
+            case ReminderCreateState.Title:
+                _titleInput.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.ScheduleType:
+                _scheduleTypeList.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.Schedule:
+                _scheduleInput.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.Instructions:
+                _instructionsInput.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.NotifyInstructions:
+                _notifyInput.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.Confirm:
+                _confirmList.HandleInput(keyInfo);
+                break;
+            case ReminderCreateState.Done:
+                _doneList.HandleInput(keyInfo);
+                break;
+        }
+
+        ViewModel.RequestRedraw();
+    }
+
+    private void HandlePaste(PasteEvent paste)
+    {
+        if (ViewModel.CurrentState.Value == ReminderCreateState.Instructions)
+            _instructionsInput.HandlePaste(paste);
+        else if (ViewModel.CurrentState.Value == ReminderCreateState.NotifyInstructions)
+            _notifyInput.HandlePaste(paste);
+    }
+
+    private static string TrimForPreview(string text)
+    {
+        var singleLine = text.Replace('\n', ' ').Trim();
+        if (singleLine.Length <= 100)
+            return singleLine;
+        return string.Concat(singleLine.AsSpan(0, 97), "...");
+    }
+}

--- a/src/Netclaw.Cli/Tui/ReminderCreateViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ReminderCreateViewModel.cs
@@ -1,0 +1,249 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using R3;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Tui;
+
+public enum ReminderCreateState
+{
+    Title,
+    ScheduleType,
+    Schedule,
+    Instructions,
+    NotifyInstructions,
+    Confirm,
+    Done
+}
+
+public sealed class ReminderCreateViewModel : ReactiveViewModel
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _baseUrl;
+
+    public ReactiveProperty<ReminderCreateState> CurrentState { get; } = new(ReminderCreateState.Title);
+    public ReactiveProperty<string> StatusMessage { get; } = new("Enter a short reminder title.");
+    public ReactiveProperty<bool> IsSubmitting { get; } = new(false);
+    public ReactiveProperty<int> StateVersion { get; } = new(0);
+
+    public string Title { get; private set; } = string.Empty;
+    public string ScheduleType { get; private set; } = "once";
+    public string Schedule { get; private set; } = string.Empty;
+    public string Instructions { get; private set; } = string.Empty;
+    public string NotifyInstructions { get; private set; } = string.Empty;
+
+    public ReminderCreateViewModel(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        var endpoint = Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT") ?? "http://127.0.0.1:5199";
+        _baseUrl = $"{endpoint.TrimEnd('/')}/api/reminders";
+    }
+
+    public void SetTitle(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            StatusMessage.Value = "Title is required.";
+            RequestRedraw();
+            return;
+        }
+
+        Title = value.Trim();
+        CurrentState.Value = ReminderCreateState.ScheduleType;
+        StatusMessage.Value = "Select schedule type.";
+        NotifyChanged();
+    }
+
+    public void SetScheduleType(string value)
+    {
+        ScheduleType = value.Trim().ToLowerInvariant();
+        CurrentState.Value = ReminderCreateState.Schedule;
+        StatusMessage.Value = "Enter schedule value (e.g. 30m, every 6h, 0 */6 * * *).";
+        NotifyChanged();
+    }
+
+    public void SetSchedule(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            StatusMessage.Value = "Schedule value is required.";
+            RequestRedraw();
+            return;
+        }
+
+        Schedule = value.Trim();
+        CurrentState.Value = ReminderCreateState.Instructions;
+        StatusMessage.Value = "Enter reminder instructions.";
+        NotifyChanged();
+    }
+
+    public void SetInstructions(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            StatusMessage.Value = "Instructions are required.";
+            RequestRedraw();
+            return;
+        }
+
+        Instructions = value.Trim();
+        CurrentState.Value = ReminderCreateState.NotifyInstructions;
+        StatusMessage.Value = "Enter notification instructions.";
+        NotifyChanged();
+    }
+
+    public void SetNotifyInstructions(string value)
+    {
+        NotifyInstructions = string.IsNullOrWhiteSpace(value)
+            ? "Reply in the originating session thread with a concise result."
+            : value.Trim();
+
+        CurrentState.Value = ReminderCreateState.Confirm;
+        StatusMessage.Value = "Review and create reminder.";
+        NotifyChanged();
+    }
+
+    public async Task SubmitAsync(CancellationToken ct = default)
+    {
+        if (IsSubmitting.Value)
+            return;
+
+        IsSubmitting.Value = true;
+        StatusMessage.Value = "Validating schedule...";
+        RequestRedraw();
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("ReminderApi");
+
+            var validate = await client.PostAsJsonAsync($"{_baseUrl}/validate", new
+            {
+                name = Title,
+                prompt = Instructions,
+                scheduleType = ScheduleType,
+                schedule = Schedule,
+                notifyInstructions = NotifyInstructions
+            }, ct);
+
+            if (!validate.IsSuccessStatusCode)
+            {
+                var error = await ReadErrorAsync(validate, ct);
+                StatusMessage.Value = $"Validation failed: {error}";
+                RequestRedraw();
+                return;
+            }
+
+            StatusMessage.Value = "Creating reminder...";
+            RequestRedraw();
+
+            var create = await client.PostAsJsonAsync(_baseUrl, new
+            {
+                name = Title,
+                prompt = Instructions,
+                scheduleType = ScheduleType,
+                schedule = Schedule,
+                notifyInstructions = NotifyInstructions
+            }, ct);
+
+            if (!create.IsSuccessStatusCode)
+            {
+                var error = await ReadErrorAsync(create, ct);
+                StatusMessage.Value = $"Create failed: {error}";
+                RequestRedraw();
+                return;
+            }
+
+            var response = await create.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            var message = response.TryGetProperty("message", out var msg)
+                ? msg.GetString() ?? "Reminder created."
+                : "Reminder created.";
+
+            CurrentState.Value = ReminderCreateState.Done;
+            StatusMessage.Value = message;
+            NotifyChanged();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage.Value = $"Unable to reach daemon: {ex.Message}";
+            RequestRedraw();
+        }
+        finally
+        {
+            IsSubmitting.Value = false;
+        }
+    }
+
+    public void Reset()
+    {
+        Title = string.Empty;
+        ScheduleType = "once";
+        Schedule = string.Empty;
+        Instructions = string.Empty;
+        NotifyInstructions = string.Empty;
+        CurrentState.Value = ReminderCreateState.Title;
+        StatusMessage.Value = "Enter a short reminder title.";
+        NotifyChanged();
+    }
+
+    public void GoBack()
+    {
+        switch (CurrentState.Value)
+        {
+            case ReminderCreateState.Title:
+                Shutdown();
+                return;
+            case ReminderCreateState.ScheduleType:
+                CurrentState.Value = ReminderCreateState.Title;
+                break;
+            case ReminderCreateState.Schedule:
+                CurrentState.Value = ReminderCreateState.ScheduleType;
+                break;
+            case ReminderCreateState.Instructions:
+                CurrentState.Value = ReminderCreateState.Schedule;
+                break;
+            case ReminderCreateState.NotifyInstructions:
+                CurrentState.Value = ReminderCreateState.Instructions;
+                break;
+            case ReminderCreateState.Confirm:
+                CurrentState.Value = ReminderCreateState.NotifyInstructions;
+                break;
+            case ReminderCreateState.Done:
+                Shutdown();
+                return;
+        }
+
+        NotifyChanged();
+    }
+
+    public void RequestQuit() => Shutdown();
+
+    private static async Task<string> ReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            if (json.TryGetProperty("error", out var err))
+                return err.GetString() ?? response.ReasonPhrase ?? "request failed";
+            return json.ToString();
+        }
+        catch
+        {
+            return response.ReasonPhrase ?? "request failed";
+        }
+    }
+
+    private void NotifyChanged()
+    {
+        StateVersion.Value++;
+        RequestRedraw();
+    }
+
+    public override void Dispose()
+    {
+        CurrentState.Dispose();
+        StatusMessage.Dispose();
+        IsSubmitting.Dispose();
+        StateVersion.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -45,6 +45,7 @@ public sealed class NetclawPaths
     public string ProjectsDirectory => Path.Combine(BasePath, "projects");
     public string EnvironmentDirectory => Path.Combine(BasePath, "environment");
     public string SchedulesDirectory => Path.Combine(BasePath, "schedules");
+    public string RemindersDirectory => Path.Combine(SchedulesDirectory, "reminders");
     public string ConfigDirectory => Path.Combine(BasePath, "config");
     public string NetclawConfigPath => Path.Combine(ConfigDirectory, "netclaw.json");
     public string SecretsPath => Path.Combine(ConfigDirectory, "secrets.json");
@@ -81,6 +82,7 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(ProjectsDirectory);
         Directory.CreateDirectory(EnvironmentDirectory);
         Directory.CreateDirectory(SchedulesDirectory);
+        Directory.CreateDirectory(RemindersDirectory);
         Directory.CreateDirectory(ConfigDirectory);
         Directory.CreateDirectory(LogsDirectory);
         Directory.CreateDirectory(SessionLogsDirectory);

--- a/src/Netclaw.Configuration/ReminderConfig.cs
+++ b/src/Netclaw.Configuration/ReminderConfig.cs
@@ -1,0 +1,28 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for the reminder system. Bound from the "Reminders" section of netclaw.json.
+/// </summary>
+public sealed record ReminderConfig
+{
+    /// <summary>
+    /// Maximum number of reminder executions running concurrently.
+    /// </summary>
+    public int MaxConcurrentExecutions { get; init; } = 3;
+
+    /// <summary>
+    /// Timeout in seconds for a single reminder execution before it is killed.
+    /// </summary>
+    public int ExecutionTimeoutSeconds { get; init; } = 300;
+
+    /// <summary>
+    /// Number of consecutive failures before a reminder is auto-cancelled.
+    /// </summary>
+    public int FailurePauseThreshold { get; init; } = 5;
+
+    /// <summary>
+    /// Minimum allowed interval in seconds for recurring reminders.
+    /// Prevents accidental tight loops.
+    /// </summary>
+    public int MinIntervalSeconds { get; init; } = 60;
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Skills;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
@@ -270,6 +271,7 @@ static void ConfigureDaemonServices(
     var reminderConfig = configuration.GetSection("Reminders")
         .Get<ReminderConfig>() ?? new ReminderConfig();
     services.AddSingleton(reminderConfig);
+    services.AddSingleton<ReminderDefinitionStore>();
 
     // Search backend selection
     var searchConfig = configuration.GetSection("Search")
@@ -447,7 +449,16 @@ static void ConfigureDaemonServices(
                 .WithInMemorySnapshotStore();
         }
 
-        akkaBuilder.WithNetclawActors();
+        var reminderStorage = persistence.Provider is PersistenceProvider.Sqlite
+            ? new NetclawAkkaHostingExtensions.ReminderStorageOptions
+            {
+                SqliteConnectionString = $"Data Source={sqlitePath}",
+                TableName = "netclaw_reminders",
+                AutoInitialize = true
+            }
+            : null;
+
+        akkaBuilder.WithNetclawActors(reminderStorage);
 
         // Register reminder tools after actors start (needs ReminderManagerActor ref)
         akkaBuilder.StartActors((system, registry, _) =>
@@ -646,6 +657,73 @@ static void MapReminderEndpoints(WebApplication app)
             : Results.Ok(new { message = result });
     });
 
+    app.MapPost("/api/reminders/validate", (
+        CreateReminderRequest request,
+        TimeProvider timeProvider,
+        ReminderConfig reminderConfig) =>
+    {
+        var (schedule, error) = ReminderScheduleParser.Parse(
+            request.ScheduleType,
+            request.Schedule,
+            timeProvider,
+            reminderConfig);
+
+        if (schedule is null)
+            return Results.BadRequest(new { valid = false, error });
+
+        return Results.Ok(new { valid = true, scheduleType = schedule.Type.ToString(), nextFire = schedule.FireAt });
+    });
+
+    app.MapPost("/api/reminders/import", async (
+        ImportReminderRequest request,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        if (request.Definition is null)
+            return Results.BadRequest(new { error = "Reminder definition is required." });
+
+        var mode = request.WriteMode?.Trim().ToLowerInvariant() switch
+        {
+            "replace" => ReminderWriteMode.Replace,
+            "upsert" => ReminderWriteMode.Upsert,
+            null or "" or "create" or "createonly" => ReminderWriteMode.CreateOnly,
+            _ => (ReminderWriteMode?)null
+        };
+
+        if (mode is null)
+            return Results.BadRequest(new { error = "Invalid writeMode. Use create, replace, or upsert." });
+
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(request.Definition, mode.Value),
+            TimeSpan.FromSeconds(10),
+            ct);
+
+        if (!response.Success)
+        {
+            var status = response.Error is ReminderSaveError.Conflict
+                ? StatusCodes.Status409Conflict
+                : response.Error is ReminderSaveError.NotFound
+                    ? StatusCodes.Status404NotFound
+                    : StatusCodes.Status400BadRequest;
+
+            return Results.Json(new
+            {
+                error = response.ErrorMessage ?? "Import failed.",
+                code = response.Error.ToString(),
+                id = response.Id.Value
+            }, statusCode: status);
+        }
+
+        return Results.Ok(new
+        {
+            id = response.Id.Value,
+            title = response.Title,
+            nextFire = response.NextFire,
+            message = $"Imported reminder '{response.Id.Value}'."
+        });
+    });
+
     app.MapDelete("/api/reminders/{id}", async (
         string id,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
@@ -659,6 +737,41 @@ static void MapReminderEndpoints(WebApplication app)
         return response.Found
             ? Results.Ok(new { message = $"Reminder '{id}' cancelled." })
             : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+    });
+
+    app.MapPost("/api/reminders/{id}/disable", async (
+        string id,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<ReminderStateResponse>(
+            new DisableReminderCommand(new ReminderId(id)),
+            TimeSpan.FromSeconds(10),
+            ct);
+
+        return !response.Found
+            ? Results.NotFound(new { error = response.ErrorMessage ?? $"Reminder '{id}' not found." })
+            : Results.Ok(new { id = id, enabled = response.Enabled, message = $"Reminder '{id}' disabled." });
+    });
+
+    app.MapPost("/api/reminders/{id}/enable", async (
+        string id,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<ReminderStateResponse>(
+            new EnableReminderCommand(new ReminderId(id)),
+            TimeSpan.FromSeconds(10),
+            ct);
+
+        if (!response.Found)
+            return Results.NotFound(new { error = response.ErrorMessage ?? $"Reminder '{id}' not found." });
+        if (!response.Enabled && !string.IsNullOrWhiteSpace(response.ErrorMessage))
+            return Results.BadRequest(new { error = response.ErrorMessage, id, enabled = false });
+
+        return Results.Ok(new { id, enabled = response.Enabled, nextFire = response.NextFire, message = $"Reminder '{id}' enabled." });
     });
 
     app.MapGet("/api/reminders/{id}", async (
@@ -697,4 +810,10 @@ sealed record CreateReminderRequest
     public required string ScheduleType { get; init; }
     public required string Schedule { get; init; }
     public string? ReportToChannel { get; init; }
+}
+
+sealed record ImportReminderRequest
+{
+    public required ReminderDefinition Definition { get; init; }
+    public string? WriteMode { get; init; }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1,3 +1,4 @@
+using Akka.Actor;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Sql.Hosting;
@@ -136,6 +137,9 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         return Results.Ok(new { status = status.ToString() });
     });
 
+    // Reminder REST API
+    MapReminderEndpoints(app);
+
     await app.RunAsync();
 }
 
@@ -261,6 +265,11 @@ static void ConfigureDaemonServices(
     var toolConfig = configuration.GetSection("Tools")
         .Get<ToolConfig>() ?? new ToolConfig();
     services.AddSingleton(toolConfig);
+
+    // Reminders
+    var reminderConfig = configuration.GetSection("Reminders")
+        .Get<ReminderConfig>() ?? new ReminderConfig();
+    services.AddSingleton(reminderConfig);
 
     // Search backend selection
     var searchConfig = configuration.GetSection("Search")
@@ -439,6 +448,14 @@ static void ConfigureDaemonServices(
         }
 
         akkaBuilder.WithNetclawActors();
+
+        // Register reminder tools after actors start (needs ReminderManagerActor ref)
+        akkaBuilder.StartActors((system, registry, _) =>
+        {
+            var reminderManager = registry.Get<Netclaw.Actors.Hosting.ReminderManagerActorKey>();
+            var tp = sp.GetRequiredService<TimeProvider>();
+            toolRegistry.WithReminderTools(reminderManager, tp);
+        });
     });
 
     // Content security (magic-byte file scanning + prompt-injection detector)
@@ -585,6 +602,76 @@ static void CopyBuiltInSkills(string skillsDirectory)
         using var fileStream = File.Create(targetPath);
         stream.CopyTo(fileStream);
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Reminder REST API
+// ═══════════════════════════════════════════════════════════════════════
+
+static void MapReminderEndpoints(WebApplication app)
+{
+    app.MapGet("/api/reminders", async (
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderListResponse>(
+            new Netclaw.Actors.Reminders.ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+        return Results.Ok(response.Reminders);
+    });
+
+    app.MapPost("/api/reminders", async (
+        Netclaw.Actors.Reminders.CreateReminderRequest request,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        TimeProvider timeProvider,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var now = timeProvider.GetUtcNow();
+
+        var tool = new Netclaw.Actors.Reminders.SetReminderTool(manager, timeProvider);
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?>
+            {
+                ["Name"] = request.Name,
+                ["Prompt"] = request.Prompt,
+                ["ScheduleType"] = request.ScheduleType,
+                ["Schedule"] = request.Schedule,
+                ["ReportToChannel"] = request.ReportToChannel
+            }, ct);
+
+        return result.StartsWith("Error", StringComparison.Ordinal)
+            ? Results.BadRequest(new { error = result })
+            : Results.Ok(new { message = result });
+    });
+
+    app.MapDelete("/api/reminders/{id}", async (
+        string id,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderCancelledResponse>(
+            new Netclaw.Actors.Reminders.CancelReminderCommand(new Netclaw.Actors.Reminders.ReminderId(id)),
+            TimeSpan.FromSeconds(10), ct);
+
+        return response.Found
+            ? Results.Ok(new { message = $"Reminder '{id}' cancelled." })
+            : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+    });
+
+    app.MapGet("/api/reminders/{id}", async (
+        string id,
+        Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        CancellationToken ct) =>
+    {
+        var manager = await actor.GetAsync(ct);
+        var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderListResponse>(
+            new Netclaw.Actors.Reminders.ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+
+        var match = response.Reminders.FirstOrDefault(r => r.Id.Value == id);
+        return match is not null ? Results.Ok(match) : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+    });
 }
 
 static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -649,7 +649,8 @@ static void MapReminderEndpoints(WebApplication app)
                 ["Prompt"] = request.Prompt,
                 ["ScheduleType"] = request.ScheduleType,
                 ["Schedule"] = request.Schedule,
-                ["ReportToChannel"] = request.ReportToChannel
+                ["ReportToChannel"] = request.ReportToChannel,
+                ["NotifyInstructions"] = request.NotifyInstructions
             }, ct);
 
         return result.StartsWith("Error", StringComparison.Ordinal)
@@ -810,6 +811,7 @@ sealed record CreateReminderRequest
     public required string ScheduleType { get; init; }
     public required string Schedule { get; init; }
     public string? ReportToChannel { get; init; }
+    public string? NotifyInstructions { get; init; }
 }
 
 sealed record ImportReminderRequest

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -454,7 +454,8 @@ static void ConfigureDaemonServices(
         {
             var reminderManager = registry.Get<Netclaw.Actors.Hosting.ReminderManagerActorKey>();
             var tp = sp.GetRequiredService<TimeProvider>();
-            toolRegistry.WithReminderTools(reminderManager, tp);
+            var rc = sp.GetRequiredService<ReminderConfig>();
+            toolRegistry.WithReminderTools(reminderManager, tp, rc);
         });
     });
 
@@ -621,15 +622,15 @@ static void MapReminderEndpoints(WebApplication app)
     });
 
     app.MapPost("/api/reminders", async (
-        Netclaw.Actors.Reminders.CreateReminderRequest request,
+        CreateReminderRequest request,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
         TimeProvider timeProvider,
+        ReminderConfig reminderConfig,
         CancellationToken ct) =>
     {
         var manager = await actor.GetAsync(ct);
-        var now = timeProvider.GetUtcNow();
 
-        var tool = new Netclaw.Actors.Reminders.SetReminderTool(manager, timeProvider);
+        var tool = new Netclaw.Actors.Reminders.SetReminderTool(manager, timeProvider, reminderConfig);
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?>
             {
@@ -666,11 +667,11 @@ static void MapReminderEndpoints(WebApplication app)
         CancellationToken ct) =>
     {
         var manager = await actor.GetAsync(ct);
-        var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderListResponse>(
-            new Netclaw.Actors.Reminders.ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+        var response = await manager.Ask<Netclaw.Actors.Reminders.GetReminderResponse>(
+            new Netclaw.Actors.Reminders.GetReminderCommand(new Netclaw.Actors.Reminders.ReminderId(id)),
+            TimeSpan.FromSeconds(10), ct);
 
-        var match = response.Reminders.FirstOrDefault(r => r.Id.Value == id);
-        return match is not null ? Results.Ok(match) : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+        return response.Reminder is not null ? Results.Ok(response.Reminder) : Results.NotFound(new { error = $"Reminder '{id}' not found." });
     });
 }
 
@@ -684,4 +685,16 @@ static Akka.Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)
         Error or Critical or None => Akka.Event.LogLevel.ErrorLevel,
         _ => Akka.Event.LogLevel.WarningLevel
     };
+}
+
+/// <summary>
+/// REST API request body for creating a reminder.
+/// </summary>
+sealed record CreateReminderRequest
+{
+    public required string Name { get; init; }
+    public required string Prompt { get; init; }
+    public required string ScheduleType { get; init; }
+    public required string Schedule { get; init; }
+    public string? ReportToChannel { get; init; }
 }


### PR DESCRIPTION
## Summary

- Adds a complete reminder subsystem: schedule prompts to execute at a future time (one-shot), on a recurring interval, or via cron expressions
- Integrates with akka-reminders for durable scheduling and Akka Streams session pipeline for execution
- Includes CLI commands (`netclaw reminder list/cancel`), REST API endpoints, and LLM tools (`set_reminder`, `cancel_reminder`, `list_reminders`)
- Supports self-targeting (reminders post back to the originating Slack thread) and channel-targeted delivery
- Adds concurrency limiting, automatic failure-based cancellation, and configurable execution timeouts
- Fixes 9 code quality issues: protobuf serialization attributes, dead code removal, TimeProvider wiring, config injection, anemic test deletion, server-side filtering for single-reminder fetch, and DTO layering

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test --filter Reminders` — 21 tests pass (3 manager actor + 7 tool + 11 cron helper)
- [x] `dotnet test` — full suite passes (710 tests)
- [x] `dotnet slopwatch analyze` — 0 issues