### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,29 +7,38 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.6.2</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.6.2 — Reminder history, onboarding chat, and turn recovery hardening
+    <VersionPrefix>0.7.0</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.7.0 — Behavioral directives, webhook alerts, tool budgets, and provider consolidation
+
+**Agents**
+
+* Added deterministic behavioral directives to the system prompt — operators can now place a `DIRECTIVES.md` file in their Netclaw config directory to inject stable, unconditional instructions that are always prepended to the agent's system prompt, independent of skills or personality files. ([#290](https://github.com/Aaronontheweb/netclaw/pull/290))
+
+**Notifications**
+
+* Added operational webhook alerts for daemon events — operators can configure HTTP webhook endpoints to receive structured JSON payloads when key daemon lifecycle events occur (startup, shutdown, error). Useful for integrating Netclaw status into external monitoring and alerting pipelines. ([#292](https://github.com/Aaronontheweb/netclaw/pull/292))
+
+**CLI**
+
+* Added `netclaw stats` command — displays live daemon statistics including uptime, session count, memory usage, reminder count, and provider health in a single glanceable output. ([#272](https://github.com/Aaronontheweb/netclaw/pull/272))
+* Unified MCP OAuth behind a shared PKCE flow — the `netclaw mcp auth` command now uses the same PKCE authorization code exchange path for all MCP OAuth providers, eliminating divergent code paths and making headless auth more predictable. ([#293](https://github.com/Aaronontheweb/netclaw/pull/293))
+
+**Session**
+
+* Reworked tool budget to use per-call counting with a budget nudge and graceful wind-down — the agent now tracks individual tool calls rather than turn-level counts, receives a soft warning as it approaches the limit, and transitions to a clean wrap-up phase instead of abruptly stopping. ([#277](https://github.com/Aaronontheweb/netclaw/pull/277), [#280](https://github.com/Aaronontheweb/netclaw/pull/280))
 
 **Reminders**
 
-* Added per-reminder execution history: every reminder execution now appends a record (fired time, success/failure, duration, session ID, error message) to `~/.netclaw/reminders/{id}.history.jsonl`. History is capped at 500 records (configurable) with atomic overflow trimming. Accessible via `netclaw reminder history &lt;id&gt; [--last N]`, `GET /api/reminders/{id}/history`, and the `get_reminder_history` agent tool (scheduling grant required). History file is deleted when a reminder is cancelled. ([#259](https://github.com/Aaronontheweb/netclaw/pull/259))
-
-**Init Wizard**
-
-* Added an interactive onboarding chat at the end of the init wizard — after health checks pass, the agent introduces itself and asks what the operator wants to use it for, updating `SOUL.md` with what it learns. This replaces the static "primary use" text field with a richer conversational approach. ([#250](https://github.com/Aaronontheweb/netclaw/pull/250))
-* Fixed the chat TUI getting stuck on "Generating..." after an idle SignalR reconnect — `IsGenerating` is now reset on disconnect. ([#250](https://github.com/Aaronontheweb/netclaw/pull/250))
+* Fixed one-shot reminders firing repeatedly after their scheduled time — reminders with `repeat: false` are now disabled immediately after first execution, preventing zombie entries from re-inflating the reminder registry. ([#289](https://github.com/Aaronontheweb/netclaw/pull/289))
 
 **Providers**
 
-* Fixed OpenAI-compatible provider fallback path using `/api/v1/` instead of the standard `/v1/` — llama.cpp, vLLM, and other servers that follow the OpenAI path convention without the `/api/` prefix now work correctly. ([#253](https://github.com/Aaronontheweb/netclaw/pull/253))
-
-**Skills Platform**
-
-* System skills are now sourced directly from the feed directory (`feeds/skills/.system/files/`) at build time, eliminating the dual-copy maintenance problem where the embedded copy and the feed copy had silently diverged. The feed directory is the single source of truth for both on-disk seeding and published feed artifacts. ([#258](https://github.com/Aaronontheweb/netclaw/pull/258))
+* Merged the `openai-codex` provider into the unified OpenAI provider — operators previously using the `openai-codex` provider type will have their configuration automatically migrated. The separate provider type is removed. ([#251](https://github.com/Aaronontheweb/netclaw/pull/251))
 
 **Stability**
 
-* Fixed agent turn recovery for empty LLM responses, forced no-tools turns, and hang scenarios — the session actor now reliably recovers and continues rather than stalling or silently dropping turns in these edge cases. ([#260](https://github.com/Aaronontheweb/netclaw/pull/260), [#269](https://github.com/Aaronontheweb/netclaw/pull/269), [#271](https://github.com/Aaronontheweb/netclaw/pull/271))</PackageReleaseNotes>
+* Implemented the delivery feedback contract for LLM error correction — when a channel cannot deliver an LLM response (e.g., Slack formatting rejection), the full error is now fed back into the LLM session so the agent can understand what went wrong and retry with corrected output. Silent failures and fallback downgrades are eliminated. ([#283](https://github.com/Aaronontheweb/netclaw/pull/283))
+* Fixed false "fallback" warning logs in Slack and ensured preamble text is surfaced correctly during tool-use turns — preamble content emitted before the first tool call is now delivered to Slack rather than silently dropped. ([#278](https://github.com/Aaronontheweb/netclaw/pull/278))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+#### 0.7.0 2026-03-20 ####
+
+Netclaw v0.7.0 — Behavioral directives, webhook alerts, tool budgets, and provider consolidation
+
+**Agents**
+
+* Added deterministic behavioral directives to the system prompt — operators can now place a `DIRECTIVES.md` file in their Netclaw config directory to inject stable, unconditional instructions that are always prepended to the agent's system prompt, independent of skills or personality files. ([#290](https://github.com/Aaronontheweb/netclaw/pull/290))
+
+**Notifications**
+
+* Added operational webhook alerts for daemon events — operators can configure HTTP webhook endpoints to receive structured JSON payloads when key daemon lifecycle events occur (startup, shutdown, error). Useful for integrating Netclaw status into external monitoring and alerting pipelines. ([#292](https://github.com/Aaronontheweb/netclaw/pull/292))
+
+**CLI**
+
+* Added `netclaw stats` command — displays live daemon statistics including uptime, session count, memory usage, reminder count, and provider health in a single glanceable output. ([#272](https://github.com/Aaronontheweb/netclaw/pull/272))
+* Unified MCP OAuth behind a shared PKCE flow — the `netclaw mcp auth` command now uses the same PKCE authorization code exchange path for all MCP OAuth providers, eliminating divergent code paths and making headless auth more predictable. ([#293](https://github.com/Aaronontheweb/netclaw/pull/293))
+
+**Session**
+
+* Reworked tool budget to use per-call counting with a budget nudge and graceful wind-down — the agent now tracks individual tool calls rather than turn-level counts, receives a soft warning as it approaches the limit, and transitions to a clean wrap-up phase instead of abruptly stopping. ([#277](https://github.com/Aaronontheweb/netclaw/pull/277), [#280](https://github.com/Aaronontheweb/netclaw/pull/280))
+
+**Reminders**
+
+* Fixed one-shot reminders firing repeatedly after their scheduled time — reminders with `repeat: false` are now disabled immediately after first execution, preventing zombie entries from re-inflating the reminder registry. ([#289](https://github.com/Aaronontheweb/netclaw/pull/289))
+
+**Providers**
+
+* Merged the `openai-codex` provider into the unified OpenAI provider — operators previously using the `openai-codex` provider type will have their configuration automatically migrated. The separate provider type is removed. ([#251](https://github.com/Aaronontheweb/netclaw/pull/251))
+
+**Stability**
+
+* Implemented the delivery feedback contract for LLM error correction — when a channel cannot deliver an LLM response (e.g., Slack formatting rejection), the full error is now fed back into the LLM session so the agent can understand what went wrong and retry with corrected output. Silent failures and fallback downgrades are eliminated. ([#283](https://github.com/Aaronontheweb/netclaw/pull/283))
+* Fixed false "fallback" warning logs in Slack and ensured preamble text is surfaced correctly during tool-use turns — preamble content emitted before the first tool call is now delivered to Slack rather than silently dropped. ([#278](https://github.com/Aaronontheweb/netclaw/pull/278))
+
 #### 0.6.2 2026-03-17 ####
 
 Netclaw v0.6.2 — Reminder history, onboarding chat, and turn recovery hardening


### PR DESCRIPTION
## Summary

- Updates `release_notes.md` with v0.7.0 release notes (dated 2026-03-20)
- Bumps version metadata via build script

## Changes included

See `release_notes.md` for the full changelog for this release.

## Pre-merge checklist

- [ ] Release notes reviewed and accurate
- [ ] Version bump is correct (0.7.0)
- [ ] CI passes on this branch

## Post-merge

After merging, the release coordinator will:
1. Sync local `dev` branch
2. Create annotated tag `v0.7.0` on HEAD of `dev`
3. Push tag to `origin` — CI/CD will handle the GitHub release automatically