### PR TITLE
fix(init): paste routing, Memory skip, token validation, health check timeouts

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -41,18 +41,27 @@ public sealed class FakeSlackProbe : ISlackProbe
     /// </summary>
     public IReadOnlyList<string>? LastResolvedNames { get; private set; }
 
-    public Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
+    /// <summary>
+    /// Optional delay before returning results. Used to test timeout behavior.
+    /// </summary>
+    public TimeSpan? DelayBeforeResult { get; set; }
+
+    public async Task<SlackProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
     {
         ProbeCallCount++;
         LastBotToken = botToken;
-        return Task.FromResult(NextResult);
+        if (DelayBeforeResult.HasValue)
+            await Task.Delay(DelayBeforeResult.Value, ct);
+        return NextResult;
     }
 
-    public Task<SlackChannelResolutionResult> ResolveChannelNamesAsync(
+    public async Task<SlackChannelResolutionResult> ResolveChannelNamesAsync(
         string botToken, IReadOnlyList<string> channelNames, CancellationToken ct = default)
     {
         ResolveCallCount++;
         LastResolvedNames = channelNames;
-        return Task.FromResult(NextResolutionResult);
+        if (DelayBeforeResult.HasValue)
+            await Task.Delay(DelayBeforeResult.Value, ct);
+        return NextResolutionResult;
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -61,10 +61,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.GoNext();
         Assert.Equal(WizardStep.BrowserAutomation, vm.CurrentStep.Value);
 
-        vm.GoNext();
-        Assert.Equal(WizardStep.Memory, vm.CurrentStep.Value);
-
-        vm.GoNext();
+        vm.GoNext(); // Memory is skipped
         Assert.Equal(WizardStep.Exposure, vm.CurrentStep.Value);
 
         vm.GoNext();
@@ -426,39 +423,37 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
-    public void ActiveStepCount_IsEight_WhenNoChatServices()
+    public void ActiveStepCount_IsSeven_WhenNoChatServices()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = false;
+        Assert.Equal(7, vm.ActiveStepCount);
+    }
+
+    [Fact]
+    public void ActiveStepCount_IsEight_WhenChatServicesEnabled()
+    {
+        using var vm = CreateViewModel();
+        vm.SlackEnabled = true;
         Assert.Equal(8, vm.ActiveStepCount);
     }
 
     [Fact]
-    public void ActiveStepCount_IsNine_WhenChatServicesEnabled()
-    {
-        using var vm = CreateViewModel();
-        vm.SlackEnabled = true;
-        Assert.Equal(9, vm.ActiveStepCount);
-    }
-
-    [Fact]
-    public void GetDisplayStepNumber_AdjustsForSkippedAcl()
+    public void GetDisplayStepNumber_AdjustsForSkippedAclAndMemory()
     {
         using var vm = CreateViewModel();
         vm.SlackEnabled = false;
 
-        // Provider = 1, ChatServices = 2, Acl would be 3 but skipped
-        // Search = 3 (adjusted from 4), BrowserAutomation = 4 (adjusted from 5),
-        // Memory = 5 (adjusted from 6), Exposure = 6 (adjusted from 7),
-        // Identity = 7, HealthCheck = 8
+        // Provider = 1, ChatServices = 2, Acl skipped, Search = 3,
+        // BrowserAutomation = 4, Memory skipped, Exposure = 5,
+        // Identity = 6, HealthCheck = 7
         Assert.Equal(1, vm.GetDisplayStepNumber(WizardStep.Provider));
         Assert.Equal(2, vm.GetDisplayStepNumber(WizardStep.ChatServices));
         Assert.Equal(3, vm.GetDisplayStepNumber(WizardStep.Search));
         Assert.Equal(4, vm.GetDisplayStepNumber(WizardStep.BrowserAutomation));
-        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.Memory));
-        Assert.Equal(6, vm.GetDisplayStepNumber(WizardStep.Exposure));
-        Assert.Equal(7, vm.GetDisplayStepNumber(WizardStep.Identity));
-        Assert.Equal(8, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
+        Assert.Equal(5, vm.GetDisplayStepNumber(WizardStep.Exposure));
+        Assert.Equal(6, vm.GetDisplayStepNumber(WizardStep.Identity));
+        Assert.Equal(7, vm.GetDisplayStepNumber(WizardStep.HealthCheck));
     }
 
     [Fact]
@@ -944,6 +939,57 @@ public sealed class InitWizardViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task HealthCheck_SlackProbeTimeout_ShowsTimeoutFailure()
+    {
+        _fakeSlackProbe.DelayBeforeResult = TimeSpan.FromMinutes(5); // way beyond 15s timeout
+        using var vm = CreateViewModel();
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = true;
+        vm.SlackBotToken = "xoxb-test-bot-token";
+        vm.SlackAppToken = "xapp-test-app-token";
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromSeconds(30));
+        Assert.True(vm.IsComplete.Value);
+
+        var slackCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Slack", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(slackCheck);
+        Assert.False(slackCheck.Passed);
+        Assert.Contains("timed out", slackCheck.Label, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task HealthCheck_BrowserBootstrapTimeout_ShowsTimeoutFailure()
+    {
+        var browserBootstrapper = new FakeBrowserAutomationBootstrapper
+        {
+            NextResult = new BrowserAutomationBootstrapResult(true, false, "ready"),
+            DelayBeforeResult = TimeSpan.FromMinutes(10) // way beyond 3m timeout
+        };
+        using var vm = CreateViewModel(browserBootstrapper);
+
+        vm.SelectedProviderType = "ollama";
+        vm.SlackEnabled = false;
+        vm.BrowserAutomationEnabled = true;
+        vm.SelectedBrowserAutomationBackend = BrowserAutomationMcpProfiles.PlaywrightBackend;
+
+        vm.CurrentStep.Value = WizardStep.HealthCheck;
+        vm.GoNext();
+
+        await vm.HealthCheckCompletion!.WaitAsync(TimeSpan.FromMinutes(5));
+        Assert.True(vm.IsComplete.Value);
+
+        var browserCheck = vm.HealthCheckResults
+            .FirstOrDefault(h => h.Label.Contains("Browser automation", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(browserCheck);
+        Assert.False(browserCheck.Passed);
+        Assert.Contains("timed out", browserCheck.Label, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void WriteIdentityFiles_GeneratesAllThreeFiles()
     {
         using var vm = CreateViewModel();
@@ -990,9 +1036,16 @@ internal sealed class FakeBrowserAutomationBootstrapper : IBrowserAutomationBoot
     public BrowserAutomationBootstrapResult NextResult { get; set; } =
         new(true, false, "ready");
 
-    public Task<BrowserAutomationBootstrapResult> EnsureReadyAsync(string backend, CancellationToken ct = default)
+    /// <summary>
+    /// Optional delay before returning results. Used to test timeout behavior.
+    /// </summary>
+    public TimeSpan? DelayBeforeResult { get; set; }
+
+    public async Task<BrowserAutomationBootstrapResult> EnsureReadyAsync(string backend, CancellationToken ct = default)
     {
         CallCount++;
-        return Task.FromResult(NextResult);
+        if (DelayBeforeResult.HasValue)
+            await Task.Delay(DelayBeforeResult.Value, ct);
+        return NextResult;
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -60,7 +60,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private SelectionListNode<string>? _commStyleList;
     private TextInputNode? _userNameInput;
     private TextInputNode? _timezoneInput;
-    private TextInputNode? _primaryUseInput;
+    private TextAreaNode? _primaryUseInput;
 
     // Track sub-step for provider (0=select, 1=auth, 2=credentials, 3=validate, 4=model)
     private int _providerSubStep;
@@ -69,7 +69,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     // Focus tracking for selection lists (mirrors _lastFocusedInput for text inputs)
     private IFocusable? _lastFocusedList;
-    private TextInputNode? _lastFocusedInput;
+    private TextInputBaseNode? _lastFocusedInput;
 
     // Dynamic layout nodes — invalidation-driven (Termina 0.7.1+).
     // Factory runs once on creation, then only on Invalidate().
@@ -88,6 +88,11 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         // Route keyboard input
         ViewModel.Input.OfType<IInputEvent, KeyPressed>()
             .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+
+        // Route bracketed paste events to the active text input
+        ViewModel.Input.OfType<IInputEvent, PasteEvent>()
+            .Subscribe(HandlePaste)
             .DisposeWith(Subscriptions);
     }
 
@@ -139,7 +144,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     WizardStep.Acl => "Access Control",
                     WizardStep.Search => "Web Search",
                     WizardStep.BrowserAutomation => "Browser Automation",
-                    WizardStep.Memory => "Memory Backend",
+
                     WizardStep.Exposure => "Exposure Mode",
                     WizardStep.Identity => "Identity",
                     WizardStep.HealthCheck => "Health Check",
@@ -193,7 +198,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 WizardStep.Acl => BuildAclStep(),
                 WizardStep.Search => BuildSearchStep(),
                 WizardStep.BrowserAutomation => BuildBrowserAutomationStep(),
-                WizardStep.Memory => BuildMemoryStep(),
+
                 WizardStep.Exposure => BuildExposureStep(),
                 WizardStep.Identity => BuildIdentityStep(),
                 _ => Layouts.Empty()
@@ -244,8 +249,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                     "  Optional. Enable this to let the agent delegate browser steering via MCP tools.",
                 WizardStep.BrowserAutomation when _browserAutomationSubStep == 1 =>
                     "  Playwright MCP is the default no-sudo path. Chrome DevTools is enabled only when a local Chrome executable is detected.",
-                WizardStep.Memory =>
-                    "  SQLite provides durable cross-session memory. No configuration required.",
+
                 WizardStep.Exposure =>
                     "  Local-only is recommended for homelab use.",
                 WizardStep.Identity when _identitySubStep == 0 =>
@@ -726,6 +730,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Where(text => !string.IsNullOrWhiteSpace(text))
             .Subscribe(text =>
             {
+                if (!text.StartsWith("xoxb-", StringComparison.OrdinalIgnoreCase))
+                {
+                    ViewModel.StatusMessage.Value = "Bot tokens start with xoxb-. Check you pasted the correct value.";
+                    return;
+                }
+                ViewModel.StatusMessage.Value = "";
                 ViewModel.SlackBotToken = text;
                 SetChatServicesSubStep(2);
             })
@@ -754,6 +764,12 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .Where(text => !string.IsNullOrWhiteSpace(text))
             .Subscribe(text =>
             {
+                if (!text.StartsWith("xapp-", StringComparison.OrdinalIgnoreCase))
+                {
+                    ViewModel.StatusMessage.Value = "App tokens start with xapp-. Check you pasted the correct value.";
+                    return;
+                }
+                ViewModel.StatusMessage.Value = "";
                 ViewModel.SlackAppToken = text;
                 SetChatServicesSubStep(3);
             })
@@ -1091,18 +1107,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .WithChild(_browserAutomationBackendList);
     }
 
-    /// <summary>
-    /// Memory step — SQLite is the only backend. Shows a static info line
-    /// and advances to the next step on Enter.
-    /// </summary>
-    private ILayoutNode BuildMemoryStep()
-    {
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  Memory backend: SQLite (local durable memory)").WithForeground(Color.White))
-            .WithChild(new TextNode(""))
-            .WithChild(new TextNode("  Press Enter to continue.").WithForeground(Color.BrightBlack));
-    }
-
     private ILayoutNode BuildExposureStep()
     {
         _exposureList = Layouts.SelectionList(
@@ -1259,8 +1263,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private ILayoutNode BuildPrimaryUseSubStep()
     {
-        _primaryUseInput = new TextInputNode()
-            .WithPlaceholder("e.g., homelab management, dev environment, home automation");
+        _primaryUseInput = new TextAreaNode()
+            .WithPlaceholder("e.g., homelab management, dev environment, home automation")
+            .WithMaxHeight(6);
 
         if (!string.IsNullOrWhiteSpace(ViewModel.PrimaryUse))
             _primaryUseInput.Text = ViewModel.PrimaryUse;
@@ -1284,7 +1289,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .WithBorder(BorderStyle.Rounded)
                 .WithBorderColor(Color.Gray)
                 .WithContent(_primaryUseInput)
-                .Height(3));
+                .Height(8));
     }
 
     private ILayoutNode BuildHealthCheckStep()
@@ -1331,6 +1336,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
         // Route input to active component
         RouteInputToActiveComponent(keyInfo);
+    }
+
+    private void HandlePaste(PasteEvent paste)
+    {
+        var activeInput = GetActiveTextInput();
+        activeInput?.HandlePaste(paste);
+        ViewModel.RequestRedraw();
     }
 
     private bool HandleSubStepBack()
@@ -1463,13 +1475,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             return;
         }
 
-        // On Memory step, Enter advances to next step
-        if (ViewModel.CurrentStep.Value == WizardStep.Memory && keyInfo.Key == ConsoleKey.Enter)
-        {
-            ViewModel.GoNext();
-            return;
-        }
-
         // On health check step, Enter triggers the check
         if (ViewModel.CurrentStep.Value == WizardStep.HealthCheck && keyInfo.Key == ConsoleKey.Enter)
         {
@@ -1498,7 +1503,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         };
     }
 
-    private TextInputNode? GetActiveTextInput()
+    private TextInputBaseNode? GetActiveTextInput()
     {
         return ViewModel.CurrentStep.Value switch
         {

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -38,6 +38,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
 {
     public const int TotalSteps = 9;
     private static readonly TimeSpan ProbeHardTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan SlackProbeHardTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ChannelResolutionHardTimeout = TimeSpan.FromSeconds(35);
+    private static readonly TimeSpan BrowserBootstrapHardTimeout = TimeSpan.FromMinutes(3);
+    private static readonly TimeSpan DaemonPollRequestTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan OverallHealthCheckTimeout = TimeSpan.FromMinutes(5);
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
@@ -196,7 +201,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// <summary>
     /// Returns the number of active steps (skipping ACL when no chat services).
     /// </summary>
-    public int ActiveStepCount => AnyChatServicesEnabled() ? TotalSteps : TotalSteps - 1;
+    public int ActiveStepCount => TotalSteps - 1 - (AnyChatServicesEnabled() ? 0 : 1);
 
     /// <summary>
     /// Returns the display number for the given step, accounting for skipped steps.
@@ -205,7 +210,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
     {
         var num = (int)step;
         if (!AnyChatServicesEnabled() && step > WizardStep.ChatServices)
-            return num - 1;
+            num--;
+        if (step > WizardStep.Memory)
+            num--;
         return num;
     }
 
@@ -226,6 +233,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
         // Skip ACL when no chat services are enabled
         if (next == WizardStep.Acl && !AnyChatServicesEnabled())
+            next = (WizardStep)((int)next + 1);
+
+        // Skip Memory — SQLite is the only backend, no user input needed
+        if (next == WizardStep.Memory)
             next = (WizardStep)((int)next + 1);
 
         CurrentStep.Value = next;
@@ -250,6 +261,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
         // Skip ACL when going back too
         if (previous == WizardStep.Acl && !AnyChatServicesEnabled())
+            previous = (WizardStep)((int)previous - 1);
+
+        // Skip Memory going back too
+        if (previous == WizardStep.Memory)
             previous = (WizardStep)((int)previous - 1);
 
         // Back-navigation clearing rules from design doc:
@@ -544,6 +559,23 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
     private async Task RunHealthCheckAsync()
     {
+        using var overallCts = new CancellationTokenSource(OverallHealthCheckTimeout);
+        try
+        {
+            await RunHealthCheckCoreAsync(overallCts.Token);
+        }
+        catch (OperationCanceledException) when (overallCts.IsCancellationRequested)
+        {
+            HealthCheckResults.Add(new HealthCheckItem("Health check timed out", false));
+            IsHealthCheckRunning.Value = false;
+            IsComplete.Value = true;
+            NotifyHealthCheckChanged();
+            StatusMessage.Value = "Setup timed out. Run `netclaw daemon start` to begin.";
+        }
+    }
+
+    private async Task RunHealthCheckCoreAsync(CancellationToken ct)
+    {
         IsHealthCheckRunning.Value = true;
         IsComplete.Value = false;
         HealthCheckResults.Clear();
@@ -552,7 +584,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         // Provider check
         HealthCheckResults.Add(new HealthCheckItem("LLM provider configured", null));
         NotifyHealthCheckChanged();
-        await Task.Delay(200); // simulate validation
+        await Task.Delay(200, ct); // simulate validation
 
         var providerOk = !string.IsNullOrWhiteSpace(SelectedProviderType);
         HealthCheckResults[^1] = new HealthCheckItem(
@@ -563,7 +595,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         // Model check
         HealthCheckResults.Add(new HealthCheckItem("Model selected", null));
         NotifyHealthCheckChanged();
-        await Task.Delay(200);
+        await Task.Delay(200, ct);
 
         var modelOk = !string.IsNullOrWhiteSpace(SelectedModelId);
         HealthCheckResults[^1] = new HealthCheckItem(
@@ -590,17 +622,27 @@ public partial class InitWizardViewModel : ReactiveViewModel
         }
         else
         {
-            var slackResult = await _slackProbe.ProbeAsync(SlackBotToken!);
-            if (slackResult.Success)
+            try
             {
-                HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Slack bot authenticated (team: {slackResult.TeamName})", true);
-                slackAuthOk = true;
+                using var slackCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                slackCts.CancelAfter(SlackProbeHardTimeout);
+                var slackResult = await _slackProbe.ProbeAsync(SlackBotToken!, slackCts.Token);
+                if (slackResult.Success)
+                {
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Slack bot authenticated (team: {slackResult.TeamName})", true);
+                    slackAuthOk = true;
+                }
+                else
+                {
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Slack auth failed: {slackResult.ErrorMessage}", false);
+                }
             }
-            else
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Slack auth failed: {slackResult.ErrorMessage}", false);
+                    "Slack auth timed out (15s). Check your network connection.", false);
             }
         }
         NotifyHealthCheckChanged();
@@ -612,25 +654,35 @@ public partial class InitWizardViewModel : ReactiveViewModel
             HealthCheckResults.Add(new HealthCheckItem("Resolving Slack channels", null));
             NotifyHealthCheckChanged();
 
-            LastChannelResolution = await _slackProbe.ResolveChannelNamesAsync(
-                SlackBotToken!, parsedChannelNames);
+            try
+            {
+                using var channelCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                channelCts.CancelAfter(ChannelResolutionHardTimeout);
+                LastChannelResolution = await _slackProbe.ResolveChannelNamesAsync(
+                    SlackBotToken!, parsedChannelNames, channelCts.Token);
 
-            if (LastChannelResolution.ErrorMessage is not null)
-            {
-                HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Slack channel lookup failed: {LastChannelResolution.ErrorMessage}", false);
+                if (LastChannelResolution.ErrorMessage is not null)
+                {
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Slack channel lookup failed: {LastChannelResolution.ErrorMessage}", false);
+                }
+                else if (LastChannelResolution.Unresolved.Count > 0)
+                {
+                    var notFound = string.Join(", ", LastChannelResolution.Unresolved.Select(n => $"#{n}"));
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Slack channels: resolved {LastChannelResolution.Resolved.Count}/{parsedChannelNames.Count}, not found: {notFound}",
+                        false);
+                }
+                else
+                {
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Slack channels resolved ({LastChannelResolution.Resolved.Count})", true);
+                }
             }
-            else if (LastChannelResolution.Unresolved.Count > 0)
-            {
-                var notFound = string.Join(", ", LastChannelResolution.Unresolved.Select(n => $"#{n}"));
-                HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Slack channels: resolved {LastChannelResolution.Resolved.Count}/{parsedChannelNames.Count}, not found: {notFound}",
-                    false);
-            }
-            else
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Slack channels resolved ({LastChannelResolution.Resolved.Count})", true);
+                    "Slack channel resolution timed out (35s). Check your network connection.", false);
             }
             NotifyHealthCheckChanged();
         }
@@ -645,34 +697,46 @@ public partial class InitWizardViewModel : ReactiveViewModel
             HealthCheckResults.Add(new HealthCheckItem("Browser automation prerequisites", null));
             NotifyHealthCheckChanged();
 
-            var bootstrap = await _browserBootstrapper.EnsureReadyAsync(SelectedBrowserAutomationBackend);
-            if (bootstrap.Success)
+            try
             {
-                var backendName = SelectedBrowserAutomationBackend == BrowserAutomationMcpProfiles.PlaywrightBackend
-                    ? "Playwright MCP"
-                    : "Chrome DevTools MCP";
-                HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Browser automation ready ({backendName})", true);
-                NotifyHealthCheckChanged();
-            }
-            else
-            {
-                var suffix = string.IsNullOrWhiteSpace(bootstrap.ManualCommand)
-                    ? string.Empty
-                    : $" Command: {bootstrap.ManualCommand}";
-
-                HealthCheckResults[^1] = new HealthCheckItem(
-                    $"Browser automation setup blocked: {bootstrap.Message}{suffix}", false);
-                NotifyHealthCheckChanged();
-
-                if (bootstrap.NeedsManualAction)
+                using var browserCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                browserCts.CancelAfter(BrowserBootstrapHardTimeout);
+                var bootstrap = await _browserBootstrapper.EnsureReadyAsync(
+                    SelectedBrowserAutomationBackend, browserCts.Token);
+                if (bootstrap.Success)
                 {
-                    IsHealthCheckRunning.Value = false;
-                    StatusMessage.Value = string.IsNullOrWhiteSpace(bootstrap.ManualCommand)
-                        ? $"{bootstrap.Message} Press Enter to retry."
-                        : $"{bootstrap.Message} Run `{bootstrap.ManualCommand}`, then press Enter to retry.";
-                    return;
+                    var backendName = SelectedBrowserAutomationBackend == BrowserAutomationMcpProfiles.PlaywrightBackend
+                        ? "Playwright MCP"
+                        : "Chrome DevTools MCP";
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Browser automation ready ({backendName})", true);
+                    NotifyHealthCheckChanged();
                 }
+                else
+                {
+                    var suffix = string.IsNullOrWhiteSpace(bootstrap.ManualCommand)
+                        ? string.Empty
+                        : $" Command: {bootstrap.ManualCommand}";
+
+                    HealthCheckResults[^1] = new HealthCheckItem(
+                        $"Browser automation setup blocked: {bootstrap.Message}{suffix}", false);
+                    NotifyHealthCheckChanged();
+
+                    if (bootstrap.NeedsManualAction)
+                    {
+                        IsHealthCheckRunning.Value = false;
+                        StatusMessage.Value = string.IsNullOrWhiteSpace(bootstrap.ManualCommand)
+                            ? $"{bootstrap.Message} Press Enter to retry."
+                            : $"{bootstrap.Message} Run `{bootstrap.ManualCommand}`, then press Enter to retry.";
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                HealthCheckResults[^1] = new HealthCheckItem(
+                    "Browser automation setup timed out (3m). Try again or skip browser automation.", false);
+                NotifyHealthCheckChanged();
             }
         }
 
@@ -699,7 +763,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             HealthCheckResults.Add(new HealthCheckItem("Starting daemon", null));
             NotifyHealthCheckChanged();
 
-            var daemonOk = await StartAndPollDaemonAsync();
+            var daemonOk = await StartAndPollDaemonAsync(ct);
             if (daemonOk)
             {
                 HealthCheckResults[^1] = new HealthCheckItem("Daemon ready", true);
@@ -733,7 +797,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// Start the daemon and poll its health endpoint until ready (up to 30s).
     /// Returns false if DaemonManager is not available or health poll times out.
     /// </summary>
-    private async Task<bool> StartAndPollDaemonAsync()
+    private async Task<bool> StartAndPollDaemonAsync(CancellationToken ct = default)
     {
         if (_daemonManager is null)
             return false;
@@ -742,14 +806,15 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (!result.Success && !result.Message.Contains("already running", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        using var httpClient = new HttpClient();
+        using var httpClient = new HttpClient { Timeout = DaemonPollRequestTimeout };
         var healthUrl = $"{_daemonEndpoint}/api/health/ready";
 
         for (var i = 0; i < 30; i++)
         {
+            ct.ThrowIfCancellationRequested();
             try
             {
-                var response = await httpClient.GetAsync(healthUrl);
+                var response = await httpClient.GetAsync(healthUrl, ct);
                 if (response.IsSuccessStatusCode)
                     return true;
             }
@@ -758,13 +823,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 HealthCheckResults[^1] = new HealthCheckItem($"Starting daemon ({i + 1}s)", null);
                 NotifyHealthCheckChanged();
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException) when (!ct.IsCancellationRequested)
             {
                 HealthCheckResults[^1] = new HealthCheckItem($"Starting daemon ({i + 1}s)", null);
                 NotifyHealthCheckChanged();
             }
 
-            await Task.Delay(1000);
+            await Task.Delay(1000, ct);
         }
 
         return false;


### PR DESCRIPTION
## Summary

- **Paste routing**: Route `PasteEvent` to the active text input in the init wizard — fixes bracketed paste being silently dropped (matching ChatPage/ReminderCreatePage behavior)
- **Memory step removed**: Skip the Memory wizard step entirely since SQLite is the only backend (health check verification retained)
- **Multi-line primary use**: Replace single-line `TextInputNode` with `TextAreaNode` for the primary use description field
- **Token prefix validation**: Validate `xoxb-`/`xapp-` prefix on Slack token submit before advancing, with inline error via StatusMessage
- **Health check timeouts**: Wrap each async health check stage with per-operation linked CTS timeouts (Slack probe 15s, channel resolution 35s, browser bootstrap 3m, daemon poll 5s/request, overall 5m) so the wizard never hangs

## Test plan

- [x] `dotnet build` compiles cleanly (0 warnings, 0 errors)
- [x] `dotnet test --filter InitWizardViewModelTests` — all 44 tests pass (including 2 new timeout tests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual smoke test: `netclaw init`, paste token, verify paste works, verify Memory step is skipped, verify bad token prefix shows error, verify primary use allows multi-line