### PR TITLE
fix(openai-compatible): use effective runtime context window

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -120,7 +120,7 @@ Named model roles. Each role points to a provider and model ID.
 |-------|------|---------|-------------|
 | `Provider` | string | `"local-ollama"` | Key into the `Providers` dictionary. |
 | `ModelId` | string | `"qwen3:30b"` | Model identifier as used by the provider's API. |
-| `ContextWindow` | int? | `null` | Context window size in tokens. Defaults to 32,768 if not set. Future: auto-discovered from provider. |
+| `ContextWindow` | int? | `null` | Effective runtime context window in tokens. When set, it clamps the detected provider value. If not set, Netclaw uses the provider-reported value when available, otherwise defaults to 32,768. |
 | `InputModalities` | string[]? | `null` | Manual override for input modalities (`"Text"`, `"Image"`, `"Audio"`, `"Video"`). When set, bypasses automated capability detection. |
 | `OutputModalities` | string[]? | `null` | Manual override for output modalities. Same values as `InputModalities`. |
 

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -32,7 +32,7 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
             return Task.FromResult(DoctorCheckResult.Warning(
                 "Context Window",
                 $"No explicit context window configured for {modelId}. Using default 32,768 tokens.",
-                "Set Models.Main.ContextWindow in netclaw.json to match your model's actual context window."));
+                "Set Models.Main.ContextWindow in netclaw.json to clamp the effective runtime context window if needed."));
         }
 
         if (contextWindow.GetValue<int>() is var cw and > 0)
@@ -45,6 +45,6 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
         return Task.FromResult(DoctorCheckResult.Error(
             "Context Window",
             "Models.Main.ContextWindow must be a positive integer.",
-            "Set Models.Main.ContextWindow to the model's context window size in tokens."));
+            "Set Models.Main.ContextWindow to the effective runtime context window size in tokens."));
     }
 }

--- a/src/Netclaw.Configuration/ModelReference.cs
+++ b/src/Netclaw.Configuration/ModelReference.cs
@@ -9,6 +9,12 @@ public sealed class ModelReference
 {
     public string Provider { get; set; } = "local-ollama";
     public string ModelId { get; set; } = "qwen3:30b";
+
+    /// <summary>
+    /// Effective context window size in tokens for this model. When set,
+    /// this value clamps the runtime session budget and takes precedence
+    /// over provider-reported capability detection.
+    /// </summary>
     public int? ContextWindow { get; set; }
 
     /// <summary>

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -200,7 +200,7 @@
       "properties": {
         "Provider": { "type": "string", "description": "Key into the Providers dictionary." },
         "ModelId": { "type": "string", "description": "Model identifier for API calls." },
-        "ContextWindow": { "type": "integer", "description": "Max context window in tokens." },
+        "ContextWindow": { "type": "integer", "description": "Effective runtime context window in tokens. When set, clamps the detected provider value." },
         "Provenance": {
           "type": ["string", "null"],
           "description": "Optional model provenance marker (e.g. AutoDetected, Manual)."

--- a/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelCapabilityResolutionTests.cs
@@ -1,0 +1,72 @@
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class ModelCapabilityResolutionTests
+{
+    [Fact]
+    public void ResolveSessionConfig_UsesConfiguredContextWindowAsClamp()
+    {
+        var model = new ModelReference
+        {
+            ContextWindow = 32768,
+            InputModalities = ModelModality.Text,
+            OutputModalities = ModelModality.Text
+        };
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 65536);
+
+        var result = ModelCapabilityResolution.ResolveSessionConfig(model, detected);
+
+        Assert.Equal(32768, result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void ResolveSessionConfig_ThrowsWhenConfiguredContextExceedsDetectedWindow()
+    {
+        var model = new ModelReference
+        {
+            ContextWindow = 131072,
+            InputModalities = ModelModality.Text,
+            OutputModalities = ModelModality.Text
+        };
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 65536);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ModelCapabilityResolution.ResolveSessionConfig(model, detected));
+
+        Assert.Contains("ContextWindow", ex.Message);
+        Assert.Contains("65536", ex.Message);
+    }
+
+    [Fact]
+    public void ResolveSessionConfig_StillValidatesConfiguredContextWhenModalitiesAreManual()
+    {
+        var model = new ModelReference
+        {
+            ContextWindow = 131072,
+            InputModalities = ModelModality.Text | ModelModality.Image,
+            OutputModalities = ModelModality.Text
+        };
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 65536);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ModelCapabilityResolution.ResolveSessionConfig(model, detected));
+    }
+
+    [Fact]
+    public void ResolveSessionConfig_UsesDetectedContextWhenNoClampConfigured()
+    {
+        var model = new ModelReference();
+        var detected = new ResolvedModelCapabilities("model", ModelModality.Text | ModelModality.Image, ModelModality.Text, 65536);
+
+        var result = ModelCapabilityResolution.ResolveSessionConfig(model, detected);
+
+        Assert.Equal(65536, result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/ModelSelectionValidatorTests.cs
@@ -1,0 +1,58 @@
+using Netclaw.Configuration;
+using Netclaw.Daemon.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class ModelSelectionValidatorTests
+{
+    private static readonly ModelSelectionValidator Validator = new();
+
+    [Fact]
+    public void NoContextWindow_Passes()
+    {
+        var selection = new ModelSelection { Main = new ModelReference() };
+
+        var result = Validator.Validate(null, selection);
+
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void ContextWindowAtMinimum_Passes()
+    {
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindow = 4096 } };
+
+        var result = Validator.Validate(null, selection);
+
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void ContextWindowBelowMinimum_Fails()
+    {
+        var selection = new ModelSelection { Main = new ModelReference { ContextWindow = 2048 } };
+
+        var result = Validator.Validate(null, selection);
+
+        Assert.True(result.Failed);
+        Assert.Contains("2048", result.FailureMessage);
+        Assert.Contains("4096", result.FailureMessage);
+    }
+
+    [Fact]
+    public void MultipleRolesBelowMinimum_AllFailuresReported()
+    {
+        var selection = new ModelSelection
+        {
+            Main = new ModelReference { ContextWindow = 1024 },
+            Compaction = new ModelReference { ContextWindow = 512 }
+        };
+
+        var result = Validator.Validate(null, selection);
+
+        Assert.True(result.Failed);
+        Assert.Contains("Main", result.FailureMessage);
+        Assert.Contains("Compaction", result.FailureMessage);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
@@ -35,6 +35,11 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
     {
         const string json = """
         {
+          "default_generation_settings": {
+            "params": {
+              "n_ctx": 65536
+            }
+          },
           "modalities": {
             "vision": true
           }
@@ -46,7 +51,7 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
         Assert.NotNull(result);
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
-        Assert.Equal(32768, result.ContextWindowTokens);
+        Assert.Equal(65536, result.ContextWindowTokens);
     }
 
     [Fact]
@@ -65,5 +70,23 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
         Assert.NotNull(result);
         Assert.Equal(ModelModality.Text, result.InputModalities);
         Assert.Equal(32768, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void ParsePropsResponse_UsesModelContextWindowWhenRuntimeValueMissing()
+    {
+        const string json = """
+        {
+          "modalities": {
+            "vision": true
+          }
+        }
+        """;
+
+        var result = OpenAiCompatibleCapabilityResolver.ParsePropsResponse(json, "Qwen3.5", 262144);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(262144, result.ContextWindowTokens);
     }
 }

--- a/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs
@@ -1,0 +1,26 @@
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Configuration;
+
+internal static class ModelCapabilityResolution
+{
+    public static (ModelModality InputModalities, ModelModality OutputModalities, int ContextWindowTokens)
+        ResolveSessionConfig(ModelReference model, ResolvedModelCapabilities? detected, int defaultContextWindow = 32_768)
+    {
+        if (model.ContextWindow is int configuredContextWindow
+            && detected?.ContextWindowTokens is int detectedContextWindow
+            && configuredContextWindow > detectedContextWindow)
+        {
+            throw new InvalidOperationException(
+                $"Models:Main:ContextWindow ({configuredContextWindow}) exceeds the " +
+                $"provider-reported effective context window ({detectedContextWindow}). " +
+                "Reduce the configured ContextWindow or adjust the provider runtime settings.");
+        }
+
+        var inputModalities = model.InputModalities ?? detected?.InputModalities ?? ModelModality.Text;
+        var outputModalities = model.OutputModalities ?? detected?.OutputModalities ?? ModelModality.Text;
+        var contextWindow = model.ContextWindow ?? detected?.ContextWindowTokens ?? defaultContextWindow;
+
+        return (inputModalities, outputModalities, contextWindow);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
+++ b/src/Netclaw.Daemon/Configuration/ModelSelectionValidator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Options;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Configuration;
+
+public sealed class ModelSelectionValidator : IValidateOptions<ModelSelection>
+{
+    private const int MinContextWindow = 4096;
+
+    public ValidateOptionsResult Validate(string? name, ModelSelection options)
+    {
+        var errors = new List<string>();
+
+        ValidateRole(nameof(options.Main), options.Main, errors);
+
+        if (options.Fallback is not null)
+            ValidateRole(nameof(options.Fallback), options.Fallback, errors);
+
+        if (options.Compaction is not null)
+            ValidateRole(nameof(options.Compaction), options.Compaction, errors);
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+
+    private static void ValidateRole(string role, ModelReference model, List<string> errors)
+    {
+        if (model.ContextWindow is int value && value < MinContextWindow)
+        {
+            errors.Add(
+                $"Models:{role}:ContextWindow ({value}) is below minimum ({MinContextWindow}). " +
+                "A context window below 4096 tokens is too small for practical use.");
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -207,6 +207,11 @@ static void ConfigureDaemonServices(
     LogLevel daemonLogLevel)
 {
     services
+        .AddOptions<ModelSelection>()
+        .Bind(configuration.GetSection("Models"))
+        .ValidateOnStart();
+    services.AddSingleton<IValidateOptions<ModelSelection>, ModelSelectionValidator>();
+    services
         .AddOptions<DaemonPersistenceOptions>()
         .Bind(configuration.GetSection("Persistence"))
         .ValidateOnStart();
@@ -248,30 +253,21 @@ static void ConfigureDaemonServices(
         ? mainProvider?.ApiKey?.Value
         : null;
 
-    var inputModalities = models.Main.InputModalities;
-    var outputModalities = models.Main.OutputModalities;
-    int? contextWindow = models.Main.ContextWindow;
-    if (inputModalities is null || outputModalities is null || contextWindow is null)
-    {
-        var detected = ResolveStartupCapabilities(
-            models.Main.ModelId, daemonLogLevel, mainProviderType, ollamaEndpoint, openAiCompatibleEndpoint, openAiCompatibleApiKey);
-        if (detected is not null)
-        {
-            inputModalities ??= detected.InputModalities;
-            outputModalities ??= detected.OutputModalities;
-            contextWindow ??= detected.ContextWindowTokens;
-        }
-    }
+    var detected = ResolveStartupCapabilities(
+        models.Main.ModelId, daemonLogLevel, mainProviderType, ollamaEndpoint, openAiCompatibleEndpoint, openAiCompatibleApiKey);
+
+    var (inputModalities, outputModalities, contextWindow) =
+        ModelCapabilityResolution.ResolveSessionConfig(models.Main, detected);
 
     // Session config: bind defaults from config section, overlay model-derived values
     var sessionConfig = configuration.GetSection("Session").Get<SessionConfig>() ?? new SessionConfig();
     var resolvedSessionConfig = sessionConfig with
     {
         ModelId = models.Main.ModelId,
-        ContextWindowTokens = contextWindow ?? 32_768,
+        ContextWindowTokens = contextWindow,
         CompactionModelId = models.Compaction?.ModelId,
-        InputModalities = inputModalities ?? ModelModality.Text,
-        OutputModalities = outputModalities ?? ModelModality.Text,
+        InputModalities = inputModalities,
+        OutputModalities = outputModalities,
     };
     services.AddSingleton(resolvedSessionConfig);
 

--- a/src/Netclaw.Daemon/Providers/OpenAiCompatibleCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/OpenAiCompatibleCapabilityResolver.cs
@@ -21,6 +21,7 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
         _httpClient = httpClient;
         _logger = logger;
         _endpoint = OpenAiCompatibleEndpoint.FromBaseUrl(endpoint, apiKey);
+        _httpClient.BaseAddress ??= _endpoint.BaseUri;
     }
 
     public async Task<ResolvedModelCapabilities?> ResolveAsync(string modelId, CancellationToken ct = default)
@@ -95,6 +96,17 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
 
+        int? effectiveContextWindow = contextWindow;
+        if (root.TryGetProperty("default_generation_settings", out var defaultGenerationSettings)
+            && defaultGenerationSettings.ValueKind == JsonValueKind.Object
+            && defaultGenerationSettings.TryGetProperty("params", out var parameters)
+            && parameters.ValueKind == JsonValueKind.Object
+            && parameters.TryGetProperty("n_ctx", out var nCtx)
+            && nCtx.ValueKind == JsonValueKind.Number)
+        {
+            effectiveContextWindow = nCtx.GetInt32();
+        }
+
         var inputModalities = ModelModality.Text;
         if (root.TryGetProperty("modalities", out var modalities)
             && modalities.ValueKind == JsonValueKind.Object
@@ -105,7 +117,7 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
             inputModalities |= ModelModality.Image;
         }
 
-        return new ResolvedModelCapabilities(modelId, inputModalities, ModelModality.Text, contextWindow);
+        return new ResolvedModelCapabilities(modelId, inputModalities, ModelModality.Text, effectiveContextWindow);
     }
 
     private void ApplyAuth(HttpRequestMessage request)


### PR DESCRIPTION
## Summary
- prefer Lemonade runtime `n_ctx` from `/props` over training metadata from `/v1/models` when resolving OpenAI-compatible context windows
- keep `ContextWindow` as the effective runtime clamp and validate configured values against detected provider capacity at startup
- update docs/schema wording and add tests for runtime context detection and clamp validation