### PR TITLE
fix: suppress SW004 in FakeBrowserAutomationBootstrapper

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1049,7 +1049,9 @@ internal sealed class FakeBrowserAutomationBootstrapper : IBrowserAutomationBoot
     {
         CallCount++;
         if (DelayBeforeResult.HasValue)
+#pragma warning disable SW004 // Intentional: fake service simulates latency for timeout testing
             await Task.Delay(DelayBeforeResult.Value, ct);
+#pragma warning restore SW004
         return NextResult;
     }
 }


### PR DESCRIPTION
## Summary

- Adds `#pragma warning disable SW004` around the `Task.Delay` in `FakeBrowserAutomationBootstrapper.EnsureReadyAsync`
- The delay is intentional: the fake service simulates latency for timeout testing, which is explicitly permitted by the project constitution
- Uses the inline suppression mechanism slopwatch itself recommends (no additional packages needed)

## Test plan

- [x] CI Slopwatch job passes without the SW004 warning
- [x] Build succeeds with 0 warnings

Closes #294