### PR TITLE
fix(slack): stop false fallback warnings and surface preamble text during tool turns

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -476,6 +476,54 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Preamble_text_surfaces_before_tool_calls()
+    {
+        // Configure: LLM returns preamble text alongside tool calls
+        _fakeChatClient.PreambleText = "Let me search for that...";
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-p1", "browser_chrome_devtools/navigate_page",
+                new Dictionary<string, object?> { ["url"] = "https://example.com" })
+        ];
+        _fakeToolExecutor.Results["browser_chrome_devtools/navigate_page"] = "page loaded";
+
+        var sessionId = new SessionId("test-channel/preamble-test");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("preamble-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search for something"
+        }, TimeSpan.FromSeconds(3));
+
+        // Preamble text should arrive before tool calls
+        var preamble = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        Assert.Equal("Let me search for that...", preamble.Text);
+
+        // BufferFlush should arrive after preamble text
+        await subscriber.ExpectMsgAsync<BufferFlush>(TimeSpan.FromSeconds(3));
+
+        // Then tool call
+        var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        Assert.Equal("browser_chrome_devtools/navigate_page", toolCall.ToolName);
+
+        // After tool execution and follow-up LLM call, final text response
+        var finalText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        Assert.Contains("fake", finalText.Text, StringComparison.OrdinalIgnoreCase);
+
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public async Task Session_recovers_state_after_actor_is_killed()
     {
         var sessionId = new SessionId("test-channel/recovery-test");
@@ -582,6 +630,13 @@ internal sealed class FakeChatClient : IChatClient
     /// Simulates providers that hallucinate tool calls after the circuit breaker fires.
     /// </summary>
     public bool IgnoreToolAvailability { get; set; }
+
+    /// <summary>
+    /// When set, tool-call responses include this text as a preamble alongside the
+    /// <see cref="FunctionCallContent"/> items. Simulates the model producing
+    /// user-facing text (e.g., "Let me search for that...") before executing tools.
+    /// </summary>
+    public string? PreambleText { get; set; }
 
     /// <summary>
     /// When set, all responses include this usage data.
@@ -756,7 +811,10 @@ internal sealed class FakeChatClient : IChatClient
 
             if (returnToolCalls)
             {
-                var toolCallContents = new List<AIContent>(ToolCallsOnFirstCall);
+                var toolCallContents = new List<AIContent>();
+                if (!string.IsNullOrWhiteSpace(PreambleText))
+                    toolCallContents.Add(new TextContent(PreambleText));
+                toolCallContents.AddRange(ToolCallsOnFirstCall);
                 var toolCallMessage = new ChatMessage(
                     Microsoft.Extensions.AI.ChatRole.Assistant,
                     toolCallContents);

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -234,6 +234,14 @@ public sealed record SubAgentOutput : SessionOutput
 }
 
 /// <summary>
+/// Signals that subscribers should flush any buffered streamed text immediately.
+/// Emitted before tool execution begins when the model produces text alongside
+/// tool calls, so preamble text is visible to users before tools run.
+/// Lifecycle — always delivered regardless of <see cref="OutputFilter"/>.
+/// </summary>
+public sealed record BufferFlush : SessionOutput;
+
+/// <summary>
 /// Session context was compacted to stay within the context window.
 /// Lifecycle — always delivered regardless of <see cref="OutputFilter"/>.
 /// </summary>

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -124,6 +124,13 @@ public static class SessionOutputDtoMapper
             FindingsCount = msg.FindingsCount
         },
 
+        BufferFlush msg => new SessionOutputDto
+        {
+            Type = "buffer_flush",
+            SessionId = msg.SessionId.Value,
+            TimestampMs = msg.TimestampMs
+        },
+
         CompactionOutput msg => new SessionOutputDto
         {
             Type = "compaction",
@@ -258,6 +265,11 @@ public static class SessionOutputDtoMapper
                 MemoryDecision = dto.MemoryDecision,
                 MemoryDecisionReason = dto.MemoryDecisionReason,
                 FindingsCount = dto.FindingsCount ?? 0
+            },
+            "buffer_flush" => new BufferFlush
+            {
+                SessionId = sessionId,
+                TimestampMs = dto.TimestampMs
             },
             "compaction" => new CompactionOutput
             {

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -161,6 +161,10 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 TrackNotificationResult(toolResult);
                 break;
 
+            case BufferFlush:
+                // Reminder accumulates full text for final result -- no mid-turn flush needed.
+                break;
+
             case TurnCompleted:
                 var result = _buffer.ToString().Trim();
                 var notifyFailureMessage = BuildNotifyFailureMessage();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1118,6 +1118,31 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var assistantMsg = ChatMessageConverter.FromAiMessage(lastMessage);
         _state = _state with { History = _state.History.Add(assistantMsg) };
 
+        // Surface preamble text immediately before tool execution starts.
+        // TextOutput handles the non-streaming (single-delta) path where no
+        // TextDeltaOutput was emitted to subscribers.
+        // BufferFlush tells streaming adapters to flush their accumulated buffer
+        // so the preamble is visible to users before the potentially long tool phase.
+        var hasPreambleText = lastMessage.Contents
+            .OfType<TextContent>()
+            .Any(t => !string.IsNullOrWhiteSpace(t.Text));
+
+        if (hasPreambleText)
+        {
+            foreach (var content in lastMessage.Contents)
+            {
+                if (content is TextContent text && !string.IsNullOrWhiteSpace(text.Text))
+                {
+                    EmitOutput(new TextOutput
+                    {
+                        SessionId = _sessionId,
+                        Text = text.Text
+                    }, OutputFilter.Text);
+                }
+            }
+            EmitOutput(new BufferFlush { SessionId = _sessionId });
+        }
+
         // Emit tool call outputs to subscribers
         foreach (var tc in toolCalls)
         {

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -413,6 +413,20 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 await SafeUploadFileAsync(file);
                 break;
 
+            case BufferFlush:
+                if (_sawTextDelta)
+                {
+                    var preamble = _buffer.ToString().Trim();
+                    if (!string.IsNullOrWhiteSpace(preamble))
+                    {
+                        await SafePostAsync(preamble);
+                        _postedThisTurn = true;
+                    }
+                }
+                _buffer.Clear();
+                _sawTextDelta = false;
+                break;
+
             case ErrorOutput err:
                 var refId = err.CorrelationId.ToString("N")[..8];
                 await SafePostAsync($":warning: {err.Message} (ref: {refId})");
@@ -425,7 +439,10 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 {
                     var reply = _buffer.ToString().Trim();
                     if (!string.IsNullOrWhiteSpace(reply))
+                    {
                         await SafePostAsync(reply);
+                        _postedThisTurn = true;
+                    }
                     else
                         _log.Debug("Turn completed with no buffered reply text");
                 }

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -229,6 +229,26 @@ public sealed class DaemonClientMappingTests
     }
 
     [Fact]
+    public void BufferFlush_roundtrips_through_dto()
+    {
+        var original = new BufferFlush
+        {
+            SessionId = new SessionId("signalr/test"),
+            TimestampMs = 777
+        };
+
+        var dto = SessionOutputDtoMapper.ToDto(original);
+        Assert.Equal("buffer_flush", dto.Type);
+        Assert.Equal("signalr/test", dto.SessionId);
+        Assert.Equal(777, dto.TimestampMs);
+
+        var roundTripped = DaemonClient.FromDto(dto);
+        var result = Assert.IsType<BufferFlush>(roundTripped);
+        Assert.Equal("signalr/test", result.SessionId.Value);
+        Assert.Equal(777, result.TimestampMs);
+    }
+
+    [Fact]
     public void ErrorOutput_defaults_to_unknown_category_when_dto_field_missing()
     {
         var dto = new SessionOutputDto


### PR DESCRIPTION
## Summary

Fixes #277 — the two most impactful Slack UX bugs:

- **False fallback warning after real content**: The Slack adapter posted ":warning: I didn't manage to produce a reply" even after real streamed text was delivered, because `_postedThisTurn` was not set after flushing the buffer on `TurnCompleted`.

- **Invisible preamble during tool turns**: When the model produced text alongside tool calls (e.g., "Let me search for that..."), the preamble sat invisible in the buffer until all tool iterations completed. Introduces a `BufferFlush` lifecycle signal emitted from `HandleToolCallResponse` that tells streaming adapters to flush their accumulated buffer before tool execution begins.

### How BufferFlush works

1. LLM returns text + tool calls in a single response
2. `HandleToolCallResponse` emits `TextOutput` (for non-streaming path) + `BufferFlush` (for streaming path)
3. Slack adapter: if streaming deltas accumulated, `BufferFlush` flushes them to Slack immediately. If no streaming happened, the `TextOutput` posts directly via existing guard.
4. Buffer is cleared and ready for the next tool iteration's output

### Files changed

| File | Change |
|------|--------|
| `SessionOutput.cs` | Add `BufferFlush` lifecycle record |
| `SessionOutputDtoMapper.cs` | DTO mapping for CLI/SignalR |
| `LlmSessionActor.cs` | Emit TextOutput + BufferFlush in `HandleToolCallResponse` |
| `SlackThreadBindingActor.cs` | Fix `_postedThisTurn` tracking; add BufferFlush handler |
| `ReminderExecutionActor.cs` | No-op BufferFlush handler |

## Test plan

- [x] `Preamble_text_surfaces_before_tool_calls` — verifies TextOutput + BufferFlush arrive before ToolCallOutput
- [x] `BufferFlush_roundtrips_through_dto` — verifies DTO serialization roundtrip
- [x] All 913 existing tests pass with zero regressions