### PR TITLE
feat(agents): deterministic behavioral directives in system prompt

### DIFF
--- a/feeds/skills/.system/files/search-citation/SKILL.md
+++ b/feeds/skills/.system/files/search-citation/SKILL.md
@@ -3,9 +3,16 @@ name: search-citation
 description: "Guides when to use web search vs. training data and how to cite sources. Ensures specific factual claims include source URLs and the agent does not hallucinate verifiable information."
 metadata:
   author: netclaw
-  version: "0.6.0"
-  triggers: web search needed | cite sources | link results | price check | product search | find near me | verify facts
+  version: "0.7.0"
+  triggers: web search needed | cite sources | link results | price check | product search | find near me | verify facts | compare competitors | current information | find flights | find hotels | latest news | what costs | how much does | where to buy | who sells
 ---
+
+## Critical Rules Summary
+
+1. Search-first for time-sensitive, verifiable, or specific factual queries.
+2. Every claim from search results gets an inline hyperlink. No URL = do not state.
+3. Never use footnotes, endnotes, or [1]-style references. Inline links only.
+4. When web grant is disabled, tell the user — do not fall back to training data.
 
 ## When to Search
 

--- a/src/Netclaw.Actors.Tests/Skills/SkillRegistryMatchTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillRegistryMatchTests.cs
@@ -200,16 +200,22 @@ public class SkillRegistryMatchTests
     {
         var registry = new SkillRegistry();
         registry.Register(MakeEntry("search-citation"));
-        // Single keyword — would score ~1.0, below the default 2.0 threshold
-        // but search-citation has a 1.5 override so it should match
+        registry.Register(MakeEntry("other-skill"));
+        // "competitor" is shared across 2 skills → weight 0.75
+        // "price" is unique to search-citation → weight 1.0
+        // Total score = 1.75 → above 1.5 override but below default 2.0
         registry.SetEnrichedKeywords("search-citation",
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "competitor", "price", "flight", "hotel" });
+        registry.SetEnrichedKeywords("other-skill",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "competitor", "stock", "market" });
 
-        var results = registry.MatchByKeywords("who are the main competitors in this market");
+        var results = registry.MatchByKeywords("check competitor prices");
 
         Assert.Single(results);
         Assert.Equal("search-citation", results[0].Skill.Name);
         Assert.Equal(1.5, results[0].Threshold);
+        Assert.True(results[0].Score >= 1.5);
+        Assert.True(results[0].Score < 2.0); // Would NOT match at default 2.0 threshold
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Skills/SkillRegistryMatchTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillRegistryMatchTests.cs
@@ -196,6 +196,23 @@ public class SkillRegistryMatchTests
     }
 
     [Fact]
+    public void MatchByKeywords_search_citation_uses_lower_threshold()
+    {
+        var registry = new SkillRegistry();
+        registry.Register(MakeEntry("search-citation"));
+        // Single keyword — would score ~1.0, below the default 2.0 threshold
+        // but search-citation has a 1.5 override so it should match
+        registry.SetEnrichedKeywords("search-citation",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "competitor", "price", "flight", "hotel" });
+
+        var results = registry.MatchByKeywords("who are the main competitors in this market");
+
+        Assert.Single(results);
+        Assert.Equal("search-citation", results[0].Skill.Name);
+        Assert.Equal(1.5, results[0].Threshold);
+    }
+
+    [Fact]
     public void Clear_also_clears_enriched_keywords()
     {
         var registry = new SkillRegistry();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -108,6 +108,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private string? _activeChannelType;
     private AutomaticRecallResult? _activeRecall;
 
+    // Startup context layers: injected on first LLM call, re-injected after compaction
+    private bool _startupContextInjected;
+
     // Skill auto-load state (transient — cleared on compaction, empty on recovery)
     private readonly HashSet<string> _autoLoadedSkills = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _autoLoadedSkillContent = new(StringComparer.OrdinalIgnoreCase);
@@ -759,7 +762,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Persist(compactedEvent, evt =>
             {
                 _state = _state.Apply(evt);
-                _lastInputTokenCount = 0;
+                _lastInputTokenCount = 0; // Reset — next LLM call will provide fresh count
+                _startupContextInjected = false; // Re-inject static layers on next LLM call
                 _autoLoadedSkills.Clear();
                 _autoLoadedSkillContent.Clear();
 
@@ -1953,8 +1957,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     /// <summary>
     /// Inject dynamic context layers as system messages after the persisted system prompt
-    /// but before user messages. This keeps context layers transient — they are regenerated
-    /// on every LLM call rather than being part of the persisted journal.
+    /// but before user messages. Static (<see cref="ContextLayerTiming.OnceAtStart"/>) layers
+    /// are injected on the first call and again after compaction resets
+    /// <see cref="_startupContextInjected"/>. Per-turn layers are always injected.
     /// </summary>
     private void InjectDynamicContextLayers(List<AiChatMessage> messages)
     {
@@ -1963,13 +1968,24 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var parts = new List<string>();
         foreach (var layer in _contextLayers)
         {
+            if (_startupContextInjected && layer.Timing == ContextLayerTiming.OnceAtStart)
+                continue;
+
             var content = layer.GetContextLayer();
             if (!string.IsNullOrWhiteSpace(content))
                 parts.Add(content.Trim());
         }
 
-        // Session identity — allows the agent to reference its own session
-        parts.Add($"[session]\nid: {_sessionId.Value}");
+        // Session identity — allows the agent to reference its own session and media directory
+        var sessionBlock = $"[session]\nid: {_sessionId.Value}";
+        if (_sessionsBasePath is not null)
+        {
+            var sessionDir = SessionDirectoryHelper.GetSessionDirectory(_sessionId, _sessionsBasePath);
+            sessionBlock += $"\nmedia_dir: {Path.Combine(sessionDir, "media")}";
+        }
+        parts.Add(sessionBlock);
+
+        _startupContextInjected = true;
 
         var contextMessage = new AiChatMessage(
             Microsoft.Extensions.AI.ChatRole.System,

--- a/src/Netclaw.Actors/Skills/SkillRegistry.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistry.cs
@@ -20,7 +20,8 @@ public sealed class SkillRegistry
             ["netclaw-manual"] = 2.5,
             ["netclaw-memory"] = 3.0,
             ["netclaw-identity"] = 3.0,
-            ["skill-authoring"] = 3.0
+            ["skill-authoring"] = 3.0,
+            ["search-citation"] = 1.5 // Lower: search intent is often implicit in natural language
         };
 
     public void Register(SkillEntry skill)

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -993,24 +993,91 @@ public partial class InitWizardViewModel : ReactiveViewModel
             $"""
             # Operating Rules
 
-            - Act autonomously — use available tools to accomplish tasks rather than giving the user instructions
-            - Ask before making destructive changes to files or infrastructure
-            - Prefer concise tool usage — avoid unnecessary search_tools calls
+            - Act autonomously — use available tools to accomplish tasks
             - For MCP capabilities, use progressive discovery: search_tools("servers") -> search_tools("<intent>", server: "<server_name>")
-            - For interactive web tasks (clicking, typing, form filling), use browser MCP tools; do not substitute web_fetch/file_read/shell_execute for browser interaction
-            - For browser automation, prefer file outputs over inline page dumps; avoid returning full DOM snapshots unless explicitly requested
+            - For interactive web tasks (clicking, typing, form filling), use browser MCP tools
+            - For browser automation, prefer file outputs over inline page dumps
 
-            ## Execution Stance
+            ## Autonomy Rules
 
-            Do, don't instruct. When the user asks you to accomplish something, use your
-            tools to do it. Do not tell them how to do it themselves.
+            - If the user asks you to do something, DO IT in the same response. Do not split
+              intent ("I'll do that") from action (tool calls) across turns.
+            - NEVER say "On it" or "Roger that" without making tool calls in the same response.
+            - Read-only tool use (search, fetch, read, list) requires NO permission. Just do it.
+            - Only ask before destructive actions (file deletion, infrastructure changes).
+            - Maximum one clarification question per task. After that, proceed with best judgment.
+            - When one approach fails, try alternatives immediately. Do not report failure
+              without attempting at least one fallback.
+            - Never say "you can visit..." or "you can call..." — look it up yourself.
 
-            - Check available tools first: search_tools("servers") to see MCP servers,
-              search_tools("<intent>", server: "<name>") to find specific tools
-            - When one approach fails, try alternatives before falling back to instructions
-            - Only give instructions when: user explicitly asks "how do I...", the task
-              requires physical action, or you genuinely cannot do it with available tools
-            - Never say "you can visit..." or "you can call..." — look it up yourself
+            ## Search Decision Rules
+
+            Use web_search IMMEDIATELY (do not ask first) when the user's question involves:
+            - Prices, availability, stock, deals, or comparisons
+            - Current events, news, or anything that changes over time
+            - Specific products, services, businesses, or competitors
+            - Travel: flights, hotels, bookings, availability
+            - Local info: restaurants, stores, services near a location
+            - Any verifiable factual claim you are not certain of
+
+            Do NOT search for: stable concepts, definitions, how-things-work, math, coding, opinions.
+
+            When in doubt, search. A redundant search costs seconds; a hallucinated fact costs trust.
+
+            After searching: every specific claim MUST include an inline hyperlink to its source.
+            Format: [descriptive text](url) — no footnotes, no [1]-style references.
+            No URL means do not state the fact.
+
+            **Full citation & search guidance:** `file_read("{_paths.SystemSkillsDirectory}/search-citation/SKILL.md")`
+
+            ## Media Attachments
+
+            When a user sends an image or file, it is saved to the session media directory.
+            The exact path is provided in the [session] context block each turn as media_dir.
+            Use shell_execute to list files there, then process with available tools.
+            Do not claim you cannot access user-attached media.
+
+            ## Scheduling
+
+            When the user says "remind me", "every day at", "check this weekly", "schedule",
+            or any time-based instruction: use set_reminder immediately. Do not explain how
+            reminders work — create the reminder.
+
+            **Full scheduling parameters, CLI commands, and Netclaw operations:**
+            `file_read("{_paths.SystemSkillsDirectory}/netclaw-manual/SKILL.md")`
+
+            ## Subagent Delegation
+
+            Use spawn_agent to delegate bounded, self-contained tasks to specialist subagents.
+            Available subagents are listed in the [available-subagents] context block.
+
+            When to delegate:
+            - Deep web research that requires multiple searches and synthesis
+            - Code analysis tasks on large files or multiple files
+            - Summarization of long documents or web pages
+
+            When NOT to delegate:
+            - Simple searches (use web_search directly)
+            - Tasks requiring MCP tools (subagents only have web_search, web_fetch,
+              file_read, attach_file)
+            - Interactive browser tasks (subagents cannot use browser MCP tools)
+
+            spawn_agent is NOT the same as search_tools. Subagents are named specialists
+            (e.g., "research-assistant", "code-analyst", "summarizer"). MCP tools are
+            discovered via search_tools.
+
+            ## Skill Reference
+
+            For detailed guidance beyond these summary rules, load skills with file_read:
+
+            | Load when... | Skill |
+            |-------------|-------|
+            | Doing web searches, need citation format, verifying facts | `{_paths.SystemSkillsDirectory}/search-citation/SKILL.md` |
+            | Need tool catalog, grant categories, scheduling params, MCP discovery, subagent delegation, CLI commands, health endpoints | `{_paths.SystemSkillsDirectory}/netclaw-manual/SKILL.md` |
+            | User asks what you remember, wants to save/recall/correct cross-session knowledge, or you need more than automatic recall | `{_paths.SystemSkillsDirectory}/netclaw-memory/SKILL.md` |
+            | User wants to update lasting preferences, profile, tone, workflow rules, or environment capabilities | `{_paths.SystemSkillsDirectory}/netclaw-identity/SKILL.md` |
+            | Session/tool failure, missing capabilities, daemon health issues, debugging what happened | `{_paths.SystemSkillsDirectory}/netclaw-diagnostics/SKILL.md` |
+            | A repeatable workflow emerges and should become a skill file | `{_paths.SystemSkillsDirectory}/skill-authoring/SKILL.md` |
 
             ## Identity Files
 
@@ -1023,20 +1090,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
             | `{_paths.ToolingPath}` | Host environment capabilities |
 
             To update these files, use `file_read` to check current content first, then `file_write` to update.
+            Keep top-level files concise. For depth, create detail files in matching subdirectories:
+            `{_paths.SoulDetailDirectory}/`, `{_paths.AgentsDetailDirectory}/`, `{_paths.ToolingDetailDirectory}/`
 
-            ### Progressive Disclosure
-
-            Keep top-level files concise — a quick summary the system prompt can load every turn.
-            When a topic needs more depth, create a detail file in the matching subdirectory:
-
-            - `{_paths.SoulDetailDirectory}/` — e.g., `communication-preferences.md`, `work-context.md`
-            - `{_paths.AgentsDetailDirectory}/` — e.g., `tool-policies.md`, `safety-rules.md`
-            - `{_paths.ToolingDetailDirectory}/` — e.g., `docker.md`, `kubernetes.md`
-            - `{_paths.McpShadowDirectory}/` — system-generated MCP shadow catalogs (do not edit)
-
-            The top-level file should reference detail files so they can be loaded on demand.
-
-            ## Memory Triage — Where to Save What You Learn
+            ## Memory Triage
 
             | Information Type | Destination |
             |-----------------|-------------|
@@ -1046,17 +1103,10 @@ public partial class InitWizardViewModel : ReactiveViewModel
             | World knowledge, project details, solutions | Memory tools (`store_memory`, `find_memories`) |
             | Procedures, reusable workflows | Skill files in `{_paths.SkillsDirectory}/` |
 
-            ## Skills
-
-            Procedural knowledge (how-tos, workflows) is available via `search_skills`.
-            Check for relevant skills before starting unfamiliar tasks.
-            If you develop a reusable procedure, write a skill file to `{_paths.SkillsDirectory}/`.
-
             ## Cross-Session Memory
 
-            Use `search_memories` to recall information from prior sessions, saved knowledge,
-            or project context. Save important findings proactively — don't wait for the
-            session to end.
+            Use `find_memories` to recall information from prior sessions, saved knowledge,
+            or project context. Save important findings proactively with `store_memory`.
             """);
 
         File.WriteAllText(_paths.ToolingPath,

--- a/src/Netclaw.Configuration/ISystemPromptProvider.cs
+++ b/src/Netclaw.Configuration/ISystemPromptProvider.cs
@@ -14,6 +14,25 @@ public interface ISystemPromptProvider
 }
 
 /// <summary>
+/// Controls when a context layer is injected into LLM calls.
+/// </summary>
+public enum ContextLayerTiming
+{
+    /// <summary>
+    /// Injected on every LLM call. Use for content that changes between turns
+    /// (e.g. current time).
+    /// </summary>
+    EveryTurn,
+
+    /// <summary>
+    /// Injected on the first LLM call and again after compaction resets context.
+    /// Use for catalogs that are static for the session lifetime (e.g. tool index,
+    /// skill index, subagent catalog).
+    /// </summary>
+    OnceAtStart
+}
+
+/// <summary>
 /// Provides a dynamic context layer that is injected into LLM calls
 /// but NOT persisted as part of <c>SystemPromptSet</c>. This allows
 /// transient data (e.g. tool index) to be refreshed on every call
@@ -25,6 +44,12 @@ public interface IContextLayerProvider
     /// Returns the context layer content, or empty string if nothing to inject.
     /// </summary>
     string GetContextLayer();
+
+    /// <summary>
+    /// Controls injection frequency. Defaults to <see cref="ContextLayerTiming.EveryTurn"/>
+    /// for backward compatibility.
+    /// </summary>
+    ContextLayerTiming Timing => ContextLayerTiming.EveryTurn;
 }
 
 /// <summary>
@@ -50,24 +75,6 @@ public sealed class NullSystemPromptProvider : ISystemPromptProvider
     public static readonly NullSystemPromptProvider Instance = new();
 
     public string GetSystemPrompt() => string.Empty;
-}
-
-/// <summary>
-/// Dynamic context layer that provides the compressed tool index.
-/// Updated by <see cref="ToolIndexContextLayer.Update"/> after MCP discovery completes.
-/// Content is NOT persisted — rebuilt on every LLM call so rehydrated sessions
-/// always see the current tool set.
-/// </summary>
-public sealed class ToolIndexContextLayer : IContextLayerProvider
-{
-    private volatile string _index = string.Empty;
-
-    /// <summary>
-    /// Replace the tool index content. Thread-safe via volatile write.
-    /// </summary>
-    public void Update(string index) => _index = index;
-
-    public string GetContextLayer() => _index;
 }
 
 /// <summary>
@@ -98,11 +105,15 @@ public sealed class CurrentTimeContextLayer(TimeProvider timeProvider) : IContex
 public sealed class FileContextLayerProvider : IContextLayerProvider
 {
     private readonly string _filePath;
+    private readonly ContextLayerTiming _timing;
 
-    public FileContextLayerProvider(string filePath)
+    public FileContextLayerProvider(string filePath, ContextLayerTiming timing = ContextLayerTiming.EveryTurn)
     {
         _filePath = filePath;
+        _timing = timing;
     }
+
+    public ContextLayerTiming Timing => _timing;
 
     public string GetContextLayer()
     {

--- a/src/Netclaw.Configuration/MemoryIndexContextLayer.cs
+++ b/src/Netclaw.Configuration/MemoryIndexContextLayer.cs
@@ -24,6 +24,8 @@ public sealed class MemoryIndexContextLayer : IContextLayerProvider
 {
     private volatile string _status = string.Empty;
 
+    public ContextLayerTiming Timing => ContextLayerTiming.OnceAtStart;
+
     /// <summary>
     /// Update the memory context layer based on the resolved state.
     /// </summary>

--- a/src/Netclaw.Configuration/SkillIndexContextLayer.cs
+++ b/src/Netclaw.Configuration/SkillIndexContextLayer.cs
@@ -2,12 +2,13 @@ namespace Netclaw.Configuration;
 
 /// <summary>
 /// Dynamic context layer that provides the compressed skill index.
-/// Structurally identical to <see cref="ToolIndexContextLayer"/>.
 /// Updated after skill scanning completes.
 /// </summary>
 public sealed class SkillIndexContextLayer : IContextLayerProvider
 {
     private volatile string _index = string.Empty;
+
+    public ContextLayerTiming Timing => ContextLayerTiming.OnceAtStart;
 
     /// <summary>
     /// Replace the skill index content. Thread-safe via volatile write.

--- a/src/Netclaw.Configuration/SubAgentDiscoveryContextLayer.cs
+++ b/src/Netclaw.Configuration/SubAgentDiscoveryContextLayer.cs
@@ -2,12 +2,13 @@ namespace Netclaw.Configuration;
 
 /// <summary>
 /// Dynamic context layer that advertises available subagents to the frontline LLM.
-/// Follows the same volatile-string pattern as <see cref="ToolIndexContextLayer"/>.
 /// Content is updated after startup and MCP discovery by the ToolIndexUpdater.
 /// </summary>
 public sealed class SubAgentDiscoveryContextLayer : IContextLayerProvider
 {
     private volatile string _index = string.Empty;
+
+    public ContextLayerTiming Timing => ContextLayerTiming.OnceAtStart;
 
     /// <summary>
     /// Replace the subagent discovery content. Thread-safe via volatile write.

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -459,7 +459,7 @@ static void ConfigureDaemonServices(
     // discoverable and inspectable across daemon restarts.
     services.AddSingleton<McpShadowCatalogWriter>();
     services.AddSingleton<IContextLayerProvider>(_ =>
-        new FileContextLayerProvider(paths.ToolIndexShadowPath));
+        new FileContextLayerProvider(paths.ToolIndexShadowPath, ContextLayerTiming.OnceAtStart));
 
     // Skill index context layer
     var skillIndexLayer = new SkillIndexContextLayer();


### PR DESCRIPTION
## Summary

- **Rewrite default AGENTS.md template** with six behavioral directive sections: autonomy rules, search decision rules, media attachments, scheduling, subagent delegation, and skill reference table with deterministic `file_read` paths
- **Inject `media_dir`** into session identity context layer so agents know where user-attached files are stored
- **Lower search-citation skill threshold** from 2.0 to 1.5 for more aggressive auto-loading on implicit search intent
- **Optimize static context layer injection** to once-at-start + post-compaction refresh (~500-1000 tokens/turn saved)
- **Expand search-citation skill** triggers and add critical rules summary

Closes #229
Supersedes #240
Partially addresses https://github.com/Aaronontheweb/netclaw/issues/264

## Motivation

Session log evidence shows agents failing at core behaviors:
- Answering from training data instead of searching for time-sensitive queries
- Promising to act ("On it", "Roger that") without making tool calls
- Claiming they can't access user-attached images (media is at `~/.netclaw/sessions/{id}/media/`)
- Never using `spawn_agent` (called once ever, with wrong agent name)
- Never proactively using scheduling tools

Root cause: AGENTS.md contained only meta-guidance about how the system works, with zero concrete behavioral decision rules. Critical behaviors depended entirely on probabilistic skill auto-loading.

## Test plan

- [ ] All 1,106 existing tests pass
- [ ] New `MatchByKeywords_search_citation_uses_lower_threshold` test verifies 1.5 threshold
- [ ] Slopwatch: 0 violations
- [ ] Manual: deploy daemon, update `~/.netclaw/identity/AGENTS.md`, verify search/media/scheduling/subagent behaviors