### PR TITLE
fix(sessions): auto-compact on context overflow instead of failing the turn

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ContextOverflowDetectionTests.cs
@@ -1,0 +1,68 @@
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Tests for <see cref="LlmSessionActor.IsContextOverflowError"/> to ensure
+/// context overflow detection works across multiple LLM providers.
+/// </summary>
+public sealed class ContextOverflowDetectionTests
+{
+    [Theory]
+    [InlineData("request (66540 tokens) exceeds the available context size (65536 tokens)")]  // llama-server
+    [InlineData("context length exceeded")]  // Ollama
+    [InlineData("This model's maximum context length is 8192 tokens")]  // OpenAI
+    [InlineData("context_length_exceeded")]  // OpenAI error code
+    [InlineData("prompt is too long: 12000 tokens > 8192 maximum")]  // Anthropic-style
+    [InlineData("Input token count (65000) exceeds model limit (32768)")]  // vLLM-style
+    public void Detects_overflow_from_plain_exception(string message)
+    {
+        var ex = new InvalidOperationException(message);
+        Assert.True(LlmSessionActor.IsContextOverflowError(ex));
+    }
+
+    [Theory]
+    [InlineData("request (66540 tokens) exceeds the available context size (65536 tokens)")]
+    [InlineData("context length exceeded")]
+    [InlineData("prompt is too long")]
+    public void Detects_overflow_from_provider_exception_with_400(string message)
+    {
+        var ex = new ProviderException(message, message, statusCode: 400);
+        Assert.True(LlmSessionActor.IsContextOverflowError(ex));
+    }
+
+    [Fact]
+    public void Detects_overflow_in_inner_exception()
+    {
+        var inner = new InvalidOperationException("context length exceeded");
+        var outer = new Exception("LLM call failed", inner);
+        Assert.True(LlmSessionActor.IsContextOverflowError(outer));
+    }
+
+    [Theory]
+    [InlineData("rate limit exceeded")]
+    [InlineData("model not found")]
+    [InlineData("invalid API key")]
+    [InlineData("server error")]
+    public void Does_not_false_positive_on_unrelated_errors(string message)
+    {
+        var ex = new InvalidOperationException(message);
+        Assert.False(LlmSessionActor.IsContextOverflowError(ex));
+    }
+
+    [Fact]
+    public void Returns_false_for_null()
+    {
+        Assert.False(LlmSessionActor.IsContextOverflowError(null));
+    }
+
+    [Fact]
+    public void Provider_exception_with_non_400_status_uses_keyword_fallback()
+    {
+        // 500 status but overflow message — should still detect via keyword fallback
+        var ex = new ProviderException("context length exceeded", "context length exceeded", statusCode: 500);
+        Assert.True(LlmSessionActor.IsContextOverflowError(ex));
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -658,6 +658,28 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<LlmCallFailed>(msg =>
         {
             StopProcessingWatchdog();
+
+            // Context overflow: compact and recover instead of failing the turn
+            if (IsContextOverflowError(msg.Cause))
+            {
+                TurnLog().Warning(msg.Cause, "turn_context_overflow — triggering emergency compaction");
+
+                EmitOutput(new ErrorOutput
+                {
+                    SessionId = _sessionId,
+                    Message = "Context window exceeded — compacting session history. Please resend your last message.",
+                    Category = ErrorCategory.ProviderFailure,
+                    CorrelationId = Guid.NewGuid(),
+                    Cause = msg.Cause
+                });
+
+                // Use the configured context window as the token count estimate since
+                // the provider rejected the request without returning usage stats.
+                Self.Tell(new CompactionTriggered { InputTokenCount = _config.ContextWindowTokens });
+                Become(Compacting);
+                return;
+            }
+
             TurnLog().Error(msg.Cause, "turn_llm_call_failed");
 
             var errorMessage = ExtractLlmErrorMessage(msg.Cause);
@@ -1669,22 +1691,44 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     /// <summary>
     /// Detect context-length overflow errors from LLM providers.
-    /// Ollama: "context length exceeded", OpenAI-compatible: "maximum context length".
+    /// Uses two signals: (1) ProviderException with HTTP 400 + overflow keywords,
+    /// (2) fallback keyword scan of the full exception chain for providers that
+    /// don't use ProviderException.
     /// </summary>
-    private static bool IsContextOverflowError(Exception? ex)
+    internal static bool IsContextOverflowError(Exception? ex)
     {
         if (ex is null) return false;
-        var message = ex.Message;
-        // Walk inner exceptions too — provider SDKs often wrap
-        while (ex.InnerException is not null)
+
+        // Preferred path: ProviderException carries structured status code
+        var providerEx = FindException<Configuration.ProviderException>(ex);
+        if (providerEx is { StatusCode: 400 } && ContainsOverflowKeyword(providerEx.Message))
+            return true;
+
+        // Fallback: walk the full exception chain for keyword matches
+        var current = ex;
+        while (current is not null)
         {
-            ex = ex.InnerException;
-            message = string.Concat(message, " ", ex.Message);
+            if (ContainsOverflowKeyword(current.Message))
+                return true;
+            current = current.InnerException;
         }
-        return message.Contains("context length", StringComparison.OrdinalIgnoreCase)
-            || message.Contains("maximum context", StringComparison.OrdinalIgnoreCase)
-            || message.Contains("context_length_exceeded", StringComparison.OrdinalIgnoreCase);
+
+        return false;
     }
+
+    // This is inherently brittle — there is no standard error format for context
+    // overflow across LLM providers. Each returns different messages. We cast a wide
+    // net with keyword matching and rely on the ContextOverflowDetectionTests to
+    // verify coverage across known provider formats.
+    private static bool ContainsOverflowKeyword(string message) =>
+        message.Contains("context length", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("context_length", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("maximum context", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("exceeds", StringComparison.OrdinalIgnoreCase)
+            && message.Contains("context", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("prompt is too long", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("token", StringComparison.OrdinalIgnoreCase)
+            && message.Contains("exceed", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Naive token estimation: total character count / 4.


### PR DESCRIPTION
## Summary

When the LLM provider rejects a request with a context overflow error (e.g., "request (66540 tokens) exceeds the available context size (65536 tokens)"), the session now triggers emergency compaction instead of failing the turn.

**Before:** `LlmCallFailed` → `FailCurrentTurn()` → user sees error, session stuck
**After:** `LlmCallFailed` → detect overflow → notify user → `CompactionTriggered` → compact → `Ready`

Uses the existing compaction pipeline (extractive reducer + observation summary). The user sees a message asking them to resend their last message after compaction completes.

Closes #314

## Test plan

- [x] `dotnet build` — clean
- [x] All 1,140 tests pass
- [ ] Test with a model that has a small context window to trigger overflow
- [ ] Verify compaction runs and session becomes usable again after overflow