### PR TITLE
Isolate Playwright MCP sessions per tool context

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.SubAgents;
+using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.Memory;
 using Netclaw.Tools;
 using Xunit;
@@ -147,6 +148,45 @@ public class SubAgentActorTests : TestKit
         await ExpectTerminatedAsync(agent, TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public async Task Tool_execution_uses_session_scope_for_mcp_invocation()
+    {
+        var invoker = new RecordingMcpToolInvoker("ok");
+        var fakePlaywrightTool = new McpToolAdapter(
+            AIFunctionFactory.Create((string url) => url, "navigate_page"),
+            "browser_playwright",
+            "navigate_page",
+            invoker: invoker);
+
+        var fakeClient = new FakeChatClient
+        {
+            ToolCallsOnFirstCall =
+            [
+                new FunctionCallContent(
+                    "call-1",
+                    "browser_playwright/navigate_page",
+                    new Dictionary<string, object?> { ["url"] = "https://example.com" })
+            ]
+        };
+
+        var definition = CreateDefinition([fakePlaywrightTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Open example.com",
+                Timeout = TimeSpan.FromSeconds(5),
+                SessionScopeId = "session/subagent-scope"
+            },
+            TimeSpan.FromSeconds(5));
+
+        Assert.True(result.Success);
+        Assert.Equal("session/subagent-scope", invoker.SessionId);
+        Assert.Equal("browser_playwright", invoker.ServerName);
+        Assert.Equal("navigate_page", invoker.ToolName);
+    }
+
     /// <summary>
     /// IChatClient that always throws on GetResponseAsync.
     /// </summary>
@@ -232,4 +272,24 @@ internal sealed class FakeChatClient : IChatClient
 
     public object? GetService(Type serviceType, object? serviceKey = null) => null;
     public void Dispose() { }
+}
+
+internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker
+{
+    public string? ServerName { get; private set; }
+    public string? ToolName { get; private set; }
+    public string? SessionId { get; private set; }
+
+    public Task<string> InvokeAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext? context,
+        CancellationToken ct = default)
+    {
+        ServerName = serverName;
+        ToolName = toolName;
+        SessionId = context?.SessionId;
+        return Task.FromResult(result);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Tools;
+using Netclaw.Tools;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -114,6 +115,69 @@ public class McpToolAdapterTests
         var result = await adapter.ExecuteAsync(args, CancellationToken.None);
 
         Assert.Equal("https://example.com", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContext_UsesInvokerWhenConfigured()
+    {
+        string ThrowingFunc() => throw new InvalidOperationException("should not run");
+        var fakeTool = AIFunctionFactory.Create((Func<string>)ThrowingFunc, "navigate_page");
+        var invoker = new RecordingMcpToolInvoker("scoped-result");
+        var adapter = new McpToolAdapter(fakeTool, "browser_playwright", "navigate_page", invoker: invoker);
+
+        var context = new ToolExecutionContext("chan/thread", null);
+        var args = new Dictionary<string, object?> { ["Url"] = "https://example.com" };
+
+        var result = await adapter.ExecuteAsync(args, context, CancellationToken.None);
+
+        Assert.Equal("scoped-result", result);
+        Assert.Equal("browser_playwright", invoker.ServerName);
+        Assert.Equal("navigate_page", invoker.ToolName);
+        Assert.Equal("chan/thread", invoker.SessionId);
+        Assert.Contains(invoker.Arguments!, kvp => Equals(kvp.Value, "https://example.com"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContext_InvokerFailure_ReturnsError()
+    {
+        var fakeTool = AIFunctionFactory.Create(() => "unused", "navigate_page");
+        var invoker = new RecordingMcpToolInvoker("ignored")
+        {
+            Failure = new InvalidOperationException("session transport failed")
+        };
+        var adapter = new McpToolAdapter(fakeTool, "browser_playwright", "navigate_page", invoker: invoker);
+
+        var context = new ToolExecutionContext("chan/thread", null);
+        var result = await adapter.ExecuteAsync(new Dictionary<string, object?>(), context, CancellationToken.None);
+
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("session transport failed", result);
+    }
+}
+
+internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker
+{
+    public string? ServerName { get; private set; }
+    public string? ToolName { get; private set; }
+    public IDictionary<string, object?>? Arguments { get; private set; }
+    public string? SessionId { get; private set; }
+    public Exception? Failure { get; init; }
+
+    public Task<string> InvokeAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext? context,
+        CancellationToken ct = default)
+    {
+        if (Failure is not null)
+            throw Failure;
+
+        ServerName = serverName;
+        ToolName = toolName;
+        Arguments = arguments;
+        SessionId = context?.SessionId;
+        return Task.FromResult(result);
     }
 }
 

--- a/src/Netclaw.Actors/Memory/MemorizerStoreMemoryTool.cs
+++ b/src/Netclaw.Actors/Memory/MemorizerStoreMemoryTool.cs
@@ -158,6 +158,9 @@ public sealed partial class MemorizerStoreMemoryTool : NetclawTool<MemorizerStor
 
         var task = FormatTask(args);
         var chatClient = _clientProvider.GetClient(definition.ModelRole);
+        var subAgentScopeId = !string.IsNullOrWhiteSpace(context.SessionId)
+            ? $"{context.SessionId}/subagent/{definition.Name}/{System.Guid.NewGuid():N}"
+            : $"subagent/{definition.Name}/{System.Guid.NewGuid():N}";
 
         // Spawn subagent as a top-level actor (not tied to a session)
         var subAgent = _actorSystem.ActorOf(
@@ -171,7 +174,8 @@ public sealed partial class MemorizerStoreMemoryTool : NetclawTool<MemorizerStor
                 new RunSubAgent
                 {
                     Task = task,
-                    Timeout = subAgentTimeout
+                    Timeout = subAgentTimeout,
+                    SessionScopeId = subAgentScopeId
                 },
                 timeout: subAgentTimeout.Add(TimeSpan.FromSeconds(5)), // slightly longer than subagent timeout
                 cancellationToken: ct);

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -34,6 +34,7 @@ public sealed class SubAgentActor : ReceiveActor
     private int _toolIterationCount;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private ICancelable? _timeoutSchedule;
+    private ToolExecutionContext _toolExecutionContext = ToolExecutionContext.Empty;
 
     public SubAgentActor(
         SubAgentDefinition definition,
@@ -65,6 +66,11 @@ public sealed class SubAgentActor : ReceiveActor
         Receive<RunSubAgent>(msg =>
         {
             _replyTo = Sender;
+
+            var scopeId = !string.IsNullOrWhiteSpace(msg.SessionScopeId)
+                ? msg.SessionScopeId!
+                : $"subagent/{_definition.Name}/{Guid.NewGuid():N}";
+            _toolExecutionContext = new ToolExecutionContext(scopeId, null);
 
             // Schedule wall-clock timeout
             _timeoutSchedule = Context.System.Scheduler.ScheduleTellOnceCancelable(
@@ -161,7 +167,7 @@ public sealed class SubAgentActor : ReceiveActor
         var self = Self;
         var executor = new DispatchingToolExecutor(_toolRegistry);
 
-        _ = ExecuteToolsAsync(executor, toolCalls, self);
+        _ = ExecuteToolsAsync(executor, toolCalls, _toolExecutionContext, self);
     }
 
     private void FireLlmCall(bool forceNoTools = false)
@@ -232,7 +238,10 @@ public sealed class SubAgentActor : ReceiveActor
     }
 
     private static async Task ExecuteToolsAsync(
-        IToolExecutor executor, List<FunctionCallContent> toolCalls, IActorRef self)
+        IToolExecutor executor,
+        List<FunctionCallContent> toolCalls,
+        ToolExecutionContext executionContext,
+        IActorRef self)
     {
         try
         {
@@ -240,7 +249,7 @@ public sealed class SubAgentActor : ReceiveActor
             {
                 try
                 {
-                    var result = await executor.ExecuteAsync(tc);
+                    var result = await executor.ExecuteAsync(tc, executionContext);
                     return new SerializableChatMessage
                     {
                         Role = Protocol.ChatRole.Tool,

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -35,6 +35,12 @@ public sealed record RunSubAgent
 
     /// <summary>Wall-clock timeout set by the caller.</summary>
     public required TimeSpan Timeout { get; init; }
+
+    /// <summary>
+    /// Optional execution scope ID used for session-scoped tool routing.
+    /// When omitted, the subagent runtime assigns a unique transient scope.
+    /// </summary>
+    public string? SessionScopeId { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Tools/IMcpToolInvoker.cs
+++ b/src/Netclaw.Actors/Tools/IMcpToolInvoker.cs
@@ -1,0 +1,18 @@
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Executes an MCP tool call against a server-specific runtime client.
+/// Implemented by daemon infrastructure so tool adapters can route calls
+/// using per-session isolation policies.
+/// </summary>
+public interface IMcpToolInvoker
+{
+    Task<string> InvokeAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext? context,
+        CancellationToken ct = default);
+}

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -15,11 +15,18 @@ public sealed class McpToolAdapter : INetclawTool
     private readonly AITool _mcpTool;
     private readonly AITool _sanitizedTool;
     private readonly string _toolName;
+    private readonly IMcpToolInvoker? _invoker;
 
-    public McpToolAdapter(AITool mcpTool, string serverName, string toolName, string? grantCategory = null)
+    public McpToolAdapter(
+        AITool mcpTool,
+        string serverName,
+        string toolName,
+        string? grantCategory = null,
+        IMcpToolInvoker? invoker = null)
     {
         _mcpTool = mcpTool;
         _toolName = toolName;
+        _invoker = invoker;
         ServerName = serverName;
         Name = $"{serverName}/{toolName}";
         GrantCategory = grantCategory ?? $"mcp:{serverName}";
@@ -54,7 +61,30 @@ public sealed class McpToolAdapter : INetclawTool
     /// </summary>
     public AITool ToAITool() => _sanitizedTool;
 
+    public async Task<string> ExecuteAsync(
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext context,
+        CancellationToken ct = default)
+    {
+        if (_invoker is null)
+            return await ExecuteViaBoundToolAsync(arguments, ct);
+
+        try
+        {
+            var normalized = McpSchemaSanitizer.NormalizeArgumentKeys(arguments, ParameterSchema);
+            var coerced = McpSchemaSanitizer.CoerceArguments(normalized);
+            return await _invoker.InvokeAsync(ServerName, _toolName, coerced, context, ct);
+        }
+        catch (Exception ex)
+        {
+            return $"Error: MCP tool '{Name}' failed: {ex.Message}";
+        }
+    }
+
     public async Task<string> ExecuteAsync(IDictionary<string, object?>? arguments, CancellationToken ct = default)
+        => await ExecuteViaBoundToolAsync(arguments, ct);
+
+    private async Task<string> ExecuteViaBoundToolAsync(IDictionary<string, object?>? arguments, CancellationToken ct)
     {
         if (_mcpTool is not AIFunction func)
             return "Error: MCP tool is not invocable.";

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -58,10 +58,11 @@ public static class ToolRegistrationExtensions
         this ToolRegistry registry,
         string serverName,
         IList<McpClientTool> tools,
-        string? grantCategory = null)
+        string? grantCategory = null,
+        IMcpToolInvoker? invoker = null)
     {
         foreach (var tool in tools)
-            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory));
+            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory, invoker));
 
         return registry;
     }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -734,6 +734,7 @@ public sealed class InitWizardViewModelTests : IDisposable
             .ToArray();
 
         Assert.Contains("@playwright/mcp@latest", args);
+        Assert.Contains("--isolated", args);
         Assert.Contains("--image-responses", args);
         Assert.Contains("omit", args);
         Assert.Contains("--snapshot-mode", args);

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationMcpProfiles.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationMcpProfiles.cs
@@ -27,6 +27,7 @@ internal static class BrowserAutomationMcpProfiles
                 [
                     "-y",
                     "@playwright/mcp@latest",
+                    "--isolated",
                     "--headless",
                     "--image-responses",
                     "omit",

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -134,6 +134,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IDisposable
             mcpServers,
             new ToolRegistry(),
             oauthService,
+            TimeProvider.System,
             NullLogger<McpClientManager>.Instance);
 
         await manager.StartAsync(CancellationToken.None);

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -156,7 +156,7 @@ public class McpStdioSmokeTests : IAsyncDisposable
             new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())),
             TimeProvider.System,
             NullLogger<McpOAuthService>.Instance);
-        var manager = new McpClientManager(serverEntries, registry, oauthService, logger);
+        var manager = new McpClientManager(serverEntries, registry, oauthService, TimeProvider.System, logger);
 
         try
         {

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -1,34 +1,55 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
 
-/// <summary>
-/// Manages MCP client connections at daemon startup. Creates clients for each enabled
-/// <see cref="McpServerEntry"/>, discovers tools, and registers them in <see cref="ToolRegistry"/>.
-/// Failed connections are logged but don't block startup.
-/// </summary>
-internal sealed class McpClientManager : IHostedService, IDisposable
+internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolInvoker
 {
+    private const string PlaywrightServerName = "browser_playwright";
+
     private readonly Dictionary<string, McpServerEntry> _serverEntries;
     private readonly ToolRegistry _toolRegistry;
     private readonly McpOAuthService _oauthService;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<McpClientManager> _logger;
-    private readonly Dictionary<string, McpClient> _clients = new();
-    private readonly Dictionary<string, McpServerStatus> _statuses = new();
+
+    private readonly ConcurrentDictionary<string, McpClient> _clients =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, Dictionary<string, AIFunction>> _sharedToolFunctions =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, McpServerStatus> _statuses =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, bool> _sessionScopedServers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, Lazy<Task<ScopedClientHandle>>> _scopedClients =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly SemaphoreSlim _scopedCleanupGate = new(1, 1);
+    private readonly TimeSpan _scopedClientIdleTimeout = TimeSpan.FromMinutes(10);
+    private readonly TimeSpan _scopedCleanupInterval = TimeSpan.FromMinutes(1);
+    private long _nextScopedCleanupAtMs;
 
     public McpClientManager(
         Dictionary<string, McpServerEntry> serverEntries,
         ToolRegistry toolRegistry,
         McpOAuthService oauthService,
+        TimeProvider timeProvider,
         ILogger<McpClientManager> logger)
     {
         _serverEntries = serverEntries;
         _toolRegistry = toolRegistry;
         _oauthService = oauthService;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -39,6 +60,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable
             if (!entry.Enabled)
             {
                 _statuses[name] = new McpServerStatus(name, McpConnectionState.Disabled, 0, null);
+                _sessionScopedServers.TryRemove(name, out _);
                 _logger.LogInformation("MCP server '{Name}' is disabled, skipping", name);
                 continue;
             }
@@ -63,6 +85,10 @@ internal sealed class McpClientManager : IHostedService, IDisposable
         }
 
         _clients.Clear();
+        _sharedToolFunctions.Clear();
+        _sessionScopedServers.Clear();
+
+        await DisposeAllScopedClientsAsync();
     }
 
     public McpClient? GetClient(string serverName)
@@ -77,85 +103,293 @@ internal sealed class McpClientManager : IHostedService, IDisposable
         if (!_serverEntries.TryGetValue(serverName, out var entry) || !entry.Enabled)
             return false;
 
-        // Dispose existing client if any
-        if (_clients.TryGetValue(serverName, out var existing))
+        if (_clients.TryRemove(serverName, out var existing))
         {
             try { await existing.DisposeAsync(); }
             catch (Exception ex) { _logger.LogDebug(ex, "Error disposing MCP client '{Name}' during reconnect", serverName); }
-            _clients.Remove(serverName);
         }
 
+        _sharedToolFunctions.TryRemove(serverName, out _);
+        await DisposeScopedClientsForServerAsync(serverName);
+
         return await ConnectAsync(serverName, entry, ct);
+    }
+
+    public async Task<string> InvokeAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext? context,
+        CancellationToken ct = default)
+    {
+        if (UsesSessionScopedClient(serverName))
+            return await InvokeScopedAsync(serverName, toolName, arguments, context, ct);
+
+        return await InvokeSharedAsync(serverName, toolName, arguments, ct);
+    }
+
+    private async Task<string> InvokeSharedAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        CancellationToken ct)
+    {
+        if (!TryGetSharedFunction(serverName, toolName, out var function) || function is null)
+        {
+            var reconnected = await TryReconnectAsync(serverName, ct);
+            if (!reconnected
+                || !TryGetSharedFunction(serverName, toolName, out function)
+                || function is null)
+            {
+                throw new InvalidOperationException(
+                    $"MCP server '{serverName}' is unavailable or tool '{toolName}' is not registered.");
+            }
+        }
+
+        try
+        {
+            return await InvokeFunctionAsync(function, arguments, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "MCP tool '{ToolName}' failed on shared client '{ServerName}', attempting reconnect",
+                toolName, serverName);
+
+            var reconnected = await TryReconnectAsync(serverName, ct);
+            if (!reconnected
+                || !TryGetSharedFunction(serverName, toolName, out var retryFunction)
+                || retryFunction is null)
+                throw;
+
+            return await InvokeFunctionAsync(retryFunction, arguments, ct);
+        }
+    }
+
+    private async Task<string> InvokeScopedAsync(
+        string serverName,
+        string toolName,
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext? context,
+        CancellationToken ct)
+    {
+        var scopeId = ResolveScopeId(context);
+        var handle = await GetOrCreateScopedClientHandleAsync(serverName, scopeId, ct);
+
+        await CleanupIdleScopedClientsIfDueAsync(ct);
+        await handle.ExecutionGate.WaitAsync(ct);
+
+        try
+        {
+            handle.Touch(_timeProvider.GetUtcNow());
+
+            if (!handle.Tools.TryGetValue(toolName, out var function))
+            {
+                throw new InvalidOperationException(
+                    $"MCP tool '{toolName}' is not available on server '{serverName}'.");
+            }
+
+            return await InvokeFunctionAsync(function, arguments, ct);
+        }
+        finally
+        {
+            handle.Touch(_timeProvider.GetUtcNow());
+            handle.ExecutionGate.Release();
+        }
+    }
+
+    private static async Task<string> InvokeFunctionAsync(
+        AIFunction function,
+        IDictionary<string, object?>? arguments,
+        CancellationToken ct)
+    {
+        var aiArgs = arguments is { Count: > 0 }
+            ? new AIFunctionArguments(arguments)
+            : null;
+
+        var result = await function.InvokeAsync(aiArgs, ct);
+        return result?.ToString() ?? "";
+    }
+
+    private bool TryGetSharedFunction(string serverName, string toolName, out AIFunction? function)
+    {
+        function = null;
+
+        if (!_sharedToolFunctions.TryGetValue(serverName, out var serverTools))
+            return false;
+
+        return serverTools.TryGetValue(toolName, out function);
+    }
+
+    private bool UsesSessionScopedClient(string serverName)
+    {
+        return _sessionScopedServers.TryGetValue(serverName, out var enabled) && enabled;
+    }
+
+    private async Task<ScopedClientHandle> GetOrCreateScopedClientHandleAsync(
+        string serverName,
+        string scopeId,
+        CancellationToken ct)
+    {
+        var key = BuildScopedClientKey(serverName, scopeId);
+
+        while (true)
+        {
+            var lazy = _scopedClients.GetOrAdd(key, _ =>
+                new Lazy<Task<ScopedClientHandle>>(
+                    () => CreateScopedClientHandleAsync(serverName),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+
+            try
+            {
+                var handle = await lazy.Value.WaitAsync(ct);
+                handle.Touch(_timeProvider.GetUtcNow());
+                return handle;
+            }
+            catch
+            {
+                _scopedClients.TryRemove(new KeyValuePair<string, Lazy<Task<ScopedClientHandle>>>(key, lazy));
+                await DisposeLazyScopedHandleAsync(lazy);
+                throw;
+            }
+        }
+    }
+
+    private async Task<ScopedClientHandle> CreateScopedClientHandleAsync(string serverName)
+    {
+        if (!_serverEntries.TryGetValue(serverName, out var entry))
+        {
+            throw new InvalidOperationException($"MCP server '{serverName}' is not configured.");
+        }
+
+        var client = await CreateClientAsync(serverName, entry, CancellationToken.None, updateStatusOnAuthFailure: false);
+        if (client is null)
+            throw new InvalidOperationException($"MCP server '{serverName}' requires OAuth authorization.");
+
+        var tools = await client.ListToolsAsync(cancellationToken: CancellationToken.None);
+        var toolMap = CreateFunctionMap(tools);
+
+        _logger.LogInformation(
+            "Created scoped MCP client for server '{ServerName}' (tools={ToolCount})",
+            serverName,
+            tools.Count);
+
+        return new ScopedClientHandle(client, toolMap, _timeProvider.GetUtcNow());
+    }
+
+    private async Task DisposeScopedClientsForServerAsync(string serverName)
+    {
+        var prefix = serverName + "::";
+
+        foreach (var (key, _) in _scopedClients.ToArray())
+        {
+            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (_scopedClients.TryRemove(key, out var lazy))
+                await DisposeLazyScopedHandleAsync(lazy);
+        }
+    }
+
+    private async Task DisposeAllScopedClientsAsync()
+    {
+        foreach (var (key, _) in _scopedClients.ToArray())
+        {
+            if (_scopedClients.TryRemove(key, out var lazy))
+                await DisposeLazyScopedHandleAsync(lazy);
+        }
+    }
+
+    private async Task DisposeLazyScopedHandleAsync(Lazy<Task<ScopedClientHandle>> lazy)
+    {
+        if (!lazy.IsValueCreated)
+            return;
+
+        try
+        {
+            var handle = await lazy.Value;
+            await handle.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error disposing scoped MCP client handle");
+        }
+    }
+
+    private async Task CleanupIdleScopedClientsIfDueAsync(CancellationToken ct)
+    {
+        if (_scopedClients.IsEmpty)
+            return;
+
+        var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        if (nowMs < Volatile.Read(ref _nextScopedCleanupAtMs))
+            return;
+
+        if (!await _scopedCleanupGate.WaitAsync(0, ct))
+            return;
+
+        try
+        {
+            nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+            if (nowMs < Volatile.Read(ref _nextScopedCleanupAtMs))
+                return;
+
+            Volatile.Write(
+                ref _nextScopedCleanupAtMs,
+                nowMs + (long)_scopedCleanupInterval.TotalMilliseconds);
+
+            var idleBeforeMs = nowMs - (long)_scopedClientIdleTimeout.TotalMilliseconds;
+
+            foreach (var (key, lazy) in _scopedClients.ToArray())
+            {
+                if (!lazy.IsValueCreated)
+                    continue;
+
+                Task<ScopedClientHandle> handleTask;
+                try
+                {
+                    handleTask = lazy.Value;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (!handleTask.IsCompletedSuccessfully)
+                    continue;
+
+                var handle = handleTask.Result;
+                if (handle.LastUsedAtMs > idleBeforeMs)
+                    continue;
+
+                if (handle.ExecutionGate.CurrentCount == 0)
+                    continue;
+
+                if (_scopedClients.TryRemove(new KeyValuePair<string, Lazy<Task<ScopedClientHandle>>>(key, lazy)))
+                    await handle.DisposeAsync();
+            }
+        }
+        finally
+        {
+            _scopedCleanupGate.Release();
+        }
     }
 
     private async Task<bool> ConnectAsync(string name, McpServerEntry entry, CancellationToken ct)
     {
         try
         {
-            // For HTTP/SSE servers, check if we already have an OAuth token
-            // (from a previous `netclaw mcp auth` run). If so, inject it.
-            // If the server requires OAuth but we have no token, auto-detect
-            // via well-known metadata and set AwaitingAuth.
-            Dictionary<string, string>? headers = entry.Headers is { Count: > 0 }
-                ? new Dictionary<string, string>(entry.Headers) : null;
-
-            if (entry.Transport is not "stdio")
-            {
-                var token = await _oauthService.GetValidTokenAsync(name, entry, ct);
-                if (token is not null)
-                {
-                    headers ??= new Dictionary<string, string>();
-                    headers["Authorization"] = $"Bearer {token}";
-                }
-                else if (entry.Url is not null)
-                {
-                    // No token — check if this server requires OAuth
-                    var metadata = await _oauthService.TryDiscoverMetadataAsync(name, entry.Url, ct);
-                    if (metadata is not null)
-                    {
-                        _statuses[name] = new McpServerStatus(name, McpConnectionState.AwaitingAuth, 0,
-                            "OAuth required. Run: netclaw mcp auth " + name);
-                        _logger.LogWarning("MCP server '{Name}' requires OAuth authorization", name);
-                        return false;
-                    }
-                }
-            }
-
-            IClientTransport transport;
-
-            if (entry.Transport is "stdio")
-            {
-                transport = new StdioClientTransport(new StdioClientTransportOptions
-                {
-                    Command = entry.Command!,
-                    Arguments = entry.Arguments ?? [],
-                    EnvironmentVariables = entry.EnvironmentVariables is { Count: > 0 }
-                        ? new Dictionary<string, string?>(entry.EnvironmentVariables!)
-                        : null,
-                    Name = name,
-                    ShutdownTimeout = TimeSpan.FromSeconds(10),
-                });
-            }
-            else
-            {
-                transport = new HttpClientTransport(new HttpClientTransportOptions
-                {
-                    Endpoint = new Uri(entry.Url!),
-                    Name = name,
-                    AdditionalHeaders = headers,
-                    TransportMode = entry.Transport is "sse"
-                        ? HttpTransportMode.Sse : HttpTransportMode.AutoDetect,
-                });
-            }
-
-            var client = await McpClient.CreateAsync(transport, new McpClientOptions
-            {
-                ClientInfo = new() { Name = "netclaw", Version = "0.1.0" },
-            }, cancellationToken: ct);
+            var client = await CreateClientAsync(name, entry, ct, updateStatusOnAuthFailure: true);
+            if (client is null)
+                return false;
 
             var tools = await client.ListToolsAsync(cancellationToken: ct);
+
             _clients[name] = client;
-            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory);
+            _sharedToolFunctions[name] = CreateFunctionMap(tools);
+            _sessionScopedServers[name] = RequiresSessionScopedClient(name, entry);
+
+            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, this);
             _statuses[name] = new McpServerStatus(name, McpConnectionState.Connected, tools.Count, null);
 
             _logger.LogInformation("MCP server '{Name}' connected ({ToolCount} tools)", name, tools.Count);
@@ -163,11 +397,153 @@ internal sealed class McpClientManager : IHostedService, IDisposable
         }
         catch (Exception ex)
         {
+            _sharedToolFunctions.TryRemove(name, out _);
+            _sessionScopedServers.TryRemove(name, out _);
             _statuses[name] = new McpServerStatus(name, McpConnectionState.Error, 0, ex.Message);
             _logger.LogWarning(ex, "Failed to connect to MCP server '{Name}'", name);
             return false;
         }
     }
+
+    private async Task<McpClient?> CreateClientAsync(
+        string name,
+        McpServerEntry entry,
+        CancellationToken ct,
+        bool updateStatusOnAuthFailure)
+    {
+        Dictionary<string, string>? headers = entry.Headers is { Count: > 0 }
+            ? new Dictionary<string, string>(entry.Headers)
+            : null;
+
+        if (entry.Transport is not "stdio")
+        {
+            var token = await _oauthService.GetValidTokenAsync(name, entry, ct);
+            if (token is not null)
+            {
+                headers ??= new Dictionary<string, string>();
+                headers["Authorization"] = $"Bearer {token}";
+            }
+            else if (updateStatusOnAuthFailure && entry.Url is not null)
+            {
+                var metadata = await _oauthService.TryDiscoverMetadataAsync(name, entry.Url, ct);
+                if (metadata is not null)
+                {
+                    _statuses[name] = new McpServerStatus(name, McpConnectionState.AwaitingAuth, 0,
+                        "OAuth required. Run: netclaw mcp auth " + name);
+                    _logger.LogWarning("MCP server '{Name}' requires OAuth authorization", name);
+                    return null;
+                }
+            }
+        }
+
+        var transport = CreateTransport(name, entry, headers);
+
+        return await McpClient.CreateAsync(transport, new McpClientOptions
+        {
+            ClientInfo = new() { Name = "netclaw", Version = "0.1.0" },
+        }, cancellationToken: ct);
+    }
+
+    private IClientTransport CreateTransport(
+        string serverName,
+        McpServerEntry entry,
+        Dictionary<string, string>? headers)
+    {
+        if (entry.Transport is "stdio")
+        {
+            var args = BuildStdioArguments(serverName, entry);
+
+            return new StdioClientTransport(new StdioClientTransportOptions
+            {
+                Command = entry.Command!,
+                Arguments = args,
+                EnvironmentVariables = entry.EnvironmentVariables is { Count: > 0 }
+                    ? entry.EnvironmentVariables.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => (string?)kvp.Value,
+                        StringComparer.OrdinalIgnoreCase)
+                    : null,
+                Name = serverName,
+                ShutdownTimeout = TimeSpan.FromSeconds(10),
+            });
+        }
+
+        return new HttpClientTransport(new HttpClientTransportOptions
+        {
+            Endpoint = new Uri(entry.Url!),
+            Name = serverName,
+            AdditionalHeaders = headers,
+            TransportMode = entry.Transport is "sse"
+                ? HttpTransportMode.Sse
+                : HttpTransportMode.AutoDetect,
+        });
+    }
+
+    private static string[] BuildStdioArguments(string serverName, McpServerEntry entry)
+    {
+        var args = entry.Arguments is { Length: > 0 }
+            ? entry.Arguments.ToList()
+            : [];
+
+        if (IsPlaywrightServer(serverName, entry)
+            && !args.Contains("--isolated", StringComparer.OrdinalIgnoreCase))
+        {
+            args.Add("--isolated");
+        }
+
+        return args.ToArray();
+    }
+
+    private static Dictionary<string, AIFunction> CreateFunctionMap(IList<McpClientTool> tools)
+    {
+        var map = new Dictionary<string, AIFunction>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tool in tools)
+            map[tool.Name] = tool;
+
+        return map;
+    }
+
+    private static bool RequiresSessionScopedClient(string serverName, McpServerEntry entry)
+        => IsPlaywrightServer(serverName, entry);
+
+    private static bool IsPlaywrightServer(string serverName, McpServerEntry entry)
+    {
+        if (serverName.Equals(PlaywrightServerName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(entry.Command)
+            && entry.Command.Contains("playwright", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (entry.Arguments is not { Length: > 0 })
+            return false;
+
+        foreach (var arg in entry.Arguments)
+        {
+            if (arg.Contains("@playwright/mcp", StringComparison.OrdinalIgnoreCase)
+                || arg.Contains("playwright/mcp", StringComparison.OrdinalIgnoreCase)
+                || arg.Contains("playwright-mcp", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private string ResolveScopeId(ToolExecutionContext? context)
+    {
+        if (!string.IsNullOrWhiteSpace(context?.SessionId))
+            return context.SessionId!;
+
+        return $"sessionless/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}-{Guid.NewGuid():N}";
+    }
+
+    private static string BuildScopedClientKey(string serverName, string scopeId)
+        => $"{serverName}::{scopeId}";
 
     public void Dispose()
     {
@@ -176,7 +552,76 @@ internal sealed class McpClientManager : IHostedService, IDisposable
             try { (client as IDisposable)?.Dispose(); }
             catch (Exception ex) { _logger.LogDebug(ex, "Error disposing MCP client during shutdown"); }
         }
+
+        foreach (var lazy in _scopedClients.Values)
+        {
+            if (!lazy.IsValueCreated)
+                continue;
+
+            try
+            {
+                var task = lazy.Value;
+                if (!task.IsCompletedSuccessfully)
+                    continue;
+
+                task.Result.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error disposing scoped MCP client during shutdown");
+            }
+        }
+
         _clients.Clear();
+        _sharedToolFunctions.Clear();
+        _scopedClients.Clear();
+        _sessionScopedServers.Clear();
+    }
+
+    private sealed class ScopedClientHandle : IAsyncDisposable, IDisposable
+    {
+        private int _disposed;
+
+        public ScopedClientHandle(
+            McpClient client,
+            Dictionary<string, AIFunction> tools,
+            DateTimeOffset createdAt)
+        {
+            Client = client;
+            Tools = tools;
+            Touch(createdAt);
+        }
+
+        public McpClient Client { get; }
+        public Dictionary<string, AIFunction> Tools { get; }
+        public SemaphoreSlim ExecutionGate { get; } = new(1, 1);
+
+        private long _lastUsedAtMs;
+
+        public long LastUsedAtMs => Volatile.Read(ref _lastUsedAtMs);
+
+        public void Touch(DateTimeOffset now)
+        {
+            Volatile.Write(ref _lastUsedAtMs, now.ToUnixTimeMilliseconds());
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+                return;
+
+            ExecutionGate.Dispose();
+            await Client.DisposeAsync();
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+                return;
+
+            ExecutionGate.Dispose();
+            (Client as IDisposable)?.Dispose();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- route MCP tool execution through a daemon-backed invoker so adapters can use per-call execution context
- isolate `browser_playwright` tool calls by session scope with scoped MCP clients, while keeping non-Playwright servers on shared clients
- propagate subagent scope IDs into tool execution and add `--isolated` to generated Playwright MCP profile defaults, with test coverage updates

## Validation
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~McpToolAdapterTests|FullyQualifiedName~SubAgentActorTests"`
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --filter "FullyQualifiedName~McpStdioSmokeTests|FullyQualifiedName~DaemonRuntimeStatusServiceTests"`
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~InitWizardViewModelTests.HealthCheck_BrowserAutomationPlaywright_WritesMcpProfileWithContextSafeFlags"`
- `dotnet slopwatch analyze`