### PR TITLE
fix(smoke): enable InvariantGlobalization to eliminate ICU dependency

### DIFF
--- a/src/Netclaw.Cli/Netclaw.Cli.csproj
+++ b/src/Netclaw.Cli/Netclaw.Cli.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Enables `InvariantGlobalization` in both `Netclaw.Cli` and `Netclaw.Daemon` csproj files
- Fixes the `Couldn't find a valid ICU package installed on the system` crash when running self-contained binaries in the bare `ubuntu:24.04` smoke sandbox container
- Makes published binaries portable to any Linux system without requiring system ICU libraries

## Root Cause

After #220 moved `dotnet publish` to the host runner (to avoid cold NuGet cache timeouts), the self-contained binaries are copied into a minimal `ubuntu:24.04` container that only has `curl` and `procps` — no `libicu`. The .NET runtime requires ICU for globalization unless `InvariantGlobalization` is explicitly enabled.

## Test plan

- [ ] Smoke sandbox workflow passes (binary no longer crashes on startup)
- [ ] PR validation build succeeds
- [ ] Verify `runtimeconfig.json` includes `"System.Globalization.Invariant": true`