### PR TITLE
fix: extract only latest release block for GitHub release body

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -41,6 +41,17 @@ jobs:
 
         echo "Version check passed: $TAG_VERSION"
 
+    - name: Extract latest release notes
+      shell: pwsh
+      run: |
+        $content = Get-Content RELEASE_NOTES.md -Raw
+        # Match from the first #### heading to just before the second one
+        if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+          $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
+        } else {
+          $content | Set-Content RELEASE_NOTES_LATEST.md
+        }
+
     - name: Create Release
       uses: actions/create-release@v1
       id: create_release
@@ -49,7 +60,7 @@ jobs:
         prerelease: false
         release_name: 'Netclaw ${{ github.ref_name }}'
         tag_name: ${{ github.ref }}
-        body_path: RELEASE_NOTES.md
+        body_path: RELEASE_NOTES_LATEST.md
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

- GitHub releases were using the full `RELEASE_NOTES.md` as the release body, causing every release to contain the entire changelog history
- Added a PowerShell step that extracts only the first `####` block (the current release) into `RELEASE_NOTES_LATEST.md` before publishing
- Release action now uses `RELEASE_NOTES_LATEST.md` instead of the full file
- Corrected all existing GitHub releases (0.1.1–0.3.1) to only contain their own release notes

Port of [petabridge/memorizer#174](https://github.com/petabridge/memorizer/pull/174).

## Test plan

- [ ] Verify the regex correctly extracts only the top release block from `RELEASE_NOTES.md`
- [ ] Confirm next tagged release on GitHub shows only the current version's notes