### PR TITLE
fix(evals): timeout reduction, daemon health check, session ID fix

### DIFF
--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 RUNS="${NETCLAW_EVAL_RUNS:-5}"
 THRESHOLD="${NETCLAW_EVAL_THRESHOLD:-0.80}"
-PROMPT_TIMEOUT="${NETCLAW_EVAL_TIMEOUT:-180}"
+PROMPT_TIMEOUT="${NETCLAW_EVAL_TIMEOUT:-60}"
 NETCLAW_BIN="${NETCLAW_BIN:-netclaw}"
 NETCLAW_HOME="${NETCLAW_HOME:-$HOME/.netclaw}"
 DAEMON_LOG="${NETCLAW_EVAL_DAEMON_LOG:-$NETCLAW_HOME/logs/daemon-$(date +%F).log}"
@@ -137,6 +137,25 @@ pick_variant() {
 
 # ─── Prompt Runner ────────────────────────────────────────────────────────────
 
+check_daemon_alive() {
+    if ! "$NETCLAW_BIN" daemon status >/dev/null 2>&1; then
+        echo ""
+        echo "ERROR: Daemon died mid-run. Aborting eval." >&2
+        # Finalize whatever results we have so far
+        finalize_db
+        local overall_score
+        overall_score=$(awk "BEGIN {printf \"%.1f\", ($PASSED_CASES / ($TOTAL_CASES > 0 ? $TOTAL_CASES : 1)) * 100}")
+        echo ""
+        echo "─────────────────────────────────────────────────"
+        echo "ABORTED: Daemon not running. Partial results: $PASSED_CASES/$TOTAL_CASES ($overall_score%)"
+        if [[ -n "$RESULTS_DB" ]]; then
+            echo "Results: $RESULTS_DB (run_id: $RUN_ID)"
+        fi
+        echo "─────────────────────────────────────────────────"
+        exit 2
+    fi
+}
+
 run_prompt() {
     local prompt="$1"
     STDOUT_FILE="$TMPDIR_EVAL/stdout_$(date +%s%N).txt"
@@ -191,7 +210,8 @@ assert_identity_repo() {
 }
 
 assert_identity_session() {
-    stdout_contains 'headless/'
+    # Daemon assigns signalr/ session IDs to headless sessions, not headless/
+    stdout_contains 'signalr/' || stdout_contains 'headless/'
 }
 
 # Category 2: Skill Auto-Loading
@@ -314,6 +334,9 @@ run_case() {
     local description="$1"; shift
     local -a prompts=("$@")
     local assert_fn="assert_${case_name}"
+
+    # Bail early if daemon died
+    check_daemon_alive
 
     # Verify assertion function exists
     if ! declare -f "$assert_fn" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- **Prompt timeout**: 180s → 60s default. Most prompts complete in 15-30s on local Qwen; the old value wasted 3 minutes per hung call.
- **Daemon health check**: `check_daemon_alive()` runs before each case. If the daemon died, aborts immediately with partial results (exit code 2) instead of burning N × 60s of timeouts per remaining case.
- **Session ID assertion**: Fixed `identity_session` — daemon assigns `signalr/` session IDs to headless sessions, not `headless/`. Now checks for either format.

Discovered during baseline eval runs where the daemon died mid-run (likely #357)
and the eval burned 30+ minutes of timeouts before reporting all-zeros.

## Test plan

- [ ] Run `NETCLAW_EVAL_RUNS=1 ./evals/run-evals.sh` — verify identity_session passes
- [ ] Kill daemon mid-run — verify eval aborts immediately with partial results
- [ ] Verify 60s timeout is sufficient for all cases on local inference