### PR TITLE
fix(identity,memory): bot identity grounding, repo URL, and enable memory recall by default

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -59,7 +59,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             SnapshotInterval = 5,
             InputModalities = ModelModality.Text | ModelModality.Image,
             OutputModalities = ModelModality.Text,
-            TitleGenerationInterval = 0
+            TitleGenerationInterval = 0,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -43,7 +43,8 @@ public class CompactionIntegrationTests : TestKit
             KeepRecentMessages = 0,
             TitleGenerationInterval = 0,
             TurnLlmTimeoutSeconds = 1,
-            SidecarLlmTimeoutSeconds = 1
+            SidecarLlmTimeoutSeconds = 1,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
@@ -34,7 +34,8 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : TestKit(ou
             TitleGenerationInterval = 0,
             TurnLlmTimeoutSeconds = 10,
             ToolExecutionTimeoutSeconds = 10,
-            SidecarLlmTimeoutSeconds = 10
+            SidecarLlmTimeoutSeconds = 10,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
         services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -29,7 +29,8 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
             TitleGenerationInterval = 0,
             TurnLlmTimeoutSeconds = 1,
             ToolExecutionTimeoutSeconds = 1,
-            SidecarLlmTimeoutSeconds = 1
+            SidecarLlmTimeoutSeconds = 1,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
         services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -38,7 +38,8 @@ public class MaxToolIterationTests : TestKit
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
             MaxToolCallsPerTurn = 3, // Low limit for testing
-            TitleGenerationInterval = 0
+            TitleGenerationInterval = 0,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant with tools."));

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -32,7 +32,8 @@ public class ModalityGateTextOnlyTests : TestKit
             ModelId = "text-only-model",
             ContextWindowTokens = 128_000,
             InputModalities = ModelModality.Text, // no Image flag
-            TitleGenerationInterval = 0
+            TitleGenerationInterval = 0,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
@@ -153,7 +154,8 @@ public class ModalityGateVisionTests : TestKit
             ModelId = "vision-model",
             ContextWindowTokens = 128_000,
             InputModalities = ModelModality.Text | ModelModality.Image, // supports vision
-            TitleGenerationInterval = 0
+            TitleGenerationInterval = 0,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -35,7 +35,8 @@ public class SubAgentSpawnIntegrationTests : TestKit
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
             TitleGenerationInterval = 0,
-            ToolExecutionTimeoutSeconds = 10
+            ToolExecutionTimeoutSeconds = 10,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant with subagent support."));

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -38,7 +38,8 @@ public class ToolExecutionIntegrationTests : TestKit
             ContextWindowTokens = 128_000,
             SnapshotInterval = 5,
             TitleGenerationInterval = 0,
-            MaxInlineToolResultChars = 120
+            MaxInlineToolResultChars = 120,
+            MemorySidecarsEnabled = false
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant with tools."));

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1008,7 +1008,7 @@ public sealed class InitWizardViewModelTests : IDisposable
         // SOUL.md
         Assert.True(File.Exists(_paths.SoulPath));
         var soul = File.ReadAllText(_paths.SoulPath);
-        Assert.Contains("# Hal", soul, StringComparison.Ordinal);
+        Assert.Contains("# You are Hal", soul, StringComparison.Ordinal);
         Assert.Contains("concise and casual", soul, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Dave", soul, StringComparison.Ordinal);
         Assert.Contains("America/Chicago", soul, StringComparison.Ordinal);

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1009,7 +1009,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
         File.WriteAllText(_paths.SoulPath,
             $"""
-            # {name}
+            # You are {name}
 
             ## Communication Style
             {styleDescription}
@@ -1144,6 +1144,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
             # Environment Capabilities
 
             No capabilities discovered yet. Run `netclaw doctor` or ask Netclaw to probe your environment.
+
+            # Source Code
+            - **Repository:** https://github.com/Aaronontheweb/netclaw (private)
             """);
     }
 

--- a/src/Netclaw.Configuration.Tests/SessionConfigDefaultsTests.cs
+++ b/src/Netclaw.Configuration.Tests/SessionConfigDefaultsTests.cs
@@ -1,0 +1,46 @@
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+/// <summary>
+/// Bear-trap tests for <see cref="SessionConfig"/> defaults.
+/// If you change a default, you must update these assertions —
+/// forcing a deliberate decision rather than an accidental drift.
+/// </summary>
+public sealed class SessionConfigDefaultsTests
+{
+    [Fact]
+    public void Memory_sidecars_enabled_by_default()
+    {
+        var config = new SessionConfig();
+        Assert.True(config.MemorySidecarsEnabled);
+    }
+
+    [Fact]
+    public void Deterministic_retrieval_enabled_by_default()
+    {
+        var config = new SessionConfig();
+        Assert.True(config.DeterministicRetrievalEnabled);
+    }
+
+    [Fact]
+    public void Compaction_threshold_is_75_percent()
+    {
+        var config = new SessionConfig();
+        Assert.Equal(0.75, config.CompactionThreshold);
+    }
+
+    [Fact]
+    public void Context_window_defaults_to_32k()
+    {
+        var config = new SessionConfig();
+        Assert.Equal(32_768, config.ContextWindowTokens);
+    }
+
+    [Fact]
+    public void Idle_timeout_defaults_to_30_minutes()
+    {
+        var config = new SessionConfig();
+        Assert.Equal(TimeSpan.FromMinutes(30), config.IdleTimeout);
+    }
+}

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -3,6 +3,9 @@ namespace Netclaw.Configuration;
 /// <summary>
 /// Configuration for an LLM session. Carries model identity and context
 /// window size so sessions can make compaction decisions.
+/// Bound from the <c>Session</c> section in <c>netclaw.json</c> at startup
+/// (see <c>Program.cs</c>). Model-derived values (ModelId, ContextWindowTokens,
+/// modalities) are overlaid after capability resolution.
 /// </summary>
 public sealed record SessionConfig
 {
@@ -99,16 +102,15 @@ public sealed record SessionConfig
 
     /// <summary>
     /// Enables structured memory sidecars for recall planning and post-turn
-    /// observation. Disabled by default until rollout gates are satisfied.
+    /// observation.
     /// </summary>
-    public bool MemorySidecarsEnabled { get; init; } = false;
+    public bool MemorySidecarsEnabled { get; init; } = true;
 
     /// <summary>
-    /// Enables deterministic retrieval request planning and request-plan
-    /// observability without requiring the full deterministic recall pipeline
-    /// to replace the legacy path yet.
+    /// Enables deterministic retrieval request planning for automatic
+    /// memory recall on each turn.
     /// </summary>
-    public bool DeterministicRetrievalEnabled { get; init; } = false;
+    public bool DeterministicRetrievalEnabled { get; init; } = true;
 
     /// <summary>
     /// Timeout in seconds for the primary per-turn LLM streaming call.

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -490,9 +490,8 @@ static void ConfigureDaemonServices(
     // Seed minimal SOUL.md if neither new nor legacy personality file exists
     if (!File.Exists(paths.SoulPath) && !File.Exists(paths.PersonalityPath))
         File.WriteAllText(paths.SoulPath,
-            "You are Netclaw, a helpful homelab operations assistant. "
-            + "Be concise and direct. Act autonomously — use your tools to do things "
-            + "rather than telling the user how.");
+            "# You are Netclaw\n\nBe concise and direct. Act autonomously — use your tools "
+            + "to do things rather than telling the user how.\n");
     var promptProvider = new FileSystemPromptProvider(paths);
     services.AddSingleton<ISystemPromptProvider>(promptProvider);
 


### PR DESCRIPTION
## Summary

Three fixes addressing the session quality issues investigated in the 0.7.2 milestone:

- **Bot identity**: SOUL.md template now starts with `# You are {name}` so the LLM knows its own identity from the first turn. Without this, the model confabulated being "OpenClaw." (#327)
- **Repo URL**: TOOLING.md template includes the Netclaw GitHub repo URL so the agent can file issues and check releases without web-searching for a private repo. (#327)
- **Memory recall enabled**: `MemorySidecarsEnabled` and `DeterministicRetrievalEnabled` now default to `true`. Both were `false` since March 10 — memory recall was completely disabled in production. Every session got `itemCount=0` on every turn. (#329)
- **Bear-trap tests**: New `SessionConfigDefaultsTests` asserts critical defaults so they can't silently drift.

Closes #327, closes #329

## Test plan

- [x] `dotnet build` — clean
- [x] All 1,135 tests pass (+ 5 new default assertion tests)
- [x] Tests that don't wire up memory providers explicitly set `MemorySidecarsEnabled = false`
- [ ] Deploy to pi1, verify new sessions show `itemCount > 0` in daemon log
- [ ] Verify `# You are` appears in SOUL.md for fresh `netclaw init`