### PR TITLE
chore: remove vestigial memory/ and memories/ directories

### DIFF
--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -37,13 +37,8 @@ public sealed class NetclawPaths
     public string CacheDirectory => Path.Combine(BasePath, "cache");
     public string SkillKeywordCacheDirectory => Path.Combine(CacheDirectory, "skill-keywords");
 
-    // ── Memory directories ──
-    public string MemoryDirectory => Path.Combine(BasePath, "memory");
+    // ── Memory ──
     public string MemorySqliteDbPath => SqliteDbPath;
-
-    // Legacy file-backed memory paths (kept for migration detection only)
-    public string MemoriesDirectory => Path.Combine(BasePath, "memories");
-    public string MemoryIndexPath => Path.Combine(MemoriesDirectory, "memory.md");
 
     // ── Binary directory (install location for self-contained binaries) ──
     public string BinDirectory => Path.Combine(BasePath, "bin");
@@ -98,8 +93,6 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(LogsDirectory);
         Directory.CreateDirectory(SessionLogsDirectory);
         Directory.CreateDirectory(AgentsDirectory);
-        Directory.CreateDirectory(MemoryDirectory);
-        Directory.CreateDirectory(MemoriesDirectory);
         Directory.CreateDirectory(SessionsDirectory);
         Directory.CreateDirectory(BinDirectory);
         Directory.CreateDirectory(KeysDirectory);


### PR DESCRIPTION
## Summary

Removes three unused path properties and their auto-creation from `NetclawPaths`:

- `MemoryDirectory` (`~/.netclaw/memory/`) — caused a ghost 0-byte `memory.db` to appear on startup
- `MemoriesDirectory` (`~/.netclaw/memories/`) — legacy file-backed memory path, no consumers in `src/`
- `MemoryIndexPath` (`~/.netclaw/memories/memory.md`) — legacy memory index, no consumers

Memory is stored in the main `~/.netclaw/netclaw.db` via `MemorySqliteDbPath` (alias for `SqliteDbPath`), which is unchanged.

## Test plan

- [x] 913/913 tests pass
- [x] Build clean, zero warnings