### PR TITLE
Harden OpenAI setup and add turn-level session telemetry

### DIFF
--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -202,6 +202,10 @@ public sealed class SessionPipeline : ISessionPipeline
         SessionPipelineOptions options,
         NetclawPaths? paths)
     {
+        var turnId = string.IsNullOrWhiteSpace(input.MessageId)
+            ? Guid.NewGuid().ToString("N")[..8]
+            : input.MessageId!;
+
         var textParts = input.Contents.OfType<TextContent>().Select(t => t.Text);
         var content = string.Join("\n", textParts);
 
@@ -248,6 +252,8 @@ public sealed class SessionPipeline : ISessionPipeline
                 ChannelType = options.ChannelType,
                 SenderId = input.SenderId,
                 ChannelId = input.ChannelId,
+                MessageId = input.MessageId,
+                TurnId = turnId,
                 ReceivedAt = input.ReceivedAt
             }
         };

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -22,6 +22,18 @@ public sealed record MessageSource
     public string? ChannelId { get; init; }
 
     /// <summary>
+    /// Optional source message identifier from the inbound transport.
+    /// Useful for routing diagnostics and dedup correlation.
+    /// </summary>
+    public string? MessageId { get; init; }
+
+    /// <summary>
+    /// Correlation identifier for this turn. Propagated across session logs
+    /// and actor boundaries for end-to-end traceability.
+    /// </summary>
+    public string? TurnId { get; init; }
+
+    /// <summary>
     /// When the message was received by the channel.
     /// </summary>
     public DateTimeOffset ReceivedAt { get; init; }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -6,6 +6,7 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.Persistence;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Actors.Tools;
@@ -69,6 +70,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private static readonly object ProcessingWatchdogTimerKey = new();
     private long _processingOperationId;
     private string? _processingOperationName;
+
+    // Per-turn diagnostic correlation (ephemeral)
+    private string? _activeTurnId;
+    private string? _activeMessageId;
+    private string? _activeChannelType;
 
     // Persistent state (immutable — replaced on each event)
     private SessionState _state = SessionState.Empty;
@@ -185,7 +191,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<SendUserMessage>(cmd =>
         {
-            _log.Info("Received user message");
+            BindTurnTelemetry(cmd.Source);
+            TurnLog().Info(
+                "turn_received channel={ChannelType} sender={SenderId} hasMedia={HasMedia} textChars={TextLength}",
+                cmd.Source?.ChannelType ?? "unknown",
+                cmd.Source?.SenderId ?? "unknown",
+                cmd.MediaReferences.Count > 0,
+                cmd.Content?.Length ?? 0);
             _logActor?.Tell(cmd);
 
             _toolIterationCount = 0;
@@ -229,7 +241,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            _state = _state.AddUserMessage(cmd.Content, mediaRefs.Count > 0 ? mediaRefs : null);
+            var userContent = cmd.Content ?? string.Empty;
+            _state = _state.AddUserMessage(userContent, mediaRefs.Count > 0 ? mediaRefs : null);
             TryReplyAck();
             FireLlmCall();
             Become(Processing);
@@ -368,14 +381,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // Safety circuit breaker: force text response when tool iteration limit reached
             if (_toolIterationCount >= _config.MaxToolIterationsPerTurn)
             {
-                _log.Warning("Tool iteration limit reached ({Count}/{Max}), forcing text response",
+                TurnLog().Warning("turn_tool_iteration_limit_reached count={Count} max={Max}",
                     _toolIterationCount, _config.MaxToolIterationsPerTurn);
                 FireLlmCall(forceNoTools: true);
                 return;
             }
 
             // Fire follow-up LLM call with tool results in context
-            _log.Info("Tool execution complete ({Iteration}/{Max}), firing follow-up LLM call with {ResultCount} results",
+            TurnLog().Info("turn_tool_execution_complete iteration={Iteration} max={Max} resultCount={ResultCount}",
                 _toolIterationCount, _config.MaxToolIterationsPerTurn, msg.ToolResults.Count);
             FireLlmCall();
         });
@@ -383,7 +396,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<ToolExecutionFailed>(msg =>
         {
             StopProcessingWatchdog();
-            _log.Error(msg.Cause, "Tool execution failed");
+            TurnLog().Error(msg.Cause, "turn_tool_execution_failed");
 
             const string errorMessage = "I encountered an error executing a tool. Please try again.";
             var category = msg.Cause is TimeoutException ? ErrorCategory.Timeout : ErrorCategory.ToolFailure;
@@ -393,7 +406,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<LlmCallFailed>(msg =>
         {
             StopProcessingWatchdog();
-            _log.Error(msg.Cause, "LLM call failed");
+            TurnLog().Error(msg.Cause, "turn_llm_call_failed");
 
             var errorMessage = IsContextOverflowError(msg.Cause)
                 ? $"Context window exceeded after compaction — the session has too many tools or a large system prompt for the {_config.ModelId} context window ({_config.ContextWindowTokens} tokens). Try reducing tools or increasing the model's context window."
@@ -889,7 +902,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             if (_buffer.Count > 0)
             {
-                _log.Info("Draining {BufferCount} buffered message(s)", _buffer.Count);
+                TurnLog().Info("turn_buffer_drain count={BufferCount}", _buffer.Count);
                 foreach (var buffered in _buffer)
                 {
                     var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
@@ -1130,6 +1143,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
 
         StartProcessingWatchdog("llm-call", timeout);
+
+        TurnLog().Info("turn_llm_call_start messages={MessageCount} toolsEnabled={ToolsEnabled} forceNoTools={ForceNoTools}",
+            messages.Count,
+            options?.Tools?.Count > 0,
+            forceNoTools);
 
         _ = InvokeLlmAsync(client, messages, options, self, timeout);
     }
@@ -1695,12 +1713,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         _state = _state.AddErrorReply(errorMessage);
 
+        var correlationId = Guid.NewGuid();
+
+        TurnLog().Error(cause,
+            "turn_failed category={Category} correlationId={CorrelationId} message={Message}",
+            category,
+            correlationId,
+            errorMessage);
+
         EmitOutput(new ErrorOutput
         {
             SessionId = _sessionId,
             Message = errorMessage,
             Category = category,
-            CorrelationId = Guid.NewGuid(),
+            CorrelationId = correlationId,
             Cause = cause
         });
         EmitOutput(new TurnCompleted
@@ -1724,6 +1750,32 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
 
         _logActor?.Tell(output);
+    }
+
+    private void BindTurnTelemetry(MessageSource? source)
+    {
+        var sourceMessageId = source?.MessageId;
+        _activeMessageId = sourceMessageId;
+        _activeTurnId = source?.TurnId
+            ?? sourceMessageId
+            ?? Guid.NewGuid().ToString("N")[..8];
+        _activeChannelType = source?.ChannelType;
+    }
+
+    private ILoggingAdapter TurnLog()
+    {
+        var log = _log;
+
+        if (!string.IsNullOrWhiteSpace(_activeTurnId))
+            log = log.WithContext("TurnId", _activeTurnId);
+
+        if (!string.IsNullOrWhiteSpace(_activeMessageId))
+            log = log.WithContext("MessageId", _activeMessageId);
+
+        if (!string.IsNullOrWhiteSpace(_activeChannelType))
+            log = log.WithContext("ChannelType", _activeChannelType);
+
+        return log;
     }
 
     private void TryReplyAck()

--- a/src/Netclaw.Channels/Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackConversationActor.cs
@@ -90,16 +90,26 @@ public sealed class SlackConversationActor : ReceiveActor
             }
 
             var sessionId = new SessionId($"{_conversationId.Value}/{threadTs.Value}");
+            var turnId = string.IsNullOrWhiteSpace(message.EventId.Value)
+                ? Guid.NewGuid().ToString("N")[..8]
+                : message.EventId.Value;
             var log = _log
                 .WithContext("SlackThreadTs", threadTs.Value)
-                .WithContext("SessionId", sessionId.Value);
+                .WithContext("SessionId", sessionId.Value)
+                .WithContext("TurnId", turnId)
+                .WithContext("SlackEventId", message.EventId.Value);
 
-            log.Debug("Routing Slack event {0} to session thread actor", message.EventId);
+            log.Info("slack_turn_routed event={EventId} hasFiles={HasFiles} textChars={TextLength}",
+                message.EventId.Value,
+                message.Files is { Count: > 0 },
+                normalized.Length);
 
             thread.Forward(new SlackThreadInbound(
                 SessionId: sessionId,
                 ChannelId: message.ChannelId,
                 ThreadTs: threadTs,
+                EventId: message.EventId,
+                TurnId: turnId,
                 SenderId: message.UserId?.Value ?? "slack-user",
                 Text: normalized,
                 ReceivedAt: _dependencies.TimeProvider.GetUtcNow(),

--- a/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels/Slack/SlackIngressMessages.cs
@@ -33,6 +33,8 @@ public sealed record SlackThreadInbound(
     SessionId SessionId,
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
+    SlackEventId EventId,
+    string TurnId,
     string SenderId,
     string Text,
     DateTimeOffset ReceivedAt,

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -142,10 +142,18 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
     private async Task HandleInboundAsync(SlackThreadInbound message)
     {
+        var inboundLog = _log
+            .WithContext("TurnId", message.TurnId)
+            .WithContext("SlackEventId", message.EventId.Value);
+
         using var inboundCts = new CancellationTokenSource(InboundProcessingTimeout);
 
         try
         {
+            inboundLog.Info("slack_turn_received textChars={TextLength} fileCount={FileCount}",
+                message.Text?.Length ?? 0,
+                message.Files?.Count ?? 0);
+
             if (!string.IsNullOrWhiteSpace(message.Text))
             {
                 PromptInjectionResult detection;
@@ -245,6 +253,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 {
                     SenderId = message.SenderId,
                     ChannelId = _channelId.Value,
+                    MessageId = message.EventId.Value,
                     Contents = contents,
                     ReceivedAt = message.ReceivedAt
                 }, queueWriteCts.Token);
@@ -262,16 +271,16 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 return;
             }
 
-            _log.Debug("Accepted inbound Slack message for session queue");
+            inboundLog.Info("slack_turn_enqueued contentItems={ContentCount}", contents.Count);
             ChannelTelemetry.RecordSlackMessageEnqueued();
         }
         catch (OperationCanceledException ex)
         {
-            _log.Warning(ex, "Inbound Slack processing timed out for session {0}", _sessionId.Value);
+            inboundLog.Warning(ex, "slack_turn_enqueue_timeout");
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to enqueue Slack message for session {0}", _sessionId.Value);
+            inboundLog.Error(ex, "slack_turn_enqueue_failed");
         }
     }
 

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -5,6 +5,7 @@ using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
+using Netclaw.Configuration.Providers.OAuth;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui;
@@ -240,6 +241,30 @@ public sealed class InitWizardViewModelTests : IDisposable
 
         Assert.Equal(false, isProbingAtResultPublish);
         Assert.False(vm.IsProbing.Value);
+    }
+
+    [Fact]
+    public async Task ProbeProvider_OAuth_UsesOAuthTokenWhenApiKeyInputEmpty()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openai";
+        vm.SelectedAuthMethod = AuthMethod.OAuthDevice;
+        vm.ApiKeyInput = null;
+        vm.OAuthResult = new OAuthDeviceFlowResult(
+            new SensitiveString("oauth-access-token"),
+            new SensitiveString("oauth-refresh-token"),
+            DateTimeOffset.UtcNow.AddHours(1));
+
+        _fakeProbe.NextResult = new ProviderProbeResult(true, null,
+        [
+            new DiscoveredModel { ModelId = "gpt-4.1" }
+        ]);
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("oauth-access-token", _fakeProbe.LastApiKey);
+        Assert.True(vm.ProbeResult.Value!.Success);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Mcp;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
@@ -217,6 +218,28 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ProbeProvider_PublishesResultAfterIsProbingClears()
+    {
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "openrouter";
+        vm.ApiKeyInput = "sk-test";
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.StartProbe();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Xunit;
@@ -192,6 +193,42 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task StartAssignment_PublishesResultAfterIsProbingClears()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-openrouter"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openrouter",
+                    ["Endpoint"] = "https://openrouter.ai/api/v1",
+                    ["AuthMethod"] = "ApiKey"
+                }
+            }
+        });
+
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.StartAssignment("Main");
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using R3;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
@@ -466,6 +467,34 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         Assert.NotNull(vm.ProbeResult.Value);
         Assert.False(vm.ProbeResult.Value!.Success);
         Assert.Contains("simulated probe failure", vm.ProbeResult.Value.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SubmitCredentials_PublishesResultAfterIsProbingClears()
+    {
+        using var vm = CreateViewModel();
+        await ActivateAndProbeAsync(vm);
+
+        var idx = vm.DisplayProviders.FindIndex(p => p.ProviderType == "openrouter");
+        vm.SelectedProviderIndex = idx;
+        vm.ActivateSelectedProvider();
+        vm.SelectAuthMethod(AuthMethod.ApiKey);
+
+        vm.NewApiKey = "sk-test";
+        _fakeProbe.NextResult = new ProviderProbeResult(false, "synthetic failure", []);
+
+        bool? isProbingAtResultPublish = null;
+        using var sub = vm.ProbeResult.Subscribe(result =>
+        {
+            if (result is not null)
+                isProbingAtResultPublish = vm.IsProbing.Value;
+        });
+
+        vm.SubmitCredentials();
+        await vm.ProbeCompletion!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(false, isProbingAtResultPublish);
+        Assert.False(vm.IsProbing.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -521,7 +521,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         return Layouts.Vertical()
             .WithChild(new TextNode($"  \u2717 {probeResult.ErrorMessage}").WithForeground(Color.Red))
             .WithChild(new TextNode(""))
-            .WithChild(new TextNode("  Press Enter to retry, or Esc to go back.").WithForeground(Color.BrightBlack));
+            .WithChild(new TextNode("  Press Enter to retry, M for manual model entry, or Esc to go back.")
+                .WithForeground(Color.BrightBlack));
     }
 
     private ILayoutNode BuildModelSelectionSubStep()
@@ -1559,6 +1560,20 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             && ViewModel.ProbeResult.Value is { Success: false })
         {
             ViewModel.StartProbe();
+            _stepContentNode?.Invalidate();
+            _helpTextNode?.Invalidate();
+            ViewModel.RequestRedraw();
+            return;
+        }
+
+        // On validation sub-step with failed result, M continues to manual model entry
+        if (ViewModel.CurrentStep.Value == WizardStep.Provider
+            && _providerSubStep == 3
+            && keyInfo.Key == ConsoleKey.M
+            && ViewModel.ProbeResult.Value is { Success: false })
+        {
+            _manualModelEntry = false;
+            SetProviderSubStep(4);
             _stepContentNode?.Invalidate();
             _helpTextNode?.Invalidate();
             ViewModel.RequestRedraw();

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -320,6 +320,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var probeId = Guid.NewGuid().ToString("N")[..8];
         var stopwatch = Stopwatch.StartNew();
         Exception? probeException = null;
+        var credential = ApiKeyInput;
+        if (string.IsNullOrWhiteSpace(credential)
+            && SelectedAuthMethod == AuthMethod.OAuthDevice
+            && OAuthResult is not null)
+        {
+            credential = OAuthResult.AccessToken.Value;
+        }
 
         IsProbing.Value = true;
         ProbeResult.Value = null;
@@ -332,7 +339,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
             providerType,
             EndpointInput,
             probeId,
-            "start");
+            "start",
+            $"auth={SelectedAuthMethod} credentialPresent={!string.IsNullOrWhiteSpace(credential)}");
 
         // Fire-and-forget timer — self-cancels via the shared CTS.
         // RunProbeTimerAsync handles OperationCanceledException internally
@@ -345,7 +353,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             result = await _probe.ProbeAsync(
                     providerType,
                     EndpointInput,
-                    ApiKeyInput,
+                    credential,
                     ct)
                 .WaitAsync(ProbeHardTimeout, ct);
         }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -384,8 +384,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (result.Success)
             DiscoveredModels.AddRange(result.Models);
 
-        ProbeResult.Value = result;
+        // Clear probing state before publishing final result so subscribers that
+        // render based on both values don't get stuck on the spinner frame.
         IsProbing.Value = false;
+        ProbeResult.Value = result;
         RequestRedraw();
     }
 

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -346,8 +346,8 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         if (result.Success)
             DiscoveredModels.AddRange(result.Models.Take(MaxDisplayedModels));
 
-        ProbeResult.Value = result;
         IsProbing.Value = false;
+        ProbeResult.Value = result;
         NotifyStateChanged();
     }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -779,8 +779,8 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 probeException);
         }
 
-        ProbeResult.Value = result;
         IsProbing.Value = false;
+        ProbeResult.Value = result;
 
         if (result.Success)
         {

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -244,9 +244,14 @@ public sealed class SessionRegistry
         if (!_sessions.TryGetValue(attachedSessionId, out var hubSession))
             throw new HubException($"Session '{sessionId}' not found.");
 
+        var signalrMessageId = $"signalr:{callerConnectionId.Value}:{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}:{Guid.NewGuid():N}";
+        if (signalrMessageId.Length > 128)
+            signalrMessageId = signalrMessageId[..128];
+
         var result = await hubSession.InputQueue.OfferAsync(new ChannelInput
         {
             SenderId = "signalr-user",
+            MessageId = signalrMessageId,
             Contents = [new TextContent(text)],
             ReceivedAt = _timeProvider.GetUtcNow()
         });


### PR DESCRIPTION
## Summary
- harden OpenAI init wizard probing by reusing OAuth access token when API key input is empty and logging auth-mode probe context
- add a manual model-entry escape hatch on provider validation failure (`M`) so setup can continue even when model listing fails
- add turn-level correlation telemetry across Slack/SignalR -> pipeline -> session actor with `TurnId` / `MessageId` context and structured turn lifecycle logs

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~Netclaw.Cli.Tests.Tui.InitWizardViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ProviderManagerViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ModelManagerViewModelTests"`
- `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj`
- `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --filter "FullyQualifiedName~SessionCatalogServiceTests|FullyQualifiedName~SessionRegistryTests"`
- `dotnet slopwatch analyze`