### PR TITLE
fix(mcp-oauth): survive daemon restarts by decrypting token section

### DIFF
--- a/src/Netclaw.Configuration.Tests/SecretsFileWriterTests.cs
+++ b/src/Netclaw.Configuration.Tests/SecretsFileWriterTests.cs
@@ -90,6 +90,43 @@ public sealed class SecretsFileWriterTests : IDisposable
     }
 
     [Fact]
+    public void DecryptJsonLeaves_round_trips_with_encrypt()
+    {
+        var paths = new NetclawPaths(_tempDir);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+
+        var json = """{"ApiKey": "sk-secret123", "Nested": {"Token": "tok-abc", "Expiry": "2026-03-21"}}""";
+
+        // Encrypt via Write
+        SecretsFileWriter.Write(_secretsPath, json, protector);
+        var encrypted = File.ReadAllText(_secretsPath);
+        Assert.Contains("ENC:", encrypted, StringComparison.Ordinal);
+        Assert.DoesNotContain("sk-secret123", encrypted, StringComparison.Ordinal);
+
+        // Decrypt
+        var decrypted = SecretsFileWriter.DecryptJsonLeaves(encrypted, protector);
+        Assert.Contains("sk-secret123", decrypted, StringComparison.Ordinal);
+        Assert.Contains("tok-abc", decrypted, StringComparison.Ordinal);
+        Assert.Contains("2026-03-21", decrypted, StringComparison.Ordinal);
+        Assert.DoesNotContain("ENC:", decrypted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DecryptJsonLeaves_leaves_plaintext_untouched()
+    {
+        var paths = new NetclawPaths(_tempDir);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+
+        var json = """{"plain": "hello", "nested": {"also_plain": "world"}}""";
+        var result = SecretsFileWriter.DecryptJsonLeaves(json, protector);
+
+        Assert.Contains("hello", result, StringComparison.Ordinal);
+        Assert.Contains("world", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CountEncryptionStatus_counts_correctly()
     {
         var json = """{"plain": "hello", "encrypted": "ENC:abc123", "nested": {"also_plain": "world"}}""";

--- a/src/Netclaw.Configuration/SecretsFileWriter.cs
+++ b/src/Netclaw.Configuration/SecretsFileWriter.cs
@@ -61,6 +61,20 @@ public static class SecretsFileWriter
     }
 
     /// <summary>
+    /// Walk a JSON tree and decrypt all <c>ENC:</c>-prefixed string leaf values.
+    /// Non-encrypted values are left untouched (idempotent).
+    /// </summary>
+    public static string DecryptJsonLeaves(string json, ISecretsProtector protector)
+    {
+        var node = JsonNode.Parse(json);
+        if (node is null)
+            return json;
+
+        DecryptNode(node, protector);
+        return node.ToJsonString(DefaultJsonOptions);
+    }
+
+    /// <summary>
     /// Count encrypted vs plaintext string leaf values in a JSON document.
     /// </summary>
     public static (int Encrypted, int Plaintext) CountEncryptionStatus(string json)
@@ -105,6 +119,43 @@ public static class SecretsFileWriter
                     else if (item is not null)
                     {
                         EncryptNode(item, protector);
+                    }
+                }
+                break;
+        }
+    }
+
+    private static void DecryptNode(JsonNode node, ISecretsProtector protector)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var (key, child) in obj.ToArray())
+                {
+                    if (child is JsonValue val && val.TryGetValue<string>(out var s))
+                    {
+                        if (ISecretsProtector.IsEncrypted(s))
+                            obj[key] = protector.Unprotect(s);
+                    }
+                    else if (child is not null)
+                    {
+                        DecryptNode(child, protector);
+                    }
+                }
+                break;
+
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    var item = arr[i];
+                    if (item is JsonValue val && val.TryGetValue<string>(out var s))
+                    {
+                        if (ISecretsProtector.IsEncrypted(s))
+                            arr[i] = protector.Unprotect(s);
+                    }
+                    else if (item is not null)
+                    {
+                        DecryptNode(item, protector);
                     }
                 }
                 break;

--- a/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpOAuthServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
 using Netclaw.Daemon.Mcp;
 using Netclaw.Providers.OAuth;
 using Xunit;
@@ -51,13 +52,62 @@ public sealed class McpOAuthServiceTests : IDisposable
         Assert.Equal(McpOAuthFlowStatus.Failed, service.GetFlowStatusByState(state));
     }
 
+    [Fact]
+    public async Task LoadTokensFromDisk_survives_encrypted_round_trip()
+    {
+        var paths = new NetclawPaths(_tempDir);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        try
+        {
+            // First service: complete auth flow → persist tokens (encrypted)
+            var service1 = CreateService(CreateDiscoveryClient(),
+                CreatePkceService(JsonResponse(new
+                {
+                    access_token = "access-tok",
+                    refresh_token = "refresh-tok",
+                    expires_in = 3600
+                })),
+                protector);
+
+            var entry = CreateHttpEntry();
+            var (_, state) = await service1.StartAuthorizationFlowAsync("notion", entry, CancellationToken.None);
+            await service1.CompleteAuthorizationAsync("auth-code", state, CancellationToken.None);
+
+            // Verify tokens were encrypted on disk
+            var onDisk = File.ReadAllText(paths.SecretsPath);
+            Assert.Contains("ENC:", onDisk, StringComparison.Ordinal);
+            Assert.DoesNotContain("access-tok", onDisk, StringComparison.Ordinal);
+
+            // Second service: simulates daemon restart — must load encrypted tokens
+            var service2 = CreateService(CreateDiscoveryClient(),
+                CreatePkceService(JsonResponse(new { access_token = "unused" })),
+                protector);
+
+            var tokenSet = service2.GetTokenSet("notion");
+            Assert.NotNull(tokenSet);
+            Assert.Equal("access-tok", tokenSet.AccessToken.Value);
+            Assert.NotNull(tokenSet.RefreshToken);
+            Assert.Equal("refresh-tok", tokenSet.RefreshToken.Value);
+            Assert.NotNull(tokenSet.ExpiresAt);
+            Assert.True(tokenSet.ExpiresAt > DateTimeOffset.UtcNow);
+        }
+        finally
+        {
+            SensitiveStringTypeConverter.Protector = null;
+        }
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, true);
     }
 
-    private McpOAuthService CreateService(HttpClient discoveryClient, OAuthPkceService pkceService)
+    private McpOAuthService CreateService(HttpClient discoveryClient, OAuthPkceService pkceService,
+        ISecretsProtector? protector = null)
     {
         return new McpOAuthService(
             discoveryClient,
@@ -65,7 +115,8 @@ public sealed class McpOAuthServiceTests : IDisposable
             TimeProvider.System,
             NullLogger<McpOAuthService>.Instance,
             pkceService,
-            NullNotificationSink.Instance);
+            NullNotificationSink.Instance,
+            protector);
     }
 
     private static McpServerEntry CreateHttpEntry()

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -569,6 +569,8 @@ internal sealed class McpOAuthService
             {
                 foreach (var (key, value) in tokens)
                     _tokens[key] = value;
+
+                _logger.LogDebug("Loaded OAuth tokens for {Count} server(s) from {Path}", tokens.Count, _paths.SecretsPath);
             }
         }
         catch (Exception ex)

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -554,8 +554,17 @@ internal sealed class McpOAuthService
             if (!doc.RootElement.TryGetProperty(TokensSectionKey, out var section))
                 return;
 
+            var sectionJson = section.GetRawText();
+
+            // Pre-decrypt all ENC: leaves so STJ can parse non-SensitiveString
+            // types (DateTimeOffset?, string?) that were blanket-encrypted by
+            // SecretsFileWriter. SensitiveStringJsonConverter already checks for
+            // ENC: prefix and skips decryption on plaintext — no double-decrypt.
+            if (_protector is not null)
+                sectionJson = SecretsFileWriter.DecryptJsonLeaves(sectionJson, _protector);
+
             var tokens = JsonSerializer.Deserialize<Dictionary<string, McpOAuthTokenSet>>(
-                section.GetRawText(), JsonOptions);
+                sectionJson, JsonOptions);
             if (tokens is not null)
             {
                 foreach (var (key, value) in tokens)


### PR DESCRIPTION
## Summary

- **Root cause**: `SecretsFileWriter` blanket-encrypts all string leaf values in `secrets.json`, including `ExpiresAt` (`DateTimeOffset?`) and `ClientId`/`McpServerUrl` (`string?`) on `McpOAuthTokenSet`. On daemon restart, `LoadTokensFromDisk()` fails because STJ cannot parse `"ENC:..."` as a `DateTimeOffset` — the exception is swallowed and zero tokens are loaded, causing all OAuth MCP servers to fall back to "awaiting auth".
- **Fix**: Add `SecretsFileWriter.DecryptJsonLeaves()` (symmetric mirror of the existing `EncryptJsonLeaves`) and call it in `LoadTokensFromDisk()` before deserialization so all property types round-trip correctly through encryption.

## Test plan

- [x] New `DecryptJsonLeaves_round_trips_with_encrypt` test — encrypt via Write, decrypt, verify original values restored
- [x] New `DecryptJsonLeaves_leaves_plaintext_untouched` test — idempotency
- [x] New `LoadTokensFromDisk_survives_encrypted_round_trip` test — full OAuth flow with real `ISecretsProtector`, persist, simulate restart, verify all token fields including `ExpiresAt`
- [x] All 1,003 existing tests pass
- [ ] Manual: `netclaw daemon restart` → `netclaw mcp list` shows Notion as "connected"