### PR TITLE
Prepare release 0.3.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,13 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.5</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.3.5 — Reminder Slack notification reliability and target UX
-
-**Reminder Notification Delivery**
-
-* Treat reminder notification delivery as part of execution success: `send_slack_message` tool results are now tracked during reminder execution and delivery failures are surfaced as execution failures rather than silently ignored. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
-* Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
+    <VersionPrefix>0.3.6</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.3.6 — Reminder Slack target UX
 
 **Reminder Target UX**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,20 @@
-#### 0.3.5 2026-03-07 ####
+#### 0.3.6 2026-03-07 ####
 
-Netclaw v0.3.5 — Reminder Slack notification reliability and target UX
-
-**Reminder Notification Delivery**
-
-* Treat reminder notification delivery as part of execution success: `send_slack_message` tool results are now tracked during reminder execution and delivery failures are surfaced as execution failures rather than silently ignored. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
-* Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
+Netclaw v0.3.6 — Reminder Slack target UX
 
 **Reminder Target UX**
 
 * Added `--target` support to `reminder create` so operators can specify destinations using human-friendly Slack identifiers (`#channel`, `@user`) or canonical Slack IDs; the daemon resolves these to canonical IDs at schedule time. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))
 * `netclaw reminder` now shows help by default — interactive TUI requires explicit `reminder ui` or `reminder tui` invocation. ([#182](https://github.com/Aaronontheweb/netclaw/pull/182))
+
+#### 0.3.5 2026-03-07 ####
+
+Netclaw v0.3.5 — Reminder Slack notification reliability
+
+**Reminder Notification Delivery**
+
+* Treat reminder notification delivery as part of execution success: `send_slack_message` tool results are now tracked during reminder execution and delivery failures are surfaced as execution failures rather than silently ignored. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
+* Made tool argument parsing resilient to common LLM key variants (`Message`/`message`, `ChannelId`/`channel_id`) and added `text` as a `Message` alias for `send_slack_message` to prevent delivery failures caused by argument name mismatches. ([#181](https://github.com/Aaronontheweb/netclaw/pull/181))
 
 #### 0.3.4 2026-03-07 ####
 


### PR DESCRIPTION
## Summary
- Bump `VersionPrefix` to `0.3.6`
- Add 0.3.6 release notes documenting reminder Slack target UX improvements from #182
- Restore 0.3.5 release notes to what actually shipped (only #181)

## Test plan
- [ ] No code changes — version bump and release notes only