### PR TITLE
feat(skills): load citation guidance after search tools

### DIFF
--- a/feeds/skills/.system/files/search-citation/SKILL.md
+++ b/feeds/skills/.system/files/search-citation/SKILL.md
@@ -3,9 +3,21 @@ name: search-citation
 description: "Guides when to use web search vs. training data and how to cite sources. Ensures specific factual claims include source URLs and the agent does not hallucinate verifiable information."
 metadata:
   author: netclaw
-  version: "0.6.0"
+  version: "0.7.0"
   triggers: web search needed | cite sources | link results | price check | product search | find near me | verify facts
 ---
+
+## Post-Tool Enforcement
+
+After `web_search` or `web_fetch` runs, Netclaw auto-loads this skill before the
+follow-up answer call even if the user's original phrasing did not explicitly
+trigger search or citation guidance.
+
+- Treat search-derived facts as citation-required on that follow-up call.
+- Keep inline links in the answer itself; do not move them into a references
+  section.
+- If the model gets nudged after an empty post-tool response, keep following the
+  same citation rules on the nudged retry.
 
 ## When to Search
 

--- a/openspec/changes/post-tool-skill-auto-load/.openspec.yaml
+++ b/openspec/changes/post-tool-skill-auto-load/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/post-tool-skill-auto-load/design.md
+++ b/openspec/changes/post-tool-skill-auto-load/design.md
@@ -1,0 +1,159 @@
+## Context
+
+Netclaw already has deterministic pre-turn skill auto-loading based on the last
+user message. That improves first-call behavior, but it does not guarantee that
+the follow-up LLM call after tool execution sees the right skill guidance.
+
+The gap matters most for search-driven turns. A user message may be too vague to
+trigger `search-citation`, yet the model can still call `web_search` or
+`web_fetch`, receive current facts, and answer without inline links. The turn is
+now in a different state: the assistant is no longer deciding whether to search;
+it is composing a response from verified tool output and needs the citation
+rules in context.
+
+Current relevant components:
+- `LlmSessionActor.FireLlmCall()` handles both the first model call and all
+  post-tool follow-up calls.
+- `ToolExecutionCompleted` appends tool results and immediately triggers another
+  `FireLlmCall()`.
+- `ResolveAndInjectAutoLoadedSkills()` currently evaluates only user-message
+  keyword matches and re-injects cached skills.
+- `ToolRegistry` owns tool registration and is the natural place to declare
+  tool-level metadata.
+- `search-citation` is the system skill that governs search-derived factual
+  claims and inline source links.
+
+This change is intentionally small: add deterministic tool-to-skill routing for
+the post-tool phase without replacing the existing pre-turn matcher.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure follow-up model calls after tool execution can auto-load required skill
+  overlays even when the original user message did not trigger them.
+- Keep the mechanism deterministic and explainable: tool name -> required skill
+  list, with explicit logs.
+- Reuse existing per-session skill caching, compaction clearing, and disk-read
+  safeguards.
+- Limit MVP scope to explicit first-party mappings, starting with
+  `web_search`/`web_fetch` -> `search-citation`.
+
+**Non-Goals:**
+- Semantic inference from arbitrary tool result text.
+- Auto-loading skills for every MCP tool or every discovered tool in this
+  change.
+- Changing the keyword enrichment service or pre-turn threshold scoring.
+- Persisting post-tool skill state in the journal.
+
+## Decisions
+
+### D1: Declare post-tool skill dependencies in tool metadata
+
+**Decision:** extend tool registration metadata so a tool can declare one or
+more required skills for the post-tool answer phase.
+
+**Why:** the dependency belongs to the tool contract, not to actor-local
+hardcoded conditionals. `web_search` and `web_fetch` know they produce
+verifiable facts that require citation guidance.
+
+**Alternatives considered:**
+- *Hardcode tool-name checks in `LlmSessionActor`* - rejected because it hides
+  routing knowledge in the session engine and scales poorly.
+- *Infer skills from tool result text* - rejected because it is less
+  deterministic and harder to test.
+
+### D2: Resolve tool-required skills only on post-tool follow-up calls
+
+**Decision:** when `ToolExecutionCompleted` fires, the session captures any
+  required skills from the executed tools and resolves them before the next
+  `FireLlmCall()`.
+
+**Why:** this keeps the existing pre-turn behavior intact and targets the exact
+moment where the missing guidance matters: after tool results exist and before
+the assistant writes the user-facing answer.
+
+**Alternatives considered:**
+- *Always evaluate tool-required skills on every call* - rejected because it
+  adds needless work and blurs the distinction between user-intent and
+  post-tool phases.
+
+### D3: Reuse the existing auto-load cache and injection path
+
+**Decision:** tool-triggered loads populate the same `_autoLoadedSkills` and
+`_autoLoadedSkillContent` collections used by keyword-triggered loads.
+
+**Why:** there should be one session-scoped skill cache, one disk-read path, and
+one compaction reset path. The injection output can stay a transient system
+message tagged per skill, with logging carrying the trigger reason.
+
+**Alternatives considered:**
+- *Separate cache for tool-triggered skills* - rejected because it duplicates
+  lifecycle logic and complicates compaction behavior.
+
+### D4: Missing or unreadable skills degrade safely
+
+**Decision:** if a mapped skill is missing from the registry or its file cannot
+be read, log a warning and continue the turn without that overlay.
+
+**Why:** search results still exist and the session must not stall on guidance
+loading. The failure should be observable but non-fatal.
+
+### D5: Observability distinguishes user-triggered vs post-tool-triggered loads
+
+**Decision:** extend `turn_skill_auto_load` logging with a reason/source field so
+operators can tell whether a skill came from user-intent matching or tool
+execution.
+
+**Why:** the behavior is subtle and needs daemon-log proof during validation.
+
+## Risks / Trade-offs
+
+- **[R1] Tool metadata drifts from actual skill expectations** -> Mitigation:
+  start with a tiny explicit mapping set and require matching system skill
+  updates in the same PR.
+- **[R2] Broad mappings over-inject skills on benign turns** -> Mitigation:
+  scope MVP to `web_search` and `web_fetch`, where citation rules are almost
+  always desirable after current-data retrieval.
+- **[R3] Follow-up calls after repeated empty responses could re-run the same
+  load work** -> Mitigation: reuse the session cache so subsequent calls only
+  re-inject cached content, not re-read disk.
+- **[R4] Missing registry entries hide operator mistakes** -> Mitigation:
+  structured warnings identify the tool name and missing skill so feed-sync or
+  packaging issues are diagnosable.
+
+## Migration Plan
+
+1. Add tool metadata support for post-tool skill dependencies.
+2. Register `search-citation` as a dependency of `web_search` and `web_fetch`.
+3. Update `LlmSessionActor` to collect and resolve required skills after tool
+   execution and before the follow-up call.
+4. Update `feeds/skills/.system/files/search-citation/SKILL.md` and bump its
+   version so published guidance reflects the enforced behavior.
+5. Validate with integration tests for search-driven turns and manual daemon-log
+   verification.
+
+Rollback is low risk: remove the metadata mapping and session hook, leaving the
+existing pre-turn auto-load path intact.
+
+## Open Questions
+
+- None for MVP. Future work can decide whether MCP tool catalogs should be able
+  to declare the same metadata once post-tool routing proves useful.
+
+## Actor Boundaries and Persistence Implications
+
+- `ToolRegistry` remains the shared registry for tool definitions and gains
+  metadata about post-tool skill dependencies.
+- `LlmSessionActor` gains transient per-turn state for pending post-tool skill
+  requirements, but no new actor messages or persistence events are needed.
+- Auto-loaded skill content remains transient session state and continues to be
+  cleared on compaction and reconstructed after recovery.
+
+## Failure Modes and Recovery
+
+| Failure | Behavior | Recovery |
+|---------|----------|----------|
+| Tool declares unknown skill | Warning log, turn continues without that overlay | Fix skill registration/feed sync, next turn picks it up |
+| Skill file read fails | Warning log, turn continues | Restore file; cache repopulates on next eligible turn |
+| Repeated post-tool follow-up call in same turn | Cached skill is re-injected without disk re-read | Automatic |
+| Actor restart before next turn | Pending post-tool requirements are lost | Next tool-using turn re-resolves dependencies |

--- a/openspec/changes/post-tool-skill-auto-load/proposal.md
+++ b/openspec/changes/post-tool-skill-auto-load/proposal.md
@@ -1,0 +1,51 @@
+Source PRDs: `PRD-001`, `PRD-007`
+
+## Why
+
+Deterministic skill auto-loading currently keys off the user's message before the
+first model call. That misses an important case: once a turn has already used
+`web_search` or `web_fetch`, the follow-up model call can still answer with
+uncited, tool-derived facts if the original user phrasing did not cross the
+auto-load threshold for `search-citation`.
+
+## What Changes
+
+- Add deterministic post-tool skill activation for follow-up model calls after
+  tool execution completes.
+- Let tools declare required skill overlays for their post-tool answer path;
+  MVP scope starts with `web_search` and `web_fetch` requiring
+  `search-citation`.
+- Reuse the session's existing skill cache and compaction reset behavior so
+  tool-triggered skill loads do not create a second context mechanism.
+- Extend observability so logs show whether a skill was loaded from user-intent
+  matching or from post-tool requirements.
+- Update the `search-citation` system skill in the same implementation cycle so
+  operator guidance stays aligned with the enforced post-search behavior.
+
+In scope for MVP: deterministic, tool-name-based skill loading on post-tool
+follow-up calls for explicitly mapped first-party tools. Out of scope: parsing
+tool result text for semantic skill inference, blanket MCP-wide auto-loading,
+or changing the existing pre-turn keyword matcher.
+
+## Capabilities
+
+### New Capabilities
+- `post-tool-skill-routing`: tool-declared skill dependencies that activate on
+  post-tool follow-up turns before the assistant composes a final answer.
+
+### Modified Capabilities
+- `netclaw-session`: the session turn pipeline injects tool-required skills on
+  follow-up LLM calls after tool execution, using the existing session-scoped
+  skill cache and compaction lifecycle.
+
+## Impact
+
+- **Code:** `LlmSessionActor`, `ToolRegistry`/tool metadata, search tool
+  registrations, integration tests around multi-step tool turns, and system
+  skill sync tests.
+- **Operational:** daemon logs gain explicit post-tool auto-load reasons so
+  operators can verify why citation guidance appeared on a turn.
+- **Security:** no grants expand and no hidden bypass is introduced; this change
+  only tightens post-search answer quality by forcing existing guidance into
+  context after verified tool usage.
+- **Dependencies:** no new external dependencies or persistence schema changes.

--- a/openspec/changes/post-tool-skill-auto-load/specs/netclaw-session/spec.md
+++ b/openspec/changes/post-tool-skill-auto-load/specs/netclaw-session/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Post-tool skill auto-loading before follow-up model calls
+
+The session system SHALL resolve and inject tool-required skills before any
+follow-up model call triggered by completed tool execution. Tool-required skills
+SHALL share the same session-scoped cache and transient system-message
+injection path used by other auto-loaded skills.
+
+#### Scenario: Follow-up call after search loads citation skill
+- **GIVEN** a turn completed `web_search` or `web_fetch`
+- **AND** `search-citation` is not yet loaded in the current session
+- **WHEN** the session prepares the follow-up LLM call with tool results in
+  context
+- **THEN** the session loads `search-citation` before the model call
+- **AND** injects it as a transient system message in that follow-up request
+
+#### Scenario: Cached tool-required skill is re-injected without disk read
+- **GIVEN** a tool-required skill was already loaded earlier in the session
+- **WHEN** another eligible post-tool follow-up call occurs
+- **THEN** the skill content is re-injected from the in-memory cache
+- **AND** the session does not re-read the skill file from disk
+
+#### Scenario: Post-tool nudge retains loaded skill context
+- **GIVEN** a tool-required skill was loaded for a follow-up call
+- **AND** the model returns an empty post-tool response that triggers a nudge
+- **WHEN** the session issues the nudged follow-up call in the same turn
+- **THEN** the already-loaded skill remains injected from cache
+
+#### Scenario: Logs show post-tool auto-load source
+- **GIVEN** one or more skills were loaded because of completed tool execution
+- **WHEN** the session logs skill auto-load activity
+- **THEN** the log entry includes that the load reason was `post-tool`
+- **AND** the entry lists the triggering tools and loaded skill names

--- a/openspec/changes/post-tool-skill-auto-load/specs/post-tool-skill-routing/spec.md
+++ b/openspec/changes/post-tool-skill-auto-load/specs/post-tool-skill-routing/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Tools can declare post-tool skill dependencies
+
+The system SHALL allow tool registrations to declare one or more required
+system skills that MUST be injected before the follow-up model call that turns
+tool results into a user-facing answer.
+
+#### Scenario: Search tool declares citation skill dependency
+- **WHEN** the first-party `web_search` tool is registered
+- **THEN** its metadata includes `search-citation` as a post-tool required skill
+
+#### Scenario: Web fetch declares citation skill dependency
+- **WHEN** the first-party `web_fetch` tool is registered
+- **THEN** its metadata includes `search-citation` as a post-tool required skill
+
+### Requirement: Post-tool skill routing is deterministic
+
+The system SHALL resolve post-tool skill loads from explicit tool metadata, not
+from semantic analysis of tool result content.
+
+#### Scenario: Executed tool batch maps to required skills
+- **GIVEN** a tool batch contains `web_search` and `web_fetch`
+- **WHEN** post-tool routing runs
+- **THEN** the required skill set contains `search-citation`
+- **AND** duplicate skill names are de-duplicated before loading
+
+#### Scenario: Tool without mapping adds no skill requirement
+- **GIVEN** a tool completes with no declared post-tool skill dependency
+- **WHEN** post-tool routing runs
+- **THEN** that tool contributes no required skill to the follow-up call
+
+### Requirement: Missing skill mappings degrade safely
+
+If a tool declares a required skill that is unavailable in the current skill
+registry or unreadable on disk, the system SHALL warn and continue the turn
+without failing tool execution.
+
+#### Scenario: Required skill missing from registry
+- **GIVEN** an executed tool declares a post-tool skill name that is not present
+  in the skill registry
+- **WHEN** post-tool routing resolves required skills
+- **THEN** a warning is logged with the tool name and missing skill name
+- **AND** the turn proceeds without that skill overlay
+
+#### Scenario: Required skill file unreadable
+- **GIVEN** a required skill is present in the registry but its `SKILL.md` file
+  cannot be read
+- **WHEN** the session attempts to load it for a follow-up call
+- **THEN** a warning is logged
+- **AND** the turn proceeds without that skill overlay

--- a/openspec/changes/post-tool-skill-auto-load/tasks.md
+++ b/openspec/changes/post-tool-skill-auto-load/tasks.md
@@ -1,0 +1,17 @@
+## 1. Tool metadata and routing primitives
+
+- [x] 1.1 Extend tool registration metadata so tools can declare post-tool required skill names.
+- [x] 1.2 Register `search-citation` as a post-tool required skill for `web_search` and `web_fetch`.
+- [x] 1.3 Add unit coverage for tool metadata/routing so duplicate required skills collapse into one deterministic set.
+
+## 2. Session follow-up call integration
+
+- [x] 2.1 Update `LlmSessionActor` to collect required skills from completed tools and resolve them before the follow-up `FireLlmCall()`.
+- [x] 2.2 Reuse the existing session auto-load cache/injection path for tool-triggered skills and log the auto-load reason as `post-tool`.
+- [x] 2.3 Degrade safely when a mapped skill is missing or unreadable, with warning logs and no turn failure.
+
+## 3. Verification and skill sync
+
+- [x] 3.1 Add integration tests covering `web_search`/`web_fetch` turns, cached reinjection on repeated follow-up calls, and post-tool empty-response nudges retaining the loaded skill.
+- [x] 3.2 Update `feeds/skills/.system/files/search-citation/SKILL.md` to document the enforced post-search citation behavior and bump `metadata.version`.
+- [x] 3.3 Run `dotnet build`, targeted actor/tool tests, and `dotnet slopwatch analyze` to verify the change compiles cleanly and introduces no new violations.

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -571,6 +571,11 @@ internal sealed class FakeChatClient : IChatClient
     public List<FunctionCallContent>? ToolCallsOnFirstCall { get; set; }
 
     /// <summary>
+    /// When true, each new user turn can trigger <see cref="ToolCallsOnFirstCall"/> once.
+    /// </summary>
+    public bool RepeatToolCallsPerUserTurn { get; set; }
+
+    /// <summary>
     /// When true, every call returns tool calls (from <see cref="ToolCallsOnFirstCall"/>)
     /// as long as <c>options.Tools</c> is non-empty. When tools are omitted from options
     /// (circuit breaker fired), returns normal text instead.
@@ -588,6 +593,9 @@ internal sealed class FakeChatClient : IChatClient
     /// default fake text response. Each entry is used as the assistant message contents.
     /// </summary>
     public Queue<IReadOnlyList<AIContent>> PlannedResponses { get; } = new();
+
+    private int _lastUserMessageCount;
+    private int _toolCallTurnMarker = -1;
 
     public async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
@@ -607,6 +615,7 @@ internal sealed class FakeChatClient : IChatClient
 
         var systemText = messageList.FirstOrDefault(m => m.Role == Microsoft.Extensions.AI.ChatRole.System)?.Text ?? string.Empty;
         var userText = messageList.LastOrDefault(m => m.Role == Microsoft.Extensions.AI.ChatRole.User)?.Text ?? string.Empty;
+        var userMessageCount = messageList.Count(m => m.Role == Microsoft.Extensions.AI.ChatRole.User);
 
         if (systemText.Contains("You are a recall planning sidecar", StringComparison.Ordinal))
         {
@@ -710,12 +719,20 @@ internal sealed class FakeChatClient : IChatClient
         // Return tool calls if configured
         if (ToolCallsOnFirstCall is not null)
         {
+            if (userMessageCount > _lastUserMessageCount)
+                _toolCallTurnMarker = -1;
+
+            _lastUserMessageCount = Math.Max(_lastUserMessageCount, userMessageCount);
+
             var returnToolCalls = AlwaysReturnToolCalls
                 ? options?.Tools?.Count > 0   // Every call, as long as tools are available
-                : _callCount == 1;            // First call only (existing behavior)
+                : RepeatToolCallsPerUserTurn
+                    ? options?.Tools?.Count > 0 && _toolCallTurnMarker != userMessageCount
+                    : _callCount == 1;            // First call only (existing behavior)
 
             if (returnToolCalls)
             {
+                _toolCallTurnMarker = userMessageCount;
                 var toolCallContents = new List<AIContent>(ToolCallsOnFirstCall);
                 var toolCallMessage = new ChatMessage(
                     Microsoft.Extensions.AI.ChatRole.Assistant,

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -9,7 +9,9 @@ using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Skills;
 using Netclaw.Actors.Tools;
+using Netclaw.Search;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,6 +26,7 @@ public class ToolExecutionIntegrationTests : TestKit
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeToolAuditLogger _fakeAuditLogger = new();
+    private readonly string _skillRoot = Path.Combine(Path.GetTempPath(), $"netclaw-skill-tests-{Guid.NewGuid():N}");
 
     public ToolExecutionIntegrationTests(ITestOutputHelper output) : base(output: output)
     {
@@ -47,10 +50,10 @@ public class ToolExecutionIntegrationTests : TestKit
 
         // Register a tool in the registry
         var registry = new ToolRegistry();
-        registry.Register(
-            AIFunctionFactory.Create(() => "search result", "web_search"),
-            "web_search");
+        registry.Register(new WebSearchTool(new FakeSearchBackend()), ["search-citation"]);
+        registry.Register(new WebFetchTool(), ["search-citation"]);
         services.AddSingleton(registry);
+        services.AddSingleton(CreateSkillRegistry());
         services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
     }
 
@@ -245,6 +248,123 @@ public class ToolExecutionIntegrationTests : TestKit
         Assert.Contains("tool result truncated", result, StringComparison.OrdinalIgnoreCase);
         Assert.True(result!.Length < 300);
     }
+
+    [Fact]
+    public async Task Web_search_followup_injects_post_tool_skill_and_reuses_cached_content()
+    {
+        _fakeChatClient.RepeatToolCallsPerUserTurn = true;
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "citations" })
+        ];
+        _fakeToolExecutor.Results["web_search"] = "Found one result with URL https://example.com";
+
+        var sessionId = new SessionId("test-channel/post-tool-skill-cache");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("post-tool-skill-cache-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search for citations"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(2, _fakeChatClient.CallCount);
+        Assert.Equal(1, _fakeChatClient.ReceivedMessages.Count(m => ContainsSkill(m, "search-citation")));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search again"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(4, _fakeChatClient.CallCount);
+        Assert.Equal(3, _fakeChatClient.ReceivedMessages.Count(m => ContainsSkill(m, "search-citation")));
+    }
+
+    [Fact]
+    public async Task Web_fetch_followup_and_post_tool_nudge_retain_loaded_skill()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_fetch",
+                new Dictionary<string, object?> { ["url"] = "https://example.com" })
+        ];
+        _fakeToolExecutor.Results["web_fetch"] = "Fetched page with URL https://example.com/details";
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+
+        var sessionId = new SessionId("test-channel/post-tool-nudge-skill");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("post-tool-nudge-skill-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(10));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Fetch the page"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(3, _fakeChatClient.CallCount);
+        Assert.True(ContainsSkill(_fakeChatClient.ReceivedMessages[1], "search-citation"));
+        Assert.True(ContainsSkill(_fakeChatClient.ReceivedMessages[2], "search-citation"));
+    }
+
+    private SkillRegistry CreateSkillRegistry()
+    {
+        Directory.CreateDirectory(_skillRoot);
+        var skillDir = Path.Combine(_skillRoot, "search-citation");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), "# Search Citation\nAlways cite search-derived facts.");
+
+        var registry = new SkillRegistry();
+        registry.Register(new SkillEntry(
+            "search-citation",
+            "Search Citation",
+            "Citation rules for search results",
+            Path.Combine(skillDir, "SKILL.md"),
+            skillDir,
+            null));
+
+        return registry;
+    }
+
+    private static bool ContainsSkill(IReadOnlyList<ChatMessage> messages, string skillName)
+        => messages.Any(m => m.Role == Microsoft.Extensions.AI.ChatRole.System
+            && (m.Text?.Contains($"[skill-auto-loaded: {skillName}]", StringComparison.Ordinal) ?? false));
+}
+
+internal sealed class FakeSearchBackend : ISearchBackend
+{
+    public Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
+        => Task.FromResult<SearchBackendResult>(new SearchBackendResult.Success([]));
 }
 
 /// <summary>

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistryTests.cs
@@ -188,6 +188,30 @@ public class ToolRegistryTests
         Assert.Empty(index);
     }
 
+    [Fact]
+    public void GetRequiredPostToolSkills_deduplicates_and_sorts_skill_names()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateFakeTool("web_search"), "web_search", ["search-citation", "search-citation", "web-safety"]);
+        registry.Register(CreateFakeTool("web_fetch"), "web_fetch", ["SEARCH-CITATION"]);
+        registry.Register(CreateFakeTool("shell_execute"), "shell");
+
+        var required = registry.GetRequiredPostToolSkills(["web_fetch", "web_search", "shell_execute"]);
+
+        Assert.Equal(["search-citation", "web-safety"], required);
+    }
+
+    [Fact]
+    public void Register_normalizes_post_tool_required_skills()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateFakeTool("search"), "web_search", ["  search-citation  ", "Search-Citation", ""]);
+
+        var registration = Assert.Single(registry.GetAllRegistrations());
+
+        Assert.Equal(["search-citation"], registration.PostToolRequiredSkills);
+    }
+
     private static AIFunction CreateFakeTool(string name)
     {
         return AIFunctionFactory.Create(() => "result", name);

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -41,6 +41,7 @@ internal sealed record LlmCallFailed
 internal sealed record ToolExecutionCompleted
 {
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
+    public List<string> ExecutedToolNames { get; init; } = [];
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
     public List<CompletedSubAgentRun> CompletedSubAgentRuns { get; init; } = [];
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -94,6 +94,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly HashSet<string> _autoLoadedSkills = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _autoLoadedSkillContent = new(StringComparer.OrdinalIgnoreCase);
     private readonly SkillRegistry? _skillRegistry;
+    private readonly HashSet<string> _pendingPostToolSkillNames = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _pendingPostToolTriggerTools = new(StringComparer.OrdinalIgnoreCase);
 
     // Persistent state (immutable — replaced on each event)
     private SessionState _state = SessionState.Empty;
@@ -390,12 +392,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             StopProcessingWatchdog();
 
+            CollectPendingPostToolSkills(msg.ExecutedToolNames);
+
             var hasVerifiedToolFinding = msg.ToolResults.Any(r =>
-                r.Name is "web_search" or "webfetch");
+                r.Name is "web_search" or "web_fetch" or "webfetch");
             if (hasVerifiedToolFinding)
             {
                 var summarized = string.Join("\n", msg.ToolResults
-                    .Where(r => r.Name is "web_search" or "webfetch")
+                    .Where(r => r.Name is "web_search" or "web_fetch" or "webfetch")
                     .Take(2)
                     .Select(r => $"[{r.Name}] {r.Content}"));
 
@@ -1465,8 +1469,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Skill auto-load: deterministic keyword matching against enriched skill index.
         // Injects matched skill content as transient system messages before the LLM decides.
         var userMessage = _state.FindLastUserMessage()?.Content;
-        if (!string.IsNullOrWhiteSpace(userMessage))
-            ResolveAndInjectAutoLoadedSkills(messages, userMessage);
+        ResolveAndInjectAutoLoadedSkills(messages, userMessage);
 
         // Inject dynamic context layers (e.g. tool index) as transient system messages.
         // These are NOT persisted — rebuilt on every call so rehydrated sessions stay fresh.
@@ -1573,57 +1576,140 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// load matching skill content from disk (first match) or cache (subsequent turns),
     /// and inject as transient system messages.
     /// </summary>
-    private void ResolveAndInjectAutoLoadedSkills(List<AiChatMessage> messages, string userMessage)
+    private void ResolveAndInjectAutoLoadedSkills(List<AiChatMessage> messages, string? userMessage)
     {
-        if (_skillRegistry is null) return;
+        if (_skillRegistry is null)
+            return;
 
-        // 1. Find NEW matches (excludes already-loaded skills)
-        var newMatches = _skillRegistry.MatchByKeywords(userMessage, _autoLoadedSkills);
-        foreach (var match in newMatches)
+        var loadedThisCall = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var keywordMatches = string.IsNullOrWhiteSpace(userMessage)
+            ? []
+            : _skillRegistry.MatchByKeywords(userMessage, _autoLoadedSkills);
+
+        foreach (var match in keywordMatches)
         {
-            try
-            {
-                _autoLoadedSkillContent[match.Skill.Name] = File.ReadAllText(match.Skill.FilePath);
-            }
-            catch (IOException ex)
-            {
-                _log.Warning(ex, "Failed to read skill for auto-load: {SkillName}", match.Skill.Name);
-                continue;
-            }
-
-            _autoLoadedSkills.Add(match.Skill.Name);
+            if (TryLoadSkillContent(match.Skill.Name, "keyword"))
+                loadedThisCall.Add(match.Skill.Name);
         }
 
-        // 2. Inject ALL loaded skills (new + previously cached)
-        if (_autoLoadedSkillContent.Count == 0) return;
+        foreach (var skillName in _pendingPostToolSkillNames.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase))
+        {
+            if (TryLoadSkillContent(skillName, "post-tool"))
+                loadedThisCall.Add(skillName);
+        }
+
+        _pendingPostToolSkillNames.Clear();
+
+        if (_autoLoadedSkillContent.Count == 0)
+        {
+            _pendingPostToolTriggerTools.Clear();
+            return;
+        }
+
+        var injectedNames = _autoLoadedSkillContent.Keys
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         var sb = new StringBuilder();
-        foreach (var (name, content) in _autoLoadedSkillContent)
+        foreach (var name in injectedNames)
         {
-            if (sb.Length > 0) sb.AppendLine();
+            if (sb.Length > 0)
+                sb.AppendLine();
+
             sb.AppendLine($"[skill-auto-loaded: {name}]");
-            sb.AppendLine(content);
+            sb.AppendLine(_autoLoadedSkillContent[name]);
         }
 
         var msg = new AiChatMessage(Microsoft.Extensions.AI.ChatRole.System, sb.ToString().TrimEnd());
         var idx = messages.FindLastIndex(m => m.Role == Microsoft.Extensions.AI.ChatRole.System);
         messages.Insert(idx >= 0 ? idx + 1 : 0, msg);
 
-        if (newMatches.Count > 0)
+        if (keywordMatches.Count > 0)
         {
-            var details = string.Join(" | ", newMatches.Select(m =>
+            var details = string.Join(" | ", keywordMatches.Select(m =>
                 $"{m.Skill.Name}:score={m.Score.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}"
                 + $"/threshold={m.Threshold.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}"
                 + $" tokens=[{string.Join(",", m.MatchedTokens)}]"
                 + $" phrases=[{string.Join(",", m.MatchedPhrases)}]"));
 
             TurnLog().Info(
-                "turn_skill_auto_load new={New} total={Total} skills={Names} tokenHits={TokenHits} phraseHits={PhraseHits} details={Details}",
-                newMatches.Count, _autoLoadedSkillContent.Count,
-                string.Join(",", newMatches.Select(m => m.Skill.Name)),
-                string.Join(",", newMatches.Select(m => m.TokenHits)),
-                string.Join(",", newMatches.Select(m => m.PhraseHits)),
-                details);
+                $"turn_skill_auto_load reason=keyword new={keywordMatches.Count} total={injectedNames.Length} skills={string.Join(",", keywordMatches.Select(m => m.Skill.Name))} tokenHits={string.Join(",", keywordMatches.Select(m => m.TokenHits))} phraseHits={string.Join(",", keywordMatches.Select(m => m.PhraseHits))} details={details}");
+        }
+
+        var newPostToolLoads = loadedThisCall
+            .Where(name => !keywordMatches.Any(match => string.Equals(match.Skill.Name, name, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (newPostToolLoads.Length > 0)
+        {
+            TurnLog().Info(
+                $"turn_skill_auto_load reason=post-tool new={newPostToolLoads.Length} total={injectedNames.Length} skills={string.Join(",", newPostToolLoads)} triggerTools={string.Join(",", _pendingPostToolTriggerTools.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase))}");
+        }
+
+        _pendingPostToolTriggerTools.Clear();
+    }
+
+    private void CollectPendingPostToolSkills(IReadOnlyList<string> executedToolNames)
+    {
+        if (_fullRegistry is null || executedToolNames.Count == 0)
+            return;
+
+        foreach (var toolName in executedToolNames)
+        {
+            if (string.IsNullOrWhiteSpace(toolName))
+                continue;
+
+            var registration = _fullRegistry.GetAllRegistrations().FirstOrDefault(t =>
+                string.Equals(t.Tool.Name, toolName, StringComparison.OrdinalIgnoreCase));
+            if (registration is null || registration.PostToolRequiredSkills.Count == 0)
+                continue;
+
+            _pendingPostToolTriggerTools.Add(registration.Tool.Name);
+            foreach (var skillName in registration.PostToolRequiredSkills)
+                _pendingPostToolSkillNames.Add(skillName);
+        }
+    }
+
+    private bool TryLoadSkillContent(string skillName, string reason)
+    {
+        if (_autoLoadedSkillContent.ContainsKey(skillName))
+            return true;
+
+        var skill = _skillRegistry?.GetByName(skillName);
+        if (skill is null)
+        {
+            TurnLog().Warning(
+                "turn_skill_auto_load_missing reason={Reason} skill={SkillName} triggerTools={TriggerTools}",
+                reason,
+                skillName,
+                string.Join(",", _pendingPostToolTriggerTools.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)));
+            return false;
+        }
+
+        try
+        {
+            _autoLoadedSkillContent[skill.Name] = File.ReadAllText(skill.FilePath);
+            _autoLoadedSkills.Add(skill.Name);
+            return true;
+        }
+        catch (IOException ex)
+        {
+            TurnLog().Warning(ex,
+                "turn_skill_auto_load_unreadable reason={Reason} skill={SkillName} file={FilePath}",
+                reason,
+                skill.Name,
+                skill.FilePath);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            TurnLog().Warning(ex,
+                "turn_skill_auto_load_unreadable reason={Reason} skill={SkillName} file={FilePath}",
+                reason,
+                skill.Name,
+                skill.FilePath);
+            return false;
         }
     }
 
@@ -1832,6 +1918,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             self.Tell(new ToolExecutionCompleted
             {
                 ToolResults = results.Select(r => r.Message).ToList(),
+                ExecutedToolNames = toolCalls.Select(tc => tc.Name).ToList(),
                 FileAttachments = fileAttachments,
                 CompletedSubAgentRuns = results
                     .SelectMany(r => r.CompletedSubAgentRuns)

--- a/src/Netclaw.Actors/Skills/SkillRegistry.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistry.cs
@@ -40,6 +40,9 @@ public sealed class SkillRegistry
 
     public IReadOnlyList<SkillEntry> GetAll() => _skills;
 
+    public SkillEntry? GetByName(string name)
+        => _skills.FirstOrDefault(skill => string.Equals(skill.Name, name, StringComparison.OrdinalIgnoreCase));
+
     /// <summary>
     /// Store enriched keywords for a skill. Called by the enrichment service
     /// after sidecar LLM generates keywords from the skill's content.

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -25,8 +25,8 @@ public static class ToolRegistrationExtensions
         registry.Register(new FileWriteTool(pathPolicy));
         registry.Register(new AttachFileTool());
         if (searchBackend is not null)
-            registry.Register(new WebSearchTool(searchBackend));
-        registry.Register(new WebFetchTool());
+            registry.Register(new WebSearchTool(searchBackend), ["search-citation"]);
+        registry.Register(new WebFetchTool(), ["search-citation"]);
 
         // Register search_tools meta-tool (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry));

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -6,9 +6,40 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Registration entry pairing a tool with its ACL grant category.
+/// Registration entry pairing a tool with its ACL grant category and any
+/// post-tool skill requirements.
 /// </summary>
-public sealed record ToolRegistration(INetclawTool Tool, string GrantCategory);
+public sealed record ToolRegistration
+{
+    public ToolRegistration(
+        INetclawTool tool,
+        string grantCategory,
+        IReadOnlyList<string>? postToolRequiredSkills = null)
+    {
+        Tool = tool;
+        GrantCategory = grantCategory;
+        PostToolRequiredSkills = NormalizeRequiredSkills(postToolRequiredSkills);
+    }
+
+    public INetclawTool Tool { get; }
+
+    public string GrantCategory { get; }
+
+    public IReadOnlyList<string> PostToolRequiredSkills { get; }
+
+    private static IReadOnlyList<string> NormalizeRequiredSkills(IReadOnlyList<string>? skills)
+    {
+        if (skills is null || skills.Count == 0)
+            return [];
+
+        return skills
+            .Where(static skill => !string.IsNullOrWhiteSpace(skill))
+            .Select(static skill => skill.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static skill => skill, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}
 
 /// <summary>
 /// Summary metadata for an MCP server used in progressive-disclosure routing.
@@ -23,17 +54,20 @@ public sealed class ToolRegistry
 {
     private readonly List<ToolRegistration> _tools = new();
 
-    public void Register(INetclawTool tool)
+    public void Register(INetclawTool tool, IReadOnlyList<string>? postToolRequiredSkills = null)
     {
-        _tools.Add(new ToolRegistration(tool, tool.GrantCategory));
+        _tools.Add(new ToolRegistration(tool, tool.GrantCategory, postToolRequiredSkills));
     }
 
     /// <summary>
     /// Register an <see cref="AITool"/> directly (for test fakes that don't implement INetclawTool).
     /// </summary>
-    public void Register(AITool tool, string grantCategory)
+    public void Register(AITool tool, string grantCategory, IReadOnlyList<string>? postToolRequiredSkills = null)
     {
-        _tools.Add(new ToolRegistration(new AIToolAdapter(tool, grantCategory), grantCategory));
+        _tools.Add(new ToolRegistration(
+            new AIToolAdapter(tool, grantCategory),
+            grantCategory,
+            postToolRequiredSkills));
     }
 
     /// <summary>All registered tools as AITool for ChatOptions.Tools.</summary>
@@ -65,6 +99,31 @@ public sealed class ToolRegistry
     /// Returns all registered tool registrations (for search and dynamic loading).
     /// </summary>
     public IReadOnlyList<ToolRegistration> GetAllRegistrations() => _tools;
+
+    /// <summary>
+    /// Returns the deterministic set of required post-tool skills for the provided tool names.
+    /// Duplicate skill names collapse into one case-insensitive set.
+    /// </summary>
+    public IReadOnlyList<string> GetRequiredPostToolSkills(IEnumerable<string> toolNames)
+    {
+        var requiredSkills = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var toolName in toolNames)
+        {
+            if (string.IsNullOrWhiteSpace(toolName))
+                continue;
+
+            var registration = _tools.FirstOrDefault(t =>
+                string.Equals(t.Tool.Name, toolName, StringComparison.OrdinalIgnoreCase));
+            if (registration is null)
+                continue;
+
+            foreach (var skill in registration.PostToolRequiredSkills)
+                requiredSkills.Add(skill);
+        }
+
+        return requiredSkills.ToArray();
+    }
 
     /// <summary>
     /// Returns tools discovered from one MCP server.

--- a/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeSlackProbe.cs
@@ -51,7 +51,7 @@ public sealed class FakeSlackProbe : ISlackProbe
         ProbeCallCount++;
         LastBotToken = botToken;
         if (DelayBeforeResult.HasValue)
-            await Task.Delay(DelayBeforeResult.Value, ct);
+            await WaitUntilCancelledAsync(ct);
         return NextResult;
     }
 
@@ -61,7 +61,20 @@ public sealed class FakeSlackProbe : ISlackProbe
         ResolveCallCount++;
         LastResolvedNames = channelNames;
         if (DelayBeforeResult.HasValue)
-            await Task.Delay(DelayBeforeResult.Value, ct);
+            await WaitUntilCancelledAsync(ct);
         return NextResolutionResult;
+    }
+
+    private static async Task WaitUntilCancelledAsync(CancellationToken ct)
+    {
+        if (ct.IsCancellationRequested)
+            ct.ThrowIfCancellationRequested();
+
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = ct.Register(static state =>
+            ((TaskCompletionSource<object?>)state!).TrySetResult(null), tcs);
+
+        await tcs.Task;
+        ct.ThrowIfCancellationRequested();
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1044,7 +1044,20 @@ internal sealed class FakeBrowserAutomationBootstrapper : IBrowserAutomationBoot
     {
         CallCount++;
         if (DelayBeforeResult.HasValue)
-            await Task.Delay(DelayBeforeResult.Value, ct);
+            await WaitUntilCancelledAsync(ct);
         return NextResult;
+    }
+
+    private static async Task WaitUntilCancelledAsync(CancellationToken ct)
+    {
+        if (ct.IsCancellationRequested)
+            ct.ThrowIfCancellationRequested();
+
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = ct.Register(static state =>
+            ((TaskCompletionSource<object?>)state!).TrySetResult(null), tcs);
+
+        await tcs.Task;
+        ct.ThrowIfCancellationRequested();
     }
 }


### PR DESCRIPTION
## Summary
- add deterministic post-tool skill routing so search and fetch turns load search-citation before the follow-up answer
- reuse the existing auto-load cache and logging path, and cover the behavior with actor integration tests
- replace timing-based timeout fakes in CLI tests with cancellation-driven synchronization to clear the existing Slopwatch warning
