### PR TITLE
Surface API error details in provider probe failures

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+# Start with one high-signal reliability rule as warning.
+dotnet_diagnostic.CA2016.severity = warning
+
+# Ramp-up candidates (kept as suggestion initially to avoid noisy CI failures).
+dotnet_diagnostic.CA1307.severity = suggestion
+dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1310.severity = suggestion
+dotnet_diagnostic.CA2000.severity = suggestion
+dotnet_diagnostic.CA2213.severity = suggestion
+dotnet_diagnostic.IDE0072.severity = suggestion
+
+[*.{md,json,yml,yaml}]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,13 +10,21 @@ trim_trailing_whitespace = true
 # Start with one high-signal reliability rule as warning.
 dotnet_diagnostic.CA2016.severity = warning
 
+# Promote string comparison correctness to warning.
+dotnet_diagnostic.CA1307.severity = warning
+dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.CA1310.severity = warning
+
 # Ramp-up candidates (kept as suggestion initially to avoid noisy CI failures).
-dotnet_diagnostic.CA1307.severity = suggestion
-dotnet_diagnostic.CA1309.severity = suggestion
-dotnet_diagnostic.CA1310.severity = suggestion
 dotnet_diagnostic.CA2000.severity = suggestion
 dotnet_diagnostic.CA2213.severity = suggestion
 dotnet_diagnostic.IDE0072.severity = suggestion
+
+[**/*Tests/**/*.cs]
+# Keep test assertion migrations incremental.
+dotnet_diagnostic.CA1307.severity = suggestion
+dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1310.severity = suggestion
 
 [*.{md,json,yml,yaml}]
 trim_trailing_whitespace = false

--- a/src/Netclaw.Actors/Memory/FileMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/FileMemoryStore.cs
@@ -331,9 +331,11 @@ public sealed partial class FileMemoryStore
         return $"{date:yyyy-MM-dd}-{kebab}.md";
     }
 
-    private static string EscapeYamlString(string value) => value.Replace("\"", "\\\"");
+    private static string EscapeYamlString(string value)
+        => value.Replace("\"", "\\\"", StringComparison.Ordinal);
 
-    private static string EscapeMarkdownPipe(string value) => value.Replace("|", "\\|");
+    private static string EscapeMarkdownPipe(string value)
+        => value.Replace("|", "\\|", StringComparison.Ordinal);
 
     private MemoryEntry? FindEntryById(string id)
     {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1398,10 +1398,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor
         foreach (var line in searchToolOutput.Split('\n'))
         {
             var trimmed = line.TrimStart();
-            if (!trimmed.Contains(" — "))
+            var separatorIndex = trimmed.IndexOf(" — ", StringComparison.Ordinal);
+            if (separatorIndex < 0)
                 continue;
 
-            var toolName = trimmed.Split(" — ")[0].Trim();
+            var toolName = trimmed[..separatorIndex].Trim();
             if (string.IsNullOrEmpty(toolName))
                 continue;
 

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -131,7 +131,9 @@ public sealed class ToolRegistry
                 var nameLower = t.Tool.Name.ToLowerInvariant();
                 var descLower = t.Tool.Description.ToLowerInvariant();
 
-                return queryParts.Any(p => nameLower.Contains(p) || descLower.Contains(p));
+                return queryParts.Any(p =>
+                    nameLower.Contains(p, StringComparison.Ordinal)
+                    || descLower.Contains(p, StringComparison.Ordinal));
             })
             .Take(maxResults)
             .Select(t => t.Tool)

--- a/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
@@ -50,12 +50,12 @@ public static partial class SlackBlockConverter
             }
 
             // Code block: ```
-            if (trimmed.StartsWith("```"))
+            if (trimmed.StartsWith("```", StringComparison.Ordinal))
             {
                 FlushRichText(blocks, currentRichTextElements);
                 i++; // skip opening ```
                 var codeLines = new List<string>();
-                while (i < lines.Length && !lines[i].TrimStart().StartsWith("```"))
+                while (i < lines.Length && !lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal))
                 {
                     codeLines.Add(lines[i]);
                     i++;
@@ -72,7 +72,7 @@ public static partial class SlackBlockConverter
             }
 
             // Blockquote: > text
-            if (trimmed.StartsWith("> "))
+            if (trimmed.StartsWith("> ", StringComparison.Ordinal))
             {
                 FlushRichText(blocks, currentRichTextElements);
                 var quoteText = trimmed[2..];
@@ -269,14 +269,15 @@ public static partial class SlackBlockConverter
 
     private static bool IsBulletListItem(string trimmed)
     {
-        return (trimmed.StartsWith("- ") || trimmed.StartsWith("* "))
-            && !trimmed.StartsWith("**"); // Don't match bold markers
+        return (trimmed.StartsWith("- ", StringComparison.Ordinal)
+                || trimmed.StartsWith("* ", StringComparison.Ordinal))
+            && !trimmed.StartsWith("**", StringComparison.Ordinal); // Don't match bold markers
     }
 
     private static string StripBulletPrefix(string trimmed)
     {
-        if (trimmed.StartsWith("- ")) return trimmed[2..];
-        if (trimmed.StartsWith("* ")) return trimmed[2..];
+        if (trimmed.StartsWith("- ", StringComparison.Ordinal)) return trimmed[2..];
+        if (trimmed.StartsWith("* ", StringComparison.Ordinal)) return trimmed[2..];
         return trimmed;
     }
 

--- a/src/Netclaw.Channels/Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackReplyClient.cs
@@ -15,7 +15,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             ThreadTs = message.ThreadTs.Value,
             Text = message.Text, // fallback for notifications
             Blocks = blocks
-        });
+        }, cancellationToken);
     }
 
     public async Task UploadFileToThreadAsync(

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -75,7 +75,7 @@ public sealed class HeadlessChannel : IChannel
 
             // Set up session log file
             _paths.EnsureDirectoriesExist();
-            var logFileName = $"{sessionId.Value.Replace("/", "-")}.log";
+            var logFileName = $"{sessionId.Value.Replace("/", "-", StringComparison.Ordinal)}.log";
             var logPath = Path.Combine(_paths.LogsDirectory, logFileName);
             await using var logWriter = new StreamWriter(logPath, append: false) { AutoFlush = true };
 

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -101,7 +101,7 @@ internal static class McpCommand
             if (args[i] == "--env" && i + 1 < args.Length)
             {
                 var kv = args[++i];
-                var eqIdx = kv.IndexOf('=');
+                var eqIdx = kv.IndexOf('=', StringComparison.Ordinal);
                 if (eqIdx > 0)
                     envVars[kv[..eqIdx]] = kv[(eqIdx + 1)..];
                 continue;
@@ -110,7 +110,7 @@ internal static class McpCommand
             if (args[i] == "--header" && i + 1 < args.Length)
             {
                 var hv = args[++i];
-                var colonIdx = hv.IndexOf(':');
+                var colonIdx = hv.IndexOf(':', StringComparison.Ordinal);
                 if (colonIdx > 0)
                     headers[hv[..colonIdx].Trim()] = hv[(colonIdx + 1)..].Trim();
                 continue;

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -128,8 +128,8 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                         _ when status.StartsWith("Connected", StringComparison.Ordinal) => Color.Green,
                         _ when status.StartsWith("Reconnected", StringComparison.Ordinal) => Color.Green,
                         _ when status.StartsWith("Disconnected", StringComparison.Ordinal) => Color.Red,
-                        _ when status.StartsWith("Generating") => Color.Yellow,
-                        _ when status.StartsWith("Connection failed") => Color.Red,
+                        _ when status.StartsWith("Generating", StringComparison.Ordinal) => Color.Yellow,
+                        _ when status.StartsWith("Connection failed", StringComparison.Ordinal) => Color.Red,
                         _ => Color.BrightBlack
                     };
 

--- a/src/Netclaw.Configuration.Tests/DataProtectionSecretsProtectorTests.cs
+++ b/src/Netclaw.Configuration.Tests/DataProtectionSecretsProtectorTests.cs
@@ -26,7 +26,7 @@ public sealed class DataProtectionSecretsProtectorTests : IDisposable
     public void Protect_returns_ENC_prefixed_value()
     {
         var result = _protector.Protect("my-secret");
-        Assert.StartsWith("ENC:", result);
+        Assert.StartsWith("ENC:", result, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Configuration.Providers;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers;
+
+public class ProbeHelpersTests
+{
+    // ── FailForStatus ──
+
+    [Fact]
+    public void FailForStatus_Forbidden_WithDetail_IncludesDetail()
+    {
+        var result = ProbeHelpers.FailForStatus(
+            HttpStatusCode.Forbidden, "openai", "Insufficient permissions for model listing.");
+
+        Assert.False(result.Success);
+        Assert.Contains("Access denied by openai", result.ErrorMessage);
+        Assert.Contains("Insufficient permissions for model listing.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Forbidden_WithoutDetail_ShowsGenericMessage()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Forbidden, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials may lack model-listing permissions", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Unauthorized_WithDetail_IncludesDetail()
+    {
+        var result = ProbeHelpers.FailForStatus(
+            HttpStatusCode.Unauthorized, "openai", "Invalid API key provided.");
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid credentials for openai", result.ErrorMessage);
+        Assert.Contains("Invalid API key provided.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Unauthorized_SaysCredentials_NotApiKey()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Unauthorized, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials", result.ErrorMessage);
+        Assert.DoesNotContain("API key", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Forbidden_SaysCredentials_NotApiKey()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Forbidden, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials", result.ErrorMessage);
+        Assert.DoesNotContain("API key", result.ErrorMessage);
+    }
+
+    // ── ExtractApiErrorDetailAsync ──
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_NestedErrorObject_ExtractsMessage()
+    {
+        var response = JsonErrorResponse(new
+        {
+            error = new { message = "You have insufficient permissions.", type = "permission_error" }
+        });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Equal("You have insufficient permissions.", detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_StringError_ExtractsString()
+    {
+        var response = JsonErrorResponse(new { error = "invalid_token" });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Equal("invalid_token", detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_EmptyBody_ReturnsNull()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("", Encoding.UTF8, "application/json")
+        };
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_InvalidJson_ReturnsNull()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("not json at all", Encoding.UTF8, "text/plain")
+        };
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_NoErrorProperty_ReturnsNull()
+    {
+        var response = JsonErrorResponse(new { status = "error", reason = "unknown" });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    // ── ExecuteProbeAsync integration with error detail ──
+
+    [Fact]
+    public async Task ExecuteProbeAsync_403WithJsonError_IncludesErrorDetailInResult()
+    {
+        var handler = new FakeHttpMessageHandler(_ => JsonErrorResponse(
+            new { error = new { message = "Token lacks model-listing scope." } },
+            HttpStatusCode.Forbidden));
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Access denied by openai", result.ErrorMessage);
+        Assert.Contains("Token lacks model-listing scope.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteProbeAsync_401WithStringError_IncludesErrorDetailInResult()
+    {
+        var handler = new FakeHttpMessageHandler(_ => JsonErrorResponse(
+            new { error = "invalid_api_key" },
+            HttpStatusCode.Unauthorized));
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid credentials for openai", result.ErrorMessage);
+        Assert.Contains("invalid_api_key", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteProbeAsync_403WithInvalidJsonBody_FallsBackToGenericMessage()
+    {
+        var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("<html>Forbidden</html>", Encoding.UTF8, "text/html")
+        });
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials may lack model-listing permissions", result.ErrorMessage);
+    }
+
+    // ── Helpers ──
+
+    private static HttpResponseMessage JsonErrorResponse(
+        object body, HttpStatusCode status = HttpStatusCode.Forbidden)
+    {
+        var json = JsonSerializer.Serialize(body);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Configuration.Tests/SecretsFileWriterTests.cs
+++ b/src/Netclaw.Configuration.Tests/SecretsFileWriterTests.cs
@@ -29,7 +29,7 @@ public sealed class SecretsFileWriterTests : IDisposable
         SecretsFileWriter.Write(_secretsPath, json);
 
         Assert.True(File.Exists(_secretsPath));
-        Assert.Contains("key", File.ReadAllText(_secretsPath));
+        Assert.Contains("key", File.ReadAllText(_secretsPath), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class SecretsFileWriterTests : IDisposable
         SecretsFileWriter.Write(_secretsPath, json, protector);
 
         var result = File.ReadAllText(_secretsPath);
-        Assert.DoesNotContain("sk-secret123", result);
-        Assert.DoesNotContain("tok-abc", result);
-        Assert.Contains("ENC:", result);
+        Assert.DoesNotContain("sk-secret123", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("tok-abc", result, StringComparison.Ordinal);
+        Assert.Contains("ENC:", result, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration/BuildInfo.cs
+++ b/src/Netclaw.Configuration/BuildInfo.cs
@@ -58,7 +58,7 @@ public static class BuildInfo
         if (informational is null)
             return "unknown";
 
-        var plusIndex = informational.IndexOf('+');
+        var plusIndex = informational.IndexOf('+', StringComparison.Ordinal);
         if (plusIndex < 0 || plusIndex + 1 >= informational.Length)
             return "unknown";
 

--- a/src/Netclaw.Configuration/ModelIdNormalizer.cs
+++ b/src/Netclaw.Configuration/ModelIdNormalizer.cs
@@ -40,7 +40,7 @@ public static partial class ModelIdNormalizer
         var working = modelId;
 
         // Strip Ollama tag suffixes (:latest, :7b, :q4_0, etc.)
-        var colonIndex = working.IndexOf(':');
+        var colonIndex = working.IndexOf(':', StringComparison.Ordinal);
         if (colonIndex > 0)
         {
             var stripped = working[..colonIndex];
@@ -57,7 +57,7 @@ public static partial class ModelIdNormalizer
         }
 
         // If no slash (not already prefixed), try adding known provider prefixes
-        if (!working.Contains('/'))
+        if (!working.Contains('/', StringComparison.Ordinal))
         {
             foreach (var (prefix, provider) in KnownPrefixes)
             {

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Configuration.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />

--- a/src/Netclaw.Configuration/Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Configuration/Providers/ProbeHelpers.cs
@@ -63,7 +63,10 @@ internal static class ProbeHelpers
             using var response = await httpClient.SendAsync(request, timeoutCts.Token);
 
             if (!response.IsSuccessStatusCode)
-                return FailForStatus(response.StatusCode, providerName);
+            {
+                var apiErrorDetail = await ExtractApiErrorDetailAsync(response, timeoutCts.Token);
+                return FailForStatus(response.StatusCode, providerName, apiErrorDetail);
+            }
 
             var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
             return parseResponse(json);
@@ -86,15 +89,20 @@ internal static class ProbeHelpers
     /// <summary>
     /// Maps HTTP status codes to user-friendly error messages.
     /// Covers auth errors (401/403), rate limiting (429), and server errors (5xx).
+    /// When <paramref name="apiErrorDetail"/> is provided, it is appended to auth
+    /// error messages so users can see the actual reason from the provider.
     /// </summary>
-    public static ProviderProbeResult FailForStatus(HttpStatusCode statusCode, string providerName)
+    public static ProviderProbeResult FailForStatus(
+        HttpStatusCode statusCode, string providerName, string? apiErrorDetail = null)
     {
         var message = statusCode switch
         {
-            HttpStatusCode.Unauthorized =>
-                $"Invalid credentials. Double-check your {providerName} API key.",
-            HttpStatusCode.Forbidden =>
-                $"Access denied. Your {providerName} API key may lack model-listing permissions.",
+            HttpStatusCode.Unauthorized => apiErrorDetail is not null
+                ? $"Invalid credentials for {providerName}: {apiErrorDetail}"
+                : $"Invalid credentials. Double-check your {providerName} credentials.",
+            HttpStatusCode.Forbidden => apiErrorDetail is not null
+                ? $"Access denied by {providerName}: {apiErrorDetail}"
+                : $"Access denied. Your {providerName} credentials may lack model-listing permissions.",
             HttpStatusCode.NotFound =>
                 $"The {providerName} models API was not found. The service may be down.",
             HttpStatusCode.TooManyRequests =>
@@ -107,5 +115,38 @@ internal static class ProbeHelpers
         };
 
         return new ProviderProbeResult(false, message, []);
+    }
+
+    /// <summary>
+    /// Best-effort extraction of an error detail string from an HTTP error response body.
+    /// Handles OpenAI-style <c>{"error": {"message": "..."}}</c> and simple
+    /// <c>{"error": "..."}</c> formats.
+    /// </summary>
+    internal static async Task<string?> ExtractApiErrorDetailAsync(
+        HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("error", out var errorProp))
+                return null;
+
+            return errorProp.ValueKind switch
+            {
+                JsonValueKind.Object when errorProp.TryGetProperty("message", out var msgProp) =>
+                    msgProp.GetString(),
+                JsonValueKind.String => errorProp.GetString(),
+                _ => null
+            };
+        }
+        catch
+        {
+            // Best-effort: malformed body, non-JSON content, etc.
+            return null;
+        }
     }
 }

--- a/src/Netclaw.Daemon/BuildInfo.cs
+++ b/src/Netclaw.Daemon/BuildInfo.cs
@@ -39,7 +39,7 @@ internal static class BuildInfo
         if (informational is null)
             return "unknown";
 
-        var plusIndex = informational.IndexOf('+');
+        var plusIndex = informational.IndexOf('+', StringComparison.Ordinal);
         if (plusIndex < 0 || plusIndex + 1 >= informational.Length)
             return "unknown";
 

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -81,7 +81,8 @@ internal sealed class McpOAuthService
             {
                 foreach (var auth in probeResponse.Headers.WwwAuthenticate)
                 {
-                    if (auth.Parameter is not null && auth.Parameter.Contains("resource_metadata"))
+                    if (auth.Parameter is not null
+                        && auth.Parameter.Contains("resource_metadata", StringComparison.Ordinal))
                     {
                         resourceMetadataUri = ExtractQuotedParam(auth.Parameter, "resource_metadata");
                     }
@@ -346,7 +347,7 @@ internal sealed class McpOAuthService
             if (!response.IsSuccessStatusCode)
             {
                 var errorBody = await response.Content.ReadAsStringAsync(ct);
-                if (errorBody.Contains("invalid_grant"))
+                if (errorBody.Contains("invalid_grant", StringComparison.Ordinal))
                 {
                     _logger.LogWarning("Refresh token rejected for MCP server '{Name}' (invalid_grant). Re-authorization required.", serverName);
                     _tokens.TryRemove(serverName, out _);

--- a/src/Netclaw.Daemon/Providers/HuggingFaceCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/HuggingFaceCapabilityResolver.cs
@@ -30,7 +30,7 @@ public sealed class HuggingFaceCapabilityResolver : IModelCapabilityResolver
         var hfId = modelId;
 
         // Strip Ollama tags
-        var colonIdx = hfId.IndexOf(':');
+        var colonIdx = hfId.IndexOf(':', StringComparison.Ordinal);
         if (colonIdx > 0)
             hfId = hfId[..colonIdx];
 

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -23,8 +23,8 @@ public class BraveSearchBackendTests
         var results = BraveSearchBackend.ParseResults(json, 30);
 
         var first = results[0];
-        Assert.Contains("akka.net", first.Url);
-        Assert.Contains("akkadotnet", first.Title.ToLowerInvariant());
+        Assert.Contains("akka.net", first.Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("akkadotnet", first.Title, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -73,11 +73,11 @@ public class BraveSearchBackendTests
 
         var first = results[0];
         // Fixture description contains "<strong>a .NET port...</strong>" and "&amp;"
-        Assert.DoesNotContain("<strong>", first.Snippet);
-        Assert.DoesNotContain("</strong>", first.Snippet);
-        Assert.DoesNotContain("&amp;", first.Snippet);
+        Assert.DoesNotContain("<strong>", first.Snippet, StringComparison.Ordinal);
+        Assert.DoesNotContain("</strong>", first.Snippet, StringComparison.Ordinal);
+        Assert.DoesNotContain("&amp;", first.Snippet, StringComparison.Ordinal);
         // Verify the decoded content is present
-        Assert.Contains("a .NET port", first.Snippet);
+        Assert.Contains("a .NET port", first.Snippet, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Search.Tests/DuckDuckGoBackendTests.cs
+++ b/src/Netclaw.Search.Tests/DuckDuckGoBackendTests.cs
@@ -21,8 +21,8 @@ public class DuckDuckGoBackendTests
         var results = DuckDuckGoBackend.ParseResults(html, 30);
 
         var first = results[0];
-        Assert.Contains("akka.net", first.Url);
-        Assert.Contains("GitHub", first.Title);
+        Assert.Contains("akka.net", first.Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("GitHub", first.Title, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -73,8 +73,8 @@ public class DuckDuckGoBackendTests
 
         Assert.All(results, r =>
         {
-            Assert.DoesNotContain("&amp;", r.Snippet);
-            Assert.DoesNotContain("&#x27;", r.Snippet);
+            Assert.DoesNotContain("&amp;", r.Snippet, StringComparison.Ordinal);
+            Assert.DoesNotContain("&#x27;", r.Snippet, StringComparison.Ordinal);
         });
     }
 
@@ -84,7 +84,7 @@ public class DuckDuckGoBackendTests
         var html = LoadFixture("ddg-lite-akka-dotnet.html");
         var results = DuckDuckGoBackend.ParseResults(html, 30);
 
-        Assert.All(results, r => Assert.StartsWith("http", r.Url));
+        Assert.All(results, r => Assert.StartsWith("http", r.Url, StringComparison.OrdinalIgnoreCase));
     }
 
     private static string LoadFixture(string filename)

--- a/src/Netclaw.Search.Tests/SearXngBackendTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendTests.cs
@@ -21,8 +21,8 @@ public class SearXngBackendTests
         var results = SearXngBackend.ParseResults(json, 30);
 
         var first = results[0];
-        Assert.Contains("akka.net", first.Url);
-        Assert.Contains("akkadotnet", first.Title.ToLowerInvariant());
+        Assert.Contains("akka.net", first.Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("akkadotnet", first.Title, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Search/DuckDuckGoBackend.cs
+++ b/src/Netclaw.Search/DuckDuckGoBackend.cs
@@ -172,7 +172,7 @@ public sealed class DuckDuckGoBackend : ISearchBackend
             if (uddgIndex >= 0)
             {
                 var encoded = rawUrl[(uddgIndex + 5)..];
-                var ampIndex = encoded.IndexOf('&');
+                var ampIndex = encoded.IndexOf('&', StringComparison.Ordinal);
                 if (ampIndex >= 0)
                     encoded = encoded[..ampIndex];
                 var decoded = Uri.UnescapeDataString(encoded);

--- a/src/Netclaw.Security.Tests/FilenameSanitizerTests.cs
+++ b/src/Netclaw.Security.Tests/FilenameSanitizerTests.cs
@@ -53,7 +53,7 @@ public sealed class FilenameSanitizerTests
         var result = FilenameSanitizer.Sanitize(longName);
 
         Assert.True(result.Length <= 255);
-        Assert.EndsWith(".png", result);
+        Assert.EndsWith(".png", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
+++ b/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
@@ -11,9 +11,9 @@ public sealed class SecretOutputRedactorTests
 
         var redacted = SecretOutputRedactor.Redact(input);
 
-        Assert.Contains("\"apiKey\": \"***REDACTED***\"", redacted);
-        Assert.Contains("\"safe\": \"ok\"", redacted);
-        Assert.DoesNotContain("sk-or-test-123", redacted);
+        Assert.Contains("\"apiKey\": \"***REDACTED***\"", redacted, StringComparison.Ordinal);
+        Assert.Contains("\"safe\": \"ok\"", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("sk-or-test-123", redacted, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -23,9 +23,9 @@ public sealed class SecretOutputRedactorTests
 
         var redacted = SecretOutputRedactor.Redact(input);
 
-        Assert.Contains("API_KEY=***REDACTED***", redacted);
-        Assert.Contains("NORMAL=value", redacted);
-        Assert.DoesNotContain("secret123", redacted);
+        Assert.Contains("API_KEY=***REDACTED***", redacted, StringComparison.Ordinal);
+        Assert.Contains("NORMAL=value", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret123", redacted, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Netclaw.Security/FilenameSanitizer.cs
+++ b/src/Netclaw.Security/FilenameSanitizer.cs
@@ -30,7 +30,7 @@ public static partial class FilenameSanitizer
         sanitized = PlatformProblemCharRegex().Replace(sanitized, "_");
 
         // Remove path traversal sequences
-        sanitized = sanitized.Replace("..", "_");
+        sanitized = sanitized.Replace("..", "_", StringComparison.Ordinal);
 
         // Trim whitespace and dots from ends
         sanitized = sanitized.Trim().Trim('.');

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -246,11 +246,11 @@ public sealed class ToolPathPolicy
         if (token.StartsWith("-", StringComparison.Ordinal))
             return false;
 
-        return token.Contains('/')
-            || token.Contains('\\')
+        return token.Contains('/', StringComparison.Ordinal)
+            || token.Contains('\\', StringComparison.Ordinal)
             || token.StartsWith(".", StringComparison.Ordinal)
             || token.StartsWith("~", StringComparison.Ordinal)
-            || token.Contains(':')
+            || token.Contains(':', StringComparison.Ordinal)
             || token.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary

- Provider probe failures (401/403) now read the HTTP response body and extract the actual error message from the provider API, surfacing it to the user instead of a generic message
- Changes "API key" wording to "credentials" in 401/403 error messages so it is accurate for both API key and OAuth authentication paths
- Adds `ExtractApiErrorDetailAsync` helper that handles both OpenAI-style `{"error": {"message": "..."}}` and simple `{"error": "..."}` JSON formats with best-effort fallback

Closes #191 (diagnostic step — enables root-cause identification for the false 403 errors)
Related: #173

## Motivation

Users report that the OpenAI provider probe returns "Access denied. Your openai API key may lack model-listing permissions" even when the same token works on other platforms. The error message was misleading because:
1. The actual API error detail was discarded — only the HTTP status code was checked
2. It said "API key" even when the user authenticated via OAuth

This change surfaces the real error so we can identify the root cause (likely missing OAuth scopes or endpoint misconfiguration) in a follow-up fix.

## Test plan

- [x] `dotnet build` — solution compiles (0 warnings, 0 errors)
- [x] `dotnet test` — all 40 Configuration tests pass (11 new ProbeHelpersTests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual: configure an OpenAI provider, trigger a 403, confirm the error message now shows the actual API error detail
- [ ] Verify Anthropic/OpenRouter/Ollama probes still work (shared ProbeHelpers infrastructure)