### PR TITLE
Fix OAuth device-flow sequencing race in TUI

### DIFF
--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -512,6 +512,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _oauthCts = new CancellationTokenSource();
         var ct = _oauthCts.Token;
 
+        ProbeElapsedSeconds.Value = 0;
+        _ = RunProbeTimerAsync(ct);
+
         var service = _oauthFactory.GetFor(descriptor);
         var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
@@ -526,6 +529,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
             var result = await service.PollForTokenAsync(config, deviceAuth,
                 state =>
                 {
+                    if (state == DeviceFlowState.Succeeded)
+                        return;
+
                     OAuthFlowState.Value = state;
                     RequestRedraw();
                 }, ct);
@@ -557,6 +563,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
             OAuthErrorMessage = ex.Message;
             OAuthFlowState.Value = DeviceFlowState.Error;
             RequestRedraw();
+        }
+        finally
+        {
+            CancelOAuthFlow();
         }
     }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -562,6 +562,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
         _oauthCts = new CancellationTokenSource();
         var ct = _oauthCts.Token;
 
+        ProbeElapsedSeconds.Value = 0;
+        _ = RunProbeTimerAsync(ct);
+
         var service = _oauthFactory.GetFor(descriptor);
         var config = OAuthDeviceFlowConfig.FromDescriptor(descriptor);
 
@@ -578,12 +581,17 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             var result = await service.PollForTokenAsync(config, deviceAuth,
                 state =>
                 {
+                    if (state == DeviceFlowState.Succeeded)
+                        return;
+
                     OAuthFlowState.Value = state;
                     NotifyStateChanged();
                 }, ct);
 
             // Step 3: Keep tokens in-memory until provider is confirmed
             OAuthResult = result;
+            OAuthFlowState.Value = DeviceFlowState.Succeeded;
+            NotifyStateChanged();
 
             // Step 4: Transition to probe validation using the OAuth token
             NewApiKey = result.AccessToken.Value;
@@ -613,6 +621,10 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
             OAuthErrorMessage = ex.Message;
             OAuthFlowState.Value = DeviceFlowState.Error;
             NotifyStateChanged();
+        }
+        finally
+        {
+            CancelOAuthFlow();
         }
     }
 


### PR DESCRIPTION
## Summary
- fix OAuth device-flow sequencing so success is only published after token assignment in both init wizard and provider manager
- prevent early validation probe startup that could run before OAuth token is available
- reset and run OAuth spinner timer during device-flow polling for visible progress feedback

## Validation
- `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~Netclaw.Cli.Tests.Tui.InitWizardViewModelTests|FullyQualifiedName~Netclaw.Cli.Tests.Tui.ProviderManagerViewModelTests"`
- `dotnet slopwatch analyze`