### PR TITLE
fix(tests): replace Thread.Sleep with async Task.Delay in test cleanup

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "createdAt": "2026-02-21T18:55:14.1378608+00:00",
-  "updatedAt": "2026-03-02T20:00:17.1880024+00:00",
+  "updatedAt": "2026-03-12T23:29:28.7781033+00:00",
   "description": "Initial baseline created by 'slopwatch init' on 2026-02-21 18:55:14 UTC",
   "entries": [
     {
@@ -30,6 +30,33 @@
       "codeSnippet": "Task.Delay(Delay, cancellationToken)",
       "message": "Test uses Task.Delay(Delay) which may indicate a timing-dependent test",
       "baselinedAt": "2026-03-02T20:00:17.1879824+00:00"
+    },
+    {
+      "hash": "b691cefe260611c6",
+      "ruleId": "SW004",
+      "filePath": "src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs",
+      "lineNumber": 117,
+      "codeSnippet": "Task.Delay(25 * (i + 1))",
+      "message": "Test uses Task.Delay(25 * (i + 1)) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-03-12T23:29:28.3091789+00:00"
+    },
+    {
+      "hash": "1305b3c2911b984b",
+      "ruleId": "SW004",
+      "filePath": "src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs",
+      "lineNumber": 204,
+      "codeSnippet": "Task.Delay(25 * (i + 1))",
+      "message": "Test uses Task.Delay(25 * (i + 1)) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-03-12T23:29:28.3181295+00:00"
+    },
+    {
+      "hash": "6ea5c8bbead4b59c",
+      "ruleId": "SW004",
+      "filePath": "src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs",
+      "lineNumber": 61,
+      "codeSnippet": "Task.Delay(25 * (i + 1))",
+      "message": "Test uses Task.Delay(25 * (i + 1)) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-03-12T23:29:28.7781027+00:00"
     }
   ]
 }

--- a/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public sealed class MemoryEvalSeedSuiteTests : IDisposable
+public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
 {
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-memory-eval-tests", Guid.NewGuid().ToString("N"));
     private readonly string _dbPath;
@@ -178,12 +178,14 @@ public sealed class MemoryEvalSeedSuiteTests : IDisposable
         Assert.True(elapsed <= TimeSpan.FromMilliseconds(300));
     }
 
-    public void Dispose()
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
     {
-        TryDeleteDirectory(_baseDir);
+        await TryDeleteDirectoryAsync(_baseDir);
     }
 
-    private static void TryDeleteDirectory(string path)
+    private static async Task TryDeleteDirectoryAsync(string path)
     {
         if (!Directory.Exists(path))
             return;
@@ -199,11 +201,11 @@ public sealed class MemoryEvalSeedSuiteTests : IDisposable
             }
             catch (IOException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
             catch (UnauthorizedAccessException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
         }
 

--- a/src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public sealed class SQLiteMemoryStoreTests : IDisposable
+public sealed class SQLiteMemoryStoreTests : IAsyncLifetime
 {
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-sqlite-memory-tests", Guid.NewGuid().ToString("N"));
     private readonly string _dbPath;
@@ -91,12 +91,14 @@ public sealed class SQLiteMemoryStoreTests : IDisposable
         Assert.Equal(1, pending);
     }
 
-    public void Dispose()
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
     {
-        TryDeleteDirectory(_baseDir);
+        await TryDeleteDirectoryAsync(_baseDir);
     }
 
-    private static void TryDeleteDirectory(string path)
+    private static async Task TryDeleteDirectoryAsync(string path)
     {
         if (!Directory.Exists(path))
             return;
@@ -112,11 +114,11 @@ public sealed class SQLiteMemoryStoreTests : IDisposable
             }
             catch (IOException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
             catch (UnauthorizedAccessException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
         }
 

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Gateway;
 
-public sealed class DaemonRuntimeStatusServiceTests : IDisposable
+public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
 {
     private static readonly SessionConfig DefaultSessionConfig = new()
     {
@@ -35,12 +35,14 @@ public sealed class DaemonRuntimeStatusServiceTests : IDisposable
 
     private NetclawPaths CreatePaths() => new(_tempBase);
 
-    public void Dispose()
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
     {
-        TryDeleteDirectory(_tempBase);
+        await TryDeleteDirectoryAsync(_tempBase);
     }
 
-    private static void TryDeleteDirectory(string path)
+    private static async Task TryDeleteDirectoryAsync(string path)
     {
         if (!Directory.Exists(path))
             return;
@@ -56,11 +58,11 @@ public sealed class DaemonRuntimeStatusServiceTests : IDisposable
             }
             catch (IOException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
             catch (UnauthorizedAccessException) when (i < 7)
             {
-                Thread.Sleep(25 * (i + 1));
+                await Task.Delay(25 * (i + 1));
             }
         }
 


### PR DESCRIPTION
## Summary
- Converts `SQLiteMemoryStoreTests`, `MemoryEvalSeedSuiteTests`, and `DaemonRuntimeStatusServiceTests` from `IDisposable` to `IAsyncLifetime`
- Replaces blocking `Thread.Sleep` with non-blocking `await Task.Delay` in temp directory cleanup retry loops
- Baselines the SW004 warnings since these are file I/O retry delays in `DisposeAsync`, not timing-dependent tests

Addresses Slopwatch SW004 warnings surfaced in #197.

## Test plan
- [x] `dotnet build -c Release` passes with 0 warnings/errors
- [x] `dotnet slopwatch analyze` reports 0 issues
- [x] All 8 `SQLiteMemoryStoreTests` + `MemoryEvalSeedSuiteTests` pass
- [x] All 8 `DaemonRuntimeStatusServiceTests` pass