### PR TITLE
ci: cache NuGet packages in Docker build using BuildKit mount

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,10 @@
     <AkkaPersistenceSqlHostingVersion>1.5.60.1</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.5.0</AkkaRemindersVersion>
     <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
+    <SlackNetVersion>0.17.9</SlackNetVersion>
+    <MimeDetectiveVersion>25.8.1</MimeDetectiveVersion>
+    <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftAspNetCoreVersion>10.0.3</MicrosoftAspNetCoreVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
@@ -18,30 +22,30 @@
     <PackageVersion Include="Aaron.Akka.Reminders.Sqlite" Version="$(AkkaRemindersVersion)" />
     <PackageVersion Include="Anthropic" Version="12.8.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="$(MicrosoftExtensionsAIVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
-    <PackageVersion Include="SlackNet" Version="0.17.9" />
-    <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="0.17.9" />
+    <PackageVersion Include="SlackNet" Version="$(SlackNetVersion)" />
+    <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.8.4" />
     <PackageVersion Include="Termina" Version="0.7.2" />
-    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
-    <PackageVersion Include="Mime-Detective.Definitions.Condensed" Version="25.8.1" />
+    <PackageVersion Include="Mime-Detective" Version="$(MimeDetectiveVersion)" />
+    <PackageVersion Include="Mime-Detective.Definitions.Condensed" Version="$(MimeDetectiveVersion)" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/docker/smoke/Dockerfile
+++ b/docker/smoke/Dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet restore Netclaw.slnx
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore Netclaw.slnx
 RUN dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj -c Release -o /out/cli
 RUN dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj -c Release -o /out/daemon
 


### PR DESCRIPTION
## Summary

- Adds `--mount=type=cache,id=nuget,target=/root/.nuget/packages` to the `dotnet restore` step in the smoke sandbox Dockerfile
- The NuGet package cache persists on the self-hosted runner host across builds, eliminating cold-restore timeouts

## Problem

The smoke sandbox Docker build was hitting the 10-minute timeout during `dotnet restore` on cold runs against our self-hosted ARC runner.

## Test plan

- [x] Local build verified: first run populates cache, second run hits `CACHED` and completes in <1s
- [ ] CI passes on self-hosted runner