### PR TITLE
spec: define policy-aware SQLite memory redesign

### DIFF
--- a/openspec/changes/memory-policy-graph-redesign/.openspec.yaml
+++ b/openspec/changes/memory-policy-graph-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-07

--- a/openspec/changes/memory-policy-graph-redesign/design.md
+++ b/openspec/changes/memory-policy-graph-redesign/design.md
@@ -20,13 +20,14 @@ This redesign makes memory a first-party Netclaw subsystem with its own local SQ
 - Make recall automatic before each user-facing turn, bounded by policy and latency budgets.
 - Move durable persistence into checkpoint-driven background curation with deterministic filtering before any LLM curator call.
 - Keep the main session as the durable-memory owner; subagents return findings, not writes.
-- Preserve a small compatibility tool surface for explicit save/search/correct workflows so existing prompts and skills keep functioning during migration.
+- Preserve a small explicit tool surface for deliberate save/search/correct workflows so prompts and skills can distinguish automatic recall from manual memory control.
 - Provide measurable success criteria and eval gates before the redesign becomes the only supported path.
 
 **Non-Goals:**
 - Embedding or vector retrieval in MVP-now.
 - Bi-directional live sync with Memorizer as a primary store.
 - Replacing the existing 4 explicit memory tools with a brand-new graph-native tool API in MVP-now.
+- Legacy markdown import or provider-compatibility work as a required MVP deliverable.
 - Full encrypted-at-rest key management beyond host filesystem controls.
 - Automatic cross-device memory replication.
 - General-purpose knowledge graph authoring UI.
@@ -106,14 +107,14 @@ Alternatives considered:
 - Allow all subagents to call durable memory tools directly. Rejected because it spreads trust and persistence policy across too many actors.
 - Forbid subagent findings entirely. Rejected because subagents still need to contribute research and summaries.
 
-### Decision: Preserve the existing 4 explicit memory tools as compatibility shims in MVP-now
+### Decision: Preserve the existing 4 explicit memory tools as deliberate manual control paths in MVP-now
 
 The frontline agent will continue to see `find_memories`, `get_memories`, `store_memory`, and `update_memory`, but they become thin facades over the SQLite memory service and policy pipeline.
 
 Rationale:
 - Minimizes prompt churn and skill breakage.
 - Keeps explicit workflows available for "remember this", "search memory", and "correct this note" requests.
-- Lets Netclaw switch the underlying substrate without forcing an immediate tool-contract rewrite.
+- Makes it clear that automatic recall is the default while explicit tools are only for deliberate operator- or agent-driven control.
 
 Alternatives considered:
 - Introduce new graph-native memory tools immediately. Rejected for MVP-now because automatic recall is the bigger value and compatibility matters.
@@ -125,7 +126,7 @@ Alternatives considered:
 
 1. `MemorySchemaMigrator`
    - Creates/upgrades `netclaw-memory.db`
-   - Tracks schema version and legacy import status
+   - Tracks schema version and health
 
 2. `MemoryRepository`
    - CRUD/query methods for anchors, documents, records, edges, and pending checkpoints
@@ -220,6 +221,37 @@ checkpoints(
 )
 ```
 
+### Example Populated Knowledge Graph
+
+```text
+[person:aaron]
+  |-- document: operator-preferences
+  |     `-- tone=concise, timezone=America/Chicago
+  |-- related_to --> [project:netclaw]
+  `-- owns --> [host:pi1]
+
+[project:netclaw]
+  |-- document: project-brief
+  |-- child_of --> [domain:business]
+  |-- contains --> [repo:stannardlabs/netclaw]
+  |-- related_to --> [service:slack-adapter]
+  `-- related_to --> [concept:memory-policy-graph-redesign]
+
+[repo:stannardlabs/netclaw]
+  |-- document: current-focus
+  |-- depends_on --> [service:sqlite-memory]
+  `-- record: issue-164-fixed@2026-03-07
+
+[host:pi1]
+  |-- document: homelab-inventory
+  `-- runs_on --> [service:netclaw-daemon]
+
+[service:sqlite-memory]
+  |-- document: schema-notes
+  |-- record: migration-disabled-for-mvp@decision
+  `-- related_to --> [concept:automatic-recall]
+```
+
 ### Policy Model
 
 Every durable memory candidate and stored object includes:
@@ -256,6 +288,49 @@ When explicit memory tools are still used:
 - user explicitly says "remember this", "forget this", or "what do you remember about X"
 - the agent needs manual follow-up beyond the automatic recall bundle
 - operator correction or cleanup workflows need a direct edit/supersede path
+
+When the frontline agent should explicitly invoke `store_memory`:
+- the user directly asks Netclaw to remember or save something
+- the agent wants to deliberately pin a high-value fact, decision, or preference instead of waiting for background checkpoint curation
+- a workflow requires immediate durable capture with an acknowledgment back to the user
+
+When the frontline agent should explicitly invoke `update_memory`:
+- the user corrects an existing preference, fact, or project summary
+- a prior record needs supersede/tombstone handling
+- sensitivity, recall mode, or other durable metadata must be intentionally changed
+
+When the frontline agent should not use explicit write tools:
+- routine user turns where automatic recall already provides what is needed
+- background curation opportunities detected by the system after the turn
+- speculative or low-confidence facts that should first pass through checkpoint filtering
+
+### System Prompt And Memory Context Guidance
+
+Session prompt guidance should teach a simple operating model:
+
+- automatic recall is primary and happens before each user-facing turn
+- explicit memory tools are manual control paths, not the default way to use memory
+- `store_memory` is for deliberate remember/save actions
+- `update_memory` is for correction, supersede, tombstone, or metadata changes
+- if memory is degraded, the prompt must say so plainly instead of implying recall is active
+
+Illustrative context guidance:
+
+```text
+[memory]
+
+Netclaw automatically recalls durable memory before each user-facing turn.
+Assume relevant durable context may already be present in the recall bundle.
+
+Use `find_memories` / `get_memories` only when you need manual follow-up beyond
+the automatic bundle or the user explicitly asks what you remember.
+
+Use `store_memory` only for deliberate save/remember actions.
+Use `update_memory` only to correct, supersede, tombstone, or change metadata on
+existing durable memory.
+
+Do not call explicit memory tools as a routine reflex on every turn.
+```
 
 ### Actor Boundaries and Recovery Behavior
 
@@ -397,27 +472,26 @@ function handleSubagentResult(parentSession, subagentResult):
 
 - [SQLite query complexity on constrained hardware] -> Keep schema small, use indexed fields only, and gate recall to top-N bounded queries.
 - [Automatic recall may inject noise] -> Keep strict candidate limits, policy filters, and eval gates for precision before rollout.
-- [Migration may strand legacy memories] -> Provide one-time import plus idempotent re-run support and operator-visible migration status.
+- [Deferred legacy compatibility might leave old data unused if it exists locally] -> Treat MVP as greenfield and document that any legacy import/provider bridge is a separate follow-up concern, not a hidden partial feature.
 - [Compatibility shims may preserve old habits too long] -> Mark them as explicit/manual paths in prompt guidance and keep graph-native APIs deferred behind a later change.
 - [Background curation can silently fail] -> Persist checkpoints with retry state, surface queue health in diagnostics, and never report a save as complete before enqueue acknowledgment.
 
-## Migration Plan
+## Delivery Plan / Compatibility Stance
 
 1. Add `memory/` directory, SQLite schema migrator, and health reporting.
 2. Build repositories and policy evaluator for anchors, documents, records, edges, and checkpoints.
-3. Add compatibility tool facades backed by the new substrate.
+3. Add explicit memory tool facades backed by the new substrate.
 4. Implement automatic recall in `LlmSessionActor` with bounded timeout and degraded fallback.
 5. Implement checkpoint detection plus `MemoryCurationWorker` retry queue.
 6. Change subagent contract to return findings envelopes; route accepted findings through the parent session.
-7. Import legacy markdown memories from `~/.netclaw/memories/` into SQLite as anchors/documents/records; leave source files untouched as read-only migration artifacts.
-8. Treat legacy `Memory.Provider` values (`files`, `memorizer`) as migration inputs only; emit warnings and write upgraded config for the new default substrate.
-9. Keep existing 4 memory tool names as shims for at least one release; deprecate backend-specific prompt guidance and system skills in the same implementation cycle.
-10. After eval gates pass, mark legacy file-backed and Memorizer-backed provider modes unsupported as primary backends.
+7. Update system-prompt guidance, memory context guidance, and system skills so automatic recall is primary and explicit tools are manual control paths.
+8. Ship the seeded eval suite and require the smaller local Ollama profile to pass before broader validation.
+9. Do not require markdown import, provider-mode migration, or Memorizer-compatibility bridges for MVP. If needed later, they should be proposed as separate follow-up changes.
 
 Rollback stance:
 - Schema migrations are additive before cutover.
-- Legacy markdown files remain untouched, so rollback can disable SQLite memory and fall back to read-only legacy behavior during the transition window.
-- Once write cutover happens, rollback keeps SQLite data intact and does not attempt reverse-sync into markdown files.
+- Rollback can disable the redesigned memory subsystem and preserve the SQLite data directory for inspection.
+- No reverse-sync or legacy import/export path is assumed in MVP.
 
 ## Success and Evaluation Criteria
 

--- a/openspec/changes/memory-policy-graph-redesign/design.md
+++ b/openspec/changes/memory-policy-graph-redesign/design.md
@@ -493,6 +493,70 @@ Rollback stance:
 - Rollback can disable the redesigned memory subsystem and preserve the SQLite data directory for inspection.
 - No reverse-sync or legacy import/export path is assumed in MVP.
 
+## Dependency Map And Sequencing
+
+This change intentionally separates the memory redesign from broader platform work that is still evolving.
+
+### What this change depends on directly
+
+- SQLite-backed durable storage, recall, checkpointing, and policy evaluation.
+- Session-layer prompt/context injection for automatic recall.
+- A parent-session-owned path for accepting or rejecting structured subagent findings.
+
+### What this change does not need to wait for
+
+- Issue `#150` (`Refactor skill system to adopt AgentSkills.io SKILL.md standard`)
+  - Not a blocker.
+  - The memory redesign only needs prompt guidance and system-skill updates explaining that automatic recall is primary and explicit memory tools are manual control paths.
+  - The memory curator should remain an internal platform role in MVP, not a discoverable user skill.
+
+- Issue `#149` (`Improve skill guidance for Playwright screenshot handoff and simplify skill routing`)
+  - Not a blocker.
+  - This memory redesign may improve general prompt discipline around explicit tools, but screenshot workflow routing is a separate skill-system concern.
+
+- Issue `#147` (`Reminder UX follow-up: allow selecting agent definition for execution`)
+  - Not a blocker.
+  - Memory curation does not require user-selectable agent profiles.
+  - The memory curator should be a platform-owned internal role with a fixed prompt/tool set, not a reminder-style user choice.
+
+### What this change should pull forward from subagent work
+
+- Structured findings on `SubAgentResult` rather than text-only output.
+- Parent-session acceptance/rejection of findings before durable checkpoint creation.
+- A safe internal invocation path for platform-owned subagents such as a future `memory-curator` role.
+
+### Recommended staging
+
+```text
+Phase A: Memory foundation
+- SQLite schema and repositories
+- automatic pre-turn recall
+- checkpoint queue and policy evaluation
+
+Phase B: Session-owned curation
+- rules-first candidate extraction
+- deterministic document/record operations
+- structured subagent findings envelopes
+
+Phase C: Internal memory-curator role (optional if deterministic-only is insufficient)
+- platform-owned internal subagent definition
+- fixed prompt + narrow tool scope
+- findings/operation handoff back to parent session
+
+Phase D: Broader platform follow-ups
+- reminder agent-definition UX (#147)
+- AgentSkills.io skill-system refactor (#150)
+- screenshot-handoff routing cleanup (#149)
+```
+
+### Recommended follow-up implementation issues
+
+- `Add structured findings envelopes to SubAgentResult and parent-session acceptance flow`
+- `Add internal platform-owned agent definition support for non-user-routable subagents`
+- `Package memory curator as an internal role if deterministic checkpoint curation proves insufficient`
+- `Refactor reminder execution to use agent-definition selection after internal agent-definition support stabilizes`
+- `Adopt AgentSkills.io SKILL.md/frontmatter without coupling it to memory-curator implementation`
+
 ## Success and Evaluation Criteria
 
 The implementation is not done until it passes a seeded memory eval suite with measurable outcomes:

--- a/openspec/changes/memory-policy-graph-redesign/design.md
+++ b/openspec/changes/memory-policy-graph-redesign/design.md
@@ -1,0 +1,442 @@
+## Context
+
+Netclaw currently treats memory as a backend choice: markdown files under `~/.netclaw/memories/` or an optional Memorizer-backed provider discovered through MCP. That model was enough to prove out persistence, but it is not enough for PRD-007's actual job: durable recall that is local-first, policy-aware, structurally organized, and reliable across long-running sessions.
+
+The current architecture has four core limits:
+
+1. Recall is mostly model-driven. If the frontline agent does not explicitly decide to call memory tools, recall does not happen.
+2. The default file store is flat. It can hold notes, but not entities, parent/child structure, freshness, or typed relationships.
+3. Durable memory policy is implicit. Domain separation, sensitivity, and update behavior are not encoded on each memory item.
+4. Subagents can become accidental durable-memory writers, which makes quality, privacy, and ownership harder to reason about.
+
+This redesign makes memory a first-party Netclaw subsystem with its own local SQLite database, policy model, retrieval pipeline, and background curation queue. The Akka session layer remains the owner of turn orchestration, but durable memory is no longer a thin wrapper around files or an optional MCP dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make local SQLite the default and normative durable memory substrate for Netclaw.
+- Represent memory around anchors/entities, hierarchy, and graph links instead of flat files.
+- Distinguish mutable `documents` from immutable `records` with explicit update semantics.
+- Make recall automatic before each user-facing turn, bounded by policy and latency budgets.
+- Move durable persistence into checkpoint-driven background curation with deterministic filtering before any LLM curator call.
+- Keep the main session as the durable-memory owner; subagents return findings, not writes.
+- Preserve a small compatibility tool surface for explicit save/search/correct workflows so existing prompts and skills keep functioning during migration.
+- Provide measurable success criteria and eval gates before the redesign becomes the only supported path.
+
+**Non-Goals:**
+- Embedding or vector retrieval in MVP-now.
+- Bi-directional live sync with Memorizer as a primary store.
+- Replacing the existing 4 explicit memory tools with a brand-new graph-native tool API in MVP-now.
+- Full encrypted-at-rest key management beyond host filesystem controls.
+- Automatic cross-device memory replication.
+- General-purpose knowledge graph authoring UI.
+
+## Decisions
+
+### Decision: Use a dedicated SQLite memory database, separate from Akka persistence
+
+Netclaw will store durable memory in a dedicated SQLite database under `~/.netclaw/memory/netclaw-memory.db` rather than markdown files or Akka persistence tables.
+
+Rationale:
+- Keeps memory schema evolution independent from Akka journal/snapshot concerns.
+- Supports indexed structured queries, parent/child traversal, and typed edges without introducing another service dependency.
+- Preserves local-first operation on `pi1` and in tests.
+
+Alternatives considered:
+- Reuse `~/.netclaw/memories/` markdown files. Rejected because flat files cannot efficiently support policy-scoped graph traversal, freshness, or background checkpoint queues.
+- Make Memorizer the default substrate. Rejected because durable core memory should not depend on optional MCP reachability.
+- Store memory in the Akka journal. Rejected because memory objects need their own query/index lifecycle and should not be coupled to framework-owned event persistence.
+
+### Decision: Model durable memory as anchors plus documents, records, and edges
+
+The core data model is:
+
+- `anchors`: canonical entities or topics (`person`, `project`, `repo`, `service`, `host`, `preference`, `task`, `concept`) with optional parent anchor.
+- `documents`: mutable living summaries attached to an anchor, such as operator preferences, project briefs, or evolving runbooks.
+- `records`: immutable observations or events attached to an anchor, such as "router IP changed" or "issue #164 fixed on 2026-03-07".
+- `edges`: typed graph relationships between anchors (`depends_on`, `owned_by`, `runs_on`, `related_to`, `child_of`).
+
+Each durable object carries policy metadata: `domain`, `sensitivity`, `recallMode`, `confidence`, `freshness`, and `updateSemantics`.
+
+Rationale:
+- Documents and records need different write rules.
+- Anchors let Netclaw recall by entity and traverse context without flattening everything into note blobs.
+- Typed edges make hierarchy and graph recall possible without full graph-database complexity.
+
+Alternatives considered:
+- Single table of notes with tags. Rejected because tags are too weak for hierarchy, relationships, and update rules.
+- Fully normalized graph-only model. Rejected for MVP because documents still need rich markdown/text bodies and simple operator-facing editing.
+
+### Decision: Make recall system-driven, not model-optional
+
+Before each user-facing turn, the session will run a bounded automatic recall pipeline and inject a structured recall bundle into the prompt/context. Explicit memory tools remain available, but they are not the primary recall mechanism.
+
+Rationale:
+- Fixes the main failure mode where the model forgets to search.
+- Makes recall quality measurable independently of model whim.
+- Lets policy filtering happen before prompt injection.
+
+Alternatives considered:
+- Keep explicit tool-driven recall only. Rejected because it is unreliable and too dependent on prompt compliance.
+- Inject the entire memory index every turn. Rejected because it is noisy and token-expensive.
+
+### Decision: Use rules-first candidate extraction before any curator LLM call
+
+Checkpoint curation starts with deterministic extraction and filtering rules. The curator LLM only processes candidates that survive policy checks, dedupe checks, and heuristic suppression.
+
+Rationale:
+- Cuts latency and noise.
+- Keeps obviously sensitive, stale, or trivial content away from the curator.
+- Reduces reward-hacking pressure to store everything.
+
+Alternatives considered:
+- LLM-only memory extraction. Rejected because it is expensive, less predictable, and prone to saving low-value text.
+- Rules-only persistence. Rejected because durable normalization still benefits from a curator on ambiguous or merge-heavy cases.
+
+### Decision: Main session owns durable writes; subagents return findings envelopes
+
+Subagents will not persist durable memory directly by default. Instead they return a structured findings envelope to the parent session, and the parent session decides whether those findings become checkpoints and durable writes.
+
+Rationale:
+- Preserves a single policy and ownership boundary for durable memory.
+- Prevents specialized subagents from creating unsupervised long-term state.
+- Makes audit, attribution, and rollback much easier.
+
+Alternatives considered:
+- Allow all subagents to call durable memory tools directly. Rejected because it spreads trust and persistence policy across too many actors.
+- Forbid subagent findings entirely. Rejected because subagents still need to contribute research and summaries.
+
+### Decision: Preserve the existing 4 explicit memory tools as compatibility shims in MVP-now
+
+The frontline agent will continue to see `find_memories`, `get_memories`, `store_memory`, and `update_memory`, but they become thin facades over the SQLite memory service and policy pipeline.
+
+Rationale:
+- Minimizes prompt churn and skill breakage.
+- Keeps explicit workflows available for "remember this", "search memory", and "correct this note" requests.
+- Lets Netclaw switch the underlying substrate without forcing an immediate tool-contract rewrite.
+
+Alternatives considered:
+- Introduce new graph-native memory tools immediately. Rejected for MVP-now because automatic recall is the bigger value and compatibility matters.
+- Remove explicit memory tools entirely. Rejected because operators still need deliberate control paths.
+
+## Architecture
+
+### Components
+
+1. `MemorySchemaMigrator`
+   - Creates/upgrades `netclaw-memory.db`
+   - Tracks schema version and legacy import status
+
+2. `MemoryRepository`
+   - CRUD/query methods for anchors, documents, records, edges, and pending checkpoints
+   - Enforces update semantics (`merge-document`, `append-document`, `supersede-record`, `immutable-record`, `tombstone`)
+
+3. `MemoryPolicyEvaluator`
+   - Applies domain separation and sensitivity rules on write and recall
+   - Produces deny/degrade reasons for diagnostics
+
+4. `MemoryRecallCoordinator`
+   - Runs on every user-facing turn before the model call
+   - Produces a compact recall bundle from SQLite under a strict time budget
+
+5. `CheckpointDetector`
+   - Examines turn completions, explicit memory requests, compaction events, tool outputs, and accepted subagent findings
+   - Emits checkpoint intents into a durable queue
+
+6. `MemoryCurationWorker`
+   - Background actor/service that consumes pending checkpoints
+   - Runs rules-first extraction, optional curator normalization, and durable writes
+   - Retries pending work after restart
+
+7. `MemoryToolFacade`
+   - Keeps the existing 4 explicit tools alive as a compatibility surface
+   - Routes all writes through the same policy + checkpoint pipeline
+
+### Data Shape
+
+Illustrative schema:
+
+```text
+anchors(
+  anchor_id,
+  anchor_type,
+  canonical_name,
+  parent_anchor_id,
+  domain,
+  sensitivity,
+  recall_mode,
+  confidence,
+  freshness_at,
+  status,
+  created_at,
+  updated_at
+)
+
+documents(
+  document_id,
+  anchor_id,
+  title,
+  markdown_body,
+  update_semantics,
+  confidence,
+  freshness_at,
+  created_at,
+  updated_at
+)
+
+records(
+  record_id,
+  anchor_id,
+  record_type,
+  payload_json,
+  supersedes_record_id,
+  confidence,
+  freshness_at,
+  created_at
+)
+
+edges(
+  edge_id,
+  from_anchor_id,
+  to_anchor_id,
+  relation_type,
+  confidence,
+  freshness_at,
+  created_at,
+  updated_at
+)
+
+checkpoints(
+  checkpoint_id,
+  session_id,
+  turn_id,
+  trigger_type,
+  priority,
+  status,
+  payload_json,
+  created_at,
+  updated_at,
+  retry_count
+)
+```
+
+### Policy Model
+
+Every durable memory candidate and stored object includes:
+
+- `domain`: `personal`, `business`, `homelab`, `project:<slug>`, or another configured domain
+- `sensitivity`: `normal`, `restricted`, `secret`
+- `recallMode`: `auto`, `manual`, `never`
+- `confidence`: `0.0-1.0`
+- `freshness`: timestamps plus optional expiry window
+- `updateSemantics`: `merge-document`, `append-document`, `supersede-record`, `immutable-record`, `tombstone`
+
+Default behavior:
+- Cross-domain recall is deny-by-default unless a policy explicitly allows it.
+- `secret` memories are never auto-injected.
+- `manual` memories are available only via explicit tool calls.
+- Stale low-confidence items lose ranking and can be filtered out entirely.
+
+### Tool Invocation Model
+
+What the frontline agent sees:
+- `find_memories`: targeted manual search when automatic recall was insufficient or the user explicitly asks what Netclaw remembers
+- `get_memories`: hydrate selected memories in full
+- `store_memory`: explicit remember/save request; routes through checkpoint pipeline instead of writing directly
+- `update_memory`: document correction, record supersede, tombstone, or recall-mode adjustment
+
+What is automated by the system:
+- pre-turn recall before each user-facing model turn
+- checkpoint detection after eligible events
+- rules-first candidate extraction
+- background curator processing
+- policy filtering on every recall and persistence path
+
+When explicit memory tools are still used:
+- user explicitly says "remember this", "forget this", or "what do you remember about X"
+- the agent needs manual follow-up beyond the automatic recall bundle
+- operator correction or cleanup workflows need a direct edit/supersede path
+
+### Actor Boundaries and Recovery Behavior
+
+- `LlmSessionActor` remains responsible for turn orchestration.
+- Automatic recall is synchronous but time-bounded; if it fails or times out, the turn continues with degraded memory status.
+- Checkpoint enqueue is synchronous only up to durable queue acknowledgment; curation itself is asynchronous.
+- `MemoryCurationWorker` owns retryable background writes and resumes pending checkpoints after daemon restart.
+- `SubAgentActor` stays ephemeral and non-persistent; it returns findings back to the parent session.
+
+Failure modes and recovery:
+- SQLite missing: create database and schema automatically.
+- SQLite unavailable or corrupted: session turns continue without automatic recall, explicit memory tools return degraded errors, and health reports degraded memory status.
+- Curator timeout/failure: checkpoint remains pending with retry metadata; no partial write is committed.
+- Policy deny during recall: item is excluded silently from prompt injection and logged for diagnostics at debug/audit level.
+
+## Pseudocode
+
+### Checkpoint detection
+
+```text
+function detectCheckpoints(turn, toolOutputs, subagentFindings, compactionState):
+  checkpoints = []
+
+  if turn.userExplicitlyRequestsRemember or turn.userExplicitlyRequestsForget:
+    checkpoints.add(highPriority("explicit-memory-request", turn))
+
+  if turn.containsStablePreference or turn.containsDurableDecision:
+    checkpoints.add(normalPriority("stable-fact", turn))
+
+  if turn.containsProjectStateChange or turn.containsResolvedAction:
+    checkpoints.add(normalPriority("project-update", turn))
+
+  if toolOutputs.includeVerifiedExternalFact:
+    checkpoints.add(normalPriority("verified-tool-finding", toolOutputs))
+
+  if subagentFindings.acceptedByParentSession:
+    checkpoints.add(normalPriority("subagent-findings", subagentFindings))
+
+  if compactionState.nearThreshold or compactionState.completed:
+    checkpoints.add(highPriority("compaction-boundary", compactionState.summary))
+
+  return checkpoints
+```
+
+### Rules-first candidate extraction
+
+```text
+function rulesFirstExtract(checkpoint, policyContext, existingMemoryIndex):
+  spans = splitIntoCandidateSpans(checkpoint.payload)
+  candidates = []
+
+  for span in spans:
+    if isSmallTalk(span) or isEphemeral(span) or lacksStableReferent(span):
+      continue
+
+    candidate = classify(span)
+    candidate.domain = inferDomain(span, policyContext)
+    candidate.sensitivity = inferSensitivity(span, policyContext)
+    candidate.anchorKey = resolveAnchorKey(candidate)
+
+    if violatesWritePolicy(candidate, policyContext):
+      continue
+
+    if isDuplicateOrLowerQuality(candidate, existingMemoryIndex):
+      continue
+
+    if candidate.confidence < 0.55 and not checkpoint.isExplicitRequest:
+      continue
+
+    candidates.add(candidate)
+
+  return candidates
+```
+
+### Curator processing
+
+```text
+function curateCandidates(candidates, currentGraph):
+  operations = []
+
+  for candidate in candidates:
+    if candidate.isDeterministic:
+      operations.add(buildDirectOperation(candidate, currentGraph))
+      continue
+
+    curated = callCuratorModel(candidate, currentGraph.summaryFor(candidate.anchorKey))
+
+    if curated.rejected:
+      continue
+
+    operations.add(normalizeToOperation(curated))
+
+  applyTransaction(operations)
+  return operations
+```
+
+### Automatic pre-turn recall
+
+```text
+function automaticRecall(session, incomingUserMessage):
+  intent = classifyIntent(incomingUserMessage, session.recentTurns)
+  policyScope = buildPolicyScope(session.channel, session.sender, session.activeProject)
+  query = buildRecallQuery(intent, incomingUserMessage, session.activeAnchors)
+
+  ranked = searchSQLiteMemory(
+    query = query,
+    domains = policyScope.allowedDomains,
+    excludedSensitivity = policyScope.autoRecallDeniedSensitivity,
+    recallModes = ["auto"],
+    freshnessBias = now()
+  )
+
+  bundle = compactToRecallBundle(ranked.top(5), tokenBudget = session.memoryBudget)
+  return bundle
+```
+
+### Subagent findings flowing back to main session
+
+```text
+function handleSubagentResult(parentSession, subagentResult):
+  if not subagentResult.success:
+    return
+
+  findings = extractFindingsEnvelope(subagentResult)
+
+  if findings.isEmpty:
+    return
+
+  if parentSession.policy.disallowsSubagentDomain(findings.domain):
+    logDrop(findings, reason = "policy")
+    return
+
+  checkpoint = buildCheckpointFromFindings(parentSession.sessionId, findings)
+  enqueueCheckpoint(checkpoint)
+  parentSession.emitObservation("subagent findings queued for memory review")
+```
+
+## Risks / Trade-offs
+
+- [SQLite query complexity on constrained hardware] -> Keep schema small, use indexed fields only, and gate recall to top-N bounded queries.
+- [Automatic recall may inject noise] -> Keep strict candidate limits, policy filters, and eval gates for precision before rollout.
+- [Migration may strand legacy memories] -> Provide one-time import plus idempotent re-run support and operator-visible migration status.
+- [Compatibility shims may preserve old habits too long] -> Mark them as explicit/manual paths in prompt guidance and keep graph-native APIs deferred behind a later change.
+- [Background curation can silently fail] -> Persist checkpoints with retry state, surface queue health in diagnostics, and never report a save as complete before enqueue acknowledgment.
+
+## Migration Plan
+
+1. Add `memory/` directory, SQLite schema migrator, and health reporting.
+2. Build repositories and policy evaluator for anchors, documents, records, edges, and checkpoints.
+3. Add compatibility tool facades backed by the new substrate.
+4. Implement automatic recall in `LlmSessionActor` with bounded timeout and degraded fallback.
+5. Implement checkpoint detection plus `MemoryCurationWorker` retry queue.
+6. Change subagent contract to return findings envelopes; route accepted findings through the parent session.
+7. Import legacy markdown memories from `~/.netclaw/memories/` into SQLite as anchors/documents/records; leave source files untouched as read-only migration artifacts.
+8. Treat legacy `Memory.Provider` values (`files`, `memorizer`) as migration inputs only; emit warnings and write upgraded config for the new default substrate.
+9. Keep existing 4 memory tool names as shims for at least one release; deprecate backend-specific prompt guidance and system skills in the same implementation cycle.
+10. After eval gates pass, mark legacy file-backed and Memorizer-backed provider modes unsupported as primary backends.
+
+Rollback stance:
+- Schema migrations are additive before cutover.
+- Legacy markdown files remain untouched, so rollback can disable SQLite memory and fall back to read-only legacy behavior during the transition window.
+- Once write cutover happens, rollback keeps SQLite data intact and does not attempt reverse-sync into markdown files.
+
+## Success and Evaluation Criteria
+
+The implementation is not done until it passes a seeded memory eval suite with measurable outcomes:
+
+- Eval execution baseline: run the seeded suite locally against smaller Ollama-hosted models first. Passing results on constrained local models is the primary quality gate before validating on larger hosted models.
+- Recall quality: at least one relevant item appears in the automatic recall bundle for >= 85% of recall-positive test cases.
+- Noise suppression: no-memory-needed cases return an empty automatic recall bundle in >= 80% of cases, and auto recall never injects more than 3 items.
+- Privacy/sensitivity: blocked domain and blocked sensitivity items leak into auto recall in 0 eval cases.
+- Operational latency: automatic recall p95 <= 300 ms and checkpoint enqueue p95 <= 25 ms on the standard local fixture; background curation p95 <= 5 s for a <= 10-candidate checkpoint.
+- Ownership: 0 durable memory writes originate directly from a default subagent path in audit logs.
+
+### Eval Harness Expectations
+
+- The seeded eval suite must support a local Ollama provider profile so Netclaw can run recall and curation evaluations entirely on local hardware.
+- The default pre-merge memory eval profile should target smaller Ollama models because they provide the strictest practical test of prompt efficiency, bounded recall bundles, and policy clarity.
+- Larger hosted models are follow-up validation targets, not the primary design bar. The architecture should be considered acceptable only if the local Ollama profile already meets the success thresholds above.
+- Eval reporting should break out at least: model ID, recall hit rate, false-positive recall rate, blocked-memory leakage count, checkpoint-to-curation latency, and average injected recall bundle size.
+
+## Open Questions
+
+- Whether future graph-native memory tools should replace the compatibility 4-tool surface after the eval suite proves automatic recall is stable. This is explicitly deferred, not blocking MVP-now.

--- a/openspec/changes/memory-policy-graph-redesign/proposal.md
+++ b/openspec/changes/memory-policy-graph-redesign/proposal.md
@@ -11,10 +11,10 @@ Netclaw's current memory model is too flat, too manual, and too backend-shaped: 
 - Add a policy envelope on durable memory covering domain separation, sensitivity, recall mode, confidence, freshness, and update semantics.
 - Move memory recall and most persistence decisions into system-managed flows: automatic pre-turn recall, checkpoint detection, background curation, and rules-first candidate filtering before any curator LLM call.
 - Make the main user-facing session the default owner of durable memory writes; subagents return findings to the parent session instead of writing durable memory directly.
-- Preserve a minimal explicit memory tool surface for operator-directed save/search/correct flows, but treat it as a compatibility layer over the new substrate rather than the primary recall path.
-- Define migration from `~/.netclaw/memories/` and legacy `Memory.Provider` settings, along with a compatibility stance for existing prompts, skills, and optional Memorizer integrations.
+- Preserve a minimal explicit memory tool surface for operator-directed save/search/correct flows, but treat it as a deliberate manual-control layer over the new substrate rather than the primary recall path.
+- Treat MVP delivery as greenfield: no legacy import or provider-compatibility work is required now, and any legacy file/provider bridge can be omitted or deferred to a follow-up change.
 - Add measurable success and eval criteria for recall quality, noise suppression, privacy behavior, and latency, with local Ollama-model evaluation as the primary pre-rollout gate.
-- Keep scope explicit: SQLite structured memory, policy-aware recall, checkpoint curation, compatibility shims, and migration are MVP-now; embeddings, external sync, and richer graph tooling remain deferred.
+- Keep scope explicit: SQLite structured memory, policy-aware recall, checkpoint curation, explicit manual memory controls, and evaluation are MVP-now; embeddings, external sync, and legacy compatibility/import work remain deferred.
 
 ## Capabilities
 
@@ -24,14 +24,14 @@ Netclaw's current memory model is too flat, too manual, and too backend-shaped: 
 
 ### Modified Capabilities
 
-- `netclaw-agent-memory`: replaces backend-centric memory with SQLite structured memory, automatic recall, policy-aware persistence, checkpoint curation, compatibility tools, and migration behavior.
+- `netclaw-agent-memory`: replaces backend-centric memory with SQLite structured memory, automatic recall, policy-aware persistence, checkpoint curation, explicit/manual memory controls, and system-prompt guidance updates.
 - `netclaw-session`: adds pre-turn automatic recall, checkpoint scheduling, and degraded recovery behavior around memory reads/writes.
 - `netclaw-subagents`: changes durable memory ownership so subagents report findings back to the main session instead of persisting by default.
 
 ## Impact
 
 - **Code/runtime**: new SQLite memory schema, repositories/query layer, checkpoint queue, recall planner, background curator worker, compatibility tool facades, and session/subagent wiring changes.
-- **Persistence**: durable memory moves out of markdown files and away from optional MCP-provider coupling into a dedicated first-party SQLite store with explicit migration from legacy data.
+- **Persistence**: durable memory moves out of markdown files and away from optional MCP-provider coupling into a dedicated first-party SQLite store designed for greenfield MVP startup.
 - **Security/privacy**: domain and sensitivity policy become part of every durable memory object; automatic recall must fail closed on policy mismatches and degrade safely on storage errors.
-- **Operations**: the daemon must surface memory health, pending checkpoints, and migration state; existing file memories remain importable during transition.
-- **Compatibility**: existing `find_memories`/`get_memories`/`store_memory`/`update_memory` usage remains supported initially through shims, while legacy file and Memorizer provider modes are deprecated as primary backends.
+- **Operations**: the daemon must surface memory health, pending checkpoints, recall degradation, and curator status.
+- **Compatibility**: `find_memories`/`get_memories`/`store_memory`/`update_memory` remain as explicit manual-control tools, while legacy file and Memorizer provider modes are not required for MVP and may be deferred entirely.

--- a/openspec/changes/memory-policy-graph-redesign/proposal.md
+++ b/openspec/changes/memory-policy-graph-redesign/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Source PRDs: `PRD-007` (primary), `PRD-001`, `PRD-002`.
+
+Netclaw's current memory model is too flat, too manual, and too backend-shaped: durable recall depends on the model explicitly calling memory tools, the file-backed store cannot represent entities or relationships, and the optional Memorizer path pushes core memory behavior into an external integration. PRD-007 needs a first-party memory architecture that is local, policy-aware, and reliable enough to drive automatic recall and durable cross-session knowledge without leaking sensitive facts across domains.
+
+## What Changes
+
+- **BREAKING** Replace the current file-backed memory store plus optional Memorizer-backed unified provider as Netclaw's primary memory architecture with a local SQLite-backed structured memory substrate.
+- Introduce anchor/entity-oriented memory with hierarchical containment, typed graph edges, and first-class `document` vs `record` semantics.
+- Add a policy envelope on durable memory covering domain separation, sensitivity, recall mode, confidence, freshness, and update semantics.
+- Move memory recall and most persistence decisions into system-managed flows: automatic pre-turn recall, checkpoint detection, background curation, and rules-first candidate filtering before any curator LLM call.
+- Make the main user-facing session the default owner of durable memory writes; subagents return findings to the parent session instead of writing durable memory directly.
+- Preserve a minimal explicit memory tool surface for operator-directed save/search/correct flows, but treat it as a compatibility layer over the new substrate rather than the primary recall path.
+- Define migration from `~/.netclaw/memories/` and legacy `Memory.Provider` settings, along with a compatibility stance for existing prompts, skills, and optional Memorizer integrations.
+- Add measurable success and eval criteria for recall quality, noise suppression, privacy behavior, and latency, with local Ollama-model evaluation as the primary pre-rollout gate.
+- Keep scope explicit: SQLite structured memory, policy-aware recall, checkpoint curation, compatibility shims, and migration are MVP-now; embeddings, external sync, and richer graph tooling remain deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `netclaw-agent-memory`: replaces backend-centric memory with SQLite structured memory, automatic recall, policy-aware persistence, checkpoint curation, compatibility tools, and migration behavior.
+- `netclaw-session`: adds pre-turn automatic recall, checkpoint scheduling, and degraded recovery behavior around memory reads/writes.
+- `netclaw-subagents`: changes durable memory ownership so subagents report findings back to the main session instead of persisting by default.
+
+## Impact
+
+- **Code/runtime**: new SQLite memory schema, repositories/query layer, checkpoint queue, recall planner, background curator worker, compatibility tool facades, and session/subagent wiring changes.
+- **Persistence**: durable memory moves out of markdown files and away from optional MCP-provider coupling into a dedicated first-party SQLite store with explicit migration from legacy data.
+- **Security/privacy**: domain and sensitivity policy become part of every durable memory object; automatic recall must fail closed on policy mismatches and degrade safely on storage errors.
+- **Operations**: the daemon must surface memory health, pending checkpoints, and migration state; existing file memories remain importable during transition.
+- **Compatibility**: existing `find_memories`/`get_memories`/`store_memory`/`update_memory` usage remains supported initially through shims, while legacy file and Memorizer provider modes are deprecated as primary backends.

--- a/openspec/changes/memory-policy-graph-redesign/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/memory-policy-graph-redesign/specs/netclaw-agent-memory/spec.md
@@ -18,7 +18,7 @@ The system SHALL replace the current single-step pre-compaction memory flush wit
 
 ### Requirement: Standard configuration directory
 
-The system SHALL use `~/.netclaw/` as the standard configuration directory with `memory/` as the durable memory home. The memory subsystem SHALL store its SQLite database, schema metadata, and migration artifacts under `~/.netclaw/memory/`. The legacy `~/.netclaw/memories/` directory SHALL be preserved as a read-only migration source during transition and SHALL NOT remain the primary write path after this redesign.
+The system SHALL use `~/.netclaw/` as the standard configuration directory with `memory/` as the durable memory home. The memory subsystem SHALL store its SQLite database, schema metadata, and health/queue state under `~/.netclaw/memory/`. The redesigned MVP SHALL NOT require any legacy memory directory or import step in order to start cleanly.
 
 #### Scenario: Memory directory and database created on startup
 - **GIVEN** `~/.netclaw/memory/` does not exist
@@ -26,31 +26,31 @@ The system SHALL use `~/.netclaw/` as the standard configuration directory with 
 - **THEN** the system creates the directory and initializes the SQLite database schema
 - **AND** the daemon reports memory status as healthy when initialization succeeds
 
-#### Scenario: Legacy file memory directory preserved during migration
-- **GIVEN** `~/.netclaw/memories/` contains legacy markdown memories
-- **WHEN** the redesigned memory subsystem starts
-- **THEN** the system leaves the legacy files untouched
-- **AND** treats them as import input rather than the active write store
+#### Scenario: Greenfield startup requires no legacy memory store
+- **GIVEN** `~/.netclaw/memory/` is empty and `~/.netclaw/memories/` does not exist
+- **WHEN** the redesigned memory subsystem starts for the first time
+- **THEN** the system initializes successfully without any import step
+- **AND** uses the SQLite memory store as the only required durable memory substrate
 
 ### Requirement: Pluggable memory backend with 4-tool surface
 
-The system SHALL use a local SQLite-backed structured memory substrate as Netclaw's default and normative durable memory implementation. The frontline model SHALL continue to see the explicit compatibility tools `find_memories`, `get_memories`, `store_memory`, and `update_memory`, but those tools SHALL operate over the SQLite memory graph and shared policy pipeline rather than selecting between file-backed and Memorizer-backed primary providers. Legacy provider settings MAY be read only for migration and compatibility messaging.
+The system SHALL use a local SQLite-backed structured memory substrate as Netclaw's default and normative durable memory implementation. The frontline model SHALL continue to see the explicit tools `find_memories`, `get_memories`, `store_memory`, and `update_memory`, but those tools SHALL operate over the SQLite memory graph and shared policy pipeline rather than selecting between file-backed and Memorizer-backed primary providers. Legacy provider modes SHALL NOT be required for MVP delivery.
 
 #### Scenario: SQLite memory is the active default substrate
 - **GIVEN** Netclaw starts with the redesigned memory system
-- **WHEN** no legacy migration override is required
+- **WHEN** the daemon initializes the memory subsystem
 - **THEN** the daemon uses the local SQLite memory database as the primary durable memory store
 - **AND** explicit memory tools route to that store
 
-#### Scenario: Legacy provider config triggers compatibility migration
-- **GIVEN** configuration still contains a legacy `Memory.Provider` value such as `files` or `memorizer`
-- **WHEN** the daemon starts after this redesign
-- **THEN** the daemon reports that the legacy provider mode is deprecated
-- **AND** begins migration or degraded compatibility behavior instead of treating the legacy provider as the normative architecture
+#### Scenario: MVP does not depend on legacy provider compatibility
+- **GIVEN** the redesigned memory subsystem is being delivered for greenfield MVP use
+- **WHEN** implementation scope is evaluated
+- **THEN** SQLite-backed memory and the explicit tool surface are sufficient for completion
+- **AND** legacy provider-mode bridging may be omitted or deferred to a future change
 
 ### Requirement: Two-phase memory retrieval
 
-Memory retrieval SHALL run in two modes: automatic pre-turn recall and explicit two-phase retrieval. Automatic recall SHALL happen before each user-facing model turn and SHALL inject a bounded recall bundle derived from the structured memory graph. Explicit retrieval SHALL continue to use `find_memories` for lightweight search and `get_memories` for full hydration when manual follow-up is needed.
+Memory retrieval SHALL run in two modes: automatic pre-turn recall and explicit two-phase retrieval. Automatic recall SHALL happen before each user-facing model turn and SHALL inject a bounded recall bundle derived from the structured memory graph. Explicit retrieval SHALL continue to use `find_memories` for lightweight search and `get_memories` for full hydration when manual follow-up is needed. Automatic recall is the primary retrieval path; explicit retrieval is a deliberate manual-control path.
 
 #### Scenario: Automatic recall runs before a user-facing turn
 - **GIVEN** a user sends a new message into an existing or new session
@@ -64,15 +64,27 @@ Memory retrieval SHALL run in two modes: automatic pre-turn recall and explicit 
 - **THEN** it receives lightweight results suitable for selection
 - **AND** can call `get_memories` to fetch full memory bodies only for the selected items
 
+#### Scenario: Routine turn relies on automatic recall first
+- **GIVEN** a normal user-facing turn begins
+- **WHEN** the automatic recall bundle already provides the relevant durable context
+- **THEN** the frontline model does not need to call explicit retrieval tools by default
+- **AND** proceeds using the system-managed recall bundle
+
 ### Requirement: Memory context layer per backend
 
-The memory context layer SHALL explain that durable recall is automatic by default and that explicit memory tools are reserved for manual search, save, and correction workflows. The layer SHALL surface degraded memory status when automatic recall or durable persistence is unavailable. It SHALL no longer teach the model that backend selection is part of normal memory usage.
+The memory context layer SHALL explain that durable recall is automatic by default and that explicit memory tools are reserved for deliberate manual search, save, and correction workflows. The layer SHALL surface degraded memory status when automatic recall or durable persistence is unavailable. It SHALL no longer teach the model that backend selection is part of normal memory usage, and it SHALL explicitly tell the frontline model not to call write tools reflexively on every turn.
 
 #### Scenario: Context layer teaches automatic recall first
 - **GIVEN** the redesigned memory subsystem is healthy
 - **WHEN** a session prompt is assembled
 - **THEN** the memory context layer explains that Netclaw automatically recalls durable memory before each turn
 - **AND** reserves explicit memory tools for deliberate memory operations
+
+#### Scenario: Context layer distinguishes store and update usage
+- **GIVEN** the redesigned memory subsystem is healthy
+- **WHEN** memory guidance is injected into the session prompt
+- **THEN** the guidance says `store_memory` is for deliberate save/remember actions
+- **AND** the guidance says `update_memory` is for correction, supersede, tombstone, or metadata changes to existing memory
 
 #### Scenario: Context layer reports degraded memory state
 - **GIVEN** the memory database is unavailable or recall has been disabled due to an operational fault
@@ -84,19 +96,19 @@ The memory context layer SHALL explain that durable recall is automatic by defau
 
 ### Requirement: Memorizer-backed store_memory delegation
 **Reason**: Durable memory ownership now belongs to Netclaw's first-party SQLite substrate and checkpoint pipeline rather than a Memorizer-backed primary provider.
-**Migration**: Route explicit `store_memory` calls through the compatibility facade and background curation pipeline; keep Memorizer only as a deferred optional integration/export path.
+**Migration**: Route explicit `store_memory` calls through the SQLite-backed explicit tool facade and background curation pipeline; keep Memorizer only as a deferred optional integration/export path if it is reintroduced later.
 
 ### Requirement: Memorizer-backed find/get/update as MCP pass-throughs
 **Reason**: Netclaw no longer treats Memorizer MCP tools as the primary durable memory implementation.
-**Migration**: Keep `find_memories`, `get_memories`, and `update_memory` as SQLite-backed compatibility tools; any future Memorizer bridge must sit behind the first-party memory service instead of replacing it.
+**Migration**: Keep `find_memories`, `get_memories`, and `update_memory` as SQLite-backed explicit tools; any future Memorizer bridge must sit behind the first-party memory service instead of replacing it.
 
 ### Requirement: File-based memory store
 **Reason**: The markdown file store is replaced by structured SQLite memory so Netclaw can support hierarchy, policy metadata, graph edges, and automatic recall.
-**Migration**: Import legacy markdown memories into SQLite and preserve source files as read-only migration artifacts.
+**Migration**: No import path is required for MVP; if legacy markdown compatibility is needed later, it should be introduced through a follow-up change.
 
 ### Requirement: Memorizer discovery guidance
 **Reason**: Core memory usage should no longer depend on discovering an optional external tool server.
-**Migration**: Update system skills and prompt guidance to teach automatic recall plus explicit compatibility tools, with optional Memorizer integration documented separately if reintroduced later.
+**Migration**: Update system skills and prompt guidance to teach automatic recall plus explicit manual tools, with optional Memorizer integration documented separately if reintroduced later.
 
 ## ADDED Requirements
 
@@ -172,6 +184,22 @@ The main user-facing session SHALL be the default owner of durable memory writes
 - **THEN** the parent session turns them into a checkpoint for durable memory review
 - **AND** the subagent does not write durable memory directly
 
+### Requirement: Explicit memory control paths
+
+The system SHALL treat `store_memory` and `update_memory` as deliberate manual-control paths layered on top of automatic recall and background curation. The frontline agent SHALL invoke `store_memory` only for explicit remember/save requests, deliberate high-value pinning, or operator-directed structured note capture. The frontline agent SHALL invoke `update_memory` only for correction, supersede, tombstone, or metadata changes to an existing durable memory item.
+
+#### Scenario: Frontline agent uses store_memory for an explicit save request
+- **GIVEN** the user explicitly asks Netclaw to remember a fact or preference
+- **WHEN** the frontline agent chooses how to persist that information
+- **THEN** it uses `store_memory` as the deliberate explicit write path
+- **AND** the request still flows through checkpoint and policy handling rather than direct uncontrolled persistence
+
+#### Scenario: Frontline agent uses update_memory for correction
+- **GIVEN** an existing durable memory item must be corrected or superseded
+- **WHEN** the frontline agent applies the user's correction
+- **THEN** it uses `update_memory`
+- **AND** it does not use `store_memory` to create an untracked duplicate for the same correction
+
 ### Requirement: Memory evaluation and operational criteria
 
 The redesigned memory subsystem SHALL ship with an eval suite and operational SLOs covering recall quality, noise suppression, privacy behavior, and latency. The implementation SHALL NOT be considered complete until the seeded eval suite demonstrates the configured thresholds.
@@ -188,18 +216,18 @@ The redesigned memory subsystem SHALL ship with an eval suite and operational SL
 - **THEN** it runs the default gate against smaller local Ollama-hosted models
 - **AND** passing larger hosted models does not waive a failing local Ollama eval result
 
-### Requirement: Legacy memory migration and compatibility stance
+### Requirement: Greenfield SQLite-first delivery stance
 
-The system SHALL provide a migration path from the legacy markdown memory directory and legacy provider-oriented configuration into the SQLite structured memory substrate. During the transition window, explicit memory tool names SHALL remain stable so existing prompts and skills continue to function.
+The redesigned memory subsystem SHALL be implementation-ready as a greenfield MVP without requiring legacy markdown import or legacy provider-mode compatibility. Explicit memory tool names SHALL remain stable within the redesigned subsystem so prompt and skill guidance can target a consistent manual-control surface.
 
-#### Scenario: Legacy markdown memories import into SQLite
-- **GIVEN** legacy markdown memories exist under `~/.netclaw/memories/`
-- **WHEN** the operator runs or accepts migration into the redesigned subsystem
-- **THEN** those memories are imported into anchors, documents, and records in SQLite
-- **AND** the original markdown files are preserved as source artifacts
+#### Scenario: Greenfield MVP completes without import work
+- **GIVEN** Netclaw has no production-deployed public memory data that must be preserved
+- **WHEN** the redesigned memory subsystem is implemented for MVP
+- **THEN** no markdown import or provider-mode migration is required for completeness
+- **AND** deferred legacy compatibility does not block delivery
 
-#### Scenario: Compatibility tool names remain stable
-- **GIVEN** an existing prompt or skill instructs the model to use `find_memories` and `store_memory`
+#### Scenario: Explicit tool names remain stable
+- **GIVEN** a prompt or skill instructs the model to use `find_memories` and `store_memory`
 - **WHEN** the redesigned memory subsystem is active
 - **THEN** those tool names continue to function
 - **AND** they execute against the SQLite memory service and policy pipeline

--- a/openspec/changes/memory-policy-graph-redesign/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/memory-policy-graph-redesign/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,205 @@
+## MODIFIED Requirements
+
+### Requirement: Pre-compaction memory flush
+
+The system SHALL replace the current single-step pre-compaction memory flush with checkpoint-driven background memory curation. The session SHALL emit durable memory checkpoints on eligible events including turn completion, explicit memory requests, compaction boundaries, verified tool findings, and accepted subagent findings. Compaction-related checkpoints SHALL be high priority, but the user-facing turn SHALL wait only for durable checkpoint enqueue acknowledgment, not for curator completion.
+
+#### Scenario: Compaction boundary creates a high-priority checkpoint
+- **GIVEN** a session is approaching or crossing the compaction threshold
+- **WHEN** the session prepares to compact history
+- **THEN** the system enqueues a high-priority memory checkpoint containing the relevant summary inputs
+- **AND** compaction continues after checkpoint enqueue succeeds
+
+#### Scenario: Checkpoint curation retries after failure
+- **GIVEN** a checkpoint was enqueued successfully
+- **WHEN** background curation fails or times out
+- **THEN** the checkpoint remains pending with retry metadata
+- **AND** durable memory is not partially committed
+
+### Requirement: Standard configuration directory
+
+The system SHALL use `~/.netclaw/` as the standard configuration directory with `memory/` as the durable memory home. The memory subsystem SHALL store its SQLite database, schema metadata, and migration artifacts under `~/.netclaw/memory/`. The legacy `~/.netclaw/memories/` directory SHALL be preserved as a read-only migration source during transition and SHALL NOT remain the primary write path after this redesign.
+
+#### Scenario: Memory directory and database created on startup
+- **GIVEN** `~/.netclaw/memory/` does not exist
+- **WHEN** the Netclaw process starts with the redesigned memory subsystem enabled
+- **THEN** the system creates the directory and initializes the SQLite database schema
+- **AND** the daemon reports memory status as healthy when initialization succeeds
+
+#### Scenario: Legacy file memory directory preserved during migration
+- **GIVEN** `~/.netclaw/memories/` contains legacy markdown memories
+- **WHEN** the redesigned memory subsystem starts
+- **THEN** the system leaves the legacy files untouched
+- **AND** treats them as import input rather than the active write store
+
+### Requirement: Pluggable memory backend with 4-tool surface
+
+The system SHALL use a local SQLite-backed structured memory substrate as Netclaw's default and normative durable memory implementation. The frontline model SHALL continue to see the explicit compatibility tools `find_memories`, `get_memories`, `store_memory`, and `update_memory`, but those tools SHALL operate over the SQLite memory graph and shared policy pipeline rather than selecting between file-backed and Memorizer-backed primary providers. Legacy provider settings MAY be read only for migration and compatibility messaging.
+
+#### Scenario: SQLite memory is the active default substrate
+- **GIVEN** Netclaw starts with the redesigned memory system
+- **WHEN** no legacy migration override is required
+- **THEN** the daemon uses the local SQLite memory database as the primary durable memory store
+- **AND** explicit memory tools route to that store
+
+#### Scenario: Legacy provider config triggers compatibility migration
+- **GIVEN** configuration still contains a legacy `Memory.Provider` value such as `files` or `memorizer`
+- **WHEN** the daemon starts after this redesign
+- **THEN** the daemon reports that the legacy provider mode is deprecated
+- **AND** begins migration or degraded compatibility behavior instead of treating the legacy provider as the normative architecture
+
+### Requirement: Two-phase memory retrieval
+
+Memory retrieval SHALL run in two modes: automatic pre-turn recall and explicit two-phase retrieval. Automatic recall SHALL happen before each user-facing model turn and SHALL inject a bounded recall bundle derived from the structured memory graph. Explicit retrieval SHALL continue to use `find_memories` for lightweight search and `get_memories` for full hydration when manual follow-up is needed.
+
+#### Scenario: Automatic recall runs before a user-facing turn
+- **GIVEN** a user sends a new message into an existing or new session
+- **WHEN** the session prepares the next model call
+- **THEN** the system runs a policy-aware automatic recall query against durable memory
+- **AND** injects a bounded recall bundle before the model sees the turn
+
+#### Scenario: Explicit two-phase retrieval remains available
+- **GIVEN** the automatic recall bundle was insufficient or the user explicitly asks what Netclaw remembers
+- **WHEN** the frontline model calls `find_memories`
+- **THEN** it receives lightweight results suitable for selection
+- **AND** can call `get_memories` to fetch full memory bodies only for the selected items
+
+### Requirement: Memory context layer per backend
+
+The memory context layer SHALL explain that durable recall is automatic by default and that explicit memory tools are reserved for manual search, save, and correction workflows. The layer SHALL surface degraded memory status when automatic recall or durable persistence is unavailable. It SHALL no longer teach the model that backend selection is part of normal memory usage.
+
+#### Scenario: Context layer teaches automatic recall first
+- **GIVEN** the redesigned memory subsystem is healthy
+- **WHEN** a session prompt is assembled
+- **THEN** the memory context layer explains that Netclaw automatically recalls durable memory before each turn
+- **AND** reserves explicit memory tools for deliberate memory operations
+
+#### Scenario: Context layer reports degraded memory state
+- **GIVEN** the memory database is unavailable or recall has been disabled due to an operational fault
+- **WHEN** a session prompt is assembled
+- **THEN** the memory context layer reports degraded memory status
+- **AND** does not claim that durable recall is functioning normally
+
+## REMOVED Requirements
+
+### Requirement: Memorizer-backed store_memory delegation
+**Reason**: Durable memory ownership now belongs to Netclaw's first-party SQLite substrate and checkpoint pipeline rather than a Memorizer-backed primary provider.
+**Migration**: Route explicit `store_memory` calls through the compatibility facade and background curation pipeline; keep Memorizer only as a deferred optional integration/export path.
+
+### Requirement: Memorizer-backed find/get/update as MCP pass-throughs
+**Reason**: Netclaw no longer treats Memorizer MCP tools as the primary durable memory implementation.
+**Migration**: Keep `find_memories`, `get_memories`, and `update_memory` as SQLite-backed compatibility tools; any future Memorizer bridge must sit behind the first-party memory service instead of replacing it.
+
+### Requirement: File-based memory store
+**Reason**: The markdown file store is replaced by structured SQLite memory so Netclaw can support hierarchy, policy metadata, graph edges, and automatic recall.
+**Migration**: Import legacy markdown memories into SQLite and preserve source files as read-only migration artifacts.
+
+### Requirement: Memorizer discovery guidance
+**Reason**: Core memory usage should no longer depend on discovering an optional external tool server.
+**Migration**: Update system skills and prompt guidance to teach automatic recall plus explicit compatibility tools, with optional Memorizer integration documented separately if reintroduced later.
+
+## ADDED Requirements
+
+### Requirement: Hierarchical anchor graph memory model
+
+The system SHALL model durable memory around anchors/entities with optional parent-child hierarchy and typed graph edges. Anchors SHALL support containment (`project` -> `repo` -> `service`) and non-hierarchical relationships (`related_to`, `depends_on`, `owned_by`) so recall can expand around the relevant entity without flattening all memory into note blobs.
+
+#### Scenario: Recall traverses anchor hierarchy
+- **GIVEN** a project anchor contains repository and service child anchors
+- **WHEN** a user asks about the project at the parent level
+- **THEN** the recall pipeline MAY retrieve child-scoped memory through the hierarchy
+- **AND** only items allowed by policy are injected into the recall bundle
+
+### Requirement: Durable memory policy envelope
+
+Every durable anchor, document, record, and edge SHALL carry policy metadata including `domain`, `sensitivity`, `recallMode`, `confidence`, `freshness`, and `updateSemantics`. The write path SHALL assign or reject these values before persistence, and the recall path SHALL filter by them before prompt injection.
+
+#### Scenario: Sensitive memory is blocked from auto recall
+- **GIVEN** a stored memory item is marked `domain=business`, `sensitivity=secret`, and `recallMode=manual`
+- **WHEN** a personal-domain session runs automatic pre-turn recall
+- **THEN** the item is excluded from the automatic recall bundle
+- **AND** it remains available only to explicit authorized workflows if policy allows
+
+### Requirement: Documents versus records semantics
+
+The system SHALL distinguish mutable `documents` from immutable `records`. Documents SHALL represent living, mergeable knowledge that can be updated in place with version history. Records SHALL represent time-bound observations that are immutable once written and can only be superseded, expired, or tombstoned by subsequent operations.
+
+#### Scenario: Preference update modifies a document
+- **GIVEN** an operator preference is stored as a document on a `person` anchor
+- **WHEN** the operator corrects that preference later
+- **THEN** the system updates the document according to its merge semantics
+- **AND** preserves version lineage for auditability
+
+#### Scenario: Historical event becomes a superseded record
+- **GIVEN** a host IP change is stored as a record on a `host` anchor
+- **WHEN** a newer verified IP change is persisted
+- **THEN** the new fact is stored as a new record
+- **AND** the older record is marked as superseded rather than overwritten
+
+### Requirement: Rules-first candidate extraction
+
+The system SHALL run deterministic rules before any curator LLM call when converting checkpoints into durable memory. These rules SHALL reject ephemeral chatter, duplicates, policy-violating content, and low-confidence candidates before invoking the curator.
+
+#### Scenario: Trivial chatter is filtered before curation
+- **GIVEN** a checkpoint contains both stable project facts and casual acknowledgments
+- **WHEN** rules-first extraction runs
+- **THEN** the stable facts survive as candidates
+- **AND** the casual acknowledgments are dropped without calling the curator for them
+
+### Requirement: Automatic pre-turn recall
+
+The system SHALL execute automatic recall before each user-facing model turn using the latest user message, recent session context, active anchors, and policy scope. Automatic recall SHALL be bounded by a latency budget and SHALL degrade safely when the memory substrate is unavailable.
+
+#### Scenario: Recall completes within budget
+- **GIVEN** the memory substrate is healthy
+- **WHEN** a new turn begins
+- **THEN** the session retrieves and injects a bounded recall bundle before the model call
+- **AND** the recall operation completes within the configured time budget or degrades safely
+
+#### Scenario: Recall failure degrades without blocking the turn
+- **GIVEN** the memory database is temporarily unavailable
+- **WHEN** the session starts automatic recall for a turn
+- **THEN** the user-facing turn continues without durable recall injection
+- **AND** the session records degraded memory status for diagnostics
+
+### Requirement: Main session owns durable memory persistence
+
+The main user-facing session SHALL be the default owner of durable memory writes. Subagents and other helper workflows SHALL return findings to the owning session, and the owning session SHALL decide whether those findings become checkpoints and durable writes.
+
+#### Scenario: Subagent findings flow through the parent session
+- **GIVEN** a subagent returns structured findings from research work
+- **WHEN** the parent session accepts those findings
+- **THEN** the parent session turns them into a checkpoint for durable memory review
+- **AND** the subagent does not write durable memory directly
+
+### Requirement: Memory evaluation and operational criteria
+
+The redesigned memory subsystem SHALL ship with an eval suite and operational SLOs covering recall quality, noise suppression, privacy behavior, and latency. The implementation SHALL NOT be considered complete until the seeded eval suite demonstrates the configured thresholds.
+
+#### Scenario: Seeded memory eval suite passes
+- **GIVEN** the seeded recall/privacy fixture suite is executed against the redesigned subsystem
+- **WHEN** the results are reported
+- **THEN** relevant recall coverage, noise suppression, privacy leakage, and latency metrics meet the thresholds defined by the change design
+- **AND** a failing metric blocks rollout from being treated as complete
+
+#### Scenario: Local Ollama eval profile is the primary gate
+- **GIVEN** the seeded memory eval suite supports multiple model profiles
+- **WHEN** Netclaw validates the redesigned memory subsystem before rollout
+- **THEN** it runs the default gate against smaller local Ollama-hosted models
+- **AND** passing larger hosted models does not waive a failing local Ollama eval result
+
+### Requirement: Legacy memory migration and compatibility stance
+
+The system SHALL provide a migration path from the legacy markdown memory directory and legacy provider-oriented configuration into the SQLite structured memory substrate. During the transition window, explicit memory tool names SHALL remain stable so existing prompts and skills continue to function.
+
+#### Scenario: Legacy markdown memories import into SQLite
+- **GIVEN** legacy markdown memories exist under `~/.netclaw/memories/`
+- **WHEN** the operator runs or accepts migration into the redesigned subsystem
+- **THEN** those memories are imported into anchors, documents, and records in SQLite
+- **AND** the original markdown files are preserved as source artifacts
+
+#### Scenario: Compatibility tool names remain stable
+- **GIVEN** an existing prompt or skill instructs the model to use `find_memories` and `store_memory`
+- **WHEN** the redesigned memory subsystem is active
+- **THEN** those tool names continue to function
+- **AND** they execute against the SQLite memory service and policy pipeline

--- a/openspec/changes/memory-policy-graph-redesign/specs/netclaw-session/spec.md
+++ b/openspec/changes/memory-policy-graph-redesign/specs/netclaw-session/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Conversation compaction
+
+The system SHALL compact long session history using a tiered approach informed by cross-SDK research. Before and after compaction boundaries, the session SHALL emit high-priority memory checkpoints into the durable memory queue instead of performing a synchronous one-off memory flush that depends on the turn path completing all curation work inline.
+
+#### Scenario: Compaction threshold reached
+- **GIVEN** `UsageDetails.InputTokenCount` exceeds `SessionConfig.CompactionTokenLimit`
+- **WHEN** compaction runs
+- **THEN** the actor enters `Compacting` behavior state
+- **AND** incoming messages are buffered during compaction
+
+#### Scenario: Compaction boundary emits memory checkpoint
+- **GIVEN** compaction is about to run or has just completed a summary reduction
+- **WHEN** the compaction boundary is reached
+- **THEN** the session enqueues a high-priority memory checkpoint for durable curation
+- **AND** the user-facing session does not wait for background curation to finish
+
+#### Scenario: Tiered compaction preserves tool/result integrity
+- **GIVEN** conversation history contains tool call/result pairs
+- **WHEN** compaction runs
+- **THEN** tool call/result pairs are never orphaned
+- **AND** older tool interactions remain representable for checkpoint extraction and summarization
+
+## ADDED Requirements
+
+### Requirement: Automatic pre-turn memory recall
+
+The session system SHALL run automatic durable-memory recall before each user-facing model turn. The recall pipeline SHALL use the incoming user message, recent turn state, active project/session context, and policy scope to assemble a bounded recall bundle. If recall exceeds its latency budget or the memory substrate is unhealthy, the turn SHALL continue in degraded mode without blocking on recall.
+
+#### Scenario: User-facing turn receives automatic recall bundle
+- **GIVEN** a session receives a new user message
+- **WHEN** the turn pipeline prepares the model request
+- **THEN** the session queries durable memory before the model call
+- **AND** injects a bounded recall bundle when eligible memories are found
+
+#### Scenario: Recall timeout degrades safely
+- **GIVEN** the memory recall pipeline exceeds its configured time budget
+- **WHEN** the session is preparing the next model call
+- **THEN** the session continues without the recall bundle
+- **AND** records degraded memory status for diagnostics and observability
+
+### Requirement: Durable memory checkpoint scheduling
+
+The session system SHALL emit durable memory checkpoints on eligible events including explicit memory requests, stable user facts, verified tool findings, compaction boundaries, and accepted subagent findings. Checkpoint enqueue SHALL be durable before the turn reports a successful explicit save, and pending checkpoints SHALL survive daemon restart.
+
+#### Scenario: Explicit remember request is durably queued
+- **GIVEN** the operator explicitly tells Netclaw to remember a fact
+- **WHEN** the session handles that request
+- **THEN** the session durably enqueues a high-priority checkpoint before reporting success
+- **AND** background curation may complete after the user-facing turn finishes
+
+#### Scenario: Pending checkpoints recover after restart
+- **GIVEN** one or more memory checkpoints were queued before daemon shutdown
+- **WHEN** the daemon restarts
+- **THEN** the memory worker reloads the pending checkpoints
+- **AND** resumes curation without losing the queued work

--- a/openspec/changes/memory-policy-graph-redesign/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/memory-policy-graph-redesign/specs/netclaw-subagents/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Subagent execution contract
+
+The system SHALL run subagents as ephemeral actors (`SubAgentActor`) that execute an autonomous LLM tool loop and return a single text result plus an optional structured findings envelope. A subagent SHALL stop itself after completing its task. Subagents SHALL NOT persist durable memory, stream direct durable-memory writes, or participate in session pub/sub by default.
+
+#### Scenario: Subagent completes with text response and findings
+- **GIVEN** a `SubAgentDefinition` with a name, system prompt, and tool list
+- **WHEN** the subagent receives a `RunSubAgent` message
+- **THEN** the subagent executes its LLM/tool loop and returns a `SubAgentResult`
+- **AND** the result MAY include structured findings for the parent session to review
+- **AND** the subagent stops itself
+
+#### Scenario: Default subagent cannot write durable memory directly
+- **GIVEN** a default subagent is executing within a user-facing session
+- **WHEN** it attempts to persist durable cross-session memory directly
+- **THEN** the durable write path is unavailable or denied to that subagent
+- **AND** the subagent must return findings to the parent session instead
+
+## ADDED Requirements
+
+### Requirement: Subagent findings handoff to owning session
+
+When a subagent discovers information that may deserve durable memory, it SHALL return that information as a structured findings envelope to the owning session. The owning session SHALL evaluate policy, convert accepted findings into checkpoints, and remain the default durable-memory owner.
+
+#### Scenario: Parent session accepts findings for checkpoint review
+- **GIVEN** a subagent returns findings that include stable project information
+- **WHEN** the parent session evaluates the subagent result
+- **THEN** the parent session converts the accepted findings into a durable memory checkpoint
+- **AND** background curation proceeds under the parent session's policy scope
+
+#### Scenario: Parent session rejects findings on policy grounds
+- **GIVEN** a subagent returns findings whose domain or sensitivity violates the parent session's durable-memory policy
+- **WHEN** the parent session evaluates the findings envelope
+- **THEN** the findings are dropped or kept transient only
+- **AND** no durable memory write occurs

--- a/openspec/changes/memory-policy-graph-redesign/tasks.md
+++ b/openspec/changes/memory-policy-graph-redesign/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Add the dedicated SQLite memory database, schema migrator, and health surface under `~/.netclaw/memory/`.
 - [ ] 1.2 Implement repositories for anchors, documents, records, edges, and pending checkpoints with policy metadata fields.
-- [ ] 1.3 Replace legacy primary-backend selection with the new substrate config plus migration warnings for old `Memory.Provider` values.
+- [ ] 1.3 Define the new SQLite-first memory configuration and explicitly leave legacy provider-mode compatibility/import out of MVP scope.
 
 ## 2. Automatic Recall In Session Turns
 
@@ -20,7 +20,7 @@
 
 - [ ] 4.1 Rewire `find_memories`, `get_memories`, `store_memory`, and `update_memory` to the SQLite memory service and policy pipeline.
 - [ ] 4.2 Implement document-vs-record update semantics in the explicit tool paths, including supersede and tombstone behavior.
-- [ ] 4.3 Preserve compatibility for existing prompts and skills while marking legacy file-backed and Memorizer-backed provider modes deprecated as primary backends.
+- [ ] 4.3 Preserve `find_memories`/`get_memories`/`store_memory`/`update_memory` as explicit manual-control paths while leaving legacy file-backed and Memorizer-backed provider modes out of MVP.
 
 ## 5. Subagent Ownership Changes
 
@@ -28,14 +28,13 @@
 - [ ] 5.2 Route accepted subagent findings through the owning session's checkpoint pipeline.
 - [ ] 5.3 Add audit and observability coverage for accepted, deferred, rejected, and retried subagent-originated memory candidates.
 
-## 6. Migration, Skills, And Evaluation
+## 6. Prompt Guidance, Skills, And Evaluation
 
-- [ ] 6.1 Add one-time import/migration from legacy `~/.netclaw/memories/` markdown memories into SQLite while preserving source files.
-- [ ] 6.2 Update system guidance artifacts that mention memory behavior, including `memory-usage` and `memorizer-usage`, to reflect the new ownership and compatibility stance.
-- [ ] 6.3 Create the seeded eval suite and operational checks for recall quality, noise suppression, privacy behavior, and latency thresholds from this change.
-- [ ] 6.4 Add a local Ollama eval profile using smaller models as the default gate for memory recall/curation quality before larger-model validation.
+- [ ] 6.1 Update system guidance artifacts that mention memory behavior, including `memory-usage` and `memorizer-usage`, to reflect automatic recall as primary and explicit tools as deliberate/manual control paths.
+- [ ] 6.2 Create the seeded eval suite and operational checks for recall quality, noise suppression, privacy behavior, and latency thresholds from this change.
+- [ ] 6.3 Add a local Ollama eval profile using smaller models as the default gate for memory recall/curation quality before larger-model validation.
 
 ## 7. Spec And Operator Surface Updates
 
 - [ ] 7.1 Sync the final `netclaw-agent-memory`, `netclaw-session`, and `netclaw-subagents` specs once implementation details settle.
-- [ ] 7.2 Update operator-facing docs, diagnostics, and migration messaging to explain SQLite memory health, pending checkpoints, and deprecated legacy provider modes.
+- [ ] 7.2 Update operator-facing docs and diagnostics to explain SQLite memory health, pending checkpoints, automatic recall behavior, and deliberate manual memory tool usage.

--- a/openspec/changes/memory-policy-graph-redesign/tasks.md
+++ b/openspec/changes/memory-policy-graph-redesign/tasks.md
@@ -1,0 +1,41 @@
+## 1. SQLite Substrate And Policy Model
+
+- [ ] 1.1 Add the dedicated SQLite memory database, schema migrator, and health surface under `~/.netclaw/memory/`.
+- [ ] 1.2 Implement repositories for anchors, documents, records, edges, and pending checkpoints with policy metadata fields.
+- [ ] 1.3 Replace legacy primary-backend selection with the new substrate config plus migration warnings for old `Memory.Provider` values.
+
+## 2. Automatic Recall In Session Turns
+
+- [ ] 2.1 Implement the pre-turn recall coordinator with bounded query/ranking logic and policy-aware filtering.
+- [ ] 2.2 Inject the automatic recall bundle into session turn assembly and degrade safely on timeout or storage failure.
+- [ ] 2.3 Update prompt/context guidance so the frontline model treats memory recall as automatic and explicit memory tools as manual-control paths.
+
+## 3. Checkpoint Detection And Background Curation
+
+- [ ] 3.1 Implement checkpoint detection for turn completion, explicit memory requests, tool findings, compaction boundaries, and accepted subagent findings.
+- [ ] 3.2 Implement rules-first candidate extraction, duplicate suppression, and policy gating before any curator LLM call.
+- [ ] 3.3 Implement the background curation worker with retryable checkpoint recovery and atomic durable writes.
+
+## 4. Explicit Memory Tools And Compatibility Layer
+
+- [ ] 4.1 Rewire `find_memories`, `get_memories`, `store_memory`, and `update_memory` to the SQLite memory service and policy pipeline.
+- [ ] 4.2 Implement document-vs-record update semantics in the explicit tool paths, including supersede and tombstone behavior.
+- [ ] 4.3 Preserve compatibility for existing prompts and skills while marking legacy file-backed and Memorizer-backed provider modes deprecated as primary backends.
+
+## 5. Subagent Ownership Changes
+
+- [ ] 5.1 Change the subagent result contract to return structured findings envelopes without default durable-memory write access.
+- [ ] 5.2 Route accepted subagent findings through the owning session's checkpoint pipeline.
+- [ ] 5.3 Add audit and observability coverage for accepted, deferred, rejected, and retried subagent-originated memory candidates.
+
+## 6. Migration, Skills, And Evaluation
+
+- [ ] 6.1 Add one-time import/migration from legacy `~/.netclaw/memories/` markdown memories into SQLite while preserving source files.
+- [ ] 6.2 Update system guidance artifacts that mention memory behavior, including `memory-usage` and `memorizer-usage`, to reflect the new ownership and compatibility stance.
+- [ ] 6.3 Create the seeded eval suite and operational checks for recall quality, noise suppression, privacy behavior, and latency thresholds from this change.
+- [ ] 6.4 Add a local Ollama eval profile using smaller models as the default gate for memory recall/curation quality before larger-model validation.
+
+## 7. Spec And Operator Surface Updates
+
+- [ ] 7.1 Sync the final `netclaw-agent-memory`, `netclaw-session`, and `netclaw-subagents` specs once implementation details settle.
+- [ ] 7.2 Update operator-facing docs, diagnostics, and migration messaging to explain SQLite memory health, pending checkpoints, and deprecated legacy provider modes.


### PR DESCRIPTION
## Summary
- replace the backend-centric memory design with a first-party SQLite structured memory architecture centered on anchors, documents, records, and policy-aware recall
- define automatic pre-turn recall, checkpoint-driven background curation, rules-first candidate filtering, and parent-session ownership of durable memory writes
- add migration, compatibility, success criteria, and local Ollama-based eval gates for validating the redesign before rollout