### PR TITLE
fix(skills): remove netclaw keyword blacklist, fix enrichment race, fix flaky test

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -158,9 +158,15 @@ public class ReminderManagerActorTests : TestKit
         var manager = await GetManagerAsync();
         var now = TimeProvider.System.GetUtcNow();
 
-        // Ensure the actor is fully started and initial reconcile has completed
-        await manager.Ask<ReminderHealthResponse>(
-            GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5));
+        // Drain PreStart's Self.Tell(ReconcileReminders) AND confirm with our own.
+        // ActorOf does not block until PreStart completes — the test's Ask can
+        // arrive before PreStart's Self.Tell enqueues the reconcile. Sending two
+        // reconcile Asks guarantees that both PreStart's reconcile and our barrier
+        // have processed before we write the zombie to the store.
+        await manager.Ask<ReminderManagerActor.ReconcileCompleted>(
+            ReminderManagerActor.ReconcileReminders.Instance, TimeSpan.FromSeconds(5));
+        await manager.Ask<ReminderManagerActor.ReconcileCompleted>(
+            ReminderManagerActor.ReconcileReminders.Instance, TimeSpan.FromSeconds(5));
 
         // Write a zombie one-shot directly to the store AFTER startup reconcile:
         // fire time in the past, still enabled, no Akka.Reminders schedule

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -549,6 +549,10 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         catch (Exception ex)
         {
             _log.Error(ex, "Reminder reconcile failed");
+
+            // Reply with a zero-result ack so external Ask callers don't hang until timeout
+            if (!sender.Equals(Self))
+                sender.Tell(new ReconcileCompleted(0, 0, 0));
         }
     }
 

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -35,8 +35,7 @@ internal sealed class SystemSkillSyncService : IHostedService
     {
         "check", "checking", "status", "support", "supported", "new", "good", "best",
         "help", "use", "using", "work", "working", "change", "changes", "run", "running",
-        "view", "show", "find", "look", "issue", "issues", "problem", "problems",
-        "netclaw"
+        "view", "show", "find", "look", "issue", "issues", "problem", "problems"
     };
 
     private static readonly HashSet<string> GenericPhraseTokens = new(StringComparer.OrdinalIgnoreCase)
@@ -322,9 +321,18 @@ internal sealed class SystemSkillSyncService : IHostedService
         _skillIndexLayer.Update(_skillRegistry.GenerateCompressedIndex());
         _logger.LogInformation("Skill index updated ({SkillCount} skills)", _skillRegistry.GetAll().Count);
 
-        // Enrich keywords for deterministic skill auto-loading (fire and forget).
-        // Requires a chat client provider for LLM-based enrichment; skipped in tests
-        // that use the internal constructor without a provider.
+        // Always apply fallback keywords first so skills are matchable immediately.
+        // LLM-enriched keywords replace these when enrichment completes.
+        foreach (var skill in _skillRegistry.GetAll())
+            ApplyFallbackKeywords(skill);
+
+        _logger.LogInformation(
+            "Fallback keyword index loaded for {SkillCount} skills", _skillRegistry.GetEnrichedKeywords().Count);
+
+        PurgeStaleKeywordCache();
+
+        // Enrich keywords via LLM sidecar (fire and forget).
+        // Enriched keywords replace the fallback set when they arrive.
         if (_chatClientProvider is not null)
         {
             _ = Task.Run(async () =>
@@ -338,15 +346,6 @@ internal sealed class SystemSkillSyncService : IHostedService
                     _logger.LogWarning(ex, "Skill keyword enrichment failed");
                 }
             });
-        }
-        else
-        {
-            foreach (var skill in _skillRegistry.GetAll())
-                ApplyFallbackKeywords(skill);
-
-            _logger.LogInformation(
-                "Skill keyword enrichment provider unavailable; loaded fallback keyword index for {SkillCount} skills",
-                _skillRegistry.GetEnrichedKeywords().Count);
         }
     }
 
@@ -542,6 +541,33 @@ internal sealed class SystemSkillSyncService : IHostedService
 
         if (keywords.Count > 0 || phrases.Count > 0)
             _skillRegistry.SetEnrichedKeywords(skill.Name, keywords, phrases);
+    }
+
+    /// <summary>
+    /// Removes keyword cache files for skill versions that no longer match any
+    /// registered skill. Prevents stale caches from accumulating after upgrades.
+    /// </summary>
+    private void PurgeStaleKeywordCache()
+    {
+        if (!Directory.Exists(_paths.SkillKeywordCacheDirectory))
+            return;
+
+        var currentKeys = _skillRegistry.GetAll()
+            .Select(s => Path.GetFileName(GetKeywordCachePath(s.Name, s.Version)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var purged = 0;
+        foreach (var file in Directory.GetFiles(_paths.SkillKeywordCacheDirectory, "*.json"))
+        {
+            if (!currentKeys.Contains(Path.GetFileName(file)))
+            {
+                try { File.Delete(file); purged++; }
+                catch (IOException) { /* best-effort cleanup */ }
+            }
+        }
+
+        if (purged > 0)
+            _logger.LogInformation("Purged {Count} stale keyword cache file(s)", purged);
     }
 
     // ── Keyword cache I/O ──

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -562,7 +562,7 @@ internal sealed class SystemSkillSyncService : IHostedService
             if (!currentKeys.Contains(Path.GetFileName(file)))
             {
                 try { File.Delete(file); purged++; }
-                catch (IOException) { /* best-effort cleanup */ }
+                catch (IOException ex) { _logger.LogDebug(ex, "Could not delete stale cache file {File}", file); }
             }
         }
 


### PR DESCRIPTION
## Summary

- Remove `"netclaw"` from `GenericKeywords` blacklist in `SystemSkillSyncService` — was preventing identity queries from triggering skill auto-loading
- Apply fallback keywords immediately on startup before LLM enrichment completes (fixes #316 race window)
- Purge stale keyword cache files when skill versions change
- Fix flaky `Reconcile_disables_zombie_oneshot_reminders` test — PreStart reconcile raced with test's zombie write
- Add error reply in `HandleReconcileAsync` catch block so Ask callers don't hang on transient failures

Closes #328, closes #316

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 1,133 tests pass
- [x] Flaky test passes 20/20 runs after fix