### PR TITLE
Fix session turn recovery and empty post-tool finalization replies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ Netclaw v0.6.2 — Reminder history, onboarding chat, and turn recovery hardenin
 **Stability**
 
 * Fixed agent turn recovery for empty LLM responses, forced no-tools turns, and hang scenarios — the session actor now reliably recovers and continues rather than stalling or silently dropping turns in these edge cases. ([#260](https://github.com/Aaronontheweb/netclaw/pull/260), [#269](https://github.com/Aaronontheweb/netclaw/pull/269), [#271](https://github.com/Aaronontheweb/netclaw/pull/271))
+* Fixed persistent post-tool empty completions to degrade into a deterministic evidence-backed assistant reply when successful tool results exist, while preserving the existing generic provider failure when the turn has no usable evidence to show.
 
 #### 0.6.1 2026-03-15 ####
 

--- a/docs/spec/SPEC-002-session-lifecycle-and-protocol.md
+++ b/docs/spec/SPEC-002-session-lifecycle-and-protocol.md
@@ -41,6 +41,13 @@ This enables:
 5. Actor emits typed `SessionOutput` events to subscribers.
 6. Actor checks compaction threshold.
 
+Failed accepted turns are also persisted as terminal turn events so restart can
+recover a consistent history instead of relying on transient in-memory error
+state.
+
+Buffered follow-up user inputs accepted while the actor is in `Processing` or
+`Compacting` are durably queued for replay in original order.
+
 ## Subscriber Model
 
 Subscribers join via `JoinSession` with an `OutputFilter` bitmask controlling
@@ -71,6 +78,15 @@ Ready → (user message) → Processing → (LLM response) → [threshold check]
 - **Compacting**: buffers incoming messages, runs tiered compaction sequence.
 
 All three states handle `JoinSession`, `LeaveSession`, and snapshot messages.
+
+## Turn Safety Guards
+
+- Every async LLM call and tool-execution batch is correlated to the active
+  operation so late completions from timed-out or superseded work are ignored.
+- Each turn has an absolute wall-clock budget in addition to per-operation
+  timeouts.
+- Hitting the tool-iteration budget degrades to a no-tools answer-or-ask path,
+  with deterministic fallback text if the model still refuses to comply.
 
 ## Compaction Lifecycle
 
@@ -132,10 +148,13 @@ are summarized as "Used {tool} for {purpose} → {outcome}".
 |-------|---------|
 | `SystemPromptSet` | System prompt set or replaced |
 | `TurnRecorded` | Completed turn (user message + assistant reply) |
+| `TurnFailedRecorded` | Failed turn recorded as a terminal assistant reply |
+| `BufferedInputAccepted` | Follow-up user input durably queued while session is busy |
 | `SessionTitleSet` | Title generated or updated |
 | `SessionCompacted` | History compacted with summary + retained messages |
 
 ## Snapshot
 
-`SessionSnapshot` captures `History`, `TurnCount`, `Title` for fast recovery.
+`SessionSnapshot` captures `History`, `TurnCount`, `Title`, and pending buffered
+inputs for fast recovery.
 Taken periodically per `SessionConfig.SnapshotInterval` and after compaction.

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -147,10 +147,11 @@ Tuning parameters for LLM session behavior.
 | `CompactionThreshold` | double | `0.75` | Context usage ratio (0.0–1.0) at which compaction triggers. |
 | `SnapshotInterval` | int | `20` | Number of turns between persistence snapshots. |
 | `KeepRecentToolResults` | int | `3` | Recent tool call/result pairs kept in full during compaction. |
-| `MaxToolIterationsPerTurn` | int | `10` | Max tool execution rounds per turn before forcing a text response. |
+| `MaxToolIterationsPerTurn` | int | `10` | Max tool execution rounds per turn before forcing a no-tools degraded completion path. |
 | `SidecarLlmTimeoutSeconds` | int | `90` | Timeout for sidecar LLM calls (title generation, observer summaries, memory extraction). |
 | `TurnLlmTimeoutSeconds` | int | `180` | Timeout for the primary per-turn LLM streaming call before forcing an error/recovery path. |
 | `ToolExecutionTimeoutSeconds` | int | `90` | Timeout for one tool-execution batch before failing the turn safely. |
+| `MaxTurnDurationSeconds` | int | `300` | Absolute wall-clock timeout for an entire user turn across all LLM and tool iterations. |
 
 ### Tools
 

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/design.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Recent production sessions showed three reliability gaps at once: hidden tool loops that kept Slack silent until the turn failed, duplicate Slack fallback warnings after a real streamed reply was already posted, and session turns whose timeout or restart recovery still depended on transient in-memory state. The current `LlmSessionActor` already tracks channel type for telemetry and already emits typed `SessionOutput` events, but it does not fully correlate late async completions to the currently active turn, and the Slack adapter only subscribes to text and file outputs.
+
+This change crosses two actor boundaries. The session actor owns correctness: active-turn ownership, persistence, timeout behavior, and deterministic terminal outcomes. The Slack thread binding actor owns presentation: whether hidden activity should produce a user-visible acknowledgement and whether a fallback message is still warranted after visible output. The design must keep those responsibilities separate so long-running turns become safer without teaching the LLM transport-specific UX rules.
+
+Source PRDs: `PRD-001` (primary), `PRD-009`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make turn ownership explicit so late LLM or tool completions cannot mutate a newer turn.
+- Persist failure and buffered follow-up state needed to recover accepted turns safely after restart.
+- Enforce an absolute wall-clock budget for a turn across multiple LLM and tool iterations.
+- End tool-budget exhaustion with a degraded but user-visible completion instead of a silent or misleading provider failure.
+- Let the Slack adapter observe hidden tool activity and emit one lightweight acknowledgement without leaking raw tool details.
+- Eliminate duplicate Slack empty-turn fallback warnings after a real reply, file, or explicit error was already delivered.
+
+**Non-Goals:**
+- No transport-specific prompting or Slack-aware instructions inside the LLM system prompt.
+- No broad new progress protocol for every adapter in this MVP slice.
+- No adaptive acknowledgement phrasing, multiple staged acknowledgements, or rich progress percentages.
+- No comprehensive loop-scoring engine beyond the existing tool-iteration budget and new wall-clock turn budget.
+- No production rollout gating beyond tests, OpenSpec validation, and existing diagnostics.
+
+## Decisions
+
+### Decision: Correlate all async completions to the active turn operation
+
+The session actor will assign turn-scoped operation identifiers to each LLM request and tool-execution batch. Completion, failure, timeout, and streaming messages must carry that identifier, and the actor will ignore messages whose identifier no longer matches the active operation.
+
+Rationale: inactivity watchdogs alone do not prevent late continuations from mutating the wrong turn after timeout, retry, or buffered replay. Explicit correlation makes stale completions safe to ignore without relying on timing assumptions.
+
+Alternative considered: rely on behavior transitions and cancellation tokens only. Rejected because the existing actor already demonstrates that async tasks can outlive the state in which they were started.
+
+### Decision: Persist failed-turn and buffered follow-up recovery state
+
+Accepted turns will gain explicit durable failure events, and buffered follow-up user inputs that are accepted while a turn is processing will be persisted in arrival order. Recovery rebuilds the pending queue and the last terminal state before processing resumes.
+
+Rationale: the current `_buffer` and failed-turn handling are in-memory only, so daemon restart can lose accepted follow-up inputs or resurrect turns in inconsistent states.
+
+Alternative considered: leave buffering transient and treat restart as best-effort during active work. Rejected because the reported failures are specifically about trust in the state machine after long-running or stuck turns.
+
+### Decision: Add an absolute wall-clock turn budget above per-operation watchdogs
+
+The session actor will track total elapsed time from turn acceptance until terminal completion. If the turn exceeds a configured ceiling, it aborts further LLM/tool work, records a timeout outcome, and advances the buffered queue.
+
+Rationale: the current watchdog is activity-based, so a stream or tool chain that keeps making small progress can still live too long and leave the user waiting indefinitely.
+
+Alternative considered: lower only the existing LLM/tool timeout values. Rejected because that bounds individual operations, not the full multi-iteration turn.
+
+### Decision: Tool-budget exhaustion degrades to answer-or-ask, then deterministic fallback
+
+The tool-iteration limit remains as a safety circuit breaker, but exhausting it no longer ends as a generic provider failure. The actor will first force a no-tools completion path aimed at producing a best-effort answer or one focused clarifying question. If the model still refuses to comply, the actor emits a deterministic degraded terminal message rather than leaving the turn empty.
+
+Rationale: the user-visible contract should be “I either answered, asked one question, or timed out clearly,” not “the model looked busy and then produced a transport-shaped error.”
+
+Alternative considered: remove the tool limit entirely. Rejected because earlier incidents showed genuine runaway tool loops.
+
+### Decision: Slack subscribes to hidden tool activity but keeps rendering policy local
+
+`SlackThreadBindingActor` will widen its session subscription to include `ToolCalls`, count hidden tool activity per turn, and post a one-shot acknowledgement such as `Working on it.` after a configurable threshold. Tool-call and tool-result details remain suppressed from the Slack thread.
+
+Rationale: Slack is the transport experiencing the silence problem, and the session actor already emits tool activity through transport-agnostic outputs. This keeps UX policy in the adapter while reusing the existing pub/sub contract.
+
+Alternative considered: add a new session-level progress output for all channels first. Rejected for MVP because Slack can solve the immediate UX issue by observing outputs that already exist.
+
+### Decision: Track acknowledgement separately from terminal output in Slack
+
+The Slack adapter will distinguish between an acknowledgement message and a terminal turn outcome. Acknowledgements do not suppress later fallback or error delivery, but any real reply, file upload, or explicit error does suppress the generic empty-turn fallback.
+
+Rationale: the current `_postedThisTurn` flag conflates “any Slack message was posted” with “the turn produced a terminal visible outcome,” which is how duplicate warnings slipped through.
+
+Alternative considered: keep a single posted flag and treat acknowledgement as terminal output. Rejected because acknowledgement-only turns still need a clear final outcome.
+
+## Risks / Trade-offs
+
+- [Risk] More persistence events and snapshot fields make recovery code more complex. -> Mitigation: keep new event types narrowly scoped to failed turns and pending buffered inputs, and add restart-focused actor tests.
+- [Risk] An acknowledgement threshold that is too low could create Slack noise on normal research turns. -> Mitigation: start with a conservative one-shot threshold and cover the fast-turn no-ack path in tests.
+- [Risk] Absolute turn budgets can stop legitimate long-running work too early. -> Mitigation: make the budget configurable and prefer a clear degraded timeout outcome over silent waiting.
+- [Risk] Degraded completion text may feel generic when the model refuses to answer after tool exhaustion. -> Mitigation: reserve deterministic fallback for noncompliant edge cases and keep the preferred path as a no-tools answer-or-ask completion.
+
+## Migration Plan
+
+1. Update OpenSpec deltas for `netclaw-session`, `netclaw-input-adapters`, and `netclaw-slack-socket`.
+2. Add session actor correlation IDs, failed-turn persistence, buffered input recovery, absolute turn-budget enforcement, and degraded tool-budget completion.
+3. Update the Slack adapter subscription and per-turn state tracking for hidden-activity acknowledgements and duplicate-fallback suppression.
+4. Add actor/integration tests for stale completion rejection, restart recovery, degraded turn completion, and Slack acknowledgement/fallback behavior.
+5. Validate with targeted tests, `openspec validate --change session-turn-hardening-and-slack-acks --strict`, and `dotnet slopwatch analyze`.
+
+Rollback does not require data migration. New event handling is additive and should default safely when replaying old sessions without the new events.
+
+## Open Questions
+
+- Should the absolute turn budget be a new session configuration field or derived from the existing per-operation timeouts in MVP?
+- Is the Slack acknowledgement threshold best expressed only as hidden tool-call count, or should a future follow-up add elapsed-time heuristics too?
+- Should the deterministic degraded message after repeated no-tools noncompliance be configurable, or is a fixed built-in message sufficient for MVP?

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/proposal.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Recent fixes reduced some permanent session hangs, but production behavior still shows turns that either fail after long hidden tool loops, emit duplicate Slack fallback warnings after a real reply, or recover poorly across timeout and restart boundaries. We need a tighter turn-state contract so Netclaw can prove a turn is still making progress, fail durably when it cannot complete, and deliver one clear user-visible outcome instead of silence or transport-shaped confusion.
+
+Source PRDs: `PRD-001` (primary), `PRD-009`
+
+## What Changes
+
+- Harden the session turn state machine so stale LLM and tool completions cannot mutate a newer turn after timeout, retry, or restart.
+- Persist accepted-turn failure outcomes and buffered follow-up inputs so restart and replay behavior stays deterministic instead of depending on transient in-memory state.
+- Add an absolute wall-clock turn budget and define degraded completion behavior after tool-budget exhaustion so long-running turns still end with a usable answer, clarifying question, or explicit timeout outcome.
+- Let the Slack adapter observe hidden tool-call activity without rendering raw tool events, and post a single lightweight in-thread acknowledgement when a turn is clearly working but still silent.
+- Fix Slack empty-turn fallback behavior so streamed or buffered replies do not trigger a second generic warning after the real reply is already posted.
+- Keep MVP-now scope focused on turn reliability and transport presentation; broader multi-channel progress UX and richer loop-detection heuristics remain follow-up work.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `netclaw-session`: define stale-completion isolation, durable failed-turn recovery, buffered replay recovery, absolute turn budgets, and degraded completion after tool-budget exhaustion.
+- `netclaw-input-adapters`: clarify that adapters may subscribe to hidden tool activity for progress heuristics without coupling session behavior to a specific transport.
+- `netclaw-slack-socket`: define one-shot Slack acknowledgement behavior for hidden work and tighten empty-turn fallback rules.
+
+## Impact
+
+- Affected systems: `LlmSessionActor`, session persistence/recovery, `SlackThreadBindingActor`, session output filters, and turn/retry telemetry.
+- Security impact: preserves default-deny behavior and does not expose hidden tool arguments or tool results to Slack users.
+- Operational impact: adds clearer terminal outcomes, restart-safe failure handling, and deterministic progress signals for long-running Slack turns.
+- In scope for MVP-now: turn-operation correlation, failed-turn durability, buffered follow-up recovery, absolute turn budget enforcement, degraded tool-budget completion, Slack hidden-work acknowledgement, and duplicate-fallback suppression.
+- Out of scope for MVP-now: generalized cross-channel progress UI contracts, adaptive acknowledgement phrasing, broad loop-scoring systems, and non-Slack transport-specific acknowledgements.
+
+### Traceability
+
+- Related capabilities: `openspec/specs/netclaw-session/spec.md`, `openspec/specs/netclaw-input-adapters/spec.md`, `openspec/specs/netclaw-slack-socket/spec.md`

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Hidden activity observation for adapter heuristics
+
+Input adapters SHALL be allowed to subscribe to session activity outputs such as `ToolCalls` for local progress heuristics without rendering those activity events directly to end users. Adapter-local progress behavior SHALL NOT change the transport-agnostic session actor contract.
+
+#### Scenario: Slack adapter observes tool activity without rendering tool details
+- **GIVEN** the Slack adapter subscribes to a session with a filter that includes `ToolCalls`
+- **WHEN** the session emits tool-call or tool-result outputs for a turn
+- **THEN** the adapter may use those outputs to track whether the turn is actively working
+- **AND** it does not post raw tool-call or tool-result details into the Slack thread
+
+#### Scenario: Hidden activity subscription does not affect other subscribers
+- **GIVEN** multiple subscribers are attached to the same session
+- **WHEN** one adapter widens its filter to observe hidden activity outputs
+- **THEN** other subscribers continue receiving only the output categories they requested
+- **AND** the session actor does not become transport-specific

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-session/spec.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-session/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Turn operation ownership isolation
+
+The session system SHALL correlate each asynchronous LLM request and tool-execution batch to the active turn operation. Late completions, failures, deltas, or timeout callbacks from superseded operations SHALL be ignored and SHALL NOT mutate history, outputs, or active-turn state.
+
+#### Scenario: Late LLM completion ignored after timeout
+- **GIVEN** an LLM operation timed out and the session already advanced to a new terminal or recovery state
+- **WHEN** the timed-out operation later reports text, tool calls, or completion
+- **THEN** the session ignores the late message
+- **AND** it does not append assistant content, emit user-visible output, or reset the active turn state
+
+#### Scenario: Late tool completion ignored after retry
+- **GIVEN** a tool-execution batch was replaced by a newer turn operation
+- **WHEN** a completion or failure arrives from the older batch
+- **THEN** the session ignores that stale tool result
+- **AND** only the active batch may influence the current turn
+
+### Requirement: Durable failed-turn and buffered replay recovery
+
+Once a user message is accepted into a turn, the session system SHALL durably record terminal failure outcomes and any accepted buffered follow-up inputs needed for replay. Recovery after actor or daemon restart SHALL rebuild the pending follow-up queue in original order and SHALL preserve the last recorded terminal outcome for the interrupted turn.
+
+#### Scenario: Failed accepted turn survives restart
+- **GIVEN** a user turn was accepted and then failed due to timeout, provider failure, or tool failure
+- **WHEN** the session recovers after restart
+- **THEN** the failed turn outcome remains represented in recovered state
+- **AND** the session does not resurrect the failed turn as if it were still processing
+
+#### Scenario: Buffered follow-up inputs replay once after restart
+- **GIVEN** one or more follow-up user messages were accepted while the current turn was processing
+- **WHEN** the actor restarts before draining the buffered queue
+- **THEN** the recovered session replays those buffered inputs once in original arrival order
+- **AND** no accepted follow-up input is silently dropped or duplicated
+
+### Requirement: Absolute wall-clock turn budget
+
+The session system SHALL enforce a cumulative wall-clock budget for each user turn in addition to per-operation watchdogs. When the budget is exceeded, the session SHALL stop further LLM and tool work, record a timed-out terminal outcome, and advance recovery or buffered follow-up processing.
+
+#### Scenario: Long multi-iteration turn exceeds wall-clock budget
+- **GIVEN** a turn spans multiple LLM calls and tool-execution batches
+- **WHEN** the total elapsed turn time exceeds the configured budget
+- **THEN** the session aborts further work for that turn
+- **AND** records a timeout outcome before advancing to any buffered follow-up input
+
+### Requirement: Degraded completion after tool-budget exhaustion
+
+The session system SHALL treat tool-iteration exhaustion as a degraded completion path rather than a silent or generic provider failure. When the tool budget is exhausted, the session SHALL first force a no-tools completion that prefers a best-effort answer or one focused clarifying question. If the model still attempts more tool work, the session SHALL emit a deterministic degraded user-visible terminal message.
+
+#### Scenario: Exhausted tool budget yields best-effort completion
+- **GIVEN** the current turn exhausted its configured tool-iteration budget
+- **WHEN** the session forces a no-tools completion
+- **THEN** the turn ends with a user-visible answer or one focused clarifying question
+- **AND** the turn does not remain empty while waiting for more tools
+
+#### Scenario: Noncompliant no-tools response yields deterministic degraded message
+- **GIVEN** the tool budget is exhausted and the model still emits tool calls while tools are disallowed
+- **WHEN** the session cannot obtain a compliant no-tools completion
+- **THEN** the session emits a deterministic degraded terminal message
+- **AND** it does not classify the turn as a generic provider failure solely because the tool budget was exhausted

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-slack-socket/spec.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/specs/netclaw-slack-socket/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: In-thread acknowledgement for hidden long-running work
+
+The Slack adapter SHALL post one brief in-thread acknowledgement when a turn has not yet produced visible text or file output but hidden session activity shows the turn is actively working. The acknowledgement threshold SHALL be based on adapter-local heuristics and SHALL NOT expose raw tool-call details.
+
+#### Scenario: Slack posts one acknowledgement after hidden tool activity
+- **GIVEN** a Slack turn has produced no visible text or file output
+- **AND** the adapter has observed enough hidden tool activity to classify the turn as actively working
+- **WHEN** the turn is still in progress
+- **THEN** Netclaw posts one brief acknowledgement in the same thread
+- **AND** it does not post additional acknowledgements for that same turn
+
+#### Scenario: Fast turn does not emit acknowledgement
+- **GIVEN** a Slack turn produces its visible reply before the hidden-activity threshold is reached
+- **WHEN** the turn completes normally
+- **THEN** Netclaw does not post a separate acknowledgement message
+
+### Requirement: Empty-turn fallback respects visible terminal output
+
+The Slack adapter SHALL emit the generic empty-turn fallback only when a turn completes without any visible terminal output. A prior acknowledgement alone does not count as terminal output, but a visible reply, file upload, or explicit error message does.
+
+#### Scenario: Streamed reply suppresses generic fallback
+- **GIVEN** the Slack adapter already posted the visible reply for a turn from streamed or buffered text
+- **WHEN** `TurnCompleted` arrives
+- **THEN** the adapter does not post the generic empty-turn fallback message
+
+#### Scenario: Acknowledgement alone does not suppress terminal failure handling
+- **GIVEN** the adapter posted a progress acknowledgement for an in-flight turn
+- **AND** the turn completes without a visible reply or file output
+- **WHEN** the terminal outcome is resolved
+- **THEN** the adapter still posts the explicit error outcome or generic empty-turn fallback
+- **AND** the acknowledgement is not treated as the final reply for that turn

--- a/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/tasks.md
+++ b/openspec/changes/archive/2026-03-17-session-turn-hardening-and-slack-acks/tasks.md
@@ -1,0 +1,23 @@
+## 1. Session turn ownership and recovery
+
+- [x] 1.1 Add turn-operation correlation for LLM and tool work so stale completions are ignored after timeout, retry, or replay.
+- [x] 1.2 Persist failed-turn outcomes and accepted buffered follow-up inputs, then recover and replay them once in original order after restart.
+- [x] 1.3 Add actor-level tests covering stale completion isolation and restart-safe buffered replay / failed-turn recovery.
+
+## 2. Turn budgets and degraded completion
+
+- [x] 2.1 Add a cumulative wall-clock turn budget and enforce a deterministic timeout outcome when the budget is exceeded.
+- [x] 2.2 Change tool-budget exhaustion to a degraded answer-or-ask completion path, with a deterministic fallback if the model still attempts more tool work.
+- [x] 2.3 Update session tests for tool-budget exhaustion, timeout behavior, and terminal-output guarantees.
+
+## 3. Slack hidden-work acknowledgement
+
+- [x] 3.1 Widen the Slack session subscription to observe hidden tool activity while continuing to suppress raw tool-call and tool-result rendering.
+- [x] 3.2 Post one lightweight Slack acknowledgement after the hidden-activity threshold is reached and no visible reply has been delivered yet.
+- [x] 3.3 Separate acknowledgement tracking from terminal output tracking so real replies, files, and explicit errors suppress duplicate empty-turn fallback warnings.
+- [x] 3.4 Add Slack adapter tests covering acknowledgement thresholds, fast-turn no-ack behavior, and duplicate-fallback suppression.
+
+## 4. Docs and validation
+
+- [x] 4.1 Update implementation-facing docs and configuration docs for the new turn-budget and degraded-completion semantics.
+- [x] 4.2 Validate the change with `openspec validate --change session-turn-hardening-and-slack-acks --strict`, targeted `dotnet test` coverage, and `dotnet slopwatch analyze`.

--- a/openspec/changes/deterministic-post-tool-replies/.openspec.yaml
+++ b/openspec/changes/deterministic-post-tool-replies/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/deterministic-post-tool-replies/design.md
+++ b/openspec/changes/deterministic-post-tool-replies/design.md
@@ -1,0 +1,78 @@
+## Context
+
+The current session actor already survives several turn-failure modes: stale completions are isolated, tool-budget exhaustion degrades to a deterministic terminal path, and accepted failures are recorded durably. The remaining gap happens later in the turn. After one or more successful tool iterations, the provider can return an empty completion with no tool calls and no assistant text. When that persists across the session's existing finalization attempts, the turn currently falls into the generic provider-failure path even though the actor has recent successful tool evidence that could support a useful answer.
+
+This is primarily a session-actor correctness problem, not a Slack problem. The actor owns tool execution, turn-finalization policy, and terminal outputs. Adapters should only observe the resulting `TextOutput` or `ErrorOutput`. That boundary must stay intact so Slack-visible improvement comes from a transport-agnostic session outcome rather than new Slack-owned recovery logic.
+
+Source PRDs: `PRD-001` (primary), `PRD-009`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect the specific degraded path where post-tool completion attempts stay empty even though the turn has successful recent tool evidence.
+- Track bounded, deterministic evidence from the active turn so fallback synthesis does not depend on another model call.
+- Emit a normal terminal session text reply when evidence is usable, allowing existing adapters to render it without transport-specific branching.
+- Preserve generic provider failure when the actor cannot derive a trustworthy best-effort answer from the current turn's evidence.
+- Keep the implementation compatible with the existing persisted turn lifecycle and terminal-output contract.
+
+**Non-Goals:**
+- No new Slack-specific synthesis or fallback logic.
+- No cross-turn or restart-persistent evidence ledger for this change.
+- No free-form LLM summarization pass after the bounded empty-response retries are exhausted.
+- No expansion of acknowledgement heuristics, progress UX, or tool-budget policy beyond this failure mode.
+
+## Decisions
+
+### Decision: Track a bounded turn-local evidence ledger from successful tool results
+
+The session actor will capture a small, ordered set of usable evidence records from successful tool results during the active turn. Each record should preserve enough deterministic detail to support a fallback answer: tool identity, success state, and a bounded textual evidence excerpt or normalized summary already available from the tool result.
+
+Rationale: once the provider starts returning empty post-tool completions, the actor needs its own reliable substrate for a best-effort answer. Re-reading raw tool payloads ad hoc would be brittle and could produce unstable output ordering.
+
+Alternative considered: inspect the full conversation history only at fallback time. Rejected because the actor would need to rediscover which tool outputs were successful and usable, making fallback behavior harder to reason about and test.
+
+### Decision: Treat persistent empty post-tool completions as a distinct degraded-finalization state
+
+The actor will explicitly classify completions that arrive after tool work but contain no assistant text, no file output, and no additional tool calls. A bounded retry counter will distinguish a transient empty completion from a persistent post-tool empty-response failure mode.
+
+Rationale: this failure is materially different from a provider exception, timeout, or tool failure. The provider completed successfully, but the turn still lacks a user-visible answer.
+
+Alternative considered: keep routing these cases through the generic provider-failure path. Rejected because it throws away usable evidence and misclassifies a degraded finalization problem as provider failure.
+
+### Decision: Synthesize the fallback reply deterministically in code, not with another model call
+
+Once the bounded empty-response threshold is reached and usable evidence exists, the actor will build a transport-agnostic best-effort reply from the evidence ledger using a fixed formatting strategy. The fallback text should clearly signal that it is a best-effort answer derived from completed tool work, while still surfacing the most relevant findings first.
+
+Rationale: deterministic synthesis guarantees a user-visible outcome even when the provider keeps returning empty completions. It also avoids re-entering the same failure mode with yet another model request.
+
+Alternative considered: make one last LLM call with a stricter prompt to summarize the evidence. Rejected because the problem is specifically that the provider has already failed to produce final text after tool work.
+
+### Decision: Keep adapter-visible behavior as an effect of ordinary session outputs
+
+The synthesized fallback reply will be emitted and persisted through the existing completed-turn pathway as ordinary session text. Adapters, including Slack, should treat it exactly like any other terminal reply and should not receive a new transport-specific recovery signal.
+
+Rationale: the user-visible behavior belongs to the session outcome contract. Existing adapter logic already knows how to render visible text and suppress generic empty-turn fallback once a real reply exists.
+
+Alternative considered: add a new adapter-specific fallback output type for Slack. Rejected because it would duplicate session logic at the transport boundary and weaken the actor contract.
+
+## Risks / Trade-offs
+
+- [Risk] Tool evidence can be noisy or only partially relevant, leading to a rough fallback answer. -> Mitigation: keep the evidence ledger bounded to successful, recent, text-usable results and prefer stable ordering over aggressive synthesis.
+- [Risk] Empty-response detection could catch legitimate but rare provider behaviors too early. -> Mitigation: require bounded repeated empty post-tool completions before synthesis and cover the threshold behavior with actor tests.
+- [Risk] Deterministic fallback wording may feel less polished than model-authored text. -> Mitigation: reserve it for the persistent empty-response edge case and make the message explicitly best-effort.
+- [Risk] Turn-local evidence is not restart-persistent in this slice. -> Mitigation: keep scope focused on the active failure mode and preserve existing durable failed-turn handling for restart safety.
+
+## Migration Plan
+
+1. Add an OpenSpec delta for `netclaw-session` covering persistent post-tool empty responses and evidence-backed completion.
+2. Extend `LlmSessionActor` turn state to capture bounded successful tool evidence and count post-tool empty finalization attempts.
+3. Emit a deterministic synthesized terminal reply when the empty-response threshold is exceeded and usable evidence exists; otherwise preserve the generic provider-failure path.
+4. Add actor and integration tests for evidence-backed completion, no-evidence failure, and adapter-visible behavior through ordinary session text outputs.
+5. Validate with `openspec validate --change deterministic-post-tool-replies --strict` and the relevant `dotnet test` / `dotnet slopwatch analyze` checks during implementation.
+
+Rollback does not require a journal migration. The change stays within turn-processing logic and existing terminal output types.
+
+## Open Questions
+
+- What is the smallest useful evidence excerpt shape for fallback synthesis without over-exposing noisy raw tool output?
+- Should the bounded empty-response threshold reuse existing no-tools recovery attempts or be tracked as a dedicated counter?

--- a/openspec/changes/deterministic-post-tool-replies/proposal.md
+++ b/openspec/changes/deterministic-post-tool-replies/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Recent turn-hardening work fixed tool-budget exhaustion and several empty-turn edge cases, but one core failure mode remains: the model can complete multiple successful tool iterations, then return repeated empty post-tool responses and cause the session actor to emit a generic provider failure. We need the session actor to end that turn with a deterministic, best-effort reply when recent tool evidence is usable, while preserving generic failure only for cases where the turn truly has nothing reliable to show the user.
+
+Source PRDs: `PRD-001` (primary), `PRD-009`
+
+## What Changes
+
+- Extend session turn-finalization behavior so repeated empty post-tool completions are treated as a degraded completion path instead of an automatic provider failure.
+- Track bounded, turn-local evidence from successful tool results so the session actor can synthesize a deterministic best-effort user-visible answer when the model refuses to produce final text after tool work.
+- Keep the synthesized outcome transport-agnostic: the session emits an ordinary terminal text reply, and adapters such as Slack only render that existing session output.
+- Preserve generic provider failure when the post-tool empty-response path has no usable evidence to synthesize from.
+- Keep MVP scope focused on session correctness and deterministic terminal outcomes; broader adapter UX changes, richer evidence scoring, and model-driven fallback summarization remain follow-up work.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `netclaw-session`: add deterministic evidence-backed completion for persistent post-tool empty responses and define when generic provider failure remains valid.
+
+## Impact
+
+- Affected systems: `LlmSessionActor`, turn-finalization state, tool-result capture, terminal reply synthesis, and actor/integration tests around empty post-tool completions.
+- Security impact: preserves transport-agnostic session behavior and reuses existing policy-gated tool evidence rather than introducing a new adapter-specific bypass.
+- Operational impact: reduces false generic provider failures after successful tool work and gives subscribers a deterministic visible outcome when the session has enough evidence to answer.
+- Slack-visible effect: existing adapters receive a normal text terminal output from the session, so no Slack-owned synthesis logic is required.
+- Out of scope: new Slack acknowledgement rules, generalized progress heuristics, cross-turn evidence persistence, and LLM-authored fallback summarization after the bounded retry path is exhausted.

--- a/openspec/changes/deterministic-post-tool-replies/specs/netclaw-session/spec.md
+++ b/openspec/changes/deterministic-post-tool-replies/specs/netclaw-session/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Deterministic evidence-backed completion after persistent post-tool empty responses
+The session system SHALL treat repeated empty completion responses after successful tool iterations as a degraded finalization path instead of automatically classifying the turn as a generic provider failure. During the active turn, the session SHALL retain a bounded set of usable evidence from successful tool results. When bounded post-tool completion attempts continue returning no user-visible text, no file output, and no additional tool calls, the session SHALL synthesize and emit a deterministic best-effort text reply from that evidence as the terminal turn outcome.
+
+#### Scenario: Successful tool work plus persistent empty completions yields synthesized reply
+- **GIVEN** the active turn has completed one or more successful tool calls with usable evidence
+- **AND** post-tool completion attempts keep returning no assistant text and no further tool calls
+- **WHEN** the session reaches its bounded empty-response threshold
+- **THEN** the session emits a deterministic best-effort text reply derived from the retained evidence
+- **AND** the turn completes without being classified as a generic provider failure
+
+#### Scenario: Persistent empty completions without usable evidence preserve provider failure
+- **GIVEN** post-tool completion attempts keep returning no assistant text and no further tool calls
+- **AND** the active turn has no usable successful tool evidence for fallback synthesis
+- **WHEN** the session reaches its bounded empty-response threshold
+- **THEN** the session emits the existing generic provider-failure terminal outcome
+- **AND** it does not synthesize a reply from failed, empty, or unusable tool results
+
+#### Scenario: Evidence-backed fallback remains transport-agnostic terminal text
+- **GIVEN** the session synthesized a best-effort reply from retained tool evidence
+- **WHEN** subscribers receive the terminal outputs for the turn
+- **THEN** they receive the synthesized reply as ordinary session text output and normal turn completion signals
+- **AND** the session does not require an adapter-specific fallback output type to make the reply user-visible

--- a/openspec/changes/deterministic-post-tool-replies/tasks.md
+++ b/openspec/changes/deterministic-post-tool-replies/tasks.md
@@ -1,0 +1,17 @@
+## 1. Session evidence capture and empty-response detection
+
+- [x] 1.1 Extend active-turn state in `LlmSessionActor` to retain a bounded, ordered set of usable evidence from successful tool results.
+- [x] 1.2 Classify empty post-tool completions separately from provider exceptions, including a bounded retry/threshold path for repeated empty finalization attempts.
+- [x] 1.3 Ensure the new degraded-finalization path reuses existing terminal turn completion/output contracts instead of introducing adapter-specific recovery signals.
+
+## 2. Deterministic evidence-backed completion
+
+- [x] 2.1 Implement deterministic best-effort reply synthesis from retained tool evidence once the persistent empty-response threshold is reached.
+- [x] 2.2 Preserve the existing generic provider-failure outcome when no usable evidence exists for fallback synthesis.
+- [x] 2.3 Persist and emit the synthesized reply through the normal completed-turn pathway so it behaves like any other terminal assistant text.
+
+## 3. Verification and docs
+
+- [x] 3.1 Add actor tests covering successful-tool evidence fallback, bounded empty-response retries, and the no-evidence generic-failure path.
+- [x] 3.2 Add integration coverage showing subscribers such as Slack observe the synthesized result as ordinary visible session text, without Slack-owned synthesis logic.
+- [x] 3.3 Update implementation-facing docs or release notes for the new post-tool empty-response recovery semantics and validate the change with `openspec validate deterministic-post-tool-replies --type change --strict`.

--- a/openspec/specs/netclaw-input-adapters/spec.md
+++ b/openspec/specs/netclaw-input-adapters/spec.md
@@ -141,6 +141,31 @@ through pub/sub without direct transport coupling to session actors.
 - **THEN** both adapters receive the broadcast independently
 - **AND** each adapter delivers through its own channel
 
+### Requirement: Hidden activity observation for adapter heuristics
+
+Input adapters SHALL be allowed to subscribe to session activity outputs such
+as `ToolCalls` for local progress heuristics without rendering those activity
+events directly to end users. Adapter-local progress behavior SHALL NOT change
+the transport-agnostic session actor contract.
+
+#### Scenario: Slack adapter observes tool activity without rendering tool details
+
+- **GIVEN** the Slack adapter subscribes to a session with a filter that
+  includes `ToolCalls`
+- **WHEN** the session emits tool-call or tool-result outputs for a turn
+- **THEN** the adapter may use those outputs to track whether the turn is
+  actively working
+- **AND** it does not post raw tool-call or tool-result details into the Slack
+  thread
+
+#### Scenario: Hidden activity subscription does not affect other subscribers
+
+- **GIVEN** multiple subscribers are attached to the same session
+- **WHEN** one adapter widens its filter to observe hidden activity outputs
+- **THEN** other subscribers continue receiving only the output categories they
+  requested
+- **AND** the session actor does not become transport-specific
+
 ### Requirement: Slack Socket Mode adapter
 
 The Slack adapter SHALL connect via Slack Socket Mode, handle `app_mention`

--- a/openspec/specs/netclaw-session/spec.md
+++ b/openspec/specs/netclaw-session/spec.md
@@ -97,6 +97,97 @@ The system SHALL recover session state from journal and snapshots.
 - **THEN** a new actor recovers from the journal with TurnCount == 2
 - **AND** the next turn continues from the recovered state
 
+### Requirement: Turn operation ownership isolation
+
+The session system SHALL correlate each asynchronous LLM request and
+tool-execution batch to the active turn operation. Late completions, failures,
+deltas, or timeout callbacks from superseded operations SHALL be ignored and
+SHALL NOT mutate history, outputs, or active-turn state.
+
+#### Scenario: Late LLM completion ignored after timeout
+
+- **GIVEN** an LLM operation timed out and the session already advanced to a new
+  terminal or recovery state
+- **WHEN** the timed-out operation later reports text, tool calls, or
+  completion
+- **THEN** the session ignores the late message
+- **AND** it does not append assistant content, emit user-visible output, or
+  reset the active turn state
+
+#### Scenario: Late tool completion ignored after retry
+
+- **GIVEN** a tool-execution batch was replaced by a newer turn operation
+- **WHEN** a completion or failure arrives from the older batch
+- **THEN** the session ignores that stale tool result
+- **AND** only the active batch may influence the current turn
+
+### Requirement: Durable failed-turn and buffered replay recovery
+
+Once a user message is accepted into a turn, the session system SHALL durably
+record terminal failure outcomes and any accepted buffered follow-up inputs
+needed for replay. Recovery after actor or daemon restart SHALL rebuild the
+pending follow-up queue in original order and SHALL preserve the last recorded
+terminal outcome for the interrupted turn.
+
+#### Scenario: Failed accepted turn survives restart
+
+- **GIVEN** a user turn was accepted and then failed due to timeout, provider
+  failure, or tool failure
+- **WHEN** the session recovers after restart
+- **THEN** the failed turn outcome remains represented in recovered state
+- **AND** the session does not resurrect the failed turn as if it were still
+  processing
+
+#### Scenario: Buffered follow-up inputs replay once after restart
+
+- **GIVEN** one or more follow-up user messages were accepted while the current
+  turn was processing
+- **WHEN** the actor restarts before draining the buffered queue
+- **THEN** the recovered session replays those buffered inputs once in original
+  arrival order
+- **AND** no accepted follow-up input is silently dropped or duplicated
+
+### Requirement: Absolute wall-clock turn budget
+
+The session system SHALL enforce a cumulative wall-clock budget for each user
+turn in addition to per-operation watchdogs. When the budget is exceeded, the
+session SHALL stop further LLM and tool work, record a timed-out terminal
+outcome, and advance recovery or buffered follow-up processing.
+
+#### Scenario: Long multi-iteration turn exceeds wall-clock budget
+
+- **GIVEN** a turn spans multiple LLM calls and tool-execution batches
+- **WHEN** the total elapsed turn time exceeds the configured budget
+- **THEN** the session aborts further work for that turn
+- **AND** records a timeout outcome before advancing to any buffered follow-up
+  input
+
+### Requirement: Degraded completion after tool-budget exhaustion
+
+The session system SHALL treat tool-iteration exhaustion as a degraded
+completion path rather than a silent or generic provider failure. When the tool
+budget is exhausted, the session SHALL first force a no-tools completion that
+prefers a best-effort answer or one focused clarifying question. If the model
+still attempts more tool work, the session SHALL emit a deterministic degraded
+user-visible terminal message.
+
+#### Scenario: Exhausted tool budget yields best-effort completion
+
+- **GIVEN** the current turn exhausted its configured tool-iteration budget
+- **WHEN** the session forces a no-tools completion
+- **THEN** the turn ends with a user-visible answer or one focused clarifying
+  question
+- **AND** the turn does not remain empty while waiting for more tools
+
+#### Scenario: Noncompliant no-tools response yields deterministic degraded message
+
+- **GIVEN** the tool budget is exhausted and the model still emits tool calls
+  while tools are disallowed
+- **WHEN** the session cannot obtain a compliant no-tools completion
+- **THEN** the session emits a deterministic degraded terminal message
+- **AND** it does not classify the turn as a generic provider failure solely
+  because the tool budget was exhausted
+
 ### Requirement: Conversation compaction
 
 The system SHALL compact long session history using a tiered approach informed

--- a/openspec/specs/netclaw-slack-socket/spec.md
+++ b/openspec/specs/netclaw-slack-socket/spec.md
@@ -29,6 +29,52 @@ the session command.
 - WHEN the turn completes
 - THEN Netclaw posts the reply in thread `T`
 
+### Requirement: In-thread acknowledgement for hidden long-running work
+
+The Slack adapter SHALL post one brief in-thread acknowledgement when a turn
+has not yet produced visible text or file output but hidden session activity
+shows the turn is actively working. The acknowledgement threshold SHALL be
+based on adapter-local heuristics and SHALL NOT expose raw tool-call details.
+
+#### Scenario: Slack posts one acknowledgement after hidden tool activity
+
+- GIVEN a Slack turn has produced no visible text or file output
+- AND the adapter has observed enough hidden tool activity to classify the turn
+  as actively working
+- WHEN the turn is still in progress
+- THEN Netclaw posts one brief acknowledgement in the same thread
+- AND it does not post additional acknowledgements for that same turn
+
+#### Scenario: Fast turn does not emit acknowledgement
+
+- GIVEN a Slack turn produces its visible reply before the hidden-activity
+  threshold is reached
+- WHEN the turn completes normally
+- THEN Netclaw does not post a separate acknowledgement message
+
+### Requirement: Empty-turn fallback respects visible terminal output
+
+The Slack adapter SHALL emit the generic empty-turn fallback only when a turn
+completes without any visible terminal output. A prior acknowledgement alone
+does not count as terminal output, but a visible reply, file upload, or
+explicit error message does.
+
+#### Scenario: Streamed reply suppresses generic fallback
+
+- GIVEN the Slack adapter already posted the visible reply for a turn from
+  streamed or buffered text
+- WHEN `TurnCompleted` arrives
+- THEN the adapter does not post the generic empty-turn fallback message
+
+#### Scenario: Acknowledgement alone does not suppress terminal failure handling
+
+- GIVEN the adapter posted a progress acknowledgement for an in-flight turn
+- AND the turn completes without a visible reply or file output
+- WHEN the terminal outcome is resolved
+- THEN the adapter still posts the explicit error outcome or generic empty-turn
+  fallback
+- AND the acknowledgement is not treated as the final reply for that turn
+
 ### Requirement: No required inbound public webhook
 
 Netclaw SHALL not require a public inbound HTTP endpoint for base Slack

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadAckIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadAckIntegrationTests.cs
@@ -1,0 +1,238 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tests.Sessions;
+using Netclaw.Actors.Tools;
+using Netclaw.Channels.Slack;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackThreadAckIntegrationTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    private readonly ToolLoopChatClient _chatClient = new();
+    private readonly FakeToolExecutor _toolExecutor = new();
+    private readonly RecordingReplyClient _replyClient = new();
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
+        services.AddSingleton(new SessionConfig
+        {
+            ModelId = "slack-ack-test-model",
+            ContextWindowTokens = 128_000,
+            SnapshotInterval = 5,
+            MaxToolIterationsPerTurn = 10,
+            TitleGenerationInterval = 0
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
+        services.AddSingleton<IToolExecutor>(_toolExecutor);
+
+        var registry = new ToolRegistry();
+        registry.Register(
+            AIFunctionFactory.Create(() => "search result", "web_search"),
+            "web_search");
+        services.AddSingleton(registry);
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+        services.AddSingleton<SessionPipeline>();
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Hidden_tool_activity_posts_single_ack_before_final_reply()
+    {
+        _chatClient.ToolCallsBeforeText = 3;
+        _toolExecutor.Results["web_search"] = "search result";
+
+        var gateway = CreateGateway("slack-gw-ack-threshold-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D7:7000"),
+            ChannelId: new SlackChannelId("D7"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("7000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "do the work",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() => Assert.Equal(2, _replyClient.PostedMessages.Count), TimeSpan.FromSeconds(10));
+
+        Assert.Equal("Working on it.", _replyClient.PostedMessages[0].Text);
+        Assert.Contains("[final]", _replyClient.PostedMessages[1].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Fast_turn_stays_quiet_until_final_reply()
+    {
+        _replyClient.PostedMessages.Clear();
+        _chatClient.ToolCallsBeforeText = 2;
+        _toolExecutor.Results["web_search"] = "search result";
+
+        var gateway = CreateGateway("slack-gw-fast-turn-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D8:8000"),
+            ChannelId: new SlackChannelId("D8"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("8000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "quick research",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() => Assert.Single(_replyClient.PostedMessages), TimeSpan.FromSeconds(10));
+        Assert.DoesNotContain(_replyClient.PostedMessages, x => string.Equals(x.Text, "Working on it.", StringComparison.Ordinal));
+        Assert.Contains("[final]", _replyClient.PostedMessages[0].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Streamed_reply_does_not_post_generic_fallback_after_real_reply()
+    {
+        _replyClient.PostedMessages.Clear();
+        _chatClient.StreamTextDeltas = true;
+
+        var gateway = CreateGateway("slack-gw-streamed-reply-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D9:9000"),
+            ChannelId: new SlackChannelId("D9"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("9000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "stream a reply",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() => Assert.Single(_replyClient.PostedMessages), TimeSpan.FromSeconds(10));
+        Assert.Equal("Hello world", _replyClient.PostedMessages[0].Text);
+        Assert.DoesNotContain("didn't manage to produce a reply", _replyClient.PostedMessages[0].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IActorRef CreateGateway(string name)
+    {
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        return Sys.ActorOf(SlackGatewayActor.CreateProps(deps), name);
+    }
+
+    private sealed class RecordingReplyClient : ISlackReplyClient
+    {
+        public List<SlackPostMessage> PostedMessages { get; } = [];
+
+        public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+        {
+            PostedMessages.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task UploadFileToThreadAsync(
+            SlackChannelId channelId,
+            SlackThreadTs threadTs,
+            string filePath,
+            string? filename = null,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class ToolLoopChatClient : IChatClient
+    {
+        private int _callCount;
+
+        public int ToolCallsBeforeText { get; set; }
+
+        public bool StreamTextDeltas { get; set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var callNumber = Interlocked.Increment(ref _callCount);
+            var hasTools = options?.Tools?.Count > 0;
+
+            if (!StreamTextDeltas && hasTools && callNumber <= ToolCallsBeforeText)
+            {
+                var toolCall = new FunctionCallContent(
+                    $"call-{callNumber}",
+                    "web_search",
+                    new Dictionary<string, object?> { ["query"] = $"query-{callNumber}" });
+                return Task.FromResult(new ChatResponse(new ChatMessage(
+                    Microsoft.Extensions.AI.ChatRole.Assistant,
+                    [toolCall])));
+            }
+
+            var text = StreamTextDeltas ? "Hello world" : $"[final] call #{callNumber}";
+            return Task.FromResult(new ChatResponse(new ChatMessage(
+                Microsoft.Extensions.AI.ChatRole.Assistant,
+                [new TextContent(text)])));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (StreamTextDeltas)
+            {
+                yield return new ChatResponseUpdate { Contents = [new TextContent("Hello")] };
+                yield return new ChatResponseUpdate { Contents = [new TextContent(" world")] };
+                yield break;
+            }
+
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            foreach (var update in response.ToChatResponseUpdates())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return update;
+            }
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadAckIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadAckIntegrationTests.cs
@@ -138,6 +138,37 @@ public sealed class SlackThreadAckIntegrationTests(ITestOutputHelper output) : T
         Assert.DoesNotContain("didn't manage to produce a reply", _replyClient.PostedMessages[0].Text, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task Post_tool_empty_recovery_is_rendered_as_normal_visible_text_in_slack()
+    {
+        _replyClient.PostedMessages.Clear();
+        _chatClient.ToolCallsBeforeText = 1;
+        _chatClient.EmptyResponsesAfterTools = 3;
+        _toolExecutor.Results["web_search"] = "Found a deterministic result";
+
+        var gateway = CreateGateway("slack-gw-post-tool-empty-recovery");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D10:10000"),
+            ChannelId: new SlackChannelId("D10"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("10000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "recover from empty tool replies",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() => Assert.Single(_replyClient.PostedMessages), TimeSpan.FromSeconds(10));
+        var posted = Assert.Single(_replyClient.PostedMessages);
+        Assert.Contains("best-effort answer", posted.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Found a deterministic result", posted.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Working on it.", posted.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
     private IActorRef CreateGateway(string name)
     {
         var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
@@ -181,10 +212,13 @@ public sealed class SlackThreadAckIntegrationTests(ITestOutputHelper output) : T
     private sealed class ToolLoopChatClient : IChatClient
     {
         private int _callCount;
+        private int _emptyResponsesServed;
 
         public int ToolCallsBeforeText { get; set; }
 
         public bool StreamTextDeltas { get; set; }
+
+        public int EmptyResponsesAfterTools { get; set; }
 
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages,
@@ -203,6 +237,14 @@ public sealed class SlackThreadAckIntegrationTests(ITestOutputHelper output) : T
                 return Task.FromResult(new ChatResponse(new ChatMessage(
                     Microsoft.Extensions.AI.ChatRole.Assistant,
                     [toolCall])));
+            }
+
+            if (EmptyResponsesAfterTools > 0 && _emptyResponsesServed < EmptyResponsesAfterTools)
+            {
+                _emptyResponsesServed++;
+                return Task.FromResult(new ChatResponse(new ChatMessage(
+                    Microsoft.Extensions.AI.ChatRole.Assistant,
+                    [])));
             }
 
             var text = StreamTextDeltas ? "Hello world" : $"[final] call #{callNumber}";

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -99,6 +99,60 @@ public sealed class SerializationRoundTripTests
         Assert.Equal(ChatRole.Assistant, result.AssistantReply.Role);
         Assert.Equal("Hi there!", result.AssistantReply.Content);
         Assert.Equal(original.RecordedAtMs, result.RecordedAtMs);
+        Assert.False(result.ConsumesBufferedInput);
+    }
+
+    [Fact]
+    public void TurnFailedRecorded_round_trips()
+    {
+        var ts = new DateTimeOffset(2026, 2, 21, 10, 2, 0, TimeSpan.Zero);
+        var original = new TurnFailedRecorded
+        {
+            SessionId = new SessionId("C99999/1708531200.000100"),
+            UserMessage = new SerializableChatMessage
+            {
+                Role = ChatRole.User,
+                Content = "Hello"
+            },
+            AssistantReply = new SerializableChatMessage
+            {
+                Role = ChatRole.Assistant,
+                Content = "Timed out"
+            },
+            RecordedAtMs = ts.ToUnixTimeMilliseconds(),
+            ConsumesBufferedInput = true,
+            ErrorCategory = (int)ErrorCategory.Timeout
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal("Hello", result.UserMessage.Content);
+        Assert.Equal("Timed out", result.AssistantReply.Content);
+        Assert.True(result.ConsumesBufferedInput);
+        Assert.Equal((int)ErrorCategory.Timeout, result.ErrorCategory);
+    }
+
+    [Fact]
+    public void BufferedInputAccepted_round_trips()
+    {
+        var ts = new DateTimeOffset(2026, 2, 21, 10, 3, 0, TimeSpan.Zero);
+        var original = new BufferedInputAccepted
+        {
+            SessionId = new SessionId("C99999/1708531200.000100"),
+            UserMessage = new SerializableChatMessage
+            {
+                Role = ChatRole.User,
+                Content = "Follow-up"
+            },
+            AcceptedAtMs = ts.ToUnixTimeMilliseconds()
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal("Follow-up", result.UserMessage.Content);
+        Assert.Equal(original.AcceptedAtMs, result.AcceptedAtMs);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -321,6 +321,57 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Tool_call_visibility_is_scoped_per_subscriber_filter_within_same_session()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "test" })
+        ];
+        _fakeToolExecutor.Results["web_search"] = "search result";
+
+        var sessionId = new SessionId("test-channel/filter-tool-visibility");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var toolAwareSub = CreateTestProbe("tool-aware-sub");
+        var textOnlySub = CreateTestProbe("text-only-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = toolAwareSub,
+            Filter = OutputFilter.Text | OutputFilter.ToolCalls
+        }, TimeSpan.FromSeconds(3));
+        await toolAwareSub.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = textOnlySub,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await textOnlySub.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Use a tool and answer"
+        }, TimeSpan.FromSeconds(3));
+
+        var toolCall = await toolAwareSub.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        Assert.Equal("web_search", toolCall.ToolName);
+
+        var toolAwareText = await toolAwareSub.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("[fake] Response #2", toolAwareText.Text, StringComparison.OrdinalIgnoreCase);
+        await toolAwareSub.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await toolAwareSub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+
+        var textOnlyText = await textOnlySub.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("[fake] Response #2", textOnlyText.Text, StringComparison.OrdinalIgnoreCase);
+        await textOnlySub.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await textOnlySub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+    }
+
+    [Fact]
     public async Task Two_sessions_are_routed_independently()
     {
         var session1 = new SessionId("channel-A/thread-1");
@@ -409,12 +460,16 @@ public class LlmSessionIntegrationTests : TestKit
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(6));
 
-        // Second turn output (batched follow-up)
+        // Second buffered follow-up turn
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(6));
 
-        // Only two LLM calls total
-        Assert.Equal(2, _fakeChatClient.CallCount);
+        // Third buffered follow-up turn
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(6));
+
+        // Three LLM calls total: initial turn plus two replayed follow-ups
+        Assert.Equal(3, _fakeChatClient.CallCount);
 
         await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
     }

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -175,7 +175,7 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
-    public async Task Empty_response_after_tool_nudge_fails_turn_and_allows_followup_prompt()
+    public async Task Persistent_empty_response_after_tool_work_synthesizes_evidence_backed_reply()
     {
         _fakeChatClient.ToolCallsOnFirstCall =
         [
@@ -184,6 +184,8 @@ public class LlmSessionIntegrationTests : TestKit
         ];
         _fakeChatClient.PlannedResponses.Enqueue([]);
         _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeToolExecutor.Results["web_search"] = "Found 3 results for test";
 
         var sessionId = new SessionId("test-channel/post-tool-empty");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
@@ -204,11 +206,59 @@ public class LlmSessionIntegrationTests : TestKit
         }, TimeSpan.FromSeconds(3));
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Equal(sessionId, text.SessionId);
+        Assert.Contains("best-effort answer", text.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("web_search", text.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Found 3 results for test", text.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(250));
+
+        Assert.Equal(4, _fakeChatClient.CallCount);
+        Assert.Empty(_fakeChatClient.ReceivedToolNames[3]);
+    }
+
+    [Fact]
+    public async Task Persistent_empty_response_after_tool_work_without_usable_evidence_preserves_provider_failure()
+    {
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "test" })
+        ];
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeToolExecutor.Results["web_search"] = "   \n   ";
+
+        var sessionId = new SessionId("test-channel/post-tool-empty-no-evidence");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("post-tool-empty-no-evidence-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search for something"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
         var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
         Assert.Equal(sessionId, error.SessionId);
         Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
-
+        Assert.Contains("Please try rephrasing", error.Message, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(250));
+
+        Assert.Equal(4, _fakeChatClient.CallCount);
+        Assert.Empty(_fakeChatClient.ReceivedToolNames[3]);
 
         await sessionManager.Ask<CommandAck>(new SendUserMessage
         {
@@ -217,7 +267,7 @@ public class LlmSessionIntegrationTests : TestKit
         }, TimeSpan.FromSeconds(3));
 
         var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
-        Assert.Contains("[fake] Response #4", text.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[fake] Response #5", text.Text, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Akka.Actor;
 using Akka.Hosting;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
 using Xunit.Abstractions;
@@ -82,6 +84,58 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
     }
 
     [Fact]
+    public async Task Stale_llm_completion_is_ignored_after_newer_turn_starts()
+    {
+        var sessionId = new SessionId("watchdog/session-stale-llm");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("watchdog-stale-llm-subscriber");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        var firstError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("timeout", firstError.Message, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var childPath = $"/user/session-manager/{escapedId}";
+        var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
+
+        child.Tell(new LlmResponseReceived
+        {
+            OperationId = 1,
+            Response = new ChatResponse(new ChatMessage(
+                Microsoft.Extensions.AI.ChatRole.Assistant,
+                [new TextContent("stale completion should be ignored")])),
+            StreamedText = false,
+            StreamedThinking = false
+        });
+
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        var secondError = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("timeout", secondError.Message, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public async Task Buffered_reprompt_is_replayed_after_failed_turn()
     {
         _chatClient.SucceedAfterFirstTimeout = true;
@@ -117,6 +171,60 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
         var recoveredText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
         Assert.Contains("recovered after timeout", recoveredText.Text, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(2, _chatClient.CallCount);
+    }
+
+    [Fact]
+    public async Task Buffered_reprompt_is_recovered_after_actor_restart()
+    {
+        _chatClient.SucceedAfterFirstTimeout = true;
+
+        var sessionId = new SessionId("watchdog/session-buffered-recovery");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("watchdog-buffered-recovery-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var childPath = $"/user/session-manager/{escapedId}";
+        var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+        Sys.Stop(child);
+        await ExpectTerminatedAsync(child);
+
+        var recoverSub = CreateTestProbe("watchdog-buffered-recovery-sub-2");
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = recoverSub,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(5));
+        await recoverSub.ExpectMsgAsync<SessionJoined>();
+
+        var recoveredText = await recoverSub.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6));
+        Assert.Contains("recovered after timeout", recoveredText.Text, StringComparison.OrdinalIgnoreCase);
+        await recoverSub.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
 
         Assert.Equal(2, _chatClient.CallCount);
     }
@@ -168,6 +276,106 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return update;
                 await Task.Yield();
+            }
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}
+
+public sealed class LlmSessionTurnBudgetTests(ITestOutputHelper output) : TestKit(output: output)
+{
+    private readonly HeartbeatStreamingChatClient _chatClient = new();
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
+        services.AddSingleton(new SessionConfig
+        {
+            ModelId = "turn-budget-test-model",
+            ContextWindowTokens = 128_000,
+            SnapshotInterval = 5,
+            TitleGenerationInterval = 0,
+            TurnLlmTimeoutSeconds = 1,
+            ToolExecutionTimeoutSeconds = 1,
+            SidecarLlmTimeoutSeconds = 1,
+            MaxTurnDurationSeconds = 2
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Turn_budget_times_out_chatty_stream_that_keeps_refreshing_watchdog()
+    {
+        var sessionId = new SessionId("watchdog/session-turn-budget");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("turn-budget-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "keep streaming forever"
+        }, TimeSpan.FromSeconds(3));
+
+        ErrorOutput? error = null;
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(6);
+        while (DateTimeOffset.UtcNow < deadline && error is null)
+        {
+            var output = await subscriber.ExpectMsgAsync<SessionOutput>(TimeSpan.FromSeconds(1));
+            if (output is ErrorOutput err)
+                error = err;
+        }
+
+        Assert.NotNull(error);
+        Assert.Contains("too long", error!.Message, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private sealed class HeartbeatStreamingChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromException<ChatResponse>(new NotSupportedException("Streaming path only in this test."));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (true)
+            {
+                var response = new ChatResponse(new ChatMessage(
+                    Microsoft.Extensions.AI.ChatRole.Assistant,
+                    [new TextContent("tick")])) ;
+
+                foreach (var update in response.ToChatResponseUpdates())
+                    yield return update;
+
+                var sw = Stopwatch.StartNew();
+                while (sw.Elapsed < TimeSpan.FromMilliseconds(200))
+                    await Task.Yield();
             }
         }
 

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -111,7 +111,7 @@ public class MaxToolIterationTests : TestKit
     }
 
     [Fact]
-    public async Task Tool_iteration_limit_fails_turn_when_model_keeps_emitting_tool_calls_without_tools()
+    public async Task Tool_iteration_limit_degrades_to_text_when_model_keeps_emitting_tool_calls_without_tools()
     {
         _fakeChatClient.ToolCallsOnFirstCall =
         [
@@ -143,9 +143,8 @@ public class MaxToolIterationTests : TestKit
         for (var i = 0; i < 3; i++)
             await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
 
-        var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5));
-        Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
-        Assert.Contains("Please try rephrasing", error.Message, StringComparison.OrdinalIgnoreCase);
+        var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        Assert.Contains("tool-use limit", text.Text, StringComparison.OrdinalIgnoreCase);
 
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -66,6 +66,65 @@ public class SessionStateTests
     }
 
     [Fact]
+    public void Apply_TurnFailedRecorded_adds_messages_and_increments_turn()
+    {
+        var state = SessionState.Empty;
+        var evt = new TurnFailedRecorded
+        {
+            SessionId = TestSessionId,
+            UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Hello" },
+            AssistantReply = new SerializableChatMessage { Role = ChatRole.Assistant, Content = "Something went wrong" },
+            ErrorCategory = (int)ErrorCategory.Timeout,
+            RecordedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        };
+
+        var next = state.Apply(evt);
+
+        Assert.Equal(2, next.History.Count);
+        Assert.Equal(ChatRole.User, next.History[0].Role);
+        Assert.Equal(ChatRole.Assistant, next.History[1].Role);
+        Assert.Equal(1, next.TurnCount);
+    }
+
+    [Fact]
+    public void Apply_BufferedInputAccepted_enqueues_pending_input()
+    {
+        var state = SessionState.Empty;
+        var next = state.Apply(new BufferedInputAccepted
+        {
+            SessionId = TestSessionId,
+            UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Buffered" },
+            AcceptedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        });
+
+        Assert.Single(next.PendingBufferedInputs);
+        Assert.Equal("Buffered", next.PendingBufferedInputs[0].Content);
+    }
+
+    [Fact]
+    public void Apply_TurnRecorded_consumes_buffered_input_when_flagged()
+    {
+        var state = SessionState.Empty.Apply(new BufferedInputAccepted
+        {
+            SessionId = TestSessionId,
+            UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Buffered" },
+            AcceptedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        });
+
+        var next = state.Apply(new TurnRecorded
+        {
+            SessionId = TestSessionId,
+            UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Buffered" },
+            AssistantReply = new SerializableChatMessage { Role = ChatRole.Assistant, Content = "Done" },
+            ConsumesBufferedInput = true,
+            RecordedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        });
+
+        Assert.Empty(next.PendingBufferedInputs);
+        Assert.Equal(2, next.History.Count);
+    }
+
+    [Fact]
     public void Apply_SystemPromptSet_inserts_at_beginning()
     {
         var state = SessionState.Empty;
@@ -267,7 +326,13 @@ public class SessionStateTests
                 UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Hello" },
                 AssistantReply = new SerializableChatMessage { Role = ChatRole.Assistant, Content = "Hi" },
             })
-            .Apply(new SessionTitleSet { SessionId = TestSessionId, Title = "Test title" });
+            .Apply(new SessionTitleSet { SessionId = TestSessionId, Title = "Test title" })
+            .Apply(new BufferedInputAccepted
+            {
+                SessionId = TestSessionId,
+                UserMessage = new SerializableChatMessage { Role = ChatRole.User, Content = "Buffered later" },
+                AcceptedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            });
 
         var snapshot = state.ToSnapshot();
         var restored = SessionState.FromSnapshot(snapshot);
@@ -275,12 +340,15 @@ public class SessionStateTests
         Assert.Equal(state.History.Count, restored.History.Count);
         Assert.Equal(state.TurnCount, restored.TurnCount);
         Assert.Equal(state.Title, restored.Title);
+        Assert.Equal(state.PendingBufferedInputs.Count, restored.PendingBufferedInputs.Count);
 
         for (int i = 0; i < state.History.Count; i++)
         {
             Assert.Equal(state.History[i].Role, restored.History[i].Role);
             Assert.Equal(state.History[i].Content, restored.History[i].Content);
         }
+
+        Assert.Equal("Buffered later", restored.PendingBufferedInputs[0].Content);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -39,7 +39,57 @@ public sealed class TurnRecorded
     [ProtoMember(4)]
     public long RecordedAtMs { get; set; }
 
+    [ProtoMember(5)]
+    public bool ConsumesBufferedInput { get; set; }
+
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
+}
+
+/// <summary>
+/// Persisted event recording a completed turn that ended with a user-visible
+/// failure reply instead of a normal assistant answer.
+/// </summary>
+[ProtoContract]
+public sealed class TurnFailedRecorded
+{
+    [ProtoMember(1)]
+    public SessionId SessionId { get; set; }
+
+    [ProtoMember(2)]
+    public SerializableChatMessage UserMessage { get; set; } = new();
+
+    [ProtoMember(3)]
+    public SerializableChatMessage AssistantReply { get; set; } = new();
+
+    [ProtoMember(4)]
+    public long RecordedAtMs { get; set; }
+
+    [ProtoMember(5)]
+    public bool ConsumesBufferedInput { get; set; }
+
+    [ProtoMember(6)]
+    public int ErrorCategory { get; set; }
+
+    public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
+}
+
+/// <summary>
+/// Persisted event recording a user message accepted while the session is busy.
+/// The message is replayed after the active turn reaches a terminal state.
+/// </summary>
+[ProtoContract]
+public sealed class BufferedInputAccepted
+{
+    [ProtoMember(1)]
+    public SessionId SessionId { get; set; }
+
+    [ProtoMember(2)]
+    public SerializableChatMessage UserMessage { get; set; } = new();
+
+    [ProtoMember(3)]
+    public long AcceptedAtMs { get; set; }
+
+    public DateTimeOffset AcceptedAt => DateTimeOffset.FromUnixTimeMilliseconds(AcceptedAtMs);
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -17,4 +17,7 @@ public sealed class SessionSnapshot
 
     [ProtoMember(3)]
     public string? Title { get; set; }
+
+    [ProtoMember(4)]
+    public List<SerializableChatMessage> PendingBufferedInputs { get; set; } = new();
 }

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -50,6 +50,7 @@ internal sealed record ToolExecutionCompleted
     public required long OperationId { get; init; }
 
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
+    public List<string> SuccessfulToolCallIds { get; init; } = [];
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
     public List<CompletedSubAgentRun> CompletedSubAgentRuns { get; init; } = [];
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -10,6 +10,8 @@ namespace Netclaw.Actors.Sessions;
 /// </summary>
 internal sealed record LlmResponseReceived
 {
+    public required long OperationId { get; init; }
+
     public required ChatResponse Response { get; init; }
 
     public bool StreamedText { get; init; }
@@ -24,6 +26,8 @@ internal sealed record LlmResponseReceived
 /// </summary>
 internal sealed record LlmResponseDeltaReceived
 {
+    public required long OperationId { get; init; }
+
     public required AIContent Content { get; init; }
 }
 
@@ -32,6 +36,8 @@ internal sealed record LlmResponseDeltaReceived
 /// </summary>
 internal sealed record LlmCallFailed
 {
+    public required long OperationId { get; init; }
+
     public required Exception Cause { get; init; }
 }
 
@@ -41,6 +47,8 @@ internal sealed record LlmCallFailed
 /// </summary>
 internal sealed record ToolExecutionCompleted
 {
+    public required long OperationId { get; init; }
+
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
     public List<CompletedSubAgentRun> CompletedSubAgentRuns { get; init; } = [];
@@ -85,6 +93,8 @@ internal sealed record AcceptedSubAgentFinding
 /// </summary>
 internal sealed record ToolExecutionFailed
 {
+    public required long OperationId { get; init; }
+
     public required Exception Cause { get; init; }
 }
 
@@ -98,6 +108,13 @@ internal sealed record ProcessingWatchdogExpired
 
     public required string OperationName { get; init; }
 }
+
+internal sealed record TurnBudgetExpired
+{
+    public required long TurnId { get; init; }
+}
+
+internal sealed record ResumeBufferedReplay;
 
 /// <summary>
 /// Marshal a child actor creation request back onto the session actor thread.

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -67,6 +67,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private int _toolIterationCount;
 
     private const int MaxPreToolEmptyResponseRetries = 2;
+    private const int MaxPostToolEmptyResponseRetries = 2;
+    private const int MaxFallbackEvidenceItems = 4;
+    private const int MaxFallbackEvidenceChars = 280;
     private const string EmptyResponseFallbackMessage = "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
     private const string ToolBudgetFallbackMessage = "I hit my tool-use limit before I could finish. Please narrow the request or tell me what to focus on next, and I'll continue from there.";
     private const string TurnBudgetFallbackMessage = "I spent too long working on that turn and had to stop. Please try again with a narrower follow-up.";
@@ -74,8 +77,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Whether we already sent a post-tool empty-response nudge in this tool chain
     private bool _postToolNudgeSent;
 
+    // Number of consecutive empty responses observed after successful tool work
+    private int _postToolEmptyResponseCount;
+
     // Number of consecutive empty responses observed before any tool work happened
     private int _preToolEmptyResponseCount;
+
+    private readonly List<ToolEvidence> _successfulToolEvidence = [];
 
     // Whether the current LLM call intentionally disabled tool use after a circuit breaker fired.
     private bool _forceNoToolsActive;
@@ -367,6 +375,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 _log.Debug("LLM produced empty response after {ToolIterations} tool iteration(s) — nudging",
                     _toolIterationCount);
                 _postToolNudgeSent = true;
+                _postToolEmptyResponseCount = 1;
                 _state = _state.AddSystemNudge(
                     "You received tool results but did not respond. "
                     + "Continue working or answer the user's question.");
@@ -376,13 +385,22 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             if (!hasText && _toolIterationCount > 0 && _postToolNudgeSent)
             {
-                _log.Warning(
-                    "LLM produced empty response after tool work and post-tool nudge; failing turn after {ToolIterations} tool iteration(s)",
-                    _toolIterationCount);
-                FailCurrentTurn(
-                    EmptyResponseFallbackMessage,
-                    new InvalidOperationException("LLM produced an empty response after tool execution and follow-up nudge."),
-                    ErrorCategory.ProviderFailure);
+                _postToolEmptyResponseCount++;
+
+                if (_postToolEmptyResponseCount <= MaxPostToolEmptyResponseRetries)
+                {
+                    _log.Warning(
+                        "LLM produced empty response after tool work; retrying degraded finalization attempt {Attempt}/{MaxAttempts}",
+                        _postToolEmptyResponseCount,
+                        MaxPostToolEmptyResponseRetries);
+                    _state = _state.AddSystemNudge(
+                        "Your previous response was still empty after tool work. "
+                        + "Return a concise final answer to the user now, using the completed tool results.");
+                    FireLlmCall(forceNoTools: true);
+                    return;
+                }
+
+                CompleteCurrentTurnFromPostToolEvidenceOrFail();
                 return;
             }
 
@@ -540,6 +558,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 _log.Info("Tool [{ToolName}] (call={CallId}) result: {Result}",
                     result.Name ?? "unknown", result.ToolCallId ?? "?", preview);
             }
+
+            CaptureSuccessfulToolEvidence(msg.ToolResults, msg.SuccessfulToolCallIds, _toolIterationCount + 1);
 
             // Dynamic tool loading: if search_tools was called, load discovered tools
             // into the available tools list so they can be called in subsequent turns
@@ -1122,6 +1142,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Model produced tool calls — reset post-tool nudge so it can fire again
         // if the model stalls later in the chain.
         _postToolNudgeSent = false;
+        _postToolEmptyResponseCount = 0;
         _preToolEmptyResponseCount = 0;
         _forceNoToolsActive = false;
 
@@ -1580,9 +1601,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         _toolIterationCount = 0;
         _postToolNudgeSent = false;
+        _postToolEmptyResponseCount = 0;
         _preToolEmptyResponseCount = 0;
         _forceNoToolsActive = false;
         _activeBufferedReplayMessage = null;
+        _successfulToolEvidence.Clear();
         PrepareDiscoveredToolsForNewTurn();
     }
 
@@ -2032,9 +2055,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private sealed record ToolCallResult(
         SerializableChatMessage Message,
+        bool Success,
         IReadOnlyList<FileAttachmentInfo> FileAttachments,
         IReadOnlyList<CompletedSubAgentRun> CompletedSubAgentRuns,
         IReadOnlyList<AcceptedSubAgentFinding> AcceptedSubAgentFindings);
+
+    private sealed record ToolEvidence(
+        string ToolName,
+        string ToolCallId,
+        string Excerpt,
+        int Iteration,
+        int Ordinal);
 
     private static async Task ExecuteToolsAsync(
         IToolExecutor executor,
@@ -2073,6 +2104,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             {
                 OperationId = operationId,
                 ToolResults = results.Select(r => r.Message).ToList(),
+                SuccessfulToolCallIds = results
+                    .Where(r => r.Success && !string.IsNullOrWhiteSpace(r.Message.ToolCallId))
+                    .Select(r => r.Message.ToolCallId!)
+                    .ToList(),
                 FileAttachments = fileAttachments,
                 CompletedSubAgentRuns = results
                     .SelectMany(r => r.CompletedSubAgentRuns)
@@ -2199,6 +2234,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 Allowed = true,
                 Duration = sw.Elapsed
             });
+
+            var message = new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.Tool,
+                Content = ClampToolResult(resultText, maxInlineToolResultChars),
+                ToolCallId = tc.CallId,
+                Name = tc.Name
+            };
+
+            return new ToolCallResult(
+                message,
+                true,
+                context.FileAttachments,
+                completedRuns,
+                acceptedFindings);
         }
         catch (Exception ex)
         {
@@ -2214,23 +2264,22 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 Allowed = true,
                 Duration = sw.Elapsed
             });
+
+            var failedMessage = new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.Tool,
+                Content = ClampToolResult(resultText, maxInlineToolResultChars),
+                ToolCallId = tc.CallId,
+                Name = tc.Name
+            };
+
+            return new ToolCallResult(
+                failedMessage,
+                false,
+                context.FileAttachments,
+                completedRuns,
+                acceptedFindings);
         }
-
-        resultText = ClampToolResult(resultText, maxInlineToolResultChars);
-
-        var message = new SerializableChatMessage
-        {
-            Role = Protocol.ChatRole.Tool,
-            Content = resultText,
-            ToolCallId = tc.CallId,
-            Name = tc.Name
-        };
-
-        return new ToolCallResult(
-            message,
-            context.FileAttachments,
-            completedRuns,
-            acceptedFindings);
     }
 
     internal static SubAgentFindingReviewResult ReviewSubAgentFinding(
@@ -2617,6 +2666,95 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ContextWindowTokens = contextWindow,
             UsagePercent = usagePercent
         }, OutputFilter.Usage);
+    }
+
+    private void CaptureSuccessfulToolEvidence(
+        IReadOnlyList<SerializableChatMessage> toolResults,
+        IReadOnlyCollection<string> successfulToolCallIds,
+        int iteration)
+    {
+        if (successfulToolCallIds.Count == 0)
+            return;
+
+        var successfulIds = successfulToolCallIds.ToHashSet(StringComparer.Ordinal);
+        var ordinal = _successfulToolEvidence.Count;
+
+        foreach (var result in toolResults)
+        {
+            if (string.IsNullOrWhiteSpace(result.ToolCallId) || !successfulIds.Contains(result.ToolCallId))
+                continue;
+
+            var excerpt = BuildToolEvidenceExcerpt(result.Content);
+            if (string.IsNullOrWhiteSpace(excerpt))
+                continue;
+
+            ordinal++;
+            _successfulToolEvidence.Add(new ToolEvidence(
+                result.Name ?? "unknown",
+                result.ToolCallId,
+                excerpt,
+                iteration,
+                ordinal));
+        }
+
+        if (_successfulToolEvidence.Count > MaxFallbackEvidenceItems)
+        {
+            _successfulToolEvidence.RemoveRange(0, _successfulToolEvidence.Count - MaxFallbackEvidenceItems);
+        }
+    }
+
+    private static string? BuildToolEvidenceExcerpt(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var normalized = string.Join(
+            " ",
+            content.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        if (normalized.StartsWith("Error executing tool:", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (normalized.Length > MaxFallbackEvidenceChars)
+            normalized = normalized[..MaxFallbackEvidenceChars].TrimEnd() + "...";
+
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private void CompleteCurrentTurnFromPostToolEvidenceOrFail()
+    {
+        if (_successfulToolEvidence.Count == 0)
+        {
+            _log.Warning(
+                "LLM produced repeated empty responses after tool work but no successful evidence was retained; failing turn");
+            FailCurrentTurn(
+                EmptyResponseFallbackMessage,
+                new InvalidOperationException("LLM produced repeated empty responses after tool execution and no usable evidence existed for fallback synthesis."),
+                ErrorCategory.ProviderFailure);
+            return;
+        }
+
+        var fallbackReply = BuildDeterministicToolEvidenceReply();
+        _log.Warning(
+            "LLM produced repeated empty responses after tool work; emitting deterministic evidence-backed fallback using {EvidenceCount} retained item(s)",
+            _successfulToolEvidence.Count);
+        CompleteCurrentTurnWithDeterministicText(fallbackReply);
+    }
+
+    private string BuildDeterministicToolEvidenceReply()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("I couldn't get the model to produce a final response, but here's a best-effort answer based on the tool work I completed:");
+
+        foreach (var evidence in _successfulToolEvidence)
+        {
+            builder.Append("- ");
+            builder.Append(evidence.ToolName);
+            builder.Append(": ");
+            builder.AppendLine(evidence.Excerpt);
+        }
+
+        return builder.ToString().TrimEnd();
     }
 
     private long StartProcessingWatchdog(string operationName, TimeSpan timeout)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -53,7 +53,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly ILoggingAdapter _log;
 
     // Transient state (not persisted)
-    private readonly List<SendUserMessage> _buffer = new();
     private readonly Dictionary<IActorRef, OutputFilter> _subscribers = new();
     private readonly List<AITool> _availableTools = new();
     private readonly ToolRegistry? _fullRegistry;
@@ -69,6 +68,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private const int MaxPreToolEmptyResponseRetries = 2;
     private const string EmptyResponseFallbackMessage = "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
+    private const string ToolBudgetFallbackMessage = "I hit my tool-use limit before I could finish. Please narrow the request or tell me what to focus on next, and I'll continue from there.";
+    private const string TurnBudgetFallbackMessage = "I spent too long working on that turn and had to stop. Please try again with a narrower follow-up.";
 
     // Whether we already sent a post-tool empty-response nudge in this tool chain
     private bool _postToolNudgeSent;
@@ -84,8 +85,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     // Processing watchdog state (non-persistent)
     private static readonly object ProcessingWatchdogTimerKey = new();
+    private static readonly object TurnBudgetTimerKey = new();
     private long _processingOperationId;
     private string? _processingOperationName;
+    private long _activeTurnBudgetId;
+    private SerializableChatMessage? _activeBufferedReplayMessage;
 
     // Per-turn diagnostic correlation (ephemeral)
     private string? _activeTurnId;
@@ -162,6 +166,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _systemPromptRecovered = true;
         });
         Recover<TurnRecorded>(evt => _state = _state.Apply(evt));
+        Recover<TurnFailedRecorded>(evt => _state = _state.Apply(evt));
+        Recover<BufferedInputAccepted>(evt => _state = _state.Apply(evt));
         Recover<SessionTitleSet>(evt => _state = _state.Apply(evt));
         Recover<SessionCompacted>(evt => _state = _state.Apply(evt));
         Recover<SnapshotOffer>(offer =>
@@ -185,6 +191,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             Become(Ready);
+
+            if (_state.PendingBufferedInputs.Count > 0)
+                Self.Tell(new ResumeBufferedReplay());
 
             if (_sessionLogsBasePath is not null)
             {
@@ -216,8 +225,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<ProcessingWatchdogExpired>(_ => { });
+        Command<TurnBudgetExpired>(_ => { });
         Command<CompactionWorkCompleted>(_ => { });
         Command<CompactionWorkFailed>(_ => { });
+        Command<ResumeBufferedReplay>(_ => ResumeBufferedReplayOrBecomeReady());
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
 
         Command<SendUserMessage>(cmd =>
@@ -231,11 +242,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 cmd.Content?.Length ?? 0);
             _logActor?.Tell(cmd);
 
-            _toolIterationCount = 0;
-            _postToolNudgeSent = false;
-            _preToolEmptyResponseCount = 0;
-            _forceNoToolsActive = false;
-            PrepareDiscoveredToolsForNewTurn();
+            ResetTurnScopedState();
 
             // Modality gate: strip unsupported media references
             var mediaRefs = cmd.MediaReferences;
@@ -275,10 +282,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             var userContent = cmd.Content ?? string.Empty;
-            _state = _state.AddUserMessage(userContent, mediaRefs.Count > 0 ? mediaRefs : null);
+            var userMessage = CreateUserMessage(userContent, mediaRefs.Count > 0 ? mediaRefs : null);
             TryReplyAck();
-            FireLlmCall(userContent);
-            Become(Processing);
+            BeginTurn(userMessage, consumesBufferedInput: false);
         });
     }
 
@@ -292,7 +298,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<SendUserMessage>(cmd =>
         {
             _log.Info("Buffering user message (LLM call in progress)");
-            _buffer.Add(cmd);
+            BufferBusyTurnInput(cmd);
             TryReplyAck();
         });
 
@@ -301,6 +307,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<LlmResponseReceived>(msg =>
         {
+            if (!IsCurrentProcessingOperation(msg.OperationId, "llm-call"))
+                return;
+
             StopProcessingWatchdog();
 
             var response = msg.Response;
@@ -314,10 +323,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     "turn_force_no_tools_violation toolCallCount={ToolCallCount} max={Max}",
                     toolCalls.Count,
                     _config.MaxToolIterationsPerTurn);
-                FailCurrentTurn(
-                    EmptyResponseFallbackMessage,
-                    new InvalidOperationException("LLM continued requesting tools after tool execution was disabled for this turn."),
-                    ErrorCategory.ProviderFailure);
+                CompleteCurrentTurnWithDeterministicText(ToolBudgetFallbackMessage);
                 return;
             }
 
@@ -386,6 +392,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<LlmResponseDeltaReceived>(msg =>
         {
+            if (!IsCurrentProcessingOperation(msg.OperationId, "llm-call"))
+                return;
+
             RefreshProcessingWatchdogIfActive();
 
             switch (msg.Content)
@@ -410,6 +419,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<ToolExecutionCompleted>(msg =>
         {
+            if (!IsCurrentProcessingOperation(msg.OperationId, "tool-execution"))
+                return;
+
             StopProcessingWatchdog();
 
             var hasVerifiedToolFinding = msg.ToolResults.Any(r =>
@@ -574,6 +586,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<ToolExecutionFailed>(msg =>
         {
+            if (!IsCurrentProcessingOperation(msg.OperationId, "tool-execution"))
+                return;
+
             StopProcessingWatchdog();
             TurnLog().Error(msg.Cause, "turn_tool_execution_failed");
 
@@ -584,6 +599,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<LlmCallFailed>(msg =>
         {
+            if (!IsCurrentProcessingOperation(msg.OperationId, "llm-call"))
+                return;
+
             StopProcessingWatchdog();
             TurnLog().Error(msg.Cause, "turn_llm_call_failed");
 
@@ -611,6 +629,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             FailCurrentTurn("I encountered a timeout while processing your message. Please try again.", timeoutCause, ErrorCategory.Timeout);
         });
 
+        Command<TurnBudgetExpired>(msg =>
+        {
+            if (!IsCurrentTurnBudget(msg))
+                return;
+
+            StopProcessingWatchdog();
+            TurnLog().Warning("turn_wall_clock_budget_exceeded maxSeconds={MaxSeconds}", _config.MaxTurnDurationSeconds);
+            FailCurrentTurn(TurnBudgetFallbackMessage, new TimeoutException(
+                $"Turn exceeded wall-clock budget of {_config.MaxTurnDurationSeconds}s"), ErrorCategory.Timeout);
+        });
+
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
     }
 
@@ -625,9 +654,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<SendUserMessage>(cmd =>
         {
             _log.Info("Buffering user message (compaction in progress)");
-            _buffer.Add(cmd);
+            BufferBusyTurnInput(cmd);
             TryReplyAck();
         });
+
+        Command<ResumeBufferedReplay>(_ => { });
 
         Command<ProcessingWatchdogExpired>(msg =>
         {
@@ -656,9 +687,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<CompactionTriggered>(msg =>
         {
             var timeout = GetCompactionTimeout();
-            StartProcessingWatchdog("compaction", timeout);
-
-            var operationId = _processingOperationId;
+            var operationId = StartProcessingWatchdog("compaction", timeout);
             var stateSnapshot = _state;
             var self = Self;
             var log = _log;
@@ -802,22 +831,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void DrainBufferOrReady()
     {
-        if (_buffer.Count > 0)
-        {
-            _log.Info("Post-compaction: draining {BufferCount} buffered message(s)", _buffer.Count);
-            foreach (var buffered in _buffer)
-            {
-                var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
-                _state = _state.AddUserMessage(buffered.Content, refs);
-            }
-            _buffer.Clear();
-            FireLlmCall();
-            Become(Processing);
-        }
-        else
-        {
-            Become(Ready);
-        }
+        ResumeBufferedReplayOrBecomeReady();
     }
 
     private TimeSpan GetCompactionTimeout()
@@ -1151,7 +1165,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var maxInlineToolResultChars = _config.MaxInlineToolResultChars;
         var toolExecutionTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.ToolExecutionTimeoutSeconds));
 
-        StartProcessingWatchdog("tool-execution", toolExecutionTimeout);
+        var operationId = StartProcessingWatchdog("tool-execution", toolExecutionTimeout);
 
         // Capture subscriber snapshot for subagent activity notifications.
         // These are emitted directly from the tool execution thread via Tell(),
@@ -1180,7 +1194,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 timeout: toolExecutionTimeout,
                 cancellationToken: ct);
 
-        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor);
+        _ = ExecuteToolsAsync(executor, toolCalls, sessionId, auditLogger, tp, sessionDir, maxInlineToolResultChars, toolExecutionTimeout, self, emitSubAgentOutput, spawnChildActor, operationId);
     }
 
     private void HandleTextResponse(
@@ -1193,13 +1207,16 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _toolIterationCount = 0; // Reset for potential buffer drain (new logical turn)
 
         var reply = ChatMessageConverter.FromAiMessage(lastMessage);
-        var userMsg = _state.FindLastUserMessage();
+        var consumesBufferedInput = _activeBufferedReplayMessage is not null;
+        var userMsg = consumesBufferedInput ? _activeBufferedReplayMessage : _state.FindLastUserMessage();
 
         // Track input token count for compaction threshold check
         if (usage?.InputTokenCount is > 0)
         {
             _lastInputTokenCount = usage.InputTokenCount.Value;
         }
+
+        StopTurnBudget();
 
         var turnEvent = new TurnRecorded
         {
@@ -1210,7 +1227,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 Content = string.Empty
             },
             AssistantReply = reply,
-            RecordedAtMs = NowMs()
+            RecordedAtMs = NowMs(),
+            ConsumesBufferedInput = consumesBufferedInput
         };
 
         Persist(turnEvent, evt =>
@@ -1218,8 +1236,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _state = _state with
             {
                 History = _state.History.Add(evt.AssistantReply),
-                TurnCount = _state.TurnCount + 1
+                TurnCount = _state.TurnCount + 1,
+                PendingBufferedInputs = evt.ConsumesBufferedInput && _state.PendingBufferedInputs.Count > 0
+                    ? _state.PendingBufferedInputs.RemoveAt(0)
+                    : _state.PendingBufferedInputs
             };
+            _activeBufferedReplayMessage = null;
 
             EmitResponseOutputs(lastMessage, usage, includeText: true, includeThinking: true);
             MaybeSnapshot();
@@ -1269,22 +1291,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void DrainBufferedMessagesOrBecomeReady()
     {
-        if (_buffer.Count > 0)
-        {
-            TurnLog().Info("turn_buffer_drain count={BufferCount}", _buffer.Count);
-            foreach (var buffered in _buffer)
-            {
-                var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
-                _state = _state.AddUserMessage(buffered.Content, refs);
-            }
-
-            _buffer.Clear();
-            FireLlmCall();
-            Become(Processing);
-            return;
-        }
-
-        Become(Ready);
+        ResumeBufferedReplayOrBecomeReady();
     }
 
     private bool ShouldCompact()
@@ -1413,12 +1420,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     protected override void PreRestart(Exception reason, object message)
     {
-        foreach (var buffered in _buffer)
-        {
-            Self.Tell(buffered);
-        }
-        _buffer.Clear();
-
         base.PreRestart(reason, message);
     }
 
@@ -1559,6 +1560,94 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private long NowMs() => _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
+    private static SerializableChatMessage CreateUserMessage(
+        string content,
+        List<SerializableMediaReference>? mediaReferences = null)
+    {
+        var msg = new SerializableChatMessage
+        {
+            Role = Protocol.ChatRole.User,
+            Content = content
+        };
+
+        if (mediaReferences is { Count: > 0 })
+            msg.MediaReferences = mediaReferences;
+
+        return msg;
+    }
+
+    private void ResetTurnScopedState()
+    {
+        _toolIterationCount = 0;
+        _postToolNudgeSent = false;
+        _preToolEmptyResponseCount = 0;
+        _forceNoToolsActive = false;
+        _activeBufferedReplayMessage = null;
+        PrepareDiscoveredToolsForNewTurn();
+    }
+
+    private void BeginTurn(SerializableChatMessage userMessage, bool consumesBufferedInput)
+    {
+        _activeBufferedReplayMessage = consumesBufferedInput ? userMessage : null;
+        _state = _state with { History = _state.History.Add(userMessage) };
+        StartTurnBudget();
+        FireLlmCall(userMessage.Content);
+        Become(Processing);
+    }
+
+    private void BufferBusyTurnInput(SendUserMessage cmd)
+    {
+        var refs = cmd.MediaReferences.Count > 0 ? cmd.MediaReferences : null;
+        var evt = new BufferedInputAccepted
+        {
+            SessionId = _sessionId,
+            UserMessage = CreateUserMessage(cmd.Content ?? string.Empty, refs),
+            AcceptedAtMs = NowMs()
+        };
+
+        Persist(evt, persisted =>
+        {
+            _state = _state.Apply(persisted);
+            TurnLog().Info("turn_buffered_input_accepted count={BufferCount}", _state.PendingBufferedInputs.Count);
+        });
+    }
+
+    private void ResumeBufferedReplayOrBecomeReady()
+    {
+        var nextBuffered = _state.PeekPendingBufferedInput();
+        if (nextBuffered is null)
+        {
+            _activeBufferedReplayMessage = null;
+            Become(Ready);
+            return;
+        }
+
+        ResetTurnScopedState();
+        TurnLog().Info("turn_buffer_drain count={BufferCount}", _state.PendingBufferedInputs.Count);
+        BeginTurn(nextBuffered, consumesBufferedInput: true);
+    }
+
+    private void StartTurnBudget()
+    {
+        _activeTurnBudgetId++;
+        Timers.StartSingleTimer(
+            TurnBudgetTimerKey,
+            new TurnBudgetExpired { TurnId = _activeTurnBudgetId },
+            TimeSpan.FromSeconds(Math.Max(1, _config.MaxTurnDurationSeconds)));
+    }
+
+    private void StopTurnBudget()
+    {
+        Timers.Cancel(TurnBudgetTimerKey);
+    }
+
+    private bool IsCurrentTurnBudget(TurnBudgetExpired msg)
+        => msg.TurnId == _activeTurnBudgetId;
+
+    private bool IsCurrentProcessingOperation(long operationId, string operationName)
+        => operationId == _processingOperationId
+           && string.Equals(operationName, _processingOperationName, StringComparison.Ordinal);
+
     private void SetSystemPrompt()
     {
         var content = _promptProvider.GetSystemPrompt();
@@ -1628,14 +1717,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             };
         }
 
-        StartProcessingWatchdog("llm-call", timeout);
+        var operationId = StartProcessingWatchdog("llm-call", timeout);
 
         TurnLog().Info("turn_llm_call_start messages={MessageCount} toolsEnabled={ToolsEnabled} forceNoTools={ForceNoTools}",
             messages.Count,
             options?.Tools?.Count > 0,
             forceNoTools);
 
-        _ = InvokeLlmAsync(client, messages, options, self, timeout);
+        _ = InvokeLlmAsync(client, messages, options, self, timeout, operationId);
     }
 
     private AutomaticRecallResult ResolveRecallBundle(string? recallQuery)
@@ -1813,18 +1902,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         List<AiChatMessage> messages,
         ChatOptions? options,
         IActorRef self,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        long operationId)
     {
         try
         {
             using var cts = new CancellationTokenSource(timeout);
-            var response = await InvokeStreamingResponseAsync(client, messages, options, self, cts.Token);
+            var response = await InvokeStreamingResponseAsync(client, messages, options, self, cts.Token, operationId);
             self.Tell(response);
         }
         catch (OperationCanceledException ex)
         {
             self.Tell(new LlmCallFailed
             {
+                OperationId = operationId,
                 Cause = new TimeoutException(
                     $"LLM call exceeded timeout of {timeout.TotalSeconds:F0}s",
                     ex)
@@ -1832,7 +1923,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         catch (Exception ex)
         {
-            self.Tell(new LlmCallFailed { Cause = ex });
+            self.Tell(new LlmCallFailed { OperationId = operationId, Cause = ex });
         }
     }
 
@@ -1841,7 +1932,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         List<AiChatMessage> messages,
         ChatOptions? options,
         IActorRef self,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long operationId)
     {
         var contents = new List<AIContent>();
         var updates = new List<ChatResponseUpdate>();
@@ -1875,11 +1967,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                                 {
                                     self.Tell(new LlmResponseDeltaReceived
                                     {
+                                        OperationId = operationId,
                                         Content = new TextContent(pendingTextDelta)
                                     });
                                 }
 
-                                self.Tell(new LlmResponseDeltaReceived { Content = content });
+                                self.Tell(new LlmResponseDeltaReceived { OperationId = operationId, Content = content });
                             }
                             break;
 
@@ -1896,11 +1989,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                                 {
                                     self.Tell(new LlmResponseDeltaReceived
                                     {
+                                        OperationId = operationId,
                                         Content = new TextReasoningContent(pendingThinkingDelta)
                                     });
                                 }
 
-                                self.Tell(new LlmResponseDeltaReceived { Content = content });
+                                self.Tell(new LlmResponseDeltaReceived { OperationId = operationId, Content = content });
                             }
                             break;
 
@@ -1928,6 +2022,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         return new LlmResponseReceived
         {
+            OperationId = operationId,
             Response = response,
             StreamedText = textDeltaCount > 1,
             StreamedThinking = thinkingDeltaCount > 1,
@@ -1952,7 +2047,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         TimeSpan timeout,
         IActorRef self,
         Action<SubAgentOutput> emitSubAgentOutput,
-        Func<object, string, CancellationToken, Task<object>> spawnChildActor)
+        Func<object, string, CancellationToken, Task<object>> spawnChildActor,
+        long operationId)
     {
         try
         {
@@ -1975,6 +2071,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var fileAttachments = results.SelectMany(r => r.FileAttachments).ToList();
             self.Tell(new ToolExecutionCompleted
             {
+                OperationId = operationId,
                 ToolResults = results.Select(r => r.Message).ToList(),
                 FileAttachments = fileAttachments,
                 CompletedSubAgentRuns = results
@@ -1989,6 +2086,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             self.Tell(new ToolExecutionFailed
             {
+                OperationId = operationId,
                 Cause = new TimeoutException(
                     $"Tool execution exceeded timeout of {timeout.TotalSeconds:F0}s",
                     ex)
@@ -1996,7 +2094,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
         catch (Exception ex)
         {
-            self.Tell(new ToolExecutionFailed { Cause = ex });
+            self.Tell(new ToolExecutionFailed { OperationId = operationId, Cause = ex });
         }
     }
 
@@ -2521,7 +2619,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }, OutputFilter.Usage);
     }
 
-    private void StartProcessingWatchdog(string operationName, TimeSpan timeout)
+    private long StartProcessingWatchdog(string operationName, TimeSpan timeout)
     {
         _processingOperationId++;
         _processingOperationName = operationName;
@@ -2534,6 +2632,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 OperationName = operationName
             },
             timeout);
+
+        return _processingOperationId;
     }
 
     private void RefreshProcessingWatchdogIfActive()
@@ -2562,9 +2662,71 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _processingOperationName = null;
     }
 
+    private void CompleteCurrentTurnWithDeterministicText(string text)
+    {
+        var consumesBufferedInput = _activeBufferedReplayMessage is not null;
+        var userMessage = consumesBufferedInput ? _activeBufferedReplayMessage : _state.FindLastUserMessage();
+        var reply = new SerializableChatMessage
+        {
+            Role = Protocol.ChatRole.Assistant,
+            Content = text
+        };
+
+        StopTurnBudget();
+
+        var evt = new TurnRecorded
+        {
+            SessionId = _sessionId,
+            UserMessage = userMessage ?? new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.User,
+                Content = string.Empty
+            },
+            AssistantReply = reply,
+            RecordedAtMs = NowMs(),
+            ConsumesBufferedInput = consumesBufferedInput
+        };
+
+        Persist(evt, persisted =>
+        {
+            _state = _state with
+            {
+                History = _state.History.Add(persisted.AssistantReply),
+                TurnCount = _state.TurnCount + 1,
+                PendingBufferedInputs = persisted.ConsumesBufferedInput && _state.PendingBufferedInputs.Count > 0
+                    ? _state.PendingBufferedInputs.RemoveAt(0)
+                    : _state.PendingBufferedInputs
+            };
+            _activeBufferedReplayMessage = null;
+
+            EmitOutput(new TextOutput
+            {
+                SessionId = _sessionId,
+                Text = text
+            }, OutputFilter.Text);
+            EmitOutput(new TurnCompleted
+            {
+                SessionId = _sessionId,
+                TurnNumber = _state.TurnCount
+            });
+
+            MaybeSnapshot();
+            MaybeGenerateTitle();
+            DrainBufferedMessagesOrBecomeReady();
+        });
+    }
+
     private void FailCurrentTurn(string errorMessage, Exception cause, ErrorCategory category = ErrorCategory.Unknown)
     {
-        _state = _state.AddErrorReply(errorMessage);
+        var consumesBufferedInput = _activeBufferedReplayMessage is not null;
+        var userMessage = consumesBufferedInput ? _activeBufferedReplayMessage : _state.FindLastUserMessage();
+        var reply = new SerializableChatMessage
+        {
+            Role = Protocol.ChatRole.Assistant,
+            Content = errorMessage
+        };
+
+        StopTurnBudget();
 
         var correlationId = Guid.NewGuid();
 
@@ -2574,21 +2736,48 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             correlationId,
             errorMessage);
 
-        EmitOutput(new ErrorOutput
+        var evt = new TurnFailedRecorded
         {
             SessionId = _sessionId,
-            Message = errorMessage,
-            Category = category,
-            CorrelationId = correlationId,
-            Cause = cause
-        });
-        EmitOutput(new TurnCompleted
-        {
-            SessionId = _sessionId,
-            TurnNumber = _state.TurnCount
-        });
+            UserMessage = userMessage ?? new SerializableChatMessage
+            {
+                Role = Protocol.ChatRole.User,
+                Content = string.Empty
+            },
+            AssistantReply = reply,
+            RecordedAtMs = NowMs(),
+            ConsumesBufferedInput = consumesBufferedInput,
+            ErrorCategory = (int)category
+        };
 
-        DrainBufferedMessagesOrBecomeReady();
+        Persist(evt, persisted =>
+        {
+            _state = _state with
+            {
+                History = _state.History.Add(persisted.AssistantReply),
+                TurnCount = _state.TurnCount + 1,
+                PendingBufferedInputs = persisted.ConsumesBufferedInput && _state.PendingBufferedInputs.Count > 0
+                    ? _state.PendingBufferedInputs.RemoveAt(0)
+                    : _state.PendingBufferedInputs
+            };
+            _activeBufferedReplayMessage = null;
+
+            EmitOutput(new ErrorOutput
+            {
+                SessionId = _sessionId,
+                Message = errorMessage,
+                Category = category,
+                CorrelationId = correlationId,
+                Cause = cause
+            });
+            EmitOutput(new TurnCompleted
+            {
+                SessionId = _sessionId,
+                TurnNumber = _state.TurnCount
+            });
+
+            DrainBufferedMessagesOrBecomeReady();
+        });
     }
 
     private void EmitOutput(SessionOutput output, OutputFilter requiredFlag = OutputFilter.None)

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -24,6 +24,9 @@ public sealed record SessionState
 
     public string? Title { get; init; }
 
+    public ImmutableList<SerializableChatMessage> PendingBufferedInputs { get; init; } =
+        ImmutableList<SerializableChatMessage>.Empty;
+
     // ── Event application (pure functions) ──
 
     public SessionState Apply(SystemPromptSet evt)
@@ -45,10 +48,29 @@ public sealed record SessionState
 
     public SessionState Apply(TurnRecorded evt)
     {
+        var pending = evt.ConsumesBufferedInput && PendingBufferedInputs.Count > 0
+            ? PendingBufferedInputs.RemoveAt(0)
+            : PendingBufferedInputs;
+
         return this with
         {
             History = History.Add(evt.UserMessage).Add(evt.AssistantReply),
-            TurnCount = TurnCount + 1
+            TurnCount = TurnCount + 1,
+            PendingBufferedInputs = pending
+        };
+    }
+
+    public SessionState Apply(TurnFailedRecorded evt)
+    {
+        var pending = evt.ConsumesBufferedInput && PendingBufferedInputs.Count > 0
+            ? PendingBufferedInputs.RemoveAt(0)
+            : PendingBufferedInputs;
+
+        return this with
+        {
+            History = History.Add(evt.UserMessage).Add(evt.AssistantReply),
+            TurnCount = TurnCount + 1,
+            PendingBufferedInputs = pending
         };
     }
 
@@ -68,6 +90,11 @@ public sealed record SessionState
 
         builder.AddRange(evt.CompactedMessages);
         return this with { History = builder.ToImmutable() };
+    }
+
+    public SessionState Apply(BufferedInputAccepted evt)
+    {
+        return this with { PendingBufferedInputs = PendingBufferedInputs.Add(evt.UserMessage) };
     }
 
     // ── Command helpers ──
@@ -105,6 +132,9 @@ public sealed record SessionState
             TurnCount = TurnCount + 1
         };
     }
+
+    public SerializableChatMessage? PeekPendingBufferedInput()
+        => PendingBufferedInputs.Count > 0 ? PendingBufferedInputs[0] : null;
 
     /// <summary>
     /// Add a transient system nudge to history to correct LLM behavior (e.g., empty response recovery).
@@ -208,7 +238,8 @@ public sealed record SessionState
         {
             History = new List<SerializableChatMessage>(History),
             TurnCount = TurnCount,
-            Title = Title
+            Title = Title,
+            PendingBufferedInputs = new List<SerializableChatMessage>(PendingBufferedInputs)
         };
     }
 
@@ -218,7 +249,8 @@ public sealed record SessionState
         {
             History = ImmutableList.CreateRange(snapshot.History),
             TurnCount = snapshot.TurnCount,
-            Title = snapshot.Title
+            Title = snapshot.Title,
+            PendingBufferedInputs = ImmutableList.CreateRange(snapshot.PendingBufferedInputs)
         };
     }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -39,6 +39,7 @@ public sealed class SubAgentActor : ReceiveActor
     private CancellationTokenSource? _executionCts;
     private CancellationTokenRegistration _externalCancellationRegistration;
     private ToolExecutionContext _toolExecutionContext = ToolExecutionContext.Empty;
+    private long _operationId;
 
     public SubAgentActor(
         SubAgentDefinition definition,
@@ -98,6 +99,9 @@ public sealed class SubAgentActor : ReceiveActor
     {
         Receive<LlmResponseReceived>(msg =>
         {
+            if (msg.OperationId != _operationId)
+                return;
+
             var response = msg.Response;
             var lastMessage = response.Messages[^1];
 
@@ -115,6 +119,9 @@ public sealed class SubAgentActor : ReceiveActor
 
         Receive<ToolExecutionCompleted>(msg =>
         {
+            if (msg.OperationId != _operationId)
+                return;
+
             // Append tool results as MEAI messages and log each result
             foreach (var result in msg.ToolResults)
             {
@@ -143,12 +150,18 @@ public sealed class SubAgentActor : ReceiveActor
 
         Receive<ToolExecutionFailed>(msg =>
         {
+            if (msg.OperationId != _operationId)
+                return;
+
             _log.Error(msg.Cause, "SubAgent [{AgentName}] tool execution failed", _definition.Name);
             Complete(false, $"Tool execution failed: {msg.Cause.Message}");
         });
 
         Receive<LlmCallFailed>(msg =>
         {
+            if (msg.OperationId != _operationId)
+                return;
+
             _log.Error(msg.Cause, "SubAgent [{AgentName}] LLM call failed", _definition.Name);
             Complete(false, $"LLM call failed: {msg.Cause.Message}");
         });
@@ -180,13 +193,15 @@ public sealed class SubAgentActor : ReceiveActor
 
         var self = Self;
         var executor = new DispatchingToolExecutor(_toolRegistry);
+        var operationId = ++_operationId;
 
         _ = ExecuteToolsAsync(
             executor,
             toolCalls,
             _toolExecutionContext,
             _executionCts?.Token ?? CancellationToken.None,
-            self);
+            self,
+            operationId);
     }
 
     private void FireLlmCall(bool forceNoTools = false)
@@ -194,6 +209,7 @@ public sealed class SubAgentActor : ReceiveActor
         var self = Self;
         var client = _chatClient;
         var messages = new List<AiChatMessage>(_history);
+        var operationId = ++_operationId;
 
         ChatOptions? options = null;
         if (!forceNoTools && _aiTools.Count > 0)
@@ -204,7 +220,7 @@ public sealed class SubAgentActor : ReceiveActor
             };
         }
 
-        _ = InvokeLlmAsync(client, messages, options, _executionCts?.Token ?? CancellationToken.None, self);
+        _ = InvokeLlmAsync(client, messages, options, _executionCts?.Token ?? CancellationToken.None, self, operationId);
     }
 
     private void Complete(bool success, string output)
@@ -312,17 +328,17 @@ public sealed class SubAgentActor : ReceiveActor
     // ── Static async helpers (same pattern as LlmSessionActor) ──
 
     private static async Task InvokeLlmAsync(
-        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, CancellationToken ct, IActorRef self)
+        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, CancellationToken ct, IActorRef self, long operationId)
     {
         try
         {
             // No streaming for subagents — just get the complete response
             var response = await client.GetResponseAsync(messages, options, ct);
-            self.Tell(new LlmResponseReceived { Response = response });
+            self.Tell(new LlmResponseReceived { OperationId = operationId, Response = response });
         }
         catch (Exception ex)
         {
-            self.Tell(new LlmCallFailed { Cause = ex });
+            self.Tell(new LlmCallFailed { OperationId = operationId, Cause = ex });
         }
     }
 
@@ -331,7 +347,8 @@ public sealed class SubAgentActor : ReceiveActor
         List<FunctionCallContent> toolCalls,
         ToolExecutionContext executionContext,
         CancellationToken ct,
-        IActorRef self)
+        IActorRef self,
+        long operationId)
     {
         try
         {
@@ -363,12 +380,13 @@ public sealed class SubAgentActor : ReceiveActor
             var results = await Task.WhenAll(tasks);
             self.Tell(new ToolExecutionCompleted
             {
+                OperationId = operationId,
                 ToolResults = results.ToList()
             });
         }
         catch (Exception ex)
         {
-            self.Tell(new ToolExecutionFailed { Cause = ex });
+            self.Tell(new ToolExecutionFailed { OperationId = operationId, Cause = ex });
         }
     }
 

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -24,9 +24,13 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
     private readonly StringBuilder _buffer = new();
     private const string EmptyTurnFallbackText = ":warning: I didn't manage to produce a reply. Please try rephrasing or sending your message again.";
+    private const string WorkingAcknowledgementText = "Working on it.";
+    private const int HiddenToolAckThreshold = 3;
     private bool _sawTextDelta;
-    private bool _postedThisTurn;
+    private bool _ackPostedThisTurn;
+    private bool _hasTerminalOutputThisTurn;
     private bool _uploadedFileThisTurn;
+    private int _toolCallCountThisTurn;
 
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
@@ -318,7 +322,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
             new SessionPipelineOptions
             {
                 ChannelType = "slack",
-                Filter = OutputFilter.Text | OutputFilter.Files
+                Filter = OutputFilter.Text | OutputFilter.Files | OutputFilter.ToolCalls
             },
             materializer: _materializer,
             cancellationToken: initCts.Token);
@@ -396,56 +400,78 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 _sawTextDelta = true;
                 break;
 
+            case ToolCallOutput:
+                _toolCallCountThisTurn++;
+                if (!_ackPostedThisTurn
+                    && !_hasTerminalOutputThisTurn
+                    && _toolCallCountThisTurn >= HiddenToolAckThreshold)
+                {
+                    if (await SafePostAsync(WorkingAcknowledgementText))
+                        _ackPostedThisTurn = true;
+                }
+
+                break;
+
             case TextOutput text:
-                if (!_sawTextDelta && !_postedThisTurn)
+                if (!_sawTextDelta && !_hasTerminalOutputThisTurn)
                 {
                     var fullText = text.Text?.Trim();
                     if (!string.IsNullOrWhiteSpace(fullText))
                     {
-                        await SafePostAsync(fullText);
-                        _postedThisTurn = true;
+                        if (await SafePostAsync(fullText))
+                            _hasTerminalOutputThisTurn = true;
                     }
                 }
 
                 break;
 
             case FileOutput file:
-                await SafeUploadFileAsync(file);
+                if (await SafeUploadFileAsync(file))
+                {
+                    _uploadedFileThisTurn = true;
+                    _hasTerminalOutputThisTurn = true;
+                }
                 break;
 
             case ErrorOutput err:
                 var refId = err.CorrelationId.ToString("N")[..8];
-                await SafePostAsync($":warning: {err.Message} (ref: {refId})");
-                _postedThisTurn = true;
+                if (await SafePostAsync($":warning: {err.Message} (ref: {refId})"))
+                    _hasTerminalOutputThisTurn = true;
                 _buffer.Clear();
                 break;
 
             case TurnCompleted:
-                if (_sawTextDelta && !_postedThisTurn)
+                if (_sawTextDelta && !_hasTerminalOutputThisTurn)
                 {
                     var reply = _buffer.ToString().Trim();
                     if (!string.IsNullOrWhiteSpace(reply))
-                        await SafePostAsync(reply);
+                    {
+                        if (await SafePostAsync(reply))
+                            _hasTerminalOutputThisTurn = true;
+                    }
                     else
                         _log.Debug("Turn completed with no buffered reply text");
                 }
 
-                if (!_postedThisTurn && !_uploadedFileThisTurn)
+                if (!_hasTerminalOutputThisTurn && !_uploadedFileThisTurn)
                 {
                     _log.Warning("Turn completed without visible Slack output; posting fallback reply");
-                    await SafePostAsync(EmptyTurnFallbackText);
+                    if (await SafePostAsync(EmptyTurnFallbackText))
+                        _hasTerminalOutputThisTurn = true;
                 }
 
                 _buffer.Clear();
                 _sawTextDelta = false;
-                _postedThisTurn = false;
+                _ackPostedThisTurn = false;
+                _hasTerminalOutputThisTurn = false;
                 _uploadedFileThisTurn = false;
+                _toolCallCountThisTurn = 0;
 
                 break;
         }
     }
 
-    private async Task SafePostAsync(string text)
+    private async Task<bool> SafePostAsync(string text)
     {
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
@@ -458,20 +484,23 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
             _log.Info("Posted Slack reply message");
             ChannelTelemetry.RecordSlackReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return true;
         }
         catch (OperationCanceledException ex)
         {
             _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return false;
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return false;
         }
     }
 
-    private async Task SafeUploadFileAsync(FileOutput file)
+    private async Task<bool> SafeUploadFileAsync(FileOutput file)
     {
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
@@ -479,7 +508,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
             if (!File.Exists(file.FilePath))
             {
                 _log.Warning("File not found for upload: {Path}", file.FilePath);
-                return;
+                return false;
             }
 
             using var cts = new CancellationTokenSource(ReplyOperationTimeout);
@@ -490,18 +519,20 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 file.FileName,
                 cts.Token);
 
-            _uploadedFileThisTurn = true;
             _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
+            return true;
         }
         catch (OperationCanceledException ex)
         {
             _log.Error(ex, "Timed out uploading file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return false;
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return false;
         }
     }
 

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -123,6 +123,13 @@ public sealed record SessionConfig
     public int ToolExecutionTimeoutSeconds { get; init; } = 90;
 
     /// <summary>
+    /// Absolute wall-clock timeout in seconds for an entire user turn across
+    /// all LLM and tool iterations. Prevents turns from remaining active
+    /// indefinitely even when individual operations keep making partial progress.
+    /// </summary>
+    public int MaxTurnDurationSeconds { get; init; } = 300;
+
+    /// <summary>
     /// How long a session can be idle before passivating.
     /// The actor saves a snapshot and stops itself; re-creation by
     /// <c>GenericChildPerEntityParent</c> on next message recovers state from journal.


### PR DESCRIPTION
## Summary
- harden session turn processing and Slack long-running reply handling so stale completions, buffered follow-ups, and empty post-tool finalization attempts recover cleanly
- synthesize a deterministic best-effort final reply from successful tool evidence when the model keeps returning empty after tool work, while preserving generic failure when no usable evidence exists
- sync the matching OpenSpec/spec updates and extend actor and Slack integration coverage for the recovered turn paths