### PR TITLE
Improve reminder Slack target UX and default reminder command behavior

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackTargetResolverTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackTargetResolverTests.cs
@@ -1,0 +1,149 @@
+using Netclaw.Channels.Slack;
+using SlackNet;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackTargetResolverTests
+{
+    [Fact]
+    public async Task Resolve_channel_name_with_hash_returns_channel_id()
+    {
+        var lookup = new FakeSlackTargetLookupClient
+        {
+            ChannelPages =
+            [
+                new SlackChannelPage(
+                [
+                    new Conversation { Id = "C1", Name = "openclaw", NameNormalized = "openclaw" }
+                ],
+                null)
+            ]
+        };
+
+        var resolver = new SlackTargetResolver(lookup);
+        var result = await resolver.ResolveAsync("#openclaw");
+
+        Assert.True(result.Success);
+        Assert.Equal("C1", result.ChannelId);
+        Assert.Null(result.UserId);
+    }
+
+    [Fact]
+    public async Task Resolve_user_mention_returns_user_id()
+    {
+        var lookup = new FakeSlackTargetLookupClient
+        {
+            UserPages =
+            [
+                new SlackUserPage(
+                [
+                    new User
+                    {
+                        Id = "U42",
+                        Name = "aaron",
+                        RealName = "Aaron Stannard",
+                        Profile = new UserProfile
+                        {
+                            DisplayName = "aaron",
+                            Email = "aaron@petabridge.com"
+                        }
+                    }
+                ],
+                null)
+            ]
+        };
+
+        var resolver = new SlackTargetResolver(lookup);
+        var result = await resolver.ResolveAsync("@aaron");
+
+        Assert.True(result.Success);
+        Assert.Equal("U42", result.UserId);
+        Assert.Null(result.ChannelId);
+    }
+
+    [Fact]
+    public async Task Resolve_ambiguous_user_query_fails()
+    {
+        var lookup = new FakeSlackTargetLookupClient
+        {
+            UserPages =
+            [
+                new SlackUserPage(
+                [
+                    new User { Id = "U1", Name = "aaron" },
+                    new User { Id = "U2", Name = "aaron" }
+                ],
+                null)
+            ]
+        };
+
+        var resolver = new SlackTargetResolver(lookup);
+        var result = await resolver.ResolveAsync("aaron");
+
+        Assert.False(result.Success);
+        Assert.Contains("Could not resolve", result.ErrorMessage);
+        Assert.Null(result.ChannelId);
+        Assert.Null(result.UserId);
+    }
+
+    [Fact]
+    public async Task Resolve_channel_name_without_hash_falls_back_to_channel_lookup()
+    {
+        var lookup = new FakeSlackTargetLookupClient
+        {
+            ChannelPages =
+            [
+                new SlackChannelPage(
+                [
+                    new Conversation { Id = "C777", Name = "openclaw" }
+                ],
+                null)
+            ]
+        };
+
+        var resolver = new SlackTargetResolver(lookup);
+        var result = await resolver.ResolveAsync("openclaw");
+
+        Assert.True(result.Success);
+        Assert.Equal("C777", result.ChannelId);
+    }
+
+    private sealed class FakeSlackTargetLookupClient : ISlackTargetLookupClient
+    {
+        public IReadOnlyList<SlackChannelPage> ChannelPages { get; init; } = [];
+        public IReadOnlyList<SlackUserPage> UserPages { get; init; } = [];
+
+        public Task<SlackChannelPage> ListChannelsAsync(string? cursor, CancellationToken ct = default)
+        {
+            if (ChannelPages.Count == 0)
+                return Task.FromResult(new SlackChannelPage([], null));
+
+            if (!int.TryParse(cursor, out var index))
+                index = 0;
+
+            if (index >= ChannelPages.Count)
+                return Task.FromResult(new SlackChannelPage([], null));
+
+            var next = index + 1 < ChannelPages.Count ? (index + 1).ToString() : null;
+            var page = ChannelPages[index] with { NextCursor = next };
+            return Task.FromResult(page);
+        }
+
+        public Task<SlackUserPage> ListUsersAsync(string? cursor, CancellationToken ct = default)
+        {
+            if (UserPages.Count == 0)
+                return Task.FromResult(new SlackUserPage([], null));
+
+            if (!int.TryParse(cursor, out var index))
+                index = 0;
+
+            if (index >= UserPages.Count)
+                return Task.FromResult(new SlackUserPage([], null));
+
+            var next = index + 1 < UserPages.Count ? (index + 1).ToString() : null;
+            var page = UserPages[index] with { NextCursor = next };
+            return Task.FromResult(page);
+        }
+    }
+}

--- a/src/Netclaw.Channels/Slack/SlackTargetResolver.cs
+++ b/src/Netclaw.Channels/Slack/SlackTargetResolver.cs
@@ -1,0 +1,158 @@
+using SlackNet;
+using SlackNet.WebApi;
+
+namespace Netclaw.Channels.Slack;
+
+public sealed record SlackTargetResolutionResult(
+    bool Success,
+    string? ErrorMessage,
+    string? ChannelId,
+    string? UserId);
+
+/// <summary>
+/// Resolves human-friendly Slack targets (e.g. #channel, @user, email) into canonical IDs.
+/// </summary>
+public interface ISlackTargetResolver
+{
+    Task<SlackTargetResolutionResult> ResolveAsync(string target, CancellationToken ct = default);
+}
+
+public sealed record SlackChannelPage(IReadOnlyList<Conversation> Channels, string? NextCursor);
+
+public sealed record SlackUserPage(IReadOnlyList<User> Users, string? NextCursor);
+
+public interface ISlackTargetLookupClient
+{
+    Task<SlackChannelPage> ListChannelsAsync(string? cursor, CancellationToken ct = default);
+    Task<SlackUserPage> ListUsersAsync(string? cursor, CancellationToken ct = default);
+}
+
+public sealed class SlackApiTargetLookupClient(ISlackApiClient slackApi) : ISlackTargetLookupClient
+{
+    public async Task<SlackChannelPage> ListChannelsAsync(string? cursor, CancellationToken ct = default)
+    {
+        var page = await slackApi.Conversations.List(
+            types: [ConversationType.PublicChannel, ConversationType.PrivateChannel],
+            cursor: cursor,
+            cancellationToken: ct);
+
+        return new SlackChannelPage(page.Channels.ToList(), page.ResponseMetadata?.NextCursor);
+    }
+
+    public async Task<SlackUserPage> ListUsersAsync(string? cursor, CancellationToken ct = default)
+    {
+        var page = await slackApi.Users.List(cursor: cursor, cancellationToken: ct);
+        return new SlackUserPage(page.Members.ToList(), page.ResponseMetadata?.NextCursor);
+    }
+}
+
+public sealed class SlackTargetResolver(ISlackTargetLookupClient lookupClient) : ISlackTargetResolver
+{
+    public async Task<SlackTargetResolutionResult> ResolveAsync(string target, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return new SlackTargetResolutionResult(false, "Target is required.", null, null);
+
+        var raw = target.Trim();
+
+        if (raw.StartsWith("C", StringComparison.Ordinal) || raw.StartsWith("G", StringComparison.Ordinal))
+            return new SlackTargetResolutionResult(true, null, raw, null);
+
+        if (raw.StartsWith("U", StringComparison.Ordinal))
+            return new SlackTargetResolutionResult(true, null, null, raw);
+
+        if (raw.StartsWith("#", StringComparison.Ordinal))
+        {
+            var channelName = raw[1..].Trim();
+            if (string.IsNullOrWhiteSpace(channelName))
+                return new SlackTargetResolutionResult(false, "Channel name is empty.", null, null);
+
+            var channelId = await ResolveChannelByNameAsync(channelName, ct);
+            return channelId is not null
+                ? new SlackTargetResolutionResult(true, null, channelId, null)
+                : new SlackTargetResolutionResult(false, $"Could not resolve Slack channel '{raw}'.", null, null);
+        }
+
+        if (raw.StartsWith("@", StringComparison.Ordinal))
+        {
+            var userQuery = raw[1..].Trim();
+            if (string.IsNullOrWhiteSpace(userQuery))
+                return new SlackTargetResolutionResult(false, "User name is empty.", null, null);
+
+            var userId = await ResolveUserAsync(userQuery, ct);
+            return userId is not null
+                ? new SlackTargetResolutionResult(true, null, null, userId)
+                : new SlackTargetResolutionResult(false, $"Could not resolve Slack user '{raw}'.", null, null);
+        }
+
+        var fallbackChannelId = await ResolveChannelByNameAsync(raw, ct);
+        if (fallbackChannelId is not null)
+            return new SlackTargetResolutionResult(true, null, fallbackChannelId, null);
+
+        var fallbackUserId = await ResolveUserAsync(raw, ct);
+        if (fallbackUserId is not null)
+            return new SlackTargetResolutionResult(true, null, null, fallbackUserId);
+
+        return new SlackTargetResolutionResult(
+            false,
+            $"Could not resolve Slack target '{target}'. Use #channel, @user, or a Slack ID (C..., G..., U...).",
+            null,
+            null);
+    }
+
+    private async Task<string?> ResolveChannelByNameAsync(string channelName, CancellationToken ct)
+    {
+        var cursor = default(string);
+        do
+        {
+            var page = await lookupClient.ListChannelsAsync(cursor, ct);
+
+            var match = page.Channels.FirstOrDefault(c =>
+                string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(c.NameNormalized, channelName, StringComparison.OrdinalIgnoreCase));
+
+            if (match is not null)
+                return match.Id;
+
+            cursor = page.NextCursor;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        return null;
+    }
+
+    private async Task<string?> ResolveUserAsync(string query, CancellationToken ct)
+    {
+        var cursor = default(string);
+        var exactMatches = new List<User>();
+
+        do
+        {
+            var response = await lookupClient.ListUsersAsync(cursor, ct);
+            foreach (var user in response.Users)
+            {
+                if (user.IsBot || user.Deleted)
+                    continue;
+
+                var displayName = user.Profile?.DisplayName ?? string.Empty;
+                var realName = user.RealName ?? string.Empty;
+                var username = user.Name ?? string.Empty;
+                var email = user.Profile?.Email ?? string.Empty;
+
+                if (string.Equals(email, query, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(displayName, query, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(realName, query, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(username, query, StringComparison.OrdinalIgnoreCase))
+                {
+                    exactMatches.Add(user);
+                }
+            }
+
+            cursor = response.NextCursor;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        if (exactMatches.Count == 1)
+            return exactMatches[0].Id;
+
+        return null;
+    }
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -411,7 +411,7 @@ static async Task RunAsync(string[] args)
     // ── Reminder management ──
     if (mode is "reminder")
     {
-        if (args.Length == 1)
+        if (args.Length > 1 && args[1] is "ui" or "tui")
         {
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -19,6 +19,12 @@ internal static class ReminderCommand
 
     public static async Task<int> RunAsync(string[] args)
     {
+        if (args.Length == 1)
+        {
+            WriteHelp();
+            return 0;
+        }
+
         var subcommand = args.Length > 1 ? args[1] : "help";
         if (subcommand is "help" or "-h" or "--help")
         {
@@ -79,10 +85,10 @@ internal static class ReminderCommand
 
     private static async Task<int> RunCreateAsync(HttpClient client, string baseUrl, string[] args)
     {
-        // netclaw reminder create <name> <scheduleType> <schedule> "<prompt>" [--channel <id>]
+        // netclaw reminder create <name> <scheduleType> <schedule> "<prompt>" [--target <#channel|@user|id>] [--channel <id>]
         if (args.Length < 6)
         {
-            Console.Error.WriteLine("Usage: netclaw reminder create <name> <scheduleType> <schedule> \"<prompt>\" [--channel <id>]");
+            Console.Error.WriteLine("Usage: netclaw reminder create <name> <scheduleType> <schedule> \"<prompt>\" [--target <#channel|@user|id>] [--channel <id>]");
             Console.Error.WriteLine();
             Console.Error.WriteLine("  scheduleType: once, interval, cron");
             Console.Error.WriteLine("  schedule:     '30m', '2h', '0 */6 * * *', etc.");
@@ -94,6 +100,7 @@ internal static class ReminderCommand
         var schedule = args[4];
         var prompt = args[5];
         string? channel = null;
+        string? reportTarget = null;
 
         for (var i = 6; i < args.Length; i++)
         {
@@ -101,7 +108,13 @@ internal static class ReminderCommand
             {
                 channel = args[++i];
             }
+            else if (args[i] is "--target" && i + 1 < args.Length)
+            {
+                reportTarget = args[++i];
+            }
         }
+
+        reportTarget ??= channel;
 
         var body = new
         {
@@ -109,7 +122,8 @@ internal static class ReminderCommand
             prompt,
             scheduleType,
             schedule,
-            reportToChannel = channel
+            reportToChannel = channel,
+            reportTarget
         };
 
         try
@@ -427,6 +441,10 @@ internal static class ReminderCommand
         Console.WriteLine("  import <file> [--replace|--upsert]            Import one reminder file");
         Console.WriteLine("  validate <file>                               Validate reminder file");
         Console.WriteLine("  show <id>                                     Show reminder details");
+        Console.WriteLine();
+        Console.WriteLine("Create options:");
+        Console.WriteLine("  --target  <#channel|@user|C...|U...>          Human-friendly or canonical Slack target");
+        Console.WriteLine("  --channel <id>                                 Back-compat alias (channel id or name)");
         Console.WriteLine();
         Console.WriteLine("Schedule types: once, interval, cron");
         Console.WriteLine("Schedule examples: '30m', '2h', '1d', '0 */6 * * *'");

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -28,6 +28,8 @@ public static class SlackChannelRegistrationExtensions
         services.AddHttpClient("slack-files");
         services.AddSingleton<ISlackReplyClient, SlackReplyClient>();
         services.AddSingleton<ISlackOutboundClient, SlackOutboundClient>();
+        services.AddSingleton<ISlackTargetLookupClient, SlackApiTargetLookupClient>();
+        services.AddSingleton<ISlackTargetResolver, SlackTargetResolver>();
         services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
         services.AddSingleton<IChannel>(sp =>
             sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -639,11 +639,39 @@ static void MapReminderEndpoints(WebApplication app)
     app.MapPost("/api/reminders", async (
         CreateReminderRequest request,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        IServiceProvider serviceProvider,
         TimeProvider timeProvider,
         ReminderConfig reminderConfig,
         CancellationToken ct) =>
     {
         var manager = await actor.GetAsync(ct);
+
+        string? reportToChannel = request.ReportToChannel;
+        string? notifyInstructions = request.NotifyInstructions;
+
+        if (!string.IsNullOrWhiteSpace(request.ReportTarget))
+        {
+            var resolver = serviceProvider.GetService<Netclaw.Channels.Slack.ISlackTargetResolver>();
+            if (resolver is null)
+                return Results.BadRequest(new { error = "Slack is not enabled; cannot resolve report target." });
+
+            var resolved = await resolver.ResolveAsync(request.ReportTarget, ct);
+            if (!resolved.Success)
+                return Results.BadRequest(new { error = resolved.ErrorMessage ?? "Failed to resolve report target." });
+
+            if (!string.IsNullOrWhiteSpace(resolved.UserId))
+            {
+                var targetUserId = resolved.UserId;
+                reportToChannel = null;
+                notifyInstructions = $"Send a direct message to Slack user {targetUserId} with your findings, or lack thereof.";
+            }
+            else
+            {
+                reportToChannel = resolved.ChannelId;
+                if (string.IsNullOrWhiteSpace(notifyInstructions))
+                    notifyInstructions = $"Post the result to Slack channel {reportToChannel}.";
+            }
+        }
 
         var tool = new Netclaw.Actors.Reminders.SetReminderTool(manager, timeProvider, reminderConfig);
         var result = await tool.ExecuteAsync(
@@ -653,8 +681,8 @@ static void MapReminderEndpoints(WebApplication app)
                 ["Prompt"] = request.Prompt,
                 ["ScheduleType"] = request.ScheduleType,
                 ["Schedule"] = request.Schedule,
-                ["ReportToChannel"] = request.ReportToChannel,
-                ["NotifyInstructions"] = request.NotifyInstructions
+                ["ReportToChannel"] = reportToChannel,
+                ["NotifyInstructions"] = notifyInstructions
             }, ct);
 
         return result.StartsWith("Error", StringComparison.Ordinal)
@@ -815,6 +843,7 @@ sealed record CreateReminderRequest
     public required string ScheduleType { get; init; }
     public required string Schedule { get; init; }
     public string? ReportToChannel { get; init; }
+    public string? ReportTarget { get; init; }
     public string? NotifyInstructions { get; init; }
 }
 


### PR DESCRIPTION
## Summary
- make `netclaw reminder` show help by default and require explicit `reminder ui`/`reminder tui` for interactive mode
- add `--target` support on reminder create so operators can use `#channel`, `@user`, or canonical Slack IDs
- resolve human-friendly Slack targets to canonical IDs in the daemon reminder API and add resolver tests for channel, user, and ambiguous resolution behavior

## Validation
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~SlackTargetResolverTests"
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter "FullyQualifiedName~SendSlackMessageToolTests|FullyQualifiedName~ReminderExecutionActorTests|FullyQualifiedName~SlackTargetResolverTests"
- dotnet build src/Netclaw.Cli/Netclaw.Cli.csproj
- dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj
- dotnet slopwatch analyze