### PR TITLE
fix(feeds): fix absolute CI paths leaking into skill manifest URLs

### DIFF
--- a/feeds/scripts/generate-skill-manifest.sh
+++ b/feeds/scripts/generate-skill-manifest.sh
@@ -93,9 +93,16 @@ build_entry() {
     # Build files array for resource files (non-SKILL.md files)
     local files_json=""
     local files_first=true
+    # Normalize skill_dir to ensure consistent path prefix stripping
+    local norm_skill_dir
+    norm_skill_dir="$(cd "$skill_dir" && pwd)"
     while IFS= read -r -d '' resource_file; do
-        local rel_path="${resource_file#"$skill_dir/"}"
+        local abs_resource
+        abs_resource="$(cd "$(dirname "$resource_file")" && pwd)/$(basename "$resource_file")"
+        local rel_path="${abs_resource#"$norm_skill_dir/"}"
         [ "$rel_path" = "SKILL.md" ] && continue
+        # Skip versioned subdirectory copies (e.g., 1.1.0/SKILL.md)
+        [[ "$rel_path" =~ ^[0-9]+\.[0-9]+ ]] && continue
 
         local file_sha256
         file_sha256=$(sha256sum "$resource_file" | cut -d' ' -f1)


### PR DESCRIPTION
## Summary

The `generate-skill-manifest.sh` script used `find` with absolute paths that leaked CI runner paths (e.g., `/home/runner/_work/netclaw/...`) into manifest resource file URLs. This caused **every skill sync to fail with 404s** — all 6 system skills failed to update from the feed on every daemon startup.

Skills were only available from the built-in seed copy baked into the binary, never updated from the CDN feed.

## Fix

- Normalize paths with `pwd` before prefix stripping
- Skip versioned subdirectories (e.g., `1.1.0/SKILL.md`) from resource file list

## Impact

This has been broken since skills with resource files were introduced. After this fix, `netclaw doctor` and daemon startup will successfully sync skills from the feed.

## Test plan

- [x] `bash feeds/scripts/generate-skill-manifest.sh` — generates clean URLs
- [x] No `/home/runner/` paths in manifest
- [x] Resource files correctly listed (`references/local-search.md` etc.)
- [ ] Deploy and verify `netclawd` startup shows `Synced skill` instead of `Download failed`