### PR TITLE
fix(channels): close delivery feedback loop so Slack errors reach the LLM session

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -560,6 +560,114 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         await ExpectTerminatedAsync(actor);
     }
 
+    [Fact]
+    public async Task Timeout_during_post_sends_transport_failure_feedback_to_session()
+    {
+        var feedbackPipeline = new RecordingSessionPipeline([
+            new TextOutput
+            {
+                SessionId = new SessionId("D7/9000.1"),
+                TimestampMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+                Text = "Hello from the LLM"
+            },
+            new TurnCompleted
+            {
+                SessionId = new SessionId("D7/9000.1"),
+                TurnNumber = 1
+            }
+        ]);
+
+        _replyClient.PostFailures.Enqueue(new OperationCanceledException("The operation was canceled."));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: feedbackPipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var actor = Sys.ActorOf(SlackThreadBindingActor.CreateProps(
+            new SessionId("D7/9000.1"),
+            new SlackChannelId("D7"),
+            new SlackThreadTs("9000.1"),
+            deps), "slack-thread-timeout-feedback-test");
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = Assert.Single(feedbackPipeline.Feedback);
+            var failure = Assert.IsType<DeliveryFailed>(feedback);
+            Assert.Equal(DeliveryFailureKind.TransportFailure, failure.FailureKind);
+            Assert.Equal(1, failure.TurnNumber);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Watch(actor);
+        Sys.Stop(actor);
+        await ExpectTerminatedAsync(actor);
+    }
+
+    [Fact]
+    public async Task Generic_exception_during_post_sends_unknown_failure_feedback_to_session()
+    {
+        var feedbackPipeline = new RecordingSessionPipeline([
+            new TextOutput
+            {
+                SessionId = new SessionId("D7/9100.1"),
+                TimestampMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+                Text = "Hello from the LLM"
+            },
+            new TurnCompleted
+            {
+                SessionId = new SessionId("D7/9100.1"),
+                TurnNumber = 1
+            }
+        ]);
+
+        _replyClient.PostFailures.Enqueue(new InvalidOperationException("Unexpected Slack error"));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: feedbackPipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var actor = Sys.ActorOf(SlackThreadBindingActor.CreateProps(
+            new SessionId("D7/9100.1"),
+            new SlackChannelId("D7"),
+            new SlackThreadTs("9100.1"),
+            deps), "slack-thread-generic-failure-feedback-test");
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = Assert.Single(feedbackPipeline.Feedback);
+            var failure = Assert.IsType<DeliveryFailed>(feedback);
+            Assert.Equal(DeliveryFailureKind.Unknown, failure.FailureKind);
+            Assert.Equal(1, failure.TurnNumber);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Watch(actor);
+        Sys.Stop(actor);
+        await ExpectTerminatedAsync(actor);
+    }
+
     /// <summary>
     /// Fake HTTP handler that serves canned image bytes for Slack file download requests.
     /// </summary>

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -412,6 +412,112 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Transport_failure_injects_nudge_without_triggering_retry()
+    {
+        var sessionId = new SessionId("test-channel/transport-failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("transport-failure-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Say hello"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // Send non-retryable transport failure — should NOT trigger LLM retry
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = completed.TurnNumber,
+            ChannelType = ChannelType.Slack,
+            FailureKind = DeliveryFailureKind.TransportFailure,
+            ErrorMessage = "Timed out posting reply"
+        });
+
+        // No retry should occur — transport failures can't be fixed by changing output
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        // On the next user message, the LLM should see the transport failure nudge
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Are you there?"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Contains(_fakeChatClient.ReceivedMessages[^1], msg =>
+            msg.Role == Microsoft.Extensions.AI.ChatRole.User
+            && msg.Text is not null
+            && msg.Text.Contains("transport error", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Unknown_delivery_failure_injects_nudge_without_triggering_retry()
+    {
+        var sessionId = new SessionId("test-channel/unknown-failure");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("unknown-failure-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Say hello"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // Send non-retryable unknown failure — should NOT trigger LLM retry
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = completed.TurnNumber,
+            ChannelType = ChannelType.Slack,
+            FailureKind = DeliveryFailureKind.Unknown,
+            ErrorMessage = "Unexpected Slack error"
+        });
+
+        // No retry should occur
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        // On the next user message, the nudge should be visible in LLM context
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Are you there?"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Contains(_fakeChatClient.ReceivedMessages[^1], msg =>
+            msg.Role == Microsoft.Extensions.AI.ChatRole.User
+            && msg.Text is not null
+            && msg.Text.Contains("unknown delivery error", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task Sidecar_observation_promotes_strong_user_assertion_into_memory()
     {
         var gate = new MemoryProposalGate();

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -327,18 +327,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (!IsRetryableDeliveryFailure(msg))
             {
                 _log.Warning(
-                    "Ignoring non-retryable delivery feedback while processing channel={Channel} turn={Turn} kind={FailureKind}",
+                    "Non-retryable delivery feedback while processing channel={Channel} turn={Turn} kind={FailureKind}; injecting context",
                     msg.ChannelType,
                     msg.TurnNumber,
                     msg.FailureKind);
+                _state = _state.AddSystemNudge(BuildDeliveryFailureNudge(msg));
                 return;
             }
 
             _log.Warning(
-                "Ignoring stale delivery feedback while processing channel={Channel} turn={Turn} eligibleTurn={EligibleTurn}",
+                "Ignoring retryable delivery feedback while processing channel={Channel} turn={Turn}",
                 msg.ChannelType,
-                msg.TurnNumber,
-                _deliveryRetryEligibleTurnNumber?.ToString() ?? "none");
+                msg.TurnNumber);
         });
 
         Command<CompactionWorkCompleted>(_ => { });
@@ -1383,16 +1383,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void HandleDeliveryFailedWhenReady(DeliveryFailed msg)
     {
-        if (!IsRetryableDeliveryFailure(msg))
-        {
-            _log.Warning(
-                "Ignoring non-retryable delivery feedback channel={Channel} turn={Turn} kind={FailureKind}",
-                msg.ChannelType,
-                msg.TurnNumber,
-                msg.FailureKind);
-            return;
-        }
-
         if (_deliveryRetryEligibleTurnNumber != msg.TurnNumber)
         {
             _log.Warning(
@@ -1400,6 +1390,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 msg.ChannelType,
                 msg.TurnNumber,
                 _deliveryRetryEligibleTurnNumber?.ToString() ?? "none");
+            return;
+        }
+
+        if (!IsRetryableDeliveryFailure(msg))
+        {
+            _log.Warning(
+                "Non-retryable delivery failure channel={Channel} turn={Turn} kind={FailureKind}; injecting context for next turn",
+                msg.ChannelType,
+                msg.TurnNumber,
+                msg.FailureKind);
+            _state = _state.AddSystemNudge(BuildDeliveryFailureNudge(msg));
             return;
         }
 
@@ -1442,7 +1443,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             DeliveryFailureKind.ContentRejected => "Produce a simpler channel-safe response and avoid the content pattern the channel rejected.",
             DeliveryFailureKind.MessageTooLarge => "Produce a shorter response that fits the channel's length limits.",
             DeliveryFailureKind.UnsupportedContent => "Avoid unsupported formatting or content types for this channel.",
-            _ => "Produce a corrected response that avoids the reported delivery issue."
+            DeliveryFailureKind.TransportFailure => "The channel experienced a transport error. Your response content was likely fine. Acknowledge to the user that delivery failed due to a technical issue and offer to retry.",
+            DeliveryFailureKind.PermissionDenied => "The bot lacks permission to post in this channel. Inform the user that a permissions issue prevented delivery.",
+            DeliveryFailureKind.Unknown or _ => "An unknown delivery error occurred. Acknowledge the issue to the user."
         };
 
         return $"Your last response could not be delivered to the user via {msg.ChannelType}. "

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -441,6 +441,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 var errorResult = await SafePostAsync($":warning: {err.Message} (ref: {refId})");
                 if (errorResult.Success)
                     _postedThisTurn = true;
+                else
+                    _lastFailedPost = errorResult;
                 _buffer.Clear();
                 break;
 
@@ -465,13 +467,9 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                     if (_lastFailedPost is { ShouldNotifySession: true, FailureKind: { } failureKind, ErrorMessage: { } errorMessage })
                     {
                         _log.Warning(
-                            "Turn completed with retryable Slack delivery failure kind={FailureKind}; notifying session",
+                            "Turn completed with Slack delivery failure kind={FailureKind}; notifying session",
                             failureKind);
                         await NotifyDeliveryFailedAsync(completed.TurnNumber, failureKind, errorMessage);
-                    }
-                    else if (_lastFailedPost is not null)
-                    {
-                        _log.Warning("Turn completed with non-retryable Slack delivery failure: {Error}", _lastFailedPost.ErrorMessage);
                     }
                     else
                     {
@@ -509,7 +507,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         {
             _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult($"Timed out posting reply: {ex.Message}");
+            return new PostResult($"Timed out posting reply: {ex.Message}", DeliveryFailureKind.TransportFailure);
         }
         catch (SlackMessageDeliveryException ex)
         {
@@ -521,7 +519,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         {
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult(ex.Message);
+            return new PostResult(ex.Message, DeliveryFailureKind.Unknown);
         }
     }
 
@@ -540,7 +538,8 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to send Slack delivery feedback to session");
+            _log.Error(ex, "Failed to send delivery feedback to session; propagating to trigger pipeline reinit");
+            throw;
         }
     }
 
@@ -550,9 +549,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
         public bool Success => ErrorMessage is null;
 
-        public bool ShouldNotifySession => FailureKind is DeliveryFailureKind.ContentRejected
-            or DeliveryFailureKind.MessageTooLarge
-            or DeliveryFailureKind.UnsupportedContent;
+        public bool ShouldNotifySession => FailureKind is not null;
     }
 
     private async Task<PostResult> SafeUploadFileAsync(FileOutput file)
@@ -563,7 +560,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
             if (!File.Exists(file.FilePath))
             {
                 _log.Warning("File not found for upload: {Path}", file.FilePath);
-                return new PostResult($"File not found for upload: {file.FilePath}");
+                return new PostResult($"File not found for upload: {file.FilePath}", DeliveryFailureKind.Unknown);
             }
 
             using var cts = new CancellationTokenSource(ReplyOperationTimeout);
@@ -582,7 +579,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         {
             _log.Error(ex, "Timed out uploading file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult($"Timed out uploading file: {ex.Message}");
+            return new PostResult($"Timed out uploading file: {ex.Message}", DeliveryFailureKind.TransportFailure);
         }
         catch (SlackMessageDeliveryException ex)
         {
@@ -597,7 +594,7 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         {
             _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
             ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
-            return new PostResult(ex.Message);
+            return new PostResult(ex.Message, DeliveryFailureKind.Unknown);
         }
     }
 


### PR DESCRIPTION
## Summary

- Slack delivery failures (timeouts, generic exceptions, permission errors) were silently lost — `PostResult` lacked a `FailureKind` and the channel adapter only reported 3 of 6 failure kinds to the session
- The LLM session never learned about the error and could not retry or inform the user, causing the agent to appear non-responsive (observed in sessions `D0AC6CKBK5K/1773983518.003979` and `D0AC6CKBK5K/1773981376.795159`)
- Root cause was 3 bugs in `SlackThreadBindingActor`: missing `FailureKind` on timeouts/generic exceptions, selective `ShouldNotifySession` gate, and silent exception swallowing in `NotifyDeliveryFailedAsync`

## Changes

**SlackThreadBindingActor.cs:**
- Assign `DeliveryFailureKind.TransportFailure` to timeout errors and `Unknown` to generic exceptions (both `SafePostAsync` and `SafeUploadFileAsync`)
- Widen `ShouldNotifySession` from 3 specific kinds to `FailureKind is not null` — session decides retryability
- Remove dead `else if` branch for non-retryable failures (now all failures have a kind)
- Rethrow in `NotifyDeliveryFailedAsync` so broken pipelines trigger `OutputStreamTerminated` → reinit
- Record `ErrorOutput` post failures in `_lastFailedPost` for consistency with other output types

**LlmSessionActor.cs:**
- Non-retryable failures in Ready state inject a nudge via `AddSystemNudge()` (visible on next user turn) instead of being silently dropped
- Non-retryable failures during Processing also inject nudge instead of being dropped
- Stale-turn check moved before retryable check for correct log messages
- Explicit nudge guidance for `TransportFailure`, `PermissionDenied`, and `Unknown`

## Test plan

- [x] 4 new integration tests covering the full feedback loop
- [x] `Transport_failure_injects_nudge_without_triggering_retry` — session receives TransportFailure, no LLM retry, nudge visible on next turn
- [x] `Unknown_delivery_failure_injects_nudge_without_triggering_retry` — same for Unknown kind
- [x] `Timeout_during_post_sends_transport_failure_feedback_to_session` — channel adapter correctly classifies and reports timeouts
- [x] `Generic_exception_during_post_sends_unknown_failure_feedback_to_session` — channel adapter correctly classifies and reports generic exceptions
- [x] All 6 existing delivery feedback tests still pass
- [x] Full suite: 1,125 tests pass, 0 failures
- [x] `dotnet slopwatch analyze` — 0 new violations