### PR TITLE
fix(worker): prevent TaskCanceledException during clean daemon shutdown

### DIFF
--- a/src/Netclaw.Daemon/Services/MemoryCurationWorkerService.cs
+++ b/src/Netclaw.Daemon/Services/MemoryCurationWorkerService.cs
@@ -32,47 +32,58 @@ internal sealed class MemoryCurationWorkerService(
 
     private async Task RunAsync(CancellationToken ct)
     {
-        await store.ResetProcessingCheckpointsAsync(ct);
-
-        while (!ct.IsCancellationRequested)
+        try
         {
-            var leased = await store.LeaseNextPendingCheckpointAsync(ct);
-            if (leased is null)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(250), ct);
-                continue;
-            }
+            await store.ResetProcessingCheckpointsAsync(ct);
 
-            try
+            while (!ct.IsCancellationRequested)
             {
-                var started = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
-                var operations = await engine.CurateAsync(leased, ct);
-                await store.ApplyCurationBatchAsync(leased.CheckpointId, operations, ct);
-
-                var ended = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
-                logger.LogInformation(
-                    "Memory checkpoint curation completed for {CheckpointId} (trigger={TriggerType}, operations={OperationCount}, durationMs={DurationMs})",
-                    leased.CheckpointId,
-                    leased.TriggerType,
-                    operations.Count,
-                    ended - started);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex,
-                    "Memory checkpoint curation failed for {CheckpointId} (trigger={TriggerType}); scheduling retry",
-                    leased.CheckpointId,
-                    leased.TriggerType);
-
-                if (string.Equals(leased.TriggerType, "subagent-findings", StringComparison.OrdinalIgnoreCase))
+                var leased = await store.LeaseNextPendingCheckpointAsync(ct);
+                if (leased is null)
                 {
-                    logger.LogWarning(
-                        "Subagent-originated memory candidate retry scheduled for checkpoint {CheckpointId}",
-                        leased.CheckpointId);
+                    await Task.Delay(TimeSpan.FromMilliseconds(250), ct);
+                    continue;
                 }
 
-                await store.MarkCheckpointRetryAsync(leased.CheckpointId, maxRetries: 5, ct);
+                try
+                {
+                    var started = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+                    var operations = await engine.CurateAsync(leased, ct);
+                    await store.ApplyCurationBatchAsync(leased.CheckpointId, operations, ct);
+
+                    var ended = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+                    logger.LogInformation(
+                        "Memory checkpoint curation completed for {CheckpointId} (trigger={TriggerType}, operations={OperationCount}, durationMs={DurationMs})",
+                        leased.CheckpointId,
+                        leased.TriggerType,
+                        operations.Count,
+                        ended - started);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Memory checkpoint curation failed for {CheckpointId} (trigger={TriggerType}); scheduling retry",
+                        leased.CheckpointId,
+                        leased.TriggerType);
+
+                    if (string.Equals(leased.TriggerType, "subagent-findings", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.LogWarning(
+                            "Subagent-originated memory candidate retry scheduled for checkpoint {CheckpointId}",
+                            leased.CheckpointId);
+                    }
+
+                    await store.MarkCheckpointRetryAsync(leased.CheckpointId, maxRetries: 5, ct);
+                }
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            logger.LogDebug("Memory curation worker stopped.");
         }
     }
 


### PR DESCRIPTION
## Summary

- `MemoryCurationWorkerService.RunAsync` now wraps the entire worker loop in an outer `try/catch (OperationCanceledException) when (ct.IsCancellationRequested)` that logs at Debug and returns cleanly — so `StopAsync` can `await _worker` without the task surfacing as an error
- Inner per-checkpoint `catch` block re-throws `OperationCanceledException` immediately, preventing a shutdown-triggered cancellation from being misclassified as a curation failure and attempting a retry against an already-cancelled token

## Root cause

`StopAsync` was calling `_cts.Cancel()` then `await _worker`. Any in-flight `Task.Delay` or store awaitable would throw `TaskCanceledException` (a subclass of `OperationCanceledException`), which propagated through `_worker` as a fault and surfaced as a crash log at daemon stop time.

## Test plan

- [ ] Start daemon, issue stop — no `TaskCanceledException` in logs
- [ ] Start daemon with a pending memory checkpoint, issue stop mid-curation — worker exits cleanly without retry attempt