### PR TITLE
Release 0.7.4 — context overflow recovery, skill compaction durability, and frontmatter stripping

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,12 +7,17 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.3</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.7.3 — Skill feed sync fix
+    <VersionPrefix>0.7.4</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.7.4 — Context overflow recovery, skill compaction durability, and frontmatter stripping
+
+**Sessions**
+
+* Fixed sessions failing the turn on context overflow — when the LLM provider rejects a request because the context window is full, the session now triggers emergency compaction and retries instead of surfacing an error. Context overflow detection is hardened across Anthropic, OpenAI, Ollama, and vLLM error formats with 16 new tests. ([#314](https://github.com/Aaronontheweb/netclaw/issues/314), [#340](https://github.com/Aaronontheweb/netclaw/pull/340))
 
 **Skills**
 
-* Fixed skill feed sync returning 404s for all resources — the manifest generator leaked CI runner absolute paths (e.g., `/home/runner/_work/...`) into resource file URLs, causing every skill sync to fail. Skills were only available from the built-in seed copy and never updated from the feed. Path normalization now uses `pwd` before prefix stripping, and versioned subdirectories are excluded from the resource list. ([#336](https://github.com/Aaronontheweb/netclaw/pull/336))</PackageReleaseNotes>
+* Fixed auto-loaded skills disappearing after context compaction — skill content injected into the system prompt was not preserved through the compaction pipeline, causing the agent to lose all skill knowledge mid-conversation. Skills are now re-injected after compaction completes. ([#339](https://github.com/Aaronontheweb/netclaw/pull/339))
+* Fixed YAML frontmatter leaking into LLM context from auto-loaded skills — skill files include metadata like version numbers in their YAML frontmatter, which the LLM could mistake for its own runtime version. Frontmatter is now stripped before injection so only the skill body reaches the model. ([#324](https://github.com/Aaronontheweb/netclaw/issues/324), [#339](https://github.com/Aaronontheweb/netclaw/pull/339))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+#### 0.7.4 2026-03-20 ####
+
+Netclaw v0.7.4 — Context overflow recovery, skill compaction durability, and frontmatter stripping
+
+**Sessions**
+
+* Fixed sessions failing the turn on context overflow — when the LLM provider rejects a request because the context window is full, the session now triggers emergency compaction and retries instead of surfacing an error. Context overflow detection is hardened across Anthropic, OpenAI, Ollama, and vLLM error formats with 16 new tests. ([#314](https://github.com/Aaronontheweb/netclaw/issues/314), [#340](https://github.com/Aaronontheweb/netclaw/pull/340))
+
+**Skills**
+
+* Fixed auto-loaded skills disappearing after context compaction — skill content injected into the system prompt was not preserved through the compaction pipeline, causing the agent to lose all skill knowledge mid-conversation. Skills are now re-injected after compaction completes. ([#339](https://github.com/Aaronontheweb/netclaw/pull/339))
+* Fixed YAML frontmatter leaking into LLM context from auto-loaded skills — skill files include metadata like version numbers in their YAML frontmatter, which the LLM could mistake for its own runtime version. Frontmatter is now stripped before injection so only the skill body reaches the model. ([#324](https://github.com/Aaronontheweb/netclaw/issues/324), [#339](https://github.com/Aaronontheweb/netclaw/pull/339))
+
 #### 0.7.3 2026-03-20 ####
 
 Netclaw v0.7.3 — Skill feed sync fix


### PR DESCRIPTION
## Summary

- Update version to 0.7.4 and add release notes
- Context overflow auto-compaction (#314, #340)
- Skill preservation across compaction and YAML frontmatter stripping (#324, #339)

## Changes

- `Directory.Build.props` — bump `VersionPrefix` from 0.7.3 to 0.7.4, update `PackageReleaseNotes`
- `RELEASE_NOTES.md` — add 0.7.4 entry

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1,156 tests passed