### PR TITLE
fix(init): stop daemon before config write to prevent restart race

### DIFF
--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -682,6 +682,23 @@ public partial class InitWizardViewModel : ReactiveViewModel
             }
         }
 
+        // Stop daemon before writing config to prevent ConfigWatcherService restart race
+        if (_daemonManager is not null)
+        {
+            var status = _daemonManager.GetStatus();
+            if (status.IsRunning)
+            {
+                HealthCheckResults.Add(new HealthCheckItem("Stopping daemon for config update", null));
+                NotifyHealthCheckChanged();
+
+                var stopResult = await _daemonManager.StopAsync();
+                HealthCheckResults[^1] = stopResult.Success
+                    ? new HealthCheckItem("Daemon stopped", true)
+                    : new HealthCheckItem($"Daemon stop failed: {stopResult.Message}", false);
+                NotifyHealthCheckChanged();
+            }
+        }
+
         // Config write
         HealthCheckResults.Add(new HealthCheckItem("Writing configuration", null));
         NotifyHealthCheckChanged();


### PR DESCRIPTION
## Summary

- When `netclaw init` runs on an existing installation with the daemon already running, writing config files triggers `ConfigWatcherService`'s file watcher, causing an uncontrolled restart mid-initialization that loses the system prompt and triggers a chat reconnection loop
- Adds a daemon stop step before the config write block in `InitWizardViewModel.RunHealthChecksAsync` — if the daemon is running, it is stopped first so no file watcher is active during the write
- Clean installs are unaffected since `status.IsRunning` is false and the stop is skipped

## Test plan

- [ ] Start daemon via `netclaw daemon start`, then run `netclaw init` and complete wizard
- [ ] Health check should show: "Stopping daemon for config update" → "Daemon stopped" → "Writing configuration" → "Configuration written" → "Starting daemon" → "Daemon ready"
- [ ] Chat should launch cleanly with system prompt intact (no reconnection loop)
- [ ] Verify clean install (no daemon running) still works — stop step should be skipped