### PR TITLE
fix(tools): change web_fetch default to preserve HTML, add format parameter

### DIFF
--- a/feeds/skills/.system/files/netclaw-manual/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-manual/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-manual
 description: "Netclaw Manual. Read when the user is asking what Netclaw can do, which command/tool to use, how to schedule work, switch models, manage providers, or discover available capabilities."
 metadata:
   author: netclaw
-  version: "0.8.2"
+  version: "0.8.3"
   triggers: what can netclaw do | what command should I use | can you schedule a cron job | schedule a reminder | switch models | change model | manage providers | manage mcp servers | list available tools | how do I do this in netclaw
 ---
 
@@ -59,7 +59,7 @@ prompt. Use the session ID to:
 | Tool | Purpose |
 |------|---------|
 | `web_search` | Search the web, returns titles/URLs/snippets |
-| `web_fetch` | Fetch URL, save text to local file, return preview |
+| `web_fetch` | Fetch URL, save content to local file, return preview. Default preserves HTML; use `format='text'` for plain text |
 
 ### file
 

--- a/feeds/skills/.system/files/search-citation/SKILL.md
+++ b/feeds/skills/.system/files/search-citation/SKILL.md
@@ -3,7 +3,7 @@ name: search-citation
 description: "Guides when to use web search vs. training data and how to cite sources. Ensures specific factual claims include source URLs and the agent does not hallucinate verifiable information."
 metadata:
   author: netclaw
-  version: "0.7.0"
+  version: "0.7.1"
   triggers: web search needed | cite sources | link results | price check | product search | find near me | verify facts | compare competitors | current information | find flights | find hotels | latest news | what costs | how much does | where to buy | who sells
 ---
 
@@ -93,6 +93,13 @@ If a search returns no useful results:
 - Do not guess or fabricate specifics to fill the gap
 - Offer alternative approaches if possible (different search terms, checking
   a specific site with `web_fetch`, trying later)
+
+## web_fetch Usage Notes
+
+`web_fetch` defaults to raw HTML mode, preserving page structure including links
+and images. This is ideal for crawling and extracting specific information. Use
+`format='text'` only when you need plain text without markup (e.g., for
+summarization of article body text).
 
 ## Cross-References
 

--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -77,31 +77,45 @@ remain identical regardless of which backend is configured.
 
 ### Requirement: Web fetch tool
 
-The system SHALL provide a web fetch tool that retrieves content from URLs,
-extracts text from HTML, and truncates output to a configurable limit to
-prevent context flooding.
+The system SHALL provide a web fetch tool that retrieves content from URLs and
+saves it to a local file. The tool SHALL support two output formats: `raw`
+(default) preserves HTML structure after removing script and style elements,
+and `text` extracts plain text. Output is saved to disk and a preview summary
+returned to prevent context flooding.
 
-#### Scenario: Fetch and extract text from URL
+#### Scenario: Fetch URL in raw mode (default)
 
 - **GIVEN** the web fetch tool is available
-- **WHEN** the agent invokes the tool with a URL
+- **WHEN** the agent invokes the tool with a URL (no format or format='raw')
 - **THEN** the tool retrieves the page content via HTTP
-- **AND** extracts text from HTML (removing markup)
-- **AND** returns the extracted text to the LLM
+- **AND** removes `<script>` and `<style>` elements
+- **AND** preserves all other HTML structure (links, images, nav, etc.)
+- **AND** saves the sanitized HTML to a `.html` file
+- **AND** returns a summary with file path and metadata preview
 
-#### Scenario: Output truncated to configured limit
+#### Scenario: Fetch URL in text mode
 
-- **GIVEN** the fetched page content exceeds the configured output limit
+- **GIVEN** the web fetch tool is available
+- **WHEN** the agent invokes the tool with a URL and format='text'
+- **THEN** the tool retrieves the page content via HTTP
+- **AND** extracts plain text from HTML (removing all markup)
+- **AND** saves the extracted text to a `.txt` file
+- **AND** returns a summary with file path and text preview
+
+#### Scenario: Output saved to disk to prevent context flooding
+
+- **GIVEN** the fetched page content is large
 - **WHEN** the tool processes the content
-- **THEN** the output is truncated to the configured character limit
-- **AND** a truncation indicator is appended to the result
+- **THEN** the full content is saved to disk
+- **AND** only a preview summary is returned to the LLM
+- **AND** the agent can use file_read to access specific sections
 
 #### Scenario: Non-HTML content returned as-is
 
 - **GIVEN** the fetched URL returns plain text or JSON content
 - **WHEN** the tool processes the response
-- **THEN** the content is returned without HTML extraction
-- **AND** output truncation still applies
+- **THEN** the content is saved without HTML processing
+- **AND** a preview summary is returned
 
 #### Scenario: Unreachable URL returns error
 

--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -176,6 +176,66 @@ public class WebFetchToolTests : IDisposable
     }
 
     [Fact]
+    public void SanitizeHtml_removes_scripts_preserves_structure()
+    {
+        var html = """
+            <html><body>
+                <script>alert('xss');</script>
+                <style>body { color: red; }</style>
+                <nav><a href="/">Home</a></nav>
+                <p>Content with <a href="/link">a link</a>.</p>
+                <img src="photo.jpg" alt="Photo" />
+                <footer>Copyright</footer>
+            </body></html>
+            """;
+
+        var result = WebFetchTool.SanitizeHtml(html);
+
+        Assert.DoesNotContain("<script>", result);
+        Assert.DoesNotContain("alert", result);
+        Assert.DoesNotContain("<style>", result);
+        Assert.DoesNotContain("color: red", result);
+        Assert.Contains("<nav>", result);
+        Assert.Contains("<a href=", result);
+        Assert.Contains("<img src=", result);
+        Assert.Contains("<footer>", result);
+    }
+
+    [Fact]
+    public void ExtractMetadataSummary_extracts_description_and_headings()
+    {
+        var html = """
+            <html>
+            <head>
+                <meta name="description" content="A test page about things." />
+            </head>
+            <body>
+                <h1>Main Title</h1>
+                <h2>Section One</h2>
+                <h3>Subsection</h3>
+            </body>
+            </html>
+            """;
+
+        var result = WebFetchTool.ExtractMetadataSummary(html);
+
+        Assert.Contains("Description: A test page about things.", result);
+        Assert.Contains("H1: Main Title", result);
+        Assert.Contains("H2: Section One", result);
+        Assert.Contains("H3: Subsection", result);
+    }
+
+    [Fact]
+    public void ExtractMetadataSummary_handles_no_metadata()
+    {
+        var html = "<html><body><p>Just text.</p></body></html>";
+
+        var result = WebFetchTool.ExtractMetadataSummary(html);
+
+        Assert.Equal("", result);
+    }
+
+    [Fact]
     public void SanitizeForFilename_replaces_special_chars()
     {
         var uri = new Uri("https://example.com/path/to/page?q=hello");
@@ -206,6 +266,7 @@ public class WebFetchToolTests : IDisposable
                 <h1>Welcome</h1>
                 <p>This is the first paragraph of content.</p>
                 <p>This is the second paragraph with more details.</p>
+                <script>alert('xss');</script>
             </body>
             </html>
             """;
@@ -222,19 +283,81 @@ public class WebFetchToolTests : IDisposable
         Assert.Contains("Fetched: https://example.com/test", result);
         Assert.Contains("Title: Test Page", result);
         Assert.Contains("Saved to:", result);
-        Assert.Contains(".txt", result);
+        Assert.Contains(".html", result);
         Assert.Contains("Preview", result);
-        Assert.Contains("Welcome", result);
 
-        // File should exist on disk
+        // File should exist on disk as .html (raw mode is default)
+        var files = Directory.GetFiles(_tempDir, "*.html");
+        Assert.Single(files);
+
+        // File content should preserve HTML structure but strip scripts
+        var fileContent = await File.ReadAllTextAsync(files[0]);
+        Assert.Contains("<h1>Welcome</h1>", fileContent);
+        Assert.Contains("<p>", fileContent);
+        Assert.DoesNotContain("<script>", fileContent);
+        Assert.DoesNotContain("alert", fileContent);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_text_mode_saves_extracted_text()
+    {
+        var html = """
+            <html>
+            <head><title>Test Page</title></head>
+            <body>
+                <h1>Welcome</h1>
+                <p>This is the first paragraph of content.</p>
+            </body>
+            </html>
+            """;
+
+        var handler = new FakeHttpHandler(html, "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient, _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/test", ["Format"] = "text" },
+            CancellationToken.None);
+
+        Assert.Contains(".txt", result);
+
         var files = Directory.GetFiles(_tempDir, "*.txt");
         Assert.Single(files);
 
-        // File content should be the extracted text
         var fileContent = await File.ReadAllTextAsync(files[0]);
         Assert.Contains("Welcome", fileContent);
         Assert.Contains("first paragraph", fileContent);
         Assert.DoesNotContain("<html>", fileContent);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_raw_mode_preserves_links_and_images()
+    {
+        var html = """
+            <html><body>
+                <nav><a href="/home">Home</a></nav>
+                <p>Check out <a href="https://example.com">this link</a>.</p>
+                <img src="https://example.com/photo.jpg" alt="Photo" />
+                <footer>Copyright 2025</footer>
+            </body></html>
+            """;
+
+        var handler = new FakeHttpHandler(html, "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient, _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/page" },
+            CancellationToken.None);
+
+        var files = Directory.GetFiles(_tempDir, "*.html");
+        Assert.Single(files);
+
+        var fileContent = await File.ReadAllTextAsync(files[0]);
+        Assert.Contains("<a href=", fileContent);
+        Assert.Contains("<img src=", fileContent);
+        Assert.Contains("<nav>", fileContent);
+        Assert.Contains("<footer>", fileContent);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Aaron.Akka.Reminders" />
     <PackageReference Include="Aaron.Akka.Reminders.Sqlite" />
     <PackageReference Include="Cronos" />
+    <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -7,13 +7,14 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Fetches a web page, extracts readable text, and saves it to a local file.
-/// Returns a summary with the file path so the agent can use file_read or
-/// shell_execute (grep) to selectively read the content without blowing
-/// out the context window.
+/// Fetches a web page and saves its content to a local file.
+/// Default format preserves HTML (links, images, structure); text mode
+/// extracts plain text only. Returns a summary with the file path so the
+/// agent can use file_read or shell_execute (grep) to selectively read
+/// the content without blowing out the context window.
 /// </summary>
 [NetclawTool("web_fetch",
-    "Fetch a web page URL, save its text content to a local file, and return the file path with a preview. Use file_read or shell_execute with grep to read specific sections.",
+    "Fetch a web page URL and save its content to a local file. Default format='raw' preserves HTML (links, images, structure); format='text' extracts plain text. Returns file path with preview. Use file_read to examine the full content.",
     Grant = "web")]
 public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
 {
@@ -33,7 +34,9 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
     private readonly Random _random = new();
 
     public record Params(
-        [property: Description("The URL to fetch")] string Url);
+        [property: Description("The URL to fetch")] string Url,
+        [property: Description("Output format: 'raw' (default) preserves HTML structure (links, images, tables); 'text' extracts plain text only")]
+        string? Format = null);
 
     public WebFetchTool(HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
     {
@@ -66,31 +69,50 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             var content = await ReadWithLimitAsync(response, ct);
             var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
 
-            string text;
+            // Determine format: null or "raw" → raw HTML; "text" → text extraction
+            var useTextMode = string.Equals(args.Format, "text", StringComparison.OrdinalIgnoreCase);
+
+            string savedContent;
             string title;
+            string extension;
+            string previewText;
+
             if (contentType.Contains("html", StringComparison.OrdinalIgnoreCase))
             {
                 title = ExtractTitle(content) ?? uri.Host;
-                text = ExtractTextFromHtml(content);
+                if (useTextMode)
+                {
+                    savedContent = ExtractTextFromHtml(content);
+                    extension = ".txt";
+                    previewText = savedContent;
+                }
+                else
+                {
+                    savedContent = SanitizeHtml(content);
+                    extension = ".html";
+                    previewText = ExtractMetadataSummary(content);
+                }
             }
             else
             {
                 title = uri.Host;
-                text = content;
+                savedContent = content;
+                extension = ".txt";
+                previewText = content;
             }
 
-            if (string.IsNullOrWhiteSpace(text))
-                return $"Fetched {args.Url} but the page contained no extractable text content.";
+            if (string.IsNullOrWhiteSpace(savedContent))
+                return $"Fetched {args.Url} but the page contained no extractable content.";
 
             // Use session-scoped directory if available, otherwise fall back to shared temp
             var fetchDir = context.SessionDirectory ?? _fetchDirectory;
 
             // Save to disk
-            var filePath = SaveToFile(text, uri, fetchDir);
-            var lineCount = text.Count(c => c == '\n') + 1;
+            var filePath = SaveToFile(savedContent, uri, fetchDir, extension);
+            var lineCount = savedContent.Count(c => c == '\n') + 1;
 
             // Build summary with preview
-            return FormatSummary(uri.ToString(), title, filePath, text.Length, lineCount, text);
+            return FormatSummary(uri.ToString(), title, filePath, savedContent.Length, lineCount, previewText);
         }
         catch (HttpRequestException ex)
         {
@@ -111,16 +133,16 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         return Encoding.UTF8.GetString(bytes);
     }
 
-    private string SaveToFile(string text, Uri uri, string directory)
+    private string SaveToFile(string content, Uri uri, string directory, string extension = ".txt")
     {
         Directory.CreateDirectory(directory);
 
         // Generate a filename from the URL host + path + timestamp
         var sanitized = SanitizeForFilename(uri);
-        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}.txt";
+        var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}{extension}";
         var filePath = Path.Combine(directory, filename);
 
-        File.WriteAllText(filePath, text, Encoding.UTF8);
+        File.WriteAllText(filePath, content, Encoding.UTF8);
         return filePath;
     }
 
@@ -175,6 +197,57 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             return null;
         var title = WebUtility.HtmlDecode(titleNode.InnerText).Trim();
         return string.IsNullOrEmpty(title) ? null : title;
+    }
+
+    /// <summary>
+    /// Remove script and style elements from HTML but preserve all other structure.
+    /// Used in raw mode to reduce noise while keeping links, images, and layout.
+    /// </summary>
+    internal static string SanitizeHtml(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var nodesToRemove = doc.DocumentNode.SelectNodes("//script|//style");
+        if (nodesToRemove is not null)
+        {
+            foreach (var node in nodesToRemove)
+                node.Remove();
+        }
+
+        return doc.DocumentNode.OuterHtml;
+    }
+
+    /// <summary>
+    /// Extract a brief metadata summary for raw-mode preview.
+    /// Shows meta description and top headings instead of raw HTML.
+    /// </summary>
+    internal static string ExtractMetadataSummary(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var sb = new StringBuilder();
+
+        var metaDesc = doc.DocumentNode.SelectSingleNode("//meta[@name='description']");
+        if (metaDesc?.GetAttributeValue("content", "") is { Length: > 0 } desc)
+            sb.AppendLine($"Description: {WebUtility.HtmlDecode(desc)}");
+
+        var headings = doc.DocumentNode.SelectNodes("//h1|//h2|//h3");
+        if (headings is { Count: > 0 })
+        {
+            var shown = 0;
+            foreach (var h in headings)
+            {
+                var text = WebUtility.HtmlDecode(h.InnerText).Trim();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    sb.AppendLine($"  {h.Name.ToUpperInvariant()}: {text}");
+                    if (++shown >= 5) break;
+                }
+            }
+        }
+
+        return sb.ToString().TrimEnd();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #338

- **Fix missing HtmlAgilityPack dependency**: Added direct package reference to `Netclaw.Actors.csproj` — the prior search-provider refactoring moved it to `Netclaw.Search` but `WebFetchTool.cs` still uses it directly, causing runtime assembly load failures
- **Change default to raw HTML**: `web_fetch` now preserves HTML structure by default (stripping only `<script>` and `<style>` elements), so agents can see images, links, navigation, and page layout
- **Add `format` parameter**: Agents can pass `format='text'` to get the old text-extraction behavior when plain text is needed (e.g., summarization)

## Changes

| File | Change |
|------|--------|
| `src/Netclaw.Actors/Netclaw.Actors.csproj` | Add direct HtmlAgilityPack package reference |
| `src/Netclaw.Actors/Tools/WebFetchTool.cs` | Add `Format` parameter, `SanitizeHtml()`, `ExtractMetadataSummary()`, branching logic, `.html`/`.txt` extension support |
| `src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs` | Update default-mode test, add 6 new tests for raw/text modes |
| `feeds/skills/.system/files/netclaw-manual/SKILL.md` | Update tool description (0.8.2 → 0.8.3) |
| `feeds/skills/.system/files/search-citation/SKILL.md` | Add web_fetch usage notes (0.7.0 → 0.7.1) |
| `openspec/specs/netclaw-tools/spec.md` | Update requirement and scenarios for dual-mode behavior |

## Test plan

- [x] All 23 WebFetchTool tests pass (including 6 new tests)
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] Manual: deploy daemon, run `web_fetch https://example.com` → verify `.html` file with preserved structure
- [ ] Manual: run `web_fetch https://example.com --text` → verify `.txt` file with extracted text