### PR TITLE
fix forced no-tools turn recovery

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -578,6 +578,12 @@ internal sealed class FakeChatClient : IChatClient
     public bool AlwaysReturnToolCalls { get; set; }
 
     /// <summary>
+    /// When true, tool calls continue even if the caller omits tools from ChatOptions.
+    /// Simulates providers that hallucinate tool calls after the circuit breaker fires.
+    /// </summary>
+    public bool IgnoreToolAvailability { get; set; }
+
+    /// <summary>
     /// When set, all responses include this usage data.
     /// Used to simulate token counts that trigger compaction.
     /// </summary>
@@ -711,7 +717,7 @@ internal sealed class FakeChatClient : IChatClient
         if (ToolCallsOnFirstCall is not null)
         {
             var returnToolCalls = AlwaysReturnToolCalls
-                ? options?.Tools?.Count > 0   // Every call, as long as tools are available
+                ? (IgnoreToolAvailability || options?.Tools?.Count > 0)   // Every call, even when tools are withheld
                 : _callCount == 1;            // First call only (existing behavior)
 
             if (returnToolCalls)

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -111,6 +111,49 @@ public class MaxToolIterationTests : TestKit
     }
 
     [Fact]
+    public async Task Tool_iteration_limit_fails_turn_when_model_keeps_emitting_tool_calls_without_tools()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "test" })
+        ];
+        _fakeChatClient.AlwaysReturnToolCalls = true;
+        _fakeChatClient.IgnoreToolAvailability = true;
+        _fakeToolExecutor.Results["web_search"] = "search result";
+
+        var sessionId = new SessionId("test-channel/max-iter-violation");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("max-iter-violation-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Keep calling tools even when disabled"
+        }, TimeSpan.FromSeconds(3));
+
+        for (var i = 0; i < 3; i++)
+            await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5));
+        Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
+        Assert.Contains("Please try rephrasing", error.Message, StringComparison.OrdinalIgnoreCase);
+
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(4, _fakeChatClient.CallCount);
+        Assert.Equal(3, _fakeToolExecutor.CallCount);
+    }
+
+    [Fact]
     public async Task Tool_iteration_counter_resets_between_turns()
     {
         // Configure: LLM always returns tool calls when tools are available

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -76,6 +76,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Number of consecutive empty responses observed before any tool work happened
     private int _preToolEmptyResponseCount;
 
+    // Whether the current LLM call intentionally disabled tool use after a circuit breaker fired.
+    private bool _forceNoToolsActive;
+
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
 
@@ -229,6 +232,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _toolIterationCount = 0;
             _postToolNudgeSent = false;
             _preToolEmptyResponseCount = 0;
+            _forceNoToolsActive = false;
             PrepareDiscoveredToolsForNewTurn();
 
             // Modality gate: strip unsupported media references
@@ -299,6 +303,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             // Check for tool calls
             var toolCalls = lastMessage.Contents.OfType<FunctionCallContent>().ToList();
+            if (toolCalls.Count > 0 && _forceNoToolsActive)
+            {
+                TurnLog().Warning(
+                    "turn_force_no_tools_violation toolCallCount={ToolCallCount} max={Max}",
+                    toolCalls.Count,
+                    _config.MaxToolIterationsPerTurn);
+                FailCurrentTurn(
+                    EmptyResponseFallbackMessage,
+                    new InvalidOperationException("LLM continued requesting tools after tool execution was disabled for this turn."),
+                    ErrorCategory.ProviderFailure);
+                return;
+            }
+
             if (toolCalls.Count > 0 && _toolExecutor is not null)
             {
                 HandleToolCallResponse(lastMessage, toolCalls, response.Usage);
@@ -974,6 +991,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // if the model stalls later in the chain.
         _postToolNudgeSent = false;
         _preToolEmptyResponseCount = 0;
+        _forceNoToolsActive = false;
 
         // Add assistant message (with tool calls) to history
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);
@@ -1442,6 +1460,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void FireLlmCall(string? recallQuery = null, bool forceNoTools = false)
     {
+        _forceNoToolsActive = forceNoTools;
+
         var sessionDir = GetSessionDirectory();
         var messages = ChatMessageConverter.ToAiMessages(_state.History, sessionDir);
 


### PR DESCRIPTION
## Summary
- fail the turn when a model keeps emitting tool calls after the max-tool-iteration breaker disables tools
- stop Slack sessions from staying stuck in processing and buffering follow-up replies forever
- add regression coverage for providers that hallucinate tool calls after tools are withheld

## Follow-ups
- #265
- #266
- #267
- #268