### PR TITLE
Remove 'dotnet pack' step from PR validation workflow

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -65,9 +65,6 @@ jobs:
         env:
           BUILD_CONFIG: Release
 
-      - name: "dotnet pack"
-        run: dotnet pack -c Release -o ./bin/nuget
-
   slopwatch:
     name: Slopwatch
     runs-on: arc-netclaw


### PR DESCRIPTION
Removed the 'dotnet pack' step from the CI workflow.