### PR TITLE
feat(channels): delivery feedback contract for LLM error correction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,13 @@ If discovery artifacts conflict with each other, update them before implementing
 - no north-star/deferred features in MVP without explicit PRD update
 - actor boundaries remain transport-agnostic (pub/sub over direct transport asks)
 - persistence types remain framework-owned and serialization-safe
+- **No fallback paths.** Do not add silent retries, plain-text downgrades, or
+  graceful degradation that hides errors. When the LLM produces output a channel
+  can't deliver, feed the full error back to the LLM session so it can
+  understand what went wrong and retry with corrected output. The only acceptable
+  error-handling pattern is: error occurs → error details propagated back to the
+  LLM → LLM retries with that context. If you believe a fallback is genuinely
+  needed, stop and ask for explicit approval first.
 - no new Slopwatch violations: run `/dotnet-skills:slopwatch` after code changes
 - use `TimeProvider` (not `DateTime.UtcNow` / `DateTimeOffset.UtcNow`) so time
   can be virtualized in tests. Inject `TimeProvider` via DI; default to

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -1,9 +1,12 @@
 using System.Net;
 using System.Net.Http.Headers;
 using Akka.Actor;
+using Akka;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
+using Akka.Streams;
+using Akka.Streams.Dsl;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -444,6 +447,119 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         }, duration: TimeSpan.FromSeconds(10));
     }
 
+    [Fact]
+    public async Task Retryable_slack_content_rejection_is_fed_back_to_session_for_correction()
+    {
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        _replyClient.PostFailures.Enqueue(new SlackMessageDeliveryException(
+            errorCode: "invalid_blocks",
+            failureKind: DeliveryFailureKind.ContentRejected,
+            message: "invalid_blocks"));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-delivery-feedback-test");
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D6:7000"),
+            ChannelId: new SlackChannelId("D6"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("7000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "first message",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: null));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Contains(_replyClient.PostedMessages,
+                message => message.Text.Contains("call #2", StringComparison.OrdinalIgnoreCase));
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Assert.DoesNotContain(_replyClient.PostedMessages,
+            message => message.Text.Contains("call #1", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Retryable_slack_file_upload_rejection_is_fed_back_to_session()
+    {
+        var tempFile = Path.Combine(_paths.BasePath, $"upload-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, "test file");
+
+        var feedbackPipeline = new RecordingSessionPipeline([
+            new FileOutput
+            {
+                SessionId = new SessionId("D7/8000.1"),
+                TimestampMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+                FilePath = tempFile,
+                FileName = "test.txt",
+                MimeType = "text/plain"
+            },
+            new TurnCompleted
+            {
+                SessionId = new SessionId("D7/8000.1"),
+                TurnNumber = 1
+            }
+        ]);
+
+        _replyClient.UploadFailures.Enqueue(new SlackMessageDeliveryException(
+            errorCode: "too_many_attachments",
+            failureKind: DeliveryFailureKind.UnsupportedContent,
+            message: "too_many_attachments"));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: feedbackPipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var actor = Sys.ActorOf(SlackThreadBindingActor.CreateProps(
+            new SessionId("D7/8000.1"),
+            new SlackChannelId("D7"),
+            new SlackThreadTs("8000.1"),
+            deps), "slack-thread-file-feedback-test");
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = Assert.Single(feedbackPipeline.Feedback);
+            var failure = Assert.IsType<DeliveryFailed>(feedback);
+            Assert.Equal(DeliveryFailureKind.UnsupportedContent, failure.FailureKind);
+            Assert.Equal(1, failure.TurnNumber);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Watch(actor);
+        Sys.Stop(actor);
+        await ExpectTerminatedAsync(actor);
+    }
+
     /// <summary>
     /// Fake HTTP handler that serves canned image bytes for Slack file download requests.
     /// </summary>
@@ -476,6 +592,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     {
         public List<SlackPostMessage> PostedMessages { get; } = [];
         public List<(SlackChannelId ChannelId, SlackThreadTs ThreadTs, string FilePath, string? FileName)> UploadedFiles { get; } = [];
+        public Queue<Exception> PostFailures { get; } = new();
+        public Queue<Exception> UploadFailures { get; } = new();
         public volatile bool BlockPostsUntilCanceled;
         private int _canceledPostCount;
 
@@ -483,6 +601,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         public async Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
+            if (PostFailures.Count > 0)
+                throw PostFailures.Dequeue();
+
             if (BlockPostsUntilCanceled)
             {
                 var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -506,7 +627,38 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             SlackChannelId channelId, SlackThreadTs threadTs, string filePath,
             string? filename = null, CancellationToken cancellationToken = default)
         {
+            if (UploadFailures.Count > 0)
+                throw UploadFailures.Dequeue();
+
             UploadedFiles.Add((channelId, threadTs, filePath, filename));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingSessionPipeline(IReadOnlyList<SessionOutput> outputs) : ISessionPipeline
+    {
+        public List<IWithSessionId> Feedback { get; } = [];
+
+        public Task<MaterializedSession> CreateAsync(
+            SessionId sessionId,
+            SessionPipelineOptions options,
+            IMaterializer? materializer = null,
+            CancellationToken cancellationToken = default)
+        {
+            var killSwitch = KillSwitches.Shared($"recording-{sessionId.Value}");
+            var input = Sink.Ignore<ChannelInput>()
+                .MapMaterializedValue<NotUsed>(_ => NotUsed.Instance);
+
+            var output = Source.From(outputs)
+                .Concat(Source.Maybe<SessionOutput>().MapMaterializedValue(_ => NotUsed.Instance))
+                .Via(killSwitch.Flow<SessionOutput>());
+
+            return Task.FromResult(new MaterializedSession(input, output, killSwitch));
+        }
+
+        public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
+        {
+            Feedback.Add(feedback);
             return Task.CompletedTask;
         }
     }

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -190,6 +190,9 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             IMaterializer? materializer = null,
             CancellationToken cancellationToken = default) =>
             throw exception;
+
+        public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 
     private sealed class ScriptedSessionPipeline(
@@ -211,6 +214,9 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
 
             return Task.FromResult(new MaterializedSession(input, output, killSwitch));
         }
+
+        public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 
     // ── History integration tests ─────────────────────────────────────────────

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -222,6 +222,194 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Delivery_failed_for_latest_turn_retries_once_with_structured_nudge()
+    {
+        var sessionId = new SessionId("test-channel/delivery-retry");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("delivery-retry-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Say hello"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = completed.TurnNumber,
+            ChannelType = "slack",
+            FailureKind = DeliveryFailureKind.MessageTooLarge,
+            ErrorMessage = "msg_too_long"
+        });
+
+        var retried = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("Response #2", retried.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Contains(_fakeChatClient.ReceivedMessages[^1], msg =>
+            msg.Role == Microsoft.Extensions.AI.ChatRole.User
+            && msg.Text is not null
+            && msg.Text.Contains("msg_too_long", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Stale_delivery_failed_is_ignored_after_new_user_turn_starts()
+    {
+        var sessionId = new SessionId("test-channel/stale-delivery-failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("stale-delivery-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var firstCompleted = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = firstCompleted.TurnNumber,
+            ChannelType = "slack",
+            FailureKind = DeliveryFailureKind.ContentRejected,
+            ErrorMessage = "invalid_blocks"
+        });
+
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+    }
+
+    [Fact]
+    public async Task Delivery_failed_while_processing_newer_turn_is_ignored()
+    {
+        var sessionId = new SessionId("test-channel/processing-delivery-failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("processing-delivery-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var firstCompleted = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        _fakeChatClient.NextResponseGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "second"
+        }, TimeSpan.FromSeconds(3));
+
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = firstCompleted.TurnNumber,
+            ChannelType = "slack",
+            FailureKind = DeliveryFailureKind.ContentRejected,
+            ErrorMessage = "invalid_blocks"
+        });
+
+        _fakeChatClient.NextResponseGate.TrySetResult();
+
+        var secondText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        Assert.Contains("Response #2", secondText.Text, StringComparison.OrdinalIgnoreCase);
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+    }
+
+    [Fact]
+    public async Task Delivery_retry_budget_stops_after_two_failed_corrections()
+    {
+        var sessionId = new SessionId("test-channel/delivery-retry-budget");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("delivery-budget-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "first"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            sessionManager.Tell(new DeliveryFailed
+            {
+                SessionId = sessionId,
+                TurnNumber = completed.TurnNumber,
+                ChannelType = "slack",
+                FailureKind = DeliveryFailureKind.ContentRejected,
+                ErrorMessage = "invalid_blocks"
+            });
+
+            await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+            completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        }
+
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = completed.TurnNumber,
+            ChannelType = "slack",
+            FailureKind = DeliveryFailureKind.ContentRejected,
+            ErrorMessage = "invalid_blocks"
+        });
+
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+    }
+
+    [Fact]
     public async Task Sidecar_observation_promotes_strong_user_assertion_into_memory()
     {
         var gate = new MemoryProposalGate();
@@ -662,6 +850,8 @@ internal sealed class FakeChatClient : IChatClient
     /// </summary>
     public Queue<IReadOnlyList<AIContent>> PlannedResponses { get; } = new();
 
+    public TaskCompletionSource? NextResponseGate { get; set; }
+
     public async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
@@ -677,6 +867,13 @@ internal sealed class FakeChatClient : IChatClient
 
         if (Delay > TimeSpan.Zero)
             await Task.Delay(Delay, cancellationToken);
+
+        if (NextResponseGate is { } nextResponseGate)
+        {
+            NextResponseGate = null;
+            using var registration = cancellationToken.Register(() => nextResponseGate.TrySetCanceled(cancellationToken));
+            await nextResponseGate.Task;
+        }
 
         var systemText = messageList.FirstOrDefault(m => m.Role == Microsoft.Extensions.AI.ChatRole.System)?.Text ?? string.Empty;
         var userText = messageList.LastOrDefault(m => m.Role == Microsoft.Extensions.AI.ChatRole.User)?.Text ?? string.Empty;

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -93,6 +93,13 @@ public interface ISessionPipeline
         SessionPipelineOptions options,
         IMaterializer? materializer = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a feedback message (e.g. <see cref="DeliveryFailed"/>) back to the
+    /// session actor. Routes via <see cref="IWithSessionId"/> — no changes to
+    /// routing infrastructure needed.
+    /// </summary>
+    Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -194,6 +201,13 @@ public sealed class SessionPipeline : ISessionPipeline
             inputSink,
             outputSource,
             killSwitch);
+    }
+
+    /// <inheritdoc />
+    public async Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
+    {
+        var sessionManager = await _sessionManagerProvider.GetAsync(ct);
+        sessionManager.Tell(feedback, ActorRefs.NoSender);
     }
 
     private static SendUserMessage MapToCommand(

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -95,9 +95,7 @@ public interface ISessionPipeline
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Sends a feedback message (e.g. <see cref="DeliveryFailed"/>) back to the
-    /// session actor. Routes via <see cref="IWithSessionId"/> — no changes to
-    /// routing infrastructure needed.
+    /// Sends delivery feedback back to the owning session actor.
     /// </summary>
     Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default);
 }
@@ -203,7 +201,6 @@ public sealed class SessionPipeline : ISessionPipeline
             killSwitch);
     }
 
-    /// <inheritdoc />
     public async Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
     {
         var sessionManager = await _sessionManagerProvider.GetAsync(ct);

--- a/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
+++ b/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
@@ -1,29 +1,45 @@
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
-/// Sent by a channel adapter to the session actor when output delivery
-/// to the end user has failed. The session injects the error details into
-/// the conversation and re-invokes the LLM so it can produce corrected output.
-/// Routes to the correct session via <see cref="IWithSessionId"/>.
-/// Not persisted — triggers a transient system nudge + LLM retry.
+/// Delivery failure categories a channel adapter can report back to the session.
+/// Only retryable categories should be fed back to the LLM.
+/// </summary>
+public enum DeliveryFailureKind
+{
+    ContentRejected,
+    MessageTooLarge,
+    UnsupportedContent,
+    PermissionDenied,
+    TransportFailure,
+    Unknown
+}
+
+/// <summary>
+/// Sent by a channel adapter when the session's output could not be delivered.
+/// The session can use this structured feedback to decide whether to retry.
 /// </summary>
 public sealed record DeliveryFailed : IWithSessionId
 {
     public required SessionId SessionId { get; init; }
 
     /// <summary>
-    /// Turn number that failed delivery, for correlation.
+    /// Completed turn number whose output failed delivery.
+    /// Used to reject stale feedback after a newer user turn has started.
     /// </summary>
     public required int TurnNumber { get; init; }
 
     /// <summary>
-    /// Channel type that experienced the failure (e.g. "slack", "teams").
+    /// Channel adapter identifier (for example: slack, discord, teams).
     /// </summary>
     public required string ChannelType { get; init; }
 
     /// <summary>
-    /// The full error message from the channel, passed directly to the LLM
-    /// so it can understand what went wrong and adjust its output.
+    /// Structured reason for the failure.
+    /// </summary>
+    public required DeliveryFailureKind FailureKind { get; init; }
+
+    /// <summary>
+    /// Raw channel error message for operator diagnostics and LLM guidance.
     /// </summary>
     public required string ErrorMessage { get; init; }
 }

--- a/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
+++ b/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
@@ -1,0 +1,29 @@
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Sent by a channel adapter to the session actor when output delivery
+/// to the end user has failed. The session injects the error details into
+/// the conversation and re-invokes the LLM so it can produce corrected output.
+/// Routes to the correct session via <see cref="IWithSessionId"/>.
+/// Not persisted — triggers a transient system nudge + LLM retry.
+/// </summary>
+public sealed record DeliveryFailed : IWithSessionId
+{
+    public required SessionId SessionId { get; init; }
+
+    /// <summary>
+    /// Turn number that failed delivery, for correlation.
+    /// </summary>
+    public required int TurnNumber { get; init; }
+
+    /// <summary>
+    /// Channel type that experienced the failure (e.g. "slack", "teams").
+    /// </summary>
+    public required string ChannelType { get; init; }
+
+    /// <summary>
+    /// The full error message from the channel, passed directly to the LLM
+    /// so it can understand what went wrong and adjust its output.
+    /// </summary>
+    public required string ErrorMessage { get; init; }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -74,6 +74,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private bool _budgetNudgeSent;
 
     private const int MaxPreToolEmptyResponseRetries = 2;
+    private const int MaxDeliveryFailureRetries = 2;
     private const string EmptyResponseFallbackMessage = "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
     private const string ToolBudgetExhaustedMessage =
         "I used all available tool calls for this turn and couldn't produce a final summary. "
@@ -88,10 +89,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Whether the current LLM call intentionally disabled tool use after a circuit breaker fired.
     private bool _forceNoToolsActive;
 
-    // Channel delivery failure: if a DeliveryFailed message arrives during Processing,
-    // the nudge is added to state immediately but the LLM retry is deferred until
-    // DrainBufferedMessagesOrBecomeReady runs.
-    private bool _deliveryFailurePending;
+    // Delivery retry state. A completed turn remains eligible until a new user turn starts.
+    private int? _deliveryRetryEligibleTurnNumber;
+    private int _deliveryRetryCount;
+    private bool _deliveryRetryChainActive;
 
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
@@ -236,26 +237,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<CompactionWorkCompleted>(_ => { });
         Command<CompactionWorkFailed>(_ => { });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
-
-        Command<DeliveryFailed>(msg =>
-        {
-            _log.Warning(
-                "delivery_failed channel={Channel} turn={Turn} error={Error}",
-                msg.ChannelType, msg.TurnNumber, msg.ErrorMessage);
-
-            _state = _state.AddSystemNudge(
-                $"Your last response could not be delivered to the user via {msg.ChannelType}. "
-                + $"The channel returned this error: {msg.ErrorMessage}\n"
-                + "The user did NOT see your response. Please produce a corrected response "
-                + "that avoids the formatting issue described in the error.");
-
-            _deliveryFailurePending = false;
-            FireLlmCall();
-            Become(Processing);
-        });
+        Command<DeliveryFailed>(HandleDeliveryFailedWhenReady);
 
         Command<SendUserMessage>(cmd =>
         {
+            ClearDeliveryRetryState();
             BindTurnTelemetry(cmd.Source);
             TurnLog().Info(
                 "turn_received channel={ChannelType} sender={SenderId} hasMedia={HasMedia} textChars={TextLength}",
@@ -325,26 +311,31 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
 
-        Command<DeliveryFailed>(msg =>
-        {
-            _log.Warning(
-                "delivery_failed_during_processing channel={Channel} turn={Turn} error={Error}",
-                msg.ChannelType, msg.TurnNumber, msg.ErrorMessage);
-
-            _state = _state.AddSystemNudge(
-                $"Your last response could not be delivered to the user via {msg.ChannelType}. "
-                + $"The channel returned this error: {msg.ErrorMessage}\n"
-                + "The user did NOT see your response. Please produce a corrected response "
-                + "that avoids the formatting issue described in the error.");
-
-            _deliveryFailurePending = true;
-        });
-
         Command<SendUserMessage>(cmd =>
         {
+            ClearDeliveryRetryState();
             _log.Info("Buffering user message (LLM call in progress)");
             _buffer.Add(cmd);
             TryReplyAck();
+        });
+
+        Command<DeliveryFailed>(msg =>
+        {
+            if (!IsRetryableDeliveryFailure(msg))
+            {
+                _log.Warning(
+                    "Ignoring non-retryable delivery feedback while processing channel={Channel} turn={Turn} kind={FailureKind}",
+                    msg.ChannelType,
+                    msg.TurnNumber,
+                    msg.FailureKind);
+                return;
+            }
+
+            _log.Warning(
+                "Ignoring stale delivery feedback while processing channel={Channel} turn={Turn} eligibleTurn={EligibleTurn}",
+                msg.ChannelType,
+                msg.TurnNumber,
+                _deliveryRetryEligibleTurnNumber?.ToString() ?? "none");
         });
 
         Command<CompactionWorkCompleted>(_ => { });
@@ -1350,6 +1341,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     Title: "turn-completion",
                     UpdateSemantics: "append-document")));
 
+            MarkTurnEligibleForDeliveryRetry(_state.TurnCount);
+
             // Check if compaction should trigger
             if (ShouldCompact())
             {
@@ -1376,22 +1369,95 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             _buffer.Clear();
-            _deliveryFailurePending = false;
-            FireLlmCall();
-            Become(Processing);
-            return;
-        }
-
-        if (_deliveryFailurePending)
-        {
-            _deliveryFailurePending = false;
-            TurnLog().Info("turn_delivery_failure_retry");
             FireLlmCall();
             Become(Processing);
             return;
         }
 
         Become(Ready);
+    }
+
+    private void HandleDeliveryFailedWhenReady(DeliveryFailed msg)
+    {
+        if (!IsRetryableDeliveryFailure(msg))
+        {
+            _log.Warning(
+                "Ignoring non-retryable delivery feedback channel={Channel} turn={Turn} kind={FailureKind}",
+                msg.ChannelType,
+                msg.TurnNumber,
+                msg.FailureKind);
+            return;
+        }
+
+        if (_deliveryRetryEligibleTurnNumber != msg.TurnNumber)
+        {
+            _log.Warning(
+                "Ignoring stale delivery feedback channel={Channel} turn={Turn} eligibleTurn={EligibleTurn}",
+                msg.ChannelType,
+                msg.TurnNumber,
+                _deliveryRetryEligibleTurnNumber?.ToString() ?? "none");
+            return;
+        }
+
+        if (_deliveryRetryCount >= MaxDeliveryFailureRetries)
+        {
+            _log.Warning(
+                "Delivery retry budget exhausted channel={Channel} turn={Turn} kind={FailureKind}",
+                msg.ChannelType,
+                msg.TurnNumber,
+                msg.FailureKind);
+            _deliveryRetryEligibleTurnNumber = null;
+            _deliveryRetryChainActive = false;
+            return;
+        }
+
+        _deliveryRetryCount++;
+        _deliveryRetryChainActive = true;
+
+        _log.Warning(
+            "Retrying after delivery failure channel={Channel} turn={Turn} kind={FailureKind} attempt={Attempt}",
+            msg.ChannelType,
+            msg.TurnNumber,
+            msg.FailureKind,
+            _deliveryRetryCount);
+
+        _state = _state.AddSystemNudge(BuildDeliveryFailureNudge(msg));
+        FireLlmCall();
+        Become(Processing);
+    }
+
+    private static bool IsRetryableDeliveryFailure(DeliveryFailed msg)
+        => msg.FailureKind is DeliveryFailureKind.ContentRejected
+            or DeliveryFailureKind.MessageTooLarge
+            or DeliveryFailureKind.UnsupportedContent;
+
+    private static string BuildDeliveryFailureNudge(DeliveryFailed msg)
+    {
+        var guidance = msg.FailureKind switch
+        {
+            DeliveryFailureKind.ContentRejected => "Produce a simpler channel-safe response and avoid the content pattern the channel rejected.",
+            DeliveryFailureKind.MessageTooLarge => "Produce a shorter response that fits the channel's length limits.",
+            DeliveryFailureKind.UnsupportedContent => "Avoid unsupported formatting or content types for this channel.",
+            _ => "Produce a corrected response that avoids the reported delivery issue."
+        };
+
+        return $"Your last response could not be delivered to the user via {msg.ChannelType}. "
+            + $"The user did not receive it. Delivery failure kind: {msg.FailureKind}. "
+            + $"Channel error: {msg.ErrorMessage}\n{guidance}";
+    }
+
+    private void ClearDeliveryRetryState()
+    {
+        _deliveryRetryEligibleTurnNumber = null;
+        _deliveryRetryCount = 0;
+        _deliveryRetryChainActive = false;
+    }
+
+    private void MarkTurnEligibleForDeliveryRetry(int turnNumber)
+    {
+        _deliveryRetryEligibleTurnNumber = turnNumber;
+        if (!_deliveryRetryChainActive)
+            _deliveryRetryCount = 0;
     }
 
     private bool ShouldCompact()
@@ -2678,6 +2744,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void FailCurrentTurn(string errorMessage, Exception cause, ErrorCategory category = ErrorCategory.Unknown)
     {
+        ClearDeliveryRetryState();
         _state = _state.AddErrorReply(errorMessage);
 
         var correlationId = Guid.NewGuid();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -88,6 +88,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Whether the current LLM call intentionally disabled tool use after a circuit breaker fired.
     private bool _forceNoToolsActive;
 
+    // Channel delivery failure: if a DeliveryFailed message arrives during Processing,
+    // the nudge is added to state immediately but the LLM retry is deferred until
+    // DrainBufferedMessagesOrBecomeReady runs.
+    private bool _deliveryFailurePending;
+
     // Child actor for per-session log file (created when session logs directory is configured)
     private IActorRef? _logActor;
 
@@ -232,6 +237,23 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<CompactionWorkFailed>(_ => { });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
 
+        Command<DeliveryFailed>(msg =>
+        {
+            _log.Warning(
+                "delivery_failed channel={Channel} turn={Turn} error={Error}",
+                msg.ChannelType, msg.TurnNumber, msg.ErrorMessage);
+
+            _state = _state.AddSystemNudge(
+                $"Your last response could not be delivered to the user via {msg.ChannelType}. "
+                + $"The channel returned this error: {msg.ErrorMessage}\n"
+                + "The user did NOT see your response. Please produce a corrected response "
+                + "that avoids the formatting issue described in the error.");
+
+            _deliveryFailurePending = false;
+            FireLlmCall();
+            Become(Processing);
+        });
+
         Command<SendUserMessage>(cmd =>
         {
             BindTurnTelemetry(cmd.Source);
@@ -302,6 +324,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Context.SetReceiveTimeout(null);
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
+
+        Command<DeliveryFailed>(msg =>
+        {
+            _log.Warning(
+                "delivery_failed_during_processing channel={Channel} turn={Turn} error={Error}",
+                msg.ChannelType, msg.TurnNumber, msg.ErrorMessage);
+
+            _state = _state.AddSystemNudge(
+                $"Your last response could not be delivered to the user via {msg.ChannelType}. "
+                + $"The channel returned this error: {msg.ErrorMessage}\n"
+                + "The user did NOT see your response. Please produce a corrected response "
+                + "that avoids the formatting issue described in the error.");
+
+            _deliveryFailurePending = true;
+        });
 
         Command<SendUserMessage>(cmd =>
         {
@@ -1339,6 +1376,16 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             _buffer.Clear();
+            _deliveryFailurePending = false;
+            FireLlmCall();
+            Become(Processing);
+            return;
+        }
+
+        if (_deliveryFailurePending)
+        {
+            _deliveryFailurePending = false;
+            TurnLog().Info("turn_delivery_failure_retry");
             FireLlmCall();
             Become(Processing);
             return;

--- a/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
@@ -184,9 +184,7 @@ public static partial class SlackBlockConverter
             remaining = remaining[(matchIndex + matchLength)..];
         }
 
-        // Guard: remove any elements with empty text — Slack rejects blocks
-        // containing text elements with 0 characters (invalid_blocks error).
-        elements.RemoveAll(e => e is RichTextText rt && string.IsNullOrEmpty(rt.Text));
+        elements.RemoveAll(e => e is RichTextText textElement && string.IsNullOrEmpty(textElement.Text));
 
         return elements;
     }

--- a/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels/Slack/SlackBlockConverter.cs
@@ -184,6 +184,10 @@ public static partial class SlackBlockConverter
             remaining = remaining[(matchIndex + matchLength)..];
         }
 
+        // Guard: remove any elements with empty text — Slack rejects blocks
+        // containing text elements with 0 characters (invalid_blocks error).
+        elements.RemoveAll(e => e is RichTextText rt && string.IsNullOrEmpty(rt.Text));
+
         return elements;
     }
 

--- a/src/Netclaw.Channels/Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels/Slack/SlackChannel.cs
@@ -12,7 +12,7 @@ namespace Netclaw.Channels.Slack;
 
 public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEventHandler<AppMention>
 {
-    private readonly SessionPipeline _pipeline;
+    private readonly ISessionPipeline _pipeline;
     private readonly ActorSystem _system;
     private readonly ISlackApiClient _slack;
     private readonly ISlackSocketModeClient _socketModeClient;
@@ -30,7 +30,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private volatile bool _connected;
 
     public SlackChannel(
-        SessionPipeline pipeline,
+        ISessionPipeline pipeline,
         ActorSystem system,
         ISlackApiClient slack,
         ISlackSocketModeClient socketModeClient,

--- a/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackGatewayActor.cs
@@ -81,7 +81,7 @@ public sealed class SlackGatewayActor : ReceiveActor
 }
 
 public sealed record SlackGatewayDependencies(
-    SessionPipeline Pipeline,
+    ISessionPipeline Pipeline,
     ActorSystem ActorSystem,
     TimeProvider TimeProvider,
     SlackChannelOptions Options,

--- a/src/Netclaw.Channels/Slack/SlackMessageDeliveryException.cs
+++ b/src/Netclaw.Channels/Slack/SlackMessageDeliveryException.cs
@@ -1,0 +1,24 @@
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Raised when Slack rejects message content after the adapter attempted delivery.
+/// </summary>
+public sealed class SlackMessageDeliveryException : Exception
+{
+    public SlackMessageDeliveryException(
+        string? errorCode,
+        DeliveryFailureKind failureKind,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        ErrorCode = errorCode;
+        FailureKind = failureKind;
+    }
+
+    public string? ErrorCode { get; }
+
+    public DeliveryFailureKind FailureKind { get; }
+}

--- a/src/Netclaw.Channels/Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels/Slack/SlackReplyClient.cs
@@ -1,22 +1,44 @@
 using SlackNet;
 using SlackNet.WebApi;
+using Netclaw.Actors.Protocol;
 
 namespace Netclaw.Channels.Slack;
 
 public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackReplyClient
 {
-    public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
+    public async Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
     {
         var blocks = SlackBlockConverter.Convert(message.Text);
 
-        return slackApiClient.Chat.PostMessage(new Message
+        try
         {
-            Channel = message.ChannelId.Value,
-            ThreadTs = message.ThreadTs.Value,
-            Text = message.Text, // fallback for notifications
-            Blocks = blocks
-        }, cancellationToken);
+            await slackApiClient.Chat.PostMessage(new Message
+            {
+                Channel = message.ChannelId.Value,
+                ThreadTs = message.ThreadTs.Value,
+                Text = message.Text,
+                Blocks = blocks
+            }, cancellationToken);
+        }
+        catch (SlackException ex)
+        {
+            throw new SlackMessageDeliveryException(
+                ex.ErrorCode,
+                MapFailureKind(ex.ErrorCode),
+                ex.Message,
+                ex);
+        }
     }
+
+    private static DeliveryFailureKind MapFailureKind(string? errorCode)
+        => errorCode switch
+        {
+            "invalid_blocks" or "invalid_arguments" => DeliveryFailureKind.ContentRejected,
+            "msg_too_long" => DeliveryFailureKind.MessageTooLarge,
+            "too_many_attachments" => DeliveryFailureKind.UnsupportedContent,
+            "not_in_channel" or "channel_not_found" or "missing_scope" or "no_permission" => DeliveryFailureKind.PermissionDenied,
+            _ => DeliveryFailureKind.Unknown
+        };
 
     public async Task UploadFileToThreadAsync(
         SlackChannelId channelId,
@@ -25,15 +47,26 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
         string? filename = null,
         CancellationToken cancellationToken = default)
     {
-        var resolvedFilename = filename ?? Path.GetFileName(filePath);
-        await using var stream = System.IO.File.OpenRead(filePath);
-        var upload = new FileUpload(resolvedFilename, stream);
+        try
+        {
+            var resolvedFilename = filename ?? Path.GetFileName(filePath);
+            await using var stream = System.IO.File.OpenRead(filePath);
+            var upload = new FileUpload(resolvedFilename, stream);
 
-        await slackApiClient.Files.Upload(
-            upload,
-            channelId.Value,
-            threadTs.Value,
-            initialComment: null,
-            cancellationToken);
+            await slackApiClient.Files.Upload(
+                upload,
+                channelId.Value,
+                threadTs.Value,
+                initialComment: null,
+                cancellationToken);
+        }
+        catch (SlackException ex)
+        {
+            throw new SlackMessageDeliveryException(
+                ex.ErrorCode,
+                MapFailureKind(ex.ErrorCode),
+                ex.Message,
+                ex);
+        }
     }
 }

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -27,6 +27,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
     private bool _sawTextDelta;
     private bool _postedThisTurn;
     private bool _uploadedFileThisTurn;
+    private PostResult? _lastFailedPost;
 
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
@@ -402,8 +403,11 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                     var fullText = text.Text?.Trim();
                     if (!string.IsNullOrWhiteSpace(fullText))
                     {
-                        await SafePostAsync(fullText);
-                        _postedThisTurn = true;
+                        var result = await SafePostAsync(fullText);
+                        if (result.Success)
+                            _postedThisTurn = true;
+                        else
+                            _lastFailedPost = result;
                     }
                 }
 
@@ -419,8 +423,11 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                     var preamble = _buffer.ToString().Trim();
                     if (!string.IsNullOrWhiteSpace(preamble))
                     {
-                        await SafePostAsync(preamble);
-                        _postedThisTurn = true;
+                        var result = await SafePostAsync(preamble);
+                        if (result.Success)
+                            _postedThisTurn = true;
+                        else
+                            _lastFailedPost = result;
                     }
                 }
                 _buffer.Clear();
@@ -429,19 +436,23 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
             case ErrorOutput err:
                 var refId = err.CorrelationId.ToString("N")[..8];
-                await SafePostAsync($":warning: {err.Message} (ref: {refId})");
-                _postedThisTurn = true;
+                var errResult = await SafePostAsync($":warning: {err.Message} (ref: {refId})");
+                if (errResult.Success)
+                    _postedThisTurn = true;
                 _buffer.Clear();
                 break;
 
-            case TurnCompleted:
+            case TurnCompleted tc:
                 if (_sawTextDelta && !_postedThisTurn)
                 {
                     var reply = _buffer.ToString().Trim();
                     if (!string.IsNullOrWhiteSpace(reply))
                     {
-                        await SafePostAsync(reply);
-                        _postedThisTurn = true;
+                        var result = await SafePostAsync(reply);
+                        if (result.Success)
+                            _postedThisTurn = true;
+                        else
+                            _lastFailedPost = result;
                     }
                     else
                         _log.Debug("Turn completed with no buffered reply text");
@@ -449,20 +460,35 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
                 if (!_postedThisTurn && !_uploadedFileThisTurn)
                 {
-                    _log.Warning("Turn completed without visible Slack output; posting fallback reply");
-                    await SafePostAsync(EmptyTurnFallbackText);
+                    if (_lastFailedPost is { IsContentError: true })
+                    {
+                        // Channel rejected the LLM's output — feed error back so LLM can retry
+                        _log.Warning("Turn completed with content delivery failure; notifying session");
+                        await NotifyDeliveryFailedAsync(tc.TurnNumber, _lastFailedPost.ErrorMessage!);
+                    }
+                    else if (_lastFailedPost is not null)
+                    {
+                        // Transport failure (timeout, network) — LLM can't fix this
+                        _log.Warning("Turn completed with transport failure: {Error}", _lastFailedPost.ErrorMessage);
+                    }
+                    else
+                    {
+                        _log.Warning("Turn completed without visible Slack output; posting fallback reply");
+                        await SafePostAsync(EmptyTurnFallbackText);
+                    }
                 }
 
                 _buffer.Clear();
                 _sawTextDelta = false;
                 _postedThisTurn = false;
                 _uploadedFileThisTurn = false;
+                _lastFailedPost = null;
 
                 break;
         }
     }
 
-    private async Task SafePostAsync(string text)
+    private async Task<PostResult> SafePostAsync(string text)
     {
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
@@ -475,17 +501,62 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
             _log.Info("Posted Slack reply message");
             ChannelTelemetry.RecordSlackReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return PostResult.Ok;
         }
         catch (OperationCanceledException ex)
         {
+            // Transport failure — LLM can't fix a timeout by producing different output
             _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult($"Timed out posting reply: {ex.Message}", IsContentError: false);
+        }
+        catch (SlackNet.SlackException ex)
+        {
+            // Slack rejected the content — LLM might fix this by producing different output
+            _log.Error(ex, "Slack rejected reply for session {0}: {1}", _sessionId.Value, ex.ErrorCode);
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult(ex.Message, IsContentError: true);
         }
         catch (Exception ex)
         {
+            // Unknown/transport failure — don't assume the LLM can fix it
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult(ex.Message, IsContentError: false);
         }
+    }
+
+    private async Task NotifyDeliveryFailedAsync(int turnNumber, string errorMessage)
+    {
+        try
+        {
+            await _dependencies.Pipeline.SendFeedbackAsync(new DeliveryFailed
+            {
+                SessionId = _sessionId,
+                TurnNumber = turnNumber,
+                ChannelType = "slack",
+                ErrorMessage = errorMessage
+            });
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to send delivery feedback to session");
+        }
+    }
+
+    /// <summary>
+    /// Result of a channel post attempt. Carries the error message on failure
+    /// so it can be fed back to the LLM session.
+    /// </summary>
+    /// <param name="ErrorMessage">The error message, or null on success.</param>
+    /// <param name="IsContentError">True if the channel rejected the content itself
+    /// (e.g. invalid_blocks) — the LLM can fix this by producing different output.
+    /// False for transport failures (timeouts, network) — retrying with different
+    /// LLM output won't help.</param>
+    private sealed record PostResult(string? ErrorMessage = null, bool IsContentError = false)
+    {
+        public static readonly PostResult Ok = new();
+        public bool Success => ErrorMessage is null;
     }
 
     private async Task SafeUploadFileAsync(FileOutput file)

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -414,7 +414,9 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 break;
 
             case FileOutput file:
-                await SafeUploadFileAsync(file);
+                var uploadResult = await SafeUploadFileAsync(file);
+                if (!uploadResult.Success)
+                    _lastFailedPost = uploadResult;
                 break;
 
             case BufferFlush:
@@ -436,13 +438,13 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
             case ErrorOutput err:
                 var refId = err.CorrelationId.ToString("N")[..8];
-                var errResult = await SafePostAsync($":warning: {err.Message} (ref: {refId})");
-                if (errResult.Success)
+                var errorResult = await SafePostAsync($":warning: {err.Message} (ref: {refId})");
+                if (errorResult.Success)
                     _postedThisTurn = true;
                 _buffer.Clear();
                 break;
 
-            case TurnCompleted tc:
+            case TurnCompleted completed:
                 if (_sawTextDelta && !_postedThisTurn)
                 {
                     var reply = _buffer.ToString().Trim();
@@ -460,16 +462,16 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
                 if (!_postedThisTurn && !_uploadedFileThisTurn)
                 {
-                    if (_lastFailedPost is { IsContentError: true })
+                    if (_lastFailedPost is { ShouldNotifySession: true, FailureKind: { } failureKind, ErrorMessage: { } errorMessage })
                     {
-                        // Channel rejected the LLM's output — feed error back so LLM can retry
-                        _log.Warning("Turn completed with content delivery failure; notifying session");
-                        await NotifyDeliveryFailedAsync(tc.TurnNumber, _lastFailedPost.ErrorMessage!);
+                        _log.Warning(
+                            "Turn completed with retryable Slack delivery failure kind={FailureKind}; notifying session",
+                            failureKind);
+                        await NotifyDeliveryFailedAsync(completed.TurnNumber, failureKind, errorMessage);
                     }
                     else if (_lastFailedPost is not null)
                     {
-                        // Transport failure (timeout, network) — LLM can't fix this
-                        _log.Warning("Turn completed with transport failure: {Error}", _lastFailedPost.ErrorMessage);
+                        _log.Warning("Turn completed with non-retryable Slack delivery failure: {Error}", _lastFailedPost.ErrorMessage);
                     }
                     else
                     {
@@ -505,28 +507,25 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         }
         catch (OperationCanceledException ex)
         {
-            // Transport failure — LLM can't fix a timeout by producing different output
             _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult($"Timed out posting reply: {ex.Message}", IsContentError: false);
+            return new PostResult($"Timed out posting reply: {ex.Message}");
         }
-        catch (SlackNet.SlackException ex)
+        catch (SlackMessageDeliveryException ex)
         {
-            // Slack rejected the content — LLM might fix this by producing different output
-            _log.Error(ex, "Slack rejected reply for session {0}: {1}", _sessionId.Value, ex.ErrorCode);
+            _log.Error(ex, "Slack rejected reply for session {0} with error code {1}", _sessionId.Value, ex.ErrorCode ?? "unknown");
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult(ex.Message, IsContentError: true);
+            return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)
         {
-            // Unknown/transport failure — don't assume the LLM can fix it
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult(ex.Message, IsContentError: false);
+            return new PostResult(ex.Message);
         }
     }
 
-    private async Task NotifyDeliveryFailedAsync(int turnNumber, string errorMessage)
+    private async Task NotifyDeliveryFailedAsync(int turnNumber, DeliveryFailureKind failureKind, string errorMessage)
     {
         try
         {
@@ -535,31 +534,28 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 SessionId = _sessionId,
                 TurnNumber = turnNumber,
                 ChannelType = "slack",
+                FailureKind = failureKind,
                 ErrorMessage = errorMessage
             });
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to send delivery feedback to session");
+            _log.Error(ex, "Failed to send Slack delivery feedback to session");
         }
     }
 
-    /// <summary>
-    /// Result of a channel post attempt. Carries the error message on failure
-    /// so it can be fed back to the LLM session.
-    /// </summary>
-    /// <param name="ErrorMessage">The error message, or null on success.</param>
-    /// <param name="IsContentError">True if the channel rejected the content itself
-    /// (e.g. invalid_blocks) — the LLM can fix this by producing different output.
-    /// False for transport failures (timeouts, network) — retrying with different
-    /// LLM output won't help.</param>
-    private sealed record PostResult(string? ErrorMessage = null, bool IsContentError = false)
+    private sealed record PostResult(string? ErrorMessage = null, DeliveryFailureKind? FailureKind = null)
     {
         public static readonly PostResult Ok = new();
+
         public bool Success => ErrorMessage is null;
+
+        public bool ShouldNotifySession => FailureKind is DeliveryFailureKind.ContentRejected
+            or DeliveryFailureKind.MessageTooLarge
+            or DeliveryFailureKind.UnsupportedContent;
     }
 
-    private async Task SafeUploadFileAsync(FileOutput file)
+    private async Task<PostResult> SafeUploadFileAsync(FileOutput file)
     {
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
@@ -567,7 +563,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
             if (!File.Exists(file.FilePath))
             {
                 _log.Warning("File not found for upload: {Path}", file.FilePath);
-                return;
+                return new PostResult($"File not found for upload: {file.FilePath}");
             }
 
             using var cts = new CancellationTokenSource(ReplyOperationTimeout);
@@ -580,16 +576,28 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
             _uploadedFileThisTurn = true;
             _log.Info("Uploaded file to Slack thread: {FileName}", file.FileName);
+            return PostResult.Ok;
         }
         catch (OperationCanceledException ex)
         {
             _log.Error(ex, "Timed out uploading file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult($"Timed out uploading file: {ex.Message}");
+        }
+        catch (SlackMessageDeliveryException ex)
+        {
+            _log.Error(ex, "Slack rejected file upload {FileName} for session {SessionId} with error code {ErrorCode}",
+                file.FileName,
+                _sessionId.Value,
+                ex.ErrorCode ?? "unknown");
+            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            return new PostResult(ex.Message);
         }
     }
 

--- a/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
@@ -27,6 +27,9 @@ public static class ChannelTelemetry
     private static readonly Counter<long> SlackRepliesFailed =
         Meter.CreateCounter<long>("netclaw.slack.replies.failed");
 
+    private static readonly Counter<long> SlackRepliesPlainTextFallback =
+        Meter.CreateCounter<long>("netclaw.slack.replies.plain_text_fallback");
+
     private static readonly Histogram<double> SlackReplyDurationMs =
         Meter.CreateHistogram<double>("netclaw.slack.reply.duration.ms", unit: "ms");
 
@@ -36,6 +39,7 @@ public static class ChannelTelemetry
     private static long _slackMessagesEnqueuedTotal;
     private static long _slackRepliesPostedTotal;
     private static long _slackRepliesFailedTotal;
+    private static long _slackRepliesPlainTextFallbackTotal;
 
     public sealed record Snapshot(
         long SlackEventsReceived,
@@ -43,7 +47,8 @@ public static class ChannelTelemetry
         long SlackEventsRouted,
         long SlackMessagesEnqueued,
         long SlackRepliesPosted,
-        long SlackRepliesFailed);
+        long SlackRepliesFailed,
+        long SlackRepliesPlainTextFallback);
 
     public static void RecordSlackEventReceived(string kind)
     {
@@ -83,6 +88,12 @@ public static class ChannelTelemetry
         SlackReplyDurationMs.Record(durationMs);
     }
 
+    public static void RecordSlackReplyPlainTextFallback()
+    {
+        Interlocked.Increment(ref _slackRepliesPlainTextFallbackTotal);
+        SlackRepliesPlainTextFallback.Add(1);
+    }
+
     public static Snapshot GetSnapshot()
         => new(
             SlackEventsReceived: Interlocked.Read(ref _slackEventsReceivedTotal),
@@ -90,7 +101,8 @@ public static class ChannelTelemetry
             SlackEventsRouted: Interlocked.Read(ref _slackEventsRoutedTotal),
             SlackMessagesEnqueued: Interlocked.Read(ref _slackMessagesEnqueuedTotal),
             SlackRepliesPosted: Interlocked.Read(ref _slackRepliesPostedTotal),
-            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal));
+            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal),
+            SlackRepliesPlainTextFallback: Interlocked.Read(ref _slackRepliesPlainTextFallbackTotal));
 
     internal static void ResetForTests()
     {
@@ -100,5 +112,6 @@ public static class ChannelTelemetry
         Interlocked.Exchange(ref _slackMessagesEnqueuedTotal, 0);
         Interlocked.Exchange(ref _slackRepliesPostedTotal, 0);
         Interlocked.Exchange(ref _slackRepliesFailedTotal, 0);
+        Interlocked.Exchange(ref _slackRepliesPlainTextFallbackTotal, 0);
     }
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1106,7 +1106,7 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
     if (status.Telemetry.SlackCounters is { } counters)
     {
         Console.WriteLine(
-            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} reply_failed={counters.RepliesFailed}");
+            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} reply_failed={counters.RepliesFailed} plain_text_fallback={counters.RepliesPlainTextFallback}");
     }
 
     if (status.Model is { } model)
@@ -1251,7 +1251,7 @@ static void WriteStatsResult(DaemonStats.Response stats, int? days)
 
     Console.WriteLine("slack:");
     Console.WriteLine($"  events: recv={stats.SlackActivity.EventsReceived} routed={stats.SlackActivity.EventsRouted} dropped={stats.SlackActivity.EventsDropped}");
-    Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} failed={stats.SlackActivity.RepliesFailed}");
+    Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} failed={stats.SlackActivity.RepliesFailed} plain_text_fallback={stats.SlackActivity.RepliesPlainTextFallback}");
 
     if (stats.Reminders is { } reminders)
     {

--- a/src/Netclaw.Cli/Tui/StatsPage.cs
+++ b/src/Netclaw.Cli/Tui/StatsPage.cs
@@ -172,7 +172,7 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         var sl = stats.SlackActivity;
         var content = Layouts.Vertical();
         content.WithChild(new TextNode($"  Events: recv={sl.EventsReceived} routed={sl.EventsRouted} dropped={sl.EventsDropped}").WithForeground(Color.White).Height(1));
-        content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} failed={sl.RepliesFailed}").WithForeground(sl.RepliesFailed > 0 ? Color.Yellow : Color.White).Height(1));
+        content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} failed={sl.RepliesFailed} plain_text_fallback={sl.RepliesPlainTextFallback}").WithForeground(sl.RepliesFailed > 0 ? Color.Yellow : Color.White).Height(1));
         return content;
     }
 

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -87,6 +87,8 @@ public static class DaemonRuntimeStatus
         public long RepliesPosted { get; init; }
 
         public long RepliesFailed { get; init; }
+
+        public long RepliesPlainTextFallback { get; init; }
     }
 
     public sealed class Model : IWireType

--- a/src/Netclaw.Configuration/DaemonStats.cs
+++ b/src/Netclaw.Configuration/DaemonStats.cs
@@ -99,6 +99,8 @@ public static class DaemonStats
         public long RepliesPosted { get; init; }
 
         public long RepliesFailed { get; init; }
+
+        public long RepliesPlainTextFallback { get; init; }
     }
 
     public sealed class Reminders : IWireType

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -96,7 +96,8 @@ internal sealed class DaemonRuntimeStatusService(
             EventsRouted = snapshot.SlackEventsRouted,
             MessagesEnqueued = snapshot.SlackMessagesEnqueued,
             RepliesPosted = snapshot.SlackRepliesPosted,
-            RepliesFailed = snapshot.SlackRepliesFailed
+            RepliesFailed = snapshot.SlackRepliesFailed,
+            RepliesPlainTextFallback = snapshot.SlackRepliesPlainTextFallback
         };
     }
 

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -75,7 +75,8 @@ internal sealed class DaemonStatsService(
                 EventsRouted = slackSnapshot.SlackEventsRouted,
                 EventsDropped = slackSnapshot.SlackEventsDropped,
                 RepliesPosted = slackSnapshot.SlackRepliesPosted,
-                RepliesFailed = slackSnapshot.SlackRepliesFailed
+                RepliesFailed = slackSnapshot.SlackRepliesFailed,
+                RepliesPlainTextFallback = slackSnapshot.SlackRepliesPlainTextFallback
             },
             Reminders = await BuildReminderStatsAsync(ct),
             DailyBreakdown = dailyBreakdown


### PR DESCRIPTION
## Summary

Closes #279

When a channel adapter cannot deliver the LLM's output to the user, feed the full error back to the LLM session so it can understand what went wrong and produce corrected output. No silent fallbacks.

- **`DeliveryFailed` message** (`IWithSessionId`) — any channel adapter sends this back to the session with the full error message
- **`ISessionPipeline.SendFeedbackAsync`** — channel-agnostic API for sending feedback to the session actor
- **`LlmSessionActor` handles `DeliveryFailed`** — injects error as system nudge, immediately re-invokes LLM (Ready state) or defers retry (Processing state via `_deliveryFailurePending` flag)
- **`PostResult` response object** — `SafePostAsync` returns structured result distinguishing content errors (e.g. `invalid_blocks` — LLM can fix) from transport errors (timeouts — LLM can't fix, no retry loop)
- **`SlackBlockConverter` hardening** — filters empty `RichTextText` elements that caused the original `invalid_blocks` rejection
- **"No fallback paths" rule** added to CLAUDE.md Universal Quality Bar
- **Telemetry** — `plain_text_fallback` counter plumbed through stats/CLI

### Design for future channels

When adding Teams/Discord support, the same contract applies:
1. Adapter tries to deliver using channel-native formatting
2. On content rejection → sends `DeliveryFailed` via `ISessionPipeline.SendFeedbackAsync`
3. Session actor injects error nudge, LLM retries with corrected output

No changes to `DeliveryFailed`, `ISessionPipeline`, or `LlmSessionActor` needed.

## Test plan

- [ ] All 1,066 existing tests pass (verified locally)
- [ ] `SlackFileFlowIntegrationTests.Timed_out_slack_post_does_not_block_later_turns` — no feedback loop on transport failures
- [ ] Manual: trigger `invalid_blocks` by having LLM produce problematic markdown → verify LLM gets error and retries