### PR TITLE
fix hang recovery follow-ups

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -329,6 +329,121 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         Assert.Equal(0, _chatClient.CallCount);
     }
 
+    [Fact]
+    public async Task Failed_turn_posts_single_error_without_generic_fallback()
+    {
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        _chatClient.Failure = new InvalidOperationException("synthetic provider failure");
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-error-turn-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D4:5000"),
+            ChannelId: new SlackChannelId("D4"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("5000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "trigger a provider failure",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Single(_replyClient.PostedMessages);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        var posted = Assert.Single(_replyClient.PostedMessages);
+        Assert.Contains(":warning:", posted.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("didn't manage to produce a reply", posted.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Timed_out_slack_post_does_not_block_later_turns()
+    {
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        _replyClient.BlockPostsUntilCanceled = true;
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-post-timeout-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D5:6000"),
+            ChannelId: new SlackChannelId("D5"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("6000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "first message",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_replyClient.CanceledPostCount > 0,
+                "Expected the first Slack post attempt to be canceled by timeout");
+        }, duration: TimeSpan.FromSeconds(15));
+
+        _replyClient.BlockPostsUntilCanceled = false;
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D5:6001"),
+            ChannelId: new SlackChannelId("D5"),
+            ThreadTs: new SlackThreadTs("6000.1"),
+            EventTs: new SlackEventTs("6001.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "second message",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Contains(_replyClient.PostedMessages,
+                message => message.Text.Contains("call #2", StringComparison.OrdinalIgnoreCase));
+        }, duration: TimeSpan.FromSeconds(10));
+    }
+
     /// <summary>
     /// Fake HTTP handler that serves canned image bytes for Slack file download requests.
     /// </summary>
@@ -361,11 +476,30 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     {
         public List<SlackPostMessage> PostedMessages { get; } = [];
         public List<(SlackChannelId ChannelId, SlackThreadTs ThreadTs, string FilePath, string? FileName)> UploadedFiles { get; } = [];
+        public volatile bool BlockPostsUntilCanceled;
+        private int _canceledPostCount;
 
-        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+        public int CanceledPostCount => _canceledPostCount;
+
+        public async Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
+            if (BlockPostsUntilCanceled)
+            {
+                var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = cancellationToken.Register(() => waitForCancellation.TrySetCanceled(cancellationToken));
+
+                try
+                {
+                    await waitForCancellation.Task;
+                }
+                catch (OperationCanceledException)
+                {
+                    Interlocked.Increment(ref _canceledPostCount);
+                    throw;
+                }
+            }
+
             PostedMessages.Add(message);
-            return Task.CompletedTask;
         }
 
         public Task UploadFileToThreadAsync(
@@ -398,6 +532,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         private int _callCount;
         public int CallCount => _callCount;
         public volatile bool ReceivedImageContent;
+        public Exception? Failure { get; set; }
 
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages,
@@ -405,6 +540,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             CancellationToken cancellationToken = default)
         {
             Interlocked.Increment(ref _callCount);
+
+            if (Failure is not null)
+                throw Failure;
 
             foreach (var msg in messages)
             {

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -41,7 +41,9 @@ public class CompactionIntegrationTests : TestKit
             SnapshotInterval = 5,
             KeepRecentToolResults = 1,
             KeepRecentMessages = 0,
-            TitleGenerationInterval = 0
+            TitleGenerationInterval = 0,
+            TurnLlmTimeoutSeconds = 1,
+            SidecarLlmTimeoutSeconds = 1
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
@@ -252,6 +254,54 @@ public class CompactionIntegrationTests : TestKit
         await subscriber.ExpectMsgAsync<TextOutput>();
         await subscriber.ExpectMsgAsync<UsageOutput>();
         await subscriber.ExpectMsgAsync<TurnCompleted>();
+    }
+
+    [Fact]
+    public async Task Buffer_drains_after_compaction_timeout()
+    {
+        _fakeChatClient.UsageOverride = new UsageDetails
+        {
+            InputTokenCount = 800,
+            OutputTokenCount = 50,
+            TotalTokenCount = 850
+        };
+        _fakeChatClient.StuckObservationCallsRemaining = 1;
+
+        var sessionId = new SessionId("test-channel/buffer-drain-compact-timeout");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("buffer-timeout-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        });
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "First message"
+        });
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Second message (buffered)"
+        });
+
+        await subscriber.ExpectMsgAsync<TextOutput>();
+        await subscriber.ExpectMsgAsync<UsageOutput>();
+        await subscriber.ExpectMsgAsync<TurnCompleted>();
+
+        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("compaction timed out", error.Message, StringComparison.OrdinalIgnoreCase);
+
+        var bufferedText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("fake", bufferedText.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<UsageOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -590,6 +590,18 @@ internal sealed class FakeChatClient : IChatClient
     public UsageDetails? UsageOverride { get; set; }
 
     /// <summary>
+    /// Number of compaction observation sidecar calls that should hang until cancellation.
+    /// Used to simulate providers that never return during compaction.
+    /// </summary>
+    public int HangingObservationCallsRemaining { get; set; }
+
+    /// <summary>
+    /// Number of compaction observation sidecar calls that should ignore cancellation
+    /// entirely and never complete. Used to simulate a wedged compaction provider.
+    /// </summary>
+    public int StuckObservationCallsRemaining { get; set; }
+
+    /// <summary>
     /// When populated, responses are dequeued in order before falling back to the
     /// default fake text response. Each entry is used as the assistant message contents.
     /// </summary>
@@ -711,6 +723,28 @@ internal sealed class FakeChatClient : IChatClient
             return new ChatResponse(new ChatMessage(
                 Microsoft.Extensions.AI.ChatRole.Assistant,
                 JsonSerializer.Serialize<IReadOnlyList<MemoryProposal>>(proposals)));
+        }
+
+        if (systemText.Contains("You are an observation compressor", StringComparison.Ordinal))
+        {
+            if (StuckObservationCallsRemaining > 0)
+            {
+                StuckObservationCallsRemaining--;
+                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                await gate.Task;
+            }
+
+            if (HangingObservationCallsRemaining > 0)
+            {
+                HangingObservationCallsRemaining--;
+                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = cancellationToken.Register(() => gate.TrySetCanceled(cancellationToken));
+                await gate.Task;
+            }
+
+            return new ChatResponse(new ChatMessage(
+                Microsoft.Extensions.AI.ChatRole.Assistant,
+                "- compacted observation"));
         }
 
         // Return tool calls if configured

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -81,11 +81,52 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
         Assert.True(_chatClient.CallCount >= 2);
     }
 
+    [Fact]
+    public async Task Buffered_reprompt_is_replayed_after_failed_turn()
+    {
+        _chatClient.SucceedAfterFirstTimeout = true;
+
+        var sessionId = new SessionId("watchdog/session-buffered-retry");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("watchdog-buffered-retry-subscriber");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("timeout", firstError.Message, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        var recoveredText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("recovered after timeout", recoveredText.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(2, _chatClient.CallCount);
+    }
+
     private sealed class HangingStreamingChatClient : IChatClient
     {
         private int _callCount;
 
         public int CallCount => _callCount;
+        public bool SucceedAfterFirstTimeout { get; set; }
 
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages,
@@ -98,7 +139,11 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
             ChatOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            Interlocked.Increment(ref _callCount);
+            var callNumber = Interlocked.Increment(ref _callCount);
+
+            if (SucceedAfterFirstTimeout && callNumber > 1)
+                return ReturnTextAsync($"recovered after timeout on call {callNumber}", cancellationToken);
+
             return NeverCompletesAsync(CancellationToken.None);
         }
 
@@ -108,6 +153,22 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
             var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await gate.Task;
             yield break;
+        }
+
+        private static async IAsyncEnumerable<ChatResponseUpdate> ReturnTextAsync(
+            string text,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = new ChatResponse(new ChatMessage(
+                Microsoft.Extensions.AI.ChatRole.Assistant,
+                [new TextContent(text)]));
+
+            foreach (var update in response.ToChatResponseUpdates())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return update;
+                await Task.Yield();
+            }
         }
 
         public object? GetService(Type serviceType, object? serviceKey = null) => null;

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -1,5 +1,6 @@
 using Akka.Actor;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Protocol;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Sessions;
@@ -115,6 +116,23 @@ internal sealed record SpawnChildActorRequest
 internal sealed record CompactionTriggered
 {
     public required long InputTokenCount { get; init; }
+}
+
+internal sealed record CompactionWorkCompleted
+{
+    public required long OperationId { get; init; }
+    public required string Summary { get; init; }
+    public required List<SerializableChatMessage> CompactedMessages { get; init; }
+    public required int MessagesBefore { get; init; }
+    public required int ClearedCount { get; init; }
+    public required long PreCompactionInputTokens { get; init; }
+    public required int KeepCountUsed { get; init; }
+}
+
+internal sealed record CompactionWorkFailed
+{
+    public required long OperationId { get; init; }
+    public required Exception Cause { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1145,22 +1145,28 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            if (_buffer.Count > 0)
-            {
-                TurnLog().Info("turn_buffer_drain count={BufferCount}", _buffer.Count);
-                foreach (var buffered in _buffer)
-                {
-                    var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
-                    _state = _state.AddUserMessage(buffered.Content, refs);
-                }
-                _buffer.Clear();
-                FireLlmCall();
-            }
-            else
-            {
-                Become(Ready);
-            }
+            DrainBufferedMessagesOrBecomeReady();
         });
+    }
+
+    private void DrainBufferedMessagesOrBecomeReady()
+    {
+        if (_buffer.Count > 0)
+        {
+            TurnLog().Info("turn_buffer_drain count={BufferCount}", _buffer.Count);
+            foreach (var buffered in _buffer)
+            {
+                var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
+                _state = _state.AddUserMessage(buffered.Content, refs);
+            }
+
+            _buffer.Clear();
+            FireLlmCall();
+            Become(Processing);
+            return;
+        }
+
+        Become(Ready);
     }
 
     private bool ShouldCompact()
@@ -2464,8 +2470,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             TurnNumber = _state.TurnCount
         });
 
-        _buffer.Clear();
-        Become(Ready);
+        DrainBufferedMessagesOrBecomeReady();
     }
 
     private void EmitOutput(SessionOutput output, OutputFilter requiredFlag = OutputFilter.None)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -216,6 +216,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<ProcessingWatchdogExpired>(_ => { });
+        Command<CompactionWorkCompleted>(_ => { });
+        Command<CompactionWorkFailed>(_ => { });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
 
         Command<SendUserMessage>(cmd =>
@@ -293,6 +295,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _buffer.Add(cmd);
             TryReplyAck();
         });
+
+        Command<CompactionWorkCompleted>(_ => { });
+        Command<CompactionWorkFailed>(_ => { });
 
         Command<LlmResponseReceived>(msg =>
         {
@@ -624,87 +629,67 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             TryReplyAck();
         });
 
-        Command<ProcessingWatchdogExpired>(_ => { });
+        Command<ProcessingWatchdogExpired>(msg =>
+        {
+            if (!IsCurrentWatchdog(msg))
+                return;
+
+            _log.Error("Compaction watchdog expired for operation {OperationName} (opId={OperationId})",
+                msg.OperationName, msg.OperationId);
+
+            StopProcessingWatchdog();
+
+            EmitOutput(new ErrorOutput
+            {
+                SessionId = _sessionId,
+                Message = "Context compaction timed out. The session will continue.",
+                Category = ErrorCategory.Timeout,
+                CorrelationId = Guid.NewGuid(),
+                Cause = new TimeoutException(
+                    $"Session compaction operation '{msg.OperationName}' exceeded watchdog timeout of {GetCompactionTimeout().TotalSeconds:F0}s")
+            });
+
+            DrainBufferOrReady();
+        });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
 
-        CommandAsync<CompactionTriggered>(async msg =>
+        Command<CompactionTriggered>(msg =>
         {
-            var messagesBefore = _state.History.Count;
-            var preCompactionInputTokens = _lastInputTokenCount;
+            var timeout = GetCompactionTimeout();
+            StartProcessingWatchdog("compaction", timeout);
 
-            // Phase 1: Clear old tool results
-            var (newState, clearedCount) = _state.ClearOldToolResults(_config.KeepRecentToolResults);
-            _state = newState;
+            var operationId = _processingOperationId;
+            var stateSnapshot = _state;
+            var self = Self;
+            var log = _log;
+            var compactionClient = _compactionClient;
 
-            if (clearedCount > 0)
-            {
-                _log.Info("Phase 1: Cleared {ClearedCount} old tool result(s)", clearedCount);
-            }
+            _ = ExecuteCompactionAsync(
+                stateSnapshot,
+                msg.InputTokenCount,
+                _config.KeepRecentToolResults,
+                _config.KeepRecentMessages,
+                _config.ContextWindowTokens,
+                TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds)),
+                timeout,
+                compactionClient,
+                self,
+                log,
+                operationId);
+        });
 
-            // Phase 2: Extractive reduction with adaptive keep count.
-            // Start with the configured keep count, then halve if estimated tokens
-            // still exceed 50% of the context window (minimum 2 messages).
-            var systemOffset = _state.History.Count > 0
-                && _state.History[0].Role == Protocol.ChatRole.System ? 1 : 0;
-            var effectiveKeepCount = _config.KeepRecentMessages;
-            List<SerializableChatMessage> compactedMessages;
-            int discardStartIndex;
+        Command<CompactionWorkCompleted>(msg =>
+        {
+            if (!IsCurrentCompactionOperation(msg.OperationId))
+                return;
 
-            while (true)
-            {
-                var reducer = new ExtractiveSessionReducer(effectiveKeepCount);
-                var meaiMessages = ChatMessageConverter.ToAiMessages(_state.History);
-                var reduced = await reducer.ReduceAsync(meaiMessages, CancellationToken.None);
-
-                var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage>
-                    ?? reduced.ToList();
-                var keptNonSystemCount = reducedList
-                    .Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
-
-                var startIndex = _state.History.Count - keptNonSystemCount;
-                discardStartIndex = startIndex;
-                compactedMessages = [];
-                for (var i = Math.Max(systemOffset, startIndex); i < _state.History.Count; i++)
-                {
-                    compactedMessages.Add(_state.History[i]);
-                }
-
-                // Estimate remaining token cost (naive chars/4 heuristic)
-                var estimatedTokens = EstimateTokens(compactedMessages, systemOffset > 0 ? _state.History[0] : null);
-                var budgetHalf = _config.ContextWindowTokens / 2;
-
-                if (estimatedTokens <= budgetHalf || effectiveKeepCount <= 2)
-                    break;
-
-                var newKeepCount = Math.Max(2, effectiveKeepCount / 2);
-                _log.Info("Adaptive compaction: estimated {EstimatedTokens} tokens > {Budget} budget half, reducing keep count {OldKeep} → {NewKeep}",
-                    estimatedTokens, budgetHalf, effectiveKeepCount, newKeepCount);
-                effectiveKeepCount = newKeepCount;
-            }
-
-            _log.Info("Phase 2: Extractive reduction (history={HistoryCount} → {KeptCount} messages, keepCount={KeepCount})",
-                _state.History.Count, compactedMessages.Count + systemOffset, effectiveKeepCount);
-
-            // Phase 2b: Observer — compress discarded messages into observations.
-            // Observations are prepended to the kept messages so context is preserved.
-            var observationText = await GenerateObservationsAsync(systemOffset, discardStartIndex);
-            if (!string.IsNullOrWhiteSpace(observationText))
-            {
-                var observationMsg = new SerializableChatMessage
-                {
-                    Role = Protocol.ChatRole.User,
-                    Content = ObservationPromptBuilder.WrapObservations(observationText)
-                };
-                compactedMessages.Insert(0, observationMsg);
-                _log.Info("Observer: generated {ObsLength} chars of observations from {DiscardedCount} discarded messages",
-                    observationText.Length, Math.Max(0, discardStartIndex - systemOffset));
-            }
+            StopProcessingWatchdog();
 
             var compactedEvent = new SessionCompacted
             {
                 SessionId = _sessionId,
-                Summary = observationText ?? string.Empty,
-                CompactedMessages = compactedMessages,
+                Summary = msg.Summary,
+                CompactedMessages = msg.CompactedMessages,
                 TurnCountBefore = _state.TurnCount,
                 CompactedAtMs = NowMs()
             };
@@ -712,7 +697,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Persist(compactedEvent, evt =>
             {
                 _state = _state.Apply(evt);
-                _lastInputTokenCount = 0; // Reset — next LLM call will provide fresh count
+                _lastInputTokenCount = 0;
                 _autoLoadedSkills.Clear();
                 _autoLoadedSkillContent.Clear();
 
@@ -725,11 +710,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         SessionId: _sessionId.Value,
                         TriggerType: "compaction-boundary",
                         Source: "compaction",
-                        Content: string.IsNullOrWhiteSpace(observationText)
+                        Content: string.IsNullOrWhiteSpace(msg.Summary)
                             ? "Compaction completed"
-                            : observationText,
+                            : msg.Summary,
                         UserContent: null,
-                        AssistantContent: observationText,
+                        AssistantContent: string.IsNullOrWhiteSpace(msg.Summary) ? null : msg.Summary,
                         IsExplicitRequest: false,
                         HasVerifiedToolFinding: false,
                         IsCompactionBoundary: true,
@@ -742,35 +727,49 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         Title: "compaction-boundary",
                         UpdateSemantics: "append-document")));
 
-                // Always snapshot after compaction
                 SaveSnapshot(_state.ToSnapshot());
 
                 EmitOutput(new CompactionOutput
                 {
                     SessionId = _sessionId,
-                    MessagesBefore = messagesBefore,
+                    MessagesBefore = msg.MessagesBefore,
                     MessagesAfter = _state.History.Count,
-                    ToolResultsCleared = clearedCount > 0,
-                    Summarized = !string.IsNullOrWhiteSpace(observationText),
+                    ToolResultsCleared = msg.ClearedCount > 0,
+                    Summarized = !string.IsNullOrWhiteSpace(msg.Summary),
                     ContextWindowTokens = _config.ContextWindowTokens,
-                    PreCompactionInputTokens = preCompactionInputTokens,
-                    KeepCountUsed = effectiveKeepCount
+                    PreCompactionInputTokens = msg.PreCompactionInputTokens,
+                    KeepCountUsed = msg.KeepCountUsed
                 });
 
                 _log.Info("Compaction complete (before={MessagesBefore}, after={MessagesAfter})",
-                    messagesBefore, _state.History.Count);
+                    msg.MessagesBefore, _state.History.Count);
 
-                // Memory extraction is optional and best-effort.
-                // If no extractor is configured, skip the async LLM call and drain immediately.
                 if (_memoryExtractor is NullMemoryExtractor)
-                {
                     DrainBufferOrReady();
-                }
                 else
-                {
                     InvokeMemoryExtractionAsync();
-                }
             });
+        });
+
+        Command<CompactionWorkFailed>(msg =>
+        {
+            if (!IsCurrentCompactionOperation(msg.OperationId))
+                return;
+
+            StopProcessingWatchdog();
+
+            _log.Warning(msg.Cause, "Compaction failed");
+
+            EmitOutput(new ErrorOutput
+            {
+                SessionId = _sessionId,
+                Message = "Context compaction encountered an error. The session will continue.",
+                Category = msg.Cause is TimeoutException ? ErrorCategory.Timeout : ErrorCategory.Unknown,
+                CorrelationId = Guid.NewGuid(),
+                Cause = msg.Cause
+            });
+
+            DrainBufferOrReady();
         });
 
         Command<MemoryExtractionCompleted>(msg =>
@@ -818,6 +817,120 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         else
         {
             Become(Ready);
+        }
+    }
+
+    private TimeSpan GetCompactionTimeout()
+        => TimeSpan.FromSeconds(Math.Max(1,
+            Math.Max(_config.TurnLlmTimeoutSeconds, _config.SidecarLlmTimeoutSeconds)));
+
+    private bool IsCurrentCompactionOperation(long operationId)
+        => _processingOperationName == "compaction" && _processingOperationId == operationId;
+
+    private static async Task ExecuteCompactionAsync(
+        SessionState stateSnapshot,
+        long preCompactionInputTokens,
+        int keepRecentToolResults,
+        int keepRecentMessages,
+        int contextWindowTokens,
+        TimeSpan sidecarTimeout,
+        TimeSpan compactionTimeout,
+        IChatClient client,
+        IActorRef self,
+        ILoggingAdapter log,
+        long operationId)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(compactionTimeout);
+
+            var messagesBefore = stateSnapshot.History.Count;
+            var (compactionState, clearedCount) = stateSnapshot.ClearOldToolResults(keepRecentToolResults);
+            var history = compactionState.History;
+
+            if (clearedCount > 0)
+            {
+                log.Info("Phase 1: Cleared {ClearedCount} old tool result(s)", clearedCount);
+            }
+
+            var systemOffset = history.Count > 0 && history[0].Role == Protocol.ChatRole.System ? 1 : 0;
+            var effectiveKeepCount = keepRecentMessages;
+            List<SerializableChatMessage> compactedMessages;
+            int discardStartIndex;
+
+            while (true)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+
+                var reducer = new ExtractiveSessionReducer(effectiveKeepCount);
+                var meaiMessages = ChatMessageConverter.ToAiMessages(history);
+                var reduced = await reducer.ReduceAsync(meaiMessages, cts.Token);
+
+                var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage> ?? reduced.ToList();
+                var keptNonSystemCount = reducedList.Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
+
+                var startIndex = history.Count - keptNonSystemCount;
+                discardStartIndex = startIndex;
+                compactedMessages = [];
+                for (var i = Math.Max(systemOffset, startIndex); i < history.Count; i++)
+                {
+                    compactedMessages.Add(history[i]);
+                }
+
+                var estimatedTokens = EstimateTokens(compactedMessages, systemOffset > 0 ? history[0] : null);
+                var budgetHalf = contextWindowTokens / 2;
+
+                if (estimatedTokens <= budgetHalf || effectiveKeepCount <= 2)
+                    break;
+
+                var newKeepCount = Math.Max(2, effectiveKeepCount / 2);
+                log.Info("Adaptive compaction: estimated {EstimatedTokens} tokens > {Budget} budget half, reducing keep count {OldKeep} -> {NewKeep}",
+                    estimatedTokens, budgetHalf, effectiveKeepCount, newKeepCount);
+                effectiveKeepCount = newKeepCount;
+            }
+
+            log.Info("Phase 2: Extractive reduction (history={HistoryCount} -> {KeptCount} messages, keepCount={KeepCount})",
+                history.Count, compactedMessages.Count + systemOffset, effectiveKeepCount);
+
+            var observationText = await GenerateObservationsAsync(
+                client,
+                history,
+                systemOffset,
+                discardStartIndex,
+                sidecarTimeout,
+                log,
+                cts.Token);
+
+            if (!string.IsNullOrWhiteSpace(observationText))
+            {
+                var observationMsg = new SerializableChatMessage
+                {
+                    Role = Protocol.ChatRole.User,
+                    Content = ObservationPromptBuilder.WrapObservations(observationText)
+                };
+                compactedMessages.Insert(0, observationMsg);
+                log.Info("Observer: generated {ObsLength} chars of observations from {DiscardedCount} discarded messages",
+                    observationText.Length, Math.Max(0, discardStartIndex - systemOffset));
+            }
+
+            self.Tell(new CompactionWorkCompleted
+            {
+                OperationId = operationId,
+                Summary = observationText ?? string.Empty,
+                CompactedMessages = compactedMessages,
+                MessagesBefore = messagesBefore,
+                ClearedCount = clearedCount,
+                PreCompactionInputTokens = preCompactionInputTokens,
+                KeepCountUsed = effectiveKeepCount
+            });
+        }
+        catch (Exception ex)
+        {
+            self.Tell(new CompactionWorkFailed
+            {
+                OperationId = operationId,
+                Cause = ex
+            });
         }
     }
 
@@ -882,13 +995,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// Observer phase: compress discarded messages into observation notes via LLM call.
     /// Returns null if no messages to compress or if the LLM call fails (graceful degradation).
     /// </summary>
-    private async Task<string?> GenerateObservationsAsync(int systemOffset, int keepStartIndex)
+    private static async Task<string?> GenerateObservationsAsync(
+        IChatClient client,
+        IReadOnlyList<SerializableChatMessage> history,
+        int systemOffset,
+        int keepStartIndex,
+        TimeSpan sidecarTimeout,
+        ILoggingAdapter log,
+        CancellationToken cancellationToken)
     {
-        // Collect messages that will be discarded
         var discardedMessages = new List<SerializableChatMessage>();
-        for (var i = systemOffset; i < keepStartIndex && i < _state.History.Count; i++)
+        for (var i = systemOffset; i < keepStartIndex && i < history.Count; i++)
         {
-            discardedMessages.Add(_state.History[i]);
+            discardedMessages.Add(history[i]);
         }
 
         if (discardedMessages.Count == 0)
@@ -896,8 +1015,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         try
         {
-            var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds));
-            using var cts = new CancellationTokenSource(timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(sidecarTimeout);
             var observerMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,
@@ -906,13 +1025,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     ObservationPromptBuilder.BuildObservationUserPrompt(discardedMessages))
             };
 
-            var response = await _compactionClient.GetResponseAsync(
+            var response = await client.GetResponseAsync(
                 observerMessages, cancellationToken: cts.Token);
             var text = response.Messages[^1].Text;
 
             if (string.IsNullOrWhiteSpace(text))
             {
-                _log.Warning("Observer returned empty observation text — falling back to extractive-only");
+                log.Warning("Observer returned empty observation text — falling back to extractive-only");
                 return null;
             }
 
@@ -920,8 +1039,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         catch (Exception ex)
         {
-            // Graceful degradation: if Observer fails, proceed with extractive-only compaction
-            _log.Warning(ex, "Observer LLM call failed — falling back to extractive-only compaction");
+            log.Warning(ex, "Observer LLM call failed — falling back to extractive-only compaction");
             return null;
         }
     }

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -39,6 +39,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
     private static readonly TimeSpan FileDownloadTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ContentScanTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ReplyOperationTimeout = TimeSpan.FromSeconds(5);
 
     public IStash Stash { get; set; } = null!;
     public ITimerScheduler Timers { get; set; } = null!;
@@ -415,6 +416,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
             case ErrorOutput err:
                 var refId = err.CorrelationId.ToString("N")[..8];
                 await SafePostAsync($":warning: {err.Message} (ref: {refId})");
+                _postedThisTurn = true;
                 _buffer.Clear();
                 break;
 
@@ -448,13 +450,19 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
         {
+            using var cts = new CancellationTokenSource(ReplyOperationTimeout);
             await _dependencies.ReplyClient.PostThreadReplyAsync(new SlackPostMessage(
                 ChannelId: _channelId,
                 ThreadTs: _threadTs,
-                Text: text));
+                Text: text), cts.Token);
 
             _log.Info("Posted Slack reply message");
             ChannelTelemetry.RecordSlackReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+        }
+        catch (OperationCanceledException ex)
+        {
+            _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
         }
         catch (Exception ex)
         {
@@ -465,6 +473,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
     private async Task SafeUploadFileAsync(FileOutput file)
     {
+        var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
         {
             if (!File.Exists(file.FilePath))
@@ -473,18 +482,26 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 return;
             }
 
+            using var cts = new CancellationTokenSource(ReplyOperationTimeout);
             await _dependencies.ReplyClient.UploadFileToThreadAsync(
                 _channelId,
                 _threadTs,
                 file.FilePath,
-                file.FileName);
+                file.FileName,
+                cts.Token);
 
             _uploadedFileThisTurn = true;
             _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
         }
+        catch (OperationCanceledException ex)
+        {
+            _log.Error(ex, "Timed out uploading file {FileName} to Slack thread", file.FileName);
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+        }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
         }
     }
 


### PR DESCRIPTION
## Summary
- add Slack reply/upload timeouts and suppress duplicate fallback warnings after explicit error outputs
- replay buffered reprompts after failed turns so follow-up Slack messages are not dropped
- move compaction work off the actor mailbox and add watchdog-based recovery when compaction wedges

Closes #265
Closes #266
Closes #267
Closes #268