### PR TITLE
fix(providers): use /v1/ prefix for OpenAI-compatible fallback paths

### DIFF
--- a/src/Netclaw.OpenAICompatible/OpenAiCompatibleEndpoint.cs
+++ b/src/Netclaw.OpenAICompatible/OpenAiCompatibleEndpoint.cs
@@ -23,8 +23,8 @@ public sealed record OpenAiCompatibleEndpoint(
 
         return new OpenAiCompatibleEndpoint(
             baseUri,
-            ChatCompletionsPath: Combine(basePath, "api/v1/chat/completions"),
-            ModelsPath: Combine(basePath, "api/v1/models"),
+            ChatCompletionsPath: Combine(basePath, "v1/chat/completions"),
+            ModelsPath: Combine(basePath, "v1/models"),
             ApiKey: apiKey);
     }
 


### PR DESCRIPTION
## Summary

- When no `/v1` suffix is present in the configured endpoint URL, the fallback path used `/api/v1/chat/completions` (Ollama-style) instead of the standard `/v1/chat/completions`
- This breaks llama.cpp and other servers that follow the OpenAI path convention without the `/api/` prefix

Two-line fix in `OpenAiCompatibleEndpoint.FromBaseUrl`.

## Test plan

- [x] Verified `http://big-gpu:11434/v1/chat/completions` returns 200, `/api/v1/chat/completions` returns 404