### PR TITLE
fix(mcp-oauth): auto-reconnect after OAuth and use daemon statuses in mcp list

### DIFF
--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -173,6 +173,21 @@ public sealed class DaemonApi
             $"{_endpoint}/api/mcp/oauth/callback?code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}", cts.Token);
     }
 
+    public async Task<JsonElement?> GetMcpServerStatusesAsync(CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        try
+        {
+            return await client.GetFromJsonAsync<JsonElement>(
+                $"{_endpoint}/api/mcp/statuses", cts.Token);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     // ── Provider OAuth ─────────────────────────────────────────────────
 
     public async Task<HttpResponseMessage> StartProviderOAuthAsync(string providerType, CancellationToken ct = default)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -43,7 +43,7 @@ internal static class McpCommand
         {
             "add" => RunAdd(args, paths, writer),
             "auth" => await RunAuthAsync(args, paths, daemonApi, writer),
-            "list" => await RunListAsync(paths, writer),
+            "list" => await RunListAsync(paths, daemonApi, writer),
             "get" => RunGet(args, paths, writer),
             "remove" => RunRemove(args, paths, writer),
             "enable" => RunToggle(args, paths, enabled: true, writer),
@@ -313,7 +313,6 @@ internal static class McpCommand
             if (pollResult)
             {
                 writer.WriteLine($"Authorization complete for '{name}'.");
-                writer.WriteLine("Run: netclaw daemon restart");
                 return 0;
             }
         }
@@ -323,7 +322,6 @@ internal static class McpCommand
             if (pasteResult)
             {
                 writer.WriteLine($"Authorization complete for '{name}'.");
-                writer.WriteLine("Run: netclaw daemon restart");
                 return 0;
             }
         }
@@ -471,7 +469,7 @@ internal static class McpCommand
         return true;
     }
 
-    private static async Task<int> RunListAsync(NetclawPaths paths, TextWriter writer)
+    private static async Task<int> RunListAsync(NetclawPaths paths, DaemonApi? daemonApi, TextWriter writer)
     {
         var servers = LoadMcpServers(paths);
 
@@ -482,15 +480,50 @@ internal static class McpCommand
             return 0;
         }
 
+        // Prefer daemon statuses — they include OAuth tokens and live connection state
+        var daemonStatuses = daemonApi is not null
+            ? await daemonApi.GetMcpServerStatusesAsync()
+            : null;
+
         writer.WriteLine($"{"Name",-20} {"Transport",-10} {"Enabled",-8} {"Status"}");
         foreach (var (name, entry) in servers)
         {
             var enabled = entry.Enabled ? "yes" : "no";
-            var probe = await ProbeServerAsync(name, entry);
-            writer.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {probe.FormatStatus()}");
+            var statusText = FormatDaemonStatus(daemonStatuses, name);
+
+            if (statusText is null)
+            {
+                // Daemon unavailable or server not tracked — fall back to direct probe
+                var probe = await ProbeServerAsync(name, entry);
+                statusText = probe.FormatStatus();
+            }
+
+            writer.WriteLine($"{name,-20} {entry.Transport,-10} {enabled,-8} {statusText}");
         }
 
         return 0;
+    }
+
+    private static string? FormatDaemonStatus(JsonElement? daemonStatuses, string serverName)
+    {
+        if (daemonStatuses is null)
+            return null;
+
+        if (!daemonStatuses.Value.TryGetProperty(serverName, out var entry))
+            return null;
+
+        var state = entry.GetProperty("state").GetString();
+        var toolCount = entry.GetProperty("toolCount").GetInt32();
+        var error = entry.TryGetProperty("error", out var errProp) ? errProp.GetString() : null;
+
+        return state switch
+        {
+            "Connected" => $"connected ({toolCount} tools)",
+            "AwaitingAuth" => "awaiting auth — run: netclaw mcp auth " + serverName,
+            "Disabled" => "disabled",
+            "Error" => $"error — {error ?? "unknown"}",
+            _ => state,
+        };
     }
 
     private static int RunGet(string[] args, NetclawPaths paths, TextWriter writer)

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -38,6 +38,9 @@ internal sealed class McpOAuthService
     // Maps PKCE state → flow context for token persistence after callback
     private readonly ConcurrentDictionary<string, McpOAuthFlowContext> _stateToContext = new();
 
+    // Maps PKCE state → server name for recently completed flows (for auto-reconnect)
+    private readonly ConcurrentDictionary<string, string> _lastCompletedServerName = new();
+
     public McpOAuthService(
         HttpClient httpClient,
         NetclawPaths paths,
@@ -296,6 +299,9 @@ internal sealed class McpOAuthService
             _tokens[context.ServerName] = tokenSet;
             PersistTokens();
 
+            // Cache the server name so callers can trigger reconnect after cleanup
+            _lastCompletedServerName[state] = context.ServerName;
+
             _logger.LogInformation("OAuth flow completed for MCP server '{Name}'", context.ServerName);
         }
         finally
@@ -303,6 +309,16 @@ internal sealed class McpOAuthService
             // Always clean up context — whether success or failure
             _stateToContext.TryRemove(state, out _);
         }
+    }
+
+    /// <summary>
+    /// Returns the server name for a recently completed OAuth flow (by state).
+    /// Used to trigger auto-reconnect after token acquisition.
+    /// </summary>
+    public string? GetServerNameForState(string state)
+    {
+        _lastCompletedServerName.TryRemove(state, out var name);
+        return name;
     }
 
     // ── Token Access ───────────────────────────────────────────────────

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -136,10 +136,11 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
             if (serverName is not null)
             {
                 var mcpManager = context.RequestServices.GetRequiredService<McpClientManager>();
+                var reconnectLogger = context.RequestServices.GetRequiredService<ILogger<McpClientManager>>();
                 _ = Task.Run(async () =>
                 {
                     try { await mcpManager.TryReconnectAsync(serverName, CancellationToken.None); }
-                    catch { /* best-effort reconnect */ }
+                    catch (Exception ex) { reconnectLogger.LogWarning(ex, "Post-OAuth reconnect failed for MCP server '{Name}'", serverName); }
                 }, CancellationToken.None);
             }
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -130,6 +130,19 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         try
         {
             await oauthService.CompleteAuthorizationAsync(code, state, ct);
+
+            // Auto-reconnect the MCP server now that we have a valid token
+            var serverName = oauthService.GetServerNameForState(state);
+            if (serverName is not null)
+            {
+                var mcpManager = context.RequestServices.GetRequiredService<McpClientManager>();
+                _ = Task.Run(async () =>
+                {
+                    try { await mcpManager.TryReconnectAsync(serverName, CancellationToken.None); }
+                    catch { /* best-effort reconnect */ }
+                }, CancellationToken.None);
+            }
+
             context.Response.ContentType = "text/html";
             await context.Response.WriteAsync(
                 "<html><body><h2>Authorization complete</h2><p>You may close this tab.</p></body></html>", ct);
@@ -141,6 +154,20 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
             await context.Response.WriteAsync(
                 $"<html><body><h2>Authorization failed</h2><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>", ct);
         }
+    });
+
+    app.MapGet("/api/mcp/statuses", (McpClientManager mcpManager) =>
+    {
+        var statuses = mcpManager.GetServerStatuses();
+        var result = statuses.ToDictionary(
+            kvp => kvp.Key,
+            kvp => new
+            {
+                state = kvp.Value.State.ToString(),
+                toolCount = kvp.Value.ToolCount,
+                error = kvp.Value.ErrorMessage,
+            });
+        return Results.Ok(result);
     });
 
     app.MapGet("/api/mcp/oauth/status/{name}", (string name, McpOAuthService oauthService) =>


### PR DESCRIPTION
## Summary

- **`mcp list` now uses daemon statuses** instead of probing MCP servers directly without OAuth tokens. Falls back to direct probing only when the daemon is unreachable.
- **Auto-reconnect after OAuth completion** — the daemon's OAuth callback endpoint now triggers `McpClientManager.TryReconnectAsync` automatically, removing the need for `netclaw daemon restart`.
- Added `GET /api/mcp/statuses` daemon endpoint exposing live MCP server connection state.

## Test plan

- [x] Existing MCP OAuth tests pass (9 daemon, 25 CLI)
- [ ] `netclaw mcp auth notion` → completes → `netclaw mcp list` shows `connected` without daemon restart
- [ ] `netclaw mcp list` falls back to direct probe when daemon is not running