### PR TITLE
refactor(cli): consolidate daemon HTTP connectivity into DaemonApi

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
@@ -15,18 +15,6 @@ namespace Netclaw.Cli.Tests.Cli;
 public sealed class DaemonClientSessionTests
 {
     [Fact]
-    public async Task ListSessionsAsync_returns_empty_list_when_daemon_unreachable()
-    {
-        // Point at a port with nothing listening
-        var port = GetFreeTcpPort();
-        await using var client = new DaemonClient($"http://127.0.0.1:{port}");
-
-        var sessions = await client.ListSessionsAsync();
-
-        Assert.Empty(sessions);
-    }
-
-    [Fact]
     public async Task ResumeSessionAsync_reattaches_to_existing_session_via_EnsureSession()
     {
         var port = GetFreeTcpPort();

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -1,0 +1,163 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Daemon;
+
+/// <summary>
+/// Single shared abstraction for all daemon REST HTTP communication.
+/// Owns endpoint resolution, client creation, timeout, and deserialization.
+/// Registered as a singleton in DI — every CLI command and TUI ViewModel
+/// uses this instead of creating its own HttpClient + endpoint logic.
+/// </summary>
+public sealed class DaemonApi
+{
+    private static readonly JsonSerializerOptions WebJsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan LongTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly IHttpClientFactory _factory;
+    private readonly string _endpoint;
+
+    public DaemonApi(IHttpClientFactory factory, IConfiguration configuration)
+    {
+        _factory = factory;
+        _endpoint = (configuration["Daemon:Endpoint"]
+            ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
+            ?? "http://127.0.0.1:5199").TrimEnd('/');
+    }
+
+    /// <summary>
+    /// The resolved daemon base endpoint (e.g. <c>http://127.0.0.1:5199</c>).
+    /// Useful for display messages and SignalR hub URL construction.
+    /// </summary>
+    public string Endpoint => _endpoint;
+
+    // ── Status ────────────────────────────────────────────────────────
+
+    public async Task<DaemonRuntimeStatus.Response?> GetStatusAsync(CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        using var response = await client.GetAsync($"{_endpoint}/api/health/status", cts.Token);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+        return await JsonSerializer.DeserializeAsync<DaemonRuntimeStatus.Response>(stream, WebJsonOptions, cts.Token);
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────
+
+    public async Task<List<SessionCatalogEntryDto>> ListSessionsAsync(CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        using var response = await client.GetAsync($"{_endpoint}/api/sessions", cts.Token);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+        return await JsonSerializer.DeserializeAsync<List<SessionCatalogEntryDto>>(stream, WebJsonOptions, cts.Token) ?? [];
+    }
+
+    // ── Reminders ─────────────────────────────────────────────────────
+
+    public async Task<HttpResponseMessage> ListRemindersAsync(CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetAsync($"{_endpoint}/api/reminders", cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> CreateReminderAsync(object request, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.PostAsJsonAsync($"{_endpoint}/api/reminders", request, cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> DeleteReminderAsync(string id, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.DeleteAsync($"{_endpoint}/api/reminders/{id}", cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> GetReminderAsync(string id, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetAsync($"{_endpoint}/api/reminders/{id}", cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> GetReminderHistoryAsync(string id, int last = 20, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetAsync($"{_endpoint}/api/reminders/{id}/history?last={last}", cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> EnableReminderAsync(string id, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.PostAsync($"{_endpoint}/api/reminders/{id}/enable", content: null, cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> DisableReminderAsync(string id, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.PostAsync($"{_endpoint}/api/reminders/{id}/disable", content: null, cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> ValidateReminderAsync(object request, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.PostAsJsonAsync($"{_endpoint}/api/reminders/validate", request, cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> ImportReminderAsync(object request, JsonSerializerOptions? options = null, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return options is not null
+            ? await client.PostAsJsonAsync($"{_endpoint}/api/reminders/import", request, options, cts.Token)
+            : await client.PostAsJsonAsync($"{_endpoint}/api/reminders/import", request, cts.Token);
+    }
+
+    // ── MCP OAuth ─────────────────────────────────────────────────────
+
+    public async Task<HttpResponseMessage> StartMcpOAuthAsync(string name, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(LongTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.PostAsync($"{_endpoint}/api/mcp/oauth/start/{Uri.EscapeDataString(name)}", null, cts.Token);
+    }
+
+    public async Task<JsonElement> GetMcpOAuthStatusAsync(string name, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetFromJsonAsync<JsonElement>(
+            $"{_endpoint}/api/mcp/oauth/status/{Uri.EscapeDataString(name)}", cts.Token);
+    }
+
+    // ── Health (for init wizard polling) ──────────────────────────────
+
+    public async Task<bool> IsHealthyAsync(CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"{_endpoint}/api/health/ready", cts.Token);
+        return response.IsSuccessStatusCode;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private static CancellationTokenSource CreateTimeoutCts(TimeSpan timeout, CancellationToken ct)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout);
+        return cts;
+    }
+}

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Json;
 using Microsoft.AspNetCore.SignalR.Client;
 using R3;
 using Microsoft.Extensions.AI;
@@ -30,7 +29,6 @@ public sealed class DaemonClient : IAsyncDisposable
     private readonly string _hubUrl;
     private readonly Subject<SessionOutput> _outputSubject = new();
     private readonly Subject<DaemonConnectionEvent> _connectionSubject = new();
-    private readonly HttpClient _httpClient = new();
     private readonly TimeProvider _timeProvider;
     private readonly SemaphoreSlim _connectGate = new(1, 1);
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
@@ -235,26 +233,6 @@ public sealed class DaemonClient : IAsyncDisposable
     }
 
     /// <summary>
-    /// Queries the daemon REST API for recent sessions.
-    /// Returns an empty list if the daemon is unreachable.
-    /// </summary>
-    public async Task<List<SessionCatalogEntryDto>> ListSessionsAsync(
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var url = $"{_daemonEndpoint}/api/sessions";
-            var result = await _httpClient.GetFromJsonAsync<List<SessionCatalogEntryDto>>(
-                url, cancellationToken);
-            return result ?? [];
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    /// <summary>
     /// Sets the session ID for subsequent calls so that <c>EnsureSession</c>
     /// attaches to (or rehydrates) an existing session instead of creating a new one.
     /// </summary>
@@ -308,7 +286,6 @@ public sealed class DaemonClient : IAsyncDisposable
         _lifetimeCts.Cancel();
         _lifetimeCts.Dispose();
         await _connection.DisposeAsync();
-        _httpClient.Dispose();
         _connectGate.Dispose();
         _sessionGate.Dispose();
     }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 using ModelContextProtocol.Client;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Mcp;
@@ -31,7 +32,7 @@ internal static class McpCommand
 {
     private static JsonSerializerOptions JsonOptions => ConfigFileHelper.JsonOptions;
 
-    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, TextWriter? output = null)
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi = null, TextWriter? output = null)
     {
         var writer = output ?? Console.Out;
         var subcommand = args.Length > 1 ? args[1] : "help";
@@ -39,7 +40,7 @@ internal static class McpCommand
         return subcommand switch
         {
             "add" => RunAdd(args, paths, writer),
-            "auth" => await RunAuthAsync(args, paths, writer),
+            "auth" => await RunAuthAsync(args, paths, daemonApi, writer),
             "list" => await RunListAsync(paths, writer),
             "get" => RunGet(args, paths, writer),
             "remove" => RunRemove(args, paths, writer),
@@ -209,11 +210,17 @@ internal static class McpCommand
         return 0;
     }
 
-    private static async Task<int> RunAuthAsync(string[] args, NetclawPaths paths, TextWriter writer)
+    private static async Task<int> RunAuthAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi, TextWriter writer)
     {
         if (args.Length < 3)
         {
             writer.WriteLine("Usage: netclaw mcp auth <name>");
+            return 1;
+        }
+
+        if (daemonApi is null)
+        {
+            writer.WriteLine("Error: DaemonApi not available. Is the daemon configured?");
             return 1;
         }
 
@@ -232,17 +239,13 @@ internal static class McpCommand
             return 1;
         }
 
-        const string daemonEndpoint = "http://127.0.0.1:5199";
-        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-
         // 1. Start the OAuth flow via daemon
         writer.WriteLine($"Starting OAuth authorization for '{name}'...");
 
         HttpResponseMessage startResponse;
         try
         {
-            startResponse = await httpClient.PostAsync(
-                $"{daemonEndpoint}/api/mcp/oauth/start/{Uri.EscapeDataString(name)}", null);
+            startResponse = await daemonApi.StartMcpOAuthAsync(name);
         }
         catch (HttpRequestException)
         {
@@ -289,8 +292,7 @@ internal static class McpCommand
 
             try
             {
-                var statusResponse = await httpClient.GetFromJsonAsync<JsonElement>(
-                    $"{daemonEndpoint}/api/mcp/oauth/status/{Uri.EscapeDataString(name)}");
+                var statusResponse = await daemonApi.GetMcpOAuthStatusAsync(name);
 
                 var status = statusResponse.GetProperty("status").GetString();
                 if (status is "Completed")

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -329,14 +329,28 @@ static async Task RunAsync(string[] args)
     // ── MCP server management (offline, except auth which needs daemon) ──
     if (mode is "mcp")
     {
-        var builder = Host.CreateApplicationBuilder(args);
-        ConfigureConfigServices(builder.Services, builder.Configuration);
-        builder.Logging.ClearProviders();
-        builder.Logging.SetMinimumLevel(LogLevel.Warning);
-        using var mcpHost = builder.Build();
-        var mcpPaths = mcpHost.Services.GetRequiredService<NetclawPaths>();
-        var mcpDaemonApi = mcpHost.Services.GetRequiredService<DaemonApi>();
-        Environment.ExitCode = await McpCommand.RunAsync(args, mcpPaths, mcpDaemonApi);
+        var mcpSubcommand = args.Length > 1 ? args[1] : "help";
+
+        if (mcpSubcommand is "auth")
+        {
+            // auth needs the daemon — spin up DI to get DaemonApi
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            using var mcpHost = builder.Build();
+            var mcpPaths = mcpHost.Services.GetRequiredService<NetclawPaths>();
+            var mcpDaemonApi = mcpHost.Services.GetRequiredService<DaemonApi>();
+            Environment.ExitCode = await McpCommand.RunAsync(args, mcpPaths, mcpDaemonApi);
+        }
+        else
+        {
+            // All other subcommands are offline config-file operations
+            var paths = new NetclawPaths();
+            paths.EnsureDirectoriesExist();
+            Environment.ExitCode = await McpCommand.RunAsync(args, paths);
+        }
+
         return;
     }
 
@@ -428,6 +442,13 @@ static async Task RunAsync(string[] args)
             return;
         }
 
+        // help and validate are offline — skip DI
+        var reminderSub = args.Length > 1 ? args[1] : "help";
+        if (reminderSub is "help" or "-h" or "--help" or "validate" || args.Length == 1)
+        {
+            Environment.ExitCode = await ReminderCommand.RunAsync(args, daemonApi: null);
+        }
+        else
         {
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
@@ -843,6 +864,13 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
             _ => 1
         };
     }
+    catch (HttpRequestException ex) when (ex.StatusCode is not null)
+    {
+        await updateCts.CancelAsync();
+        Console.WriteLine($"[FAIL] status: daemon returned {(int)ex.StatusCode} from {api.Endpoint}");
+        Console.WriteLine("       fix: run `netclaw daemon status` and `netclaw daemon start`.");
+        return 1;
+    }
     catch (Exception ex)
     {
         await updateCts.CancelAsync();
@@ -887,6 +915,12 @@ static async Task<int> RunSessionsOnceAsync(IServiceProvider services, bool json
         }
 
         return 0;
+    }
+    catch (HttpRequestException ex) when (ex.StatusCode is not null)
+    {
+        Console.WriteLine($"[FAIL] sessions: daemon returned {(int)ex.StatusCode} from {api.Endpoint}");
+        Console.WriteLine("       fix: run `netclaw daemon status` and `netclaw daemon start`.");
+        return 1;
     }
     catch (Exception ex)
     {

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -136,14 +136,10 @@ static async Task RunAsync(string[] args)
             builder.Services.AddSingleton<DaemonManager>();
             builder.Services.AddSingleton<IBrowserAutomationBootstrapper, BrowserAutomationBootstrapper>();
 
-            var daemonEndpoint =
-                Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-                ?? "http://127.0.0.1:5199";
-
             // Register DaemonClient, ChatNavigationState, and SessionConfig for ChatPage
             // (uses freshly-written config from the wizard's WriteConfig)
             builder.Services.AddSingleton(new ChatNavigationState());
-            builder.Services.AddSingleton(new DaemonClient(daemonEndpoint));
+            builder.Services.AddSingleton(sp => new DaemonClient(sp.GetRequiredService<DaemonApi>().Endpoint));
             builder.Services.AddSingleton(sp =>
             {
                 // Read the just-written config files for session settings
@@ -272,14 +268,13 @@ static async Task RunAsync(string[] args)
 
         var builder = Host.CreateApplicationBuilder(args);
         ConfigureConfigServices(builder.Services, builder.Configuration);
-        builder.Services.AddHttpClient();
 
         builder.Logging.ClearProviders();
         builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
         using var host = builder.Build();
         using var scope = host.Services.CreateScope();
-        var exitCode = await RunStatusAsync(scope.ServiceProvider, builder.Configuration, statusAsJson);
+        var exitCode = await RunStatusAsync(scope.ServiceProvider, statusAsJson);
         Environment.ExitCode = exitCode;
         return;
     }
@@ -331,12 +326,17 @@ static async Task RunAsync(string[] args)
         }
     }
 
-    // ── MCP server management (offline) ──
+    // ── MCP server management (offline, except auth which needs daemon) ──
     if (mode is "mcp")
     {
-        var paths = new NetclawPaths();
-        paths.EnsureDirectoriesExist();
-        Environment.ExitCode = await McpCommand.RunAsync(args, paths);
+        var builder = Host.CreateApplicationBuilder(args);
+        ConfigureConfigServices(builder.Services, builder.Configuration);
+        builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        using var mcpHost = builder.Build();
+        var mcpPaths = mcpHost.Services.GetRequiredService<NetclawPaths>();
+        var mcpDaemonApi = mcpHost.Services.GetRequiredService<DaemonApi>();
+        Environment.ExitCode = await McpCommand.RunAsync(args, mcpPaths, mcpDaemonApi);
         return;
     }
 
@@ -417,10 +417,6 @@ static async Task RunAsync(string[] args)
             ConfigureConfigServices(builder.Services, builder.Configuration);
             builder.Logging.ClearProviders();
             builder.Logging.SetMinimumLevel(LogLevel.Warning);
-            builder.Services.AddHttpClient("ReminderApi", client =>
-            {
-                client.Timeout = TimeSpan.FromSeconds(10);
-            });
 
             var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-reminder-trace.log");
             builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
@@ -432,7 +428,14 @@ static async Task RunAsync(string[] args)
             return;
         }
 
-        Environment.ExitCode = await ReminderCommand.RunAsync(args);
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            using var host = builder.Build();
+            Environment.ExitCode = await ReminderCommand.RunAsync(args, host.Services.GetRequiredService<DaemonApi>());
+        }
         return;
     }
 
@@ -487,14 +490,12 @@ static async Task RunAsync(string[] args)
         {
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
-            builder.Services.AddHttpClient();
             builder.Logging.ClearProviders();
             builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
             using var host = builder.Build();
             using var scope = host.Services.CreateScope();
-            Environment.ExitCode = await RunSessionsOnceAsync(
-                scope.ServiceProvider, builder.Configuration, sessionsJsonOutput);
+            Environment.ExitCode = await RunSessionsOnceAsync(scope.ServiceProvider, sessionsJsonOutput);
             return;
         }
     }
@@ -793,40 +794,19 @@ static void WriteSimpleDiff(string original, string updated)
     }
 }
 
-static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration configuration, bool jsonOutput)
+static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput)
 {
-    var endpoint = configuration["Daemon:Endpoint"]
-        ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-        ?? "http://127.0.0.1:5199";
-
-    var url = $"{endpoint.TrimEnd('/')}/api/health/status";
+    var api = services.GetRequiredService<DaemonApi>();
     var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
-    var client = httpClientFactory.CreateClient();
 
     // Start CLI update check concurrently with daemon status fetch (3s timeout, non-blocking).
-    // Use a shared CTS so early-return paths can cancel it promptly.
     using var updateCts = new CancellationTokenSource();
     var updateClient = httpClientFactory.CreateClient();
     var updateTask = StatusUpdateChecker.CheckAsync(updateClient, BuildInfo.Version, updateCts.Token);
 
     try
     {
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        using var response = await client.GetAsync(url, timeoutCts.Token);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            await updateCts.CancelAsync();
-            Console.WriteLine($"[FAIL] status: daemon returned {(int)response.StatusCode} from {url}");
-            Console.WriteLine("       fix: run `netclaw daemon status` and `netclaw daemon start`.");
-            return 1;
-        }
-
-        var payload = await response.Content.ReadAsStreamAsync(timeoutCts.Token);
-        var status = await JsonSerializer.DeserializeAsync<DaemonRuntimeStatus.Response>(
-            payload,
-            new JsonSerializerOptions(JsonSerializerDefaults.Web),
-            timeoutCts.Token);
+        var status = await api.GetStatusAsync();
 
         if (status is null)
         {
@@ -835,12 +815,10 @@ static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration 
             return 1;
         }
 
-        // Await the CLI update check (it has its own 3s timeout so this should be fast)
         var cliUpdate = await updateTask;
 
         if (jsonOutput)
         {
-            // Merge CLI update result into the JSON output so consumers always see a fresh State.
             var node = JsonSerializer.SerializeToNode(
                 status, new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
             var updateNode = (node["update"] as JsonObject) ?? new JsonObject();
@@ -855,7 +833,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration 
         }
         else
         {
-            WriteStatusResult(status, endpoint, cliUpdate);
+            WriteStatusResult(status, api.Endpoint, cliUpdate);
         }
 
         return status.Overall.ToLowerInvariant() switch
@@ -868,42 +846,19 @@ static async Task<int> RunStatusAsync(IServiceProvider services, IConfiguration 
     catch (Exception ex)
     {
         await updateCts.CancelAsync();
-        Console.WriteLine($"[FAIL] status: unable to reach daemon at {url}: {ex.Message}");
+        Console.WriteLine($"[FAIL] status: unable to reach daemon at {api.Endpoint}: {ex.Message}");
         Console.WriteLine("       fix: run `netclaw daemon start` and retry.");
         return 1;
     }
 }
 
-static async Task<int> RunSessionsOnceAsync(
-    IServiceProvider services,
-    IConfiguration configuration,
-    bool jsonOutput)
+static async Task<int> RunSessionsOnceAsync(IServiceProvider services, bool jsonOutput)
 {
-    var endpoint = configuration["Daemon:Endpoint"]
-        ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-        ?? "http://127.0.0.1:5199";
-
-    var url = $"{endpoint.TrimEnd('/')}/api/sessions";
-    var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
-    var client = httpClientFactory.CreateClient();
+    var api = services.GetRequiredService<DaemonApi>();
 
     try
     {
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        using var response = await client.GetAsync(url, timeoutCts.Token);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            Console.WriteLine($"[FAIL] sessions: daemon returned {(int)response.StatusCode} from {url}");
-            Console.WriteLine("       fix: run `netclaw daemon status` and `netclaw daemon start`.");
-            return 1;
-        }
-
-        var stream = await response.Content.ReadAsStreamAsync(timeoutCts.Token);
-        var sessions = await JsonSerializer.DeserializeAsync<List<SessionCatalogEntryDto>>(
-            stream,
-            new JsonSerializerOptions(JsonSerializerDefaults.Web),
-            timeoutCts.Token) ?? [];
+        var sessions = await api.ListSessionsAsync();
 
         if (jsonOutput)
         {
@@ -935,7 +890,7 @@ static async Task<int> RunSessionsOnceAsync(
     }
     catch (Exception ex)
     {
-        Console.WriteLine($"[FAIL] sessions: unable to reach daemon at {url}: {ex.Message}");
+        Console.WriteLine($"[FAIL] sessions: unable to reach daemon at {api.Endpoint}: {ex.Message}");
         Console.WriteLine("       fix: run `netclaw daemon start` and retry.");
         return 1;
     }
@@ -1062,6 +1017,10 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
     // TimeProvider (virtualized for testing)
     services.AddSingleton(TimeProvider.System);
 
+    // Shared daemon HTTP API client — single endpoint resolution for all commands
+    services.AddHttpClient();
+    services.AddSingleton<DaemonApi>();
+
     return paths;
 }
 
@@ -1084,9 +1043,6 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
         CompactionModelId = models.Compaction?.ModelId,
     });
 
-    var daemonEndpoint =
-        configuration["Daemon:Endpoint"]
-        ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-        ?? "http://127.0.0.1:5199";
-    services.AddSingleton(new DaemonClient(daemonEndpoint));
+    // DaemonClient uses the endpoint from DaemonApi (already registered in ConfigureConfigServices)
+    services.AddSingleton(sp => new DaemonClient(sp.GetRequiredService<DaemonApi>().Endpoint));
 }

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -1,13 +1,13 @@
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Netclaw.Actors.Reminders;
+using Netclaw.Cli.Daemon;
 
 namespace Netclaw.Cli.Reminder;
 
 /// <summary>
 /// Handles <c>netclaw reminder</c> CLI subcommands.
-/// All commands require the daemon to be running (HTTP to REST API).
+/// All commands require the daemon to be running (HTTP to REST API via <see cref="DaemonApi"/>).
 /// </summary>
 internal static class ReminderCommand
 {
@@ -17,7 +17,7 @@ internal static class ReminderCommand
         Converters = { new JsonStringEnumConverter() }
     };
 
-    public static async Task<int> RunAsync(string[] args)
+    public static async Task<int> RunAsync(string[] args, DaemonApi api)
     {
         if (args.Length == 1)
         {
@@ -32,32 +32,26 @@ internal static class ReminderCommand
             return 0;
         }
 
-        var endpoint = Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-            ?? "http://127.0.0.1:5199";
-        var baseUrl = $"{endpoint.TrimEnd('/')}/api/reminders";
-
-        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-
         return subcommand switch
         {
-            "list" => await RunListAsync(client, baseUrl),
-            "create" => await RunCreateAsync(client, baseUrl, args),
-            "cancel" or "delete" => await RunDeleteAsync(client, baseUrl, args),
-            "disable" => await RunDisableAsync(client, baseUrl, args),
-            "enable" => await RunEnableAsync(client, baseUrl, args),
-            "import" => await RunImportAsync(client, baseUrl, args),
+            "list" => await RunListAsync(api),
+            "create" => await RunCreateAsync(api, args),
+            "cancel" or "delete" => await RunDeleteAsync(api, args),
+            "disable" => await RunDisableAsync(api, args),
+            "enable" => await RunEnableAsync(api, args),
+            "import" => await RunImportAsync(api, args),
             "validate" => RunValidate(args),
-            "show" => await RunShowAsync(client, baseUrl, args),
-            "history" => await RunHistoryAsync(client, baseUrl, args),
+            "show" => await RunShowAsync(api, args),
+            "history" => await RunHistoryAsync(api, args),
             _ => WriteHelp()
         };
     }
 
-    private static async Task<int> RunListAsync(HttpClient client, string baseUrl)
+    private static async Task<int> RunListAsync(DaemonApi api)
     {
         try
         {
-            var response = await client.GetAsync(baseUrl);
+            using var response = await api.ListRemindersAsync();
             if (!response.IsSuccessStatusCode)
             {
                 Console.Error.WriteLine($"[FAIL] daemon returned {(int)response.StatusCode}");
@@ -84,7 +78,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunCreateAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunCreateAsync(DaemonApi api, string[] args)
     {
         // netclaw reminder create <id> <scheduleType> <schedule> "<prompt>" [--name <title>] [--target <#channel|@user|id>] [--channel <id>]
         if (args.Length < 6)
@@ -139,7 +133,7 @@ internal static class ReminderCommand
 
         try
         {
-            var response = await client.PostAsJsonAsync(baseUrl, body);
+            using var response = await api.CreateReminderAsync(body);
             var json = await response.Content.ReadAsStringAsync();
             var result = JsonSerializer.Deserialize<JsonElement>(json);
 
@@ -165,7 +159,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunDeleteAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunDeleteAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -176,7 +170,7 @@ internal static class ReminderCommand
         var id = args[2];
         try
         {
-            var response = await client.DeleteAsync($"{baseUrl}/{id}");
+            using var response = await api.DeleteReminderAsync(id);
             var json = await response.Content.ReadAsStringAsync();
             var result = JsonSerializer.Deserialize<JsonElement>(json);
 
@@ -193,7 +187,7 @@ internal static class ReminderCommand
                 Console.Error.WriteLine($"[FAIL] {err.GetString()}");
             else
                 Console.Error.WriteLine($"[FAIL] {json}");
-            return response.StatusCode == System.Net.HttpStatusCode.NotFound ? 1 : 1;
+            return 1;
         }
         catch (Exception ex)
         {
@@ -202,7 +196,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunDisableAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunDisableAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -210,10 +204,10 @@ internal static class ReminderCommand
             return 1;
         }
 
-        return await RunSimplePostByIdAsync(client, baseUrl, args[2], "disable");
+        return await RunToggleAsync(api, args[2], enable: false);
     }
 
-    private static async Task<int> RunEnableAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunEnableAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -221,14 +215,16 @@ internal static class ReminderCommand
             return 1;
         }
 
-        return await RunSimplePostByIdAsync(client, baseUrl, args[2], "enable");
+        return await RunToggleAsync(api, args[2], enable: true);
     }
 
-    private static async Task<int> RunSimplePostByIdAsync(HttpClient client, string baseUrl, string id, string action)
+    private static async Task<int> RunToggleAsync(DaemonApi api, string id, bool enable)
     {
         try
         {
-            var response = await client.PostAsync($"{baseUrl}/{id}/{action}", content: null);
+            using var response = enable
+                ? await api.EnableReminderAsync(id)
+                : await api.DisableReminderAsync(id);
             var json = await response.Content.ReadAsStringAsync();
             var result = JsonSerializer.Deserialize<JsonElement>(json);
 
@@ -254,7 +250,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunImportAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunImportAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -303,7 +299,7 @@ internal static class ReminderCommand
 
         try
         {
-            var response = await client.PostAsJsonAsync($"{baseUrl}/import", new
+            using var response = await api.ImportReminderAsync(new
             {
                 definition,
                 writeMode = mode
@@ -404,7 +400,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunShowAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunShowAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -415,7 +411,7 @@ internal static class ReminderCommand
         var id = args[2];
         try
         {
-            var response = await client.GetAsync($"{baseUrl}/{id}");
+            using var response = await api.GetReminderAsync(id);
             var json = await response.Content.ReadAsStringAsync();
 
             if (response.IsSuccessStatusCode)
@@ -439,7 +435,7 @@ internal static class ReminderCommand
         }
     }
 
-    private static async Task<int> RunHistoryAsync(HttpClient client, string baseUrl, string[] args)
+    private static async Task<int> RunHistoryAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
         {
@@ -461,7 +457,7 @@ internal static class ReminderCommand
 
         try
         {
-            var response = await client.GetAsync($"{baseUrl}/{id}/history?last={last}");
+            using var response = await api.GetReminderHistoryAsync(id, last);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -17,7 +17,7 @@ internal static class ReminderCommand
         Converters = { new JsonStringEnumConverter() }
     };
 
-    public static async Task<int> RunAsync(string[] args, DaemonApi api)
+    public static async Task<int> RunAsync(string[] args, DaemonApi? daemonApi)
     {
         if (args.Length == 1)
         {
@@ -32,17 +32,27 @@ internal static class ReminderCommand
             return 0;
         }
 
+        // validate is offline — no daemon needed
+        if (subcommand is "validate")
+            return RunValidate(args);
+
+        if (daemonApi is null)
+        {
+            Console.Error.WriteLine($"[FAIL] reminder {subcommand}: requires a running daemon.");
+            Console.Error.WriteLine("       fix: run `netclaw daemon start` and retry.");
+            return 1;
+        }
+
         return subcommand switch
         {
-            "list" => await RunListAsync(api),
-            "create" => await RunCreateAsync(api, args),
-            "cancel" or "delete" => await RunDeleteAsync(api, args),
-            "disable" => await RunDisableAsync(api, args),
-            "enable" => await RunEnableAsync(api, args),
-            "import" => await RunImportAsync(api, args),
-            "validate" => RunValidate(args),
-            "show" => await RunShowAsync(api, args),
-            "history" => await RunHistoryAsync(api, args),
+            "list" => await RunListAsync(daemonApi),
+            "create" => await RunCreateAsync(daemonApi, args),
+            "cancel" or "delete" => await RunDeleteAsync(daemonApi, args),
+            "disable" => await RunDisableAsync(daemonApi, args),
+            "enable" => await RunEnableAsync(daemonApi, args),
+            "import" => await RunImportAsync(daemonApi, args),
+            "show" => await RunShowAsync(daemonApi, args),
+            "history" => await RunHistoryAsync(daemonApi, args),
             _ => WriteHelp()
         };
     }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -58,7 +58,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// </summary>
     public ProviderDescriptorRegistry Registry => _registry;
     private readonly DaemonManager? _daemonManager;
-    private readonly string _daemonEndpoint;
+    private readonly DaemonApi? _daemonApi;
     private CancellationTokenSource? _probeCts;
 
     public ReactiveProperty<WizardStep> CurrentStep { get; } = new(WizardStep.Provider);
@@ -152,8 +152,8 @@ public partial class InitWizardViewModel : ReactiveViewModel
         ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
-        string? daemonEndpoint = null)
-        : this(paths, registry, registry, slackProbe, null, navigationState, oauthFactory, daemonManager, daemonEndpoint)
+        DaemonApi? daemonApi = null)
+        : this(paths, registry, registry, slackProbe, null, navigationState, oauthFactory, daemonManager, daemonApi)
     {
     }
 
@@ -169,7 +169,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
-        string? daemonEndpoint = null)
+        DaemonApi? daemonApi = null)
     {
         _paths = paths;
         _probe = probe;
@@ -179,7 +179,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         _browserBootstrapper = browserBootstrapper ?? new BrowserAutomationBootstrapper();
         _oauthFactory = oauthFactory;
         _daemonManager = daemonManager;
-        _daemonEndpoint = daemonEndpoint ?? "http://127.0.0.1:5199";
+        _daemonApi = daemonApi;
 
         var chromeDetection = BrowserAutomationRuntimeDetector.DetectChrome();
         IsChromeDevToolsAvailable = chromeDetection.IsInstalled;
@@ -811,16 +811,12 @@ public partial class InitWizardViewModel : ReactiveViewModel
         if (!result.Success && !result.Message.Contains("already running", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        using var httpClient = new HttpClient { Timeout = DaemonPollRequestTimeout };
-        var healthUrl = $"{_daemonEndpoint}/api/health/ready";
-
         for (var i = 0; i < 30; i++)
         {
             ct.ThrowIfCancellationRequested();
             try
             {
-                var response = await httpClient.GetAsync(healthUrl, ct);
-                if (response.IsSuccessStatusCode)
+                if (_daemonApi is not null && await _daemonApi.IsHealthyAsync(ct))
                     return true;
             }
             catch (HttpRequestException)

--- a/src/Netclaw.Cli/Tui/ReminderCreateViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ReminderCreateViewModel.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using Netclaw.Cli.Daemon;
 using R3;
 using Termina.Reactive;
 
@@ -18,8 +19,7 @@ public enum ReminderCreateState
 
 public sealed class ReminderCreateViewModel : ReactiveViewModel
 {
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly string _baseUrl;
+    private readonly DaemonApi _api;
 
     public ReactiveProperty<ReminderCreateState> CurrentState { get; } = new(ReminderCreateState.Title);
     public ReactiveProperty<string> StatusMessage { get; } = new("Enter a short reminder title.");
@@ -32,11 +32,9 @@ public sealed class ReminderCreateViewModel : ReactiveViewModel
     public string Instructions { get; private set; } = string.Empty;
     public string NotifyInstructions { get; private set; } = string.Empty;
 
-    public ReminderCreateViewModel(IHttpClientFactory httpClientFactory)
+    public ReminderCreateViewModel(DaemonApi api)
     {
-        _httpClientFactory = httpClientFactory;
-        var endpoint = Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT") ?? "http://127.0.0.1:5199";
-        _baseUrl = $"{endpoint.TrimEnd('/')}/api/reminders";
+        _api = api;
     }
 
     public void SetTitle(string value)
@@ -114,16 +112,16 @@ public sealed class ReminderCreateViewModel : ReactiveViewModel
 
         try
         {
-            using var client = _httpClientFactory.CreateClient("ReminderApi");
-
-            var validate = await client.PostAsJsonAsync($"{_baseUrl}/validate", new
+            var payload = new
             {
                 name = Title,
                 prompt = Instructions,
                 scheduleType = ScheduleType,
                 schedule = Schedule,
                 notifyInstructions = NotifyInstructions
-            }, ct);
+            };
+
+            using var validate = await _api.ValidateReminderAsync(payload, ct);
 
             if (!validate.IsSuccessStatusCode)
             {
@@ -136,14 +134,7 @@ public sealed class ReminderCreateViewModel : ReactiveViewModel
             StatusMessage.Value = "Creating reminder...";
             RequestRedraw();
 
-            var create = await client.PostAsJsonAsync(_baseUrl, new
-            {
-                name = Title,
-                prompt = Instructions,
-                scheduleType = ScheduleType,
-                schedule = Schedule,
-                notifyInstructions = NotifyInstructions
-            }, ct);
+            using var create = await _api.CreateReminderAsync(payload, ct);
 
             if (!create.IsSuccessStatusCode)
             {

--- a/src/Netclaw.Cli/Tui/SessionsViewModel.cs
+++ b/src/Netclaw.Cli/Tui/SessionsViewModel.cs
@@ -12,7 +12,7 @@ namespace Netclaw.Cli.Tui;
 /// </summary>
 public sealed class SessionsViewModel : ReactiveViewModel
 {
-    private readonly DaemonClient _daemonClient;
+    private readonly DaemonApi _daemonApi;
     private readonly ChatNavigationState _navigationState;
     private readonly TimeProvider _timeProvider;
 
@@ -22,11 +22,11 @@ public sealed class SessionsViewModel : ReactiveViewModel
     public ReactiveProperty<int> SelectedIndex { get; } = new(0);
 
     public SessionsViewModel(
-        DaemonClient daemonClient,
+        DaemonApi daemonApi,
         ChatNavigationState navigationState,
         TimeProvider timeProvider)
     {
-        _daemonClient = daemonClient;
+        _daemonApi = daemonApi;
         _navigationState = navigationState;
         _timeProvider = timeProvider;
     }
@@ -46,7 +46,7 @@ public sealed class SessionsViewModel : ReactiveViewModel
     {
         try
         {
-            var sessions = await _daemonClient.ListSessionsAsync();
+            var sessions = await _daemonApi.ListSessionsAsync();
             Sessions.Clear();
             Sessions.AddRange(sessions);
 


### PR DESCRIPTION
## Summary

- Introduces `DaemonApi` singleton — single shared abstraction for all daemon REST HTTP communication
- Replaces 4 different HTTP patterns (IHttpClientFactory, raw `new HttpClient()`, hardcoded constants, DaemonClient internal HttpClient) across 7 files with one consistent path
- Endpoint resolution done once: `Daemon:Endpoint` config → `NETCLAW_DAEMON_ENDPOINT` env → `http://127.0.0.1:5199`
- Registered in `ConfigureConfigServices()` so every CLI mode gets it automatically
- Net -94 lines of code across the refactored files

## Changes

| File | Change |
|------|--------|
| `DaemonApi.cs` | **New** — singleton with typed methods for status, sessions, reminders CRUD, MCP OAuth, health |
| `Program.cs` | Register DaemonApi in shared config; simplify RunStatusAsync, RunSessionsOnceAsync, ConfigureCliChatServices |
| `DaemonClient.cs` | Remove `_httpClient` field + `ListSessionsAsync()` — now pure SignalR |
| `ReminderCommand.cs` | Accept `DaemonApi` instead of `new HttpClient()` + env-only endpoint |
| `McpCommand.cs` | Accept `DaemonApi` for auth; replace hardcoded `127.0.0.1:5199` |
| `SessionsViewModel.cs` | Inject `DaemonApi` instead of `DaemonClient` for listing |
| `ReminderCreateViewModel.cs` | Inject `DaemonApi` instead of `IHttpClientFactory` + manual endpoint |
| `InitWizardViewModel.cs` | Accept `DaemonApi?` for health polling instead of raw HttpClient |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/Netclaw.Cli.Tests` — 211 passed
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Smoke test: `netclaw status` against running daemon
- [x] Smoke test: `netclaw sessions --once` against running daemon
- [x] Smoke test: `netclaw reminder list` against running daemon
- [x] Smoke test: `NETCLAW_DAEMON_ENDPOINT=http://localhost:9999 netclaw status` shows unreachable error