### PR TITLE
fix(reminders): auto-delete single-shot reminders after firing

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -153,7 +153,7 @@ public class ReminderManagerActorTests : TestKit
     }
 
     [Fact]
-    public async Task Reconcile_disables_zombie_oneshot_reminders()
+    public async Task Reconcile_deletes_zombie_oneshot_reminders()
     {
         var manager = await GetManagerAsync();
         var now = TimeProvider.System.GetUtcNow();
@@ -196,12 +196,11 @@ public class ReminderManagerActorTests : TestKit
         // Trigger reconciliation and wait for completion ack
         var reconcileResult = await manager.Ask<ReminderManagerActor.ReconcileCompleted>(
             ReminderManagerActor.ReconcileReminders.Instance, TimeSpan.FromSeconds(30));
-        Assert.Equal(1, reconcileResult.DisabledZombies);
+        Assert.Equal(1, reconcileResult.DeletedOneShots);
 
-        // Verify definition still exists but is now disabled
+        // Verify definition has been deleted from the store
         var afterReconcile = _definitionStore.Get(new ReminderId("zombie-oneshot"));
-        Assert.NotNull(afterReconcile);
-        Assert.False(afterReconcile.Enabled);
+        Assert.Null(afterReconcile);
     }
 
     private static ReminderDefinition CreateDefinition(string name, string instructions)

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -259,6 +259,27 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         return new ReminderStateResponse(id, Found: true, Enabled: false);
     }
 
+    /// <summary>
+    /// Permanently removes a reminder definition, its schedule, history, and any
+    /// in-memory tracking state. Used for automatic cleanup of fired one-shot reminders.
+    /// </summary>
+    private async Task DeleteReminderInternalAsync(ReminderId id)
+    {
+        _definitionStore.Delete(id);
+        await CancelScheduleOnlyAsync(id);
+        _failureCounts.Remove(id);
+        RemoveFromDeferredQueue(id);
+
+        try
+        {
+            _historyStore.DeleteHistory(id);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to delete history for reminder '{0}'", id.Value);
+        }
+    }
+
     private async Task<ReminderStateResponse> EnableReminderInternalAsync(ReminderId id)
     {
         var definition = _definitionStore.Get(id);
@@ -480,11 +501,11 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             }
         }
 
-        // One-shot reminders cannot fire again — disable after execution
-        if (definition is { Enabled: true, Schedule.Type: ReminderScheduleType.OneShot })
+        // One-shot reminders cannot fire again — delete after execution
+        if (definition is { Schedule.Type: ReminderScheduleType.OneShot })
         {
-            _log.Info("One-shot reminder '{0}' completed, disabling", completed.Id.Value);
-            await DisableReminderInternalAsync(completed.Id);
+            _log.Info("One-shot reminder '{0}' completed, deleting", completed.Id.Value);
+            await DeleteReminderInternalAsync(completed.Id);
         }
 
         await ProcessDeferredQueueAsync();
@@ -520,31 +541,31 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                     restoredSchedules++;
             }
 
-            // Disable zombie one-shots: enabled definitions with fire time in the past
+            // Delete stale one-shots: definitions with fire time in the past
             // and no active Akka.Reminders schedule (already fired, never cleaned up).
+            // Includes both enabled zombies and already-disabled leftovers.
             var now = _timeProvider.GetUtcNow();
-            var disabledZombies = 0;
+            var deletedOneShots = 0;
             foreach (var definition in definitions.Where(d =>
-                         d.Enabled &&
                          d.Schedule.Type == ReminderScheduleType.OneShot &&
                          d.Schedule.FireAt <= now &&
                          !scheduled.ContainsKey(d.Id)))
             {
-                await DisableReminderInternalAsync(new ReminderId(definition.Id));
-                disabledZombies++;
+                await DeleteReminderInternalAsync(new ReminderId(definition.Id));
+                deletedOneShots++;
             }
 
-            if (cancelledOrphans > 0 || restoredSchedules > 0 || disabledZombies > 0)
+            if (cancelledOrphans > 0 || restoredSchedules > 0 || deletedOneShots > 0)
             {
-                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}, disabled_zombies={2}",
+                _log.Info("Reminder reconcile complete: cancelled_orphans={0}, restored={1}, deleted_oneshots={2}",
                     cancelledOrphans,
                     restoredSchedules,
-                    disabledZombies);
+                    deletedOneShots);
             }
 
             // Only ack external callers — skip Self.Tell from PreStart
             if (!sender.Equals(Self))
-                sender.Tell(new ReconcileCompleted(cancelledOrphans, restoredSchedules, disabledZombies));
+                sender.Tell(new ReconcileCompleted(cancelledOrphans, restoredSchedules, deletedOneShots));
         }
         catch (Exception ex)
         {
@@ -755,5 +776,5 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// Ack sent back to <see cref="ReconcileReminders"/> callers so they can
     /// synchronize on reconcile completion instead of polling.
     /// </summary>
-    internal sealed record ReconcileCompleted(int CancelledOrphans, int RestoredSchedules, int DisabledZombies);
+    internal sealed record ReconcileCompleted(int CancelledOrphans, int RestoredSchedules, int DeletedOneShots);
 }


### PR DESCRIPTION
## Summary
- Single-shot reminders are now fully deleted (definition file, schedule, history) after firing, instead of just being disabled
- Startup reconciliation also deletes stale one-shots (both enabled zombies and already-disabled leftovers) rather than disabling them
- Adds `DeleteReminderInternalAsync` helper for clean, reusable reminder deletion

Closes #349

## Test plan
- [x] `Reconcile_deletes_zombie_oneshot_reminders` test updated and passing — verifies definition is removed from store (not just disabled)
- [x] All 6 `ReminderManagerActorTests` pass
- [x] Full build succeeds with no warnings