### PR TITLE
fix(providers): surface provider error details to users

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -495,9 +495,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             StopProcessingWatchdog();
             TurnLog().Error(msg.Cause, "turn_llm_call_failed");
 
-            var errorMessage = IsContextOverflowError(msg.Cause)
-                ? $"Context window exceeded after compaction — the session has too many tools or a large system prompt for the {_config.ModelId} context window ({_config.ContextWindowTokens} tokens). Try reducing tools or increasing the model's context window."
-                : "I encountered an error processing your message. Please try again.";
+            var errorMessage = ExtractLlmErrorMessage(msg.Cause);
             var category = msg.Cause is TimeoutException ? ErrorCategory.Timeout : ErrorCategory.ProviderFailure;
             FailCurrentTurn(errorMessage, msg.Cause, category);
         });
@@ -1196,6 +1194,42 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     // ── Helpers ──
+
+    /// <summary>
+    /// Extracts the best user-facing error message from an LLM call failure.
+    /// Checks for ProviderException (user-safe message), context overflow,
+    /// timeouts, and falls back to a generic message.
+    /// </summary>
+    private string ExtractLlmErrorMessage(Exception? cause)
+    {
+        if (cause is null)
+            return "I encountered an error processing your message. Please try again.";
+
+        // ProviderException carries a pre-formatted user-safe message
+        var providerEx = FindException<Configuration.ProviderException>(cause);
+        if (providerEx is not null)
+            return providerEx.UserMessage;
+
+        if (IsContextOverflowError(cause))
+            return $"Context window exceeded after compaction — the session has too many tools or a large system prompt for the {_config.ModelId} context window ({_config.ContextWindowTokens} tokens). Try reducing tools or increasing the model's context window.";
+
+        return "I encountered an error processing your message. Please try again.";
+    }
+
+    /// <summary>
+    /// Walks the exception chain (including inner exceptions) to find an exception
+    /// of the specified type.
+    /// </summary>
+    private static T? FindException<T>(Exception? ex) where T : Exception
+    {
+        while (ex is not null)
+        {
+            if (ex is T match)
+                return match;
+            ex = ex.InnerException;
+        }
+        return null;
+    }
 
     /// <summary>
     /// Detect context-length overflow errors from LLM providers.

--- a/src/Netclaw.Configuration/ProviderException.cs
+++ b/src/Netclaw.Configuration/ProviderException.cs
@@ -1,0 +1,28 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Exception thrown by LLM provider transport layers when the provider returns
+/// an error with actionable diagnostic information. The <see cref="UserMessage"/>
+/// is safe to surface to end users; <see cref="Exception.Message"/> retains
+/// full technical detail for logging.
+/// </summary>
+public sealed class ProviderException : Exception
+{
+    /// <summary>
+    /// A concise, user-safe description of what went wrong.
+    /// Suitable for displaying in Slack, TUI, or other user-facing channels.
+    /// </summary>
+    public string UserMessage { get; }
+
+    /// <summary>
+    /// HTTP status code from the provider, if applicable.
+    /// </summary>
+    public int? StatusCode { get; }
+
+    public ProviderException(string userMessage, string technicalMessage, int? statusCode = null, Exception? innerException = null)
+        : base(technicalMessage, innerException)
+    {
+        UserMessage = userMessage;
+        StatusCode = statusCode;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -424,6 +424,61 @@ data: [DONE]
         Assert.Contains("data:image/png;base64,", body, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ExtractUserMessage_ParsesOpenAiErrorObject()
+    {
+        var body = """{"error":{"code":500,"message":"image input is not supported - hint: if this is unexpected, you may need to provide the mmproj","type":"server_error"}}""";
+        var result = OpenAiCompatibleChatClient.ExtractUserMessage(body, 400);
+
+        Assert.Contains("image input is not supported", result, StringComparison.Ordinal);
+        Assert.Contains("400", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExtractUserMessage_ParsesSimpleErrorString()
+    {
+        var body = """{"error":"something went wrong"}""";
+        var result = OpenAiCompatibleChatClient.ExtractUserMessage(body, 500);
+
+        Assert.Contains("something went wrong", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExtractUserMessage_FallsBackOnInvalidJson()
+    {
+        var result = OpenAiCompatibleChatClient.ExtractUserMessage("not json", 502);
+
+        Assert.Contains("502", result, StringComparison.Ordinal);
+        Assert.Contains("not valid JSON", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExtractUserMessage_FallsBackOnNullBody()
+    {
+        var result = OpenAiCompatibleChatClient.ExtractUserMessage(null, 401);
+
+        Assert.Contains("credentials", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ThrowsProviderException_OnHttpError()
+    {
+        var errorResponse = """{"error":{"message":"model not found"}}""";
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorResponse, Encoding.UTF8, "application/json")
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        var ex = await Assert.ThrowsAsync<Netclaw.Configuration.ProviderException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]));
+
+        Assert.Contains("model not found", ex.UserMessage, StringComparison.Ordinal);
+        Assert.Equal(404, ex.StatusCode);
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;

--- a/src/Netclaw.OpenAICompatible/Netclaw.OpenAICompatible.csproj
+++ b/src/Netclaw.OpenAICompatible/Netclaw.OpenAICompatible.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 

--- a/src/Netclaw.OpenAICompatible/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.OpenAICompatible/OpenAiCompatibleChatClient.cs
@@ -219,8 +219,57 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             ? null
             : await response.Content.ReadAsStringAsync(cancellationToken);
 
-        throw new HttpRequestException(
-            $"OpenAI-compatible request failed: status={(int)response.StatusCode} path={_endpoint.ChatCompletionsPath} payload={payload.ToJsonString(JsonOptions)} response={responseBody}");
+        var statusCode = (int)response.StatusCode;
+        var technicalMessage =
+            $"OpenAI-compatible request failed: status={statusCode} path={_endpoint.ChatCompletionsPath} payload={payload.ToJsonString(JsonOptions)} response={responseBody}";
+        var userMessage = ExtractUserMessage(responseBody, statusCode);
+
+        throw new Configuration.ProviderException(userMessage, technicalMessage, statusCode);
+    }
+
+    /// <summary>
+    /// Extracts a user-friendly error message from an OpenAI-compatible error response.
+    /// Falls back to a generic message if the response can't be parsed.
+    /// </summary>
+    internal static string ExtractUserMessage(string? responseBody, int statusCode)
+    {
+        if (!string.IsNullOrWhiteSpace(responseBody))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(responseBody);
+                if (doc.RootElement.TryGetProperty("error", out var error))
+                {
+                    if (error.ValueKind == JsonValueKind.Object
+                        && error.TryGetProperty("message", out var msg)
+                        && msg.ValueKind == JsonValueKind.String
+                        && msg.GetString() is { Length: > 0 } errorMessage)
+                    {
+                        return $"LLM provider error ({statusCode}): {errorMessage}";
+                    }
+
+                    if (error.ValueKind == JsonValueKind.String
+                        && error.GetString() is { Length: > 0 } simpleError)
+                    {
+                        return $"LLM provider error ({statusCode}): {simpleError}";
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Response wasn't valid JSON — fall through to status-code-based message.
+                // This is expected when providers return HTML error pages or plain text.
+                return $"LLM provider returned an error (HTTP {statusCode}). Response was not valid JSON.";
+            }
+        }
+
+        return statusCode switch
+        {
+            401 or 403 => "LLM provider rejected the request — check credentials.",
+            429 => "LLM provider is rate-limiting requests. Try again shortly.",
+            >= 500 => $"LLM provider returned a server error ({statusCode}). The provider may be experiencing issues.",
+            _ => $"LLM provider returned an error (HTTP {statusCode}). Please try again."
+        };
     }
 
     internal static JsonObject ToMessage(ChatMessage message)


### PR DESCRIPTION
## Summary

- Adds `ProviderException` to `Netclaw.Configuration` — carries a user-safe message alongside full technical detail for logging
- `OpenAiCompatibleChatClient.EnsureSuccessAsync` now parses provider error JSON and throws `ProviderException` with a readable message
- `LlmSessionActor` checks for `ProviderException` and surfaces its `UserMessage` instead of the generic "I encountered an error processing your message"

**Before:** `:warning: I encountered an error processing your message. Please try again. (ref: 886bc4fe)`

**After:** `:warning: LLM provider error (400): image input is not supported - hint: if this is unexpected, you may need to provide the mmproj`

## Test plan

- [x] All 953 tests pass
- [x] 5 new tests for error message extraction and ProviderException throwing
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual: trigger a provider error and verify user sees actionable message