### PR TITLE
Fix Slack allowlist persistence in init wizard

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -827,7 +827,7 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
-    public async Task HealthCheck_AutoEnablesDm_WhenUserIdsProvided()
+    public async Task HealthCheck_WritesAllowedUsers_WithoutAutoEnablingDm()
     {
         using var vm = CreateViewModel();
         vm.SelectedProviderType = "ollama";
@@ -844,7 +844,7 @@ public sealed class InitWizardViewModelTests : IDisposable
 
         var config = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
         Assert.True(config.RootElement.TryGetProperty("Slack", out var slack));
-        Assert.True(slack.GetProperty("AllowDirectMessages").GetBoolean());
+        Assert.False(slack.TryGetProperty("AllowDirectMessages", out _));
 
         var allowedUsers = slack.GetProperty("AllowedUserIds");
         Assert.Equal(1, allowedUsers.GetArrayLength());

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -236,7 +236,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.ChatServices when _chatServicesSubStep == 4 =>
                     "  DMs create a private session per conversation. Each top-level DM starts a new session.",
                 WizardStep.ChatServices when _chatServicesSubStep == 5 =>
-                    "  Restrict DM access to specific Slack user IDs. Leave blank to allow all workspace members.",
+                    "  Restrict Slack access to specific user IDs for both channels and DMs. Leave blank to allow all workspace members.",
                 WizardStep.ChatServices =>
                     "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
                 WizardStep.Acl =>
@@ -825,15 +825,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 if (selected.Count > 0)
                 {
                     ViewModel.SlackAllowDirectMessages = selected[0].StartsWith("Yes", StringComparison.Ordinal);
-                    if (ViewModel.SlackAllowDirectMessages)
-                    {
-                        SetChatServicesSubStep(5);
-                    }
-                    else
-                    {
-                        _chatServicesSubStep = 0;
-                        ViewModel.GoNext();
-                    }
+                    SetChatServicesSubStep(5);
                 }
             })
             .DisposeWith(_stepSubs);

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -870,7 +870,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             }
 
             var userIds = ParseUserIds(SlackAllowedUserIdsInput);
-            if (SlackAllowDirectMessages || userIds.Count > 0)
+            if (SlackAllowDirectMessages)
             {
                 slackSection["AllowDirectMessages"] = true;
             }


### PR DESCRIPTION
## Summary
- always show the Slack allowed-user-ID step in `netclaw init` after DM preference, so user restrictions are captured even when DMs are disabled
- stop auto-enabling `AllowDirectMessages` when `AllowedUserIds` are provided; DM enablement now stays explicit
- update init wizard tests to verify allowlisted users persist without implicitly turning on DMs

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~InitWizardViewModelTests"`
- `dotnet slopwatch analyze`