### PR TITLE
fix(reminders): disable one-shot reminders after firing

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -16,6 +16,7 @@ namespace Netclaw.Actors.Tests.Reminders;
 public class ReminderManagerActorTests : TestKit
 {
     private readonly string _basePath = Path.Combine(Path.GetTempPath(), $"netclaw-reminder-tests-{Guid.NewGuid():N}");
+    private ReminderDefinitionStore _definitionStore = null!;
 
     public ReminderManagerActorTests(ITestOutputHelper output) : base(output: output) { }
 
@@ -28,7 +29,8 @@ public class ReminderManagerActorTests : TestKit
         var paths = new NetclawPaths(_basePath);
         paths.EnsureDirectoriesExist();
         var reminderConfig = new ReminderConfig();
-        var definitionStore = new ReminderDefinitionStore(paths);
+        _definitionStore = new ReminderDefinitionStore(paths);
+        var definitionStore = _definitionStore;
         var historyStore = new ReminderHistoryStore(paths, reminderConfig);
 
         // Wire local reminders with in-memory storage
@@ -147,6 +149,58 @@ public class ReminderManagerActorTests : TestKit
         Assert.Equal(0, health.ScheduledCount);
         Assert.Equal(0, health.ActiveExecutions);
         Assert.Equal(0, health.FailedCount);
+    }
+
+    [Fact]
+    public async Task Reconcile_disables_zombie_oneshot_reminders()
+    {
+        var manager = await GetManagerAsync();
+        var now = TimeProvider.System.GetUtcNow();
+
+        // Ensure the actor is fully started and initial reconcile has completed
+        await manager.Ask<ReminderHealthResponse>(
+            GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5));
+
+        // Write a zombie one-shot directly to the store AFTER startup reconcile:
+        // fire time in the past, still enabled, no Akka.Reminders schedule
+        var zombie = new ReminderDefinition
+        {
+            Id = "zombie-oneshot",
+            Title = "Expired one-shot",
+            Instructions = "This already fired",
+            NotifyInstructions = "n/a",
+            Schedule = new ReminderSchedule
+            {
+                Type = ReminderScheduleType.OneShot,
+                FireAt = now.AddHours(-1)
+            },
+            Enabled = true,
+            CreatedBy = "test",
+            CreatedAt = now.AddHours(-2),
+            UpdatedAt = now.AddHours(-2)
+        };
+        _definitionStore.Save(zombie);
+
+        // Confirm it shows up as scheduled
+        var healthBefore = await manager.Ask<ReminderHealthResponse>(
+            GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5));
+        Assert.Equal(1, healthBefore.ScheduledCount);
+
+        // Trigger reconciliation
+        manager.Tell(ReminderManagerActor.ReconcileReminders.Instance);
+
+        // Wait for the zombie to be disabled
+        await AwaitAssertAsync(() =>
+        {
+            var health = manager.Ask<ReminderHealthResponse>(
+                GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5)).Result;
+            Assert.Equal(0, health.ScheduledCount);
+        }, TimeSpan.FromSeconds(10));
+
+        // Verify definition still exists but is now disabled
+        var afterReconcile = _definitionStore.Get(new ReminderId("zombie-oneshot"));
+        Assert.NotNull(afterReconcile);
+        Assert.False(afterReconcile.Enabled);
     }
 
     private static ReminderDefinition CreateDefinition(string name, string instructions)

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -440,6 +440,14 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             }
         }
 
+        // One-shot reminders cannot fire again — disable after execution
+        var definition = _definitionStore.Get(completed.Id);
+        if (definition is { Enabled: true, Schedule.Type: ReminderScheduleType.OneShot })
+        {
+            _log.Info("One-shot reminder '{0}' completed, disabling", completed.Id.Value);
+            await DisableReminderInternalAsync(completed.Id);
+        }
+
         await ProcessDeferredQueueAsync();
     }
 
@@ -472,11 +480,26 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                     restoredSchedules++;
             }
 
-            if (cancelledOrphans > 0 || restoredSchedules > 0)
+            // Disable zombie one-shots: enabled definitions with fire time in the past
+            // and no active Akka.Reminders schedule (already fired, never cleaned up).
+            var now = _timeProvider.GetUtcNow();
+            var disabledZombies = 0;
+            foreach (var definition in definitions.Where(d =>
+                         d.Enabled &&
+                         d.Schedule.Type == ReminderScheduleType.OneShot &&
+                         d.Schedule.FireAt <= now &&
+                         !scheduled.ContainsKey(d.Id)))
             {
-                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}",
+                await DisableReminderInternalAsync(new ReminderId(definition.Id));
+                disabledZombies++;
+            }
+
+            if (cancelledOrphans > 0 || restoredSchedules > 0 || disabledZombies > 0)
+            {
+                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}, disabled_zombies={2}",
                     cancelledOrphans,
-                    restoredSchedules);
+                    restoredSchedules,
+                    disabledZombies);
             }
         }
         catch (Exception ex)
@@ -675,7 +698,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         public static ScheduleAttempt Fail(string message) => new(false, null, message);
     }
 
-    private sealed record ReconcileReminders
+    internal sealed record ReconcileReminders
     {
         public static readonly ReconcileReminders Instance = new();
     }


### PR DESCRIPTION
## Summary
- One-shot reminders that already fired remained on disk with `enabled: true` forever, inflating `ScheduledCount` in the stats command (e.g. showing `scheduled: 8` when only 1 reminder was genuinely active)
- Disable one-shots after execution completes (`HandleExecutionCompletedAsync`) and catch existing zombies on startup reconciliation (`HandleReconcileAsync`)
- Definitions are disabled (not deleted) so history and audit trails are preserved

## Test plan
- [x] New test: `Reconcile_disables_zombie_oneshot_reminders` — writes a zombie definition, triggers reconcile, verifies it's disabled while definition file is preserved
- [x] All 6 existing `ReminderManagerActorTests` pass
- [x] `dotnet slopwatch analyze` — no new violations