### PR TITLE
Prepare release 0.3.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,12 +8,17 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.5</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.3.5 — Reminder Slack notification reliability
+    <PackageReleaseNotes>Netclaw v0.3.5 — Reminder Slack notification reliability and target UX
 
 **Reminder Notification Delivery**
 
 * Treat reminder notification delivery as part of execution success: `send_slack_message` tool results are now tracked during reminder execution and delivery failures are surfaced as execution failures rather than silently ignored. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
-* Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))</PackageReleaseNotes>
+* Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
+
+**Reminder Target UX**
+
+* Added `--target` support to `reminder create` so operators can specify destinations using human-friendly Slack identifiers (`#channel`, `@user`) or canonical Slack IDs; the daemon resolves these to canonical IDs at schedule time. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))
+* `netclaw reminder` now shows help by default — interactive TUI requires explicit `reminder ui` or `reminder tui` invocation. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,16 @@
 #### 0.3.5 2026-03-07 ####
 
-Netclaw v0.3.5 — Reminder Slack notification reliability
+Netclaw v0.3.5 — Reminder Slack notification reliability and target UX
 
 **Reminder Notification Delivery**
 
 * Treat reminder notification delivery as part of execution success: `send_slack_message` tool results are now tracked during reminder execution and delivery failures are surfaced as execution failures rather than silently ignored. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
 * Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
+
+**Reminder Target UX**
+
+* Added `--target` support to `reminder create` so operators can specify destinations using human-friendly Slack identifiers (`#channel`, `@user`) or canonical Slack IDs; the daemon resolves these to canonical IDs at schedule time. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))
+* `netclaw reminder` now shows help by default — interactive TUI requires explicit `reminder ui` or `reminder tui` invocation. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))
 
 #### 0.3.4 2026-03-07 ####
 


### PR DESCRIPTION
## Summary
- Add PR #182 (reminder Slack target UX improvements) to 0.3.5 release notes in `RELEASE_NOTES.md` and `Directory.Build.props`
- 0.3.5 now documents both Slack-focused changes: reminder notification delivery reliability (#181) and reminder target UX (#182)

## Test plan
- [ ] No code changes — release notes only