### PR TITLE
fix(security): remove MimeDetective dependency from MagicByteValidator

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <AkkaRemindersVersion>0.5.1</AkkaRemindersVersion>
     <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
     <SlackNetVersion>0.17.9</SlackNetVersion>
-    <MimeDetectiveVersion>25.8.1</MimeDetectiveVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.5</MicrosoftAspNetCoreVersion>
   </PropertyGroup>
@@ -44,8 +43,6 @@
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.8.4" />
     <PackageVersion Include="Termina" Version="0.8.0" />
-    <PackageVersion Include="Mime-Detective" Version="$(MimeDetectiveVersion)" />
-    <PackageVersion Include="Mime-Detective.Definitions.Condensed" Version="$(MimeDetectiveVersion)" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>

--- a/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
+++ b/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
@@ -167,22 +167,37 @@ public sealed class MagicByteValidatorTests
         Assert.False(MagicByteValidator.HasExecutableSignature(JpegHeader));
     }
 
-    [Fact]
-    public void Validate_still_works_when_DetectMimeType_returns_null()
+    [Theory]
+    [InlineData(nameof(PngHeader), "image/png")]
+    [InlineData(nameof(JpegHeader), "image/jpeg")]
+    [InlineData(nameof(GifHeader), "image/gif")]
+    [InlineData(nameof(WebpHeader), "image/webp")]
+    public void DetectMimeType_identifies_supported_image_types(string headerField, string expectedMime)
     {
-        // Core validation uses direct byte checks, not MimeDetective.
-        // Even if DetectMimeType returns null, Validate should still allow
-        // valid images through — the detected MIME type is diagnostic only.
-        var result = MagicByteValidator.Validate(PngHeader, "image/png", "photo.png");
-        Assert.True(result.IsAllowed);
+        var header = headerField switch
+        {
+            nameof(PngHeader) => PngHeader,
+            nameof(JpegHeader) => JpegHeader,
+            nameof(GifHeader) => GifHeader,
+            nameof(WebpHeader) => WebpHeader,
+            _ => throw new ArgumentException(headerField)
+        };
 
-        result = MagicByteValidator.Validate(JpegHeader, "image/jpeg", "photo.jpg");
-        Assert.True(result.IsAllowed);
+        Assert.Equal(expectedMime, MagicByteValidator.DetectMimeType(header));
+    }
 
-        result = MagicByteValidator.Validate(GifHeader, "image/gif", "animation.gif");
-        Assert.True(result.IsAllowed);
+    [Fact]
+    public void DetectMimeType_returns_null_for_unknown_content()
+    {
+        byte[] randomBytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D];
+        Assert.Null(MagicByteValidator.DetectMimeType(randomBytes));
+    }
 
-        result = MagicByteValidator.Validate(WebpHeader, "image/webp", "photo.webp");
-        Assert.True(result.IsAllowed);
+    [Fact]
+    public void DetectMimeType_returns_null_for_empty_or_short_content()
+    {
+        Assert.Null(MagicByteValidator.DetectMimeType(ReadOnlySpan<byte>.Empty));
+        Assert.Null(MagicByteValidator.DetectMimeType(new byte[] { 0xFF }));
+        Assert.Null(MagicByteValidator.DetectMimeType(new byte[] { 0xFF, 0xD8 }));
     }
 }

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -1,22 +1,13 @@
 using System.Collections.Frozen;
-using MimeDetective;
 
 namespace Netclaw.Security;
 
 /// <summary>
 /// Validates file content using magic byte (file signature) analysis.
 /// Narrowed to image types for Netclaw's multimodal pipeline.
-/// Adapted from TextForge's MagicByteValidator.
 /// </summary>
 public static class MagicByteValidator
 {
-    // Lazily initialized inside DetectMimeType() — NOT a static field initializer.
-    // Keeping MimeDetective out of the static constructor prevents a transient
-    // MimeDetective loading failure from poisoning the entire type via
-    // TypeInitializationException (which .NET caches permanently).
-    private static IContentInspector? s_inspector;
-    private static bool s_inspectorResolved;
-
     private static readonly FrozenSet<string> AllowedImageMimeTypes =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -116,49 +107,36 @@ public static class MagicByteValidator
         return ValidateImageContent(content, declaredMimeType);
     }
 
+    /// <summary>
+    /// Detects MIME type from magic bytes for the supported image types.
+    /// Returns null for unrecognized content.
+    /// </summary>
     public static string? DetectMimeType(ReadOnlySpan<byte> content)
     {
-        if (content.Length == 0)
-            return null;
+        if (content.Length >= 8 &&
+            content[0] == 0x89 && content[1] == 0x50 &&
+            content[2] == 0x4E && content[3] == 0x47 &&
+            content[4] == 0x0D && content[5] == 0x0A &&
+            content[6] == 0x1A && content[7] == 0x0A)
+            return "image/png";
 
-        try
-        {
-            var inspector = GetOrCreateInspector();
-            if (inspector is null)
-                return null;
+        if (content.Length >= 3 &&
+            content[0] == 0xFF && content[1] == 0xD8 && content[2] == 0xFF)
+            return "image/jpeg";
 
-            var results = inspector.Inspect(content);
-            var topMatch = results.OrderByDescending(r => r.Points).FirstOrDefault();
-            return topMatch?.Definition.File.MimeType;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        if (content.Length >= 4 &&
+            content[0] == 0x47 && content[1] == 0x49 &&
+            content[2] == 0x46 && content[3] == 0x38)
+            return "image/gif";
 
-    private static IContentInspector? GetOrCreateInspector()
-    {
-        if (s_inspectorResolved)
-            return s_inspector;
+        if (content.Length >= 12 &&
+            content[0] == 0x52 && content[1] == 0x49 &&
+            content[2] == 0x46 && content[3] == 0x46 &&
+            content[8] == 0x57 && content[9] == 0x45 &&
+            content[10] == 0x42 && content[11] == 0x50)
+            return "image/webp";
 
-        try
-        {
-            s_inspector = new ContentInspectorBuilder()
-            {
-                Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
-            }.Build();
-        }
-        catch (Exception)
-        {
-            // MimeDetective failed to initialize — detection unavailable.
-            // This is purely diagnostic; core validation uses direct byte checks.
-            // Swallow intentionally: s_inspector stays null, DetectMimeType returns null.
-            s_inspector = null;
-        }
-
-        s_inspectorResolved = true;
-        return s_inspector;
+        return null;
     }
 
     public static bool HasExecutableSignature(ReadOnlySpan<byte> content)

--- a/src/Netclaw.Security/Netclaw.Security.csproj
+++ b/src/Netclaw.Security/Netclaw.Security.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mime-Detective" />
-    <PackageReference Include="Mime-Detective.Definitions.Condensed" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Remove `Mime-Detective` and `Mime-Detective.Definitions.Condensed` NuGet packages from `Netclaw.Security`
- Replace `DetectMimeType()` with native magic byte checks for PNG/JPEG/GIF/WebP — the same patterns already used by `ValidateImageContent()`
- Remove `GetOrCreateInspector()`, `s_inspector`, `s_inspectorResolved` fields, and `using MimeDetective` directive
- Add `DetectMimeType` unit tests for all supported image types, unknown content, and empty/short content

MimeDetective was only used for diagnostic MIME type strings in error messages and `ContentScanResult.DetectedMimeType`, which no downstream code consumes. The actual security validation (magic byte checks, executable detection, allowlist enforcement) was always done by direct byte comparison. MimeDetective caused two production incidents via `TypeInitializationException` when its assembly loading failed — permanently poisoning the static type and silently dropping all Slack image attachments for the process lifetime.

## Test plan

- [x] `dotnet test src/Netclaw.Security.Tests/` — 54 passed
- [x] `dotnet test src/Netclaw.Actors.Tests/ --filter SlackFileFlow` — 12 passed
- [x] `grep -r "MimeDetective" src/` — zero matches