### PR TITLE
Fix provider probe hangs and add diagnostics logging

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
@@ -31,6 +31,12 @@ public sealed class FakeProviderProbe : IProviderProbe
         ]);
 
     /// <summary>
+    /// Optional exception to throw from <see cref="ProbeAsync"/>.
+    /// Useful for testing probe error handling paths.
+    /// </summary>
+    public Exception? ExceptionToThrow { get; set; }
+
+    /// <summary>
     /// Number of times <see cref="ProbeAsync"/> has been called.
     /// </summary>
     public int ProbeCallCount { get; private set; }
@@ -53,6 +59,9 @@ public sealed class FakeProviderProbe : IProviderProbe
         LastProviderType = providerType;
         LastApiKey = apiKey;
         ProbedTypes.Add(providerType);
+
+        if (ExceptionToThrow is not null)
+            return Task.FromException<ProviderProbeResult>(ExceptionToThrow);
 
         var result = TypeResults.TryGetValue(providerType, out var typeResult)
             ? typeResult

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -203,6 +203,23 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task ProbeProvider_WhenProbeThrows_ReportsFailureAndStopsProbing()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openai";
+        vm.ApiKeyInput = "oauth-token";
+        _fakeProbe.ExceptionToThrow = new InvalidOperationException("simulated probe failure");
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(vm.IsProbing.Value);
+        Assert.NotNull(vm.ProbeResult.Value);
+        Assert.False(vm.ProbeResult.Value!.Success);
+        Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
     public async Task HealthCheck_WritesOllamaConfig()
     {
         using var vm = CreateViewModel();

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -164,6 +164,37 @@ public sealed class ModelManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task StartAssignment_WhenProbeThrows_ReportsFailureAndStopsProbing()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        _fakeProbe.ExceptionToThrow = new InvalidOperationException("simulated probe failure");
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(vm.IsProbing.Value);
+        Assert.NotNull(vm.ProbeResult.Value);
+        Assert.False(vm.ProbeResult.Value!.Success);
+        Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
     public void ClearRole_Main_IsRejected()
     {
         using var vm = CreateViewModel();

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -446,6 +446,29 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task SubmitCredentials_WhenProbeThrows_ReportsFailureAndStopsProbing()
+    {
+        _fakeProbe.ExceptionToThrow = new InvalidOperationException("simulated probe failure");
+
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+        vm.SelectAuthMethod(AuthMethod.ApiKey);
+
+        vm.NewApiKey = "sk-test";
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(vm.IsProbing.Value);
+        Assert.NotNull(vm.ProbeResult.Value);
+        Assert.False(vm.ProbeResult.Value!.Success);
+        Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
     public async Task ConfirmAdd_OAuth_TokensPersistOnlyOnSave()
     {
         using var vm = CreateViewModel();

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1,4 +1,5 @@
 using System.Net.Sockets;
+using System.Diagnostics;
 using System.Text.Json;
 using Netclaw.Channels.Slack;
 using Netclaw.Cli.Daemon;
@@ -37,6 +38,7 @@ public enum WizardStep
 public partial class InitWizardViewModel : ReactiveViewModel
 {
     public const int TotalSteps = 9;
+    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -314,25 +316,69 @@ public partial class InitWizardViewModel : ReactiveViewModel
     {
         _probeCts = new CancellationTokenSource();
         var ct = _probeCts.Token;
+        var providerType = SelectedProviderType ?? "unknown";
+        var probeId = Guid.NewGuid().ToString("N")[..8];
+        var stopwatch = Stopwatch.StartNew();
+        Exception? probeException = null;
 
         IsProbing.Value = true;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         RequestRedraw();
 
+        ProbeDiagnosticsLog.Write(
+            _paths,
+            "init-wizard",
+            providerType,
+            EndpointInput,
+            probeId,
+            "start");
+
         // Fire-and-forget timer — self-cancels via the shared CTS.
         // RunProbeTimerAsync handles OperationCanceledException internally
         // and exits cleanly, so no need to await it after cancellation.
         _ = RunProbeTimerAsync(ct);
 
-        var result = await _probe.ProbeAsync(
-            SelectedProviderType ?? "unknown",
-            EndpointInput,
-            ApiKeyInput,
-            ct);
+        var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
+        try
+        {
+            result = await _probe.ProbeAsync(
+                    providerType,
+                    EndpointInput,
+                    ApiKeyInput,
+                    ct)
+                .WaitAsync(ProbeHardTimeout, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            result = new ProviderProbeResult(false, "Validation cancelled.", []);
+        }
+        catch (TimeoutException)
+        {
+            result = new ProviderProbeResult(false,
+                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds. Check network connectivity and try again.", []);
+        }
+        catch (Exception ex)
+        {
+            probeException = ex;
+            result = new ProviderProbeResult(false, $"Validation failed: {ex.Message}", []);
+        }
+        finally
+        {
+            // Stop the timer and cancel any in-flight probe request
+            CancelProbe();
 
-        // Stop the timer
-        CancelProbe();
+            ProbeDiagnosticsLog.Write(
+                _paths,
+                "init-wizard",
+                providerType,
+                EndpointInput,
+                probeId,
+                result.Success ? "success" : "failure",
+                result.ErrorMessage,
+                stopwatch.Elapsed,
+                probeException);
+        }
 
         DiscoveredModels.Clear();
         if (result.Success)

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Diagnostics;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using R3;
@@ -25,6 +26,7 @@ public enum ModelManagerState
 public sealed class ModelManagerViewModel : ReactiveViewModel
 {
     private const int MaxDisplayedModels = 30;
+    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -280,6 +282,10 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
         _probeCts = new CancellationTokenSource();
         var ct = _probeCts.Token;
+        var providerType = provider.Entry.Type;
+        var probeId = Guid.NewGuid().ToString("N")[..8];
+        var stopwatch = Stopwatch.StartNew();
+        Exception? probeException = null;
 
         IsProbing.Value = true;
         ProbeResult.Value = null;
@@ -287,15 +293,55 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         DiscoveredModels.Clear();
         RequestRedraw();
 
+        ProbeDiagnosticsLog.Write(
+            _paths,
+            "model-manager",
+            providerType,
+            provider.Entry.Endpoint,
+            probeId,
+            "start");
+
         _ = RunProbeTimerAsync(ct);
 
-        var result = await _probe.ProbeAsync(
-            provider.Entry.Type,
-            string.IsNullOrWhiteSpace(provider.Entry.Endpoint) ? null : provider.Entry.Endpoint,
-            provider.Entry.ApiKey?.Value ?? provider.Entry.OAuthAccessToken?.Value,
-            ct);
+        var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
+        try
+        {
+            result = await _probe.ProbeAsync(
+                    providerType,
+                    string.IsNullOrWhiteSpace(provider.Entry.Endpoint) ? null : provider.Entry.Endpoint,
+                    provider.Entry.ApiKey?.Value ?? provider.Entry.OAuthAccessToken?.Value,
+                    ct)
+                .WaitAsync(ProbeHardTimeout, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            result = new ProviderProbeResult(false, "Validation cancelled.", []);
+        }
+        catch (TimeoutException)
+        {
+            result = new ProviderProbeResult(false,
+                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds. Check network connectivity and try again.", []);
+        }
+        catch (Exception ex)
+        {
+            probeException = ex;
+            result = new ProviderProbeResult(false, $"Validation failed: {ex.Message}", []);
+        }
+        finally
+        {
+            CancelProbe();
 
-        CancelProbe();
+            ProbeDiagnosticsLog.Write(
+                _paths,
+                "model-manager",
+                providerType,
+                provider.Entry.Endpoint,
+                probeId,
+                result.Success ? "success" : "failure",
+                result.ErrorMessage,
+                stopwatch.Elapsed,
+                probeException);
+        }
 
         if (result.Success)
             DiscoveredModels.AddRange(result.Models.Take(MaxDisplayedModels));

--- a/src/Netclaw.Cli/Tui/ProbeDiagnosticsLog.cs
+++ b/src/Netclaw.Cli/Tui/ProbeDiagnosticsLog.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using System.Diagnostics;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Tui;
+
+internal static class ProbeDiagnosticsLog
+{
+    private static readonly object Gate = new();
+
+    public static void Write(
+        NetclawPaths paths,
+        string source,
+        string providerType,
+        string? endpoint,
+        string probeId,
+        string outcome,
+        string? detail = null,
+        TimeSpan? elapsed = null,
+        Exception? exception = null)
+    {
+        try
+        {
+            paths.EnsureDirectoriesExist();
+            var logPath = Path.Combine(paths.LogsDirectory, "provider-probe.log");
+
+            var endpointHost = GetEndpointHost(endpoint);
+            var elapsedMs = elapsed.HasValue ? ((long)elapsed.Value.TotalMilliseconds).ToString() : "-";
+            var exceptionType = exception?.GetType().Name ?? "-";
+            var exceptionMessage = exception?.Message ?? "-";
+
+            var line = new StringBuilder()
+                .Append(DateTimeOffset.UtcNow.ToString("O"))
+                .Append(" source=").Append(source)
+                .Append(" probeId=").Append(probeId)
+                .Append(" provider=").Append(providerType)
+                .Append(" endpointHost=").Append(endpointHost)
+                .Append(" outcome=").Append(outcome)
+                .Append(" elapsedMs=").Append(elapsedMs)
+                .Append(" detail=").Append(Sanitize(detail ?? "-"))
+                .Append(" exType=").Append(exceptionType)
+                .Append(" ex=").Append(Sanitize(exceptionMessage))
+                .AppendLine()
+                .ToString();
+
+            lock (Gate)
+            {
+                File.AppendAllText(logPath, line);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Never fail probe flow because diagnostics logging failed.
+            Debug.WriteLine($"Probe diagnostics log write failed: {ex.Message}");
+        }
+    }
+
+    private static string GetEndpointHost(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+            return "default";
+
+        return Uri.TryCreate(endpoint, UriKind.Absolute, out var uri)
+            ? (uri.Host.Length > 0 ? uri.Host : "invalid")
+            : "invalid";
+    }
+
+    private static string Sanitize(string input)
+        => input.Replace('\r', ' ').Replace('\n', ' ').Trim();
+}

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Diagnostics;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
@@ -61,6 +62,8 @@ public sealed class ProviderDisplayItem
 /// </summary>
 public sealed class ProviderManagerViewModel : ReactiveViewModel
 {
+    private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
+
     private readonly NetclawPaths _paths;
     private readonly ProviderDescriptorRegistry _registry;
     private readonly IProviderProbe _probe;
@@ -716,21 +719,66 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     {
         _probeCts = new CancellationTokenSource();
         var ct = _probeCts.Token;
+        var providerType = NewProviderType ?? "unknown";
+        var probeId = Guid.NewGuid().ToString("N")[..8];
+        var stopwatch = Stopwatch.StartNew();
+        Exception? probeException = null;
 
         IsProbing.Value = true;
         ProbeResult.Value = null;
         ProbeElapsedSeconds.Value = 0;
         RequestRedraw();
 
+        ProbeDiagnosticsLog.Write(
+            _paths,
+            "provider-manager",
+            providerType,
+            NewEndpoint,
+            probeId,
+            "start");
+
         _ = RunProbeTimerAsync(ct);
 
-        var result = await _probe.ProbeAsync(
-            NewProviderType ?? "unknown",
-            NewEndpoint,
-            NewApiKey,
-            ct);
+        var result = new ProviderProbeResult(false, "Validation failed before probe completed.", []);
+        try
+        {
+            result = await _probe.ProbeAsync(
+                    providerType,
+                    NewEndpoint,
+                    NewApiKey,
+                    ct)
+                .WaitAsync(ProbeHardTimeout, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            result = new ProviderProbeResult(false, "Validation cancelled.", []);
+        }
+        catch (TimeoutException)
+        {
+            result = new ProviderProbeResult(false,
+                $"Validation timed out after {(int)ProbeHardTimeout.TotalSeconds} seconds. Check network connectivity and try again.", []);
+        }
+        catch (Exception ex)
+        {
+            probeException = ex;
+            result = new ProviderProbeResult(false, $"Validation failed: {ex.Message}", []);
+        }
+        finally
+        {
+            CancelProbe();
 
-        CancelProbe();
+            ProbeDiagnosticsLog.Write(
+                _paths,
+                "provider-manager",
+                providerType,
+                NewEndpoint,
+                probeId,
+                result.Success ? "success" : "failure",
+                result.ErrorMessage,
+                stopwatch.Elapsed,
+                probeException);
+        }
+
         ProbeResult.Value = result;
         IsProbing.Value = false;
 


### PR DESCRIPTION
## Summary
- harden provider probing across init wizard, provider manager, and model manager with timeout and exception handling so validation no longer hangs indefinitely
- add probe diagnostics log output to `~/.netclaw/logs/provider-probe.log` with probe id, source, endpoint host, elapsed time, and failure details
- extend TUI probe tests with thrown-exception scenarios to prevent regressions in hang handling

## Validation
- dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter \"FullyQualifiedName~Netclaw.Cli.Tests.Tui.InitWizardViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ProviderManagerViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ModelManagerViewModelTests\"
- dotnet slopwatch analyze