### PR TITLE
fix empty-response turn recovery

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -131,6 +131,97 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Repeated_pre_tool_empty_responses_fail_turn_and_allow_followup_prompt()
+    {
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+
+        var sessionId = new SessionId("test-channel/pre-tool-empty");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("pre-tool-empty-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Please answer"
+        }, TimeSpan.FromSeconds(3));
+
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Equal(sessionId, error.SessionId);
+        Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
+        Assert.Contains("Please try rephrasing", error.Message, StringComparison.OrdinalIgnoreCase);
+
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        Assert.Equal(sessionId, completed.SessionId);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Try again"
+        }, TimeSpan.FromSeconds(3));
+
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("[fake] Response #4", text.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task Empty_response_after_tool_nudge_fails_turn_and_allows_followup_prompt()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "test" })
+        ];
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+
+        var sessionId = new SessionId("test-channel/post-tool-empty");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("post-tool-empty-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search for something"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Equal(sessionId, error.SessionId);
+        Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
+
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Try again after the failure"
+        }, TimeSpan.FromSeconds(3));
+
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("[fake] Response #4", text.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public async Task Sidecar_observation_promotes_strong_user_assertion_into_memory()
     {
         var gate = new MemoryProposalGate();
@@ -492,6 +583,12 @@ internal sealed class FakeChatClient : IChatClient
     /// </summary>
     public UsageDetails? UsageOverride { get; set; }
 
+    /// <summary>
+    /// When populated, responses are dequeued in order before falling back to the
+    /// default fake text response. Each entry is used as the assistant message contents.
+    /// </summary>
+    public Queue<IReadOnlyList<AIContent>> PlannedResponses { get; } = new();
+
     public async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
@@ -628,6 +725,17 @@ internal sealed class FakeChatClient : IChatClient
                     toolResponse.Usage = UsageOverride;
                 return toolResponse;
             }
+        }
+
+        if (PlannedResponses.Count > 0)
+        {
+            var plannedContents = PlannedResponses.Dequeue();
+            var plannedResponse = new ChatResponse(new ChatMessage(
+                Microsoft.Extensions.AI.ChatRole.Assistant,
+                new List<AIContent>(plannedContents)));
+            if (UsageOverride is not null)
+                plannedResponse.Usage = UsageOverride;
+            return plannedResponse;
         }
 
         var contents = new List<AIContent>();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -67,8 +67,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Tool iteration counter (reset per turn, incremented on each ToolExecutionCompleted)
     private int _toolIterationCount;
 
+    private const int MaxPreToolEmptyResponseRetries = 2;
+    private const string EmptyResponseFallbackMessage = "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
+
     // Whether we already sent a post-tool empty-response nudge in this tool chain
     private bool _postToolNudgeSent;
+
+    // Number of consecutive empty responses observed before any tool work happened
+    private int _preToolEmptyResponseCount;
 
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
@@ -222,6 +228,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             _toolIterationCount = 0;
             _postToolNudgeSent = false;
+            _preToolEmptyResponseCount = 0;
             PrepareDiscoveredToolsForNewTurn();
 
             // Modality gate: strip unsupported media references
@@ -303,6 +310,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var hasText = lastMessage.Contents.OfType<TextContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
             if (!hasText && _toolIterationCount == 0)
             {
+                _preToolEmptyResponseCount++;
+                if (_preToolEmptyResponseCount > MaxPreToolEmptyResponseRetries)
+                {
+                    _log.Warning(
+                        "LLM produced empty response after {RetryCount} pre-tool retries; failing turn",
+                        _preToolEmptyResponseCount - 1);
+                    FailCurrentTurn(
+                        EmptyResponseFallbackMessage,
+                        new InvalidOperationException("LLM produced repeated empty responses before any tool execution."),
+                        ErrorCategory.ProviderFailure);
+                    return;
+                }
+
                 _log.Warning("LLM produced empty response (no text, no tool calls) — retrying with nudge");
                 _state = _state.AddSystemNudge(
                     "Your previous response was empty. If you need MCP capabilities, call search_tools(\"servers\") to pick a server "
@@ -323,6 +343,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     "You received tool results but did not respond. "
                     + "Continue working or answer the user's question.");
                 FireLlmCall();
+                return;
+            }
+
+            if (!hasText && _toolIterationCount > 0 && _postToolNudgeSent)
+            {
+                _log.Warning(
+                    "LLM produced empty response after tool work and post-tool nudge; failing turn after {ToolIterations} tool iteration(s)",
+                    _toolIterationCount);
+                FailCurrentTurn(
+                    EmptyResponseFallbackMessage,
+                    new InvalidOperationException("LLM produced an empty response after tool execution and follow-up nudge."),
+                    ErrorCategory.ProviderFailure);
                 return;
             }
 
@@ -941,6 +973,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Model produced tool calls — reset post-tool nudge so it can fire again
         // if the model stalls later in the chain.
         _postToolNudgeSent = false;
+        _preToolEmptyResponseCount = 0;
 
         // Add assistant message (with tool calls) to history
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -23,8 +23,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
     private readonly ILoggingAdapter _log;
 
     private readonly StringBuilder _buffer = new();
+    private const string EmptyTurnFallbackText = ":warning: I didn't manage to produce a reply. Please try rephrasing or sending your message again.";
     private bool _sawTextDelta;
     private bool _postedThisTurn;
+    private bool _uploadedFileThisTurn;
 
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
@@ -426,9 +428,16 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                         _log.Debug("Turn completed with no buffered reply text");
                 }
 
+                if (!_postedThisTurn && !_uploadedFileThisTurn)
+                {
+                    _log.Warning("Turn completed without visible Slack output; posting fallback reply");
+                    await SafePostAsync(EmptyTurnFallbackText);
+                }
+
                 _buffer.Clear();
                 _sawTextDelta = false;
                 _postedThisTurn = false;
+                _uploadedFileThisTurn = false;
 
                 break;
         }
@@ -470,6 +479,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 file.FilePath,
                 file.FileName);
 
+            _uploadedFileThisTurn = true;
             _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- fail turns closed after repeated empty model responses instead of silently completing or looping forever
- post a Slack fallback reply when a turn completes without visible output
- add regression tests covering empty-response recovery and follow-up reprompts