### PR TITLE
Prepare release 0.3.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,26 +7,22 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.2</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.3.2 - Session hardening, diagnostics, CLI updates
+    <VersionPrefix>0.3.3</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.3.3 — OpenAI setup reliability and session traceability
 
-**Session Catalog Hardening**
+**OpenAI Setup Reliability**
 
-* Fixed provider catalog refresh to properly handle missing provider entries and prevent crash loops when a provider is removed. ([#170](https://github.com/Aaronontheweb/netclaw/pull/170))
+* Fixed OAuth probing in the init wizard by reusing the OAuth access token when API key input is empty, preventing false "missing credentials" probe failures after successful device auth.
+* Added a manual model-entry continuation path on provider validation failure (`M`) so setup can proceed when model discovery fails due to permissions or endpoint behavior. ([#176](https://github.com/Aaronontheweb/netclaw/pull/176))
 
-**Enhanced Diagnostics**
+**Session and Slack Telemetry**
 
-* Added `netclaw doctor diagnostics` command to collect comprehensive diagnostic information including version info, configuration analysis, session health, and logs for troubleshooting. ([#170](https://github.com/Aaronontheweb/netclaw/pull/170))
+* Added turn-level correlation metadata (`TurnId`, `MessageId`) across Slack/SignalR ingress, session pipeline, and session actor logs for end-to-end tracing.
+* Added structured session lifecycle events for turn receive, LLM call start, tool iteration limit, and turn failure to make "amnesia" and reply continuity issues diagnosable from logs. ([#176](https://github.com/Aaronontheweb/netclaw/pull/176))
 
-**CLI Improvements**
+**Validation UX**
 
-* Improved completion handling in `init wizard` to prevent duplicate completion calls. ([#170](https://github.com/Aaronontheweb/netclaw/pull/170))
-
-**Provider Probe Resilience**
-
-* Hardened provider probe flows in the init wizard, provider manager, and model manager with explicit timeout and exception handling so validation failures no longer hang indefinitely. ([#158](https://github.com/Aaronontheweb/netclaw/pull/158))
-
-* Added provider probe diagnostics logging to `~/.netclaw/logs/provider-probe.log` with probe ID, source, endpoint host, elapsed time, and failure details to make OAuth and model discovery failures easier to diagnose. ([#158](https://github.com/Aaronontheweb/netclaw/pull/158))</PackageReleaseNotes>
+* Fixed probe state publication ordering so validation screens no longer get stuck showing a spinner after probe completion. ([#174](https://github.com/Aaronontheweb/netclaw/pull/174))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 0.3.3 2026-03-07 ####
+
+Netclaw v0.3.3 — OpenAI setup reliability and session traceability
+
+**OpenAI Setup Reliability**
+
+* Fixed OAuth probing in the init wizard by reusing the OAuth access token when API key input is empty, preventing false "missing credentials" probe failures after successful device auth.
+* Added a manual model-entry continuation path on provider validation failure (`M`) so setup can proceed when model discovery fails due to permissions or endpoint behavior. ([#176](https://github.com/Aaronontheweb/netclaw/pull/176))
+
+**Session and Slack Telemetry**
+
+* Added turn-level correlation metadata (`TurnId`, `MessageId`) across Slack/SignalR ingress, session pipeline, and session actor logs for end-to-end tracing.
+* Added structured session lifecycle events for turn receive, LLM call start, tool iteration limit, and turn failure to make "amnesia" and reply continuity issues diagnosable from logs. ([#176](https://github.com/Aaronontheweb/netclaw/pull/176))
+
+**Validation UX**
+
+* Fixed probe state publication ordering so validation screens no longer get stuck showing a spinner after probe completion. ([#174](https://github.com/Aaronontheweb/netclaw/pull/174))
+
 #### 0.3.2 2026-03-06 ####
 
 Netclaw v0.3.2 — Session catalog hardening, diagnostics, and CLI improvements


### PR DESCRIPTION
## Summary
- bump package/version metadata to `0.3.3`
- add release notes section for OpenAI setup reliability improvements and turn-level session telemetry

## Validation
- `pwsh ./build.ps1`