### PR TITLE
ci: add 10-minute timeout to smoke sandbox image build step

### DIFF
--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build smoke sandbox image (cached)
+        timeout-minutes: 10
         uses: docker/build-push-action@v7
         with:
           context: .


### PR DESCRIPTION
Prevent indefinitely hung Docker builds by enforcing a 10-minute timeout on the "Build smoke sandbox image" step in the smoke_sandbox workflow.