### PR TITLE
Fix OpenAI OAuth: use proprietary device flow instead of RFC 8628

### DIFF
--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -108,6 +108,11 @@ static async Task RunAsync(string[] args)
                 new OAuthDeviceFlowService(
                     sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
                     sp.GetService<TimeProvider>()));
+            builder.Services.AddSingleton(sp =>
+                new OpenAiDeviceFlowService(
+                    sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                    sp.GetService<TimeProvider>()));
+            builder.Services.AddSingleton<DeviceFlowServiceFactory>();
             builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
 
             // Init wizard + chat page dependencies (daemon lifecycle + SignalR)
@@ -338,6 +343,11 @@ static async Task RunAsync(string[] args)
                 new OAuthDeviceFlowService(
                     sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
                     sp.GetService<TimeProvider>()));
+            builder.Services.AddSingleton(sp =>
+                new OpenAiDeviceFlowService(
+                    sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                    sp.GetService<TimeProvider>()));
+            builder.Services.AddSingleton<DeviceFlowServiceFactory>();
             builder.Logging.ClearProviders();
             builder.Logging.SetMinimumLevel(LogLevel.Warning);
 

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -217,11 +217,15 @@ internal static class ProviderCommand
 
         var config = new OAuthDeviceFlowConfig(
             descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId);
+            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId,
+            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
+                ? descriptor.OAuthTokenEndpoint : null);
 
         using var httpClient = new HttpClient();
-        var service = new OAuthDeviceFlowService(httpClient);
+        IDeviceFlowService service = descriptor.UseProprietaryDeviceFlow
+            ? new OpenAiDeviceFlowService(httpClient)
+            : new OAuthDeviceFlowService(httpClient);
 
         try
         {

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -24,7 +24,7 @@ internal static class ProviderCommand
         return subcommand switch
         {
             "list" => Task.FromResult(RunList(paths, writer)),
-            "add" => Task.FromResult(RunAdd(args, paths, registry, writer)),
+            "add" => RunAddAsync(args, paths, registry, writer),
             "remove" => Task.FromResult(RunRemove(args, paths, writer)),
             "help" or "-h" or "--help" => Task.FromResult(WriteHelp(registry, writer)),
             _ => Task.FromResult(WriteHelp(registry, writer))
@@ -51,7 +51,7 @@ internal static class ProviderCommand
         return 0;
     }
 
-    private static int RunAdd(string[] args, NetclawPaths paths, ProviderDescriptorRegistry registry, TextWriter writer)
+    private static async Task<int> RunAddAsync(string[] args, NetclawPaths paths, ProviderDescriptorRegistry registry, TextWriter writer)
     {
         // Parse: netclaw provider add <name> <type> [--api-key <key>] [--endpoint <url>] [--auth <method>]
         if (args.Length < 4)
@@ -128,7 +128,7 @@ internal static class ProviderCommand
                 return 1;
             }
 
-            return RunOAuthDeviceFlow(name, type, endpoint, descriptor, paths, writer);
+            return await RunOAuthDeviceFlowAsync(name, type, endpoint, descriptor, paths, writer);
         }
 
         if (requestedAuthMethod == AuthMethod.ApiKey && !supportedAuth.Contains(AuthMethod.ApiKey))
@@ -202,7 +202,7 @@ internal static class ProviderCommand
         return 0;
     }
 
-    private static int RunOAuthDeviceFlow(
+    private static async Task<int> RunOAuthDeviceFlowAsync(
         string name, string type, string? endpoint,
         IProviderDescriptor descriptor, NetclawPaths paths, TextWriter writer)
     {
@@ -215,12 +215,7 @@ internal static class ProviderCommand
 
         endpoint ??= descriptor.DefaultEndpoint;
 
-        var config = new OAuthDeviceFlowConfig(
-            descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId,
-            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
-                ? descriptor.OAuthTokenEndpoint : null);
+        var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
         using var httpClient = new HttpClient();
         IDeviceFlowService service = descriptor.UseProprietaryDeviceFlow
@@ -231,7 +226,7 @@ internal static class ProviderCommand
         {
             // Start device authorization
             writer.WriteLine("Starting OAuth device authorization...");
-            var deviceAuth = service.StartDeviceAuthorizationAsync(config).GetAwaiter().GetResult();
+            var deviceAuth = await service.StartDeviceAuthorizationAsync(config);
 
             writer.WriteLine();
             writer.WriteLine($"  Visit:      {deviceAuth.VerificationUri}");
@@ -240,12 +235,12 @@ internal static class ProviderCommand
             writer.Write("Waiting for authorization...");
 
             // Poll for token
-            var result = service.PollForTokenAsync(config, deviceAuth,
+            var result = await service.PollForTokenAsync(config, deviceAuth,
                 state =>
                 {
                     if (state == DeviceFlowState.Polling)
                         writer.Write(".");
-                }).GetAwaiter().GetResult();
+                });
 
             writer.WriteLine();
             writer.WriteLine("Authorization successful!");

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -206,16 +206,18 @@ internal static class ProviderCommand
         string name, string type, string? endpoint,
         IProviderDescriptor descriptor, NetclawPaths paths, TextWriter writer)
     {
-        if (descriptor.OAuthDeviceEndpoint is null || descriptor.OAuthTokenEndpoint is null
-            || descriptor.OAuthDefaultClientId is null)
+        endpoint ??= descriptor.DefaultEndpoint;
+
+        OAuthDeviceFlowConfig config;
+        try
+        {
+            config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
+        }
+        catch (ArgumentException)
         {
             writer.WriteLine($"Error: Provider '{type}' missing OAuth endpoint configuration.");
             return 1;
         }
-
-        endpoint ??= descriptor.DefaultEndpoint;
-
-        var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
         using var httpClient = new HttpClient();
         IDeviceFlowService service = descriptor.UseProprietaryDeviceFlow

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -43,7 +43,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     private readonly ProviderDescriptorRegistry _registry;
     private readonly ISlackProbe _slackProbe;
     private readonly IBrowserAutomationBootstrapper _browserBootstrapper;
-    private readonly OAuthDeviceFlowService? _oauthService;
+    private readonly DeviceFlowServiceFactory? _oauthFactory;
     private CancellationTokenSource? _oauthCts;
 
     /// <summary>
@@ -160,10 +160,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         NetclawPaths paths,
         ProviderDescriptorRegistry registry,
         ISlackProbe slackProbe,
-        OAuthDeviceFlowService? oauthService = null,
+        DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
-        : this(paths, registry, registry, slackProbe, null, oauthService, daemonManager, daemonEndpoint)
+        : this(paths, registry, registry, slackProbe, null, oauthFactory, daemonManager, daemonEndpoint)
     {
     }
 
@@ -176,7 +176,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         IProviderProbe probe,
         ISlackProbe slackProbe,
         IBrowserAutomationBootstrapper? browserBootstrapper = null,
-        OAuthDeviceFlowService? oauthService = null,
+        DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
     {
@@ -185,7 +185,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _registry = registry;
         _slackProbe = slackProbe;
         _browserBootstrapper = browserBootstrapper ?? new BrowserAutomationBootstrapper();
-        _oauthService = oauthService;
+        _oauthFactory = oauthFactory;
         _daemonManager = daemonManager;
         _daemonEndpoint = daemonEndpoint ?? "http://127.0.0.1:5199";
     }
@@ -428,7 +428,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     internal async Task StartOAuthDeviceFlowAsync()
     {
-        if (_oauthService is null || SelectedProviderType is null)
+        if (_oauthFactory is null || SelectedProviderType is null)
         {
             OAuthErrorMessage = "OAuth service not available.";
             OAuthFlowState.Value = DeviceFlowState.Error;
@@ -449,20 +449,23 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _oauthCts = new CancellationTokenSource();
         var ct = _oauthCts.Token;
 
+        var service = _oauthFactory.GetFor(descriptor);
         var config = new OAuthDeviceFlowConfig(
             descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId);
+            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId,
+            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
+                ? descriptor.OAuthTokenEndpoint : null);
 
         try
         {
-            var deviceAuth = await _oauthService.StartDeviceAuthorizationAsync(config, ct);
+            var deviceAuth = await service.StartDeviceAuthorizationAsync(config, ct);
             OAuthUserCode = deviceAuth.UserCode;
             OAuthVerificationUri = deviceAuth.VerificationUri;
             OAuthFlowState.Value = DeviceFlowState.WaitingForUser;
             RequestRedraw();
 
-            var result = await _oauthService.PollForTokenAsync(config, deviceAuth,
+            var result = await service.PollForTokenAsync(config, deviceAuth,
                 state =>
                 {
                     OAuthFlowState.Value = state;

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -457,12 +457,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var ct = _oauthCts.Token;
 
         var service = _oauthFactory.GetFor(descriptor);
-        var config = new OAuthDeviceFlowConfig(
-            descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId,
-            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
-                ? descriptor.OAuthTokenEndpoint : null);
+        var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
         try
         {

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -64,7 +64,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     private readonly NetclawPaths _paths;
     private readonly ProviderDescriptorRegistry _registry;
     private readonly IProviderProbe _probe;
-    private readonly OAuthDeviceFlowService? _oauthService;
+    private readonly DeviceFlowServiceFactory? _oauthFactory;
     private CancellationTokenSource? _probeCts;
     private CancellationTokenSource? _oauthCts;
 
@@ -138,18 +138,18 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     public ProviderDescriptorRegistry Registry => _registry;
 
     public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry,
-        OAuthDeviceFlowService? oauthService = null)
-        : this(paths, registry, registry, oauthService)
+        DeviceFlowServiceFactory? oauthFactory = null)
+        : this(paths, registry, registry, oauthFactory)
     {
     }
 
     public ProviderManagerViewModel(NetclawPaths paths, ProviderDescriptorRegistry registry, IProviderProbe probe,
-        OAuthDeviceFlowService? oauthService = null)
+        DeviceFlowServiceFactory? oauthFactory = null)
     {
         _paths = paths;
         _registry = registry;
         _probe = probe;
-        _oauthService = oauthService;
+        _oauthFactory = oauthFactory;
     }
 
     public override void OnActivated()
@@ -538,7 +538,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     /// </summary>
     internal async Task StartOAuthDeviceFlowAsync()
     {
-        if (_oauthService is null || NewProviderType is null)
+        if (_oauthFactory is null || NewProviderType is null)
         {
             OAuthErrorMessage = "OAuth service not available.";
             OAuthFlowState.Value = DeviceFlowState.Error;
@@ -559,22 +559,25 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         _oauthCts = new CancellationTokenSource();
         var ct = _oauthCts.Token;
 
+        var service = _oauthFactory.GetFor(descriptor);
         var config = new OAuthDeviceFlowConfig(
             descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId);
+            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
+            descriptor.OAuthDefaultClientId,
+            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
+                ? descriptor.OAuthTokenEndpoint : null);
 
         try
         {
             // Step 1: Start device authorization
-            var deviceAuth = await _oauthService.StartDeviceAuthorizationAsync(config, ct);
+            var deviceAuth = await service.StartDeviceAuthorizationAsync(config, ct);
             OAuthUserCode = deviceAuth.UserCode;
             OAuthVerificationUri = deviceAuth.VerificationUri;
             OAuthFlowState.Value = DeviceFlowState.WaitingForUser;
             NotifyStateChanged();
 
             // Step 2: Poll for token
-            var result = await _oauthService.PollForTokenAsync(config, deviceAuth,
+            var result = await service.PollForTokenAsync(config, deviceAuth,
                 state =>
                 {
                     OAuthFlowState.Value = state;

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -560,12 +560,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         var ct = _oauthCts.Token;
 
         var service = _oauthFactory.GetFor(descriptor);
-        var config = new OAuthDeviceFlowConfig(
-            descriptor.OAuthDeviceEndpoint,
-            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint,
-            descriptor.OAuthDefaultClientId,
-            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
-                ? descriptor.OAuthTokenEndpoint : null);
+        var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
         try
         {
@@ -841,7 +836,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 return candidate;
         }
 
-        return $"my-{type}-{Guid.NewGuid():N[..6]}";
+        return $"my-{type}-{Guid.NewGuid().ToString("N")[..6]}";
     }
 
     private void ClearAddState()

--- a/src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj
+++ b/src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/DeviceFlowServiceFactoryTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/DeviceFlowServiceFactoryTests.cs
@@ -1,0 +1,79 @@
+using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+public class DeviceFlowServiceFactoryTests
+{
+    [Fact]
+    public void FromDescriptor_ProprietaryFlow_UsesPollingAndPkceExchangeEndpoints()
+    {
+        var descriptor = new TestDescriptor(
+            oauthDeviceEndpoint: "https://auth.example.com/usercode",
+            oauthTokenEndpoint: "https://auth.example.com/oauth/token",
+            oauthDefaultClientId: "client-1",
+            oauthPollingEndpoint: "https://auth.example.com/deviceauth/token",
+            useProprietaryDeviceFlow: true);
+
+        var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
+
+        Assert.Equal("https://auth.example.com/usercode", config.DeviceAuthorizationEndpoint);
+        Assert.Equal("https://auth.example.com/deviceauth/token", config.TokenEndpoint);
+        Assert.Equal("https://auth.example.com/oauth/token", config.PkceExchangeEndpoint);
+    }
+
+    [Fact]
+    public void Factory_ProprietaryDescriptor_ReturnsOpenAiService()
+    {
+        var factory = new DeviceFlowServiceFactory(
+            new OAuthDeviceFlowService(new HttpClient()),
+            new OpenAiDeviceFlowService(new HttpClient()));
+
+        var descriptor = new TestDescriptor(useProprietaryDeviceFlow: true);
+
+        var service = factory.GetFor(descriptor);
+
+        Assert.IsType<OpenAiDeviceFlowService>(service);
+    }
+
+    [Fact]
+    public void Factory_StandardDescriptor_ReturnsStandardOAuthService()
+    {
+        var factory = new DeviceFlowServiceFactory(
+            new OAuthDeviceFlowService(new HttpClient()),
+            new OpenAiDeviceFlowService(new HttpClient()));
+
+        var descriptor = new TestDescriptor(useProprietaryDeviceFlow: false);
+
+        var service = factory.GetFor(descriptor);
+
+        Assert.IsType<OAuthDeviceFlowService>(service);
+    }
+
+    private sealed class TestDescriptor(
+        string? oauthDeviceEndpoint = "https://example.com/device",
+        string? oauthTokenEndpoint = "https://example.com/token",
+        string? oauthDefaultClientId = "client-id",
+        string? oauthPollingEndpoint = null,
+        bool useProprietaryDeviceFlow = false) : IProviderDescriptor
+    {
+        public string TypeKey => "test";
+        public string DisplayName => "Test";
+        public IReadOnlyList<AuthMethod> SupportedAuthMethods => [AuthMethod.OAuthDevice];
+        public string DefaultEndpoint => "https://example.com";
+        public string ModelListingPath => "/models";
+        public CredentialInputMode CredentialMode => CredentialInputMode.ApiKey;
+        public string? ApiKeyGuidanceUrl => null;
+        public string? OAuthDeviceEndpoint => oauthDeviceEndpoint;
+        public string? OAuthTokenEndpoint => oauthTokenEndpoint;
+        public string? OAuthDefaultClientId => oauthDefaultClientId;
+        public string? OAuthPollingEndpoint => oauthPollingEndpoint;
+        public bool UseProprietaryDeviceFlow => useProprietaryDeviceFlow;
+
+        public Task<ProviderProbeResult> ProbeAsync(ProviderEntry entry, CancellationToken ct = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
@@ -204,4 +204,25 @@ public class OAuthDeviceFlowServiceTests
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task RefreshToken_StringOverload_RemainsSupported()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                expires_in = 3600
+            }));
+
+        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.example.com/token",
+            "client-id",
+            "old-refresh-token");
+
+        Assert.NotNull(result);
+        Assert.Equal("new-at", result!.AccessToken.Value);
+    }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs
@@ -1,8 +1,8 @@
 using System.Net;
-using System.Text;
-using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration.Providers.OAuth;
 using Xunit;
+using static Netclaw.Configuration.Tests.Providers.OAuth.OAuthTestHelpers;
 
 namespace Netclaw.Configuration.Tests.Providers.OAuth;
 
@@ -55,18 +55,24 @@ public class OAuthDeviceFlowServiceTests
             });
         });
 
-        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OAuthDeviceFlowService(new HttpClient(handler), timeProvider);
 
-        // Use a very short interval device auth to keep the test fast
         var deviceAuth = new DeviceAuthorizationResponse(
             DeviceCode: "dc-test",
             UserCode: "UC-TEST",
             VerificationUri: "https://auth.example.com/verify",
             ExpiresIn: 30,
-            Interval: 1); // test-friendly interval; code clamps to max(interval, 1)
+            Interval: 1);
 
         var states = new List<DeviceFlowState>();
-        var result = await service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+
+        // Advance time to trigger each poll interval
+        for (var i = 0; i < 3; i++)
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await pollTask;
 
         Assert.Equal("at-secret", result.AccessToken.Value);
         Assert.NotNull(result.RefreshToken);
@@ -90,10 +96,18 @@ public class OAuthDeviceFlowServiceTests
             return JsonResponse(new { access_token = "token", expires_in = 3600 });
         });
 
-        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OAuthDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
 
-        var result = await service.PollForTokenAsync(TestConfig, deviceAuth);
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+
+        // First poll at 1s interval
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        // After slow_down, interval increases to 6s (1+5)
+        timeProvider.Advance(TimeSpan.FromSeconds(6));
+
+        var result = await pollTask;
 
         Assert.Equal("token", result.AccessToken.Value);
         Assert.True(callCount >= 2);
@@ -105,11 +119,14 @@ public class OAuthDeviceFlowServiceTests
         var handler = new FakeHttpMessageHandler(_ =>
             JsonResponse(new { error = "access_denied" }, HttpStatusCode.BadRequest));
 
-        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OAuthDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
 
-        await Assert.ThrowsAsync<OAuthDeviceFlowDeniedException>(
-            () => service.PollForTokenAsync(TestConfig, deviceAuth));
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<OAuthDeviceFlowDeniedException>(() => pollTask);
     }
 
     [Fact]
@@ -118,11 +135,14 @@ public class OAuthDeviceFlowServiceTests
         var handler = new FakeHttpMessageHandler(_ =>
             JsonResponse(new { error = "expired_token" }, HttpStatusCode.BadRequest));
 
-        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OAuthDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
 
-        await Assert.ThrowsAsync<OAuthDeviceFlowExpiredException>(
-            () => service.PollForTokenAsync(TestConfig, deviceAuth));
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<OAuthDeviceFlowExpiredException>(() => pollTask);
     }
 
     [Fact]
@@ -131,13 +151,18 @@ public class OAuthDeviceFlowServiceTests
         var handler = new FakeHttpMessageHandler(_ =>
             JsonResponse(new { error = "authorization_pending" }, HttpStatusCode.BadRequest));
 
-        var service = new OAuthDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OAuthDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse("dc", "UC", "https://x.com/v", 60, 1);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var cts = new CancellationTokenSource();
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token));
+        // Cancel before advancing time
+        cts.Cancel();
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pollTask);
     }
 
     [Fact]
@@ -156,7 +181,7 @@ public class OAuthDeviceFlowServiceTests
         var result = await service.RefreshTokenAsync(
             "https://auth.example.com/token",
             "client-id",
-            "old-refresh-token");
+            new SensitiveString("old-refresh-token"));
 
         Assert.NotNull(result);
         Assert.Equal("new-at", result!.AccessToken.Value);
@@ -175,36 +200,8 @@ public class OAuthDeviceFlowServiceTests
         var result = await service.RefreshTokenAsync(
             "https://auth.example.com/token",
             "client-id",
-            "expired-refresh-token");
+            new SensitiveString("expired-refresh-token"));
 
         Assert.Null(result);
-    }
-
-    // ── Helpers ──
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-    {
-        var json = JsonSerializer.Serialize(body);
-        return new HttpResponseMessage(status)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json")
-        };
-    }
-
-    private sealed class FakeHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_handler(request));
-        }
     }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTestHelpers.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthTestHelpers.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+internal static class OAuthTestHelpers
+{
+    public static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var json = JsonSerializer.Serialize(body);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+}
+
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        _handler = handler;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_handler(request));
+    }
+}

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Configuration.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers.OAuth;
+
+public class OpenAiDeviceFlowServiceTests
+{
+    private static readonly OAuthDeviceFlowConfig TestConfig = new(
+        DeviceAuthorizationEndpoint: "https://auth.openai.com/api/accounts/deviceauth/usercode",
+        TokenEndpoint: "https://auth.openai.com/api/accounts/deviceauth/token",
+        ClientId: "test-client-id",
+        PkceExchangeEndpoint: "https://auth.openai.com/oauth/token");
+
+    [Fact]
+    public async Task StartDeviceAuthorization_PostsJsonWithClientId_ReturnsUserCode()
+    {
+        string? capturedBody = null;
+        string? capturedContentType = null;
+
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            capturedContentType = request.Content?.Headers.ContentType?.MediaType;
+            return JsonResponse(new
+            {
+                device_auth_id = "daid-123",
+                user_code = "ABCD-1234",
+                interval = 5
+            });
+        });
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var result = await service.StartDeviceAuthorizationAsync(TestConfig);
+
+        // Verify JSON body with client_id
+        Assert.Equal("application/json", capturedContentType);
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody!);
+        Assert.Equal("test-client-id", doc.RootElement.GetProperty("client_id").GetString());
+
+        // Verify response mapping
+        Assert.Equal("daid-123", result.DeviceCode); // device_auth_id → DeviceCode
+        Assert.Equal("ABCD-1234", result.UserCode);
+        Assert.Equal("https://auth.openai.com/codex/device", result.VerificationUri);
+        Assert.Equal(5, result.Interval);
+    }
+
+    [Fact]
+    public async Task StartDeviceAuthorization_404_ThrowsWithGuidance()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.StartDeviceAuthorizationAsync(TestConfig));
+
+        Assert.Contains("not available", ex.Message);
+        Assert.Contains("API key", ex.Message);
+    }
+
+    [Fact]
+    public async Task PollForToken_403Pending_ThenSuccess_ExchangesForToken()
+    {
+        var callCount = 0;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            callCount++;
+            var url = request.RequestUri!.ToString();
+
+            // First two calls are polls returning 403 (pending)
+            if (url.Contains("deviceauth/token") && callCount <= 2)
+                return new HttpResponseMessage(HttpStatusCode.Forbidden);
+
+            // Third poll returns auth code
+            if (url.Contains("deviceauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    authorization_code = "auth-code-123",
+                    code_challenge = "challenge-abc",
+                    code_verifier = "verifier-xyz"
+                });
+            }
+
+            // Token exchange
+            if (url.Contains("oauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    access_token = "at-secret",
+                    refresh_token = "rt-secret",
+                    expires_in = 3600
+                });
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        });
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse(
+            DeviceCode: "daid-test",
+            UserCode: "UC-TEST",
+            VerificationUri: "https://auth.openai.com/codex/device",
+            ExpiresIn: 30,
+            Interval: 1);
+
+        var states = new List<DeviceFlowState>();
+        var result = await service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+
+        Assert.Equal("at-secret", result.AccessToken.Value);
+        Assert.NotNull(result.RefreshToken);
+        Assert.Equal("rt-secret", result.RefreshToken!.Value);
+        Assert.NotNull(result.ExpiresAt);
+        Assert.Contains(DeviceFlowState.WaitingForUser, states);
+        Assert.Contains(DeviceFlowState.Succeeded, states);
+        // 2 pending polls + 1 success poll + 1 token exchange = 4 calls total
+        Assert.Equal(4, callCount);
+    }
+
+    [Fact]
+    public async Task PollForToken_Cancellation_ThrowsOperationCanceled()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.Forbidden));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var deviceAuth = new DeviceAuthorizationResponse(
+            "daid", "UC", "https://auth.openai.com/codex/device", 60, 1);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task RefreshToken_Success_ReturnsNewToken()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                refresh_token = "new-rt",
+                expires_in = 3600
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.openai.com/oauth/token",
+            "client-id",
+            "old-refresh-token");
+
+        Assert.NotNull(result);
+        Assert.Equal("new-at", result!.AccessToken.Value);
+        Assert.NotNull(result.RefreshToken);
+        Assert.Equal("new-rt", result.RefreshToken!.Value);
+    }
+
+    [Fact]
+    public async Task RefreshToken_InvalidGrant_ReturnsNull()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "invalid_grant" }, HttpStatusCode.BadRequest));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.openai.com/oauth/token",
+            "client-id",
+            "expired-refresh-token");
+
+        Assert.Null(result);
+    }
+
+    // ── Helpers ──
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var json = JsonSerializer.Serialize(body);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
@@ -1,8 +1,9 @@
 using System.Net;
-using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration.Providers.OAuth;
 using Xunit;
+using static Netclaw.Configuration.Tests.Providers.OAuth.OAuthTestHelpers;
 
 namespace Netclaw.Configuration.Tests.Providers.OAuth;
 
@@ -42,7 +43,7 @@ public class OpenAiDeviceFlowServiceTests
         Assert.Equal("test-client-id", doc.RootElement.GetProperty("client_id").GetString());
 
         // Verify response mapping
-        Assert.Equal("daid-123", result.DeviceCode); // device_auth_id → DeviceCode
+        Assert.Equal("daid-123", result.DeviceCode); // device_auth_id -> DeviceCode
         Assert.Equal("ABCD-1234", result.UserCode);
         Assert.Equal("https://auth.openai.com/codex/device", result.VerificationUri);
         Assert.Equal(5, result.Interval);
@@ -82,7 +83,6 @@ public class OpenAiDeviceFlowServiceTests
                 return JsonResponse(new
                 {
                     authorization_code = "auth-code-123",
-                    code_challenge = "challenge-abc",
                     code_verifier = "verifier-xyz"
                 });
             }
@@ -101,7 +101,8 @@ public class OpenAiDeviceFlowServiceTests
             return new HttpResponseMessage(HttpStatusCode.InternalServerError);
         });
 
-        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse(
             DeviceCode: "daid-test",
             UserCode: "UC-TEST",
@@ -110,7 +111,13 @@ public class OpenAiDeviceFlowServiceTests
             Interval: 1);
 
         var states = new List<DeviceFlowState>();
-        var result = await service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth, s => states.Add(s));
+
+        // Advance time to trigger each poll interval
+        for (var i = 0; i < 3; i++)
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await pollTask;
 
         Assert.Equal("at-secret", result.AccessToken.Value);
         Assert.NotNull(result.RefreshToken);
@@ -123,19 +130,112 @@ public class OpenAiDeviceFlowServiceTests
     }
 
     [Fact]
+    public async Task PollForToken_5xxTransient_KeepsPolling()
+    {
+        var callCount = 0;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            callCount++;
+            var url = request.RequestUri!.ToString();
+
+            if (url.Contains("deviceauth/token"))
+            {
+                // First call returns 502 (transient)
+                if (callCount == 1)
+                    return new HttpResponseMessage(HttpStatusCode.BadGateway);
+
+                // Second call returns auth code
+                return JsonResponse(new
+                {
+                    authorization_code = "auth-code-123",
+                    code_verifier = "verifier-xyz"
+                });
+            }
+
+            // Token exchange
+            if (url.Contains("oauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    access_token = "at-secret",
+                    expires_in = 3600
+                });
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        });
+
+        var timeProvider = new FakeTimeProvider();
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
+        var deviceAuth = new DeviceAuthorizationResponse(
+            "daid", "UC", "https://auth.openai.com/codex/device", 30, 1);
+
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await pollTask;
+
+        Assert.Equal("at-secret", result.AccessToken.Value);
+        // 1 transient 502 + 1 success poll + 1 token exchange = 3 calls
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public async Task PollForToken_PkceExchangeFailure_ThrowsWithContext()
+    {
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+
+            // Poll returns auth code immediately
+            if (url.Contains("deviceauth/token"))
+            {
+                return JsonResponse(new
+                {
+                    authorization_code = "auth-code-123",
+                    code_verifier = "verifier-xyz"
+                });
+            }
+
+            // PKCE exchange fails
+            if (url.Contains("oauth/token"))
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        });
+
+        var timeProvider = new FakeTimeProvider();
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
+        var deviceAuth = new DeviceAuthorizationResponse(
+            "daid", "UC", "https://auth.openai.com/codex/device", 30, 1);
+
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        // PKCE exchange failure should propagate as HttpRequestException
+        await Assert.ThrowsAsync<HttpRequestException>(() => pollTask);
+    }
+
+    [Fact]
     public async Task PollForToken_Cancellation_ThrowsOperationCanceled()
     {
         var handler = new FakeHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.Forbidden));
 
-        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var timeProvider = new FakeTimeProvider();
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
         var deviceAuth = new DeviceAuthorizationResponse(
             "daid", "UC", "https://auth.openai.com/codex/device", 60, 1);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var cts = new CancellationTokenSource();
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => service.PollForTokenAsync(TestConfig, deviceAuth, ct: cts.Token));
+        cts.Cancel();
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pollTask);
     }
 
     [Fact]
@@ -154,7 +254,7 @@ public class OpenAiDeviceFlowServiceTests
         var result = await service.RefreshTokenAsync(
             "https://auth.openai.com/oauth/token",
             "client-id",
-            "old-refresh-token");
+            new SensitiveString("old-refresh-token"));
 
         Assert.NotNull(result);
         Assert.Equal("new-at", result!.AccessToken.Value);
@@ -173,36 +273,8 @@ public class OpenAiDeviceFlowServiceTests
         var result = await service.RefreshTokenAsync(
             "https://auth.openai.com/oauth/token",
             "client-id",
-            "expired-refresh-token");
+            new SensitiveString("expired-refresh-token"));
 
         Assert.Null(result);
-    }
-
-    // ── Helpers ──
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-    {
-        var json = JsonSerializer.Serialize(body);
-        return new HttpResponseMessage(status)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json")
-        };
-    }
-
-    private sealed class FakeHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_handler(request));
-        }
     }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
@@ -29,7 +29,8 @@ public class OpenAiDeviceFlowServiceTests
             {
                 device_auth_id = "daid-123",
                 user_code = "ABCD-1234",
-                interval = 5
+                interval = 5,
+                expires_in = 1200
             });
         });
 
@@ -46,7 +47,25 @@ public class OpenAiDeviceFlowServiceTests
         Assert.Equal("daid-123", result.DeviceCode); // device_auth_id -> DeviceCode
         Assert.Equal("ABCD-1234", result.UserCode);
         Assert.Equal("https://auth.openai.com/codex/device", result.VerificationUri);
+        Assert.Equal(1200, result.ExpiresIn);
         Assert.Equal(5, result.Interval);
+    }
+
+    [Fact]
+    public async Task StartDeviceAuthorization_MissingExpiresIn_UsesDefaultExpiry()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                device_auth_id = "daid-123",
+                user_code = "ABCD-1234",
+                interval = 5
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+        var result = await service.StartDeviceAuthorizationAsync(TestConfig);
+
+        Assert.Equal(900, result.ExpiresIn);
     }
 
     [Fact]
@@ -183,6 +202,25 @@ public class OpenAiDeviceFlowServiceTests
     }
 
     [Fact]
+    public async Task PollForToken_404_FailsFastWithConfigurationGuidance()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var timeProvider = new FakeTimeProvider();
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler), timeProvider);
+        var deviceAuth = new DeviceAuthorizationResponse(
+            "daid", "UC", "https://auth.openai.com/codex/device", 30, 1);
+
+        var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => pollTask);
+        Assert.Contains("endpoint", ex.Message);
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
     public async Task PollForToken_PkceExchangeFailure_Propagates()
     {
         var handler = new FakeHttpMessageHandler(request =>
@@ -280,5 +318,26 @@ public class OpenAiDeviceFlowServiceTests
             new SensitiveString("expired-refresh-token"));
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task RefreshToken_StringOverload_RemainsSupported()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new
+            {
+                access_token = "new-at",
+                expires_in = 3600
+            }));
+
+        var service = new OpenAiDeviceFlowService(new HttpClient(handler));
+
+        var result = await service.RefreshTokenAsync(
+            "https://auth.openai.com/oauth/token",
+            "client-id",
+            "old-refresh-token");
+
+        Assert.NotNull(result);
+        Assert.Equal("new-at", result!.AccessToken.Value);
     }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OpenAiDeviceFlowServiceTests.cs
@@ -183,7 +183,7 @@ public class OpenAiDeviceFlowServiceTests
     }
 
     [Fact]
-    public async Task PollForToken_PkceExchangeFailure_ThrowsWithContext()
+    public async Task PollForToken_PkceExchangeFailure_Propagates()
     {
         var handler = new FakeHttpMessageHandler(request =>
         {
@@ -199,9 +199,13 @@ public class OpenAiDeviceFlowServiceTests
                 });
             }
 
-            // PKCE exchange fails
+            // PKCE exchange fails with 400
             if (url.Contains("oauth/token"))
-                return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            {
+                return JsonResponse(
+                    new { error = "invalid_grant", error_description = "code_verifier mismatch" },
+                    HttpStatusCode.BadRequest);
+            }
 
             return new HttpResponseMessage(HttpStatusCode.InternalServerError);
         });
@@ -214,8 +218,8 @@ public class OpenAiDeviceFlowServiceTests
         var pollTask = service.PollForTokenAsync(TestConfig, deviceAuth);
         timeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        // PKCE exchange failure should propagate as HttpRequestException
-        await Assert.ThrowsAsync<HttpRequestException>(() => pollTask);
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => pollTask);
+        Assert.Contains("400", ex.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration/Providers/Descriptors/OpenAiDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OpenAiDescriptor.cs
@@ -21,9 +21,11 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
     public string ModelListingPath => "/v1/models";
     public CredentialInputMode CredentialMode => CredentialInputMode.ApiKey;
     public string? ApiKeyGuidanceUrl => "https://platform.openai.com/api-keys";
-    public string? OAuthDeviceEndpoint => "https://auth.openai.com/codex/device";
+    public string? OAuthDeviceEndpoint => "https://auth.openai.com/api/accounts/deviceauth/usercode";
     public string? OAuthTokenEndpoint => "https://auth.openai.com/oauth/token";
     public string? OAuthDefaultClientId => "app_EMoamEEZ73f0CkXaXp7hrann";
+    public string? OAuthPollingEndpoint => "https://auth.openai.com/api/accounts/deviceauth/token";
+    public bool UseProprietaryDeviceFlow => true;
 
     public Task<ProviderProbeResult> ProbeAsync(
         ProviderEntry entry, CancellationToken ct = default)

--- a/src/Netclaw.Configuration/Providers/IProviderDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/IProviderDescriptor.cs
@@ -35,7 +35,9 @@ public interface IProviderDescriptor
     string? ApiKeyGuidanceUrl { get; }
 
     /// <summary>
-    /// RFC 8628 device authorization endpoint URL.
+    /// Device authorization endpoint URL (user-code request).
+    /// For RFC 8628: the standard device authorization endpoint.
+    /// For OpenAI: the <c>/api/accounts/deviceauth/usercode</c> endpoint.
     /// Null for providers that don't support OAuth device flow.
     /// </summary>
     string? OAuthDeviceEndpoint { get; }
@@ -51,6 +53,20 @@ public interface IProviderDescriptor
     /// Null for providers that don't support OAuth.
     /// </summary>
     string? OAuthDefaultClientId { get; }
+
+    /// <summary>
+    /// Polling endpoint for proprietary device flows (e.g. OpenAI's
+    /// <c>/api/accounts/deviceauth/token</c>). Null for standard RFC 8628 flows
+    /// where polling goes to <see cref="OAuthTokenEndpoint"/>.
+    /// </summary>
+    string? OAuthPollingEndpoint => null;
+
+    /// <summary>
+    /// Whether this provider uses a proprietary device flow instead of RFC 8628.
+    /// When true, the system uses <see cref="OAuthPollingEndpoint"/> for poll requests
+    /// and performs a PKCE exchange at <see cref="OAuthTokenEndpoint"/> after polling succeeds.
+    /// </summary>
+    bool UseProprietaryDeviceFlow => false;
 
     /// <summary>
     /// Validate credentials and discover available models.

--- a/src/Netclaw.Configuration/Providers/OAuth/DeviceFlowServiceFactory.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/DeviceFlowServiceFactory.cs
@@ -1,0 +1,22 @@
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// Selects the correct <see cref="IDeviceFlowService"/> implementation
+/// based on the provider descriptor.
+/// </summary>
+public sealed class DeviceFlowServiceFactory
+{
+    private readonly OAuthDeviceFlowService _standard;
+    private readonly OpenAiDeviceFlowService _openAi;
+
+    public DeviceFlowServiceFactory(
+        OAuthDeviceFlowService standard,
+        OpenAiDeviceFlowService openAi)
+    {
+        _standard = standard;
+        _openAi = openAi;
+    }
+
+    public IDeviceFlowService GetFor(IProviderDescriptor descriptor) =>
+        descriptor.UseProprietaryDeviceFlow ? _openAi : _standard;
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
@@ -28,6 +28,6 @@ public interface IDeviceFlowService
     Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
         string tokenEndpoint,
         string clientId,
-        string refreshToken,
+        SensitiveString refreshToken,
         CancellationToken ct = default);
 }

--- a/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
@@ -1,0 +1,33 @@
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// Abstraction for device authorization flows.
+/// Implementations may use standard RFC 8628 or provider-specific protocols.
+/// </summary>
+public interface IDeviceFlowService
+{
+    /// <summary>
+    /// Initiate device authorization — requests a user code and verification URI.
+    /// </summary>
+    Task<DeviceAuthorizationResponse> StartDeviceAuthorizationAsync(
+        OAuthDeviceFlowConfig config, CancellationToken ct = default);
+
+    /// <summary>
+    /// Poll until the user authorizes, denies, or the code expires.
+    /// </summary>
+    Task<OAuthDeviceFlowResult> PollForTokenAsync(
+        OAuthDeviceFlowConfig config,
+        DeviceAuthorizationResponse deviceAuth,
+        Action<DeviceFlowState>? onStateChanged = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Exchange a refresh token for a new access token.
+    /// Returns null if the refresh token is invalid or revoked.
+    /// </summary>
+    Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default);
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/IDeviceFlowService.cs
@@ -30,4 +30,14 @@ public interface IDeviceFlowService
         string clientId,
         SensitiveString refreshToken,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Backward-compatible overload that accepts a raw refresh token string.
+    /// </summary>
+    Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default) =>
+        RefreshTokenAsync(tokenEndpoint, clientId, new SensitiveString(refreshToken), ct);
 }

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
@@ -5,13 +5,19 @@ using System.Text.Json.Serialization;
 namespace Netclaw.Configuration.Providers.OAuth;
 
 /// <summary>
-/// Configuration for an RFC 8628 device authorization grant flow.
+/// Configuration for a device authorization grant flow.
+/// For RFC 8628, <see cref="DeviceAuthorizationEndpoint"/> is the device auth endpoint
+/// and <see cref="TokenEndpoint"/> is the token endpoint.
+/// For OpenAI's proprietary flow, <see cref="DeviceAuthorizationEndpoint"/> is the
+/// user-code endpoint, <see cref="TokenEndpoint"/> is the polling endpoint, and
+/// <see cref="PkceExchangeEndpoint"/> is the final token exchange endpoint.
 /// </summary>
 public sealed record OAuthDeviceFlowConfig(
     string DeviceAuthorizationEndpoint,
     string TokenEndpoint,
     string ClientId,
-    string? Scope = null);
+    string? Scope = null,
+    string? PkceExchangeEndpoint = null);
 
 /// <summary>
 /// Response from the device authorization endpoint (RFC 8628 §3.2).
@@ -50,7 +56,7 @@ public enum DeviceFlowState
 /// Generic RFC 8628 device authorization grant implementation.
 /// Parameterized by provider endpoints so it can be reused across providers.
 /// </summary>
-public sealed class OAuthDeviceFlowService
+public sealed class OAuthDeviceFlowService : IDeviceFlowService
 {
     private readonly HttpClient _httpClient;
     private readonly TimeProvider _timeProvider;

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
@@ -222,6 +222,13 @@ public sealed class OAuthDeviceFlowService : IDeviceFlowService
         return ParseTokenResponse(doc.RootElement);
     }
 
+    public Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default) =>
+        RefreshTokenAsync(tokenEndpoint, clientId, new SensitiveString(refreshToken), ct);
+
     private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
     {
         var accessToken = root.GetProperty("access_token").GetString()

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
@@ -17,7 +17,22 @@ public sealed record OAuthDeviceFlowConfig(
     string TokenEndpoint,
     string ClientId,
     string? Scope = null,
-    string? PkceExchangeEndpoint = null);
+    string? PkceExchangeEndpoint = null)
+{
+    /// <summary>
+    /// Build a config from a provider descriptor's OAuth endpoint properties.
+    /// </summary>
+    public static OAuthDeviceFlowConfig FromDescriptor(IProviderDescriptor descriptor) =>
+        new(
+            descriptor.OAuthDeviceEndpoint
+                ?? throw new ArgumentException("Descriptor missing OAuthDeviceEndpoint", nameof(descriptor)),
+            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint
+                ?? throw new ArgumentException("Descriptor missing OAuthTokenEndpoint", nameof(descriptor)),
+            descriptor.OAuthDefaultClientId
+                ?? throw new ArgumentException("Descriptor missing OAuthDefaultClientId", nameof(descriptor)),
+            PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
+                ? descriptor.OAuthTokenEndpoint : null);
+}
 
 /// <summary>
 /// Response from the device authorization endpoint (RFC 8628 §3.2).
@@ -168,14 +183,14 @@ public sealed class OAuthDeviceFlowService : IDeviceFlowService
     public async Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
         string tokenEndpoint,
         string clientId,
-        string refreshToken,
+        SensitiveString refreshToken,
         CancellationToken ct = default)
     {
         var tokenParams = new Dictionary<string, string>
         {
             ["grant_type"] = "refresh_token",
             ["client_id"] = clientId,
-            ["refresh_token"] = refreshToken
+            ["refresh_token"] = refreshToken.Value
         };
 
         var response = await _httpClient.PostAsync(

--- a/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OAuthDeviceFlowService.cs
@@ -22,16 +22,22 @@ public sealed record OAuthDeviceFlowConfig(
     /// <summary>
     /// Build a config from a provider descriptor's OAuth endpoint properties.
     /// </summary>
-    public static OAuthDeviceFlowConfig FromDescriptor(IProviderDescriptor descriptor) =>
-        new(
-            descriptor.OAuthDeviceEndpoint
-                ?? throw new ArgumentException("Descriptor missing OAuthDeviceEndpoint", nameof(descriptor)),
-            descriptor.OAuthPollingEndpoint ?? descriptor.OAuthTokenEndpoint
-                ?? throw new ArgumentException("Descriptor missing OAuthTokenEndpoint", nameof(descriptor)),
-            descriptor.OAuthDefaultClientId
-                ?? throw new ArgumentException("Descriptor missing OAuthDefaultClientId", nameof(descriptor)),
+    public static OAuthDeviceFlowConfig FromDescriptor(IProviderDescriptor descriptor)
+    {
+        var deviceEndpoint = descriptor.OAuthDeviceEndpoint
+            ?? throw new ArgumentException("Descriptor missing OAuthDeviceEndpoint", nameof(descriptor));
+        var tokenEndpoint = descriptor.OAuthTokenEndpoint
+            ?? throw new ArgumentException("Descriptor missing OAuthTokenEndpoint", nameof(descriptor));
+        var clientId = descriptor.OAuthDefaultClientId
+            ?? throw new ArgumentException("Descriptor missing OAuthDefaultClientId", nameof(descriptor));
+
+        return new(
+            deviceEndpoint,
+            descriptor.OAuthPollingEndpoint ?? tokenEndpoint,
+            clientId,
             PkceExchangeEndpoint: descriptor.UseProprietaryDeviceFlow
-                ? descriptor.OAuthTokenEndpoint : null);
+                ? tokenEndpoint : null);
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Configuration.Providers.OAuth;
+
+/// <summary>
+/// OpenAI proprietary device authorization flow.
+/// Unlike RFC 8628, OpenAI uses a custom 4-step protocol:
+/// 1. POST JSON {client_id} to usercode endpoint → {device_auth_id, user_code, interval}
+/// 2. User visits verification URL and enters user_code
+/// 3. Poll token endpoint with {device_auth_id, user_code} → {authorization_code, code_verifier}
+/// 4. PKCE exchange at /oauth/token with authorization_code + code_verifier → access_token
+/// </summary>
+public sealed class OpenAiDeviceFlowService : IDeviceFlowService
+{
+    private const string VerificationUri = "https://auth.openai.com/codex/device";
+    private const string RedirectUri = "https://auth.openai.com/deviceauth/callback";
+    private const int DefaultExpiresIn = 900; // 15 minutes
+
+    private readonly HttpClient _httpClient;
+    private readonly TimeProvider _timeProvider;
+
+    public OpenAiDeviceFlowService(HttpClient httpClient, TimeProvider? timeProvider = null)
+    {
+        _httpClient = httpClient;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Step 1: POST JSON {client_id} to the usercode endpoint.
+    /// Maps OpenAI's response shape to <see cref="DeviceAuthorizationResponse"/>.
+    /// </summary>
+    public async Task<DeviceAuthorizationResponse> StartDeviceAuthorizationAsync(
+        OAuthDeviceFlowConfig config, CancellationToken ct = default)
+    {
+        var payload = new { client_id = config.ClientId };
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _httpClient.PostAsJsonAsync(
+                config.DeviceAuthorizationEndpoint, payload, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException(
+                "Could not reach OpenAI authentication servers. Check your internet connection and try again.",
+                ex);
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new InvalidOperationException(
+                "Device code login is not available for your OpenAI account. " +
+                "Try using an API key instead, or contact your workspace admin to enable device code authentication.");
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<OpenAiUserCodeResponse>(ct);
+        if (result is null)
+            throw new InvalidOperationException("Empty device authorization response from OpenAI.");
+
+        // Map OpenAI's response to the shared DeviceAuthorizationResponse
+        return new DeviceAuthorizationResponse(
+            DeviceCode: result.DeviceAuthId,
+            UserCode: result.UserCode,
+            VerificationUri: VerificationUri,
+            ExpiresIn: DefaultExpiresIn,
+            Interval: Math.Max(result.Interval, 1));
+    }
+
+    /// <summary>
+    /// Steps 3-4: Poll for authorization code, then exchange via PKCE for tokens.
+    /// </summary>
+    public async Task<OAuthDeviceFlowResult> PollForTokenAsync(
+        OAuthDeviceFlowConfig config,
+        DeviceAuthorizationResponse deviceAuth,
+        Action<DeviceFlowState>? onStateChanged = null,
+        CancellationToken ct = default)
+    {
+        var interval = Math.Max(deviceAuth.Interval, 1);
+        var deadline = _timeProvider.GetUtcNow().AddSeconds(deviceAuth.ExpiresIn);
+
+        onStateChanged?.Invoke(DeviceFlowState.WaitingForUser);
+
+        while (_timeProvider.GetUtcNow() < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            await Task.Delay(TimeSpan.FromSeconds(interval), _timeProvider, ct);
+
+            onStateChanged?.Invoke(DeviceFlowState.Polling);
+
+            // Step 3: Poll for authorization code
+            var pollPayload = new
+            {
+                device_auth_id = deviceAuth.DeviceCode,
+                user_code = deviceAuth.UserCode
+            };
+
+            HttpResponseMessage response;
+            try
+            {
+                response = await _httpClient.PostAsJsonAsync(
+                    config.TokenEndpoint, pollPayload, ct);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException(
+                    "Lost connection to OpenAI authentication servers. Check your internet connection.",
+                    ex);
+            }
+
+            // 403/404 = authorization pending, keep polling
+            if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+                continue;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                onStateChanged?.Invoke(DeviceFlowState.Error);
+                throw new InvalidOperationException(
+                    $"OpenAI returned an unexpected error (HTTP {(int)response.StatusCode}). Please try again.");
+            }
+
+            // Success: parse the authorization code + PKCE material
+            var authCodeResponse = await response.Content
+                .ReadFromJsonAsync<OpenAiAuthCodeResponse>(ct);
+
+            if (authCodeResponse is null)
+            {
+                onStateChanged?.Invoke(DeviceFlowState.Error);
+                throw new InvalidOperationException(
+                    "Empty authorization response from OpenAI.");
+            }
+
+            // Step 4: Exchange authorization code for tokens via PKCE
+            var exchangeEndpoint = config.PkceExchangeEndpoint ?? config.TokenEndpoint;
+            var result = await ExchangeCodeForTokensAsync(
+                exchangeEndpoint, config.ClientId, authCodeResponse, ct);
+
+            onStateChanged?.Invoke(DeviceFlowState.Succeeded);
+            return result;
+        }
+
+        onStateChanged?.Invoke(DeviceFlowState.Expired);
+        throw new OAuthDeviceFlowExpiredException();
+    }
+
+    /// <inheritdoc />
+    public async Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default)
+    {
+        var tokenParams = new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["client_id"] = clientId,
+            ["refresh_token"] = refreshToken
+        };
+
+        var response = await _httpClient.PostAsync(
+            tokenEndpoint,
+            new FormUrlEncodedContent(tokenParams),
+            ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorJson = await response.Content.ReadAsStringAsync(ct);
+            using var errorDoc = JsonDocument.Parse(errorJson);
+            var error = errorDoc.RootElement.TryGetProperty("error", out var errProp)
+                ? errProp.GetString() : null;
+
+            if (error == "invalid_grant")
+                return null;
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return ParseTokenResponse(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Step 4: Exchange the authorization code for access/refresh tokens using PKCE.
+    /// </summary>
+    private async Task<OAuthDeviceFlowResult> ExchangeCodeForTokensAsync(
+        string tokenEndpoint,
+        string clientId,
+        OpenAiAuthCodeResponse authCode,
+        CancellationToken ct)
+    {
+        var tokenParams = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = clientId,
+            ["code"] = authCode.AuthorizationCode,
+            ["code_verifier"] = authCode.CodeVerifier,
+            ["redirect_uri"] = RedirectUri
+        };
+
+        var response = await _httpClient.PostAsync(
+            tokenEndpoint,
+            new FormUrlEncodedContent(tokenParams),
+            ct);
+
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return ParseTokenResponse(doc.RootElement);
+    }
+
+    private OAuthDeviceFlowResult ParseTokenResponse(JsonElement root)
+    {
+        var accessToken = root.GetProperty("access_token").GetString()
+            ?? throw new InvalidOperationException("Missing access_token in response.");
+
+        string? refreshToken = root.TryGetProperty("refresh_token", out var refreshProp)
+            ? refreshProp.GetString() : null;
+
+        DateTimeOffset? expiresAt = root.TryGetProperty("expires_in", out var expiresProp)
+            ? _timeProvider.GetUtcNow().AddSeconds(expiresProp.GetInt32())
+            : null;
+
+        return new OAuthDeviceFlowResult(
+            new SensitiveString(accessToken),
+            refreshToken is not null ? new SensitiveString(refreshToken) : null,
+            expiresAt);
+    }
+
+    // OpenAI-specific response DTOs
+
+    private sealed record OpenAiUserCodeResponse(
+        [property: JsonPropertyName("device_auth_id")] string DeviceAuthId,
+        [property: JsonPropertyName("user_code")] string UserCode,
+        [property: JsonPropertyName("interval")] int Interval);
+
+    private sealed record OpenAiAuthCodeResponse(
+        [property: JsonPropertyName("authorization_code")] string AuthorizationCode,
+        [property: JsonPropertyName("code_challenge")] string CodeChallenge,
+        [property: JsonPropertyName("code_verifier")] string CodeVerifier);
+}

--- a/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
@@ -64,11 +64,13 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
             throw new InvalidOperationException("Empty device authorization response from OpenAI.");
 
         // Map OpenAI's response to the shared DeviceAuthorizationResponse
+        var expiresIn = result.ExpiresIn is > 0 ? result.ExpiresIn.Value : DefaultExpiresIn;
+
         return new DeviceAuthorizationResponse(
             DeviceCode: result.DeviceAuthId,
             UserCode: result.UserCode,
             VerificationUri: VerificationUri,
-            ExpiresIn: DefaultExpiresIn,
+            ExpiresIn: expiresIn,
             Interval: Math.Max(result.Interval, 1));
     }
 
@@ -114,9 +116,16 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
                     ex);
             }
 
-            // 403/404 = authorization pending, keep polling
-            if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+            // 403 = authorization pending, keep polling
+            if (response.StatusCode == HttpStatusCode.Forbidden)
                 continue;
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                onStateChanged?.Invoke(DeviceFlowState.Error);
+                throw new InvalidOperationException(
+                    "OpenAI device polling endpoint was not found (HTTP 404). Check provider OAuth endpoint configuration and try again.");
+            }
 
             // 5xx = transient server error, keep polling (momentary 502/503 shouldn't kill the flow)
             if ((int)response.StatusCode >= 500)
@@ -190,6 +199,13 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
         return ParseTokenResponse(doc.RootElement);
     }
 
+    public Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
+        string tokenEndpoint,
+        string clientId,
+        string refreshToken,
+        CancellationToken ct = default) =>
+        RefreshTokenAsync(tokenEndpoint, clientId, new SensitiveString(refreshToken), ct);
+
     /// <summary>
     /// Step 4: Exchange the authorization code for access/refresh tokens using PKCE.
     /// </summary>
@@ -243,7 +259,8 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
     private sealed record OpenAiUserCodeResponse(
         [property: JsonPropertyName("device_auth_id")] string DeviceAuthId,
         [property: JsonPropertyName("user_code")] string UserCode,
-        [property: JsonPropertyName("interval")] int Interval);
+        [property: JsonPropertyName("interval")] int Interval,
+        [property: JsonPropertyName("expires_in")] int? ExpiresIn);
 
     private sealed record OpenAiAuthCodeResponse(
         [property: JsonPropertyName("authorization_code")] string AuthorizationCode,

--- a/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
+++ b/src/Netclaw.Configuration/Providers/OAuth/OpenAiDeviceFlowService.cs
@@ -118,6 +118,10 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
             if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
                 continue;
 
+            // 5xx = transient server error, keep polling (momentary 502/503 shouldn't kill the flow)
+            if ((int)response.StatusCode >= 500)
+                continue;
+
             if (!response.IsSuccessStatusCode)
             {
                 onStateChanged?.Invoke(DeviceFlowState.Error);
@@ -153,14 +157,14 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
     public async Task<OAuthDeviceFlowResult?> RefreshTokenAsync(
         string tokenEndpoint,
         string clientId,
-        string refreshToken,
+        SensitiveString refreshToken,
         CancellationToken ct = default)
     {
         var tokenParams = new Dictionary<string, string>
         {
             ["grant_type"] = "refresh_token",
             ["client_id"] = clientId,
-            ["refresh_token"] = refreshToken
+            ["refresh_token"] = refreshToken.Value
         };
 
         var response = await _httpClient.PostAsync(
@@ -243,6 +247,5 @@ public sealed class OpenAiDeviceFlowService : IDeviceFlowService
 
     private sealed record OpenAiAuthCodeResponse(
         [property: JsonPropertyName("authorization_code")] string AuthorizationCode,
-        [property: JsonPropertyName("code_challenge")] string CodeChallenge,
         [property: JsonPropertyName("code_verifier")] string CodeVerifier);
 }

--- a/src/Netclaw.Daemon/Providers/LlmProviderServiceExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/LlmProviderServiceExtensions.cs
@@ -24,12 +24,17 @@ public static class LlmProviderServiceExtensions
         // Register descriptors (shared with CLI)
         services.AddProviderDescriptors();
 
-        // OAuth device flow service (for future auto-refresh)
+        // OAuth device flow services (for future auto-refresh)
         services.AddHttpClient("OAuthDeviceFlow");
         services.AddSingleton(sp =>
             new OAuthDeviceFlowService(
                 sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
                 sp.GetService<TimeProvider>()));
+        services.AddSingleton(sp =>
+            new OpenAiDeviceFlowService(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("OAuthDeviceFlow"),
+                sp.GetService<TimeProvider>()));
+        services.AddSingleton<DeviceFlowServiceFactory>();
 
         // Register daemon-specific plugins
         services.AddSingleton<OllamaProviderPlugin>();


### PR DESCRIPTION
## Summary

- OpenAI uses a **custom proprietary device auth flow**, not standard RFC 8628. Our implementation was POSTing to `/codex/device` (the browser URL) which returns 403 Forbidden.
- Adds `OpenAiDeviceFlowService` implementing the correct 4-step flow: JSON usercode request → poll with 403=pending → PKCE exchange → tokens
- Extracts `IDeviceFlowService` interface and `DeviceFlowServiceFactory` to select the right implementation per provider, keeping the generic RFC 8628 path intact for future providers
- Fixes `OpenAiDescriptor` endpoints to point to the correct API URLs
- Includes friendly error messages for 404 (device code disabled) and network failures

## Test plan

- [x] All 14 OAuth tests pass (8 existing RFC 8628 + 6 new OpenAI proprietary)
- [x] `dotnet build` — clean
- [x] `dotnet slopwatch analyze` — no new violations
- [ ] Manual test: `netclaw provider` TUI → OpenAI → OAuth Device Flow → complete browser auth