### PR TITLE
feat(config): add ContextWindowOverride with startup validation

### DIFF
--- a/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Model/ModelCommandTests.cs
@@ -88,7 +88,7 @@ public sealed class ModelCommandTests : IDisposable
         Assert.Equal("my-ollama", main.GetProperty("Provider").GetString());
         Assert.Equal("qwen3:30b", main.GetProperty("ModelId").GetString());
         Assert.Equal("Manual", main.GetProperty("Provenance").GetString());
-        Assert.Equal(32768, main.GetProperty("ContextWindow").GetInt32());
+        Assert.Equal(32768, main.GetProperty("ContextWindowOverride").GetInt32());
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -22,17 +22,17 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
             return Task.FromResult(DoctorCheckResult.Warning(
                 "Context Window",
                 "No Models.Main section in config. Using default context window (32,768 tokens).",
-                "Add a Models.Main section with ContextWindow to netclaw.json."));
+                "Add a Models.Main section with ContextWindowOverride to netclaw.json."));
         }
 
-        var contextWindow = main["ContextWindow"];
+        var contextWindow = main["ContextWindowOverride"];
         if (contextWindow is null)
         {
             var modelId = main["ModelId"]?.GetValue<string>() ?? "unknown";
             return Task.FromResult(DoctorCheckResult.Warning(
                 "Context Window",
                 $"No explicit context window configured for {modelId}. Using default 32,768 tokens.",
-                "Set Models.Main.ContextWindow in netclaw.json to match your model's actual context window."));
+                "Set Models.Main.ContextWindowOverride in netclaw.json to match your model's effective context window."));
         }
 
         if (contextWindow.GetValue<int>() is var cw and > 0)
@@ -44,7 +44,7 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
 
         return Task.FromResult(DoctorCheckResult.Error(
             "Context Window",
-            "Models.Main.ContextWindow must be a positive integer.",
-            "Set Models.Main.ContextWindow to the model's context window size in tokens."));
+            "Models.Main.ContextWindowOverride must be a positive integer.",
+            "Set Models.Main.ContextWindowOverride to the model's effective context window size in tokens."));
     }
 }

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -63,8 +63,8 @@ internal static class ModelCommand
 
     private static void WriteModelRow(string role, ModelReference model, TextWriter writer)
     {
-        var ctxWindow = model.ContextWindow.HasValue
-            ? $"{model.ContextWindow.Value:N0} tokens"
+        var ctxWindow = model.ContextWindowOverride.HasValue
+            ? $"{model.ContextWindowOverride.Value:N0} tokens"
             : "(default)";
         writer.WriteLine($"{role,-12} {model.Provider,-20} {model.ModelId,-30} {ctxWindow}");
     }
@@ -128,11 +128,11 @@ internal static class ModelCommand
 
         // Check for context window downgrade
         var currentModels = LoadModelSelection(paths);
-        if (roleKey == "Main" && currentModels?.Main.ContextWindow is > 0 && contextWindow.HasValue)
+        if (roleKey == "Main" && currentModels?.Main.ContextWindowOverride is > 0 && contextWindow.HasValue)
         {
-            if (contextWindow.Value < currentModels.Main.ContextWindow.Value)
+            if (contextWindow.Value < currentModels.Main.ContextWindowOverride.Value)
             {
-                writer.WriteLine($"Warning: Context window shrinking from {currentModels.Main.ContextWindow.Value:N0} to {contextWindow.Value:N0} tokens.");
+                writer.WriteLine($"Warning: Context window shrinking from {currentModels.Main.ContextWindowOverride.Value:N0} to {contextWindow.Value:N0} tokens.");
                 writer.WriteLine("         Existing sessions with longer history may fail until compacted.");
             }
         }
@@ -149,7 +149,7 @@ internal static class ModelCommand
         };
 
         if (contextWindow.HasValue)
-            modelEntry["ContextWindow"] = contextWindow.Value;
+            modelEntry["ContextWindowOverride"] = contextWindow.Value;
 
         modelsSection[roleKey] = modelEntry;
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, config);

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -160,7 +160,7 @@ static async Task RunAsync(string[] args)
                 return sessionConfig with
                 {
                     ModelId = models.Main.ModelId,
-                    ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
+                    ContextWindowTokens = models.Main.ContextWindowOverride ?? 32_768,
                     CompactionModelId = models.Compaction?.ModelId,
                 };
             });
@@ -1087,7 +1087,7 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
     services.AddSingleton(sessionConfig with
     {
         ModelId = models.Main.ModelId,
-        ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
+        ContextWindowTokens = models.Main.ContextWindowOverride ?? 32_768,
         CompactionModelId = models.Compaction?.ModelId,
     });
 

--- a/src/Netclaw.Configuration/ModelReference.cs
+++ b/src/Netclaw.Configuration/ModelReference.cs
@@ -9,7 +9,14 @@ public sealed class ModelReference
 {
     public string Provider { get; set; } = "local-ollama";
     public string ModelId { get; set; } = "qwen3:30b";
-    public int? ContextWindow { get; set; }
+    /// <summary>
+    /// Override for the effective context window size in tokens.
+    /// Useful when parallelism factors reduce the actual usable window
+    /// (e.g., Lemonade with parallelism=4 reduces a 262,144-token window to ~65,536).
+    /// If not specified, the provider-reported window is used.
+    /// Must be >= 8192.
+    /// </summary>
+    public int? ContextWindowOverride { get; set; }
 
     /// <summary>
     /// How this model ID was resolved during onboarding or model selection.

--- a/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
@@ -1,0 +1,71 @@
+using Netclaw.Configuration;
+using Xunit;
+using Netclaw.Daemon.Configuration;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class ModelSelectionValidatorTests
+{
+    private static readonly ModelSelectionValidator Validator = new();
+
+    [Fact]
+    public void NoOverride_Passes()
+    {
+        var selection = new ModelSelection { Main = new ModelReference() };
+        var result = Validator.Validate(null, selection);
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void OverrideAtMinimum_Passes()
+    {
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 8192 } };
+        var result = Validator.Validate(null, selection);
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void OverrideAboveMinimum_Passes()
+    {
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 65536 } };
+        var result = Validator.Validate(null, selection);
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void OverrideBelowMinimum_Fails()
+    {
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 4096 } };
+        var result = Validator.Validate(null, selection);
+        Assert.True(result.Failed);
+        Assert.Contains("4096", result.FailureMessage);
+        Assert.Contains("8192", result.FailureMessage);
+    }
+
+    [Fact]
+    public void MultipleRolesBelowMinimum_AllFailuresReported()
+    {
+        var selection = new ModelSelection
+        {
+            Main = new ModelReference { ContextWindowOverride = 1024 },
+            Compaction = new ModelReference { ContextWindowOverride = 512 }
+        };
+        var result = Validator.Validate(null, selection);
+        Assert.True(result.Failed);
+        Assert.Contains("Main", result.FailureMessage);
+        Assert.Contains("Compaction", result.FailureMessage);
+    }
+
+    [Fact]
+    public void NullOptionalRoles_DoNotCauseErrors()
+    {
+        var selection = new ModelSelection
+        {
+            Main = new ModelReference { ContextWindowOverride = 32768 },
+            Fallback = null,
+            Compaction = null
+        };
+        var result = Validator.Validate(null, selection);
+        Assert.False(result.Failed);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
@@ -19,7 +19,7 @@ public sealed class ModelSelectionValidatorTests
     [Fact]
     public void OverrideAtMinimum_Passes()
     {
-        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 8192 } };
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 4096 } };
         var result = Validator.Validate(null, selection);
         Assert.False(result.Failed);
     }
@@ -35,11 +35,11 @@ public sealed class ModelSelectionValidatorTests
     [Fact]
     public void OverrideBelowMinimum_Fails()
     {
-        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 4096 } };
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindowOverride = 2048 } };
         var result = Validator.Validate(null, selection);
         Assert.True(result.Failed);
+        Assert.Contains("2048", result.FailureMessage);
         Assert.Contains("4096", result.FailureMessage);
-        Assert.Contains("8192", result.FailureMessage);
     }
 
     [Fact]

--- a/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class ModelSelectionValidator : IValidateOptions<ModelSelection>
+{
+    private const int MinContextWindow = 8192;
+
+    public ValidateOptionsResult Validate(string? name, ModelSelection options)
+    {
+        var errors = new List<string>();
+        ValidateRole(nameof(options.Main), options.Main, errors);
+        if (options.Fallback is not null)
+            ValidateRole(nameof(options.Fallback), options.Fallback, errors);
+        if (options.Compaction is not null)
+            ValidateRole(nameof(options.Compaction), options.Compaction, errors);
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+
+    private static void ValidateRole(string role, ModelReference model, List<string> errors)
+    {
+        if (model.ContextWindowOverride is int value && value < MinContextWindow)
+            errors.Add(
+                $"Models:{role}:ContextWindowOverride ({value}) is below minimum ({MinContextWindow}). " +
+                "A context window below 8192 tokens is too small for practical use.");
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
@@ -5,7 +5,7 @@ namespace Netclaw.Daemon.Configuration;
 
 public sealed class ModelSelectionValidator : IValidateOptions<ModelSelection>
 {
-    private const int MinContextWindow = 8192;
+    private const int MinContextWindow = 4096;
 
     public ValidateOptionsResult Validate(string? name, ModelSelection options)
     {
@@ -26,6 +26,6 @@ public sealed class ModelSelectionValidator : IValidateOptions<ModelSelection>
         if (model.ContextWindowOverride is int value && value < MinContextWindow)
             errors.Add(
                 $"Models:{role}:ContextWindowOverride ({value}) is below minimum ({MinContextWindow}). " +
-                "A context window below 8192 tokens is too small for practical use.");
+                "A context window below 4096 tokens is too small for practical use.");
     }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -221,6 +221,11 @@ static void ConfigureDaemonServices(
     });
 
     // Resolve models for session config
+    services
+        .AddOptions<ModelSelection>()
+        .Bind(configuration.GetSection("Models"))
+        .ValidateOnStart();
+    services.AddSingleton<IValidateOptions<ModelSelection>, ModelSelectionValidator>();
     var models = configuration.GetSection("Models")
         .Get<ModelSelection>() ?? new ModelSelection();
     services.AddSingleton(models);
@@ -250,7 +255,7 @@ static void ConfigureDaemonServices(
 
     var inputModalities = models.Main.InputModalities;
     var outputModalities = models.Main.OutputModalities;
-    int? contextWindow = models.Main.ContextWindow;
+    int? contextWindow = models.Main.ContextWindowOverride;
     if (inputModalities is null || outputModalities is null || contextWindow is null)
     {
         var detected = ResolveStartupCapabilities(
@@ -259,6 +264,18 @@ static void ConfigureDaemonServices(
         {
             inputModalities ??= detected.InputModalities;
             outputModalities ??= detected.OutputModalities;
+
+            // Validate override does not exceed provider-reported limit
+            if (models.Main.ContextWindowOverride is int overrideValue
+                && detected.ContextWindowTokens is int detectedValue
+                && overrideValue > detectedValue)
+            {
+                throw new InvalidOperationException(
+                    $"Models:Main:ContextWindowOverride ({overrideValue}) exceeds the " +
+                    $"provider-reported context window ({detectedValue}). " +
+                    "The override must be <= the provider's reported context window.");
+            }
+
             contextWindow ??= detected.ContextWindowTokens;
         }
     }


### PR DESCRIPTION
## Summary

- Renames `ModelReference.ContextWindow` → `ContextWindowOverride` to make explicit that this is a user-controlled effective-window override (useful when parallelism factors reduce the actual usable window below what the provider reports)
- Adds `IValidateOptions<ModelSelection>` that rejects values below 4096 at startup
- Adds an inline upper-bound guard after capability detection that rejects overrides exceeding the provider-reported window, preventing the crash scenario described in #232
- Updates `netclaw model set --context-window` to write `ContextWindowOverride` to `netclaw.json`
- Updates doctor check and all CLI display paths

## Test plan

- [ ] `ModelSelectionValidatorTests` — 6 unit tests covering min boundary, multi-role failure aggregation, null optional roles
- [ ] Existing `ModelCommandTests.Set_MainModel_WritesConfig` updated to assert new JSON key
- [ ] Full suite: 920 tests passing, 0 failures

Closes #232