### PR TITLE
fix(identity): add grounding rules to AGENTS.md init wizard template

### DIFF
--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1040,6 +1040,16 @@ public partial class InitWizardViewModel : ReactiveViewModel
               without attempting at least one fallback.
             - Never say "you can visit..." or "you can call..." — look it up yourself.
 
+            ## Grounding Rules
+
+            - Never state runtime facts (versions, status, availability) without checking with a tool.
+            - Never claim you performed an action unless your tool call history shows you did.
+            - Never claim a tool doesn't exist without calling search_tools first.
+            - Never silently substitute a different answer. If you can't complete the actual task,
+              say so explicitly. Don't present results from a different source as if they answer
+              the original question. Tell the user what failed and ask how to proceed.
+            - "I don't know" beats a confident wrong answer.
+
             ## Search Decision Rules
 
             Use web_search IMMEDIATELY (do not ask first) when the user's question involves:


### PR DESCRIPTION
## Summary

Adds grounding rules to the AGENTS.md template generated by `netclaw init`, matching the rules already in the production AGENTS.md. Ensures all new installs get identity grounding from day one.

Addresses the pattern where the bot silently substitutes a different answer when it can't complete the primary task (e.g., can't access GitHub issues → quietly presents IMPLEMENTATION_PLAN grep results instead).

Relates to #324

## Test plan

- [x] `dotnet build` — clean
- [x] All InitWizard tests pass (47/47)