### PR TITLE
chore: prepare 0.6.0 release notes and version metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,34 +7,44 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.5.0 — Observer-driven memory recall, local model reliability, and skills platform overhaul
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.6.0 — Subagents, deterministic skill loading, and reminder idempotency
 
-**Memory Recall Planning**
+IMPORTANT: This is a breaking change release. All installs prior to 0.6.0 are unsupported and no migration path is provided. Read the Breaking Changes section before upgrading.
 
-* Added sidecar-driven memory observation and recall planning with deterministic policy gates, expiry handling, and SQLite-backed retrieval — the agent now plans what to recall before acting, rather than issuing ad-hoc memory queries. ([#198](https://github.com/Aaronontheweb/netclaw/pull/198))
-* Fixed memory curation worker shutdown: `TaskCanceledException` from in-flight store awaitables during daemon stop is now caught and discarded cleanly instead of surfacing as a crash log. ([#190](https://github.com/Aaronontheweb/netclaw/pull/190))
+**Breaking Changes**
 
-**Local Model Reliability**
+* The skills feed has moved to skills.netclaw.dev and all skill version numbers have been bumped to 0.6.0. The feed format is incompatible with daemons older than 0.6.0 — older installs will not receive skill updates and may fail to parse the new manifest. There is no plan to support or maintain any Netclaw version prior to 0.6.0.
+* Removed memorizer and files memory backend options. MemoryConfig.Provider no longer accepts memorizer or files values — SQLite is now the only supported memory backend. Configurations referencing either removed option must be updated before upgrading. ([#233](https://github.com/Aaronontheweb/netclaw/pull/233))
+* set_reminder now requires a caller-provided Id as a mandatory parameter. Existing reminder automations or scripts that omit an ID will fail. The reminder create CLI command now takes &lt;id&gt; as its first positional argument. ([#241](https://github.com/Aaronontheweb/netclaw/pull/241))
 
-* Fixed multi-turn tool calling for OpenAI-compatible providers: assistant messages with tool calls and tool result messages now serialize `tool_calls` and `tool_call_id` correctly — previously the second LLM request in a tool loop contained malformed history causing models to fall back to emitting tool calls as raw text. ([#210](https://github.com/Aaronontheweb/netclaw/pull/210))
-* Added text-based tool call extraction for models that emit tool calls as XML-like prose instead of structured fields (observed with Qwen3.5) — the parser activates as a fallback when no structured tool calls are present, making these models usable for multi-step tool workflows. ([#213](https://github.com/Aaronontheweb/netclaw/pull/213))
-* Added OpenAI-compatible local endpoint support — operators can now configure endpoints like Ollama or LM Studio as a first-class provider type. ([#208](https://github.com/Aaronontheweb/netclaw/pull/208))
-* Fixed capability detection for GGUF and quantized model IDs: the normalizer now strips `.gguf` extensions, GGML quantization suffixes (`-Q5_K_M`, `-IQ2_XXS`, `-Q4_K_XL`), and build-variant segments (`-UD`, `-BPW4`) before capability resolution — models now correctly report multimodal context windows and input types instead of falling back to text-only defaults. ([#215](https://github.com/Aaronontheweb/netclaw/pull/215))
+**Subagents**
+
+* Added spawn_agent tool and SubAgentDefinitionRegistry so the frontline agent can delegate tasks to named subagents — research-assistant, code-analyst, and summarizer are seeded during netclaw init. Operators can define custom agents by placing ~/.netclaw/agents/&lt;name&gt;.json and companion &lt;name&gt;.md prompt files in that directory. ([#226](https://github.com/Aaronontheweb/netclaw/pull/226))
 
 **Skills Platform**
 
-* Adopted the AgentSkills.io SKILL.md standard: skills now use YAML frontmatter (name, description, triggers, license, compatibility, allowed-tools) and a directory-based layout (`skill-name/SKILL.md`) with progressive disclosure via `references/`, `scripts/`, and `assets/` subdirectories. Feed manifest supports per-file SHA-256 verification for multi-file skills. ([#216](https://github.com/Aaronontheweb/netclaw/pull/216))
-* Added `capability-reference` system skill — the agent's single authoritative reference for all 16 built-in tools across 5 grant categories, CLI commands, scheduling syntax, MCP discovery patterns, and session context. Also updates `self-diagnostics` to v1.2.0 with a cross-reference. ([#217](https://github.com/Aaronontheweb/netclaw/pull/217))
-* Added `search-citation` system skill — guides the agent on when to use `web_search` versus training data, requires source URLs for all specific factual claims, and covers local search, travel, and product search verticals with progressive disclosure reference files. ([#219](https://github.com/Aaronontheweb/netclaw/pull/219))
+* Skills now load deterministically before each LLM call based on conversation context — a keyword index scores skills against the current turn. This fixes cases where the agent omitted source URLs in search responses because search-citation was never loaded. ([#230](https://github.com/Aaronontheweb/netclaw/pull/230))
+* System skills are now published to skills.netclaw.dev (Cloudflare R2) with cumulative historical retention. The manifest gains an allVersions array for future version pinning and rollback. ([#243](https://github.com/Aaronontheweb/netclaw/pull/243))
+* System skills renamed to Netclaw-prefixed intent-based IDs (netclaw-manual, netclaw-memory, netclaw-diagnostics). On-disk skill directories migrate automatically on next daemon start. ([#239](https://github.com/Aaronontheweb/netclaw/pull/239))
+* Fixed search responses in Slack to use inline hyperlinks instead of footnote-style citation markers. ([#235](https://github.com/Aaronontheweb/netclaw/pull/235))
 
-**Session Self-Awareness**
+**Reminders**
 
-* The agent's session ID (`{channelId}/{threadTs}`) is now injected into the per-turn dynamic context layers, allowing the agent to be self-referential about its own session in tool calls and memory operations. ([#218](https://github.com/Aaronontheweb/netclaw/pull/218))
+* set_reminder upsert semantics: same ID updates the existing reminder instead of creating a duplicate. Schedule descriptions are now human-readable (e.g. weekdays at 09:00 UTC; next-fire times include day-of-week and local timezone). ([#241](https://github.com/Aaronontheweb/netclaw/pull/241))
+
+**Local Model Reliability**
+
+* Context window detection for OpenAI-compatible providers now prefers the live runtime value from the model server over training metadata, with startup validation against the runtime maximum. ([#238](https://github.com/Aaronontheweb/netclaw/pull/238))
+* Fixed image handling for OpenAI-compatible providers: images attached in Slack were silently dropped in multi-turn conversations. Also suppressed raw tool_call XML leaking into Slack responses and fixed duplicate tool call loops. ([#227](https://github.com/Aaronontheweb/netclaw/pull/227))
+
+**Provider Diagnostics**
+
+* Provider probe failures now surface the actual API error message from the response body instead of a generic message. Error wording updated from API key to credentials to be accurate for OAuth paths. ([#228](https://github.com/Aaronontheweb/netclaw/pull/228), [#224](https://github.com/Aaronontheweb/netclaw/pull/224))
 
 **Stability**
 
-* Fixed a stream materializer actor leak in the SignalR session binding: stream stage actors were previously created under the global `StreamSupervisor-0` and accumulated over the daemon's lifetime. A new per-session `SignalRSessionActor` scopes the materializer to the session lifecycle, so all stream children are torn down automatically when the session ends. ([#192](https://github.com/Aaronontheweb/netclaw/pull/192))</PackageReleaseNotes>
+* Fixed a startup crash on minimal Linux systems without ICU libraries — self-contained netclawd and netclaw binaries now enable InvariantGlobalization and no longer require libicu at runtime. ([#223](https://github.com/Aaronontheweb/netclaw/pull/223))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,43 @@
+#### 0.6.0 2026-03-15 ####
+
+Netclaw v0.6.0 — Subagents, deterministic skill loading, and reminder idempotency
+
+**IMPORTANT: This is a breaking change release. All installs prior to 0.6.0 are unsupported and no migration path is provided. Please read the Breaking Changes section before upgrading.**
+
+**Breaking Changes**
+
+* The skills feed has moved to `skills.netclaw.dev` and all skill version numbers have been bumped to 0.6.0. The feed format is incompatible with daemons older than 0.6.0 — older installs will not receive skill updates and may fail to parse the new manifest. There is no plan to support or maintain any Netclaw version prior to 0.6.0.
+* Removed `memorizer` and `files` memory backend options. `MemoryConfig.Provider` no longer accepts `memorizer` or `files` values — SQLite is now the only supported memory backend. Configurations referencing either removed option must be updated before upgrading. ([#233](https://github.com/Aaronontheweb/netclaw/pull/233))
+* `set_reminder` now requires a caller-provided `Id` as a mandatory parameter. Existing reminder automations or scripts that omit an ID will fail. The `reminder create` CLI command now takes `<id>` as its first positional argument. ([#241](https://github.com/Aaronontheweb/netclaw/pull/241))
+
+**Subagents**
+
+* Added `spawn_agent` tool and `SubAgentDefinitionRegistry` so the frontline agent can delegate tasks to named subagents — research-assistant, code-analyst, and summarizer are seeded during `netclaw init`. Operators can define custom agents by placing `~/.netclaw/agents/<name>.json` and companion `<name>.md` prompt files in that directory. ([#226](https://github.com/Aaronontheweb/netclaw/pull/226))
+
+**Skills Platform**
+
+* Skills now load deterministically before each LLM call based on conversation context — a keyword index (built by a sidecar LLM at scan time and cached per skill version+content hash) scores skills against the current turn. This fixes cases where the agent omitted source URLs in search responses because `search-citation` was never loaded. ([#230](https://github.com/Aaronontheweb/netclaw/pull/230))
+* System skills are now published to `skills.netclaw.dev` (Cloudflare R2) with cumulative historical retention — each version of every skill file is preserved at a versioned URL. The manifest gains an `allVersions` array for future version pinning and rollback. Skills publish on release tags and manual dispatch; dev pushes no longer auto-publish. ([#243](https://github.com/Aaronontheweb/netclaw/pull/243))
+* System skills renamed to Netclaw-prefixed intent-based IDs (e.g., `netclaw-manual`, `netclaw-memory`, `netclaw-diagnostics`). On-disk skill directories, caches, and references migrate automatically to the new names on next daemon start. ([#239](https://github.com/Aaronontheweb/netclaw/pull/239))
+* Fixed search responses in Slack to use inline hyperlinks (`[text](url)`) instead of footnote-style citation markers (`[1]`, `[2]` with a trailing reference list) — the `search-citation` skill now explicitly requires the inline format. ([#235](https://github.com/Aaronontheweb/netclaw/pull/235))
+
+**Reminders**
+
+* `set_reminder` upsert semantics: calling with the same ID now updates the existing reminder instead of creating a duplicate. IDs are normalized to lowercase kebab-case with a 50-character cap. Schedule descriptions in all tool responses, the REST API, and the CLI are now human-readable (e.g., `0 9 * * MON-FRI` → "weekdays at 09:00 UTC"; next-fire times include day-of-week and local timezone). ([#241](https://github.com/Aaronontheweb/netclaw/pull/241))
+
+**Local Model Reliability**
+
+* Context window detection for OpenAI-compatible providers now prefers the live runtime value from the model server (e.g., Lemonade `/props` `n_ctx`) over training metadata from `/v1/models`. The configured `ContextWindow` is validated against the detected provider capacity at startup and clamped to the runtime maximum. ([#238](https://github.com/Aaronontheweb/netclaw/pull/238))
+* Fixed image handling for OpenAI-compatible providers: images attached in Slack were silently dropped in multi-turn conversations. Also suppressed raw `<tool_call>` XML leaking into Slack responses and fixed duplicate tool call loops that could repeat 15+ times when assistant history was malformed. ([#227](https://github.com/Aaronontheweb/netclaw/pull/227))
+
+**Provider Diagnostics**
+
+* Provider probe failures now surface the actual API error message extracted from the response body (handles both `{"error": {"message": "..."}}` and `{"error": "..."}` JSON formats) instead of a generic "API key may lack permissions" message. Error wording updated from "API key" to "credentials" to be accurate for OAuth authentication paths. ([#228](https://github.com/Aaronontheweb/netclaw/pull/228), [#224](https://github.com/Aaronontheweb/netclaw/pull/224))
+
+**Stability**
+
+* Fixed a startup crash on minimal Linux systems (containers, VMs) that do not have ICU libraries installed — self-contained `netclawd` and `netclaw` binaries now enable `InvariantGlobalization` and no longer require `libicu` at runtime. ([#223](https://github.com/Aaronontheweb/netclaw/pull/223))
+
 #### 0.5.0 2026-03-13 ####
 
 Netclaw v0.5.0 — Observer-driven memory recall, local model reliability, and skills platform overhaul


### PR DESCRIPTION
## Summary

This is the release preparation PR for **Netclaw v0.6.0**.

**This is a breaking change release.** All installs prior to 0.6.0 are unsupported and no migration path is provided.

### Breaking Changes

- Skills feed migrated to `skills.netclaw.dev` (Cloudflare R2) — feed format is incompatible with daemons older than 0.6.0; all skill versions bumped to 0.6.0
- `memorizer` and `files` memory backend options removed — SQLite is the only supported backend; configs using either option must be updated
- `set_reminder` now requires a mandatory caller-provided `Id` — automations or scripts omitting an ID will fail; `reminder create` CLI now takes `<id>` as first positional arg

### What's in this release

- `spawn_agent` tool and subagent definition registry with seeded built-in agents (#226)
- Deterministic skill auto-loading via LLM-enriched keyword index before each LLM call (#230)
- Skills feed migration to `skills.netclaw.dev` with historical retention and `allVersions` manifest (#243)
- System skill renames to Netclaw-prefixed intent-based IDs with automatic on-disk migration (#239)
- Search citation skill updated to require inline hyperlinks in Slack (#235)
- `set_reminder` upsert semantics and human-readable schedule descriptions (#241)
- Runtime context window detection for OpenAI-compatible providers with startup validation (#238)
- OpenAI-compatible message serialization rewrite: fixed images, suppressed XML leaks, fixed tool call loops (#227)
- Provider probe failures now surface real API error details (#228, #224)
- Removed memorizer/file-backed memory backends (#233)
- Linux ICU startup crash fix via `InvariantGlobalization` (#223)

## Files changed

- `RELEASE_NOTES.md` — new 0.6.0 block prepended with prominent breaking change notice
- `Directory.Build.props` — `VersionPrefix` bumped to `0.6.0`, `PackageReleaseNotes` updated to match

## Test plan

- [ ] PR CI passes
- [ ] Merge, then tag `v0.6.0` from `dev` and push — CI/CD handles the release build and publish