### PR TITLE
Surface API error details in provider probe failures

### DIFF
--- a/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/ProbeHelpersTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Configuration.Providers;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Providers;
+
+public class ProbeHelpersTests
+{
+    // ── FailForStatus ──
+
+    [Fact]
+    public void FailForStatus_Forbidden_WithDetail_IncludesDetail()
+    {
+        var result = ProbeHelpers.FailForStatus(
+            HttpStatusCode.Forbidden, "openai", "Insufficient permissions for model listing.");
+
+        Assert.False(result.Success);
+        Assert.Contains("Access denied by openai", result.ErrorMessage);
+        Assert.Contains("Insufficient permissions for model listing.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Forbidden_WithoutDetail_ShowsGenericMessage()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Forbidden, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials may lack model-listing permissions", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Unauthorized_WithDetail_IncludesDetail()
+    {
+        var result = ProbeHelpers.FailForStatus(
+            HttpStatusCode.Unauthorized, "openai", "Invalid API key provided.");
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid credentials for openai", result.ErrorMessage);
+        Assert.Contains("Invalid API key provided.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Unauthorized_SaysCredentials_NotApiKey()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Unauthorized, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials", result.ErrorMessage);
+        Assert.DoesNotContain("API key", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailForStatus_Forbidden_SaysCredentials_NotApiKey()
+    {
+        var result = ProbeHelpers.FailForStatus(HttpStatusCode.Forbidden, "openai");
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials", result.ErrorMessage);
+        Assert.DoesNotContain("API key", result.ErrorMessage);
+    }
+
+    // ── ExtractApiErrorDetailAsync ──
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_NestedErrorObject_ExtractsMessage()
+    {
+        var response = JsonErrorResponse(new
+        {
+            error = new { message = "You have insufficient permissions.", type = "permission_error" }
+        });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Equal("You have insufficient permissions.", detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_StringError_ExtractsString()
+    {
+        var response = JsonErrorResponse(new { error = "invalid_token" });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Equal("invalid_token", detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_EmptyBody_ReturnsNull()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("", Encoding.UTF8, "application/json")
+        };
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_InvalidJson_ReturnsNull()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("not json at all", Encoding.UTF8, "text/plain")
+        };
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public async Task ExtractApiErrorDetail_NoErrorProperty_ReturnsNull()
+    {
+        var response = JsonErrorResponse(new { status = "error", reason = "unknown" });
+
+        var detail = await ProbeHelpers.ExtractApiErrorDetailAsync(response, CancellationToken.None);
+
+        Assert.Null(detail);
+    }
+
+    // ── ExecuteProbeAsync integration with error detail ──
+
+    [Fact]
+    public async Task ExecuteProbeAsync_403WithJsonError_IncludesErrorDetailInResult()
+    {
+        var handler = new FakeHttpMessageHandler(_ => JsonErrorResponse(
+            new { error = new { message = "Token lacks model-listing scope." } },
+            HttpStatusCode.Forbidden));
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Access denied by openai", result.ErrorMessage);
+        Assert.Contains("Token lacks model-listing scope.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteProbeAsync_401WithStringError_IncludesErrorDetailInResult()
+    {
+        var handler = new FakeHttpMessageHandler(_ => JsonErrorResponse(
+            new { error = "invalid_api_key" },
+            HttpStatusCode.Unauthorized));
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid credentials for openai", result.ErrorMessage);
+        Assert.Contains("invalid_api_key", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteProbeAsync_403WithInvalidJsonBody_FallsBackToGenericMessage()
+    {
+        var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("<html>Forbidden</html>", Encoding.UTF8, "text/html")
+        });
+
+        var httpClient = new HttpClient(handler);
+        var result = await ProbeHelpers.ExecuteProbeAsync(
+            httpClient, "openai", "https://api.example.com", "/v1/models",
+            null, _ => { }, _ => throw new InvalidOperationException("Should not parse on error"),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("credentials may lack model-listing permissions", result.ErrorMessage);
+    }
+
+    // ── Helpers ──
+
+    private static HttpResponseMessage JsonErrorResponse(
+        object body, HttpStatusCode status = HttpStatusCode.Forbidden)
+    {
+        var json = JsonSerializer.Serialize(body);
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Netclaw.Configuration.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />

--- a/src/Netclaw.Configuration/Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Configuration/Providers/ProbeHelpers.cs
@@ -63,7 +63,10 @@ internal static class ProbeHelpers
             using var response = await httpClient.SendAsync(request, timeoutCts.Token);
 
             if (!response.IsSuccessStatusCode)
-                return FailForStatus(response.StatusCode, providerName);
+            {
+                var apiErrorDetail = await ExtractApiErrorDetailAsync(response, timeoutCts.Token);
+                return FailForStatus(response.StatusCode, providerName, apiErrorDetail);
+            }
 
             var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
             return parseResponse(json);
@@ -86,15 +89,20 @@ internal static class ProbeHelpers
     /// <summary>
     /// Maps HTTP status codes to user-friendly error messages.
     /// Covers auth errors (401/403), rate limiting (429), and server errors (5xx).
+    /// When <paramref name="apiErrorDetail"/> is provided, it is appended to auth
+    /// error messages so users can see the actual reason from the provider.
     /// </summary>
-    public static ProviderProbeResult FailForStatus(HttpStatusCode statusCode, string providerName)
+    public static ProviderProbeResult FailForStatus(
+        HttpStatusCode statusCode, string providerName, string? apiErrorDetail = null)
     {
         var message = statusCode switch
         {
-            HttpStatusCode.Unauthorized =>
-                $"Invalid credentials. Double-check your {providerName} API key.",
-            HttpStatusCode.Forbidden =>
-                $"Access denied. Your {providerName} API key may lack model-listing permissions.",
+            HttpStatusCode.Unauthorized => apiErrorDetail is not null
+                ? $"Invalid credentials for {providerName}: {apiErrorDetail}"
+                : $"Invalid credentials. Double-check your {providerName} credentials.",
+            HttpStatusCode.Forbidden => apiErrorDetail is not null
+                ? $"Access denied by {providerName}: {apiErrorDetail}"
+                : $"Access denied. Your {providerName} credentials may lack model-listing permissions.",
             HttpStatusCode.NotFound =>
                 $"The {providerName} models API was not found. The service may be down.",
             HttpStatusCode.TooManyRequests =>
@@ -107,5 +115,38 @@ internal static class ProbeHelpers
         };
 
         return new ProviderProbeResult(false, message, []);
+    }
+
+    /// <summary>
+    /// Best-effort extraction of an error detail string from an HTTP error response body.
+    /// Handles OpenAI-style <c>{"error": {"message": "..."}}</c> and simple
+    /// <c>{"error": "..."}</c> formats.
+    /// </summary>
+    internal static async Task<string?> ExtractApiErrorDetailAsync(
+        HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("error", out var errorProp))
+                return null;
+
+            return errorProp.ValueKind switch
+            {
+                JsonValueKind.Object when errorProp.TryGetProperty("message", out var msgProp) =>
+                    msgProp.GetString(),
+                JsonValueKind.String => errorProp.GetString(),
+                _ => null
+            };
+        }
+        catch
+        {
+            // Best-effort: malformed body, non-JSON content, etc.
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Provider probe failures (401/403) now read the HTTP response body and extract the actual error message from the provider API, surfacing it to the user instead of a generic message
- Changes "API key" wording to "credentials" in 401/403 error messages so it is accurate for both API key and OAuth authentication paths
- Adds `ExtractApiErrorDetailAsync` helper that handles both OpenAI-style `{"error": {"message": "..."}}` and simple `{"error": "..."}` JSON formats with best-effort fallback

Closes #191 (diagnostic step — enables root-cause identification for the false 403 errors)
Related: #173

## Motivation

Users report that the OpenAI provider probe returns "Access denied. Your openai API key may lack model-listing permissions" even when the same token works on other platforms. The error message was misleading because:
1. The actual API error detail was discarded — only the HTTP status code was checked
2. It said "API key" even when the user authenticated via OAuth

This change surfaces the real error so we can identify the root cause (likely missing OAuth scopes or endpoint misconfiguration) in a follow-up fix.

## Test plan

- [x] `dotnet build` — solution compiles (0 warnings, 0 errors)
- [x] `dotnet test` — all 55 Configuration tests pass (11 new ProbeHelpersTests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual: configure an OpenAI provider, trigger a 403, confirm the error message now shows the actual API error detail
- [ ] Verify Anthropic/OpenRouter/Ollama probes still work (shared ProbeHelpers infrastructure)