### PR TITLE
Fix probe validation screens getting stuck on spinner

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Mcp;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
@@ -217,6 +218,28 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ProbeProvider_PublishesResultAfterIsProbingClears()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openrouter";
+        vm.ApiKeyInput = "sk-test";
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Xunit;
@@ -192,6 +193,42 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task StartAssignment_PublishesResultAfterIsProbingClears()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
@@ -466,6 +467,34 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SubmitCredentials_PublishesResultAfterIsProbingClears()
+    {
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+        vm.SelectAuthMethod(AuthMethod.ApiKey);
+
+        vm.NewApiKey = "sk-test";
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -384,8 +384,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (result.Success)
             DiscoveredModels.AddRange(result.Models);
 
-        ProbeResult.Value = result;
+        // Clear probing state before publishing final result so subscribers that
+        // render based on both values don't get stuck on the spinner frame.
         IsProbing.Value = false;
+        ProbeResult.Value = result;
         RequestRedraw();
     }
 

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -346,8 +346,8 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         if (result.Success)
             DiscoveredModels.AddRange(result.Models.Take(MaxDisplayedModels));
 
-        ProbeResult.Value = result;
         IsProbing.Value = false;
+        ProbeResult.Value = result;
         NotifyStateChanged();
     }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -779,8 +779,8 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 probeException);
         }
 
-        ProbeResult.Value = result;
         IsProbing.Value = false;
+        ProbeResult.Value = result;
 
         if (result.Success)
         {


### PR DESCRIPTION
## Summary
- fix probe completion ordering in init wizard, provider manager, and model manager so `IsProbing` clears before publishing `ProbeResult`
- prevent a stale spinner frame from masking probe failures/success when probe state transitions complete quickly
- add regression tests in all three TUI viewmodel suites to assert result publication happens after probing state clears

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~Netclaw.Cli.Tests.Tui.InitWizardViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ProviderManagerViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ModelManagerViewModelTests"`
- `dotnet slopwatch analyze`