### PR TITLE
fix(sessions): re-register subscribers after session actor passivation

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -884,6 +884,150 @@ public class LlmSessionIntegrationTests : TestKit
         var completed = await recoverSub.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
         Assert.Equal(3, completed.TurnNumber); // Continues from recovered state
     }
+
+    [Fact]
+    public async Task Rejoin_suppresses_duplicate_SessionJoined_on_subscriber()
+    {
+        var sessionId = new SessionId("test-channel/rejoin-suppress");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("rejoin-sub");
+
+        // First join — subscriber receives SessionJoined
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        // Re-join via Tell (piggybacked path) — subscriber should NOT get a duplicate
+        sessionManager.Tell(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, ActorRefs.NoSender);
+
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        // Re-join via Ask still returns SessionJoined to the caller (not the subscriber)
+        var rejoined = await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        Assert.Equal(sessionId, rejoined.SessionId);
+
+        // Subscriber still should not have received a duplicate
+        await subscriber.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+    }
+
+    [Fact]
+    public async Task Session_does_not_passivate_with_active_subscribers()
+    {
+        var sessionId = new SessionId("test-channel/no-passivate-sub");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("active-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        // Resolve session actor
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var childPath = $"/user/session-manager/{escapedId}";
+        var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+
+        // Send ReceiveTimeout directly — with active subscriber, should be deferred
+        child.Tell(ReceiveTimeout.Instance);
+
+        // Actor should still be alive
+        await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+        // Session should still process messages
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Still alive?"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task Subscriber_survives_session_actor_passivation_via_piggyback_rejoin()
+    {
+        var sessionId = new SessionId("test-channel/passivation-rejoin");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriberA = CreateTestProbe("sub-a");
+
+        // Phase 1: Join with subscriber A, complete a turn
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriberA,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriberA.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "First message"
+        }, TimeSpan.FromSeconds(3));
+        await subscriberA.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriberA.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        // Phase 2: Kill session actor (simulating passivation)
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var childPath = $"/user/session-manager/{escapedId}";
+        var child = await Sys.ActorSelection(childPath).ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+        Sys.Stop(child);
+        await ExpectTerminatedAsync(child);
+
+        // Phase 3: Join with subscriber B (triggers re-creation)
+        var subscriberB = CreateTestProbe("sub-b");
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriberB,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(5));
+        await subscriberB.ExpectMsgAsync<SessionJoined>();
+
+        // Phase 4: Piggybacked JoinSession for A + SendUserMessage
+        // This simulates what ChannelPipeline does on each inbound message
+        sessionManager.Tell(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriberA,
+            Filter = OutputFilter.TextOnly
+        }, ActorRefs.NoSender);
+
+        await subscriberA.ExpectMsgAsync<SessionJoined>(TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "After passivation"
+        }, TimeSpan.FromSeconds(3));
+
+        // Both subscribers should receive output
+        await subscriberA.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriberA.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        await subscriberB.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriberB.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -163,10 +163,28 @@ public sealed class SessionPipeline : ISessionPipeline
                 .PreMaterialize(_system);
 
         // Inbound: ChannelInput → SendUserMessage → session manager (direct Tell)
+        // Re-assert subscription before each message to recover from session actor
+        // passivation/re-creation (JoinSession is idempotent).
+        var joinMsg = new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = options.Filter
+        };
+
+        // Ordering safety: both Tell calls target the same SessionId, so
+        // GenericChildPerEntityParent routes them to the same child actor.
+        // Akka guarantees FIFO delivery from a single sender (this stream
+        // stage thread), so JoinSession is always processed before the
+        // SendUserMessage that follows it.
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options, _paths))
             .Via(killSwitch.Flow<SendUserMessage>())
-            .To(Sink.ForEach<SendUserMessage>(cmd => sessionManager.Tell(cmd, ActorRefs.NoSender)));
+            .To(Sink.ForEach<SendUserMessage>(cmd =>
+            {
+                sessionManager.Tell(joinMsg, ActorRefs.NoSender);
+                sessionManager.Tell(cmd, ActorRefs.NoSender);
+            }));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source
         // When a lifecycle observer is registered, tap the stream so every output

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -231,6 +231,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<ReceiveTimeout>(_ =>
         {
+            if (_subscribers.Count > 0)
+            {
+                _log.Info(
+                    "Session idle but {SubscriberCount} subscriber(s) active; deferring passivation",
+                    _subscribers.Count);
+                return;
+            }
+
             _log.Info("Session idle, passivating (timeout={Timeout})", _config.IdleTimeout);
             SaveSnapshot(_state.ToSnapshot());
             Context.Stop(Self);
@@ -1544,11 +1552,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<JoinSession>(cmd =>
         {
-            _subscribers[cmd.Subscriber] = cmd.Filter;
-            Context.WatchWith(cmd.Subscriber,
-                new LeaveSession { SessionId = _sessionId, Subscriber = cmd.Subscriber });
+            // Detect re-join: same subscriber already registered with same filter.
+            var isReJoin = _subscribers.TryGetValue(cmd.Subscriber, out var existingFilter)
+                           && existingFilter == cmd.Filter;
 
-            _log.Info("{Subscriber} joined (filter={Filter})", cmd.Subscriber, cmd.Filter);
+            if (!isReJoin)
+            {
+                _subscribers[cmd.Subscriber] = cmd.Filter;
+                Context.WatchWith(cmd.Subscriber,
+                    new LeaveSession { SessionId = _sessionId, Subscriber = cmd.Subscriber });
+
+                _log.Info("{Subscriber} joined (filter={Filter})", cmd.Subscriber, cmd.Filter);
+            }
 
             var joined = new SessionJoined
             {
@@ -1557,6 +1572,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 TurnCount = _state.TurnCount,
                 RecentMessages = ExtractRecentMessages(_state.History)
             };
+
+            // On re-join, only reply to the Sender (for Ask callers) — don't
+            // push a duplicate SessionJoined to the subscriber's output stream.
+            if (isReJoin)
+            {
+                if (!Sender.IsNobody() && !Equals(Sender, Context.System.DeadLetters))
+                {
+                    Sender.Tell(joined);
+                }
+
+                return;
+            }
 
             cmd.Subscriber.Tell(joined);
 

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -214,22 +214,50 @@ public sealed class SessionRegistry
 
     /// <summary>
     /// Cleans up session state when a SignalR connection disconnects.
-    /// Session is intentionally preserved for reconnection.
+    /// Shuts down the <see cref="SignalRSessionActor"/> so its subscriber is stopped,
+    /// triggering <c>WatchWith</c> → <c>LeaveSession</c> on the LLM session actor.
+    /// Removes the session from <c>_knownSessions</c> so that reconnection via
+    /// <see cref="EnsureSessionAsync"/> takes the "unknown session" path and sends
+    /// <see cref="StartSignalRSession"/> — required because a new child actor starts
+    /// in <c>Initializing</c> and will only transition to <c>Active</c> on that message.
     /// </summary>
-    public Task OnDisconnectedAsync(string connectionId)
+    public async Task OnDisconnectedAsync(string connectionId)
     {
         var parsed = ParseConnectionId(connectionId);
 
-        if (_connections.TryGetSessionForConnection(parsed, out var sessionId))
+        await _sessionMutationGate.WaitAsync();
+        try
         {
-            _logger.LogDebug(
-                "Connection {ConnectionId} disconnected; detached from session {SessionId}.",
-                connectionId, sessionId.Value);
+            if (_connections.TryGetSessionForConnection(parsed, out var sessionId))
+            {
+                _logger.LogDebug(
+                    "Connection {ConnectionId} disconnected; shutting down SignalR session {SessionId}.",
+                    connectionId, sessionId.Value);
+
+                _connections.Disconnect(parsed);
+                _knownSessions.Remove(sessionId);
+
+                try
+                {
+                    var gateway = await _gatewayProvider.GetAsync();
+                    gateway.Tell(new ShutdownSignalRSession(sessionId));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to send shutdown to SignalR session {SessionId}.",
+                        sessionId.Value);
+                }
+            }
+            else
+            {
+                _connections.Disconnect(parsed);
+            }
         }
-
-        _connections.Disconnect(parsed);
-
-        return Task.CompletedTask;
+        finally
+        {
+            _sessionMutationGate.Release();
+        }
     }
 
     public async Task ShutdownAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- **Piggyback `JoinSession` on every inbound message** in `ChannelPipeline` so channels re-assert their subscription after session actor passivation/re-creation, preventing orphaned subscribers that silently lose output
- **Suppress duplicate `SessionJoined` on re-join** (same subscriber + filter) to avoid flooding subscriber output streams, while still replying to `Ask` callers
- **Defer passivation with active subscribers** — `ReceiveTimeout` returns early if `_subscribers` is non-empty; passivation resumes once all subscribers leave via `WatchWith`/`LeaveSession`
- **Shut down `SignalRSessionActor` on TUI disconnect** and remove from `_knownSessions` so reconnection correctly takes the `StartSignalRSession` initialization path instead of sending `AttachSignalRConnection` to a stuck `Initializing` actor

## Test plan

- [x] `Rejoin_suppresses_duplicate_SessionJoined_on_subscriber` — verifies Tell re-join is silent on subscriber, Ask re-join still replies
- [x] `Session_does_not_passivate_with_active_subscribers` — sends `ReceiveTimeout` directly, verifies actor stays alive and processes messages
- [x] `Subscriber_survives_session_actor_passivation_via_piggyback_rejoin` — kills actor, joins B, piggybacks join for A, verifies both A and B receive output
- [x] All 20 `LlmSessionIntegrationTests` pass
- [x] All 247 `Netclaw.Daemon.Tests` pass
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] Manual: start daemon, create Slack session, wait >30min idle, open from TUI, send Slack message — verify both channels show output