### PR TITLE
refactor(mcp-oauth): unify MCP OAuth with shared PKCE flow

### DIFF
--- a/feeds/skills/.system/files/netclaw-manual/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-manual/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-manual
 description: "Netclaw Manual. Read when the user is asking what Netclaw can do, which command/tool to use, how to schedule work, switch models, manage providers, or discover available capabilities."
 metadata:
   author: netclaw
-  version: "0.8.0"
+  version: "0.8.1"
   triggers: what can netclaw do | what command should I use | can you schedule a cron job | schedule a reminder | switch models | change model | manage providers | manage mcp servers | list available tools | how do I do this in netclaw
 ---
 
@@ -212,6 +212,15 @@ result, and LLM response from that run. Use this when a reminder shows
 | `netclaw model` | Manage model assignments (TUI or subcommands) |
 | `netclaw mcp` | Manage MCP servers (`add`, `auth`, `list`, `get`, `remove`, `enable`, `disable`) |
 | `netclaw secrets` | Manage encrypted secrets |
+
+## MCP OAuth Auth Flow
+
+Use `netclaw mcp auth <name>` for HTTP/SSE MCP servers that require OAuth.
+
+- Netclaw starts the OAuth flow through the daemon and polls by flow `state` until it completes or times out.
+- It tries to open the browser automatically, but always prints the authorization URL for manual use.
+- In headless or callback-unreachable environments, paste the full redirect URL from the browser address bar back into the CLI.
+- Empty or malformed pasted URLs do not cancel the flow; Netclaw keeps polling and lets the operator try again.
 
 ### Reminders
 

--- a/feeds/skills/.system/files/netclaw-manual/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-manual/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-manual
 description: "Netclaw Manual. Read when the user is asking what Netclaw can do, which command/tool to use, how to schedule work, switch models, manage providers, or discover available capabilities."
 metadata:
   author: netclaw
-  version: "0.8.1"
+  version: "0.8.2"
   triggers: what can netclaw do | what command should I use | can you schedule a cron job | schedule a reminder | switch models | change model | manage providers | manage mcp servers | list available tools | how do I do this in netclaw
 ---
 
@@ -219,6 +219,7 @@ Use `netclaw mcp auth <name>` for HTTP/SSE MCP servers that require OAuth.
 
 - Netclaw starts the OAuth flow through the daemon and polls by flow `state` until it completes or times out.
 - It tries to open the browser automatically, but always prints the authorization URL for manual use.
+- When running in a compatible terminal, Netclaw also emits an OSC 52 clipboard copy for the authorization URL.
 - In headless or callback-unreachable environments, paste the full redirect URL from the browser address bar back into the CLI.
 - Empty or malformed pasted URLs do not cancel the flow; Netclaw keeps polling and lets the operator try again.
 

--- a/openspec/changes/browser-oauth-provider-auth/tasks.md
+++ b/openspec/changes/browser-oauth-provider-auth/tasks.md
@@ -22,7 +22,7 @@
 - [x] 4.1 Add `GET /api/provider/oauth/callback` endpoint in daemon `Program.cs` — accept `code` and `state` params, validate state, exchange code for tokens, return HTML success/error page
 - [x] 4.2 Add `POST /api/provider/oauth/start` endpoint — accept provider type, generate PKCE + auth URL using `OAuthPkceService`, store pending flow, return `{ authorizationUrl, state }`
 - [x] 4.3 Add `GET /api/provider/oauth/status/{state}` endpoint — return `Completed`, `Pending`, or `Failed` for a pending flow
-- [ ] 4.4 Write integration tests for daemon callback endpoints using `WebApplicationFactory`
+- [x] 4.4 Write integration tests for daemon callback endpoints using ASP.NET Core test host coverage around the mapped routes
 
 ## 5. CLI/TUI Browser OAuth Flow
 

--- a/openspec/changes/browser-oauth-provider-auth/tasks.md
+++ b/openspec/changes/browser-oauth-provider-auth/tasks.md
@@ -10,7 +10,7 @@
 - [x] 2.2 Add token exchange method to `OAuthPkceService` (POST authorization code + code_verifier to token endpoint, return `OAuthDeviceFlowResult`)
 - [x] 2.3 Add token refresh method to `OAuthPkceService` (POST refresh_token, handle `invalid_grant`)
 - [x] 2.4 Write unit tests for `OAuthPkceService` — PKCE generation, URL construction, token exchange with mock HTTP, refresh with mock HTTP
-- [ ] 2.5 Refactor `McpOAuthService` to delegate PKCE generation and token exchange to `OAuthPkceService` (verify MCP OAuth still works via existing tests)
+- [x] 2.5 Refactor `McpOAuthService` to delegate PKCE generation and token exchange to `OAuthPkceService` (verify MCP OAuth still works via existing tests)
 
 ## 3. Provider Descriptor Changes
 
@@ -35,11 +35,11 @@
 
 ## 6. MCP OAuth Improvements
 
-- [ ] 6.1 Refactor `McpCommand` OAuth flow to use `OAuthPkceService` for state tracking instead of polling by server name
+- [x] 6.1 Refactor `McpCommand` OAuth flow to use `OAuthPkceService` for state tracking instead of polling by server name
 - [ ] 6.2 Add `CopyableTextNode` for auth URL display in MCP OAuth (replace plain text `"If it doesn't open, visit:"`)
 - [ ] 6.3 Add redirect URL paste fallback `TextInputNode` to MCP OAuth flow for headless environments
 - [ ] 6.4 Add `ToastOverlayNode` clipboard feedback when auth URL is copied via OSC 52
-- [ ] 6.5 Refactor MCP callback endpoint to delegate token exchange to `OAuthPkceService`
+- [x] 6.5 Refactor MCP callback endpoint to delegate token exchange to `OAuthPkceService`
 
 ## 7. Cleanup and Verification
 

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -284,6 +284,17 @@ public sealed class McpCommandTests : IDisposable
         Assert.Contains("Redirect URL was rejected", output.ToString());
     }
 
+    [Fact]
+    public void TryEmitOsc52Copy_StringWriter_ReturnsFalse()
+    {
+        var output = new StringWriter();
+
+        var copied = McpCommand.TryEmitOsc52Copy(output, "https://example.com/oauth");
+
+        Assert.False(copied);
+        Assert.Equal(string.Empty, output.ToString());
+    }
+
     private static JsonDocument ReadConfigFile(string path)
     {
         return JsonDocument.Parse(File.ReadAllText(path));

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Netclaw.Cli.Mcp;
 using Netclaw.Configuration;
@@ -224,6 +225,63 @@ public sealed class McpCommandTests : IDisposable
 
         var servers = McpCommand.LoadMcpServers(_paths);
         Assert.True(servers["memorizer"].Enabled);
+    }
+
+    [Fact]
+    public async Task ReadPasteRedirectAsync_InvalidUrl_AllowsRetryUntilSuccess()
+    {
+        var lines = new Queue<string?>([
+            "not-a-url",
+            "http://127.0.0.1:5199/api/mcp/oauth/callback?code=auth-code&state=flow-state"
+        ]);
+
+        var submissions = 0;
+        var output = new StringWriter();
+
+        var result = await McpCommand.ReadPasteRedirectAsync(
+            output,
+            _ => Task.FromResult(lines.Dequeue()),
+            (code, state, _) =>
+            {
+                submissions++;
+                Assert.Equal("auth-code", code);
+                Assert.Equal("flow-state", state);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            },
+            CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(1, submissions);
+        Assert.Contains("Invalid redirect URL", output.ToString());
+    }
+
+    [Fact]
+    public async Task ReadPasteRedirectAsync_RejectedRedirect_AllowsRetry()
+    {
+        var lines = new Queue<string?>([
+            "http://127.0.0.1:5199/api/mcp/oauth/callback?code=bad-code&state=flow-state",
+            "http://127.0.0.1:5199/api/mcp/oauth/callback?code=good-code&state=flow-state"
+        ]);
+
+        var submissions = 0;
+        var output = new StringWriter();
+
+        var result = await McpCommand.ReadPasteRedirectAsync(
+            output,
+            _ => Task.FromResult(lines.Dequeue()),
+            (code, _, _) =>
+            {
+                submissions++;
+                var status = code == "bad-code"
+                    ? HttpStatusCode.BadRequest
+                    : HttpStatusCode.OK;
+                return Task.FromResult(new HttpResponseMessage(status));
+            },
+            CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(2, submissions);
+        Assert.Contains("Redirect URL was rejected", output.ToString());
     }
 
     private static JsonDocument ReadConfigFile(string path)

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -157,6 +157,22 @@ public sealed class DaemonApi
             $"{_endpoint}/api/mcp/oauth/status/{Uri.EscapeDataString(name)}", cts.Token);
     }
 
+    public async Task<JsonElement> GetMcpOAuthStatusByStateAsync(string state, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetFromJsonAsync<JsonElement>(
+            $"{_endpoint}/api/mcp/oauth/status-by-state/{Uri.EscapeDataString(state)}", cts.Token);
+    }
+
+    public async Task<HttpResponseMessage> McpOAuthCallbackAsync(string code, string state, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(LongTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetAsync(
+            $"{_endpoint}/api/mcp/oauth/callback?code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}", cts.Token);
+    }
+
     // ── Provider OAuth ─────────────────────────────────────────────────
 
     public async Task<HttpResponseMessage> StartProviderOAuthAsync(string providerType, CancellationToken ct = default)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -296,8 +296,9 @@ internal static class McpCommand
         writer.WriteLine();
 
         // 3. Start polling + listen for paste concurrently
+        writer.Write("Waiting for authorization");
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
-        var pollTask = PollMcpOAuthStatusAsync(daemonApi, flowState, cts.Token);
+        var pollTask = PollMcpOAuthStatusAsync(daemonApi, flowState, writer, cts.Token);
         var pasteTask = ReadPasteRedirectAsync(daemonApi, writer, cts.Token);
 
         var completedTask = await Task.WhenAny(pollTask, pasteTask);
@@ -330,7 +331,7 @@ internal static class McpCommand
     }
 
     private static async Task<bool> PollMcpOAuthStatusAsync(
-        DaemonApi daemonApi, string state, CancellationToken ct)
+        DaemonApi daemonApi, string state, TextWriter writer, CancellationToken ct)
     {
         var pollInterval = TimeSpan.FromSeconds(2);
 
@@ -339,13 +340,22 @@ internal static class McpCommand
             try
             {
                 await Task.Delay(pollInterval, ct);
+                writer.Write(".");
+
                 var statusResponse = await daemonApi.GetMcpOAuthStatusByStateAsync(state, ct);
                 var status = statusResponse.GetProperty("status").GetString();
 
                 if (status is "Completed")
+                {
+                    writer.WriteLine();
                     return true;
+                }
+
                 if (status is "Failed")
+                {
+                    writer.WriteLine();
                     return false;
+                }
             }
             catch (OperationCanceledException)
             {
@@ -357,31 +367,25 @@ internal static class McpCommand
             }
         }
 
+        writer.WriteLine();
         return false;
     }
 
     private static async Task<bool> ReadPasteRedirectAsync(
         DaemonApi daemonApi, TextWriter writer, CancellationToken ct)
     {
+        // Skip paste fallback when stdin is redirected (CI, piped input)
+        if (Console.IsInputRedirected)
+            return false;
+
         try
         {
-            // Read from stdin on a background thread (Console.ReadLine blocks)
-            var line = await Task.Run(() =>
-            {
-                while (!ct.IsCancellationRequested)
-                {
-                    if (Console.KeyAvailable || !Console.IsInputRedirected)
-                    {
-                        var input = Console.ReadLine();
-                        if (!string.IsNullOrWhiteSpace(input))
-                            return input;
-                    }
-                }
+            // Read from stdin on a background thread (Console.ReadLine blocks
+            // and does not respect cancellation, so the thread will outlive
+            // the CancellationToken — this is acceptable for a CLI command).
+            var line = await Task.Run(Console.ReadLine, ct);
 
-                return null;
-            }, ct);
-
-            if (line is null)
+            if (string.IsNullOrWhiteSpace(line))
                 return false;
 
             if (!OAuthRedirectParser.TryParse(line, out var code, out var state, out var error))

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -376,31 +376,79 @@ internal static class McpCommand
     {
         // Skip paste fallback when stdin is redirected (CI, piped input)
         if (Console.IsInputRedirected)
-            return false;
+            return await WaitUntilCancelledAsync(ct);
 
-        try
+        return await ReadPasteRedirectAsync(
+            writer,
+            token => Task.Run(Console.ReadLine, token),
+            (code, state, token) => daemonApi.McpOAuthCallbackAsync(code, state, token),
+            ct);
+    }
+
+    internal static async Task<bool> ReadPasteRedirectAsync(
+        TextWriter writer,
+        Func<CancellationToken, Task<string?>> readLineAsync,
+        Func<string, string, CancellationToken, Task<HttpResponseMessage>> submitRedirectAsync,
+        CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
         {
-            // Read from stdin on a background thread (Console.ReadLine blocks
-            // and does not respect cancellation, so the thread will outlive
-            // the CancellationToken — this is acceptable for a CLI command).
-            var line = await Task.Run(Console.ReadLine, ct);
+            string? line;
+            try
+            {
+                line = await readLineAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+
+            // End-of-input means paste fallback is unavailable; keep polling alive.
+            if (line is null)
+                return await WaitUntilCancelledAsync(ct);
 
             if (string.IsNullOrWhiteSpace(line))
-                return false;
+                continue;
 
             if (!OAuthRedirectParser.TryParse(line, out var code, out var state, out var error))
             {
                 writer.WriteLine($"Invalid redirect URL: {error}");
-                return false;
+                continue;
             }
 
-            var response = await daemonApi.McpOAuthCallbackAsync(code, state, ct);
-            return response.IsSuccessStatusCode;
+            try
+            {
+                using var response = await submitRedirectAsync(code, state, ct);
+                if (response.IsSuccessStatusCode)
+                    return true;
+
+                writer.WriteLine("Redirect URL was rejected. Paste the latest redirect URL or wait for automatic completion.");
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                writer.WriteLine($"Failed to submit redirect URL: {ex.Message}");
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> WaitUntilCancelledAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
         }
         catch (OperationCanceledException)
         {
             return false;
         }
+
+        return false;
     }
 
     private static async Task<int> RunListAsync(NetclawPaths paths, TextWriter writer)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Net.Sockets;
+using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Client;
 using Netclaw.Cli.Config;
@@ -289,6 +290,8 @@ internal static class McpCommand
 
         writer.WriteLine();
         writer.WriteLine($"Authorization URL: {authUrl}");
+        if (TryEmitOsc52Copy(writer, authUrl))
+            writer.WriteLine("Copied authorization URL to clipboard via OSC 52.");
         writer.WriteLine();
         writer.WriteLine("Complete the authorization in your browser, then either:");
         writer.WriteLine("  1. Wait for the callback to be received automatically");
@@ -449,6 +452,23 @@ internal static class McpCommand
         }
 
         return false;
+    }
+
+    internal static bool TryEmitOsc52Copy(TextWriter writer, string text)
+    {
+        if (string.IsNullOrEmpty(text)
+            || !ReferenceEquals(writer, Console.Out)
+            || Console.IsOutputRedirected)
+            return false;
+
+        var term = Environment.GetEnvironmentVariable("TERM");
+        if (string.IsNullOrWhiteSpace(term)
+            || string.Equals(term, "dumb", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+        writer.Write($"\u001b]52;c;{payload}\u0007");
+        return true;
     }
 
     private static async Task<int> RunListAsync(NetclawPaths paths, TextWriter writer)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -6,6 +6,7 @@ using ModelContextProtocol.Client;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
+using Netclaw.Providers.OAuth;
 
 namespace Netclaw.Cli.Mcp;
 
@@ -262,63 +263,140 @@ internal static class McpCommand
 
         var startResult = await startResponse.Content.ReadFromJsonAsync<JsonElement>();
         var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
+        var flowState = startResult.GetProperty("state").GetString()!;
 
-        // 2. Open browser (best-effort)
+        // 2. Open browser (detect headless first)
+        var canOpenBrowser = BrowserDetection.CanOpenBrowser();
         writer.WriteLine();
-        writer.WriteLine("Opening browser for authorization...");
-        writer.WriteLine($"If it doesn't open, visit: {authUrl}");
-        writer.WriteLine();
 
-        try
+        if (canOpenBrowser)
         {
-            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            writer.WriteLine($"Could not open browser automatically: {ex.Message}");
-        }
-
-        // 3. Poll for completion
-        writer.Write("Waiting for authorization");
-        var pollTimeout = TimeSpan.FromMinutes(5);
-        var pollInterval = TimeSpan.FromSeconds(2);
-        var elapsed = TimeSpan.Zero;
-
-        while (elapsed < pollTimeout)
-        {
-            await Task.Delay(pollInterval);
-            elapsed += pollInterval;
-            writer.Write(".");
-
+            writer.WriteLine("Opening browser for authorization...");
             try
             {
-                var statusResponse = await daemonApi.GetMcpOAuthStatusAsync(name);
-
-                var status = statusResponse.GetProperty("status").GetString();
-                if (status is "Completed")
-                {
-                    writer.WriteLine();
-                    writer.WriteLine($"Authorization complete for '{name}'.");
-                    writer.WriteLine("Run: netclaw daemon restart");
-                    return 0;
-                }
-
-                if (status is "Failed")
-                {
-                    writer.WriteLine();
-                    writer.WriteLine($"Authorization failed for '{name}'.");
-                    return 1;
-                }
+                Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
             }
-            catch (Exception ex)
+            catch
             {
-                writer.Write($"(poll error: {ex.Message})");
+                canOpenBrowser = false;
             }
         }
 
+        if (!canOpenBrowser)
+        {
+            writer.WriteLine("Could not open browser automatically (headless environment detected).");
+        }
+
         writer.WriteLine();
-        writer.WriteLine("Timed out waiting for authorization. Try again with: netclaw mcp auth " + name);
+        writer.WriteLine($"Authorization URL: {authUrl}");
+        writer.WriteLine();
+        writer.WriteLine("Complete the authorization in your browser, then either:");
+        writer.WriteLine("  1. Wait for the callback to be received automatically");
+        writer.WriteLine("  2. Paste the redirect URL below if the callback can't reach this machine");
+        writer.WriteLine();
+
+        // 3. Start polling + listen for paste concurrently
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var pollTask = PollMcpOAuthStatusAsync(daemonApi, flowState, cts.Token);
+        var pasteTask = ReadPasteRedirectAsync(daemonApi, writer, cts.Token);
+
+        var completedTask = await Task.WhenAny(pollTask, pasteTask);
+        cts.Cancel();
+
+        if (completedTask == pollTask)
+        {
+            var pollResult = await pollTask;
+            if (pollResult)
+            {
+                writer.WriteLine($"Authorization complete for '{name}'.");
+                writer.WriteLine("Run: netclaw daemon restart");
+                return 0;
+            }
+        }
+        else if (completedTask == pasteTask)
+        {
+            var pasteResult = await pasteTask;
+            if (pasteResult)
+            {
+                writer.WriteLine($"Authorization complete for '{name}'.");
+                writer.WriteLine("Run: netclaw daemon restart");
+                return 0;
+            }
+        }
+
+        writer.WriteLine($"Authorization failed or timed out for '{name}'.");
+        writer.WriteLine("Try again with: netclaw mcp auth " + name);
         return 1;
+    }
+
+    private static async Task<bool> PollMcpOAuthStatusAsync(
+        DaemonApi daemonApi, string state, CancellationToken ct)
+    {
+        var pollInterval = TimeSpan.FromSeconds(2);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(pollInterval, ct);
+                var statusResponse = await daemonApi.GetMcpOAuthStatusByStateAsync(state, ct);
+                var status = statusResponse.GetProperty("status").GetString();
+
+                if (status is "Completed")
+                    return true;
+                if (status is "Failed")
+                    return false;
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // Transient poll error — keep trying
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> ReadPasteRedirectAsync(
+        DaemonApi daemonApi, TextWriter writer, CancellationToken ct)
+    {
+        try
+        {
+            // Read from stdin on a background thread (Console.ReadLine blocks)
+            var line = await Task.Run(() =>
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    if (Console.KeyAvailable || !Console.IsInputRedirected)
+                    {
+                        var input = Console.ReadLine();
+                        if (!string.IsNullOrWhiteSpace(input))
+                            return input;
+                    }
+                }
+
+                return null;
+            }, ct);
+
+            if (line is null)
+                return false;
+
+            if (!OAuthRedirectParser.TryParse(line, out var code, out var state, out var error))
+            {
+                writer.WriteLine($"Invalid redirect URL: {error}");
+                return false;
+            }
+
+            var response = await daemonApi.McpOAuthCallbackAsync(code, state, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
     }
 
     private static async Task<int> RunListAsync(NetclawPaths paths, TextWriter writer)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -361,9 +361,9 @@ internal static class McpCommand
             {
                 break;
             }
-            catch
+            catch (Exception)
             {
-                // Transient poll error — keep trying
+                writer.Write("!"); // transient poll error — keep trying
             }
         }
 

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -176,8 +176,56 @@ public sealed class OAuthFlowCoordinator : IDisposable
 
     // ── Browser Authorization Code + PKCE flow ───────────────────────
 
-    private async Task RunBrowserFlowAsync(
+    private Task RunBrowserFlowAsync(
         string providerType, Action<OAuthDeviceFlowResult>? onSuccess, CancellationToken ct)
+    {
+        return RunBrowserFlowCoreAsync(
+            startFlow: async token => await _daemonApi!.StartProviderOAuthAsync(providerType, token),
+            pollStatus: (state, token) => _daemonApi!.GetProviderOAuthStatusAsync(state, token),
+            parseResult: statusResponse =>
+            {
+                var accessToken = statusResponse.TryGetProperty("accessToken", out var atProp)
+                    ? atProp.GetString() : null;
+                var refreshToken = statusResponse.TryGetProperty("refreshToken", out var rtProp)
+                    ? rtProp.GetString() : null;
+                var expiresAt = statusResponse.TryGetProperty("expiresAt", out var expProp)
+                    ? expProp.GetString() : null;
+
+                if (!string.IsNullOrEmpty(accessToken))
+                {
+                    return new OAuthDeviceFlowResult(
+                        new SensitiveString(accessToken),
+                        refreshToken is not null ? new SensitiveString(refreshToken) : null,
+                        expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null);
+                }
+
+                return null;
+            },
+            onSuccess,
+            ct);
+    }
+
+    private Task RunMcpBrowserFlowAsync(
+        string serverName, Action<OAuthDeviceFlowResult>? onSuccess, CancellationToken ct)
+    {
+        return RunBrowserFlowCoreAsync(
+            startFlow: async token => await _daemonApi!.StartMcpOAuthAsync(serverName, token),
+            pollStatus: (state, token) => _daemonApi!.GetMcpOAuthStatusByStateAsync(state, token),
+            parseResult: _ => null, // MCP tokens are persisted daemon-side
+            onSuccess,
+            ct);
+    }
+
+    /// <summary>
+    /// Shared browser PKCE flow: start → open browser → poll for completion.
+    /// Parameterized by delegates so provider and MCP flows share the same logic.
+    /// </summary>
+    private async Task RunBrowserFlowCoreAsync(
+        Func<CancellationToken, Task<HttpResponseMessage>> startFlow,
+        Func<string, CancellationToken, Task<JsonElement>> pollStatus,
+        Func<JsonElement, OAuthDeviceFlowResult?> parseResult,
+        Action<OAuthDeviceFlowResult>? onSuccess,
+        CancellationToken ct)
     {
         if (_daemonApi is null)
         {
@@ -190,7 +238,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
         try
         {
             // Step 1: Ask daemon to start the OAuth flow
-            var startResponse = await _daemonApi.StartProviderOAuthAsync(providerType, ct);
+            var startResponse = await startFlow(ct);
 
             if (!startResponse.IsSuccessStatusCode)
             {
@@ -235,149 +283,12 @@ public sealed class OAuthFlowCoordinator : IDisposable
                 await Task.Delay(pollInterval, ct);
                 elapsed += pollInterval;
 
-                var statusResponse = await _daemonApi.GetProviderOAuthStatusAsync(flowState, ct);
+                var statusResponse = await pollStatus(flowState, ct);
 
                 var status = statusResponse.GetProperty("status").GetString();
                 if (status is "Completed")
                 {
-                    var accessToken = statusResponse.TryGetProperty("accessToken", out var atProp)
-                        ? atProp.GetString() : null;
-                    var refreshToken = statusResponse.TryGetProperty("refreshToken", out var rtProp)
-                        ? rtProp.GetString() : null;
-                    var expiresAt = statusResponse.TryGetProperty("expiresAt", out var expProp)
-                        ? expProp.GetString() : null;
-
-                    if (!string.IsNullOrEmpty(accessToken))
-                    {
-                        Result = new OAuthDeviceFlowResult(
-                            new SensitiveString(accessToken),
-                            refreshToken is not null ? new SensitiveString(refreshToken) : null,
-                            expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null);
-                    }
-
-                    FlowState.Value = DeviceFlowState.Succeeded;
-                    _requestRedraw();
-                    onSuccess?.Invoke(Result!);
-                    return;
-                }
-
-                if (status is "Failed")
-                {
-                    ErrorMessage = "Authorization failed.";
-                    FlowState.Value = DeviceFlowState.Error;
-                    _requestRedraw();
-                    return;
-                }
-            }
-
-            ErrorMessage = "Authorization timed out after 5 minutes.";
-            FlowState.Value = DeviceFlowState.Expired;
-            _requestRedraw();
-        }
-        catch (OperationCanceledException)
-        {
-            FlowState.Value = DeviceFlowState.Cancelled;
-            _requestRedraw();
-        }
-        catch (HttpRequestException)
-        {
-            ErrorMessage = "Could not reach the daemon. Is it running?";
-            FlowState.Value = DeviceFlowState.Error;
-            _requestRedraw();
-        }
-        catch (Exception ex)
-        {
-            ErrorMessage = ex.Message;
-            FlowState.Value = DeviceFlowState.Error;
-            _requestRedraw();
-        }
-        finally
-        {
-            Cancel();
-        }
-    }
-
-    // ── MCP Browser Authorization Code + PKCE flow ────────────────────
-
-    private async Task RunMcpBrowserFlowAsync(
-        string serverName, Action<OAuthDeviceFlowResult>? onSuccess, CancellationToken ct)
-    {
-        if (_daemonApi is null)
-        {
-            ErrorMessage = "Daemon API not available.";
-            FlowState.Value = DeviceFlowState.Error;
-            _requestRedraw();
-            return;
-        }
-
-        try
-        {
-            // Step 1: Ask daemon to start the MCP OAuth flow
-            var startResponse = await _daemonApi.StartMcpOAuthAsync(serverName, ct);
-
-            if (!startResponse.IsSuccessStatusCode)
-            {
-                var errorBody = await startResponse.Content.ReadAsStringAsync(ct);
-                ErrorMessage = $"Failed to start OAuth flow: {errorBody}";
-                FlowState.Value = DeviceFlowState.Error;
-                _requestRedraw();
-                return;
-            }
-
-            var startResult = await startResponse.Content.ReadFromJsonAsync<JsonElement>(ct);
-            var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
-            var flowState = startResult.GetProperty("state").GetString()!;
-
-            // Step 2: Try to open browser (detect headless first)
-            VerificationUri = authUrl;
-            BrowserOpenFailed = !BrowserDetection.CanOpenBrowser();
-            FlowState.Value = DeviceFlowState.WaitingForUser;
-            _requestRedraw();
-
-            if (!BrowserOpenFailed)
-            {
-                try
-                {
-                    Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
-                }
-                catch
-                {
-                    BrowserOpenFailed = true;
-                    _requestRedraw();
-                }
-            }
-
-            // Step 3: Poll daemon for completion (state-based)
-            var pollTimeout = TimeSpan.FromMinutes(5);
-            var pollInterval = TimeSpan.FromSeconds(2);
-            var elapsed = TimeSpan.Zero;
-
-            while (elapsed < pollTimeout)
-            {
-                ct.ThrowIfCancellationRequested();
-                await Task.Delay(pollInterval, ct);
-                elapsed += pollInterval;
-
-                var statusResponse = await _daemonApi.GetMcpOAuthStatusByStateAsync(flowState, ct);
-
-                var status = statusResponse.GetProperty("status").GetString();
-                if (status is "Completed")
-                {
-                    var accessToken = statusResponse.TryGetProperty("accessToken", out var atProp)
-                        ? atProp.GetString() : null;
-                    var refreshToken = statusResponse.TryGetProperty("refreshToken", out var rtProp)
-                        ? rtProp.GetString() : null;
-                    var expiresAt = statusResponse.TryGetProperty("expiresAt", out var expProp)
-                        ? expProp.GetString() : null;
-
-                    if (!string.IsNullOrEmpty(accessToken))
-                    {
-                        Result = new OAuthDeviceFlowResult(
-                            new SensitiveString(accessToken),
-                            refreshToken is not null ? new SensitiveString(refreshToken) : null,
-                            expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null);
-                    }
-
+                    Result = parseResult(statusResponse);
                     FlowState.Value = DeviceFlowState.Succeeded;
                     _requestRedraw();
                     onSuccess?.Invoke(Result!);

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -23,6 +23,9 @@ public sealed class OAuthFlowCoordinator : IDisposable
     private readonly Action _requestRedraw;
     private CancellationTokenSource? _cts;
 
+    // Set during flow start to route SubmitRedirectUrlAsync to the correct callback
+    private Func<string, string, Task<HttpResponseMessage>>? _activeCallbackFunc;
+
     // ── Observable state ──────────────────────────────────────────────
 
     public ReactiveProperty<DeviceFlowState> FlowState { get; } = new(DeviceFlowState.NotStarted);
@@ -50,7 +53,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
     }
 
     /// <summary>
-    /// Start browser-based Authorization Code + PKCE flow.
+    /// Start browser-based Authorization Code + PKCE flow for a provider.
     /// Returns a <see cref="CancellationToken"/> that fires when the flow ends —
     /// callers use it to drive UI timers (spinner, elapsed seconds).
     /// </summary>
@@ -59,7 +62,26 @@ public sealed class OAuthFlowCoordinator : IDisposable
     {
         Cancel();
         _cts = new CancellationTokenSource();
+        _activeCallbackFunc = _daemonApi is not null
+            ? (code, state) => _daemonApi.ProviderOAuthCallbackAsync(code, state)
+            : null;
         Completion = RunBrowserFlowAsync(providerType, onSuccess, _cts.Token);
+        return _cts.Token;
+    }
+
+    /// <summary>
+    /// Start browser-based Authorization Code + PKCE flow for an MCP server.
+    /// Returns a <see cref="CancellationToken"/> that fires when the flow ends.
+    /// </summary>
+    public CancellationToken StartMcpBrowserFlow(
+        string serverName, Action<OAuthDeviceFlowResult>? onSuccess = null)
+    {
+        Cancel();
+        _cts = new CancellationTokenSource();
+        _activeCallbackFunc = _daemonApi is not null
+            ? (code, state) => _daemonApi.McpOAuthCallbackAsync(code, state)
+            : null;
+        Completion = RunMcpBrowserFlowAsync(serverName, onSuccess, _cts.Token);
         return _cts.Token;
     }
 
@@ -89,7 +111,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
             return;
         }
 
-        if (_daemonApi is null)
+        if (_activeCallbackFunc is null)
         {
             ErrorMessage = "Daemon API not available.";
             _requestRedraw();
@@ -98,7 +120,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
 
         try
         {
-            var response = await _daemonApi.ProviderOAuthCallbackAsync(code, state);
+            var response = await _activeCallbackFunc(code, state);
 
             if (response.IsSuccessStatusCode)
             {
@@ -214,6 +236,129 @@ public sealed class OAuthFlowCoordinator : IDisposable
                 elapsed += pollInterval;
 
                 var statusResponse = await _daemonApi.GetProviderOAuthStatusAsync(flowState, ct);
+
+                var status = statusResponse.GetProperty("status").GetString();
+                if (status is "Completed")
+                {
+                    var accessToken = statusResponse.TryGetProperty("accessToken", out var atProp)
+                        ? atProp.GetString() : null;
+                    var refreshToken = statusResponse.TryGetProperty("refreshToken", out var rtProp)
+                        ? rtProp.GetString() : null;
+                    var expiresAt = statusResponse.TryGetProperty("expiresAt", out var expProp)
+                        ? expProp.GetString() : null;
+
+                    if (!string.IsNullOrEmpty(accessToken))
+                    {
+                        Result = new OAuthDeviceFlowResult(
+                            new SensitiveString(accessToken),
+                            refreshToken is not null ? new SensitiveString(refreshToken) : null,
+                            expiresAt is not null ? DateTimeOffset.Parse(expiresAt) : null);
+                    }
+
+                    FlowState.Value = DeviceFlowState.Succeeded;
+                    _requestRedraw();
+                    onSuccess?.Invoke(Result!);
+                    return;
+                }
+
+                if (status is "Failed")
+                {
+                    ErrorMessage = "Authorization failed.";
+                    FlowState.Value = DeviceFlowState.Error;
+                    _requestRedraw();
+                    return;
+                }
+            }
+
+            ErrorMessage = "Authorization timed out after 5 minutes.";
+            FlowState.Value = DeviceFlowState.Expired;
+            _requestRedraw();
+        }
+        catch (OperationCanceledException)
+        {
+            FlowState.Value = DeviceFlowState.Cancelled;
+            _requestRedraw();
+        }
+        catch (HttpRequestException)
+        {
+            ErrorMessage = "Could not reach the daemon. Is it running?";
+            FlowState.Value = DeviceFlowState.Error;
+            _requestRedraw();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            FlowState.Value = DeviceFlowState.Error;
+            _requestRedraw();
+        }
+        finally
+        {
+            Cancel();
+        }
+    }
+
+    // ── MCP Browser Authorization Code + PKCE flow ────────────────────
+
+    private async Task RunMcpBrowserFlowAsync(
+        string serverName, Action<OAuthDeviceFlowResult>? onSuccess, CancellationToken ct)
+    {
+        if (_daemonApi is null)
+        {
+            ErrorMessage = "Daemon API not available.";
+            FlowState.Value = DeviceFlowState.Error;
+            _requestRedraw();
+            return;
+        }
+
+        try
+        {
+            // Step 1: Ask daemon to start the MCP OAuth flow
+            var startResponse = await _daemonApi.StartMcpOAuthAsync(serverName, ct);
+
+            if (!startResponse.IsSuccessStatusCode)
+            {
+                var errorBody = await startResponse.Content.ReadAsStringAsync(ct);
+                ErrorMessage = $"Failed to start OAuth flow: {errorBody}";
+                FlowState.Value = DeviceFlowState.Error;
+                _requestRedraw();
+                return;
+            }
+
+            var startResult = await startResponse.Content.ReadFromJsonAsync<JsonElement>(ct);
+            var authUrl = startResult.GetProperty("authorizationUrl").GetString()!;
+            var flowState = startResult.GetProperty("state").GetString()!;
+
+            // Step 2: Try to open browser (detect headless first)
+            VerificationUri = authUrl;
+            BrowserOpenFailed = !BrowserDetection.CanOpenBrowser();
+            FlowState.Value = DeviceFlowState.WaitingForUser;
+            _requestRedraw();
+
+            if (!BrowserOpenFailed)
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+                }
+                catch
+                {
+                    BrowserOpenFailed = true;
+                    _requestRedraw();
+                }
+            }
+
+            // Step 3: Poll daemon for completion (state-based)
+            var pollTimeout = TimeSpan.FromMinutes(5);
+            var pollInterval = TimeSpan.FromSeconds(2);
+            var elapsed = TimeSpan.Zero;
+
+            while (elapsed < pollTimeout)
+            {
+                ct.ThrowIfCancellationRequested();
+                await Task.Delay(pollInterval, ct);
+                elapsed += pollInterval;
+
+                var statusResponse = await _daemonApi.GetMcpOAuthStatusByStateAsync(flowState, ct);
 
                 var status = statusResponse.GetProperty("status").GetString();
                 if (status is "Completed")

--- a/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowCoordinator.cs
@@ -74,7 +74,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
     /// Returns a <see cref="CancellationToken"/> that fires when the flow ends.
     /// </summary>
     public CancellationToken StartMcpBrowserFlow(
-        string serverName, Action<OAuthDeviceFlowResult>? onSuccess = null)
+        string serverName, Action? onSuccess = null)
     {
         Cancel();
         _cts = new CancellationTokenSource();
@@ -201,18 +201,24 @@ public sealed class OAuthFlowCoordinator : IDisposable
 
                 return null;
             },
-            onSuccess,
+            onSuccess: result =>
+            {
+                if (result is null)
+                    throw new InvalidOperationException("Provider OAuth completed without token payload.");
+
+                onSuccess?.Invoke(result);
+            },
             ct);
     }
 
     private Task RunMcpBrowserFlowAsync(
-        string serverName, Action<OAuthDeviceFlowResult>? onSuccess, CancellationToken ct)
+        string serverName, Action? onSuccess, CancellationToken ct)
     {
         return RunBrowserFlowCoreAsync(
             startFlow: async token => await _daemonApi!.StartMcpOAuthAsync(serverName, token),
             pollStatus: (state, token) => _daemonApi!.GetMcpOAuthStatusByStateAsync(state, token),
             parseResult: _ => null, // MCP tokens are persisted daemon-side
-            onSuccess,
+            onSuccess: _ => onSuccess?.Invoke(),
             ct);
     }
 
@@ -224,7 +230,7 @@ public sealed class OAuthFlowCoordinator : IDisposable
         Func<CancellationToken, Task<HttpResponseMessage>> startFlow,
         Func<string, CancellationToken, Task<JsonElement>> pollStatus,
         Func<JsonElement, OAuthDeviceFlowResult?> parseResult,
-        Action<OAuthDeviceFlowResult>? onSuccess,
+        Action<OAuthDeviceFlowResult?>? onSuccess,
         CancellationToken ct)
     {
         if (_daemonApi is null)
@@ -288,10 +294,11 @@ public sealed class OAuthFlowCoordinator : IDisposable
                 var status = statusResponse.GetProperty("status").GetString();
                 if (status is "Completed")
                 {
-                    Result = parseResult(statusResponse);
+                    var result = parseResult(statusResponse);
+                    onSuccess?.Invoke(result);
+                    Result = result;
                     FlowState.Value = DeviceFlowState.Succeeded;
                     _requestRedraw();
-                    onSuccess?.Invoke(Result!);
                     return;
                 }
 

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
@@ -220,4 +220,124 @@ public class OAuthPkceServiceTests
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public void StartAuthorizationFlow_WithExtraParams_IncludesThemInUrl()
+    {
+        var service = new OAuthPkceService(new HttpClient());
+
+        var extraParams = new Dictionary<string, string>
+        {
+            ["resource"] = "https://mcp.example.com/mcp",
+        };
+
+        var (url, _) = service.StartAuthorizationFlow(
+            "https://auth.example.com/authorize",
+            "https://auth.example.com/token",
+            "test-client",
+            "http://127.0.0.1:5199/callback",
+            extraParams: extraParams);
+
+        Assert.Contains("resource=https%3A%2F%2Fmcp.example.com%2Fmcp", url);
+    }
+
+    [Fact]
+    public async Task ExchangeCodeForTokens_WithExtraParams_MergesIntoRequest()
+    {
+        string? capturedBody = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            return JsonResponse(new
+            {
+                access_token = "at-secret",
+                expires_in = 3600
+            });
+        });
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var extraParams = new Dictionary<string, string>
+        {
+            ["resource"] = "https://mcp.example.com/mcp",
+        };
+
+        await service.ExchangeCodeForTokensAsync(
+            "https://auth.example.com/token",
+            "test-client",
+            "auth-code",
+            "verifier",
+            "http://127.0.0.1:5199/callback",
+            extraParams);
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("resource=https%3A%2F%2Fmcp.example.com%2Fmcp", capturedBody);
+        Assert.Contains("grant_type=authorization_code", capturedBody);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithExtraParams_MergesIntoRequest()
+    {
+        string? capturedBody = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            return JsonResponse(new
+            {
+                access_token = "new-at",
+                expires_in = 3600
+            });
+        });
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var extraParams = new Dictionary<string, string>
+        {
+            ["resource"] = "https://mcp.example.com/mcp",
+        };
+
+        await service.RefreshTokenAsync(
+            "https://auth.example.com/token",
+            "test-client",
+            new SensitiveString("old-refresh"),
+            extraParams);
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("resource=https%3A%2F%2Fmcp.example.com%2Fmcp", capturedBody);
+        Assert.Contains("grant_type=refresh_token", capturedBody);
+    }
+
+    [Fact]
+    public async Task CompleteAuthorization_WithExtraTokenParams_PassesToExchange()
+    {
+        string? capturedBody = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            return JsonResponse(new
+            {
+                access_token = "at-from-callback",
+                expires_in = 3600
+            });
+        });
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var extraTokenParams = new Dictionary<string, string>
+        {
+            ["resource"] = "https://mcp.example.com/mcp",
+        };
+
+        var (_, state) = service.StartAuthorizationFlow(
+            "https://auth.example.com/authorize",
+            "https://auth.example.com/token",
+            "test-client",
+            "http://127.0.0.1:5199/callback",
+            extraTokenParams: extraTokenParams);
+
+        await service.CompleteAuthorizationAsync("callback-code", state);
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("resource=https%3A%2F%2Fmcp.example.com%2Fmcp", capturedBody);
+    }
 }

--- a/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
+++ b/src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthPkceServiceTests.cs
@@ -182,6 +182,27 @@ public class OAuthPkceServiceTests
     }
 
     [Fact]
+    public async Task CompleteAuthorizationAsync_TokenExchangeFailure_MarksFlowFailed()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            JsonResponse(new { error = "invalid_request" }, HttpStatusCode.BadRequest));
+
+        var service = new OAuthPkceService(new HttpClient(handler));
+
+        var (_, state) = service.StartAuthorizationFlow(
+            "https://auth.example.com/authorize",
+            "https://auth.example.com/token",
+            "test-client",
+            "http://127.0.0.1:5199/callback",
+            "openid");
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => service.CompleteAuthorizationAsync("callback-code", state));
+
+        Assert.Equal(OAuthPkceFlowStatus.Failed, service.GetFlowStatus(state));
+    }
+
+    [Fact]
     public async Task RefreshToken_Success_ReturnsNewTokenPreservingRefresh()
     {
         var handler = new FakeHttpMessageHandler(_ =>

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -10,6 +10,7 @@ using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Providers.OAuth;
 using Xunit;
 
 namespace Netclaw.Daemon.Tests.Gateway;
@@ -150,11 +151,13 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             }
         };
 
+        var pkceService = new OAuthPkceService(new HttpClient());
         var oauthService = new McpOAuthService(
             new HttpClient(),
             new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())),
             TimeProvider.System,
-            NullLogger<McpOAuthService>.Instance);
+            NullLogger<McpOAuthService>.Instance,
+            pkceService);
         var manager = new McpClientManager(
             mcpServers,
             new ToolRegistry(),

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -157,7 +157,8 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())),
             TimeProvider.System,
             NullLogger<McpOAuthService>.Instance,
-            pkceService);
+            pkceService,
+            NullNotificationSink.Instance);
         var manager = new McpClientManager(
             mcpServers,
             new ToolRegistry(),

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Mcp;
+using Netclaw.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+public sealed class McpOAuthServiceTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-mcp-oauth-{Guid.NewGuid():N}");
+
+    [Fact]
+    public async Task GetFlowStatusByState_ReauthWithExistingToken_RemainsPending()
+    {
+        var service = CreateService(
+            CreateDiscoveryClient(),
+            CreatePkceService(JsonResponse(new
+            {
+                access_token = "access-token",
+                refresh_token = "refresh-token",
+                expires_in = 3600
+            })));
+
+        var entry = CreateHttpEntry();
+
+        var (_, initialState) = await service.StartAuthorizationFlowAsync("textforge", entry, CancellationToken.None);
+        await service.CompleteAuthorizationAsync("first-code", initialState, CancellationToken.None);
+
+        var (_, reauthState) = await service.StartAuthorizationFlowAsync("textforge", entry, CancellationToken.None);
+
+        Assert.Equal(McpOAuthFlowStatus.Pending, service.GetFlowStatusByState(reauthState));
+        Assert.Equal(McpOAuthFlowStatus.Pending, service.GetFlowStatus("textforge"));
+    }
+
+    [Fact]
+    public async Task GetFlowStatusByState_WhenTokenExchangeFails_ReturnsFailed()
+    {
+        var service = CreateService(
+            CreateDiscoveryClient(),
+            CreatePkceService(JsonResponse(new { error = "invalid_request" }, HttpStatusCode.BadRequest)));
+
+        var (_, state) = await service.StartAuthorizationFlowAsync("textforge", CreateHttpEntry(), CancellationToken.None);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => service.CompleteAuthorizationAsync("bad-code", state, CancellationToken.None));
+
+        Assert.Equal(McpOAuthFlowStatus.Failed, service.GetFlowStatusByState(state));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private McpOAuthService CreateService(HttpClient discoveryClient, OAuthPkceService pkceService)
+    {
+        return new McpOAuthService(
+            discoveryClient,
+            new NetclawPaths(_tempDir),
+            TimeProvider.System,
+            NullLogger<McpOAuthService>.Instance,
+            pkceService);
+    }
+
+    private static McpServerEntry CreateHttpEntry()
+    {
+        return new McpServerEntry
+        {
+            Transport = "http",
+            Url = "https://mcp.example.com",
+            OAuthClientId = "test-client"
+        };
+    }
+
+    private static HttpClient CreateDiscoveryClient()
+    {
+        return new HttpClient(new FakeHttpMessageHandler(request => request.RequestUri!.ToString() switch
+        {
+            "https://mcp.example.com/" or "https://mcp.example.com" => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            "https://mcp.example.com/.well-known/oauth-protected-resource" => JsonResponse(new
+            {
+                authorization_servers = new[] { "https://auth.example.com" },
+                resource = "https://mcp.example.com/resource"
+            }),
+            "https://auth.example.com/.well-known/oauth-authorization-server" => JsonResponse(new
+            {
+                authorization_endpoint = "https://auth.example.com/authorize",
+                token_endpoint = "https://auth.example.com/token"
+            }),
+            _ => throw new InvalidOperationException($"Unexpected request URI: {request.RequestUri}")
+        }));
+    }
+
+    private static OAuthPkceService CreatePkceService(HttpResponseMessage tokenResponse)
+    {
+        return new OAuthPkceService(new HttpClient(new FakeHttpMessageHandler(request => request.RequestUri!.ToString() switch
+        {
+            "https://auth.example.com/token" => tokenResponse,
+            _ => throw new InvalidOperationException($"Unexpected request URI: {request.RequestUri}")
+        })));
+    }
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
@@ -64,7 +64,8 @@ public sealed class McpOAuthServiceTests : IDisposable
             new NetclawPaths(_tempDir),
             TimeProvider.System,
             NullLogger<McpOAuthService>.Instance,
-            pkceService);
+            pkceService,
+            NullNotificationSink.Instance);
     }
 
     private static McpServerEntry CreateHttpEntry()

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -158,7 +158,8 @@ public class McpStdioSmokeTests : IAsyncDisposable
             new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())),
             TimeProvider.System,
             NullLogger<McpOAuthService>.Instance,
-            pkceService);
+            pkceService,
+            NullNotificationSink.Instance);
         var manager = new McpClientManager(serverEntries, registry, oauthService, NullNotificationSink.Instance, TimeProvider.System, logger);
 
         try

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -4,6 +4,7 @@ using ModelContextProtocol.Client;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Providers.OAuth;
 using Xunit;
 
 namespace Netclaw.Daemon.Tests.Mcp;
@@ -151,11 +152,13 @@ public class McpStdioSmokeTests : IAsyncDisposable
 
         var registry = new ToolRegistry();
         var logger = NullLogger<McpClientManager>.Instance;
+        var pkceService = new OAuthPkceService(new HttpClient());
         var oauthService = new McpOAuthService(
             new HttpClient(),
             new NetclawPaths(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())),
             TimeProvider.System,
-            NullLogger<McpOAuthService>.Instance);
+            NullLogger<McpOAuthService>.Instance,
+            pkceService);
         var manager = new McpClientManager(serverEntries, registry, oauthService, NullNotificationSink.Instance, TimeProvider.System, logger);
 
         try

--- a/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
+++ b/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Providers;
+using Netclaw.Providers;
+using Netclaw.Providers.OAuth;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class ProviderOAuthEndpointTests
+{
+    [Fact]
+    public async Task StartEndpoint_ReturnsAuthorizationUrl_AndPendingStatus()
+    {
+        await using var host = await CreateHostAsync(_ => SuccessfulTokenResponse());
+        var client = host.GetTestClient();
+
+        var startResponse = await client.PostAsync("/api/provider/oauth/start?provider=test-oauth", null);
+        startResponse.EnsureSuccessStatusCode();
+
+        var startPayload = await startResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var state = startPayload.GetProperty("state").GetString();
+        var authorizationUrl = startPayload.GetProperty("authorizationUrl").GetString();
+
+        Assert.NotNull(state);
+        Assert.NotNull(authorizationUrl);
+        Assert.Contains("code_challenge=", authorizationUrl);
+        Assert.Contains($"state={state}", authorizationUrl);
+
+        var statusPayload = await client.GetFromJsonAsync<JsonElement>($"/api/provider/oauth/status/{state}");
+        Assert.Equal("Pending", statusPayload.GetProperty("status").GetString());
+        Assert.False(statusPayload.GetProperty("hasToken").GetBoolean());
+    }
+
+    [Fact]
+    public async Task CallbackEndpoint_CompletesFlow_AndStatusReturnsTokens()
+    {
+        await using var host = await CreateHostAsync(_ => SuccessfulTokenResponse());
+        var client = host.GetTestClient();
+
+        var startResponse = await client.PostAsync("/api/provider/oauth/start?provider=test-oauth", null);
+        var startPayload = await startResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var state = startPayload.GetProperty("state").GetString();
+
+        var callbackResponse = await client.GetAsync($"/api/provider/oauth/callback?code=test-code&state={state}");
+        callbackResponse.EnsureSuccessStatusCode();
+        var html = await callbackResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Authorization complete", html);
+
+        var statusPayload = await client.GetFromJsonAsync<JsonElement>($"/api/provider/oauth/status/{state}");
+        Assert.Equal("Completed", statusPayload.GetProperty("status").GetString());
+        Assert.True(statusPayload.GetProperty("hasToken").GetBoolean());
+        Assert.Equal("access-token", statusPayload.GetProperty("accessToken").GetString());
+        Assert.Equal("refresh-token", statusPayload.GetProperty("refreshToken").GetString());
+    }
+
+    [Fact]
+    public async Task CallbackEndpoint_OnExchangeFailure_Returns500_AndFailedStatus()
+    {
+        await using var host = await CreateHostAsync(_ =>
+            JsonResponse(new { error = "invalid_request" }, HttpStatusCode.BadRequest));
+        var client = host.GetTestClient();
+
+        var startResponse = await client.PostAsync("/api/provider/oauth/start?provider=test-oauth", null);
+        var startPayload = await startResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var state = startPayload.GetProperty("state").GetString();
+
+        var callbackResponse = await client.GetAsync($"/api/provider/oauth/callback?code=bad-code&state={state}");
+        Assert.Equal(HttpStatusCode.InternalServerError, callbackResponse.StatusCode);
+        var html = await callbackResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Authorization failed", html);
+
+        var statusPayload = await client.GetFromJsonAsync<JsonElement>($"/api/provider/oauth/status/{state}");
+        Assert.Equal("Failed", statusPayload.GetProperty("status").GetString());
+        Assert.False(statusPayload.GetProperty("hasToken").GetBoolean());
+    }
+
+    private static async Task<WebApplication> CreateHostAsync(Func<HttpRequestMessage, HttpResponseMessage> tokenHandler)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddSingleton(new OAuthPkceService(new HttpClient(new FakeHttpMessageHandler(tokenHandler))));
+        builder.Services.AddSingleton<IProviderOAuthCallbackListener, NoOpProviderOAuthCallbackListener>();
+        builder.Services.AddSingleton(new ProviderDescriptorRegistry([new TestOAuthDescriptor()]));
+
+        var app = builder.Build();
+        app.MapProviderOAuthEndpoints();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static HttpResponseMessage SuccessfulTokenResponse()
+    {
+        return JsonResponse(new
+        {
+            access_token = "access-token",
+            refresh_token = "refresh-token",
+            expires_in = 3600
+        });
+    }
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
+    }
+
+    private sealed class NoOpProviderOAuthCallbackListener : IProviderOAuthCallbackListener
+    {
+        public void StartListening(string redirectUri, string state)
+        {
+        }
+    }
+
+    private sealed class TestOAuthDescriptor : IProviderDescriptor
+    {
+        public string TypeKey => "test-oauth";
+        public string DisplayName => "Test OAuth";
+        public string DefaultEndpoint => "https://api.example.com";
+        public string ModelListingPath => "/v1/models";
+
+        public IProviderAuth Auth { get; } = new OAuthAuth
+        {
+            SupportedAuthMethods = [AuthMethod.OAuthPkce],
+            TokenEndpoint = new Uri("https://auth.example.com/token"),
+            ClientId = "test-client",
+            AuthorizationEndpoint = new Uri("https://auth.example.com/authorize"),
+            RedirectUri = new Uri("http://127.0.0.1:1455/auth/callback"),
+            Scope = "openid profile email offline_access"
+        };
+
+        public Task<ProviderProbeResult> ProbeAsync(ProviderEntry entry, CancellationToken ct = default)
+        {
+            return Task.FromResult(new ProviderProbeResult(true, null, []));
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -28,6 +28,7 @@ internal sealed class McpOAuthService
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<McpOAuthService> _logger;
     private readonly OAuthPkceService _pkceService;
+    private readonly IOperationalNotificationSink _notificationSink;
     private readonly ISecretsProtector? _protector;
 
     // In-memory caches, loaded from disk at construction
@@ -43,6 +44,7 @@ internal sealed class McpOAuthService
         TimeProvider timeProvider,
         ILogger<McpOAuthService> logger,
         OAuthPkceService pkceService,
+        IOperationalNotificationSink notificationSink,
         ISecretsProtector? protector = null)
     {
         _httpClient = httpClient;
@@ -50,6 +52,7 @@ internal sealed class McpOAuthService
         _timeProvider = timeProvider;
         _logger = logger;
         _pkceService = pkceService;
+        _notificationSink = notificationSink;
         _protector = protector;
 
         LoadTokensFromDisk();
@@ -323,6 +326,23 @@ internal sealed class McpOAuthService
         if (tokenSet.RefreshToken is null)
         {
             _logger.LogWarning("Access token expired for MCP server '{Name}' with no refresh token", serverName);
+
+            _notificationSink.Emit(new OperationalAlert
+            {
+                AlertId = Guid.NewGuid().ToString("N")[..12],
+                Type = "mcp.auth.expired",
+                Category = AlertType.McpAuthExpired,
+                Summary = $"MCP server '{serverName}' access token expired with no refresh token. Run: netclaw mcp auth {serverName}",
+                Timestamp = _timeProvider.GetUtcNow(),
+                Severity = "warning",
+                Source = serverName,
+                Context = new Dictionary<string, string>
+                {
+                    ["serverName"] = serverName,
+                    ["reason"] = "no_refresh_token",
+                }
+            });
+
             return null;
         }
 
@@ -364,6 +384,23 @@ internal sealed class McpOAuthService
                 _logger.LogWarning("Refresh token rejected for MCP server '{Name}' (invalid_grant). Re-authorization required.", serverName);
                 _tokens.TryRemove(serverName, out _);
                 PersistTokens();
+
+                _notificationSink.Emit(new OperationalAlert
+                {
+                    AlertId = Guid.NewGuid().ToString("N")[..12],
+                    Type = "mcp.auth.expired",
+                    Category = AlertType.McpAuthExpired,
+                    Summary = $"MCP server '{serverName}' refresh token rejected (invalid_grant). Run: netclaw mcp auth {serverName}",
+                    Timestamp = _timeProvider.GetUtcNow(),
+                    Severity = "warning",
+                    Source = serverName,
+                    Context = new Dictionary<string, string>
+                    {
+                        ["serverName"] = serverName,
+                        ["reason"] = "invalid_grant",
+                    }
+                });
+
                 return null;
             }
 

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -1,19 +1,19 @@
 using System.Collections.Concurrent;
 using System.Net.Http.Json;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
+using Netclaw.Providers.OAuth;
 
 namespace Netclaw.Daemon.Mcp;
 
 /// <summary>
 /// Orchestrates the OAuth 2.1 Authorization Code + PKCE lifecycle for MCP servers.
-/// Handles discovery, PKCE generation, auth flow coordination, token persistence,
-/// and automatic token refresh.
+/// Handles discovery, DCR, token persistence, and automatic token refresh.
+/// Delegates PKCE generation, authorization URL construction, and token exchange
+/// to <see cref="OAuthPkceService"/>.
 /// </summary>
 internal sealed class McpOAuthService
 {
@@ -27,24 +27,29 @@ internal sealed class McpOAuthService
     private readonly NetclawPaths _paths;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<McpOAuthService> _logger;
+    private readonly OAuthPkceService _pkceService;
     private readonly ISecretsProtector? _protector;
 
     // In-memory caches, loaded from disk at construction
     private readonly ConcurrentDictionary<string, McpOAuthTokenSet> _tokens = new();
     private readonly ConcurrentDictionary<string, McpOAuthServerMetadata> _metadata = new();
-    private readonly ConcurrentDictionary<string, McpOAuthPendingFlow> _pendingFlows = new();
+
+    // Maps PKCE state → flow context for token persistence after callback
+    private readonly ConcurrentDictionary<string, McpOAuthFlowContext> _stateToContext = new();
 
     public McpOAuthService(
         HttpClient httpClient,
         NetclawPaths paths,
         TimeProvider timeProvider,
         ILogger<McpOAuthService> logger,
+        OAuthPkceService pkceService,
         ISecretsProtector? protector = null)
     {
         _httpClient = httpClient;
         _paths = paths;
         _timeProvider = timeProvider;
         _logger = logger;
+        _pkceService = pkceService;
         _protector = protector;
 
         LoadTokensFromDisk();
@@ -205,8 +210,8 @@ internal sealed class McpOAuthService
     // ── Start Authorization Flow ───────────────────────────────────────
 
     /// <summary>
-    /// Generate PKCE parameters, build the authorization URL, and store
-    /// the pending flow. Returns the URL the user should open in their browser.
+    /// Discover metadata, ensure client registration, then delegate to
+    /// <see cref="OAuthPkceService"/> for PKCE generation and URL construction.
     /// </summary>
     public async Task<(string AuthorizationUrl, string State)> StartAuthorizationFlowAsync(
         string serverName, McpServerEntry entry, CancellationToken ct)
@@ -217,45 +222,40 @@ internal sealed class McpOAuthService
                 "No /.well-known/oauth-protected-resource was found.");
         var clientId = await EnsureClientRegisteredAsync(serverName, entry, metadata, ct);
 
-        // PKCE: generate code_verifier and code_challenge
-        var codeVerifier = GenerateCodeVerifier();
-        var codeChallenge = ComputeCodeChallenge(codeVerifier);
-        var state = Guid.NewGuid().ToString("N");
-
         var redirectUri = "http://127.0.0.1:5199/api/mcp/oauth/callback";
 
-        var queryParams = new Dictionary<string, string>
-        {
-            ["response_type"] = "code",
-            ["client_id"] = clientId,
-            ["redirect_uri"] = redirectUri,
-            ["code_challenge"] = codeChallenge,
-            ["code_challenge_method"] = "S256",
-            ["state"] = state,
-        };
-
+        // Build extra params for authorization URL (resource indicator)
+        Dictionary<string, string>? extraAuthParams = null;
         if (!string.IsNullOrWhiteSpace(metadata.ResourceIndicator))
-            queryParams["resource"] = metadata.ResourceIndicator;
-
-        if (!string.IsNullOrWhiteSpace(entry.OAuthScope))
-            queryParams["scope"] = entry.OAuthScope;
-
-        var authUrl = metadata.AuthorizationEndpoint + "?" + string.Join("&",
-            queryParams.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-
-        var pendingFlow = new McpOAuthPendingFlow
         {
-            ServerName = serverName,
-            CodeVerifier = codeVerifier,
-            State = state,
-            RedirectUri = redirectUri,
-            ClientId = clientId,
-            TokenEndpoint = metadata.TokenEndpoint,
-            ResourceIndicator = metadata.ResourceIndicator,
-            Completion = new TaskCompletionSource<bool>(),
-        };
+            extraAuthParams = new Dictionary<string, string>
+            {
+                ["resource"] = metadata.ResourceIndicator,
+            };
+        }
 
-        _pendingFlows[state] = pendingFlow;
+        // Build extra params for token exchange/refresh (resource indicator per RFC 8707)
+        Dictionary<string, string>? extraTokenParams = null;
+        if (!string.IsNullOrWhiteSpace(metadata.ResourceIndicator))
+        {
+            extraTokenParams = new Dictionary<string, string>
+            {
+                ["resource"] = metadata.ResourceIndicator,
+            };
+        }
+
+        var (authUrl, state) = _pkceService.StartAuthorizationFlow(
+            metadata.AuthorizationEndpoint,
+            metadata.TokenEndpoint,
+            clientId,
+            redirectUri,
+            entry.OAuthScope,
+            extraAuthParams,
+            extraTokenParams);
+
+        // Store context so we can persist tokens when the callback arrives
+        _stateToContext[state] = new McpOAuthFlowContext(
+            serverName, clientId, metadata.ResourceIndicator);
 
         _logger.LogInformation("Started OAuth flow for MCP server '{Name}' (state={State})", serverName, state);
         return (authUrl, state);
@@ -264,37 +264,31 @@ internal sealed class McpOAuthService
     // ── Complete Authorization Flow (callback) ─────────────────────────
 
     /// <summary>
-    /// Exchange the authorization code for tokens. Called when the browser
-    /// redirects back to our callback endpoint.
+    /// Exchange the authorization code for tokens via <see cref="OAuthPkceService"/>,
+    /// then persist the result as an <see cref="McpOAuthTokenSet"/>.
     /// </summary>
     public async Task CompleteAuthorizationAsync(string code, string state, CancellationToken ct)
     {
-        if (!_pendingFlows.TryRemove(state, out var flow))
+        if (!_stateToContext.TryGetValue(state, out var context))
             throw new InvalidOperationException($"Unknown OAuth state: {state}");
 
-        try
+        var result = await _pkceService.CompleteAuthorizationAsync(code, state, ct);
+
+        // Convert OAuthDeviceFlowResult → McpOAuthTokenSet for persistence
+        var tokenSet = new McpOAuthTokenSet
         {
-            var tokenRequest = new FormUrlEncodedContent(BuildTokenRequestParams(
-                "authorization_code", flow.ClientId, flow.RedirectUri,
-                flow.ResourceIndicator, code: code, codeVerifier: flow.CodeVerifier));
+            AccessToken = result.AccessToken,
+            RefreshToken = result.RefreshToken,
+            ExpiresAt = result.ExpiresAt,
+            ClientId = context.ClientId,
+            McpServerUrl = context.ResourceIndicator,
+        };
 
-            var response = await _httpClient.PostAsync(flow.TokenEndpoint, tokenRequest, ct);
-            response.EnsureSuccessStatusCode();
+        _tokens[context.ServerName] = tokenSet;
+        PersistTokens();
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
-
-            var tokenSet = ParseTokenResponse(tokenResponse, flow.ClientId, flow.ResourceIndicator);
-            _tokens[flow.ServerName] = tokenSet;
-            PersistTokens();
-
-            flow.Completion.TrySetResult(true);
-            _logger.LogInformation("OAuth flow completed for MCP server '{Name}'", flow.ServerName);
-        }
-        catch (Exception ex)
-        {
-            flow.Completion.TrySetException(ex);
-            throw;
-        }
+        _stateToContext.TryRemove(state, out _);
+        _logger.LogInformation("OAuth flow completed for MCP server '{Name}'", context.ServerName);
     }
 
     // ── Token Access ───────────────────────────────────────────────────
@@ -337,32 +331,39 @@ internal sealed class McpOAuthService
 
         try
         {
-            var refreshRequest = new FormUrlEncodedContent(BuildTokenRequestParams(
-                "refresh_token", tokenSet.ClientId ?? entry.OAuthClientId ?? "",
-                resourceIndicator: metadata.ResourceIndicator,
-                refreshToken: tokenSet.RefreshToken!.Value));
-
-            var response = await _httpClient.PostAsync(metadata.TokenEndpoint, refreshRequest, ct);
-
-            if (!response.IsSuccessStatusCode)
+            // Build extra params for resource indicator
+            Dictionary<string, string>? extraParams = null;
+            if (!string.IsNullOrWhiteSpace(metadata.ResourceIndicator))
             {
-                var errorBody = await response.Content.ReadAsStringAsync(ct);
-                if (errorBody.Contains("invalid_grant", StringComparison.Ordinal))
+                extraParams = new Dictionary<string, string>
                 {
-                    _logger.LogWarning("Refresh token rejected for MCP server '{Name}' (invalid_grant). Re-authorization required.", serverName);
-                    _tokens.TryRemove(serverName, out _);
-                    PersistTokens();
-                    return null;
-                }
-
-                response.EnsureSuccessStatusCode(); // throw for other errors
+                    ["resource"] = metadata.ResourceIndicator,
+                };
             }
 
-            var tokenResponse = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
-            var newTokenSet = ParseTokenResponse(tokenResponse, tokenSet.ClientId, tokenSet.McpServerUrl);
+            var result = await _pkceService.RefreshTokenAsync(
+                metadata.TokenEndpoint,
+                tokenSet.ClientId ?? entry.OAuthClientId ?? "",
+                tokenSet.RefreshToken!,
+                extraParams,
+                ct);
 
-            // Preserve the existing refresh token if the server didn't issue a new one
-            newTokenSet.RefreshToken ??= tokenSet.RefreshToken;
+            if (result is null)
+            {
+                _logger.LogWarning("Refresh token rejected for MCP server '{Name}' (invalid_grant). Re-authorization required.", serverName);
+                _tokens.TryRemove(serverName, out _);
+                PersistTokens();
+                return null;
+            }
+
+            var newTokenSet = new McpOAuthTokenSet
+            {
+                AccessToken = result.AccessToken,
+                RefreshToken = result.RefreshToken ?? tokenSet.RefreshToken,
+                ExpiresAt = result.ExpiresAt,
+                ClientId = tokenSet.ClientId,
+                McpServerUrl = tokenSet.McpServerUrl,
+            };
 
             _tokens[serverName] = newTokenSet;
             PersistTokens();
@@ -385,86 +386,41 @@ internal sealed class McpOAuthService
         if (_tokens.ContainsKey(serverName))
             return McpOAuthFlowStatus.Completed;
 
-        // Check if there's a pending flow
-        foreach (var flow in _pendingFlows.Values)
+        // Check if there's a pending flow via state context
+        foreach (var ctx in _stateToContext.Values)
         {
-            if (flow.ServerName == serverName)
+            if (ctx.ServerName == serverName)
                 return McpOAuthFlowStatus.Pending;
         }
 
         return McpOAuthFlowStatus.NotStarted;
     }
 
-    // ── PKCE Helpers ───────────────────────────────────────────────────
-
-    internal static string GenerateCodeVerifier()
+    /// <summary>
+    /// Get flow status by PKCE state value. Delegates to <see cref="OAuthPkceService"/>.
+    /// </summary>
+    public McpOAuthFlowStatus GetFlowStatusByState(string state)
     {
-        var bytes = RandomNumberGenerator.GetBytes(32);
-        return Base64UrlEncode(bytes);
+        // If we already persisted tokens for this state, it's completed
+        if (_stateToContext.TryGetValue(state, out var ctx) && _tokens.ContainsKey(ctx.ServerName))
+            return McpOAuthFlowStatus.Completed;
+
+        var pkceStatus = _pkceService.GetFlowStatus(state);
+        return pkceStatus switch
+        {
+            OAuthPkceFlowStatus.Completed => McpOAuthFlowStatus.Completed,
+            OAuthPkceFlowStatus.Pending => McpOAuthFlowStatus.Pending,
+            OAuthPkceFlowStatus.Failed => McpOAuthFlowStatus.Failed,
+            _ => McpOAuthFlowStatus.NotStarted,
+        };
     }
 
-    internal static string ComputeCodeChallenge(string codeVerifier)
-    {
-        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier));
-        return Base64UrlEncode(hash);
-    }
-
-    private static string Base64UrlEncode(byte[] data)
-    {
-        return Convert.ToBase64String(data)
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
-    }
+    /// <summary>
+    /// Get the completed flow result by PKCE state. Returns null if not complete.
+    /// </summary>
+    public OAuthDeviceFlowResult? GetFlowResult(string state) => _pkceService.GetFlowResult(state);
 
     // ── Private Helpers ────────────────────────────────────────────────
-
-    private static Dictionary<string, string> BuildTokenRequestParams(
-        string grantType, string? clientId, string? redirectUri = null,
-        string? resourceIndicator = null, string? code = null,
-        string? codeVerifier = null, string? refreshToken = null)
-    {
-        var parameters = new Dictionary<string, string>
-        {
-            ["grant_type"] = grantType,
-        };
-
-        if (!string.IsNullOrWhiteSpace(clientId))
-            parameters["client_id"] = clientId;
-        if (!string.IsNullOrWhiteSpace(redirectUri))
-            parameters["redirect_uri"] = redirectUri;
-        if (!string.IsNullOrWhiteSpace(resourceIndicator))
-            parameters["resource"] = resourceIndicator;
-        if (!string.IsNullOrWhiteSpace(code))
-            parameters["code"] = code;
-        if (!string.IsNullOrWhiteSpace(codeVerifier))
-            parameters["code_verifier"] = codeVerifier;
-        if (!string.IsNullOrWhiteSpace(refreshToken))
-            parameters["refresh_token"] = refreshToken;
-
-        return parameters;
-    }
-
-    private McpOAuthTokenSet ParseTokenResponse(
-        JsonElement response, string? clientId, string? mcpServerUrl)
-    {
-        var accessToken = response.GetProperty("access_token").GetString()!;
-        string? refreshToken = response.TryGetProperty("refresh_token", out var rtProp)
-            ? rtProp.GetString() : null;
-        int? expiresIn = response.TryGetProperty("expires_in", out var expProp)
-            ? expProp.GetInt32() : null;
-
-        return new McpOAuthTokenSet
-        {
-            AccessToken = new SensitiveString(accessToken),
-            RefreshToken = refreshToken is not null ? new SensitiveString(refreshToken) : null,
-            ExpiresAt = expiresIn is not null
-                ? _timeProvider.GetUtcNow().AddSeconds(expiresIn.Value)
-                : null,
-            ClientId = clientId,
-            McpServerUrl = mcpServerUrl,
-        };
-    }
 
     private static string? ExtractQuotedParam(string headerValue, string paramName)
     {
@@ -582,14 +538,11 @@ internal enum McpOAuthFlowStatus
     Failed,
 }
 
-internal sealed class McpOAuthPendingFlow
-{
-    public required string ServerName { get; init; }
-    public required string CodeVerifier { get; init; }
-    public required string State { get; init; }
-    public required string RedirectUri { get; init; }
-    public required string ClientId { get; init; }
-    public required string TokenEndpoint { get; init; }
-    public string? ResourceIndicator { get; init; }
-    public required TaskCompletionSource<bool> Completion { get; init; }
-}
+/// <summary>
+/// Tracks per-flow context needed to convert <see cref="OAuthDeviceFlowResult"/>
+/// into a persistable <see cref="McpOAuthTokenSet"/> after callback.
+/// </summary>
+internal sealed record McpOAuthFlowContext(
+    string ServerName,
+    string ClientId,
+    string? ResourceIndicator);

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -272,23 +272,30 @@ internal sealed class McpOAuthService
         if (!_stateToContext.TryGetValue(state, out var context))
             throw new InvalidOperationException($"Unknown OAuth state: {state}");
 
-        var result = await _pkceService.CompleteAuthorizationAsync(code, state, ct);
-
-        // Convert OAuthDeviceFlowResult → McpOAuthTokenSet for persistence
-        var tokenSet = new McpOAuthTokenSet
+        try
         {
-            AccessToken = result.AccessToken,
-            RefreshToken = result.RefreshToken,
-            ExpiresAt = result.ExpiresAt,
-            ClientId = context.ClientId,
-            McpServerUrl = context.ResourceIndicator,
-        };
+            var result = await _pkceService.CompleteAuthorizationAsync(code, state, ct);
 
-        _tokens[context.ServerName] = tokenSet;
-        PersistTokens();
+            // Convert OAuthDeviceFlowResult → McpOAuthTokenSet for persistence
+            var tokenSet = new McpOAuthTokenSet
+            {
+                AccessToken = result.AccessToken,
+                RefreshToken = result.RefreshToken,
+                ExpiresAt = result.ExpiresAt,
+                ClientId = context.ClientId,
+                McpServerUrl = context.ResourceIndicator,
+            };
 
-        _stateToContext.TryRemove(state, out _);
-        _logger.LogInformation("OAuth flow completed for MCP server '{Name}'", context.ServerName);
+            _tokens[context.ServerName] = tokenSet;
+            PersistTokens();
+
+            _logger.LogInformation("OAuth flow completed for MCP server '{Name}'", context.ServerName);
+        }
+        finally
+        {
+            // Always clean up context — whether success or failure
+            _stateToContext.TryRemove(state, out _);
+        }
     }
 
     // ── Token Access ───────────────────────────────────────────────────
@@ -414,11 +421,6 @@ internal sealed class McpOAuthService
             _ => McpOAuthFlowStatus.NotStarted,
         };
     }
-
-    /// <summary>
-    /// Get the completed flow result by PKCE state. Returns null if not complete.
-    /// </summary>
-    public OAuthDeviceFlowResult? GetFlowResult(string state) => _pkceService.GetFlowResult(state);
 
     // ── Private Helpers ────────────────────────────────────────────────
 

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -122,9 +122,10 @@ internal sealed class McpOAuthService
                 if (resourceMeta.TryGetProperty("resource", out var resProp))
                     resourceIndicator = resProp.GetString();
             }
-            catch
+            catch (Exception ex)
             {
                 // No OAuth metadata found — server doesn't require OAuth
+                _logger.LogDebug(ex, "No OAuth metadata at {Url} — server does not require OAuth", wellKnownUrl);
                 return null;
             }
         }
@@ -255,7 +256,10 @@ internal sealed class McpOAuthService
 
         // Store context so we can persist tokens when the callback arrives
         _stateToContext[state] = new McpOAuthFlowContext(
-            serverName, clientId, metadata.ResourceIndicator);
+            serverName, clientId, metadata.ResourceIndicator, _timeProvider.GetUtcNow());
+
+        // Prune abandoned flows older than 10 minutes
+        PruneStaleFlowContexts();
 
         _logger.LogInformation("Started OAuth flow for MCP server '{Name}' (state={State})", serverName, state);
         return (authUrl, state);
@@ -418,6 +422,23 @@ internal sealed class McpOAuthService
         };
     }
 
+    // ── Flow Cleanup ───────────────────────────────────────────────────
+
+    private static readonly TimeSpan FlowContextTtl = TimeSpan.FromMinutes(10);
+
+    private void PruneStaleFlowContexts()
+    {
+        var cutoff = _timeProvider.GetUtcNow() - FlowContextTtl;
+        foreach (var (state, ctx) in _stateToContext)
+        {
+            if (ctx.CreatedAt < cutoff)
+            {
+                if (_stateToContext.TryRemove(state, out _))
+                    _logger.LogDebug("Pruned abandoned OAuth flow context (state={State}, server={Server})", state, ctx.ServerName);
+            }
+        }
+    }
+
     // ── Private Helpers ────────────────────────────────────────────────
 
     private static string? ExtractQuotedParam(string headerValue, string paramName)
@@ -543,4 +564,5 @@ internal enum McpOAuthFlowStatus
 internal sealed record McpOAuthFlowContext(
     string ServerName,
     string ClientId,
-    string? ResourceIndicator);
+    string? ResourceIndicator,
+    DateTimeOffset CreatedAt);

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -389,16 +389,16 @@ internal sealed class McpOAuthService
 
     public McpOAuthFlowStatus GetFlowStatus(string serverName)
     {
-        // Check if there's a completed token
-        if (_tokens.ContainsKey(serverName))
-            return McpOAuthFlowStatus.Completed;
-
-        // Check if there's a pending flow via state context
+        // An active flow takes precedence over any previously stored token.
         foreach (var ctx in _stateToContext.Values)
         {
             if (ctx.ServerName == serverName)
                 return McpOAuthFlowStatus.Pending;
         }
+
+        // Check if there's a completed token
+        if (_tokens.ContainsKey(serverName))
+            return McpOAuthFlowStatus.Completed;
 
         return McpOAuthFlowStatus.NotStarted;
     }
@@ -408,10 +408,6 @@ internal sealed class McpOAuthService
     /// </summary>
     public McpOAuthFlowStatus GetFlowStatusByState(string state)
     {
-        // If we already persisted tokens for this state, it's completed
-        if (_stateToContext.TryGetValue(state, out var ctx) && _tokens.ContainsKey(ctx.ServerName))
-            return McpOAuthFlowStatus.Completed;
-
         var pkceStatus = _pkceService.GetFlowStatus(state);
         return pkceStatus switch
         {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -152,14 +152,8 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     app.MapGet("/api/mcp/oauth/status-by-state/{state}", (string state, McpOAuthService oauthService) =>
     {
         var status = oauthService.GetFlowStatusByState(state);
-        var result = oauthService.GetFlowResult(state);
-        return Results.Ok(new
-        {
-            status = status.ToString(),
-            accessToken = result?.AccessToken.Value,
-            refreshToken = result?.RefreshToken?.Value,
-            expiresAt = result?.ExpiresAt?.ToString("o"),
-        });
+        // Tokens are persisted daemon-side — never expose them over HTTP.
+        return Results.Ok(new { status = status.ToString() });
     });
 
     // Provider OAuth endpoints (browser-based Authorization Code + PKCE)
@@ -481,7 +475,7 @@ static void ConfigureDaemonServices(
         var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("ProviderOAuth");
         return new OAuthPkceService(httpClient);
     });
-    services.AddHttpClient<McpOAuthService>();
+    services.AddHttpClient(nameof(McpOAuthService));
     services.AddSingleton(sp => new McpOAuthService(
         sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(McpOAuthService)),
         paths,

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -149,6 +149,19 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         return Results.Ok(new { status = status.ToString() });
     });
 
+    app.MapGet("/api/mcp/oauth/status-by-state/{state}", (string state, McpOAuthService oauthService) =>
+    {
+        var status = oauthService.GetFlowStatusByState(state);
+        var result = oauthService.GetFlowResult(state);
+        return Results.Ok(new
+        {
+            status = status.ToString(),
+            accessToken = result?.AccessToken.Value,
+            refreshToken = result?.RefreshToken?.Value,
+            expiresAt = result?.ExpiresAt?.ToString("o"),
+        });
+    });
+
     // Provider OAuth endpoints (browser-based Authorization Code + PKCE)
     app.MapPost("/api/provider/oauth/start", (
         HttpContext context,
@@ -462,14 +475,20 @@ static void ConfigureDaemonServices(
     var mcpServers = configuration.GetSection("McpServers")
         .Get<Dictionary<string, McpServerEntry>>() ?? new();
     services.AddSingleton(mcpServers);
-    services.AddHttpClient<McpOAuthService>();
-    services.AddSingleton<McpOAuthService>();
+    services.AddHttpClient("ProviderOAuth");
     services.AddSingleton(sp =>
     {
         var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("ProviderOAuth");
         return new OAuthPkceService(httpClient);
     });
-    services.AddHttpClient("ProviderOAuth");
+    services.AddHttpClient<McpOAuthService>();
+    services.AddSingleton(sp => new McpOAuthService(
+        sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(McpOAuthService)),
+        paths,
+        sp.GetRequiredService<TimeProvider>(),
+        sp.GetRequiredService<ILogger<McpOAuthService>>(),
+        sp.GetRequiredService<OAuthPkceService>(),
+        sp.GetService<ISecretsProtector>()));
     services.AddSingleton<McpClientManager>();
     services.AddHostedService(sp => sp.GetRequiredService<McpClientManager>());
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -156,84 +156,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         return Results.Ok(new { status = status.ToString() });
     });
 
-    // Provider OAuth endpoints (browser-based Authorization Code + PKCE)
-    app.MapPost("/api/provider/oauth/start", (
-        HttpContext context,
-        OAuthPkceService pkceService,
-        ProviderDescriptorRegistry registry) =>
-    {
-        var providerType = context.Request.Query["provider"].ToString();
-        if (string.IsNullOrEmpty(providerType))
-            return Results.BadRequest(new { error = "Missing 'provider' query parameter" });
-
-        if (!registry.TryGet(providerType, out var descriptor))
-            return Results.NotFound(new { error = $"Unknown provider type: {providerType}" });
-
-        var oauth = descriptor.Auth.GetOAuthConfig();
-        if (oauth is null || oauth.AuthorizationEndpoint is null || oauth.RedirectUri is null)
-            return Results.BadRequest(new { error = $"Provider '{providerType}' does not support browser OAuth" });
-
-        var (authUrl, state) = pkceService.StartAuthorizationFlow(
-            oauth.AuthorizationEndpoint.AbsoluteUri,
-            oauth.TokenEndpoint.AbsoluteUri,
-            oauth.ClientId,
-            oauth.RedirectUri.AbsoluteUri,
-            oauth.Scope,
-            oauth.ExtraAuthParams);
-
-        // Start temporary callback listener on the redirect URI's port
-        _ = pkceService.ListenForCallbackAsync(oauth.RedirectUri.AbsoluteUri, state);
-
-        return Results.Ok(new { authorizationUrl = authUrl, state });
-    });
-
-    app.MapGet("/api/provider/oauth/callback", async (
-        HttpContext context,
-        OAuthPkceService pkceService,
-        CancellationToken ct) =>
-    {
-        var code = context.Request.Query["code"].ToString();
-        var state = context.Request.Query["state"].ToString();
-
-        if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
-        {
-            context.Response.ContentType = "text/html";
-            await context.Response.WriteAsync(
-                "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>", ct);
-            return;
-        }
-
-        try
-        {
-            await pkceService.CompleteAuthorizationAsync(code, state, ct);
-            context.Response.ContentType = "text/html";
-            await context.Response.WriteAsync(
-                "<html><body><h2>Authorization complete</h2><p>You may close this tab and return to the terminal.</p></body></html>", ct);
-        }
-        catch (Exception ex)
-        {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "text/html";
-            await context.Response.WriteAsync(
-                $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>", ct);
-        }
-    });
-
-    app.MapGet("/api/provider/oauth/status/{state}", (
-        string state,
-        OAuthPkceService pkceService) =>
-    {
-        var status = pkceService.GetFlowStatus(state);
-        var result = pkceService.GetFlowResult(state);
-        return Results.Ok(new
-        {
-            status = status.ToString(),
-            hasToken = result is not null,
-            accessToken = result?.AccessToken.Value,
-            refreshToken = result?.RefreshToken?.Value,
-            expiresAt = result?.ExpiresAt?.ToString("o"),
-        });
-    });
+    app.MapProviderOAuthEndpoints();
 
     // Register channel-specific tools after DI is built (tools need resolved services).
     ChannelToolRegistration.RegisterChannelTools(app.Services);
@@ -475,6 +398,7 @@ static void ConfigureDaemonServices(
         var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("ProviderOAuth");
         return new OAuthPkceService(httpClient);
     });
+    services.AddSingleton<IProviderOAuthCallbackListener, ProviderOAuthCallbackListener>();
     services.AddHttpClient(nameof(McpOAuthService));
     services.AddSingleton(sp => new McpOAuthService(
         sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(McpOAuthService)),
@@ -1091,3 +1015,5 @@ sealed record ImportReminderRequest
     public required ReminderDefinition Definition { get; init; }
     public string? WriteMode { get; init; }
 }
+
+public partial class Program;

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -406,6 +406,7 @@ static void ConfigureDaemonServices(
         sp.GetRequiredService<TimeProvider>(),
         sp.GetRequiredService<ILogger<McpOAuthService>>(),
         sp.GetRequiredService<OAuthPkceService>(),
+        sp.GetRequiredService<IOperationalNotificationSink>(),
         sp.GetService<ISecretsProtector>()));
     services.AddSingleton<McpClientManager>();
     services.AddHostedService(sp => sp.GetRequiredService<McpClientManager>());

--- a/src/Netclaw.Daemon/Providers/IProviderOAuthCallbackListener.cs
+++ b/src/Netclaw.Daemon/Providers/IProviderOAuthCallbackListener.cs
@@ -1,0 +1,23 @@
+using Netclaw.Providers.OAuth;
+
+namespace Netclaw.Daemon.Providers;
+
+internal interface IProviderOAuthCallbackListener
+{
+    void StartListening(string redirectUri, string state);
+}
+
+internal sealed class ProviderOAuthCallbackListener : IProviderOAuthCallbackListener
+{
+    private readonly OAuthPkceService _pkceService;
+
+    public ProviderOAuthCallbackListener(OAuthPkceService pkceService)
+    {
+        _pkceService = pkceService;
+    }
+
+    public void StartListening(string redirectUri, string state)
+    {
+        _ = _pkceService.ListenForCallbackAsync(redirectUri, state);
+    }
+}

--- a/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,90 @@
+using Netclaw.Providers;
+using Netclaw.Providers.OAuth;
+
+namespace Netclaw.Daemon.Providers;
+
+internal static class ProviderOAuthEndpointRouteBuilderExtensions
+{
+    public static IEndpointRouteBuilder MapProviderOAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/provider/oauth/start", (
+            HttpContext context,
+            OAuthPkceService pkceService,
+            ProviderDescriptorRegistry registry,
+            IProviderOAuthCallbackListener callbackListener) =>
+        {
+            var providerType = context.Request.Query["provider"].ToString();
+            if (string.IsNullOrEmpty(providerType))
+                return Results.BadRequest(new { error = "Missing 'provider' query parameter" });
+
+            if (!registry.TryGet(providerType, out var descriptor))
+                return Results.NotFound(new { error = $"Unknown provider type: {providerType}" });
+
+            var oauth = descriptor.Auth.GetOAuthConfig();
+            if (oauth is null || oauth.AuthorizationEndpoint is null || oauth.RedirectUri is null)
+                return Results.BadRequest(new { error = $"Provider '{providerType}' does not support browser OAuth" });
+
+            var (authUrl, state) = pkceService.StartAuthorizationFlow(
+                oauth.AuthorizationEndpoint.AbsoluteUri,
+                oauth.TokenEndpoint.AbsoluteUri,
+                oauth.ClientId,
+                oauth.RedirectUri.AbsoluteUri,
+                oauth.Scope,
+                oauth.ExtraAuthParams);
+
+            callbackListener.StartListening(oauth.RedirectUri.AbsoluteUri, state);
+
+            return Results.Ok(new { authorizationUrl = authUrl, state });
+        });
+
+        app.MapGet("/api/provider/oauth/callback", async (
+            HttpContext context,
+            OAuthPkceService pkceService,
+            CancellationToken ct) =>
+        {
+            var code = context.Request.Query["code"].ToString();
+            var state = context.Request.Query["state"].ToString();
+
+            if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+            {
+                context.Response.ContentType = "text/html";
+                await context.Response.WriteAsync(
+                    "<html><body><h2>Authorization failed</h2><p>Missing code or state parameter.</p></body></html>", ct);
+                return;
+            }
+
+            try
+            {
+                await pkceService.CompleteAuthorizationAsync(code, state, ct);
+                context.Response.ContentType = "text/html";
+                await context.Response.WriteAsync(
+                    "<html><body><h2>Authorization complete</h2><p>You may close this tab and return to the terminal.</p></body></html>", ct);
+            }
+            catch (Exception ex)
+            {
+                context.Response.StatusCode = 500;
+                context.Response.ContentType = "text/html";
+                await context.Response.WriteAsync(
+                    $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>", ct);
+            }
+        });
+
+        app.MapGet("/api/provider/oauth/status/{state}", (
+            string state,
+            OAuthPkceService pkceService) =>
+        {
+            var status = pkceService.GetFlowStatus(state);
+            var result = pkceService.GetFlowResult(state);
+            return Results.Ok(new
+            {
+                status = status.ToString(),
+                hasToken = result is not null,
+                accessToken = result?.AccessToken.Value,
+                refreshToken = result?.RefreshToken?.Value,
+                expiresAt = result?.ExpiresAt?.ToString("o"),
+            });
+        });
+
+        return app;
+    }
+}

--- a/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
@@ -127,11 +127,7 @@ public sealed class OAuthPkceService
             ["redirect_uri"] = redirectUri,
         };
 
-        if (extraParams is not null)
-        {
-            foreach (var (key, value) in extraParams)
-                tokenParams[key] = value;
-        }
+        MergeExtraParams(tokenParams, extraParams);
 
         var response = await _httpClient.PostAsync(
             tokenEndpoint,
@@ -163,11 +159,7 @@ public sealed class OAuthPkceService
             ["refresh_token"] = refreshToken.Value,
         };
 
-        if (extraParams is not null)
-        {
-            foreach (var (key, value) in extraParams)
-                tokenParams[key] = value;
-        }
+        MergeExtraParams(tokenParams, extraParams);
 
         var response = await _httpClient.PostAsync(
             tokenEndpoint,
@@ -283,6 +275,25 @@ public sealed class OAuthPkceService
     public OAuthDeviceFlowResult? GetFlowResult(string state)
     {
         return _completedFlows.TryGetValue(state, out var result) ? result : null;
+    }
+
+    // ── Extra Params ──────────────────────────────────────────────────
+
+    // OAuth grant parameters that must not be overridden by extraParams.
+    private static readonly HashSet<string> ReservedTokenParamKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "grant_type", "client_id", "code", "code_verifier", "redirect_uri", "refresh_token",
+    };
+
+    private static void MergeExtraParams(
+        Dictionary<string, string> target, IReadOnlyDictionary<string, string>? extraParams)
+    {
+        if (extraParams is null) return;
+        foreach (var (key, value) in extraParams)
+        {
+            if (!ReservedTokenParamKeys.Contains(key))
+                target[key] = value;
+        }
     }
 
     // ── PKCE Helpers ───────────────────────────────────────────────────

--- a/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
@@ -37,7 +37,8 @@ public sealed class OAuthPkceService
         string clientId,
         string redirectUri,
         string? scope = null,
-        IReadOnlyDictionary<string, string>? extraParams = null)
+        IReadOnlyDictionary<string, string>? extraParams = null,
+        IReadOnlyDictionary<string, string>? extraTokenParams = null)
     {
         var codeVerifier = GenerateCodeVerifier();
         var codeChallenge = ComputeCodeChallenge(codeVerifier);
@@ -71,6 +72,7 @@ public sealed class OAuthPkceService
             RedirectUri: redirectUri,
             ClientId: clientId,
             TokenEndpoint: tokenEndpoint,
+            ExtraTokenParams: extraTokenParams,
             Completion: new TaskCompletionSource<OAuthDeviceFlowResult>());
 
         _pendingFlows[state] = pendingFlow;
@@ -91,7 +93,7 @@ public sealed class OAuthPkceService
         {
             var result = await ExchangeCodeForTokensAsync(
                 flow.TokenEndpoint, flow.ClientId, code,
-                flow.CodeVerifier, flow.RedirectUri, ct);
+                flow.CodeVerifier, flow.RedirectUri, flow.ExtraTokenParams, ct);
 
             _completedFlows[state] = result;
             flow.Completion.TrySetResult(result);
@@ -113,6 +115,7 @@ public sealed class OAuthPkceService
         string code,
         string codeVerifier,
         string redirectUri,
+        IReadOnlyDictionary<string, string>? extraParams = null,
         CancellationToken ct = default)
     {
         var tokenParams = new Dictionary<string, string>
@@ -123,6 +126,12 @@ public sealed class OAuthPkceService
             ["code_verifier"] = codeVerifier,
             ["redirect_uri"] = redirectUri,
         };
+
+        if (extraParams is not null)
+        {
+            foreach (var (key, value) in extraParams)
+                tokenParams[key] = value;
+        }
 
         var response = await _httpClient.PostAsync(
             tokenEndpoint,
@@ -144,6 +153,7 @@ public sealed class OAuthPkceService
         string tokenEndpoint,
         string clientId,
         SensitiveString refreshToken,
+        IReadOnlyDictionary<string, string>? extraParams = null,
         CancellationToken ct = default)
     {
         var tokenParams = new Dictionary<string, string>
@@ -152,6 +162,12 @@ public sealed class OAuthPkceService
             ["client_id"] = clientId,
             ["refresh_token"] = refreshToken.Value,
         };
+
+        if (extraParams is not null)
+        {
+            foreach (var (key, value) in extraParams)
+                tokenParams[key] = value;
+        }
 
         var response = await _httpClient.PostAsync(
             tokenEndpoint,
@@ -328,6 +344,7 @@ public sealed record OAuthPkcePendingFlow(
     string RedirectUri,
     string ClientId,
     string TokenEndpoint,
+    IReadOnlyDictionary<string, string>? ExtraTokenParams,
     TaskCompletionSource<OAuthDeviceFlowResult> Completion);
 
 /// <summary>

--- a/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
@@ -20,6 +20,7 @@ public sealed class OAuthPkceService
     private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, OAuthPkcePendingFlow> _pendingFlows = new();
     private readonly ConcurrentDictionary<string, OAuthDeviceFlowResult> _completedFlows = new();
+    private readonly ConcurrentDictionary<string, string> _failedFlows = new();
 
     public OAuthPkceService(HttpClient httpClient, TimeProvider? timeProvider = null)
     {
@@ -101,6 +102,7 @@ public sealed class OAuthPkceService
         }
         catch (Exception ex)
         {
+            _failedFlows[state] = ex.Message;
             flow.Completion.TrySetException(ex);
             throw;
         }
@@ -260,6 +262,9 @@ public sealed class OAuthPkceService
     {
         if (_completedFlows.ContainsKey(state))
             return OAuthPkceFlowStatus.Completed;
+
+        if (_failedFlows.ContainsKey(state))
+            return OAuthPkceFlowStatus.Failed;
 
         if (!_pendingFlows.TryGetValue(state, out var flow))
             return OAuthPkceFlowStatus.NotStarted;

--- a/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthPkceService.cs
@@ -16,11 +16,13 @@ namespace Netclaw.Providers.OAuth;
 /// </summary>
 public sealed class OAuthPkceService
 {
+    private static readonly TimeSpan CompletedFlowTtl = TimeSpan.FromMinutes(10);
+
     private readonly HttpClient _httpClient;
     private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, OAuthPkcePendingFlow> _pendingFlows = new();
-    private readonly ConcurrentDictionary<string, OAuthDeviceFlowResult> _completedFlows = new();
-    private readonly ConcurrentDictionary<string, string> _failedFlows = new();
+    private readonly ConcurrentDictionary<string, (OAuthDeviceFlowResult Result, DateTimeOffset CompletedAt)> _completedFlows = new();
+    private readonly ConcurrentDictionary<string, (string Error, DateTimeOffset FailedAt)> _failedFlows = new();
 
     public OAuthPkceService(HttpClient httpClient, TimeProvider? timeProvider = null)
     {
@@ -78,6 +80,8 @@ public sealed class OAuthPkceService
 
         _pendingFlows[state] = pendingFlow;
 
+        PruneStaleFlows();
+
         return (authUrl, state);
     }
 
@@ -96,13 +100,13 @@ public sealed class OAuthPkceService
                 flow.TokenEndpoint, flow.ClientId, code,
                 flow.CodeVerifier, flow.RedirectUri, flow.ExtraTokenParams, ct);
 
-            _completedFlows[state] = result;
+            _completedFlows[state] = (result, _timeProvider.GetUtcNow());
             flow.Completion.TrySetResult(result);
             return result;
         }
         catch (Exception ex)
         {
-            _failedFlows[state] = ex.Message;
+            _failedFlows[state] = (ex.Message, _timeProvider.GetUtcNow());
             flow.Completion.TrySetException(ex);
             throw;
         }
@@ -279,7 +283,32 @@ public sealed class OAuthPkceService
     /// </summary>
     public OAuthDeviceFlowResult? GetFlowResult(string state)
     {
-        return _completedFlows.TryGetValue(state, out var result) ? result : null;
+        return _completedFlows.TryGetValue(state, out var entry) ? entry.Result : null;
+    }
+
+    // ── Flow Cleanup ──────────────────────────────────────────────────
+
+    private void PruneStaleFlows()
+    {
+        var cutoff = _timeProvider.GetUtcNow() - CompletedFlowTtl;
+
+        foreach (var (state, entry) in _completedFlows)
+        {
+            if (entry.CompletedAt < cutoff)
+                _completedFlows.TryRemove(state, out _);
+        }
+
+        foreach (var (state, entry) in _failedFlows)
+        {
+            if (entry.FailedAt < cutoff)
+                _failedFlows.TryRemove(state, out _);
+        }
+
+        foreach (var (state, flow) in _pendingFlows)
+        {
+            if (flow.Completion.Task.IsCompleted)
+                _pendingFlows.TryRemove(state, out _);
+        }
     }
 
     // ── Extra Params ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #288. Unifies MCP OAuth with the shared PKCE flow in `OAuthPkceService`, removing ~120 lines of duplicated PKCE crypto/token-exchange code from `McpOAuthService`.

- **OAuthPkceService**: Added `extraTokenParams` support for RFC 8707 resource indicators needed by MCP OAuth, with reserved-key guard preventing accidental override of security-critical grant parameters
- **McpOAuthService**: Refactored to delegate all PKCE operations to `OAuthPkceService`; removed duplicated `GenerateCodeVerifier`, `ComputeCodeChallenge`, `Base64UrlEncode`, `BuildTokenRequestParams`, `ParseTokenResponse`, and `McpOAuthPendingFlow`
- **State-based tracking**: Added `GetFlowStatusByState()` and `GET /api/mcp/oauth/status-by-state/{state}` endpoint (status-only, no token exposure)
- **OAuthFlowCoordinator**: Extracted shared `RunBrowserFlowCoreAsync` with delegate parameters; added `StartMcpBrowserFlow` for TUI MCP auth
- **McpCommand CLI**: Upgraded `RunAuthAsync` with browser detection (`BrowserDetection.CanOpenBrowser()`), state-based polling with progress dots, and concurrent paste-redirect-URL fallback for headless environments
- **DaemonApi**: Added `GetMcpOAuthStatusByStateAsync()` and `McpOAuthCallbackAsync()` methods

Also filed #291 for operational notification webhooks (headless re-auth alerting).

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — all 1,111 tests pass
- [x] `dotnet slopwatch analyze` — 0 new violations
- [x] New tests: 4 tests for `extraTokenParams` merge into exchange/refresh/complete flows
- [ ] Manual: `netclaw mcp auth notion` from workstation with browser
- [ ] Manual: `netclaw mcp auth textforge` from workstation with browser
- [ ] Manual: `netclaw mcp auth notion` from headless terminal (paste redirect URL)
- [ ] Manual: `netclaw mcp list` shows connected after daemon restart