### PR TITLE
fix(signalr): scope stream materializer to per-session actor to prevent actor leak

### DIFF
--- a/src/Netclaw.Daemon.Tests/Gateway/SessionRegistryTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionRegistryTests.cs
@@ -1,10 +1,6 @@
-using Akka;
 using Akka.Actor;
-using Akka.Streams;
-using Akka.Streams.Dsl;
-using Microsoft.AspNetCore.SignalR;
+using Akka.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
-using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Daemon.Gateway;
 using Xunit;
@@ -12,173 +8,138 @@ using Xunit;
 namespace Netclaw.Daemon.Tests.Gateway;
 
 /// <summary>
-/// Integration tests for <see cref="SessionRegistry"/> using a real ActorSystem
-/// for Akka.Streams materialization and a fake <see cref="ISessionPipeline"/>.
+/// Unit tests for <see cref="SessionRegistry"/> coordination behavior.
+/// Stream materialization and pipeline lifecycle are now handled by
+/// <see cref="SignalRSessionActor"/> — these tests focus on the registry's
+/// session-tracking, connection-binding, and message-routing responsibilities.
 /// </summary>
-public sealed class SessionRegistryTests : IAsyncLifetime
+public sealed class SessionRegistryTests
 {
-    private ActorSystem _system = null!;
-
-    public Task InitializeAsync()
-    {
-        _system = ActorSystem.Create("session-registry-tests",
-            "akka { loglevel = WARNING }");
-        return Task.CompletedTask;
-    }
-
-    public async Task DisposeAsync()
-    {
-        await _system.Terminate();
-    }
-
-    [Fact]
-    public async Task EnsureSession_rematerializes_pipeline_when_output_stream_has_completed()
-    {
-        var pipeline = new TrackingFakeSessionPipeline(_system, neverComplete: false);
-        var registry = BuildRegistry(pipeline);
-
-        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
-        var sessionIdParsed = new SessionId(sessionId);
-
-        // Source.Empty completes immediately; wait for the output sink to finish
-        var outputCompletion = registry.GetOutputCompletionForTesting(sessionIdParsed);
-        Assert.NotNull(outputCompletion);
-        await outputCompletion.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // EnsureSession from a new connection ID (simulate reconnect)
-        var result = await registry.EnsureSessionAsync("conn-2", sessionId, "tui");
-
-        // Pipeline should have been re-created because the output stream was dead
-        Assert.Equal(2, pipeline.CreateCount);
-        Assert.Equal(sessionId, result.SessionId);
-        Assert.False(result.Created);
-    }
-
-    [Fact]
-    public async Task EnsureSession_reuses_pipeline_when_output_stream_still_active()
-    {
-        var pipeline = new TrackingFakeSessionPipeline(_system, neverComplete: true);
-        var registry = BuildRegistry(pipeline);
-
-        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
-
-        // EnsureSession from another connection — stream is alive, no re-materialization needed
-        var result = await registry.EnsureSessionAsync("conn-2", sessionId, "tui");
-
-        Assert.Equal(1, pipeline.CreateCount);
-        Assert.Equal(sessionId, result.SessionId);
-        Assert.False(result.Created);
-    }
-
-    [Fact]
-    public async Task AttachSession_rematerializes_pipeline_when_output_stream_has_completed()
-    {
-        var pipeline = new TrackingFakeSessionPipeline(_system, neverComplete: false);
-        var registry = BuildRegistry(pipeline);
-
-        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
-        var sessionIdParsed = new SessionId(sessionId);
-
-        var outputCompletion = registry.GetOutputCompletionForTesting(sessionIdParsed);
-        Assert.NotNull(outputCompletion);
-        await outputCompletion.WaitAsync(TimeSpan.FromSeconds(5));
-
-        // AttachSession from new connection after passivation
-        await registry.AttachSessionAsync("conn-2", sessionId);
-
-        Assert.Equal(2, pipeline.CreateCount);
-    }
-
-    [Fact]
-    public async Task AttachSession_reuses_pipeline_when_output_stream_still_active()
-    {
-        var pipeline = new TrackingFakeSessionPipeline(_system, neverComplete: true);
-        var registry = BuildRegistry(pipeline);
-
-        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
-
-        // Attach from another connection — stream is alive, no re-materialization needed
-        await registry.AttachSessionAsync("conn-2", sessionId);
-
-        Assert.Equal(1, pipeline.CreateCount);
-    }
-
-    private SessionRegistry BuildRegistry(ISessionPipeline pipeline)
+    private SessionRegistry BuildRegistry()
         => new(
-            pipeline,
-            _system,
+            new StubRequiredActor(),
             TimeProvider.System,
-            new NoopHubContext(),
             NullLogger<SessionRegistry>.Instance);
 
+    [Fact]
+    public async Task CreateSession_returns_valid_session_id()
+    {
+        var registry = BuildRegistry();
+
+        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
+
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+        Assert.StartsWith("signalr/", sessionId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EnsureSession_creates_new_session_when_no_id_provided()
+    {
+        var registry = BuildRegistry();
+
+        var result = await registry.EnsureSessionAsync("conn-1", null, "tui");
+
+        Assert.True(result.Created);
+        Assert.False(string.IsNullOrWhiteSpace(result.SessionId));
+    }
+
+    [Fact]
+    public async Task EnsureSession_reuses_existing_session_when_id_is_known()
+    {
+        var registry = BuildRegistry();
+        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
+
+        var result = await registry.EnsureSessionAsync("conn-2", sessionId, "tui");
+
+        Assert.False(result.Created);
+        Assert.Equal(sessionId, result.SessionId);
+    }
+
+    [Fact]
+    public async Task EnsureSession_creates_binding_when_id_is_unknown()
+    {
+        var registry = BuildRegistry();
+        // Provide a session ID we haven't seen before
+        var unknownId = "signalr/00000000000000000000000000000000";
+
+        var result = await registry.EnsureSessionAsync("conn-1", unknownId, "tui");
+
+        Assert.False(result.Created);
+        Assert.Equal(unknownId, result.SessionId);
+
+        // Subsequent EnsureSession should find it now
+        var result2 = await registry.EnsureSessionAsync("conn-2", unknownId, "tui");
+        Assert.False(result2.Created);
+        Assert.Equal(unknownId, result2.SessionId);
+    }
+
+    [Fact]
+    public async Task AttachSession_throws_when_session_not_found()
+    {
+        var registry = BuildRegistry();
+
+        await Assert.ThrowsAsync<Microsoft.AspNetCore.SignalR.HubException>(
+            () => registry.AttachSessionAsync("conn-1", "signalr/nonexistent"));
+    }
+
+    [Fact]
+    public async Task AttachSession_succeeds_for_known_session()
+    {
+        var registry = BuildRegistry();
+        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
+
+        // Should not throw
+        await registry.AttachSessionAsync("conn-2", sessionId);
+    }
+
+    [Fact]
+    public async Task SendMessage_throws_when_connection_has_no_session()
+    {
+        var registry = BuildRegistry();
+        await registry.CreateSessionAsync("conn-1", "tui");
+
+        // conn-2 is not attached to any session
+        await Assert.ThrowsAsync<Microsoft.AspNetCore.SignalR.HubException>(
+            () => registry.SendMessageAsync("conn-2", "signalr/any", "hello"));
+    }
+
+    [Fact]
+    public async Task SendMessage_throws_when_connection_attached_to_different_session()
+    {
+        var registry = BuildRegistry();
+        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
+        var otherSessionId = await registry.CreateSessionAsync("conn-2", "tui");
+
+        // conn-1 is attached to sessionId, not otherSessionId
+        await Assert.ThrowsAsync<Microsoft.AspNetCore.SignalR.HubException>(
+            () => registry.SendMessageAsync("conn-1", otherSessionId, "hello"));
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_clears_all_sessions()
+    {
+        var registry = BuildRegistry();
+        await registry.CreateSessionAsync("conn-1", "tui");
+        await registry.CreateSessionAsync("conn-2", "tui");
+
+        await registry.ShutdownAsync(CancellationToken.None);
+
+        // After shutdown, no sessions should be known; EnsureSession creates a fresh one
+        var result = await registry.EnsureSessionAsync("conn-3", "signalr/any-old-id", "tui");
+        // The old ID was unknown after shutdown, so it's created fresh
+        Assert.Equal("signalr/any-old-id", result.SessionId);
+    }
+
     /// <summary>
-    /// Fake pipeline that returns <see cref="MaterializedSession"/> instances backed by
-    /// controllable Akka.Streams sources. When <paramref name="neverComplete"/> is false,
-    /// output uses <see cref="Source.Empty{TOut}"/> which completes immediately — simulating
-    /// a dead output stream after actor passivation. When true, uses
-    /// <see cref="Source.Never{T}"/> to keep the stream alive.
+    /// Stub implementation of <see cref="IRequiredActor{T}"/> that returns
+    /// <see cref="ActorRefs.Nobody"/> for all requests. Used to isolate
+    /// <see cref="SessionRegistry"/> from the actor system in unit tests.
     /// </summary>
-    private sealed class TrackingFakeSessionPipeline : ISessionPipeline
+    private sealed class StubRequiredActor : IRequiredActor<SignalRGatewayActorKey>
     {
-        private readonly ActorSystem _system;
-        private readonly bool _neverComplete;
-        private int _createCount;
+        public IActorRef ActorRef => ActorRefs.Nobody;
 
-        public int CreateCount => _createCount;
-
-        public TrackingFakeSessionPipeline(ActorSystem system, bool neverComplete)
-        {
-            _system = system;
-            _neverComplete = neverComplete;
-        }
-
-        public Task<MaterializedSession> CreateAsync(
-            SessionId sessionId,
-            SessionPipelineOptions options,
-            IMaterializer? materializer = null,
-            CancellationToken cancellationToken = default)
-        {
-            var n = Interlocked.Increment(ref _createCount);
-
-            var killSwitch = KillSwitches.Shared($"test-{sessionId.Value}-{n}");
-
-            var input = Sink.Ignore<ChannelInput>()
-                .MapMaterializedValue<NotUsed>(_ => NotUsed.Instance);
-
-            Source<SessionOutput, NotUsed> output = _neverComplete
-                ? Source.Never<SessionOutput>().Via(killSwitch.Flow<SessionOutput>())
-                : Source.Empty<SessionOutput>().Via(killSwitch.Flow<SessionOutput>());
-
-            return Task.FromResult(new MaterializedSession(input, output, killSwitch));
-        }
-    }
-
-    /// <summary>Minimal hub context that silently accepts all output.</summary>
-    private sealed class NoopHubContext : IHubContext<SessionHub, ISessionHubClient>
-    {
-        private static readonly NoopHubClients s_clients = new();
-
-        public IHubClients<ISessionHubClient> Clients => s_clients;
-        public IGroupManager Groups => throw new NotSupportedException();
-    }
-
-    private sealed class NoopHubClients : IHubClients<ISessionHubClient>
-    {
-        private static readonly NoopClient s_client = new();
-
-        public ISessionHubClient All => s_client;
-        public ISessionHubClient AllExcept(IReadOnlyList<string> excluded) => s_client;
-        public ISessionHubClient Client(string connectionId) => s_client;
-        public ISessionHubClient Clients(IReadOnlyList<string> connectionIds) => s_client;
-        public ISessionHubClient Group(string groupName) => s_client;
-        public ISessionHubClient GroupExcept(string groupName, IReadOnlyList<string> excluded) => s_client;
-        public ISessionHubClient Groups(IReadOnlyList<string> groupNames) => s_client;
-        public ISessionHubClient User(string userId) => s_client;
-        public ISessionHubClient Users(IReadOnlyList<string> userIds) => s_client;
-    }
-
-    private sealed class NoopClient : ISessionHubClient
-    {
-        public Task ReceiveOutput(SessionOutputDto dto) => Task.CompletedTask;
+        public Task<IActorRef> GetAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IActorRef>(ActorRefs.Nobody);
     }
 }

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -1,7 +1,5 @@
-using System.Collections.Concurrent;
 using Akka.Actor;
-using Akka.Streams;
-using Akka.Streams.Dsl;
+using Akka.Hosting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -12,42 +10,40 @@ namespace Netclaw.Daemon.Gateway;
 
 /// <summary>
 /// Singleton service managing the lifecycle of SignalR-connected sessions.
-/// Bridges <see cref="SessionHub"/> (transient per-invocation) to
-/// <see cref="ISessionPipeline"/> (Akka.Streams) via
-/// <see cref="IHubContext{THub,T}"/> for thread-safe output delivery.
+/// Bridges <see cref="SessionHub"/> (transient per-invocation) to per-session
+/// <see cref="SignalRSessionActor"/> instances via the <c>signalr-gateway</c> actor.
 /// </summary>
+/// <remarks>
+/// Stream materialization is now delegated to <see cref="SignalRSessionActor"/>, which
+/// creates a <see cref="ActorMaterializer"/> scoped to its own actor context. This ensures
+/// all Akka.Streams stage actors are children of the session actor and are automatically
+/// stopped when the session ends — eliminating the StreamSupervisor actor accumulation
+/// that previously occurred when streams were materialized at the system level.
+/// </remarks>
 public sealed class SessionRegistry
 {
-    private readonly ISessionPipeline _pipeline;
-    private readonly ActorSystem _system;
+    private readonly IRequiredActor<SignalRGatewayActorKey> _gatewayProvider;
     private readonly TimeProvider _timeProvider;
-    private readonly IHubContext<SessionHub, ISessionHubClient> _hubContext;
     private readonly ILogger<SessionRegistry> _logger;
 
-    // sessionId → session state
-    private readonly ConcurrentDictionary<SessionId, HubSessionState> _sessions = new();
+    // session ID → channel type (retained for re-create on re-materialization)
+    private readonly Dictionary<SessionId, string> _knownSessions = new();
     private readonly SemaphoreSlim _sessionMutationGate = new(1, 1);
 
     private readonly SessionConnectionMap _connections = new();
 
     public SessionRegistry(
-        ISessionPipeline pipeline,
-        ActorSystem system,
+        IRequiredActor<SignalRGatewayActorKey> gatewayProvider,
         TimeProvider timeProvider,
-        IHubContext<SessionHub, ISessionHubClient> hubContext,
         ILogger<SessionRegistry> logger)
     {
-        _pipeline = pipeline;
-        _system = system;
+        _gatewayProvider = gatewayProvider;
         _timeProvider = timeProvider;
-        _hubContext = hubContext;
         _logger = logger;
     }
 
     /// <summary>
     /// Creates a new session for the given SignalR connection.
-    /// Materializes Akka.Streams pipelines for input (queue) and output
-    /// (routed back to the caller via <see cref="IHubContext{THub,T}"/>).
     /// </summary>
     public async Task<string> CreateSessionAsync(string connectionId, string channelType)
     {
@@ -69,54 +65,26 @@ public sealed class SessionRegistry
         string channelType)
     {
         var sessionId = new SessionId($"signalr/{Guid.NewGuid():N}");
-        await MaterializeAndBindSessionAsync(sessionId, callerConnectionId, channelType);
-        return sessionId.Value;
-    }
 
-    private async Task MaterializeAndBindSessionAsync(
-        SessionId sessionId,
-        SignalRConnectionId callerConnectionId,
-        string channelType)
-    {
-        var existing = _sessions.TryGetValue(sessionId, out var existingSession)
-            ? existingSession
-            : null;
-
-        var session = await _pipeline.CreateAsync(sessionId, new SessionPipelineOptions
-        {
-            ChannelType = channelType
-        });
-
-        // Materialize input: imperative queue → session sink
-        var inputQueue = Source.Queue<ChannelInput>(16, OverflowStrategy.Backpressure)
-            .ToMaterialized(session.Input, Keep.Left)
-            .Run(_system);
-
-        // Materialize output: stream → currently attached SignalR connection.
-        // Track completion to detect post-passivation stream death.
-        var outputCompletion = session.Output
-            .ToMaterialized(
-                Sink.ForEach<SessionOutput>(output => PublishOutput(sessionId, output)),
-                Keep.Right)
-            .Run(_system);
-
-        var hubSession = new HubSessionState(session, inputQueue, channelType, outputCompletion);
-
-        _sessions[sessionId] = hubSession;
-
-        // Guard: one session per connection — dispose previous if caller retries.
+        _knownSessions[sessionId] = channelType;
         var previousSessionId = _connections.BindNewSession(sessionId, callerConnectionId);
-        if (previousSessionId.HasValue && _sessions.TryRemove(previousSessionId.Value, out var previous))
+
+        // Remove displaced session from known sessions
+        if (previousSessionId.HasValue)
         {
-            await previous.Session.DisposeAsync();
+            _knownSessions.Remove(previousSessionId.Value);
+            var gateway = await _gatewayProvider.GetAsync();
+            gateway.Tell(new ShutdownSignalRSession(previousSessionId.Value));
         }
 
-        if (existing is not null)
-            await existing.Session.DisposeAsync();
+        var gw = await _gatewayProvider.GetAsync();
+        gw.Tell(new StartSignalRSession(sessionId, channelType, callerConnectionId));
 
         _logger.LogDebug(
-            "Session {SessionId} pipeline materialized and bound to connection {ConnectionId}.",
+            "Session {SessionId} created and bound to connection {ConnectionId}.",
             sessionId.Value, callerConnectionId.Value);
+
+        return sessionId.Value;
     }
 
     public async Task<SessionEnsureResultDto> EnsureSessionAsync(
@@ -132,26 +100,18 @@ public sealed class SessionRegistry
             if (!string.IsNullOrWhiteSpace(sessionId))
             {
                 var requestedSessionId = ParseSessionId(sessionId);
-                if (_sessions.TryGetValue(requestedSessionId, out var hubSession))
+
+                if (_knownSessions.ContainsKey(requestedSessionId))
                 {
-                    if (hubSession.IsOutputCompleted)
-                    {
-                        _logger.LogWarning(
-                            "Session {SessionId} output stream has completed (post-passivation); " +
-                            "re-materializing pipeline for connection {ConnectionId}.",
-                            requestedSessionId.Value, callerConnectionId.Value);
+                    // Session exists — attach the new connection; actor handles re-init internally
+                    _connections.AttachSession(requestedSessionId, callerConnectionId);
 
-                        await MaterializeAndBindSessionAsync(
-                            requestedSessionId, callerConnectionId, hubSession.ChannelType);
-                    }
-                    else
-                    {
-                        _logger.LogDebug(
-                            "Attaching connection {ConnectionId} to existing session {SessionId}.",
-                            callerConnectionId.Value, requestedSessionId.Value);
+                    var gateway = await _gatewayProvider.GetAsync();
+                    gateway.Tell(new AttachSignalRConnection(requestedSessionId, callerConnectionId));
 
-                        _connections.AttachSession(requestedSessionId, callerConnectionId);
-                    }
+                    _logger.LogDebug(
+                        "Attaching connection {ConnectionId} to existing session {SessionId}.",
+                        callerConnectionId.Value, requestedSessionId.Value);
 
                     return new SessionEnsureResultDto
                     {
@@ -160,7 +120,13 @@ public sealed class SessionRegistry
                     };
                 }
 
-                await MaterializeAndBindSessionAsync(requestedSessionId, callerConnectionId, channelType);
+                // Session ID provided but unknown — create a fresh session binding
+                _knownSessions[requestedSessionId] = channelType;
+                _connections.BindNewSession(requestedSessionId, callerConnectionId);
+
+                var gw2 = await _gatewayProvider.GetAsync();
+                gw2.Tell(new StartSignalRSession(requestedSessionId, channelType, callerConnectionId));
+
                 return new SessionEnsureResultDto
                 {
                     SessionId = requestedSessionId.Value,
@@ -184,8 +150,6 @@ public sealed class SessionRegistry
     /// <summary>
     /// Attaches the current SignalR connection to an existing session.
     /// Supports reconnect flows where connection IDs rotate.
-    /// If the session's output stream has completed (post-passivation), the pipeline
-    /// is re-materialized so output delivery resumes.
     /// </summary>
     public async Task AttachSessionAsync(string connectionId, string sessionId)
     {
@@ -195,27 +159,17 @@ public sealed class SessionRegistry
         await _sessionMutationGate.WaitAsync();
         try
         {
-            if (!_sessions.TryGetValue(requestedSessionId, out var hubSession))
+            if (!_knownSessions.TryGetValue(requestedSessionId, out var channelType))
                 throw new HubException($"Session '{sessionId}' not found.");
 
-            if (hubSession.IsOutputCompleted)
-            {
-                _logger.LogWarning(
-                    "Session {SessionId} output stream has completed (post-passivation); " +
-                    "re-materializing pipeline for connection {ConnectionId}.",
-                    requestedSessionId.Value, callerConnectionId.Value);
+            _connections.AttachSession(requestedSessionId, callerConnectionId);
 
-                await MaterializeAndBindSessionAsync(
-                    requestedSessionId, callerConnectionId, hubSession.ChannelType);
-            }
-            else
-            {
-                _logger.LogDebug(
-                    "Attaching connection {ConnectionId} to session {SessionId}.",
-                    callerConnectionId.Value, requestedSessionId.Value);
+            var gateway = await _gatewayProvider.GetAsync();
+            gateway.Tell(new AttachSignalRConnection(requestedSessionId, callerConnectionId));
 
-                _connections.AttachSession(requestedSessionId, callerConnectionId);
-            }
+            _logger.LogDebug(
+                "Attaching connection {ConnectionId} to session {SessionId}.",
+                callerConnectionId.Value, requestedSessionId.Value);
         }
         finally
         {
@@ -232,35 +186,28 @@ public sealed class SessionRegistry
         var requestedSessionId = ParseSessionId(sessionId);
 
         if (!_connections.TryGetSessionForConnection(callerConnectionId, out var attachedSessionId))
-        {
             throw new HubException($"Session '{sessionId}' is not attached to this connection.");
-        }
 
         if (!attachedSessionId.Equals(requestedSessionId))
-        {
             throw new HubException($"Session '{sessionId}' is not attached to this connection.");
-        }
 
-        if (!_sessions.TryGetValue(attachedSessionId, out var hubSession))
+        if (!_knownSessions.ContainsKey(attachedSessionId))
             throw new HubException($"Session '{sessionId}' not found.");
 
         var signalrMessageId = $"signalr:{callerConnectionId.Value}:{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}:{Guid.NewGuid():N}";
         if (signalrMessageId.Length > 128)
             signalrMessageId = signalrMessageId[..128];
 
-        var result = await hubSession.InputQueue.OfferAsync(new ChannelInput
+        var input = new ChannelInput
         {
             SenderId = "signalr-user",
             MessageId = signalrMessageId,
             Contents = [new TextContent(text)],
             ReceivedAt = _timeProvider.GetUtcNow()
-        });
+        };
 
-        if (result is QueueOfferResult.Failure failure)
-            throw new HubException($"Failed to enqueue message: {failure.Cause.Message}");
-
-        if (result is QueueOfferResult.QueueClosed)
-            throw new HubException($"Session '{sessionId}' is closed.");
+        var gateway = await _gatewayProvider.GetAsync();
+        gateway.Tell(new EnqueueSignalRInput(attachedSessionId, input));
     }
 
     /// <summary>
@@ -288,62 +235,33 @@ public sealed class SessionRegistry
         await _sessionMutationGate.WaitAsync(cancellationToken);
         try
         {
-            var sessions = _sessions.ToArray();
-            _sessions.Clear();
+            var sessions = _knownSessions.Keys.ToArray();
+            _knownSessions.Clear();
             _connections.Clear();
 
-            var disposeTasks = sessions
-                .Select(x => x.Value.Session.DisposeAsync().AsTask())
-                .ToArray();
-
-            if (disposeTasks.Length == 0)
+            if (sessions.Length == 0)
                 return;
 
+            IActorRef gateway;
             try
             {
-                await Task.WhenAll(disposeTasks).WaitAsync(cancellationToken);
+                gateway = await _gatewayProvider.GetAsync(cancellationToken);
             }
             catch (OperationCanceledException)
             {
-                _logger.LogWarning("Timed out while disposing {Count} active session(s) during shutdown.", disposeTasks.Length);
+                _logger.LogWarning("Timed out resolving gateway actor during shutdown; {Count} session(s) may not have been notified.", sessions.Length);
+                return;
             }
+
+            foreach (var sessionId in sessions)
+                gateway.Tell(new ShutdownSignalRSession(sessionId));
+
+            _logger.LogDebug("Shutdown signals sent to {Count} session(s).", sessions.Length);
         }
         finally
         {
             _sessionMutationGate.Release();
         }
-    }
-
-    /// <summary>
-    /// Returns the output completion task for the given session.
-    /// FOR TESTING ONLY — used to await stream completion in integration tests.
-    /// </summary>
-    internal Task? GetOutputCompletionForTesting(SessionId sessionId)
-        => _sessions.TryGetValue(sessionId, out var s) ? s.OutputCompletion : null;
-
-    private void PublishOutput(SessionId sessionId, SessionOutput output)
-    {
-        if (!_sessions.ContainsKey(sessionId))
-            return;
-
-        if (!_connections.TryGetConnectionForSession(sessionId, out var connectionId))
-        {
-            _logger.LogDebug(
-                "Session {SessionId} has no active connection binding; dropping {OutputType} output.",
-                sessionId.Value, output.GetType().Name);
-            return;
-        }
-
-        var dto = SessionOutputDtoMapper.ToDto(output);
-        _hubContext.Clients.Client(connectionId.Value).ReceiveOutput(dto)
-            .ContinueWith(t =>
-            {
-                if (t.IsFaulted)
-                {
-                    _logger.LogDebug(t.Exception,
-                        "Failed to send output to connection {ConnectionId}", connectionId);
-                }
-            }, TaskContinuationOptions.OnlyOnFaulted);
     }
 
     private static SignalRConnectionId ParseConnectionId(string connectionId)
@@ -364,38 +282,5 @@ public sealed class SessionRegistry
             throw new HubException("Session ID cannot be empty.");
 
         return new SessionId(sessionId);
-    }
-
-    /// <summary>
-    /// Internal state for a SignalR-connected session.
-    /// </summary>
-    private sealed class HubSessionState
-    {
-        public HubSessionState(
-            MaterializedSession session,
-            ISourceQueueWithComplete<ChannelInput> inputQueue,
-            string channelType,
-            Task outputCompletion)
-        {
-            Session = session;
-            InputQueue = inputQueue;
-            ChannelType = channelType;
-            OutputCompletion = outputCompletion;
-        }
-
-        public MaterializedSession Session { get; }
-        public ISourceQueueWithComplete<ChannelInput> InputQueue { get; }
-
-        /// <summary>Channel type used when creating the pipeline (needed for re-materialization).</summary>
-        public string ChannelType { get; }
-
-        /// <summary>
-        /// Completes when the Akka.Streams output pipeline terminates.
-        /// Used to detect post-passivation stream death before deciding whether to re-materialize.
-        /// </summary>
-        public Task OutputCompletion { get; }
-
-        /// <summary>True when the output stream has terminated (e.g. after actor passivation).</summary>
-        public bool IsOutputCompleted => OutputCompletion.IsCompleted;
     }
 }

--- a/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
+++ b/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
@@ -1,0 +1,290 @@
+using System.Threading.Channels;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Microsoft.AspNetCore.SignalR;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Daemon.Gateway;
+
+/// <summary>
+/// Per-session binding actor for SignalR connections.
+/// Owns a <see cref="ActorMaterializer"/> scoped to this actor context so that
+/// all Akka.Streams stage actors become children and are automatically stopped
+/// when this actor stops — eliminating the StreamSupervisor actor leak that
+/// occurred when streams were materialized at the system level.
+/// </summary>
+/// <remarks>
+/// Mirrors the pattern used by <c>SlackThreadBindingActor</c> for Slack sessions.
+/// </remarks>
+internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, IWithTimers
+{
+    private readonly SessionId _sessionId;
+    private readonly ISessionPipeline _pipeline;
+    private readonly IHubContext<SessionHub, ISessionHubClient> _hubContext;
+    private readonly ILoggingAdapter _log;
+
+    private ActorMaterializer? _materializer;
+    private MaterializedSession? _session;
+    private ChannelWriter<ChannelInput>? _inputQueue;
+    private SignalRConnectionId _currentConnectionId;
+    private string _channelType = "tui";
+    private int _pipelineGeneration;
+    private bool _isReinitializing;
+
+    private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
+    private static readonly object ReinitializeTimerKey = new();
+
+    public IStash Stash { get; set; } = null!;
+    public ITimerScheduler Timers { get; set; } = null!;
+
+    public SignalRSessionActor(
+        string entityId,
+        ISessionPipeline pipeline,
+        IHubContext<SessionHub, ISessionHubClient> hubContext)
+    {
+        _sessionId = new SessionId(entityId);
+        _pipeline = pipeline;
+        _hubContext = hubContext;
+        _log = Context.GetLogger()
+            .WithContext("Adapter", "signalr")
+            .WithContext("SessionId", _sessionId.Value);
+
+        Initializing();
+    }
+
+    public static Props CreateProps(string entityId, ISessionPipeline pipeline,
+        IHubContext<SessionHub, ISessionHubClient> hubContext)
+        => Props.Create(() => new SignalRSessionActor(entityId, pipeline, hubContext));
+
+    private void Initializing()
+    {
+        ReceiveAsync<StartSignalRSession>(async msg =>
+        {
+            _channelType = msg.ChannelType;
+            _currentConnectionId = msg.ConnectionId;
+
+            try
+            {
+                await EnsureInitializedAsync();
+                Become(Active);
+                Stash.UnstashAll();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to initialize SignalR session pipeline; stopping actor");
+                Context.Stop(Self);
+            }
+        });
+
+        ReceiveAny(_ => Stash.Stash());
+    }
+
+    private void Active()
+    {
+        Receive<AttachSignalRConnection>(msg =>
+        {
+            _currentConnectionId = msg.ConnectionId;
+            _log.Debug("Connection {ConnectionId} attached to session", msg.ConnectionId.Value);
+        });
+
+        ReceiveAsync<EnqueueSignalRInput>(async msg =>
+        {
+            var writer = _inputQueue;
+            if (writer is null)
+            {
+                _log.Warning("Input queue not initialized; dropping message for session {SessionId}", _sessionId.Value);
+                return;
+            }
+
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await writer.WriteAsync(msg.Input, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                _log.Warning("Timed out writing to input queue for session {SessionId}", _sessionId.Value);
+            }
+            catch (ChannelClosedException)
+            {
+                _log.Warning("Input queue closed for session {SessionId}; reinitializing", _sessionId.Value);
+                Self.Tell(new ReinitializePipeline("input queue closed"));
+            }
+        });
+
+        Receive<OutputReceived>(msg =>
+        {
+            if (_currentConnectionId == default)
+                return;
+
+            var dto = SessionOutputDtoMapper.ToDto(msg.Output);
+            _hubContext.Clients.Client(_currentConnectionId.Value)
+                .ReceiveOutput(dto)
+                .ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        _log.Debug(t.Exception,
+                            "Failed to deliver output to connection {ConnectionId}", _currentConnectionId.Value);
+                    }
+                }, TaskContinuationOptions.OnlyOnFaulted);
+        });
+
+        Receive<OutputStreamTerminated>(msg =>
+        {
+            if (msg.Generation != _pipelineGeneration)
+                return;
+
+            var reason = msg.Cause is null
+                ? "completed"
+                : $"faulted: {msg.Cause.Message}";
+
+            _log.Warning("SignalR output stream terminated ({Reason}); reinitializing pipeline", reason);
+            Self.Tell(new ReinitializePipeline(reason));
+        });
+
+        ReceiveAsync<ReinitializePipeline>(async msg => await ReinitializePipelineAsync(msg.Reason));
+
+        Receive<ShutdownSignalRSession>(_ =>
+        {
+            _log.Debug("Shutdown requested for session {SessionId}", _sessionId.Value);
+            Context.Stop(Self);
+        });
+    }
+
+    protected override void PostStop()
+    {
+        _inputQueue?.TryComplete();
+        _session?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _materializer?.Dispose();
+        base.PostStop();
+    }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_session is not null)
+            return;
+
+        _log.Info("Initializing SignalR session pipeline");
+        var self = Self;
+
+        _materializer = Context.Materializer(namePrefix: "signalr");
+
+        using var initCts = new CancellationTokenSource(PipelineInitTimeout);
+        var materialized = await _pipeline.CreateAsync(
+            _sessionId,
+            new SessionPipelineOptions { ChannelType = _channelType },
+            materializer: _materializer,
+            cancellationToken: initCts.Token);
+
+        var inputQueue = Source.Channel<ChannelInput>(512, true)
+            .ToMaterialized(materialized.Input, Keep.Left)
+            .Run(_materializer);
+
+        var generation = ++_pipelineGeneration;
+        var outputCompletion = materialized.Output
+            .ToMaterialized(
+                Sink.ForEach<SessionOutput>(output => self.Tell(new OutputReceived(output))),
+                Keep.Right)
+            .Run(_materializer);
+
+        _ = outputCompletion.ContinueWith(t =>
+            {
+                var cause = t.IsFaulted ? t.Exception?.GetBaseException() : null;
+                self.Tell(new OutputStreamTerminated(generation, cause));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        _session = materialized;
+        _inputQueue = inputQueue;
+
+        _log.Info("SignalR session pipeline initialized");
+    }
+
+    private async Task ReinitializePipelineAsync(string reason)
+    {
+        if (_isReinitializing)
+            return;
+
+        _isReinitializing = true;
+        try
+        {
+            _log.Warning("Reinitializing SignalR session pipeline: {Reason}", reason);
+
+            _inputQueue?.TryComplete();
+            _inputQueue = null;
+
+            if (_session is not null)
+            {
+                await _session.DisposeAsync();
+                _session = null;
+            }
+
+            _materializer?.Dispose();
+            _materializer = null;
+
+            await EnsureInitializedAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "SignalR pipeline reinitialization failed; scheduling retry");
+            Timers.StartSingleTimer(
+                ReinitializeTimerKey,
+                new ReinitializePipeline("retry after failed reinit"),
+                TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            _isReinitializing = false;
+        }
+    }
+
+    // ─── Message protocol ───────────────────────────────────────────────────
+
+    private sealed record OutputReceived(SessionOutput Output);
+    private sealed record OutputStreamTerminated(int Generation, Exception? Cause);
+    private sealed record ReinitializePipeline(string Reason);
+}
+
+// ─── Gateway-routable messages (implement ISignalRSessionMessage) ────────────
+
+/// <summary>Marker for messages routable to a <see cref="SignalRSessionActor"/>.</summary>
+internal interface ISignalRSessionMessage
+{
+    SessionId SessionId { get; }
+}
+
+/// <summary>Creates (or re-creates) a SignalR session binding actor.</summary>
+internal sealed record StartSignalRSession(
+    SessionId SessionId,
+    string ChannelType,
+    SignalRConnectionId ConnectionId) : ISignalRSessionMessage;
+
+/// <summary>Updates the active connection ID for an existing session.</summary>
+internal sealed record AttachSignalRConnection(
+    SessionId SessionId,
+    SignalRConnectionId ConnectionId) : ISignalRSessionMessage;
+
+/// <summary>Delivers a user message to the session's input pipeline.</summary>
+internal sealed record EnqueueSignalRInput(
+    SessionId SessionId,
+    ChannelInput Input) : ISignalRSessionMessage;
+
+/// <summary>Requests graceful actor shutdown and stream cleanup.</summary>
+internal sealed record ShutdownSignalRSession(SessionId SessionId) : ISignalRSessionMessage;
+
+/// <summary>
+/// Routes messages to <see cref="SignalRSessionActor"/> children by session ID.
+/// </summary>
+internal sealed class SignalRMessageExtractor : Akka.Cluster.Sharding.HashCodeMessageExtractor
+{
+    public SignalRMessageExtractor() : base(40) { }
+
+    public override string? EntityId(object message)
+        => message is ISignalRSessionMessage msg ? msg.SessionId.Value : null;
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -19,6 +19,7 @@ using Netclaw.Configuration;
 using Netclaw.Configuration.Providers;
 using Netclaw.Configuration.Secrets;
 using Netclaw.Configuration.Feeds;
+using Netclaw.Daemon;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
@@ -471,6 +472,7 @@ static void ConfigureDaemonServices(
             : null;
 
         akkaBuilder.WithNetclawActors(reminderStorage);
+        akkaBuilder.WithSignalRGateway();
 
         // Register reminder tools after actors start (needs ReminderManagerActor ref)
         akkaBuilder.StartActors((system, registry, _) =>

--- a/src/Netclaw.Daemon/SignalRGatewayHostingExtensions.cs
+++ b/src/Netclaw.Daemon/SignalRGatewayHostingExtensions.cs
@@ -1,0 +1,40 @@
+using Akka.Hosting;
+using Netclaw.Actors.Hosting;
+using Netclaw.Daemon.Gateway;
+
+namespace Netclaw.Daemon;
+
+/// <summary>
+/// Marker type for <see cref="Akka.Hosting.IActorRegistry"/> lookup of the SignalR
+/// gateway parent actor (GenericChildPerEntityParent routing to SignalRSessionActors).
+/// </summary>
+public sealed class SignalRGatewayActorKey;
+
+/// <summary>
+/// Akka.Hosting extension that registers the SignalR session gateway actor.
+/// </summary>
+public static class SignalRGatewayHostingExtensions
+{
+    /// <summary>
+    /// Registers the <c>signalr-gateway</c> actor, a
+    /// <see cref="GenericChildPerEntityParent"/> that creates and routes messages to
+    /// per-session <see cref="SignalRSessionActor"/> children.
+    /// Stream actors created by each <see cref="SignalRSessionActor"/> are scoped to
+    /// that actor's materializer and are automatically stopped on actor passivation,
+    /// eliminating the StreamSupervisor actor leak caused by system-level materialization.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithSignalRGateway(
+        this AkkaConfigurationBuilder builder)
+    {
+        return builder.StartActors((system, registry, resolver) =>
+        {
+            var gateway = system.ActorOf(
+                GenericChildPerEntityParent.CreateProps(
+                    new SignalRMessageExtractor(),
+                    entityId => resolver.Props<SignalRSessionActor>(entityId)),
+                "signalr-gateway");
+
+            registry.Register<SignalRGatewayActorKey>(gateway);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `SessionRegistry.MaterializeAndBindSessionAsync()` called `.Run(_system)` for all stream materializations, creating stream stage actors under the global `StreamSupervisor-0`. These accumulated over the daemon's lifetime and were only torn down at full system shutdown — visible as a large burst of `Flow-*-actorRefSource*` actors in shutdown logs.
- **Fix**: Introduces `SignalRSessionActor`, a per-session binding actor mirroring the `SlackThreadBindingActor` pattern. Each actor creates `Context.Materializer(namePrefix:"signalr")` scoped to its own context, making all stream actors its children. When the session ends, the actor stops → materializer disposes → all stream children are automatically cleaned up.
- **New actor hierarchy**: `/netclaw/user/signalr-gateway/{sessionId}` (owned, lifecycle-bound streams) replaces orphaned actors under `StreamSupervisor-0`.

## Changes

- `SignalRSessionActor` — per-session binding actor with `Initializing`/`Active` state machine, scoped materializer, pipeline reinitialization on stream termination, and `PostStop` cleanup
- `SignalRGatewayHostingExtensions` — registers `signalr-gateway` (`GenericChildPerEntityParent`) and `SignalRGatewayActorKey`
- `SessionRegistry` — rewritten to delegate pipeline lifecycle to the actor via `Tell`; now tracks session existence only (no stream state)
- `Program.cs` — wires `.WithSignalRGateway()` into the Akka builder
- `SessionRegistryTests` — rewritten to cover registry coordination behavior using a `StubRequiredActor`

## Test plan

- [ ] All existing tests pass (`dotnet test`)
- [ ] `dotnet slopwatch analyze` — no new violations
- [ ] Start daemon, run sessions, shut down — shutdown logs should show no `Flow-*-actorRefSource*` burst under `StreamSupervisor-0`
- [ ] Session actors appear under `/netclaw/user/signalr-gateway/` and stop when sessions end