### PR TITLE
Fix reminder Slack notification delivery and failure signaling

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -129,6 +129,42 @@ public sealed class SendSlackMessageToolTests
     }
 
     [Fact]
+    public async Task Accepts_lowercase_message_and_snake_case_channel_id()
+    {
+        var fake = new FakeSlackOutboundClient();
+        var gateway = new FakeGatewayActor();
+        var tool = CreateTool(outbound: fake, gatewayAccessor: () => gateway);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["message"] = "hello from lowercase",
+            ["channel_id"] = "C1"
+        }, CancellationToken.None);
+
+        Assert.Contains("Message sent to channel C1", result);
+        Assert.Single(fake.PostedThreads);
+        Assert.Equal("hello from lowercase", fake.PostedThreads[0].Text);
+    }
+
+    [Fact]
+    public async Task Accepts_text_alias_for_message_parameter()
+    {
+        var fake = new FakeSlackOutboundClient();
+        var gateway = new FakeGatewayActor();
+        var tool = CreateTool(outbound: fake, gatewayAccessor: () => gateway);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["text"] = "hello from text alias",
+            ["ChannelId"] = "C1"
+        }, CancellationToken.None);
+
+        Assert.Contains("Message sent to channel C1", result);
+        Assert.Single(fake.PostedThreads);
+        Assert.Equal("hello from text alias", fake.PostedThreads[0].Text);
+    }
+
+    [Fact]
     public async Task Successful_DM()
     {
         var fake = new FakeSlackOutboundClient();

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -1,4 +1,6 @@
 using Akka.Actor;
+using Akka;
+using Akka.Streams.Dsl;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Streams;
@@ -64,6 +66,62 @@ public class ReminderExecutionActorTests : TestKit
         Assert.Equal("pipeline initialization failed", completed.ErrorMessage);
     }
 
+    [Fact]
+    public async Task Execution_fails_when_notification_tool_returns_error()
+    {
+        var pipeline = new ScriptedSessionPipeline(sessionId =>
+        [
+            new ToolResultOutput
+            {
+                SessionId = sessionId,
+                CallId = "call-1",
+                ToolName = "send_slack_message",
+                Result = "Error parsing arguments for tool 'send_slack_message': Required parameter 'Message' is missing or empty."
+            },
+            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+        ]);
+
+        var definition = CreateDefinition("notify-fail-test");
+        var probe = CreateTestProbe();
+        Sys.ActorOf(
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline)),
+            "exec-parent-3");
+
+        var completed = await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5));
+
+        Assert.False(completed.Success);
+        Assert.Equal("notify-fail-test", completed.Id.Value);
+        Assert.Contains("Required parameter 'Message'", completed.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Execution_succeeds_when_notification_tool_reports_success()
+    {
+        var pipeline = new ScriptedSessionPipeline(sessionId =>
+        [
+            new ToolResultOutput
+            {
+                SessionId = sessionId,
+                CallId = "call-2",
+                ToolName = "send_slack_message",
+                Result = "Message sent to channel C1. Thread: C1/1234567890.000001"
+            },
+            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+        ]);
+
+        var definition = CreateDefinition("notify-success-test");
+        var probe = CreateTestProbe();
+        Sys.ActorOf(
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline)),
+            "exec-parent-4");
+
+        var completed = await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5));
+
+        Assert.True(completed.Success);
+        Assert.Equal("notify-success-test", completed.Id.Value);
+        Assert.Null(completed.ErrorMessage);
+    }
+
     private static ReminderDefinition CreateDefinition(string id)
     {
         var now = TimeProvider.System.GetUtcNow();
@@ -116,5 +174,26 @@ public class ReminderExecutionActorTests : TestKit
             IMaterializer? materializer = null,
             CancellationToken cancellationToken = default) =>
             throw exception;
+    }
+
+    private sealed class ScriptedSessionPipeline(
+        Func<SessionId, IReadOnlyList<SessionOutput>> outputFactory) : ISessionPipeline
+    {
+        public Task<MaterializedSession> CreateAsync(
+            SessionId sessionId,
+            SessionPipelineOptions options,
+            IMaterializer? materializer = null,
+            CancellationToken cancellationToken = default)
+        {
+            var killSwitch = KillSwitches.Shared($"scripted-{sessionId.Value}");
+
+            var input = Sink.Ignore<ChannelInput>()
+                .MapMaterializedValue<NotUsed>(_ => NotUsed.Instance);
+
+            var output = Source.From(outputFactory(sessionId).ToList())
+                .Via(killSwitch.Flow<SessionOutput>());
+
+            return Task.FromResult(new MaterializedSession(input, output, killSwitch));
+        }
     }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -27,6 +27,9 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private readonly StringBuilder _buffer = new();
     private bool _sawTextDelta;
     private bool _completed;
+    private bool _notifyAttempted;
+    private bool _notifyFailed;
+    private string? _notifyFailureDetail;
 
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
@@ -147,15 +150,21 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                     _buffer.Append(text.Text);
                 break;
 
+            case ToolResultOutput toolResult:
+                TrackNotificationResult(toolResult);
+                break;
+
             case TurnCompleted:
                 var result = _buffer.ToString().Trim();
+                var notifyFailureMessage = BuildNotifyFailureMessage();
+                var success = notifyFailureMessage is null;
                 _log.Info(
-                    $"ReminderExecution Completed: execution_id={_executionId} reminder_id={_definition.Id} title={_definition.Title} success=true output_length={result.Length} dispatched_at={_dispatchedAt} completed_at={_timeProvider.GetUtcNow()}");
+                    $"ReminderExecution Completed: execution_id={_executionId} reminder_id={_definition.Id} title={_definition.Title} success={success} output_length={result.Length} notify_attempted={_notifyAttempted} notify_failed={_notifyFailed} dispatched_at={_dispatchedAt} completed_at={_timeProvider.GetUtcNow()}");
 
                 if (string.IsNullOrWhiteSpace(result))
                     result = $"(Reminder '{_definition.Title}' executed but produced no output)";
 
-                ReportAndStop(true);
+                ReportAndStop(success, notifyFailureMessage);
                 break;
 
             case ErrorOutput err:
@@ -189,6 +198,52 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             success,
             errorMessage));
         Context.Stop(Self);
+    }
+
+    private void TrackNotificationResult(ToolResultOutput toolResult)
+    {
+        if (!string.Equals(toolResult.ToolName, "send_slack_message", StringComparison.Ordinal))
+            return;
+
+        _notifyAttempted = true;
+
+        var result = toolResult.Result?.Trim() ?? string.Empty;
+        if (result.StartsWith("Error", StringComparison.OrdinalIgnoreCase))
+        {
+            _notifyFailed = true;
+            _notifyFailureDetail = result;
+            _log.Warning(
+                "ReminderExecution NotifyFailed: execution_id={0} reminder_id={1} tool={2} call_id={3} detail={4}",
+                _executionId,
+                _definition.Id,
+                toolResult.ToolName,
+                toolResult.CallId,
+                result);
+            return;
+        }
+
+        _notifyFailed = false;
+        _notifyFailureDetail = null;
+        _log.Info(
+            "ReminderExecution NotifySucceeded: execution_id={0} reminder_id={1} tool={2} call_id={3}",
+            _executionId,
+            _definition.Id,
+            toolResult.ToolName,
+            toolResult.CallId);
+    }
+
+    private string? BuildNotifyFailureMessage()
+    {
+        if (string.IsNullOrWhiteSpace(_definition.NotifyInstructions))
+            return null;
+
+        if (!_notifyAttempted)
+            return "Notification instructions were provided but no notification tool was invoked.";
+
+        if (_notifyFailed)
+            return _notifyFailureDetail ?? "Notification tool returned an unspecified error.";
+
+        return null;
     }
 
     protected override void PostStop()

--- a/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
@@ -9,9 +9,70 @@ namespace Netclaw.Tools;
 /// </summary>
 public static class ToolArgumentHelper
 {
+    private static bool TryGetValueFlexible(IDictionary<string, object?> arguments, string key, out object? value)
+    {
+        if (arguments.TryGetValue(key, out value))
+            return true;
+
+        // Case-insensitive exact-name fallback
+        foreach (var kvp in arguments)
+        {
+            if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = kvp.Value;
+                return true;
+            }
+        }
+
+        // Normalized-name fallback: treat ChannelId == channel_id == channel-id
+        var normalizedKey = NormalizeKey(key);
+        foreach (var kvp in arguments)
+        {
+            if (string.Equals(NormalizeKey(kvp.Key), normalizedKey, StringComparison.OrdinalIgnoreCase))
+            {
+                value = kvp.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static string NormalizeKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return string.Empty;
+
+        var buffer = new char[key.Length];
+        var count = 0;
+
+        foreach (var ch in key)
+        {
+            if (char.IsLetterOrDigit(ch))
+                buffer[count++] = ch;
+        }
+
+        return count == 0 ? string.Empty : new string(buffer, 0, count);
+    }
+
     public static string? GetString(IDictionary<string, object?> arguments, string key)
     {
-        if (!arguments.TryGetValue(key, out var value) || value is null)
+        if (string.Equals(key, "Message", StringComparison.OrdinalIgnoreCase)
+            && !TryGetValueFlexible(arguments, key, out _)
+            && TryGetValueFlexible(arguments, "text", out var textAlias)
+            && textAlias is not null)
+        {
+            return textAlias switch
+            {
+                string s => s,
+                JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+                JsonElement je => je.ToString(),
+                _ => textAlias.ToString()
+            };
+        }
+
+        if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
 
         return value switch
@@ -25,7 +86,7 @@ public static class ToolArgumentHelper
 
     public static int? GetNullableInt(IDictionary<string, object?> arguments, string key)
     {
-        if (!arguments.TryGetValue(key, out var value) || value is null)
+        if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
 
         return value switch
@@ -42,7 +103,7 @@ public static class ToolArgumentHelper
 
     public static double? GetNullableDouble(IDictionary<string, object?> arguments, string key)
     {
-        if (!arguments.TryGetValue(key, out var value) || value is null)
+        if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
 
         return value switch
@@ -60,7 +121,7 @@ public static class ToolArgumentHelper
 
     public static bool? GetNullableBool(IDictionary<string, object?> arguments, string key)
     {
-        if (!arguments.TryGetValue(key, out var value) || value is null)
+        if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
 
         return value switch


### PR DESCRIPTION
## Summary
- make tool argument parsing resilient for common LLM key variants (`Message/message`, `ChannelId/channel_id`) and support `text` as a `Message` alias for `send_slack_message`
- treat reminder notification delivery as part of reminder execution success by tracking `send_slack_message` tool results and surfacing notify failures as execution failures
- add deterministic reminder/slack tests that reproduce and prevent the notification mismatch regression without relying on a real LLM

## Validation
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~SendSlackMessageToolTests|FullyQualifiedName~ReminderExecutionActorTests"
- dotnet slopwatch analyze