### PR TITLE
fix(providers): serialize tool calls and tool results in conversation history

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -154,6 +154,54 @@ data: [DONE]
         Assert.Equal("what is TextForge", toolCall.Arguments!["Query"]?.ToString());
     }
 
+    [Fact]
+    public async Task SerializesAssistantToolCalls_AndToolResults_InConversationHistory()
+    {
+        string? body = null;
+        using var handler = new RecordingHandler(req =>
+        {
+            body = req.Content is null ? null : req.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"id\":\"1\",\"model\":\"test\",\"choices\":[{\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"The answer is 4.\"}}]}",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        // Simulate a conversation with tool call history
+        var assistantWithToolCall = new ChatMessage(ChatRole.Assistant,
+        [
+            new FunctionCallContent("call_42", "calculator", new Dictionary<string, object?> { ["expression"] = "2+2" })
+        ]);
+        var toolResult = new ChatMessage(ChatRole.Tool,
+        [
+            new FunctionResultContent("call_42", "4")
+        ]);
+
+        await client.GetResponseAsync(
+        [
+            new ChatMessage(ChatRole.User, "What is 2+2?"),
+            assistantWithToolCall,
+            toolResult,
+            new ChatMessage(ChatRole.User, "Thanks, and what about 3+3?")
+        ]);
+
+        Assert.NotNull(body);
+
+        // Assistant message should include tool_calls array with id, function name, arguments
+        Assert.Contains("\"tool_calls\":", body, StringComparison.Ordinal);
+        Assert.Contains("\"id\":\"call_42\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"name\":\"calculator\"", body, StringComparison.Ordinal);
+
+        // Tool result message should include tool_call_id
+        Assert.Contains("\"tool_call_id\":\"call_42\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"role\":\"tool\"", body, StringComparison.Ordinal);
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;

--- a/src/Netclaw.OpenAICompatible/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.OpenAICompatible/OpenAiCompatibleChatClient.cs
@@ -167,11 +167,49 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
 
     private static object ToMessage(ChatMessage message)
     {
-        var text = message.Text;
+        var toolCalls = message.Contents.OfType<FunctionCallContent>().ToList();
+        var toolResult = message.Contents.OfType<FunctionResultContent>().FirstOrDefault();
+
+        // Tool result message — needs tool_call_id
+        if (message.Role == ChatRole.Tool && toolResult is not null)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["role"] = "tool",
+                ["tool_call_id"] = toolResult.CallId,
+                ["content"] = toolResult.Result?.ToString() ?? string.Empty
+            };
+        }
+
+        // Assistant message with tool calls — needs tool_calls array
+        if (message.Role == ChatRole.Assistant && toolCalls.Count > 0)
+        {
+            var text = message.Contents.OfType<TextContent>().FirstOrDefault()?.Text;
+            var calls = toolCalls.Select(tc => new Dictionary<string, object?>
+            {
+                ["id"] = tc.CallId,
+                ["type"] = "function",
+                ["function"] = new Dictionary<string, object?>
+                {
+                    ["name"] = tc.Name,
+                    ["arguments"] = tc.Arguments is not null
+                        ? JsonSerializer.Serialize(tc.Arguments, JsonOptions)
+                        : "{}"
+                }
+            }).ToArray();
+
+            return new Dictionary<string, object?>
+            {
+                ["role"] = "assistant",
+                ["content"] = text,
+                ["tool_calls"] = calls
+            };
+        }
+
         return new Dictionary<string, object?>
         {
             ["role"] = ToRole(message.Role),
-            ["content"] = text
+            ["content"] = message.Text
         };
     }
 


### PR DESCRIPTION
## Summary

- `OpenAiCompatibleChatClient.ToMessage()` was serializing all non-system messages as simple `{"role": "...", "content": "..."}` objects, dropping `tool_calls` from assistant messages and `tool_call_id` from tool result messages
- This broke multi-turn tool calling: the first tool call would succeed, but follow-up LLM requests contained malformed history causing the model to fall back to emitting tool calls as raw text
- Fix adds proper serialization for assistant messages with `FunctionCallContent` (emits `tool_calls` array) and tool result messages with `FunctionResultContent` (emits `tool_call_id`)

## Test plan

- [x] New test `SerializesAssistantToolCalls_AndToolResults_InConversationHistory` verifies correct payload structure
- [x] All 6 existing `OpenAiCompatibleChatClientTests` pass
- [x] Hit-tested against live lemonade/Qwen3.5 endpoint on big-gpu — single and multi-tool calls confirmed working via `netclaw -p`