### PR TITLE
feat(install): add download progress indicators to installer scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -17,6 +17,62 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Invoke-DownloadWithProgress {
+    param(
+        [string]$Uri,
+        [string]$OutFile,
+        [string]$Label
+    )
+
+    $isInteractive = [Environment]::UserInteractive -and $Host.UI.RawUI -ne $null
+
+    if (-not $isInteractive) {
+        Write-Host "  Downloading $Label..."
+        $oldPref = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
+        } finally {
+            $ProgressPreference = $oldPref
+        }
+        return
+    }
+
+    # Interactive: download in background runspace, spinner in foreground
+    $runspace = [runspacefactory]::CreateRunspace()
+    $runspace.Open()
+
+    $ps = [powershell]::Create().AddScript({
+        param($uri, $outFile)
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $uri -OutFile $outFile -UseBasicParsing
+    }).AddArgument($Uri).AddArgument($OutFile)
+
+    $ps.Runspace = $runspace
+    $handle = $ps.BeginInvoke()
+
+    $spinChars = @('|', '/', '-', '\')
+    $i = 0
+    try {
+        while (-not $handle.IsCompleted) {
+            $char = $spinChars[$i % $spinChars.Length]
+            Write-Host -NoNewline "`r  Downloading $Label... $char"
+            Start-Sleep -Milliseconds 120
+            $i++
+        }
+        Write-Host -NoNewline "`r  Downloading $Label... done"
+        Write-Host ""
+
+        $ps.EndInvoke($handle)
+        if ($ps.HadErrors) {
+            throw $ps.Streams.Error[0]
+        }
+    } finally {
+        $ps.Dispose()
+        $runspace.Close()
+    }
+}
+
 $ManifestUrl = "https://releases.netclaw.dev/manifest.json"
 $DefaultInstallDir = Join-Path $env:LOCALAPPDATA "Programs\netclaw"
 
@@ -78,9 +134,8 @@ try {
         $fileName = [System.IO.Path]::GetFileName([Uri]::new($asset.url).AbsolutePath)
         $downloadPath = Join-Path $tempDir $fileName
 
-        Write-Host "  Downloading $ComponentName..."
         try {
-            Invoke-WebRequest -Uri $asset.url -OutFile $downloadPath -UseBasicParsing
+            Invoke-DownloadWithProgress -Uri $asset.url -OutFile $downloadPath -Label $ComponentName
         } catch {
             Write-Error "Failed to download $($asset.url): $_"
             return $false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+# Progress display: show curl progress bar when stderr is a terminal
+if [ -t 2 ]; then
+    CURL_PROGRESS=(--progress-bar)
+else
+    CURL_PROGRESS=(-s)
+fi
+
 MANIFEST_URL="https://releases.netclaw.dev/manifest.json"
 
 # ── Argument parsing ──
@@ -131,7 +138,7 @@ download_component() {
     filename=$(basename "$url")
 
     echo "  Downloading $component..."
-    curl -sSL --fail -o "$TMPDIR/$filename" "$url" || {
+    curl "${CURL_PROGRESS[@]}" -fL -o "$TMPDIR/$filename" "$url" || {
         echo "  Error: Failed to download $url" >&2
         return 1
     }


### PR DESCRIPTION
## Summary
- **Bash**: Use `curl --progress-bar` when stderr is a TTY to show a `###` progress bar with percentage during binary downloads. Falls back to silent in non-interactive contexts (CI).
- **PowerShell**: Add spinner (`|/-\`) via background runspace while `Invoke-WebRequest` runs with `$ProgressPreference = 'SilentlyContinue'`. Avoids the notorious PS 5.1 `Write-Progress` performance penalty (10x slower downloads). Falls back to static message in non-interactive contexts.
- Manifest fetch remains silent on both platforms (small/fast).

## Test plan
- [ ] Bash interactive: `bash scripts/install.sh` — confirm `###` progress bar appears during download
- [ ] Bash non-interactive: `bash scripts/install.sh 2>/dev/null` — confirm clean silent download
- [ ] PowerShell interactive: `.\scripts\install.ps1` — confirm spinner animates during download
- [ ] Error case: test with a bad URL to confirm errors propagate through both progress mechanisms