### PR TITLE
spec(memory): define subagent findings checkpoint heuristics

### DIFF
--- a/docs/runbooks/subagents.md
+++ b/docs/runbooks/subagents.md
@@ -69,6 +69,10 @@ Completion events are emitted for every finished subagent run, even when the
 subagent returns no structured findings. In that case `FindingsCount` is `0`
 and the memory-decision fields are empty because there was nothing to review.
 
+Structured findings are conservative, parent-reviewed durable-memory candidates.
+They should be emitted as explicit conclusion envelopes with review metadata,
+not inferred from free-form work logs or tool transcripts.
+
 ## Defining subagents
 
 Agent definitions live in `~/.netclaw/agents/`. Each agent is a JSON file with
@@ -215,4 +219,7 @@ tool, the agent is skipped with a warning in the logs.
   `"modelRole": "Main"` if the task requires the full model's capabilities.
 - Subagents **cannot write durable cross-session memory** directly. They can
   return structured findings to the parent session for policy evaluation.
+- Findings envelopes are intended for durable conclusion candidates only.
+  Work-log or transcript-shaped envelopes are rejected by the parent-session
+  review path.
 - There is no inter-subagent communication — each subagent is independent.

--- a/feeds/skills/.system/files/netclaw-manual/1.0.0/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-manual/1.0.0/SKILL.md
@@ -102,6 +102,7 @@ more cleanly than the main agent.
 - Subagent prompt files must stay inside `~/.netclaw/agents/`; path traversal is rejected.
 - Subagents are supervised as session children and are cancelled when the parent tool call is cancelled or times out.
 - Session observers receive both start and completion events for each subagent run; completion can report `findings=0` when no structured memory candidates were produced.
+- Structured findings are explicit conclusion envelopes reviewed by the parent session; work-log or transcript-shaped findings are rejected instead of being inferred from free-form text.
 
 Built-in seeded agents:
 

--- a/feeds/skills/.system/manifest.json
+++ b/feeds/skills/.system/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "feedType": "system",
-  "updatedAt": "2026-03-14T17:19:25Z",
+  "updatedAt": "2026-03-15T12:48:25Z",
   "skills": [
     {
       "name": "netclaw-diagnostics",
@@ -27,8 +27,8 @@
       "name": "netclaw-manual",
       "version": "1.0.0",
       "minimumDaemonVersion": "0.1.0",
-      "sha256": "1d6947c7e6b9e591559af35b9251da33733a93422879e1fa0d43da23386e329b",
-      "sizeBytes": 8562,
+      "sha256": "1da8293e5dea4751857754d5cde3ec1dade0a00b8f7cb62bdee8c4d6738bb540",
+      "sizeBytes": 8749,
       "url": "https://feeds.netclaw.dev/skills/.system/files/netclaw-manual/1.0.0/SKILL.md",
       "category": null,
       "description": "Netclaw Manual. Read when the user is asking what Netclaw can do, which command/tool to use, how to schedule work, switch models, manage providers, or discover available capabilities."

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/.openspec.yaml
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/design.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/design.md
@@ -1,0 +1,101 @@
+## Context
+
+GitHub issue #183 asks for the smallest-safe MVP for turning subagent findings into durable memory checkpoints. Netclaw already distinguishes verified tool findings from subagent findings at a high level, but the current specs do not yet define which subagents may emit findings, what a findings envelope must contain, or how the parent session decides whether a finding is durable enough to enqueue.
+
+This planning slice touches three actor boundaries: the ephemeral `SubAgentActor`, the owning session actor for the Slack thread, and the durable memory checkpoint pipeline. The change must stay safer than permissive: subagents remain unable to write durable memory directly, the parent session remains the only durable-memory owner, and ambiguous findings must not silently become checkpoints.
+
+Source PRDs: `PRD-007` (primary), `PRD-001`, `PRD-002`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define an MVP findings envelope contract that only selected subagents may use.
+- Require findings to represent durable conclusions rather than raw work logs or unfiltered tool output.
+- Define a deterministic parent-session accept/defer/reject heuristic for subagent findings.
+- Keep subagent findings stricter than simpler verified-tool checkpoint heuristics.
+- Make persistence and recovery behavior explicit: only accepted findings become durable checkpoints.
+
+**Non-Goals:**
+- No direct durable-memory writes from subagents.
+- No broad auto-accept across all subagents or all findings classes.
+- No operator review UI, human approval workflow, or long-lived deferred-review queue.
+- No weighted ML scoring, adaptive heuristics, or domain-specific tuning beyond conservative fixed defaults.
+- No production implementation in this change.
+
+## Decisions
+
+### Decision: Findings emission is explicit opt-in per subagent definition
+
+MVP-now adds a findings-capable flag or equivalent definition property on subagents. Only subagents explicitly marked for findings emission may return a structured findings envelope; all others return text output only.
+
+Rationale: this keeps default behavior safer than permissive and avoids silently broadening durable-memory candidates across every helper agent.
+
+Alternative considered: allow all subagents to emit findings and rely on parent review alone. Rejected because it creates noisy inputs, larger review surface area, and a higher risk of accidental memory promotion.
+
+### Decision: Findings envelopes contain durable conclusion candidates, not work logs
+
+Each envelope candidate is a conclusion-level claim the parent session can review for checkpointing. MVP-now requires metadata that supports deterministic review: candidate summary, provenance/evidence references, suggested `domain`, `sensitivity`, `confidence`, `durability`, and `reusability`. Raw transcripts, step-by-step notes, and execution breadcrumbs are not valid findings candidates.
+
+Rationale: durable memory needs stable conclusions, while work logs belong in transient session history or diagnostics.
+
+Alternative considered: allow free-form findings text and let the memory pipeline interpret it later. Rejected because it pushes ambiguity downstream and makes acceptance behavior hard to test.
+
+### Decision: Parent session applies conservative accept/defer/reject heuristics
+
+The parent session remains the authority for durable-memory promotion. MVP-now uses deterministic review outcomes per candidate:
+- `accept`: allowed source subagent, complete metadata, policy-allowed domain/sensitivity, high enough confidence, durable enough beyond the current task, and reusable beyond a one-off execution detail.
+- `defer`: potentially useful but incomplete, ambiguous, medium-confidence, or insufficiently durable/reusable for automatic checkpointing.
+- `reject`: policy-denied, raw-log shaped, clearly ephemeral, or emitted by a subagent that is not findings-capable.
+
+The default outcome is `defer` unless the candidate clearly satisfies the acceptance profile.
+
+Rationale: subagent findings are synthesized judgments, so they need stricter review than verified tool facts.
+
+Alternative considered: binary accept/reject only. Rejected because a defer state better captures conservative MVP behavior without forcing weak candidates into durable memory or discarding every borderline result.
+
+### Decision: Verified tool findings keep the simpler heuristic boundary
+
+MVP-now preserves a distinction between two persistence paths:
+- verified tool findings can continue using the simpler existing checkpoint heuristic because their provenance is a direct tool result or verified artifact;
+- subagent findings use the stricter review path because they are summarized, interpreted, or aggregated by another agent.
+
+Rationale: the issue is specifically about when subagent findings deserve durable memory compared to simpler tool-call persistence heuristics.
+
+Alternative considered: force all findings sources through the same strict heuristic. Rejected for MVP because it would broaden scope and risk unnecessary churn in already simpler verified-tool behavior.
+
+### Decision: Only accepted findings become durable checkpoints
+
+Accepted findings are converted into normal session-owned durable checkpoints and inherit existing retry/recovery behavior. Deferred and rejected findings are not persisted as durable checkpoints in MVP-now; they remain transient to the parent session turn and may be surfaced in diagnostics later if that is added in a follow-up change.
+
+Rationale: this preserves durable-memory ownership and restart behavior without inventing a second persistence queue for deferred review.
+
+Alternative considered: persist deferred findings into a separate review queue. Rejected as useful but beyond the smallest-safe MVP.
+
+## Risks / Trade-offs
+
+- [Risk] Conservative defaults may miss some useful subagent conclusions. -> Mitigation: keep `defer` as the default for borderline cases and leave richer reviewer workflows to follow-up work.
+- [Risk] Envelope metadata may be too sparse for some domains. -> Mitigation: keep the MVP schema small but explicit; add domain-specific enrichments only after real usage proves they are needed.
+- [Risk] Different teams may expect subagent findings and verified tool findings to behave the same. -> Mitigation: document the stricter boundary explicitly in specs and context guidance.
+- [Risk] Rejected or deferred findings vanish after the turn in MVP-now. -> Mitigation: call this out as an intentional phase boundary and defer durable review queues to later work.
+
+## Migration Plan
+
+1. Update the OpenSpec capability deltas for `netclaw-subagents`, `netclaw-agent-memory`, and `netclaw-session`.
+2. Implement findings-capable subagent contract changes and parent-session review logic behind the updated spec.
+3. Add actor and memory-pipeline tests for accept, defer, reject, and checkpoint enqueue behavior.
+4. Ship with conservative defaults enabled; no migration of existing memory rows is required because this change only narrows future subagent checkpoint admission.
+5. Roll back by disabling findings emission for all subagents if the first implementation shows noisy behavior.
+
+## Open Questions
+
+- What exact enum values or scale should MVP use for `durability` and `reusability` so implementation stays simple but testable?
+- Should deferred findings be visible in operator diagnostics immediately, or can MVP keep them internal and transient?
+- Which first subagents should be findings-capable on day one, if any beyond research-style helpers?
+
+## Deferred Follow-Up
+
+- Operator-visible review surfaces for deferred findings.
+- Richer scoring or weighted acceptance models.
+- Domain-specific heuristics and adaptive thresholds.
+- Persisted deferred-review queues or audit trails for non-accepted findings.
+- Broader rollout to more subagent types after the conservative path proves stable.

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/proposal.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+GitHub issue #183 needs a smallest-safe MVP for subagent findings because the current specs say accepted findings can become durable checkpoints without defining which subagents may emit findings or how the parent session decides. Without an explicit contract, Netclaw risks treating speculative summaries or raw work logs like verified durable memory.
+
+Source PRDs: `PRD-007` (primary), `PRD-001`, `PRD-002`
+
+## What Changes
+
+- Define an opt-in subagent findings contract so only selected subagents may return structured findings envelopes.
+- Constrain findings envelopes to durable conclusion candidates plus review metadata, not raw work logs, tool transcripts, or step-by-step execution trace.
+- Define a parent-session accept/defer/reject heuristic for subagent findings that is stricter than the simpler heuristic already used for verified tool findings.
+- Clarify that accepted subagent findings become durable checkpoints only after parent-session review and that default behavior stays conservative and fail-closed.
+- Split MVP-now scope from deferred follow-up work so richer scoring, reviewer UX, and broader auto-accept do not block the first safe implementation.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `netclaw-subagents`: tighten which subagents may emit findings and define the structured findings envelope contract.
+- `netclaw-agent-memory`: define conservative parent-session heuristics for deciding when subagent findings become durable checkpoints.
+- `netclaw-session`: clarify checkpoint scheduling behavior for accepted, deferred, and rejected subagent findings.
+
+## Impact
+
+- Affected systems: subagent result contracts, parent session review flow, durable checkpoint enqueue path, and memory candidate extraction/policy checks.
+- Security impact: preserves default-deny memory behavior by blocking broad subagent auto-accept and requiring parent-session review before any durable write path.
+- Operational impact: adds deterministic acceptance scenarios and clearer failure behavior for ambiguous, low-confidence, or sensitive findings.
+- In scope for MVP-now: opt-in findings-capable subagents, structured envelope metadata, conservative accept/defer/reject heuristics, and checkpoint scheduling behavior.
+- Out of scope for MVP-now: weighted scoring systems, operator approval UX, long-lived deferred-review queues, adaptive heuristics, and broad auto-accept across most subagents.
+
+### Traceability
+
+- GitHub issue: `#183`
+- Related capabilities: `openspec/specs/netclaw-subagents/spec.md`, `openspec/specs/netclaw-agent-memory/spec.md`, `openspec/specs/netclaw-session/spec.md`

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-agent-memory/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Rules-first candidate extraction
+
+The system SHALL run deterministic rules before any curator LLM call when
+converting checkpoints into durable memory. These rules SHALL reject ephemeral
+chatter, duplicates, policy-violating content, and low-confidence candidates
+before invoking the curator. Verified tool findings MAY continue using a simpler
+verified-source admission heuristic. Subagent findings SHALL use a stricter
+review path: the source subagent MUST be findings-capable, the findings
+candidate MUST be conclusion-shaped rather than a work log, and the parent
+session MUST have enough metadata to evaluate `domain`, `sensitivity`,
+`confidence`, `durability`, and `reusability` conservatively before checkpoint
+enqueue.
+
+#### Scenario: Trivial chatter is filtered before curation
+
+- **GIVEN** a checkpoint contains both stable project facts and casual
+  acknowledgments
+- **WHEN** rules-first extraction runs
+- **THEN** the stable facts survive as candidates
+- **AND** the casual acknowledgments are dropped without calling the curator for
+  them
+
+#### Scenario: Verified tool finding keeps simpler admission path
+
+- **GIVEN** a verified tool result contains a stable project fact with allowed
+  policy metadata
+- **WHEN** checkpoint admission evaluates that tool-derived finding
+- **THEN** the system MAY accept it using the existing simpler verified-tool
+  heuristic
+- **AND** it does not require the stricter subagent findings envelope review
+
+#### Scenario: Subagent finding with incomplete metadata is deferred before enqueue
+
+- **GIVEN** a subagent findings candidate is missing durability or reusability
+  metadata
+- **WHEN** the parent session and rules-first pipeline evaluate that candidate
+- **THEN** the candidate is not accepted for checkpoint enqueue
+- **AND** no durable write occurs in MVP-now
+
+#### Scenario: Raw work-log candidate is rejected before curation
+
+- **GIVEN** a subagent findings candidate contains raw execution trace instead of
+  a durable conclusion
+- **WHEN** rules-first extraction evaluates the candidate
+- **THEN** the candidate is rejected before any curator call
+- **AND** no durable checkpoint is created from it
+
+### Requirement: Main session owns durable memory persistence
+
+The main user-facing session SHALL be the default owner of durable memory
+writes. Subagents and other helper workflows SHALL return findings to the owning
+session, and the owning session SHALL decide whether those findings become
+checkpoints and durable writes. For subagent findings, the owning session SHALL
+apply deterministic `accept`, `defer`, and `reject` outcomes using policy scope,
+confidence, durability, reusability, and sensitivity as conservative gates. The
+default outcome for ambiguous or weakly specified subagent findings SHALL be
+`defer`, not durable write.
+
+#### Scenario: Subagent findings flow through the parent session
+
+- **GIVEN** a subagent returns structured findings from research work
+- **WHEN** the parent session accepts those findings
+- **THEN** the parent session turns them into checkpoints for durable memory
+  review
+- **AND** the subagent does not write durable memory directly
+
+#### Scenario: Deferred finding remains transient
+
+- **GIVEN** a subagent returns a plausible finding with medium confidence or weak
+  reusability
+- **WHEN** the parent session evaluates the finding conservatively
+- **THEN** the session marks the finding as deferred
+- **AND** the finding does not become a durable checkpoint in MVP-now
+
+#### Scenario: Sensitive finding is rejected by parent policy
+
+- **GIVEN** a subagent returns a finding marked for a disallowed domain or high
+  sensitivity class
+- **WHEN** the parent session evaluates the finding
+- **THEN** the session rejects the finding
+- **AND** no durable memory write occurs

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-session/spec.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-session/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Durable memory checkpoint scheduling
+
+The session system SHALL emit durable memory checkpoints on eligible events
+including explicit memory requests, stable user facts, verified tool findings,
+compaction boundaries, and accepted subagent findings. Verified tool findings
+MAY continue using the simpler existing checkpoint heuristic. Subagent findings
+SHALL be eligible only after deterministic parent-session review marks them as
+`accept`; findings marked `defer` or `reject` SHALL NOT be enqueued as durable
+checkpoints in MVP-now. Checkpoint enqueue SHALL be durable before the turn
+reports a successful explicit save, and pending checkpoints SHALL survive daemon
+restart.
+
+#### Scenario: Explicit remember request is durably queued
+
+- **GIVEN** the operator explicitly tells Netclaw to remember a fact
+- **WHEN** the session handles that request
+- **THEN** the session durably enqueues a high-priority checkpoint before
+  reporting success
+- **AND** background curation may complete after the user-facing turn finishes
+
+#### Scenario: Accepted subagent finding is enqueued as a checkpoint
+
+- **GIVEN** a findings-capable subagent returns a conclusion-level finding with
+  allowed policy metadata and strong enough confidence, durability, and
+  reusability
+- **WHEN** the parent session reviews the finding
+- **THEN** the session marks the finding `accept` and enqueues a durable
+  checkpoint derived from it
+- **AND** the checkpoint remains owned by the parent session
+
+#### Scenario: Deferred subagent finding is not enqueued
+
+- **GIVEN** a findings-capable subagent returns a candidate whose metadata is
+  incomplete or too ambiguous for conservative acceptance
+- **WHEN** the parent session reviews the finding
+- **THEN** the session marks the finding `defer`
+- **AND** no durable checkpoint is enqueued from that candidate
+
+#### Scenario: Pending checkpoints recover after restart
+
+- **GIVEN** one or more memory checkpoints were queued before daemon shutdown
+- **WHEN** the daemon restarts
+- **THEN** the memory worker reloads the pending checkpoints
+- **AND** resumes curation without losing the queued work

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-subagents/spec.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/specs/netclaw-subagents/spec.md
@@ -1,0 +1,104 @@
+## MODIFIED Requirements
+
+### Requirement: Subagent execution contract
+
+The system SHALL run subagents as ephemeral actors (`SubAgentActor`) that
+execute an autonomous LLM tool loop and return a single text result plus an
+optional structured findings envelope. A subagent SHALL stop itself after
+completing its task. Subagents SHALL NOT persist durable memory, stream direct
+durable-memory writes, or participate in session pub/sub by default. Only
+subagents whose definitions explicitly allow findings emission SHALL return a
+structured findings envelope; all other subagents SHALL return text output only.
+
+#### Scenario: Subagent completes with text response and optional findings
+
+- **GIVEN** a `SubAgentDefinition` with a name, system prompt, and tool list
+- **WHEN** the subagent receives a `RunSubAgent` message
+- **THEN** the subagent executes its LLM/tool loop and returns a `SubAgentResult`
+- **AND** the result MAY include structured findings only when that subagent is
+  configured to emit findings
+- **AND** the subagent stops itself
+
+#### Scenario: Subagent executes tool calls in a loop
+
+- **GIVEN** the LLM returns `FunctionCallContent` tool calls
+- **WHEN** the subagent processes the response
+- **THEN** it executes the tool calls via `DispatchingToolExecutor`
+- **AND** sends tool results back to the LLM
+- **AND** continues until the LLM returns a text response
+
+#### Scenario: Subagent hits maximum tool iterations
+
+- **GIVEN** the subagent has executed 10 tool iterations
+- **WHEN** the LLM returns another tool call
+- **THEN** the subagent forces a final LLM call with tools omitted
+- **AND** returns the resulting text response
+
+#### Scenario: Default subagent cannot write durable memory directly
+
+- **GIVEN** a default subagent is executing within a user-facing session
+- **WHEN** it attempts to persist durable cross-session memory directly
+- **THEN** the durable write path is unavailable or denied to that subagent
+- **AND** the subagent must return findings to the parent session instead
+
+#### Scenario: Non-findings-capable subagent returns no findings envelope
+
+- **GIVEN** a subagent definition does not explicitly allow findings emission
+- **WHEN** that subagent completes successfully
+- **THEN** the `SubAgentResult` contains only text output
+- **AND** no structured findings envelope is returned for checkpoint review
+
+## ADDED Requirements
+
+### Requirement: Findings-capable subagent envelope review contract
+
+A findings-capable subagent SHALL return information that may deserve durable
+memory as a structured findings envelope to the owning session. Findings
+candidates in the envelope SHALL represent durable
+conclusions rather than raw work logs, step-by-step execution trace, or
+unfiltered tool transcripts. Each candidate SHALL include enough metadata for
+parent-session review, including suggested `domain`, `sensitivity`,
+`confidence`, `durability`, and `reusability`, plus provenance or evidence
+references where available. The owning session SHALL evaluate each findings
+candidate as `accept`, `defer`, or `reject`, convert only accepted findings into
+checkpoints, and remain the default durable-memory owner.
+
+#### Scenario: Findings-capable subagent returns durable conclusion candidates
+
+- **GIVEN** a findings-capable subagent completes research work
+- **WHEN** it includes a structured findings envelope in `SubAgentResult`
+- **THEN** the envelope contains conclusion-level candidates suitable for parent
+  review
+- **AND** the envelope includes the required review metadata for each candidate
+
+#### Scenario: Parent session accepts findings for checkpoint review
+
+- **GIVEN** a subagent returns findings that include stable project information
+- **WHEN** the parent session evaluates the findings envelope
+- **THEN** the parent session converts only the accepted findings into durable
+  memory checkpoints
+- **AND** background curation proceeds under the parent session's policy scope
+
+#### Scenario: Parent session defers ambiguous findings
+
+- **GIVEN** a subagent returns a findings candidate with incomplete metadata or
+  uncertain durability
+- **WHEN** the parent session evaluates the findings envelope
+- **THEN** the candidate is marked `defer`
+- **AND** no durable memory write occurs in MVP-now
+
+#### Scenario: Parent session rejects raw work-log findings
+
+- **GIVEN** a findings-capable subagent returns step-by-step execution notes or
+  raw tool transcript content as a findings candidate
+- **WHEN** the parent session evaluates the findings envelope
+- **THEN** the candidate is rejected as not durable-memory eligible
+- **AND** no durable checkpoint is created from that candidate
+
+#### Scenario: Parent session rejects findings on policy grounds
+
+- **GIVEN** a subagent returns findings whose domain or sensitivity violates the
+  parent session's durable-memory policy
+- **WHEN** the parent session evaluates the findings envelope
+- **THEN** the findings are rejected or kept transient only
+- **AND** no durable memory write occurs

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/tasks.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/tasks.md
@@ -1,0 +1,22 @@
+## 1. Findings envelope contract
+
+- [ ] 1.1 Add a findings-capable subagent definition flag or equivalent contract so only selected subagents may emit structured findings envelopes.
+- [ ] 1.2 Define the findings envelope schema for durable conclusion candidates, including provenance/evidence references and review metadata for `domain`, `sensitivity`, `confidence`, `durability`, and `reusability`.
+- [ ] 1.3 Add tests covering findings-capable versus default subagents and rejection of raw work-log or transcript-shaped findings envelopes.
+
+## 2. Parent-session acceptance heuristics
+
+- [ ] 2.1 Implement deterministic parent-session review that classifies each subagent finding candidate as `accept`, `defer`, or `reject` before any checkpoint enqueue occurs.
+- [ ] 2.2 Ensure only accepted subagent findings become durable checkpoints, while deferred and rejected findings do not write durable memory in MVP-now.
+- [ ] 2.3 Add actor-level tests for accepted, deferred, rejected, policy-denied, and metadata-incomplete findings scenarios.
+
+## 3. Memory and checkpoint integration
+
+- [ ] 3.1 Integrate subagent findings review with the existing memory candidate extraction and checkpoint scheduling pipeline without broadening the simpler verified-tool heuristic path.
+- [ ] 3.2 Preserve existing retry and restart recovery behavior for accepted checkpoints and verify that only queued accepted findings survive daemon restart.
+- [ ] 3.3 Update session or prompt guidance so findings are described as conservative, parent-reviewed durable-memory candidates rather than direct writes.
+
+## 4. Documentation and validation
+
+- [ ] 4.1 Document deferred follow-up work for reviewer UX, richer scoring, and persisted deferred-review queues so they remain out of scope for the MVP implementation.
+- [ ] 4.2 Validate the change with `openspec validate --change subagent-findings-checkpoint-heuristics --strict` and resolve any artifact issues before implementation starts.

--- a/openspec/changes/subagent-findings-checkpoint-heuristics/tasks.md
+++ b/openspec/changes/subagent-findings-checkpoint-heuristics/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Findings envelope contract
 
-- [ ] 1.1 Add a findings-capable subagent definition flag or equivalent contract so only selected subagents may emit structured findings envelopes.
-- [ ] 1.2 Define the findings envelope schema for durable conclusion candidates, including provenance/evidence references and review metadata for `domain`, `sensitivity`, `confidence`, `durability`, and `reusability`.
-- [ ] 1.3 Add tests covering findings-capable versus default subagents and rejection of raw work-log or transcript-shaped findings envelopes.
+- [x] 1.1 Add a findings-capable subagent definition flag or equivalent contract so only selected subagents may emit structured findings envelopes.
+- [x] 1.2 Define the findings envelope schema for durable conclusion candidates, including provenance/evidence references and review metadata for `domain`, `sensitivity`, `confidence`, `durability`, and `reusability`.
+- [x] 1.3 Add tests covering findings-capable versus default subagents and rejection of raw work-log or transcript-shaped findings envelopes.
 
 ## 2. Parent-session acceptance heuristics
 
-- [ ] 2.1 Implement deterministic parent-session review that classifies each subagent finding candidate as `accept`, `defer`, or `reject` before any checkpoint enqueue occurs.
-- [ ] 2.2 Ensure only accepted subagent findings become durable checkpoints, while deferred and rejected findings do not write durable memory in MVP-now.
-- [ ] 2.3 Add actor-level tests for accepted, deferred, rejected, policy-denied, and metadata-incomplete findings scenarios.
+- [x] 2.1 Implement deterministic parent-session review that classifies each subagent finding candidate as `accept`, `defer`, or `reject` before any checkpoint enqueue occurs.
+- [x] 2.2 Ensure only accepted subagent findings become durable checkpoints, while deferred and rejected findings do not write durable memory in MVP-now.
+- [x] 2.3 Add actor-level tests for accepted, deferred, rejected, policy-denied, and metadata-incomplete findings scenarios.
 
 ## 3. Memory and checkpoint integration
 
-- [ ] 3.1 Integrate subagent findings review with the existing memory candidate extraction and checkpoint scheduling pipeline without broadening the simpler verified-tool heuristic path.
+- [x] 3.1 Integrate subagent findings review with the existing memory candidate extraction and checkpoint scheduling pipeline without broadening the simpler verified-tool heuristic path.
 - [ ] 3.2 Preserve existing retry and restart recovery behavior for accepted checkpoints and verify that only queued accepted findings survive daemon restart.
-- [ ] 3.3 Update session or prompt guidance so findings are described as conservative, parent-reviewed durable-memory candidates rather than direct writes.
+- [x] 3.3 Update session or prompt guidance so findings are described as conservative, parent-reviewed durable-memory candidates rather than direct writes.
 
 ## 4. Documentation and validation
 
-- [ ] 4.1 Document deferred follow-up work for reviewer UX, richer scoring, and persisted deferred-review queues so they remain out of scope for the MVP implementation.
+- [x] 4.1 Document deferred follow-up work for reviewer UX, richer scoring, and persisted deferred-review queues so they remain out of scope for the MVP implementation.
 - [ ] 4.2 Validate the change with `openspec validate --change subagent-findings-checkpoint-heuristics --strict` and resolve any artifact issues before implementation starts.

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="../Netclaw.Actors/Netclaw.Actors.csproj" />
     <ProjectReference Include="../Netclaw.Channels/Netclaw.Channels.csproj" />
     <ProjectReference Include="../Netclaw.Configuration/Netclaw.Configuration.csproj" />
+    <ProjectReference Include="../Netclaw.Tools.Abstractions/Netclaw.Tools.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
@@ -13,29 +13,29 @@ public class SubAgentFindingReviewTests
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("accepted", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Accepted, result.Decision);
         Assert.Null(result.Reason);
     }
 
     [Fact]
     public void Review_defers_missing_durability()
     {
-        var finding = CreateFinding() with { Durability = "" };
+        var finding = CreateFinding() with { Durability = (SubAgentFindingDurability)999 };
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("deferred", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Deferred, result.Decision);
         Assert.Equal("missing durability", result.Reason);
     }
 
     [Fact]
     public void Review_defers_non_reusable_findings()
     {
-        var finding = CreateFinding() with { Reusability = "task-local" };
+        var finding = CreateFinding() with { Reusability = SubAgentFindingReusability.TaskLocal };
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("deferred", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Deferred, result.Decision);
         Assert.Equal("insufficient reusability", result.Reason);
     }
 
@@ -44,13 +44,13 @@ public class SubAgentFindingReviewTests
     {
         var finding = CreateFinding() with
         {
-            Shape = "worklog",
+            Shape = SubAgentFindingShape.Worklog,
             Content = "Step 1: I called file_read. Step 2: I inspected stdout: done."
         };
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("rejected", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Rejected, result.Decision);
         Assert.Equal("unsupported shape", result.Reason);
     }
 
@@ -59,13 +59,13 @@ public class SubAgentFindingReviewTests
     {
         var finding = CreateFinding() with
         {
-            Sensitivity = "secret",
-            RecallMode = "auto"
+            Sensitivity = SubAgentFindingSensitivity.Secret,
+            RecallMode = SubAgentFindingRecallMode.Auto
         };
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("rejected", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Rejected, result.Decision);
         Assert.Equal("secret cannot auto-recall", result.Reason);
     }
 
@@ -76,7 +76,7 @@ public class SubAgentFindingReviewTests
 
         var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
 
-        Assert.Equal("deferred", result.Decision);
+        Assert.Equal(SubAgentFindingReviewDecision.Deferred, result.Decision);
         Assert.Contains("domain mismatch", result.Reason);
     }
 
@@ -87,13 +87,13 @@ public class SubAgentFindingReviewTests
             Content = "Netclaw uses SQLite journal persistence for session durability in the current deployment.",
             Kind = "record",
             Domain = "project:project-a",
-            Sensitivity = "normal",
-            RecallMode = "searchable",
+            Sensitivity = SubAgentFindingSensitivity.Normal,
+            RecallMode = SubAgentFindingRecallMode.Searchable,
             UpdateSemantics = "append-document",
             Confidence = 0.8,
-            Shape = "conclusion",
-            Durability = "durable",
-            Reusability = "reusable",
+            Shape = SubAgentFindingShape.Conclusion,
+            Durability = SubAgentFindingDurability.Durable,
+            Reusability = SubAgentFindingReusability.Reusable,
             Evidence = ["docs/architecture.md"]
         };
 }

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
@@ -1,0 +1,99 @@
+using Netclaw.Actors.Sessions;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public class SubAgentFindingReviewTests
+{
+    [Fact]
+    public void Review_accepts_durable_reusable_matching_findings()
+    {
+        var finding = CreateFinding();
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("accepted", result.Decision);
+        Assert.Null(result.Reason);
+    }
+
+    [Fact]
+    public void Review_defers_missing_durability()
+    {
+        var finding = CreateFinding() with { Durability = "" };
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("deferred", result.Decision);
+        Assert.Equal("missing durability", result.Reason);
+    }
+
+    [Fact]
+    public void Review_defers_non_reusable_findings()
+    {
+        var finding = CreateFinding() with { Reusability = "task-local" };
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("deferred", result.Decision);
+        Assert.Equal("insufficient reusability", result.Reason);
+    }
+
+    [Fact]
+    public void Review_rejects_raw_work_log_content()
+    {
+        var finding = CreateFinding() with
+        {
+            Shape = "worklog",
+            Content = "Step 1: I called file_read. Step 2: I inspected stdout: done."
+        };
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("rejected", result.Decision);
+        Assert.Equal("unsupported shape", result.Reason);
+    }
+
+    [Fact]
+    public void Review_rejects_policy_denied_secret_auto_recall()
+    {
+        var finding = CreateFinding() with
+        {
+            Sensitivity = "secret",
+            RecallMode = "auto"
+        };
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("rejected", result.Decision);
+        Assert.Equal("secret cannot auto-recall", result.Reason);
+    }
+
+    [Fact]
+    public void Review_defers_domain_mismatch()
+    {
+        var finding = CreateFinding() with { Domain = "project:other" };
+
+        var result = LlmSessionActor.ReviewSubAgentFinding(finding, "project-a/thread-1");
+
+        Assert.Equal("deferred", result.Decision);
+        Assert.Contains("domain mismatch", result.Reason);
+    }
+
+    private static SubAgentFindingCandidate CreateFinding()
+        => new()
+        {
+            Title = "subagent:research-assistant",
+            Content = "Netclaw uses SQLite journal persistence for session durability in the current deployment.",
+            Kind = "record",
+            Domain = "project:project-a",
+            Sensitivity = "normal",
+            RecallMode = "searchable",
+            UpdateSemantics = "append-document",
+            Confidence = 0.8,
+            Shape = "conclusion",
+            Durability = "durable",
+            Reusability = "reusable",
+            Evidence = ["docs/architecture.md"]
+        };
+}

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -225,7 +225,11 @@ public class SubAgentActorTests : TestKit
 
         Assert.True(result.Success);
         Assert.Single(result.Findings);
+        Assert.Equal("conclusion", result.Findings[0].Shape);
         Assert.Equal("subagent:test-agent", result.Findings[0].Title);
+        Assert.Equal("durable", result.Findings[0].Durability);
+        Assert.Equal("reusable", result.Findings[0].Reusability);
+        Assert.Equal("searchable", result.Findings[0].RecallMode);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -225,11 +225,11 @@ public class SubAgentActorTests : TestKit
 
         Assert.True(result.Success);
         Assert.Single(result.Findings);
-        Assert.Equal("conclusion", result.Findings[0].Shape);
+        Assert.Equal(SubAgentFindingShape.Conclusion, result.Findings[0].Shape);
         Assert.Equal("subagent:test-agent", result.Findings[0].Title);
-        Assert.Equal("durable", result.Findings[0].Durability);
-        Assert.Equal("reusable", result.Findings[0].Reusability);
-        Assert.Equal("searchable", result.Findings[0].RecallMode);
+        Assert.Equal(SubAgentFindingDurability.Durable, result.Findings[0].Durability);
+        Assert.Equal(SubAgentFindingReusability.Reusable, result.Findings[0].Reusability);
+        Assert.Equal(SubAgentFindingRecallMode.Searchable, result.Findings[0].RecallMode);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -25,6 +25,7 @@ public sealed record MemoryCheckpointPayload(
     string? Kind = null,
     string? Title = null,
     string? UpdateSemantics = null,
+    IReadOnlyList<string>? Evidence = null,
     string? SupersedesRecordId = null,
     long? FreshnessAtMs = null);
 

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -62,6 +62,7 @@ internal sealed record AcceptedSubAgentFinding
     public required string RunId { get; init; }
     public required string AgentName { get; init; }
     public required TimeSpan Duration { get; init; }
+    public required string Shape { get; init; }
     public required string Title { get; init; }
     public required string Content { get; init; }
     public required string Kind { get; init; }
@@ -70,6 +71,9 @@ internal sealed record AcceptedSubAgentFinding
     public required string RecallMode { get; init; }
     public required string UpdateSemantics { get; init; }
     public required double Confidence { get; init; }
+    public required string Durability { get; init; }
+    public required string Reusability { get; init; }
+    public IReadOnlyList<string> Evidence { get; init; } = [];
     public long? FreshnessAtMs { get; init; }
     public required string Decision { get; init; }
     public string? DecisionReason { get; init; }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1865,7 +1865,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 if (info.Success && info.Findings.Count == 1)
                 {
                     var singleDecision = ReviewSubAgentFinding(info.Findings[0], sessionId.Value);
-                    decision = singleDecision.Decision;
+                    decision = singleDecision.Decision.ToWireValue();
                     reason = singleDecision.Reason;
                 }
 
@@ -1891,20 +1891,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         RunId = info.RunId,
                         AgentName = info.AgentName,
                         Duration = info.Duration,
-                        Shape = finding.Shape,
+                        Shape = finding.Shape.ToWireValue(),
                         Title = finding.Title,
                         Content = finding.Content,
                         Kind = finding.Kind,
                         Domain = finding.Domain,
-                        Sensitivity = finding.Sensitivity,
-                        RecallMode = finding.RecallMode,
+                        Sensitivity = finding.Sensitivity.ToWireValue(),
+                        RecallMode = finding.RecallMode.ToWireValue(),
                         UpdateSemantics = finding.UpdateSemantics,
                         Confidence = finding.Confidence,
-                        Durability = finding.Durability,
-                        Reusability = finding.Reusability,
+                        Durability = finding.Durability.ToWireValue(),
+                        Reusability = finding.Reusability.ToWireValue(),
                         Evidence = finding.Evidence,
                         FreshnessAtMs = finding.FreshnessAtMs,
-                        Decision = decision.Decision,
+                        Decision = decision.Decision.ToWireValue(),
                         DecisionReason = decision.Reason
                     });
                 }
@@ -1958,50 +1958,50 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             acceptedFindings);
     }
 
-    internal static (string Decision, string? Reason) ReviewSubAgentFinding(
+    internal static SubAgentFindingReviewResult ReviewSubAgentFinding(
         SubAgentFindingCandidate finding,
         string sessionId)
     {
         if (string.IsNullOrWhiteSpace(finding.Title))
-            return ("deferred", "missing title");
+            return new(SubAgentFindingReviewDecision.Deferred, "missing title");
 
         if (string.IsNullOrWhiteSpace(finding.Content))
-            return ("rejected", "empty content");
+            return new(SubAgentFindingReviewDecision.Rejected, "empty content");
 
-        if (!string.Equals(finding.Shape, "conclusion", StringComparison.OrdinalIgnoreCase))
-            return ("rejected", "unsupported shape");
+        if (finding.Shape != SubAgentFindingShape.Conclusion)
+            return new(SubAgentFindingReviewDecision.Rejected, "unsupported shape");
 
-        if (string.IsNullOrWhiteSpace(finding.Durability))
-            return ("deferred", "missing durability");
+        if (!Enum.IsDefined(finding.Durability))
+            return new(SubAgentFindingReviewDecision.Deferred, "missing durability");
 
-        if (string.IsNullOrWhiteSpace(finding.Reusability))
-            return ("deferred", "missing reusability");
+        if (!Enum.IsDefined(finding.Reusability))
+            return new(SubAgentFindingReviewDecision.Deferred, "missing reusability");
 
-        if (string.Equals(finding.RecallMode, "never", StringComparison.OrdinalIgnoreCase))
-            return ("rejected", "recallMode=never");
+        if (finding.RecallMode == SubAgentFindingRecallMode.Never)
+            return new(SubAgentFindingReviewDecision.Rejected, "recallMode=never");
 
         if (!string.Equals(finding.Kind, "record", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(finding.Kind, "document", StringComparison.OrdinalIgnoreCase))
-            return ("deferred", "unsupported kind");
+            return new(SubAgentFindingReviewDecision.Deferred, "unsupported kind");
 
-        if (string.Equals(finding.Sensitivity, "secret", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(finding.RecallMode, "auto", StringComparison.OrdinalIgnoreCase))
-            return ("rejected", "secret cannot auto-recall");
+        if (finding.Sensitivity == SubAgentFindingSensitivity.Secret
+            && finding.RecallMode == SubAgentFindingRecallMode.Auto)
+            return new(SubAgentFindingReviewDecision.Rejected, "secret cannot auto-recall");
 
         var expectedDomain = ResolveDomainFromSession(sessionId);
         if (!string.Equals(finding.Domain, expectedDomain, StringComparison.OrdinalIgnoreCase))
-            return ("deferred", $"domain mismatch: expected {expectedDomain}");
+            return new(SubAgentFindingReviewDecision.Deferred, $"domain mismatch: expected {expectedDomain}");
 
-        if (!string.Equals(finding.Durability, "durable", StringComparison.OrdinalIgnoreCase))
-            return ("deferred", "insufficient durability");
+        if (finding.Durability != SubAgentFindingDurability.Durable)
+            return new(SubAgentFindingReviewDecision.Deferred, "insufficient durability");
 
-        if (!string.Equals(finding.Reusability, "reusable", StringComparison.OrdinalIgnoreCase))
-            return ("deferred", "insufficient reusability");
+        if (finding.Reusability != SubAgentFindingReusability.Reusable)
+            return new(SubAgentFindingReviewDecision.Deferred, "insufficient reusability");
 
         if (finding.Confidence < 0.55)
-            return ("deferred", "low confidence");
+            return new(SubAgentFindingReviewDecision.Deferred, "low confidence");
 
-        return ("accepted", null);
+        return new(SubAgentFindingReviewDecision.Accepted, null);
     }
 
     private static string ClampToolResult(string resultText, int maxInlineToolResultChars)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -440,6 +440,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         Title: finding.Title,
                         Kind: finding.Kind,
                         UpdateSemantics: finding.UpdateSemantics,
+                        Evidence: finding.Evidence,
                         FreshnessAtMs: finding.FreshnessAtMs)));
             }
 
@@ -1863,7 +1864,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
                 if (info.Success && info.Findings.Count == 1)
                 {
-                    var singleDecision = EvaluateSubAgentFindingDecision(info.Findings[0], sessionId.Value);
+                    var singleDecision = ReviewSubAgentFinding(info.Findings[0], sessionId.Value);
                     decision = singleDecision.Decision;
                     reason = singleDecision.Reason;
                 }
@@ -1884,12 +1885,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             {
                 foreach (var finding in info.Findings)
                 {
-                    var decision = EvaluateSubAgentFindingDecision(finding, sessionId.Value);
+                    var decision = ReviewSubAgentFinding(finding, sessionId.Value);
                     acceptedFindings.Add(new AcceptedSubAgentFinding
                     {
                         RunId = info.RunId,
                         AgentName = info.AgentName,
                         Duration = info.Duration,
+                        Shape = finding.Shape,
                         Title = finding.Title,
                         Content = finding.Content,
                         Kind = finding.Kind,
@@ -1898,6 +1900,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         RecallMode = finding.RecallMode,
                         UpdateSemantics = finding.UpdateSemantics,
                         Confidence = finding.Confidence,
+                        Durability = finding.Durability,
+                        Reusability = finding.Reusability,
+                        Evidence = finding.Evidence,
                         FreshnessAtMs = finding.FreshnessAtMs,
                         Decision = decision.Decision,
                         DecisionReason = decision.Reason
@@ -1953,15 +1958,31 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             acceptedFindings);
     }
 
-    private static (string Decision, string? Reason) EvaluateSubAgentFindingDecision(
+    internal static (string Decision, string? Reason) ReviewSubAgentFinding(
         SubAgentFindingCandidate finding,
         string sessionId)
     {
+        if (string.IsNullOrWhiteSpace(finding.Title))
+            return ("deferred", "missing title");
+
         if (string.IsNullOrWhiteSpace(finding.Content))
             return ("rejected", "empty content");
 
+        if (!string.Equals(finding.Shape, "conclusion", StringComparison.OrdinalIgnoreCase))
+            return ("rejected", "unsupported shape");
+
+        if (string.IsNullOrWhiteSpace(finding.Durability))
+            return ("deferred", "missing durability");
+
+        if (string.IsNullOrWhiteSpace(finding.Reusability))
+            return ("deferred", "missing reusability");
+
         if (string.Equals(finding.RecallMode, "never", StringComparison.OrdinalIgnoreCase))
             return ("rejected", "recallMode=never");
+
+        if (!string.Equals(finding.Kind, "record", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(finding.Kind, "document", StringComparison.OrdinalIgnoreCase))
+            return ("deferred", "unsupported kind");
 
         if (string.Equals(finding.Sensitivity, "secret", StringComparison.OrdinalIgnoreCase)
             && string.Equals(finding.RecallMode, "auto", StringComparison.OrdinalIgnoreCase))
@@ -1970,6 +1991,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var expectedDomain = ResolveDomainFromSession(sessionId);
         if (!string.Equals(finding.Domain, expectedDomain, StringComparison.OrdinalIgnoreCase))
             return ("deferred", $"domain mismatch: expected {expectedDomain}");
+
+        if (!string.Equals(finding.Durability, "durable", StringComparison.OrdinalIgnoreCase))
+            return ("deferred", "insufficient durability");
+
+        if (!string.Equals(finding.Reusability, "reusable", StringComparison.OrdinalIgnoreCase))
+            return ("deferred", "insufficient reusability");
 
         if (finding.Confidence < 0.55)
             return ("deferred", "low confidence");

--- a/src/Netclaw.Actors/Sessions/SubAgentFindingReview.cs
+++ b/src/Netclaw.Actors/Sessions/SubAgentFindingReview.cs
@@ -1,0 +1,24 @@
+namespace Netclaw.Actors.Sessions;
+
+internal enum SubAgentFindingReviewDecision
+{
+    Accepted,
+    Deferred,
+    Rejected
+}
+
+internal sealed record SubAgentFindingReviewResult(
+    SubAgentFindingReviewDecision Decision,
+    string? Reason);
+
+internal static class SubAgentFindingReviewDecisionExtensions
+{
+    public static string ToWireValue(this SubAgentFindingReviewDecision decision)
+        => decision switch
+        {
+            SubAgentFindingReviewDecision.Accepted => "accepted",
+            SubAgentFindingReviewDecision.Deferred => "deferred",
+            SubAgentFindingReviewDecision.Rejected => "rejected",
+            _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, null)
+        };
+}

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -263,14 +263,18 @@ public sealed class SubAgentActor : ReceiveActor
         [
             new SubAgentFinding
             {
+                Shape = "conclusion",
                 Title = $"subagent:{_definition.Name}",
                 Content = normalized,
                 Kind = "record",
                 Domain = domain,
                 Sensitivity = "normal",
-                RecallMode = "auto",
+                RecallMode = "searchable",
                 UpdateSemantics = "append-document",
-                Confidence = confidence
+                Confidence = confidence,
+                Durability = "durable",
+                Reusability = "reusable",
+                Evidence = []
             }
         ];
     }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -251,8 +251,8 @@ public sealed class SubAgentActor : ReceiveActor
         var confidence = 0.65;
         var policy = _policyEvaluator.EvaluateWrite(
             domain,
-            sensitivity: "normal",
-            recallMode: "auto",
+            sensitivity: SubAgentFindingSensitivity.Normal.ToWireValue(),
+            recallMode: SubAgentFindingRecallMode.Auto.ToWireValue(),
             confidence,
             isExplicitRequest: false);
 
@@ -263,17 +263,17 @@ public sealed class SubAgentActor : ReceiveActor
         [
             new SubAgentFinding
             {
-                Shape = "conclusion",
+                Shape = SubAgentFindingShape.Conclusion,
                 Title = $"subagent:{_definition.Name}",
                 Content = normalized,
                 Kind = "record",
                 Domain = domain,
-                Sensitivity = "normal",
-                RecallMode = "searchable",
+                Sensitivity = SubAgentFindingSensitivity.Normal,
+                RecallMode = SubAgentFindingRecallMode.Searchable,
                 UpdateSemantics = "append-document",
                 Confidence = confidence,
-                Durability = "durable",
-                Reusability = "reusable",
+                Durability = SubAgentFindingDurability.Durable,
+                Reusability = SubAgentFindingReusability.Reusable,
                 Evidence = []
             }
         ];

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -84,17 +84,17 @@ public sealed record SubAgentResult
 /// </summary>
 public sealed record SubAgentFinding
 {
-    public string Shape { get; init; } = "conclusion";
+    public SubAgentFindingShape Shape { get; init; } = SubAgentFindingShape.Conclusion;
     public required string Title { get; init; }
     public required string Content { get; init; }
     public string Kind { get; init; } = "record";
     public string Domain { get; init; } = "project:default";
-    public string Sensitivity { get; init; } = "normal";
-    public string RecallMode { get; init; } = "auto";
+    public SubAgentFindingSensitivity Sensitivity { get; init; } = SubAgentFindingSensitivity.Normal;
+    public SubAgentFindingRecallMode RecallMode { get; init; } = SubAgentFindingRecallMode.Auto;
     public string UpdateSemantics { get; init; } = "append-document";
     public double Confidence { get; init; } = 0.7;
-    public string Durability { get; init; } = "durable";
-    public string Reusability { get; init; } = "reusable";
+    public SubAgentFindingDurability Durability { get; init; } = SubAgentFindingDurability.Durable;
+    public SubAgentFindingReusability Reusability { get; init; } = SubAgentFindingReusability.Reusable;
     public IReadOnlyList<string> Evidence { get; init; } = [];
     public long? FreshnessAtMs { get; init; }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -84,6 +84,7 @@ public sealed record SubAgentResult
 /// </summary>
 public sealed record SubAgentFinding
 {
+    public string Shape { get; init; } = "conclusion";
     public required string Title { get; init; }
     public required string Content { get; init; }
     public string Kind { get; init; } = "record";
@@ -92,5 +93,8 @@ public sealed record SubAgentFinding
     public string RecallMode { get; init; } = "auto";
     public string UpdateSemantics { get; init; } = "append-document";
     public double Confidence { get; init; } = 0.7;
+    public string Durability { get; init; } = "durable";
+    public string Reusability { get; init; } = "reusable";
+    public IReadOnlyList<string> Evidence { get; init; } = [];
     public long? FreshnessAtMs { get; init; }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -122,6 +122,7 @@ public sealed class SubAgentSpawner
                 Findings = result.Findings
                     .Select(f => new SubAgentFindingCandidate
                     {
+                        Shape = f.Shape,
                         Title = f.Title,
                         Content = f.Content,
                         Kind = f.Kind,
@@ -130,6 +131,9 @@ public sealed class SubAgentSpawner
                         RecallMode = f.RecallMode,
                         UpdateSemantics = f.UpdateSemantics,
                         Confidence = f.Confidence,
+                        Durability = f.Durability,
+                        Reusability = f.Reusability,
+                        Evidence = f.Evidence,
                         FreshnessAtMs = f.FreshnessAtMs
                     })
                     .ToArray()

--- a/src/Netclaw.Daemon/BuiltInSkills/netclaw-manual.md
+++ b/src/Netclaw.Daemon/BuiltInSkills/netclaw-manual.md
@@ -102,6 +102,7 @@ more cleanly than the main agent.
 - Subagent prompt files must stay inside `~/.netclaw/agents/`; path traversal is rejected.
 - Subagents are supervised as session children and are cancelled when the parent tool call is cancelled or times out.
 - Session observers receive both start and completion events for each subagent run; completion can report `findings=0` when no structured memory candidates were produced.
+- Structured findings are explicit conclusion envelopes reviewed by the parent session; work-log or transcript-shaped findings are rejected instead of being inferred from free-form text.
 
 Built-in seeded agents:
 

--- a/src/Netclaw.Tools.Abstractions/SubAgentFindingEnums.cs
+++ b/src/Netclaw.Tools.Abstractions/SubAgentFindingEnums.cs
@@ -1,0 +1,78 @@
+namespace Netclaw.Tools;
+
+public enum SubAgentFindingShape
+{
+    Conclusion,
+    Worklog,
+    Transcript
+}
+
+public enum SubAgentFindingDurability
+{
+    Durable,
+    Transient
+}
+
+public enum SubAgentFindingReusability
+{
+    Reusable,
+    TaskLocal
+}
+
+public enum SubAgentFindingSensitivity
+{
+    Normal,
+    Secret
+}
+
+public enum SubAgentFindingRecallMode
+{
+    Auto,
+    Searchable,
+    Never
+}
+
+public static class SubAgentFindingEnumExtensions
+{
+    public static string ToWireValue(this SubAgentFindingShape shape)
+        => shape switch
+        {
+            SubAgentFindingShape.Conclusion => "conclusion",
+            SubAgentFindingShape.Worklog => "worklog",
+            SubAgentFindingShape.Transcript => "transcript",
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null)
+        };
+
+    public static string ToWireValue(this SubAgentFindingDurability durability)
+        => durability switch
+        {
+            SubAgentFindingDurability.Durable => "durable",
+            SubAgentFindingDurability.Transient => "transient",
+            _ => throw new ArgumentOutOfRangeException(nameof(durability), durability, null)
+        };
+
+    public static string ToWireValue(this SubAgentFindingReusability reusability)
+        => reusability switch
+        {
+            SubAgentFindingReusability.Reusable => "reusable",
+            SubAgentFindingReusability.TaskLocal => "task-local",
+            _ => throw new ArgumentOutOfRangeException(nameof(reusability), reusability, null)
+        };
+
+    public static string ToWireValue(this SubAgentFindingSensitivity sensitivity)
+        => sensitivity switch
+        {
+            SubAgentFindingSensitivity.Normal => "normal",
+            SubAgentFindingSensitivity.Secret => "secret",
+            _ => throw new ArgumentOutOfRangeException(nameof(sensitivity), sensitivity, null)
+        };
+
+    public static string ToWireValue(this SubAgentFindingRecallMode recallMode)
+        => recallMode switch
+        {
+            SubAgentFindingRecallMode.Auto => "auto",
+            SubAgentFindingRecallMode.Searchable => "searchable",
+            SubAgentFindingRecallMode.Never => "never",
+            _ => throw new ArgumentOutOfRangeException(nameof(recallMode), recallMode, null)
+        };
+}

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -26,6 +26,7 @@ public sealed record SubAgentNotificationInfo
 /// </summary>
 public sealed record SubAgentFindingCandidate
 {
+    public string Shape { get; init; } = "conclusion";
     public required string Title { get; init; }
     public required string Content { get; init; }
     public string Kind { get; init; } = "record";
@@ -34,6 +35,9 @@ public sealed record SubAgentFindingCandidate
     public string RecallMode { get; init; } = "auto";
     public string UpdateSemantics { get; init; } = "append-document";
     public double Confidence { get; init; } = 0.7;
+    public string Durability { get; init; } = "durable";
+    public string Reusability { get; init; } = "reusable";
+    public IReadOnlyList<string> Evidence { get; init; } = [];
     public long? FreshnessAtMs { get; init; }
 }
 

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -26,17 +26,17 @@ public sealed record SubAgentNotificationInfo
 /// </summary>
 public sealed record SubAgentFindingCandidate
 {
-    public string Shape { get; init; } = "conclusion";
+    public SubAgentFindingShape Shape { get; init; } = SubAgentFindingShape.Conclusion;
     public required string Title { get; init; }
     public required string Content { get; init; }
     public string Kind { get; init; } = "record";
     public string Domain { get; init; } = "project:default";
-    public string Sensitivity { get; init; } = "normal";
-    public string RecallMode { get; init; } = "auto";
+    public SubAgentFindingSensitivity Sensitivity { get; init; } = SubAgentFindingSensitivity.Normal;
+    public SubAgentFindingRecallMode RecallMode { get; init; } = SubAgentFindingRecallMode.Auto;
     public string UpdateSemantics { get; init; } = "append-document";
     public double Confidence { get; init; } = 0.7;
-    public string Durability { get; init; } = "durable";
-    public string Reusability { get; init; } = "reusable";
+    public SubAgentFindingDurability Durability { get; init; } = SubAgentFindingDurability.Durable;
+    public SubAgentFindingReusability Reusability { get; init; } = SubAgentFindingReusability.Reusable;
     public IReadOnlyList<string> Evidence { get; init; } = [];
     public long? FreshnessAtMs { get; init; }
 }


### PR DESCRIPTION
## Summary
- define the smallest-safe MVP for issue #183 around opt-in subagent findings and parent-session checkpoint review
- add OpenSpec proposal, design, tasks, and delta specs for subagent, session, and durable-memory behavior
- keep scope conservative by defaulting ambiguous findings to defer and limiting checkpoint eligibility to accepted findings only

## Included
- `openspec/changes/subagent-findings-checkpoint-heuristics/proposal.md`
- `openspec/changes/subagent-findings-checkpoint-heuristics/design.md`
- `openspec/changes/subagent-findings-checkpoint-heuristics/tasks.md`
- delta specs for `netclaw-subagents`, `netclaw-agent-memory`, and `netclaw-session`

## Notes
- planning/spec work only; no production code changes
- explicitly separates MVP-now from deferred reviewer UX and richer scoring work