### PR TITLE
Release 0.7.3 — skill feed sync fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,28 +7,12 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.2</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.7.2 — Session passivation recovery, memory recall activation, skill loading fixes, and per-session log directories
-
-**Stability**
-
-* Fixed sessions going silent after idle passivation — when a session actor passivated due to inactivity and was later re-created, its subscriber list was empty so channels never received output. Channels now re-assert their subscription on each inbound message, recovering transparently. Passivation is also deferred while active subscribers exist. ([#325](https://github.com/Aaronontheweb/netclaw/pull/325))
-
-**Memory**
-
-* Enabled memory recall in production — `MemorySidecarsEnabled` and `DeterministicRetrievalEnabled` were both defaulting to `false` since initial development, which meant `store_memory` wrote to SQLite but nothing read it back automatically. Every session received zero recalled memories on every turn. Both flags now default to `true`. ([#334](https://github.com/Aaronontheweb/netclaw/pull/334))
-
-**Identity**
-
-* Added bot identity grounding to the SOUL.md template — the system prompt now starts with "You are {name}" so the LLM knows its own identity from the first turn instead of confabulating a different persona. Also adds the Netclaw GitHub repo URL to TOOLING.md so the agent can file issues and check releases without web searching. ([#334](https://github.com/Aaronontheweb/netclaw/pull/334))
+    <VersionPrefix>0.7.3</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.7.3 — Skill feed sync fix
 
 **Skills**
 
-* Fixed skill auto-loading failures for identity queries — "netclaw" was in the keyword blacklist so queries like "What version of Netclaw?" could not trigger `netclaw-manual`. TF-IDF weighting already handles common tokens, so the blacklist entry was unnecessary. Also fixed a startup race where skills had zero keywords until LLM enrichment completed, and stale keyword cache files are now purged during rescan. ([#333](https://github.com/Aaronontheweb/netclaw/pull/333))
-
-**Diagnostics**
-
-* Moved session logs into per-session directories — logs now live at `{sessionsBase}/{session_id}/logs/` instead of the shared global `~/.netclaw/logs/sessions/` directory. Multiple log files within a session directory clearly show passivation and rehydration cycles. ([#332](https://github.com/Aaronontheweb/netclaw/pull/332))</PackageReleaseNotes>
+* Fixed skill feed sync returning 404s for all resources — the manifest generator leaked CI runner absolute paths (e.g., `/home/runner/_work/...`) into resource file URLs, causing every skill sync to fail. Skills were only available from the built-in seed copy and never updated from the feed. Path normalization now uses `pwd` before prefix stripping, and versioned subdirectories are excluded from the resource list. ([#336](https://github.com/Aaronontheweb/netclaw/pull/336))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 0.7.3 2026-03-20 ####
+
+Netclaw v0.7.3 — Skill feed sync fix
+
+**Skills**
+
+* Fixed skill feed sync returning 404s for all resources — the manifest generator leaked CI runner absolute paths (e.g., `/home/runner/_work/...`) into resource file URLs, causing every skill sync to fail. Skills were only available from the built-in seed copy and never updated from the feed. Path normalization now uses `pwd` before prefix stripping, and versioned subdirectories are excluded from the resource list. ([#336](https://github.com/Aaronontheweb/netclaw/pull/336))
+
 #### 0.7.2 2026-03-20 ####
 
 Netclaw v0.7.2 — Session passivation recovery, memory recall activation, skill loading fixes, and per-session log directories


### PR DESCRIPTION
## Summary

- Bump version to 0.7.3 and add release notes
- Single-fix hot-patch: the manifest generator in `generate-skill-manifest.sh` leaked CI runner absolute paths into resource file URLs, breaking all skill feed syncs ([#336](https://github.com/Aaronontheweb/netclaw/pull/336))

## Test plan

- [x] `dotnet build` passes with zero warnings
- [x] All 1,140 tests pass across 7 test projects
- [ ] After merge, tag `0.7.3` and push — CI creates the release