### PR TITLE
Fix Slack progress preambles during tool turns

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -222,6 +222,45 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Text_is_emitted_immediately_when_response_also_contains_tool_calls()
+    {
+        _fakeChatClient.PlannedResponses.Enqueue(
+        [
+            new TextContent("I'll look into that and send back the results."),
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "dell ai desktop" })
+        ]);
+
+        var sessionId = new SessionId("test-channel/tool-preamble");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("tool-preamble-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Find me images of Dell's newest AI desktop"
+        }, TimeSpan.FromSeconds(3));
+
+        var preamble = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Equal("I'll look into that and send back the results.", preamble.Text);
+
+        var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        Assert.Equal("web_search", toolCall.ToolName);
+
+        var finalText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("[fake] Response #2", finalText.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public async Task Sidecar_observation_promotes_strong_user_assertion_into_memory()
     {
         var gate = new MemoryProposalGate();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1118,6 +1118,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);
         _state = _state with { History = _state.History.Add(assistantMsg) };
 
+        // If the model included short user-facing text alongside tool calls,
+        // surface it immediately instead of waiting until the turn completes.
+        foreach (var content in lastMessage.Contents)
+        {
+            if (content is TextContent text && !string.IsNullOrWhiteSpace(text.Text))
+            {
+                EmitOutput(new TextOutput
+                {
+                    SessionId = _sessionId,
+                    Text = text.Text
+                }, OutputFilter.Text);
+            }
+        }
+
         // Emit tool call outputs to subscribers
         foreach (var tc in toolCalls)
         {


### PR DESCRIPTION
## Summary
- surface model-authored preamble text immediately when an assistant response includes both visible text and tool calls
- keep Slack users informed during long-running tool turns without relying on the generic channel-level fallback message
- add a regression test covering mixed text-plus-tool-call responses so future Slack/tool-turn changes preserve this behavior