### PR TITLE
feat(session): rethink tool budget with per-call counting and graceful wind-down

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -134,7 +134,7 @@ Tuning parameters for LLM session behavior.
     "CompactionThreshold": 0.75,
     "SnapshotInterval": 20,
     "KeepRecentToolResults": 3,
-    "MaxToolIterationsPerTurn": 10,
+    "MaxToolCallsPerTurn": 30,
     "SidecarLlmTimeoutSeconds": 90,
     "TurnLlmTimeoutSeconds": 180,
     "ToolExecutionTimeoutSeconds": 90
@@ -147,7 +147,7 @@ Tuning parameters for LLM session behavior.
 | `CompactionThreshold` | double | `0.75` | Context usage ratio (0.0–1.0) at which compaction triggers. |
 | `SnapshotInterval` | int | `20` | Number of turns between persistence snapshots. |
 | `KeepRecentToolResults` | int | `3` | Recent tool call/result pairs kept in full during compaction. |
-| `MaxToolIterationsPerTurn` | int | `10` | Max tool execution rounds per turn before forcing a text response. |
+| `MaxToolCallsPerTurn` | int | `30` | Max individual tool calls per turn. At ~75% a budget nudge is injected; at 100% tools are stripped and the model is asked to summarize. |
 | `SidecarLlmTimeoutSeconds` | int | `90` | Timeout for sidecar LLM calls (title generation, observer summaries, memory extraction). |
 | `TurnLlmTimeoutSeconds` | int | `180` | Timeout for the primary per-turn LLM streaming call before forcing an error/recovery path. |
 | `ToolExecutionTimeoutSeconds` | int | `90` | Timeout for one tool-execution batch before failing the turn safely. |
@@ -286,7 +286,7 @@ export NETCLAW_Telemetry__Enabled="true"
 export NETCLAW_Telemetry__Otlp__Endpoint="http://127.0.0.1:4317"
 
 # Override session settings
-export NETCLAW_Session__MaxToolIterationsPerTurn="5"
+export NETCLAW_Session__MaxToolCallsPerTurn="30"
 ```
 
 ## Complete Example
@@ -320,7 +320,7 @@ export NETCLAW_Session__MaxToolIterationsPerTurn="5"
     "CompactionThreshold": 0.75,
     "SnapshotInterval": 20,
     "KeepRecentToolResults": 3,
-    "MaxToolIterationsPerTurn": 10,
+    "MaxToolCallsPerTurn": 30,
     "TurnLlmTimeoutSeconds": 180,
     "ToolExecutionTimeoutSeconds": 90
   },

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -37,7 +37,7 @@ public class MaxToolIterationTests : TestKit
             ModelId = "fake-model",
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
-            MaxToolIterationsPerTurn = 3, // Low limit for testing
+            MaxToolCallsPerTurn = 3, // Low limit for testing
             TitleGenerationInterval = 0
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
@@ -145,7 +145,7 @@ public class MaxToolIterationTests : TestKit
 
         var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5));
         Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
-        Assert.Contains("Please try rephrasing", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tool calls", error.Message, StringComparison.OrdinalIgnoreCase);
 
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -64,11 +64,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Last observed input token count from LLM response (for compaction trigger)
     private long _lastInputTokenCount;
 
-    // Tool iteration counter (reset per turn, incremented on each ToolExecutionCompleted)
+    // Tool call counter (reset per turn, incremented by the number of tool calls in each batch)
+    private int _toolCallCount;
+
+    // Tool iteration counter (reset per turn, incremented once per ToolExecutionCompleted batch — for logging)
     private int _toolIterationCount;
+
+    // Whether the budget-awareness nudge has been injected for this turn
+    private bool _budgetNudgeSent;
 
     private const int MaxPreToolEmptyResponseRetries = 2;
     private const string EmptyResponseFallbackMessage = "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
+    private const string ToolBudgetExhaustedMessage =
+        "I used all available tool calls for this turn and couldn't produce a final summary. "
+        + "You can ask me to summarize what was done, or rephrase your request.";
 
     // Whether we already sent a post-tool empty-response nudge in this tool chain
     private bool _postToolNudgeSent;
@@ -234,7 +243,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 cmd.Content?.Length ?? 0);
             _logActor?.Tell(cmd);
 
+            _toolCallCount = 0;
             _toolIterationCount = 0;
+            _budgetNudgeSent = false;
             _postToolNudgeSent = false;
             _preToolEmptyResponseCount = 0;
             _forceNoToolsActive = false;
@@ -314,11 +325,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (toolCalls.Count > 0 && _forceNoToolsActive)
             {
                 TurnLog().Warning(
-                    "turn_force_no_tools_violation toolCallCount={ToolCallCount} max={Max}",
+                    "turn_force_no_tools_violation toolCallCount={ToolCallCount} budgetUsed={BudgetUsed} max={Max}",
                     toolCalls.Count,
-                    _config.MaxToolIterationsPerTurn);
+                    _toolCallCount,
+                    _config.MaxToolCallsPerTurn);
                 FailCurrentTurn(
-                    EmptyResponseFallbackMessage,
+                    ToolBudgetExhaustedMessage,
                     new InvalidOperationException("LLM continued requesting tools after tool execution was disabled for this turn."),
                     ErrorCategory.ProviderFailure);
                 return;
@@ -558,20 +570,39 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 }, OutputFilter.Files);
             }
 
+            _toolCallCount += msg.ToolResults.Count;
             _toolIterationCount++;
 
-            // Safety circuit breaker: force text response when tool iteration limit reached
-            if (_toolIterationCount >= _config.MaxToolIterationsPerTurn)
+            // Safety circuit breaker: force text response when tool call budget exhausted
+            if (_toolCallCount >= _config.MaxToolCallsPerTurn)
             {
-                TurnLog().Warning("turn_tool_iteration_limit_reached count={Count} max={Max}",
-                    _toolIterationCount, _config.MaxToolIterationsPerTurn);
+                TurnLog().Warning("turn_tool_call_limit_reached callCount={CallCount} max={Max} iteration={Iteration}",
+                    _toolCallCount, _config.MaxToolCallsPerTurn, _toolIterationCount);
+                _state = _state.AddSystemNudge(
+                    "You have reached the tool call limit for this turn. "
+                    + "Do NOT request any more tools. "
+                    + "Summarize the work you completed and answer the user's question "
+                    + "based on the information you have gathered so far. "
+                    + "If you could not complete the task, explain what you found and what remains.");
                 FireLlmCall(forceNoTools: true);
                 return;
             }
 
+            // Budget-awareness nudge: warn the model when approaching the limit
+            var budgetThreshold = (int)(_config.MaxToolCallsPerTurn * 0.75);
+            if (_toolCallCount >= budgetThreshold && !_budgetNudgeSent)
+            {
+                var remaining = _config.MaxToolCallsPerTurn - _toolCallCount;
+                _state = _state.AddSystemNudge(
+                    $"You have used {_toolCallCount} of {_config.MaxToolCallsPerTurn} tool calls for this turn. "
+                    + $"You have approximately {remaining} tool calls remaining. "
+                    + "Start wrapping up your tool usage and prepare to answer the user's question.");
+                _budgetNudgeSent = true;
+            }
+
             // Fire follow-up LLM call with tool results in context
-            TurnLog().Info("turn_tool_execution_complete iteration={Iteration} max={Max} resultCount={ResultCount}",
-                _toolIterationCount, _config.MaxToolIterationsPerTurn, msg.ToolResults.Count);
+            TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
+                _toolIterationCount, _toolCallCount, _config.MaxToolCallsPerTurn, msg.ToolResults.Count);
             FireLlmCall();
         });
 
@@ -1218,7 +1249,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         bool streamedThinking,
         AutomaticRecallResult? recallResult)
     {
-        _toolIterationCount = 0; // Reset for potential buffer drain (new logical turn)
+        _toolCallCount = 0; // Reset for potential buffer drain (new logical turn)
+        _toolIterationCount = 0;
 
         var reply = ChatMessageConverter.FromAiMessage(lastMessage);
         var userMsg = _state.FindLastUserMessage();

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -46,11 +46,13 @@ public sealed record SessionConfig
     public int KeepRecentToolResults { get; init; } = 3;
 
     /// <summary>
-    /// Maximum number of tool execution iterations allowed per turn.
-    /// When the limit is reached, the next LLM call omits tools to force a text response.
-    /// Prevents unbounded agentic loops from runaway tool chains.
+    /// Maximum number of individual tool calls allowed per turn.
+    /// Each tool call in a batch counts separately (e.g., 3 parallel calls = 3).
+    /// At ~75% of this limit, a budget-awareness nudge is injected so the model
+    /// can start wrapping up. At 100%, tools are stripped and the model is asked
+    /// to summarize its work.
     /// </summary>
-    public int MaxToolIterationsPerTurn { get; init; } = 10;
+    public int MaxToolCallsPerTurn { get; init; } = 30;
 
     /// <summary>
     /// Maximum number of characters from a single tool result that may be


### PR DESCRIPTION
## Summary

Continues #277 — replaces the iteration-based tool circuit breaker with a smarter three-phase approach inspired by [OpenCode](https://opencode.ai) (tool stripping + summary prompt) and [LangGraph](https://docs.langchain.com) (budget awareness nudge).

**Problem**: The old circuit breaker counted iteration rounds (default 10), then hard-stripped tools. Models (especially Qwen) often hallucinated tool calls after tools were removed, causing a `turn_force_no_tools_violation` with the misleading "I didn't produce a reply" message.

**Solution**: Three-phase budget with per-call counting:

1. **Per-call counting** (`MaxToolCallsPerTurn=30`): Each tool call counts individually. 3 parallel calls in one batch = 3 against the budget. More accurate than counting rounds.

2. **Budget nudge at ~75%**: Injects a system message: "You have used X of Y tool calls. Start wrapping up." Gives the model awareness to self-regulate.

3. **Graceful wind-down at 100%**: Strips tools AND injects "Summarize your work and answer the user's question." The model gets one turn to produce a proper summary instead of being abruptly cut off.

4. **Specific violation message**: If the model still hallucinate tool calls, the error says "I used all available tool calls" instead of the generic fallback.

### Files changed

| File | Change |
|------|--------|
| `SessionConfig.cs` | `MaxToolIterationsPerTurn` → `MaxToolCallsPerTurn` (default 30) |
| `LlmSessionActor.cs` | Per-call counting, budget nudge, summary prompt, specific violation message |
| `MaxToolIterationTests.cs` | Updated for new config name and violation message |
| `configuration.md` | Updated config docs |

## Test plan

- [x] `Tool_iteration_limit_forces_text_response` — budget triggers at correct call count
- [x] `Tool_iteration_limit_fails_turn_when_model_keeps_emitting_tool_calls_without_tools` — violation uses specific message
- [x] `Tool_iteration_counter_resets_between_turns` — counters reset correctly
- [x] `Normal_tool_use_within_limit_works_unchanged` — normal flow unaffected
- [x] All 913 tests pass with zero regressions