### PR TITLE
fix(security): prevent MagicByteValidator type poisoning from dropping Slack images

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -669,6 +669,136 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         await ExpectTerminatedAsync(actor);
     }
 
+    [Fact]
+    public async Task Inbound_image_with_real_scanner_flows_to_llm()
+    {
+        // Uses the production MagicByteContentScanner instead of NullContentScanner
+        // to verify the real scanner doesn't reject valid PNG images.
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        var httpClient = new HttpClient(_httpHandler);
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new MagicByteContentScanner(new ContentPolicy()),
+            HttpClient: httpClient);
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-real-scanner-test");
+
+        var files = new List<SlackFileReference>
+        {
+            new("F_REAL", "photo.png", "image/png", FakePngBytes.Length,
+                "https://files.slack.com/files-pri/T1234-F_REAL/photo.png")
+        };
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D_RS:10000"),
+            ChannelId: new SlackChannelId("D_RS"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("10000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "check this image",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: files));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_replyClient.PostedMessages.Count > 0,
+                "Expected at least one Slack reply to be posted");
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Assert.True(_chatClient.ReceivedImageContent,
+            "Expected LLM to receive DataContent (image) via real MagicByteContentScanner");
+    }
+
+    [Fact]
+    public async Task Scanner_failure_does_not_silently_drop_image()
+    {
+        // When the content scanner itself is broken (e.g. TypeInitializationException),
+        // images should still flow through to the LLM rather than being silently dropped.
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        var httpClient = new HttpClient(_httpHandler);
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new FailingContentScanner(),
+            HttpClient: httpClient);
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-failing-scanner-test");
+
+        var files = new List<SlackFileReference>
+        {
+            new("F_FAIL", "drawing.png", "image/png", FakePngBytes.Length,
+                "https://files.slack.com/files-pri/T1234-F_FAIL/drawing.png")
+        };
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D_FS:11000"),
+            ChannelId: new SlackChannelId("D_FS"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("11000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "my daughter made this",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: files));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_replyClient.PostedMessages.Count > 0,
+                "Expected at least one Slack reply to be posted");
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Assert.True(_chatClient.ReceivedImageContent,
+            "Expected LLM to receive image even when scanner is broken");
+    }
+
+    /// <summary>
+    /// Content scanner that simulates a broken scanner returning ScanFailure,
+    /// matching what happens when MagicByteValidator's type initializer fails.
+    /// </summary>
+    private sealed class FailingContentScanner : IContentScanner
+    {
+        public Task<ContentScanResult> ScanAsync(
+            ReadOnlyMemory<byte> content, string filename, string declaredMimeType,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ContentScanResult.Rejected(
+                ContentScanError.ScanFailure,
+                "Content scan failed: The type initializer for 'Netclaw.Security.MagicByteValidator' threw an exception."));
+        }
+    }
+
     /// <summary>
     /// Fake HTTP handler that serves canned image bytes for Slack file download requests.
     /// </summary>

--- a/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels/Slack/SlackThreadBindingActor.cs
@@ -216,9 +216,20 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
 
                         if (!scanResult.IsAllowed)
                         {
-                            _log.Warning("Content scan rejected file {Name}: {Message}",
-                                file.Name, scanResult.Message ?? scanResult.Error?.ToString());
-                            continue;
+                            if (scanResult.Error == ContentScanError.ScanFailure)
+                            {
+                                // Scanner itself is broken — allow the file through rather
+                                // than silently dropping valid images. The LLM provider
+                                // will still validate content on its end.
+                                _log.Error("Content scanner failed for file {Name}: {Message} — allowing file through",
+                                    file.Name, scanResult.Message);
+                            }
+                            else
+                            {
+                                _log.Warning("Content scan rejected file {Name}: {Message}",
+                                    file.Name, scanResult.Message ?? scanResult.Error?.ToString());
+                                continue;
+                            }
                         }
 
                         contents.Add(new DataContent(bytes.ToArray(), file.MimeType));

--- a/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
+++ b/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
@@ -166,4 +166,23 @@ public sealed class MagicByteValidatorTests
         Assert.False(MagicByteValidator.HasExecutableSignature(PngHeader));
         Assert.False(MagicByteValidator.HasExecutableSignature(JpegHeader));
     }
+
+    [Fact]
+    public void Validate_still_works_when_DetectMimeType_returns_null()
+    {
+        // Core validation uses direct byte checks, not MimeDetective.
+        // Even if DetectMimeType returns null, Validate should still allow
+        // valid images through — the detected MIME type is diagnostic only.
+        var result = MagicByteValidator.Validate(PngHeader, "image/png", "photo.png");
+        Assert.True(result.IsAllowed);
+
+        result = MagicByteValidator.Validate(JpegHeader, "image/jpeg", "photo.jpg");
+        Assert.True(result.IsAllowed);
+
+        result = MagicByteValidator.Validate(GifHeader, "image/gif", "animation.gif");
+        Assert.True(result.IsAllowed);
+
+        result = MagicByteValidator.Validate(WebpHeader, "image/webp", "photo.webp");
+        Assert.True(result.IsAllowed);
+    }
 }

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -10,11 +10,12 @@ namespace Netclaw.Security;
 /// </summary>
 public static class MagicByteValidator
 {
-    private static readonly Lazy<IContentInspector> Inspector = new(() =>
-        new ContentInspectorBuilder()
-        {
-            Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
-        }.Build());
+    // Lazily initialized inside DetectMimeType() — NOT a static field initializer.
+    // Keeping MimeDetective out of the static constructor prevents a transient
+    // MimeDetective loading failure from poisoning the entire type via
+    // TypeInitializationException (which .NET caches permanently).
+    private static IContentInspector? s_inspector;
+    private static bool s_inspectorResolved;
 
     private static readonly FrozenSet<string> AllowedImageMimeTypes =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -122,7 +123,11 @@ public static class MagicByteValidator
 
         try
         {
-            var results = Inspector.Value.Inspect(content);
+            var inspector = GetOrCreateInspector();
+            if (inspector is null)
+                return null;
+
+            var results = inspector.Inspect(content);
             var topMatch = results.OrderByDescending(r => r.Points).FirstOrDefault();
             return topMatch?.Definition.File.MimeType;
         }
@@ -130,6 +135,28 @@ public static class MagicByteValidator
         {
             return null;
         }
+    }
+
+    private static IContentInspector? GetOrCreateInspector()
+    {
+        if (s_inspectorResolved)
+            return s_inspector;
+
+        try
+        {
+            s_inspector = new ContentInspectorBuilder()
+            {
+                Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
+            }.Build();
+        }
+        catch
+        {
+            // MimeDetective failed to initialize — detection unavailable.
+            // This is purely diagnostic; core validation uses direct byte checks.
+        }
+
+        s_inspectorResolved = true;
+        return s_inspector;
     }
 
     public static bool HasExecutableSignature(ReadOnlySpan<byte> content)

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -149,10 +149,12 @@ public static class MagicByteValidator
                 Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
             }.Build();
         }
-        catch
+        catch (Exception)
         {
             // MimeDetective failed to initialize — detection unavailable.
             // This is purely diagnostic; core validation uses direct byte checks.
+            // Swallow intentionally: s_inspector stays null, DetectMimeType returns null.
+            s_inspector = null;
         }
 
         s_inspectorResolved = true;


### PR DESCRIPTION
## Summary

- **Root cause**: `MagicByteValidator`'s `Lazy<IContentInspector>` static field referenced MimeDetective types. A transient loading failure during the static constructor permanently poisoned the type via cached `TypeInitializationException`, causing ALL image content scans to fail silently for the process lifetime.
- **Fix**: Moved MimeDetective inspector initialization out of static fields into a lazily-initialized method with try-catch. Core magic byte validation (PNG/JPEG/GIF/WebP headers, executable detection) uses direct byte comparison and never needed MimeDetective.
- **Error handling**: `SlackThreadBindingActor` now distinguishes scanner crashes (`ContentScanError.ScanFailure`) from policy rejections — scanner failures allow the file through with an error log instead of silently dropping valid images.
- **Test coverage**: Added integration tests using the production `MagicByteContentScanner` and a `FailingContentScanner` to prevent regressions. All 216 tests pass.

## Test plan

- [x] `dotnet test src/Netclaw.Security.Tests/` — 49 tests pass (including new resilience test)
- [x] `dotnet test src/Netclaw.Actors.Tests/ --filter SlackFileFlow` — 12 tests pass (including 2 new integration tests)
- [x] `dotnet test` — full suite 216/216 green
- [x] `dotnet slopwatch analyze` — 0 violations