### PR TITLE
Reduce attach_file friction for screenshot handoff between sessions

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -238,4 +238,75 @@ public class AttachFileToolTests : IDisposable
                 File.Delete(outsideFile);
         }
     }
+
+    [Fact]
+    public async Task File_from_sibling_session_directory_is_copied_and_attached()
+    {
+        var sessionsRoot = Path.Combine(_tempDir, "sessions");
+        var currentSessionDir = Path.Combine(sessionsRoot, "current");
+        var siblingSessionDir = Path.Combine(sessionsRoot, "sibling");
+        Directory.CreateDirectory(currentSessionDir);
+        Directory.CreateDirectory(siblingSessionDir);
+
+        var sourcePath = Path.Combine(siblingSessionDir, "report.png");
+        await File.WriteAllBytesAsync(sourcePath, [0x89, 0x50, 0x4E, 0x47]);
+
+        var context = new ToolExecutionContext("test-session", currentSessionDir);
+        var args = new Dictionary<string, object?>
+        {
+            ["Path"] = sourcePath,
+            ["DisplayName"] = "Copied Report.png"
+        };
+
+        var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Contains("File attached", result);
+        Assert.Contains("copied into current session", result, StringComparison.OrdinalIgnoreCase);
+
+        var attachment = Assert.Single(context.FileAttachments);
+        Assert.StartsWith(Path.Combine(currentSessionDir, "attachments"), attachment.FilePath, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(attachment.FilePath));
+        Assert.Equal("Copied Report.png", attachment.FileName);
+        Assert.Equal("image/png", attachment.MimeType);
+    }
+
+    [Fact]
+    public async Task Symlink_from_sibling_session_to_outside_root_is_rejected()
+    {
+        var sessionsRoot = Path.Combine(_tempDir, "sessions");
+        var currentSessionDir = Path.Combine(sessionsRoot, "current");
+        var siblingSessionDir = Path.Combine(sessionsRoot, "sibling");
+        Directory.CreateDirectory(currentSessionDir);
+        Directory.CreateDirectory(siblingSessionDir);
+
+        var outsidePath = Path.Combine(_tempDir, "outside.txt");
+        await File.WriteAllTextAsync(outsidePath, "secret");
+
+        var symlinkPath = Path.Combine(siblingSessionDir, "linked.txt");
+        try
+        {
+            File.CreateSymbolicLink(symlinkPath, outsidePath);
+
+            var context = new ToolExecutionContext("test-session", currentSessionDir);
+            var args = new Dictionary<string, object?>
+            {
+                ["Path"] = symlinkPath
+            };
+
+            var result = await _tool.ExecuteAsync(args, context, CancellationToken.None);
+
+            Assert.Contains("Error", result);
+            Assert.Contains("session", result, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(context.FileAttachments);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return;
+        }
+        finally
+        {
+            if (File.Exists(symlinkPath))
+                File.Delete(symlinkPath);
+        }
+    }
 }

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -5,11 +5,13 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Attaches a file from the session directory as output to the user.
-/// Validates that the file path is within the session directory to prevent traversal.
+/// Attaches a file as output to the user.
+/// Paths inside the current session are attached directly. Paths from sibling
+/// Netclaw session directories are copied into the current session first.
+/// All other paths are rejected to prevent traversal/exfiltration.
 /// </summary>
 [NetclawTool("attach_file",
-    "Attach a file from the session directory to send to the user. The path must be within the session working directory.",
+    "Attach a file to send to the user. Paths in the current session attach directly; files from other Netclaw session folders are copied into this session first.",
     Grant = "file")]
 public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
 {
@@ -31,22 +33,37 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var sessionDir = NormalizeDirectoryPath(context.SessionDirectory);
         var requestedPath = Path.GetFullPath(args.Path);
 
-        if (!IsPathWithinDirectory(requestedPath, sessionDir))
-            return Task.FromResult($"Error: File path must be within the session directory ({sessionDir}).");
-
         if (!File.Exists(requestedPath))
             return Task.FromResult($"Error: File not found: {requestedPath}");
 
         var resolvedPath = ResolveFinalPath(requestedPath);
+        var attachPath = resolvedPath;
+
         if (!IsPathWithinDirectory(resolvedPath, sessionDir))
-            return Task.FromResult($"Error: File path must be within the session directory ({sessionDir}).");
+        {
+            var sessionRoot = TryGetSessionRootDirectory(sessionDir);
+            if (sessionRoot is null || !IsPathWithinDirectory(resolvedPath, sessionRoot))
+            {
+                return Task.FromResult(
+                    $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
+            }
 
-        var rawFilename = args.DisplayName ?? Path.GetFileName(resolvedPath);
+            attachPath = CopyIntoCurrentSession(resolvedPath, sessionDir);
+        }
+
+        if (!IsPathWithinDirectory(attachPath, sessionDir))
+            return Task.FromResult($"Error: Attach path escaped the session directory ({sessionDir}).");
+
+        var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
         var sanitizedFilename = FilenameSanitizer.Sanitize(rawFilename);
-        var mimeType = GuessMimeType(resolvedPath);
+        var mimeType = GuessMimeType(attachPath);
 
-        context.AddFileAttachment(resolvedPath, sanitizedFilename, mimeType);
-        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {resolvedPath}");
+        context.AddFileAttachment(attachPath, sanitizedFilename, mimeType);
+        var copiedText = string.Equals(attachPath, resolvedPath, StringComparison.Ordinal)
+            ? string.Empty
+            : " (copied into current session)";
+
+        return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {attachPath}{copiedText}");
     }
 
     private static string NormalizeDirectoryPath(string directoryPath)
@@ -75,6 +92,45 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         var fileInfo = new FileInfo(path);
         var target = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
         return target is null ? fileInfo.FullName : target.FullName;
+    }
+
+    private static string? TryGetSessionRootDirectory(string sessionDir)
+    {
+        var parent = Directory.GetParent(sessionDir);
+        if (parent is null)
+            return null;
+
+        var name = parent.Name;
+        if (name.Equals("sessions", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("netclaw-sessions", StringComparison.OrdinalIgnoreCase))
+        {
+            return NormalizeDirectoryPath(parent.FullName);
+        }
+
+        return null;
+    }
+
+    private static string CopyIntoCurrentSession(string sourcePath, string sessionDir)
+    {
+        var attachmentsDir = Path.Combine(sessionDir, "attachments");
+        Directory.CreateDirectory(attachmentsDir);
+
+        var baseName = Path.GetFileNameWithoutExtension(sourcePath);
+        var extension = Path.GetExtension(sourcePath);
+        var sanitizedBase = FilenameSanitizer.Sanitize(baseName);
+        var fileName = sanitizedBase + extension;
+        var destination = Path.Combine(attachmentsDir, fileName);
+        var suffix = 1;
+
+        while (File.Exists(destination))
+        {
+            fileName = $"{sanitizedBase}-{suffix}{extension}";
+            destination = Path.Combine(attachmentsDir, fileName);
+            suffix++;
+        }
+
+        File.Copy(sourcePath, destination);
+        return destination;
     }
 
     private static string GuessMimeType(string path)

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -31,25 +31,34 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             return Task.FromResult("Error: No session directory available.");
 
         var sessionDir = NormalizeDirectoryPath(context.SessionDirectory);
+        var sessionRoot = TryGetSessionRootDirectory(sessionDir);
         var requestedPath = Path.GetFullPath(args.Path);
+
+        var requestedInCurrentSession = IsPathWithinDirectory(requestedPath, sessionDir);
+        var requestedInSessionRoot = sessionRoot is not null && IsPathWithinDirectory(requestedPath, sessionRoot);
+
+        if (!requestedInCurrentSession && !requestedInSessionRoot)
+        {
+            return Task.FromResult(
+                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
+        }
 
         if (!File.Exists(requestedPath))
             return Task.FromResult($"Error: File not found: {requestedPath}");
 
         var resolvedPath = ResolveFinalPath(requestedPath);
-        var attachPath = resolvedPath;
+        var resolvedInCurrentSession = IsPathWithinDirectory(resolvedPath, sessionDir);
+        var resolvedInSessionRoot = sessionRoot is not null && IsPathWithinDirectory(resolvedPath, sessionRoot);
 
-        if (!IsPathWithinDirectory(resolvedPath, sessionDir))
+        if (!resolvedInCurrentSession && !resolvedInSessionRoot)
         {
-            var sessionRoot = TryGetSessionRootDirectory(sessionDir);
-            if (sessionRoot is null || !IsPathWithinDirectory(resolvedPath, sessionRoot))
-            {
-                return Task.FromResult(
-                    $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
-            }
-
-            attachPath = CopyIntoCurrentSession(resolvedPath, sessionDir);
+            return Task.FromResult(
+                $"Error: File path must be within the current session directory ({sessionDir}) or another Netclaw session under {sessionRoot ?? "<unknown>"}.");
         }
+
+        var attachPath = resolvedInCurrentSession
+            ? resolvedPath
+            : CopyIntoCurrentSession(resolvedPath, sessionDir);
 
         if (!IsPathWithinDirectory(attachPath, sessionDir))
             return Task.FromResult($"Error: Attach path escaped the session directory ({sessionDir}).");


### PR DESCRIPTION
## Why
Agent logs show repeated `attach_file` failures when the model tries to attach screenshots generated in a previous session directory. The tool currently rejects all paths outside the current session, forcing awkward manual copy steps.

## What changed
- Keep strict default-deny behavior for arbitrary filesystem paths.
- Allow `attach_file` to import files from sibling Netclaw session roots (`.../sessions/*` and `.../netclaw-sessions/*`) by copying them into the current session's `attachments/` folder first.
- Continue rejecting paths outside recognized Netclaw session roots and reject symlink escapes.
- Update tool description text so agents understand cross-session handoff behavior.
- Add tests for:
  - sibling-session copy-and-attach success
  - symlink escape from sibling session rejection

## Validation
- `dotnet test --filter FullyQualifiedName~AttachFileToolTests`
- `dotnet test --filter FullyQualifiedName~SlackFileFlowIntegrationTests`
- `dotnet test --nologo`
- `dotnet slopwatch analyze`

## Observed regression evidence
From `sys76-3` daemon logs:
- `Error: File path must be within the session directory ...` for `attach_file` calls that referenced prior session screenshot paths.
- Follow-up calls succeeded only after explicitly copying the same files into the current session directory.