### PR TITLE
Release 0.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,38 +7,21 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.7.0 — Behavioral directives, webhook alerts, tool budgets, and provider consolidation
-
-**Agents**
-
-* Added deterministic behavioral directives to the system prompt — operators can now place a `DIRECTIVES.md` file in their Netclaw config directory to inject stable, unconditional instructions that are always prepended to the agent's system prompt, independent of skills or personality files. ([#290](https://github.com/Aaronontheweb/netclaw/pull/290))
-
-**Notifications**
-
-* Added operational webhook alerts for daemon events — operators can configure HTTP webhook endpoints to receive structured JSON payloads when key daemon lifecycle events occur (startup, shutdown, error). Useful for integrating Netclaw status into external monitoring and alerting pipelines. ([#292](https://github.com/Aaronontheweb/netclaw/pull/292))
-
-**CLI**
-
-* Added `netclaw stats` command — displays live daemon statistics including uptime, session count, memory usage, reminder count, and provider health in a single glanceable output. ([#272](https://github.com/Aaronontheweb/netclaw/pull/272))
-* Unified MCP OAuth behind a shared PKCE flow — the `netclaw mcp auth` command now uses the same PKCE authorization code exchange path for all MCP OAuth providers, eliminating divergent code paths and making headless auth more predictable. ([#293](https://github.com/Aaronontheweb/netclaw/pull/293))
-
-**Session**
-
-* Reworked tool budget to use per-call counting with a budget nudge and graceful wind-down — the agent now tracks individual tool calls rather than turn-level counts, receives a soft warning as it approaches the limit, and transitions to a clean wrap-up phase instead of abruptly stopping. ([#277](https://github.com/Aaronontheweb/netclaw/pull/277), [#280](https://github.com/Aaronontheweb/netclaw/pull/280))
-
-**Reminders**
-
-* Fixed one-shot reminders firing repeatedly after their scheduled time — reminders with `repeat: false` are now disabled immediately after first execution, preventing zombie entries from re-inflating the reminder registry. ([#289](https://github.com/Aaronontheweb/netclaw/pull/289))
-
-**Providers**
-
-* Merged the `openai-codex` provider into the unified OpenAI provider — operators previously using the `openai-codex` provider type will have their configuration automatically migrated. The separate provider type is removed. ([#251](https://github.com/Aaronontheweb/netclaw/pull/251))
+    <VersionPrefix>0.7.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.7.1 — Delivery feedback hardening, token stats, MCP OAuth reconnect, and init race fix
 
 **Stability**
 
-* Implemented the delivery feedback contract for LLM error correction — when a channel cannot deliver an LLM response (e.g., Slack formatting rejection), the full error is now fed back into the LLM session so the agent can understand what went wrong and retry with corrected output. Silent failures and fallback downgrades are eliminated. ([#283](https://github.com/Aaronontheweb/netclaw/pull/283))
-* Fixed false "fallback" warning logs in Slack and ensured preamble text is surfaced correctly during tool-use turns — preamble content emitted before the first tool call is now delivered to Slack rather than silently dropped. ([#278](https://github.com/Aaronontheweb/netclaw/pull/278))</PackageReleaseNotes>
+* Fixed Slack delivery failures silently disappearing — transport errors (timeouts, permission denials) now propagate back to the LLM session so the agent can acknowledge the failure on the next turn and operators can see what went wrong. Previously these failures were swallowed and the agent appeared non-responsive. ([#311](https://github.com/Aaronontheweb/netclaw/pull/311))
+* Fixed `netclaw init` triggering an uncontrolled daemon restart when run on an existing installation — the daemon is now stopped before config files are written, preventing the file watcher from firing mid-initialization and causing a reconnect loop or lost system prompt. ([#300](https://github.com/Aaronontheweb/netclaw/pull/300))
+
+**CLI**
+
+* Fixed `netclaw stats` reporting zero tokens in/out for OpenAI-compatible providers — the provider now parses the `usage` field from API responses and requests streaming usage data so token counts are accurate. ([#303](https://github.com/Aaronontheweb/netclaw/pull/303))
+
+**MCP**
+
+* Fixed MCP OAuth servers (e.g., Notion) requiring a manual daemon restart after completing OAuth authorization — the daemon now reconnects automatically after a successful token exchange. Fixed `mcp list` to prefer daemon-side statuses for OAuth-protected servers instead of probing directly without credentials. ([#301](https://github.com/Aaronontheweb/netclaw/pull/301))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+#### 0.7.1 2026-03-20 ####
+
+Netclaw v0.7.1 — Delivery feedback hardening, token stats, MCP OAuth reconnect, and init race fix
+
+**Stability**
+
+* Fixed Slack delivery failures silently disappearing — transport errors (timeouts, permission denials) now propagate back to the LLM session so the agent can acknowledge the failure on the next turn and operators can see what went wrong. Previously these failures were swallowed and the agent appeared non-responsive. ([#311](https://github.com/Aaronontheweb/netclaw/pull/311))
+* Fixed `netclaw init` triggering an uncontrolled daemon restart when run on an existing installation — the daemon is now stopped before config files are written, preventing the file watcher from firing mid-initialization and causing a reconnect loop or lost system prompt. ([#300](https://github.com/Aaronontheweb/netclaw/pull/300))
+
+**CLI**
+
+* Fixed `netclaw stats` reporting zero tokens in/out for OpenAI-compatible providers — the provider now parses the `usage` field from API responses and requests streaming usage data so token counts are accurate. ([#303](https://github.com/Aaronontheweb/netclaw/pull/303))
+
+**MCP**
+
+* Fixed MCP OAuth servers (e.g., Notion) requiring a manual daemon restart after completing OAuth authorization — the daemon now reconnects automatically after a successful token exchange. Fixed `mcp list` to prefer daemon-side statuses for OAuth-protected servers instead of probing directly without credentials. ([#301](https://github.com/Aaronontheweb/netclaw/pull/301))
+
 #### 0.7.0 2026-03-20 ####
 
 Netclaw v0.7.0 — Behavioral directives, webhook alerts, tool budgets, and provider consolidation


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` to `0.7.1` in `Directory.Build.props` and update `PackageReleaseNotes`
- Add `0.7.1` entry to `RELEASE_NOTES.md`

## Changes in this release

**Stability**

- Fixed Slack delivery failures (timeouts, permission errors) silently disappearing — they now propagate back to the LLM session so the agent can acknowledge the failure and operators can diagnose it ([#311](https://github.com/Aaronontheweb/netclaw/pull/311))
- Fixed `netclaw init` on a running installation triggering an uncontrolled restart race — daemon is now stopped before config files are written ([#300](https://github.com/Aaronontheweb/netclaw/pull/300))

**CLI**

- Fixed `netclaw stats` reporting zero tokens in/out for OpenAI-compatible providers ([#303](https://github.com/Aaronontheweb/netclaw/pull/303))

**MCP**

- Fixed MCP OAuth servers (e.g., Notion) requiring a manual restart after authorization — daemon now auto-reconnects after successful token exchange; `mcp list` uses daemon-side statuses for OAuth-protected servers ([#301](https://github.com/Aaronontheweb/netclaw/pull/301))

## Test plan

- [ ] Verify `VersionPrefix` is `0.7.1` in `Directory.Build.props`
- [ ] Verify `RELEASE_NOTES.md` top entry is `0.7.1 2026-03-20`
- [ ] CI passes (build + tests)