### PR TITLE
refactor(sessions): move session logs into per-session directory and add diagnosis skill

### DIFF
--- a/.claude/skills/netclaw-session-diagnosis.md
+++ b/.claude/skills/netclaw-session-diagnosis.md
@@ -1,0 +1,157 @@
+# Netclaw Session Diagnosis
+
+Use this skill when investigating Netclaw session quality issues — identity
+failures, memory recall misses, skill loading failures, amnesia, or unexpected
+behavior reported from production sessions.
+
+## Log Locations
+
+| Log Type | Path | Format |
+|----------|------|--------|
+| Session logs | `~/.netclaw/sessions/{sanitized_id}/logs/{timestamp}.log` | `[ISO 8601] {message}` |
+| Legacy session logs | `~/.netclaw/logs/sessions/{timestamp}_{sanitized_id}.log` | Same (pre-0.7.2) |
+| Daemon logs | `~/.netclaw/logs/daemon-{YYYY-MM-DD}.log` | `HH:mm:ss.fff [LVL] Category: message` |
+| Crash logs | `~/.netclaw/logs/crash-{yyyyMMdd-HHmmss}.log` | Full stack trace |
+| Headless logs | `~/.netclaw/logs/headless-{guid}.log` | `[ISO 8601] EVENT: data` |
+| Reminder logs | `~/.netclaw/sessions/reminder_{name}_{id}/logs/{timestamp}.log` | Same as session |
+
+**Session ID sanitization:** `/` → `_`, `.` → `_`
+Example: `D0AC6CKBK5K/1774023557.531309` → `D0AC6CKBK5K_1774023557_531309`
+
+**Multiple log files** in a session's `logs/` directory = the session passivated
+(idle timeout or daemon restart) and was rehydrated. Each file is one lifecycle.
+
+**Per-session directory layout:**
+```
+~/.netclaw/sessions/{sanitized_id}/
+├── logs/           # Timestamped log files (one per lifecycle)
+│   ├── 20260320-154444.log
+│   └── 20260320-154847.log
+└── media/          # Session-scoped temp files, attachments
+```
+
+## Investigation Workflow
+
+Given a session ID (e.g., `D0AC6CKBK5K/1774023557.531309`):
+
+### Step 1: Find all session log files
+
+```bash
+SANITIZED="D0AC6CKBK5K_1774023557_531309"
+# New location (0.7.2+)
+ls -la ~/.netclaw/sessions/${SANITIZED}/logs/
+# Legacy location (pre-0.7.2)
+ls -la ~/.netclaw/logs/sessions/*${SANITIZED}* 2>/dev/null
+```
+
+Multiple files = passivation cycles. Note timestamps to identify gaps.
+
+### Step 2: Check turn completions
+
+```bash
+grep "Turn.*completed" ~/.netclaw/sessions/${SANITIZED}/logs/*.log
+```
+
+- Present: turns were persisted to journal. State survives restart.
+- **Absent: turns were never committed.** All in-flight work is lost on
+  restart/passivation. This is the smoking gun for unpersisted state loss.
+
+### Step 3: Check daemon log for recovery state
+
+```bash
+DATE="2026-03-20"  # adjust to session date
+grep "D0AC6CKBK5K/1774023557.531309" ~/.netclaw/logs/daemon-${DATE}.log | grep "Recovery complete"
+```
+
+Output: `Recovery complete (turns=N, history=N)`
+- `turns=0, history=0` → brand new session or state was lost
+- `turns=N, history=M` → recovered from journal/snapshot
+
+### Step 4: Check memory recall
+
+```bash
+grep "turn_memory_recall" ~/.netclaw/logs/daemon-${DATE}.log | grep "D0AC6CKBK5K/1774023557.531309"
+```
+
+Key fields:
+- `degraded=True` → recall coordinator failed, returned empty
+- `itemCount=0` → no memories matched the query
+- `itemCount=N` → N memories recalled, check `itemIds`
+- `durationMs=0` → instant return (possibly empty store or fast search)
+- `durationMs>300` → approaching the 300ms timeout
+
+### Step 5: Check skill auto-loading
+
+```bash
+grep "turn_skill_auto_load" ~/.netclaw/logs/daemon-${DATE}.log | grep "D0AC6CKBK5K/1774023557.531309"
+```
+
+- Present: shows which skills loaded, match scores, keyword/phrase hits
+- **Absent: no skills auto-loaded.** Check enrichment state (Step 8).
+
+### Step 6: Check for daemon restarts
+
+```bash
+grep "ConfigWatcherService" ~/.netclaw/logs/daemon-${DATE}.log
+```
+
+- `Config change detected` → config file was modified → restart triggered
+- Check for `file_write` tool calls to `netclaw.json` nearby in the daemon log
+
+### Step 7: Check for errors
+
+```bash
+grep "\[ERR\]\|\[WRN\]" ~/.netclaw/logs/daemon-${DATE}.log | grep "D0AC6CKBK5K/1774023557.531309" | head -20
+```
+
+### Step 8: Check skill enrichment state
+
+```bash
+# Keyword cache files (version should match current skill version)
+ls ~/.netclaw/cache/skill-keywords/
+cat ~/.netclaw/cache/skill-keywords/netclaw-manual-*.json | head -5
+```
+
+Stale cache (version mismatch with installed skill) → enrichment must re-run
+→ race window with no keywords available for matching.
+
+## Data Store Queries
+
+SQLite memory store at `~/.netclaw/netclaw.db`:
+
+```bash
+# Count memories by domain
+sqlite3 ~/.netclaw/netclaw.db "SELECT domain, COUNT(*) FROM memory_documents GROUP BY domain;"
+
+# Search for specific memories
+sqlite3 ~/.netclaw/netclaw.db "SELECT document_id, title, domain FROM memory_documents WHERE title LIKE '%keyword%';"
+
+# Check session catalog
+sqlite3 ~/.netclaw/netclaw.db "SELECT persistence_id, turn_count, status, title FROM sessions ORDER BY last_activity DESC LIMIT 10;"
+```
+
+## Common Failure Patterns
+
+| Symptom | Log Pattern | Root Cause |
+|---------|-------------|------------|
+| Identity failure ("I'm OpenClaw") | No `turn_skill_auto_load` + zero recall + SOUL.md lacks bot identity | Missing identity grounding (#327) |
+| Post-passivation amnesia | Multiple log files, `Turn 1` in later file | Transient state lost on rehydration (#315) |
+| Config overwrite → restart | `file_write` to `netclaw.json` + `ConfigWatcherService` restart | Bot edited config, daemon restarted (#326) |
+| Hallucinated action/inaction | Tool call in history but bot claims otherwise | LLM reasoning failure (#324) |
+| Zero memory recall every turn | `itemCount=0` + `durationMs=0` on all turns | Empty domain, bad search terms, or planner failure (#329) |
+| Skills never load | No `turn_skill_auto_load` in daemon log | Enrichment race (#316), "netclaw" blacklisted (#328) |
+| Turn never completed | Zero `Turn N completed` in session log | LLM in tool call loop, or daemon restarted mid-turn |
+
+## Code References
+
+| Component | File |
+|-----------|------|
+| Session log actor | `src/Netclaw.Actors/Sessions/SessionLogActor.cs` |
+| LLM session actor | `src/Netclaw.Actors/Sessions/LlmSessionActor.cs` |
+| Skill registry & matching | `src/Netclaw.Actors/Skills/SkillRegistry.cs` |
+| Skill enrichment & generic keywords | `src/Netclaw.Daemon/Services/SystemSkillSyncService.cs` |
+| Memory recall coordinator | `src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs` |
+| Config watcher → restart | `src/Netclaw.Daemon/Services/ConfigWatcherService.cs` |
+| System prompt / identity | `src/Netclaw.Configuration/ISystemPromptProvider.cs` |
+| Session directory helper | `src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs` |
+| Paths (directory layout) | `src/Netclaw.Configuration/NetclawPaths.cs` |

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -160,7 +160,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _memoryCheckpointSink = memoryCheckpointSink ?? NullMemoryCheckpointSink.Instance;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _sessionsBasePath = paths?.SessionsDirectory;
-        _sessionLogsBasePath = paths?.SessionLogsDirectory;
+        _sessionLogsBasePath = paths?.SessionsDirectory;
         PersistenceId = $"session-{entityId}";
 
         // Enrich logger with session context — all log messages automatically include SessionId

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -7,30 +7,44 @@ namespace Netclaw.Actors.Sessions;
 
 /// <summary>
 /// Per-session child actor that owns the log file lifecycle.
-/// Created by <see cref="LlmSessionActor"/> when a session logs directory is configured.
+/// Created by <see cref="LlmSessionActor"/> when a sessions base directory is configured.
 /// Not persistent — log files are best-effort observability.
 /// The actor opens the log file in <see cref="PreStart"/> and disposes it in <see cref="PostStop"/>,
 /// ensuring the file handle is properly released when the session actor passivates.
+///
+/// Log files are stored inside the session's own directory:
+/// <c>{sessionsBase}/{sanitized_id}/logs/{timestamp}.log</c>
+/// Multiple log files in the same directory indicate passivation/rehydration cycles.
 /// </summary>
 public sealed class SessionLogActor : ReceiveActor
 {
     private readonly SessionId _sessionId;
-    private readonly string _logDirectory;
+    private readonly string _sessionsBasePath;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log = Context.GetLogger();
     private StreamWriter? _writer;
 
-    public static Props CreateProps(SessionId sessionId, string logDirectory, TimeProvider timeProvider) =>
-        Props.Create(() => new SessionLogActor(sessionId, logDirectory, timeProvider));
+    public static Props CreateProps(SessionId sessionId, string sessionsBasePath, TimeProvider timeProvider) =>
+        Props.Create(() => new SessionLogActor(sessionId, sessionsBasePath, timeProvider));
 
-    public SessionLogActor(SessionId sessionId, string logDirectory, TimeProvider timeProvider)
+    public SessionLogActor(SessionId sessionId, string sessionsBasePath, TimeProvider timeProvider)
     {
         _sessionId = sessionId;
-        _logDirectory = logDirectory;
+        _sessionsBasePath = sessionsBasePath;
         _timeProvider = timeProvider;
 
         Receive<SendUserMessage>(OnUserMessage);
         Receive<SessionOutput>(OnOutput);
+    }
+
+    /// <summary>
+    /// Computes the logs directory for this session:
+    /// <c>{sessionsBase}/{sanitized_id}/logs/</c>
+    /// </summary>
+    internal static string GetSessionLogsDirectory(SessionId sessionId, string sessionsBasePath)
+    {
+        var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
+        return Path.Combine(sessionsBasePath, sanitized, "logs");
     }
 
     protected override void PreStart()
@@ -38,9 +52,9 @@ public sealed class SessionLogActor : ReceiveActor
         try
         {
             var now = _timeProvider.GetUtcNow();
-            var sanitized = SessionDirectoryHelper.SanitizeSessionId(_sessionId.Value);
-            var logPath = Path.Combine(_logDirectory, $"{now:yyyyMMdd-HHmmss}_{sanitized}.log");
-            Directory.CreateDirectory(_logDirectory);
+            var logsDir = GetSessionLogsDirectory(_sessionId, _sessionsBasePath);
+            var logPath = Path.Combine(logsDir, $"{now:yyyyMMdd-HHmmss}.log");
+            Directory.CreateDirectory(logsDir);
             _writer = new StreamWriter(logPath, append: true) { AutoFlush = true };
             _writer.WriteLine($"[{now:o}] Session log started: {_sessionId.Value}");
         }

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -56,7 +56,12 @@ public sealed class NetclawPaths
     public string NetclawConfigPath => Path.Combine(ConfigDirectory, "netclaw.json");
     public string SecretsPath => Path.Combine(ConfigDirectory, "secrets.json");
     public string LogsDirectory => Path.Combine(BasePath, "logs");
-    public string SessionLogsDirectory => Path.Combine(LogsDirectory, "sessions");
+    /// <summary>
+    /// Legacy path. Session logs now live inside each session's directory:
+    /// <c>{SessionsDirectory}/{sanitized_id}/logs/</c>.
+    /// Kept for migration detection and backward-compatible log search.
+    /// </summary>
+    public string LegacySessionLogsDirectory => Path.Combine(LogsDirectory, "sessions");
     public string DaemonLogPath => Path.Combine(LogsDirectory, "daemon.log");
     public string SessionsDirectory => Path.Combine(BasePath, "sessions");
     public string PidFilePath => Path.Combine(BasePath, "netclaw.pid");
@@ -91,7 +96,8 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(RemindersDirectory);
         Directory.CreateDirectory(ConfigDirectory);
         Directory.CreateDirectory(LogsDirectory);
-        Directory.CreateDirectory(SessionLogsDirectory);
+        // Note: per-session log directories (sessions/{id}/logs/) are created
+        // on-demand by SessionLogActor, not pre-created here.
         Directory.CreateDirectory(AgentsDirectory);
         Directory.CreateDirectory(SessionsDirectory);
         Directory.CreateDirectory(BinDirectory);

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -55,10 +55,10 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
 
         try
         {
-            // Compute expected log path deterministically — the child SessionLogActor
-            // independently creates the file at this same path.
+            // Compute expected log directory deterministically — the child SessionLogActor
+            // independently creates timestamped log files at this same directory.
             var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
-            var logPath = Path.Combine(_paths.SessionLogsDirectory, $"{sanitized}.log");
+            var logPath = Path.Combine(_paths.SessionsDirectory, sanitized, "logs");
 
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();


### PR DESCRIPTION
## Summary

- Session logs now live inside each session's own directory at `{sessionsBase}/{sanitized_id}/logs/{timestamp}.log` instead of the global `~/.netclaw/logs/sessions/` directory
- Multiple log files in a session's `logs/` dir clearly show passivation/rehydration cycles
- Adds a Claude Code diagnosis skill (`.claude/skills/netclaw-session-diagnosis.md`) codifying the investigation workflow for session quality issues

Closes #330, closes #320

## Changes

| File | Change |
|------|--------|
| `SessionLogActor.cs` | Computes per-session log dir from sessions base path; adds `GetSessionLogsDirectory()` static helper |
| `LlmSessionActor.cs` | Passes `SessionsDirectory` instead of `SessionLogsDirectory` to log actor |
| `NetclawPaths.cs` | Renames `SessionLogsDirectory` → `LegacySessionLogsDirectory`; removes from `EnsureDirectoriesExist()` |
| `SessionCatalogService.cs` | Updates `log_path` in session catalog to point at new per-session logs dir |
| `netclaw-session-diagnosis.md` | New Claude Code skill with investigation workflow, diagnostic patterns, SQLite queries, failure pattern table |

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test` — 1,132 tests pass
- [ ] Deploy to pi1 and verify new sessions create logs at `~/.netclaw/sessions/{id}/logs/`
- [ ] Verify legacy logs at `~/.netclaw/logs/sessions/` are still readable (not deleted)