### PR TITLE
feat(init): interactive onboarding chat + provider fixes

### DIFF
--- a/.claude/skills/local-binary-swap.md
+++ b/.claude/skills/local-binary-swap.md
@@ -1,0 +1,74 @@
+---
+name: local-binary-swap
+description: Publish and swap local netclaw/netclawd binaries for live integration testing. Activate when user says "swap binaries", "publish locally", "test locally", or wants to test CLI/daemon changes against their running install.
+---
+
+# Local Binary Swap for Integration Testing
+
+Publish the CLI and/or daemon from the current worktree and swap them into the
+user's local `~/.netclaw/bin/` install for live testing.
+
+## Safety Protocol
+
+1. **Stop the daemon first** — never overwrite a running binary
+2. **Back up originals** — always create `.bak` copies before overwriting
+3. **Confirm with user** before swapping if unsure about their intent
+
+## Procedure
+
+### 1. Stop any running daemon
+
+```bash
+netclaw daemon stop 2>&1 || true
+```
+
+If a daemon is still running (check `pgrep netclawd`), warn the user and abort.
+
+### 2. Back up existing binaries
+
+```bash
+cp ~/.netclaw/bin/netclaw ~/.netclaw/bin/netclaw.bak
+cp ~/.netclaw/bin/netclawd ~/.netclaw/bin/netclawd.bak
+```
+
+### 3. Publish from current worktree
+
+```bash
+dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj \
+  -c Release -r linux-x64 --self-contained \
+  -p:PublishSingleFile=true -o /tmp/netclaw-publish
+
+dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj \
+  -c Release -r linux-x64 --self-contained \
+  -p:PublishSingleFile=true -o /tmp/netclawd-publish
+```
+
+### 4. Swap binaries
+
+```bash
+cp /tmp/netclaw-publish/netclaw ~/.netclaw/bin/netclaw
+cp /tmp/netclawd-publish/netclawd ~/.netclaw/bin/netclawd
+```
+
+### 5. Verify
+
+```bash
+netclaw --version   # should show dev version or updated output
+```
+
+## Restore Procedure
+
+To revert to the original binaries:
+
+```bash
+cp ~/.netclaw/bin/netclaw.bak ~/.netclaw/bin/netclaw
+cp ~/.netclaw/bin/netclawd.bak ~/.netclaw/bin/netclawd
+```
+
+## Notes
+
+- Published binaries will be larger than release builds (self-contained includes
+  the .NET runtime; release builds may use NativeAOT/trimming)
+- Only swap what changed — if only CLI code changed, no need to republish the daemon
+- The `.bak` files are not cleaned up automatically; remove them manually when done
+- On macOS, use `-r osx-arm64` or `-r osx-x64` instead of `linux-x64`

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -997,7 +997,6 @@ public sealed class InitWizardViewModelTests : IDisposable
         vm.CommunicationStyle = "Concise & casual";
         vm.UserName = "Dave";
         vm.UserTimezone = "America/Chicago";
-        vm.PrimaryUse = "Managing Kubernetes clusters";
 
         vm.WriteIdentityFiles();
 
@@ -1008,7 +1007,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Contains("concise and casual", soul, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Dave", soul, StringComparison.Ordinal);
         Assert.Contains("America/Chicago", soul, StringComparison.Ordinal);
-        Assert.Contains("Managing Kubernetes clusters", soul, StringComparison.Ordinal);
+        Assert.DoesNotContain("Primary use", soul, StringComparison.OrdinalIgnoreCase);
 
         // AGENTS.md
         Assert.True(File.Exists(_paths.AgentsPath));

--- a/src/Netclaw.Cli/Tui/ChatNavigationState.cs
+++ b/src/Netclaw.Cli/Tui/ChatNavigationState.cs
@@ -22,4 +22,21 @@ public sealed class ChatNavigationState
         ResumeSessionId = null;
         return id;
     }
+
+    /// <summary>
+    /// When set, <see cref="ChatViewModel"/> will auto-send this message
+    /// (hidden from the UI) after the session is established. Used by the
+    /// init wizard to trigger the onboarding interview.
+    /// </summary>
+    public string? InitialMessage { get; set; }
+
+    /// <summary>
+    /// Takes and clears the initial message in one operation.
+    /// </summary>
+    public string? TakeInitialMessage()
+    {
+        var msg = InitialMessage;
+        InitialMessage = null;
+        return msg;
+    }
 }

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -18,6 +18,7 @@ public partial class ChatViewModel : ReactiveViewModel
     private readonly TimeProvider _timeProvider;
     private readonly SessionConfig _sessionConfig;
     private string? _resumeSessionId;
+    private string? _initialMessage;
 
     private readonly Subject<SessionOutput> _outputSubject = new();
     private readonly Queue<string> _pendingMessages = new();
@@ -55,6 +56,7 @@ public partial class ChatViewModel : ReactiveViewModel
         _timeProvider = timeProvider;
         _sessionConfig = sessionConfig;
         _resumeSessionId = navigationState.TakeResumeSessionId();
+        _initialMessage = navigationState.TakeInitialMessage();
     }
 
     public override void OnActivated()
@@ -89,6 +91,7 @@ public partial class ChatViewModel : ReactiveViewModel
                 if (evt.State is DaemonConnectionState.Disconnected or DaemonConnectionState.Reconnecting)
                 {
                     _sessionReady = false;
+                    IsGenerating.Value = false;
                 }
 
                 if (evt.State is DaemonConnectionState.Connected)
@@ -225,6 +228,24 @@ public partial class ChatViewModel : ReactiveViewModel
                 Contents = [new TextContent(pending)],
                 ReceivedAt = _timeProvider.GetUtcNow()
             });
+        }
+
+        // Auto-send hidden trigger message (e.g., onboarding interview prompt).
+        // Not rendered as a user bubble — the LLM's greeting is the first visible thing.
+        if (_initialMessage is not null)
+        {
+            var trigger = _initialMessage;
+            _initialMessage = null;
+            IsGenerating.Value = true;
+            StatusMessage.Value = "Generating...";
+            RequestRedraw();
+            await _daemonClient.SendAsync(new ChannelInput
+            {
+                SenderId = "system-init",
+                Contents = [new TextContent(trigger)],
+                ReceivedAt = _timeProvider.GetUtcNow()
+            });
+            return;
         }
 
         if (!IsGenerating.Value)

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -60,12 +60,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private SelectionListNode<string>? _commStyleList;
     private TextInputNode? _userNameInput;
     private TextInputNode? _timezoneInput;
-    private TextAreaNode? _primaryUseInput;
-
     // Track sub-step for provider (0=select, 1=auth, 2=credentials, 3=validate, 4=model)
     private int _providerSubStep;
     private int _chatServicesSubStep; // 0=enable?, 1=bot token, 2=app token, 3=channel names
-    private int _identitySubStep; // 0=agent name, 1=comm style, 2=user name, 3=timezone, 4=primary use
+    private int _identitySubStep; // 0=agent name, 1=comm style, 2=user name, 3=timezone
 
     // Focus tracking for selection lists (mirrors _lastFocusedInput for text inputs)
     private IFocusable? _lastFocusedList;
@@ -436,7 +434,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .DisposeWith(_stepSubs);
 
             return Layouts.Vertical()
-                .WithChild(new TextNode("  Ollama endpoint:").WithForeground(Color.White))
+                .WithChild(new TextNode($"  {providerType} endpoint:").WithForeground(Color.White))
                 .WithChild(new PanelNode()
                     .WithTitle("Endpoint")
                     .WithBorder(BorderStyle.Rounded)
@@ -1143,7 +1141,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             1 => BuildCommStyleSubStep(),
             2 => BuildUserNameSubStep(),
             3 => BuildTimezoneSubStep(),
-            4 => BuildPrimaryUseSubStep(),
             _ => Layouts.Empty()
         };
     }
@@ -1247,7 +1244,8 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             {
                 ViewModel.UserTimezone = string.IsNullOrWhiteSpace(text)
                     ? TimeZoneInfo.Local.Id : text;
-                SetIdentitySubStep(4);
+                _identitySubStep = 0;
+                ViewModel.GoNext();
             })
             .DisposeWith(_stepSubs);
 
@@ -1259,37 +1257,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .WithBorderColor(Color.Gray)
                 .WithContent(_timezoneInput)
                 .Height(3));
-    }
-
-    private ILayoutNode BuildPrimaryUseSubStep()
-    {
-        _primaryUseInput = new TextAreaNode()
-            .WithPlaceholder("e.g., homelab management, dev environment, home automation")
-            .WithMaxHeight(6);
-
-        if (!string.IsNullOrWhiteSpace(ViewModel.PrimaryUse))
-            _primaryUseInput.Text = ViewModel.PrimaryUse;
-
-        _primaryUseInput.OnFocused();
-        _lastFocusedInput = _primaryUseInput;
-
-        _primaryUseInput.Submitted
-            .Subscribe(text =>
-            {
-                ViewModel.PrimaryUse = string.IsNullOrWhiteSpace(text) ? null : text;
-                _identitySubStep = 0;
-                ViewModel.GoNext();
-            })
-            .DisposeWith(_stepSubs);
-
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  What will you primarily use this for?").WithForeground(Color.White))
-            .WithChild(new PanelNode()
-                .WithTitle("Primary Use")
-                .WithBorder(BorderStyle.Rounded)
-                .WithBorderColor(Color.Gray)
-                .WithContent(_primaryUseInput)
-                .Height(8));
     }
 
     private ILayoutNode BuildHealthCheckStep()
@@ -1520,7 +1487,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             WizardStep.Identity when _identitySubStep == 0 => _agentNameInput,
             WizardStep.Identity when _identitySubStep == 2 => _userNameInput,
             WizardStep.Identity when _identitySubStep == 3 => _timezoneInput,
-            WizardStep.Identity when _identitySubStep == 4 => _primaryUseInput,
             _ => null
         };
     }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -48,6 +48,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     private readonly IProviderProbe _probe;
     private readonly ProviderDescriptorRegistry _registry;
     private readonly ISlackProbe _slackProbe;
+    private readonly ChatNavigationState? _navigationState;
     private readonly IBrowserAutomationBootstrapper _browserBootstrapper;
     private readonly DeviceFlowServiceFactory? _oauthFactory;
     private CancellationTokenSource? _oauthCts;
@@ -130,7 +131,6 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public string? CommunicationStyle { get; set; }
     public string? UserName { get; set; }
     public string UserTimezone { get; set; } = TimeZoneInfo.Local.Id;
-    public string? PrimaryUse { get; set; }
 
     // ── Step 9: Health Check ──
     public List<HealthCheckItem> HealthCheckResults { get; } = [];
@@ -149,10 +149,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
         NetclawPaths paths,
         ProviderDescriptorRegistry registry,
         ISlackProbe slackProbe,
+        ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
-        : this(paths, registry, registry, slackProbe, null, oauthFactory, daemonManager, daemonEndpoint)
+        : this(paths, registry, registry, slackProbe, null, navigationState, oauthFactory, daemonManager, daemonEndpoint)
     {
     }
 
@@ -165,6 +166,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         IProviderProbe probe,
         ISlackProbe slackProbe,
         IBrowserAutomationBootstrapper? browserBootstrapper = null,
+        ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
         string? daemonEndpoint = null)
@@ -173,6 +175,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _probe = probe;
         _registry = registry;
         _slackProbe = slackProbe;
+        _navigationState = navigationState;
         _browserBootstrapper = browserBootstrapper ?? new BrowserAutomationBootstrapper();
         _oauthFactory = oauthFactory;
         _daemonManager = daemonManager;
@@ -784,6 +787,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
         allPassed = HealthCheckResults.All(h => h.Passed == true);
         if (allPassed)
         {
+            if (_navigationState is not null)
+                _navigationState.InitialMessage = BuildOnboardingTrigger();
             StatusMessage.Value = "Setup complete! Launching chat...";
             Navigate?.Invoke("/chat");
         }
@@ -1052,7 +1057,6 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var name = AgentName;
         var userName = string.IsNullOrWhiteSpace(UserName) ? "User" : UserName;
         var timezone = UserTimezone;
-        var primaryUse = string.IsNullOrWhiteSpace(PrimaryUse) ? "General purpose" : PrimaryUse;
 
         File.WriteAllText(_paths.SoulPath,
             $"""
@@ -1064,7 +1068,6 @@ public partial class InitWizardViewModel : ReactiveViewModel
             ## User
             - Name: {userName}
             - Timezone: {timezone}
-            - Primary use: {primaryUse}
             """);
 
         File.WriteAllText(_paths.AgentsPath,
@@ -1143,6 +1146,26 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
             No capabilities discovered yet. Run `netclaw doctor` or ask Netclaw to probe your environment.
             """);
+    }
+
+    internal string BuildOnboardingTrigger()
+    {
+        var userName = string.IsNullOrWhiteSpace(UserName) ? "User" : UserName;
+        var commStyle = CommunicationStyle ?? "Concise & casual";
+        var soulPath = _paths.SoulPath;
+
+        return $"""
+            I just finished setting up. My name is {userName} and I chose "{commStyle}" as my communication style.
+
+            This is our first conversation. I'd like you to get to know me so you can be more helpful. Please:
+
+            1. Introduce yourself briefly
+            2. Ask me what I'd primarily like to use you for
+            3. Ask if there's anything else you should know about me — my background, how I work, tools I use, preferences, etc.
+            4. After our conversation, update my profile in SOUL.md ({soulPath}) with what you've learned. Use file_read to check current content first, then file_write to update it. Keep the existing structure but enrich it with the details from our conversation.
+
+            Keep it natural and conversational — don't ask everything at once.
+            """;
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/Providers/Descriptors/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Configuration/Providers/Descriptors/OpenAiCompatibleDescriptor.cs
@@ -16,7 +16,7 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
 
     public string TypeKey => "openai-compatible";
     public string DisplayName => "OpenAI-Compatible";
-    public IReadOnlyList<AuthMethod> SupportedAuthMethods => [AuthMethod.None, AuthMethod.ApiKey];
+    public IReadOnlyList<AuthMethod> SupportedAuthMethods => [AuthMethod.None];
     public string DefaultEndpoint => "http://localhost:11434";
     public string ModelListingPath => "/v1/models";
     public CredentialInputMode CredentialMode => CredentialInputMode.EndpointOnly;

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -23,7 +23,7 @@ public sealed class OpenAiCompatibleChatClientTests
 
         var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]);
 
-        Assert.Equal("/api/v1/chat/completions", handler.Requests.Single().RequestUri!.AbsolutePath);
+        Assert.Equal("/v1/chat/completions", handler.Requests.Single().RequestUri!.AbsolutePath);
         Assert.Equal("hi", response.Text);
     }
 

--- a/src/Netclaw.OpenAICompatible/OpenAiCompatibleEndpoint.cs
+++ b/src/Netclaw.OpenAICompatible/OpenAiCompatibleEndpoint.cs
@@ -23,8 +23,8 @@ public sealed record OpenAiCompatibleEndpoint(
 
         return new OpenAiCompatibleEndpoint(
             baseUri,
-            ChatCompletionsPath: Combine(basePath, "api/v1/chat/completions"),
-            ModelsPath: Combine(basePath, "api/v1/models"),
+            ChatCompletionsPath: Combine(basePath, "v1/chat/completions"),
+            ModelsPath: Combine(basePath, "v1/models"),
             ApiKey: apiKey);
     }
 


### PR DESCRIPTION
## Summary

- After `netclaw init` completes, auto-sends a hidden trigger message that starts a conversational onboarding interview — the LLM introduces itself, asks the user what they want to use it for, and updates SOUL.md with what it learns. Replaces the static "primary use" text field with a richer conversational approach.
- Fixes stale "Generating..." state after SignalR reconnect by resetting `IsGenerating` on disconnect
- Fixes OpenAI-compatible default endpoint path (`/api/v1/` → `/v1/`) for Ollama, llama.cpp, vLLM
- Skips unnecessary auth method step for openai-compatible provider and fixes hardcoded "Ollama endpoint:" label

## Test plan

- [x] `dotnet build` compiles cleanly
- [x] `dotnet test` on Netclaw.Cli.Tests — 212 tests pass
- [x] `dotnet slopwatch analyze` — no violations
- [x] Live integration test: `netclaw init` end-to-end with openai-compatible provider
- [x] Onboarding chat triggers, agent conducts interview and updates SOUL.md
- [ ] Verify idle disconnect/reconnect no longer gets stuck on "Generating..."
- [ ] Verify `netclaw chat` (non-init) has no onboarding trigger