### PR TITLE
feat(lifecycle): daemon startup/shutdown webhook notifications and exit reason logging

### DIFF
--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -20,12 +20,26 @@ public sealed class DaemonApi
     private readonly IHttpClientFactory _factory;
     private readonly string _endpoint;
 
+    /// <summary>
+    /// Default daemon endpoint when no override is configured.
+    /// </summary>
+    public const string DefaultEndpoint = "http://127.0.0.1:5199";
+
     public DaemonApi(IHttpClientFactory factory, IConfiguration configuration)
     {
         _factory = factory;
-        _endpoint = (configuration["Daemon:Endpoint"]
+        _endpoint = ResolveEndpoint(configuration);
+    }
+
+    /// <summary>
+    /// Resolves the daemon endpoint from config, environment, or default.
+    /// Usable without DI for callers that don't have <see cref="IConfiguration"/>.
+    /// </summary>
+    public static string ResolveEndpoint(IConfiguration? configuration = null)
+    {
+        return (configuration?["Daemon:Endpoint"]
             ?? Environment.GetEnvironmentVariable("NETCLAW_DAEMON_ENDPOINT")
-            ?? "http://127.0.0.1:5199").TrimEnd('/');
+            ?? DefaultEndpoint).TrimEnd('/');
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -108,13 +108,9 @@ public sealed partial class DaemonManager
                 $"{endpoint}/api/lifecycle/shutdown?reason={Uri.EscapeDataString(reason)}",
                 null);
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            // Daemon HTTP endpoint unreachable — proceed with signal
-        }
-        catch (TaskCanceledException)
-        {
-            // Timed out reaching daemon — proceed with signal
+            Console.Error.WriteLine($"Note: could not notify daemon of shutdown reason: {ex.Message}");
         }
 
         // Graceful shutdown: SIGTERM on Unix, Kill on Windows (no SIGTERM equivalent)

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -65,9 +65,15 @@ public sealed partial class DaemonManager
     }
 
     /// <summary>
-    /// Stops the daemon gracefully (SIGTERM on Unix, Kill on Windows).
+    /// Stops the daemon gracefully. Posts the shutdown reason to the daemon's
+    /// lifecycle endpoint before sending SIGTERM, so the daemon can fire
+    /// webhook notifications and (in the future) drain active sessions.
     /// </summary>
-    public async Task<DaemonResult> StopAsync()
+    /// <param name="reason">
+    /// Why the daemon is being stopped (e.g., "cli-stop", "update").
+    /// Included in the shutdown webhook notification.
+    /// </param>
+    public async Task<DaemonResult> StopAsync(string reason)
     {
         if (!TryReadPid(out var pid))
             return new DaemonResult(false, "Daemon is not running (no PID file).");
@@ -90,6 +96,25 @@ public sealed partial class DaemonManager
             return new DaemonResult(false,
                 $"PID {pid} is not a netclawd process (was '{process.ProcessName}'). " +
                 "Stale PID file cleaned up.");
+        }
+
+        // Notify the daemon of the shutdown reason before sending the signal.
+        // Best-effort — the daemon may already be unreachable.
+        try
+        {
+            var endpoint = DaemonApi.ResolveEndpoint();
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            await http.PostAsync(
+                $"{endpoint}/api/lifecycle/shutdown?reason={Uri.EscapeDataString(reason)}",
+                null);
+        }
+        catch (HttpRequestException)
+        {
+            // Daemon HTTP endpoint unreachable — proceed with signal
+        }
+        catch (TaskCanceledException)
+        {
+            // Timed out reaching daemon — proceed with signal
         }
 
         // Graceful shutdown: SIGTERM on Unix, Kill on Windows (no SIGTERM equivalent)
@@ -197,6 +222,10 @@ public sealed partial class DaemonManager
             ".config", "systemd", "user");
         Directory.CreateDirectory(unitDir);
 
+        // CLI binary is in the same directory as the daemon binary
+        var installDir = Path.GetDirectoryName(binaryPath)!;
+        var cliBinaryPath = Path.Combine(installDir, "netclaw");
+
         var unitPath = Path.Combine(unitDir, "netclaw.service");
         var unitContent = $"""
             [Unit]
@@ -206,6 +235,7 @@ public sealed partial class DaemonManager
             [Service]
             Type=simple
             ExecStart={binaryPath}
+            ExecStop={cliBinaryPath} daemon stop
             Restart=always
             RestartSec=5
             Environment=DOTNET_ENVIRONMENT=Production

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -416,7 +416,7 @@ static async Task RunAsync(string[] args)
                 return;
 
             case "stop":
-                var stopResult = await manager.StopAsync();
+                var stopResult = await manager.StopAsync("cli-stop");
                 WriteDaemonResult(stopResult);
                 return;
 

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -691,7 +691,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 HealthCheckResults.Add(new HealthCheckItem("Stopping daemon for config update", null));
                 NotifyHealthCheckChanged();
 
-                var stopResult = await _daemonManager.StopAsync();
+                var stopResult = await _daemonManager.StopAsync("config-update");
                 HealthCheckResults[^1] = stopResult.Success
                     ? new HealthCheckItem("Daemon stopped", true)
                     : new HealthCheckItem($"Daemon stop failed: {stopResult.Message}", false);

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -119,7 +119,7 @@ internal static class UpdateCommand
             if (daemonWasRunning)
             {
                 Console.Write("Stopping daemon...");
-                var stopResult = await manager.StopAsync();
+                var stopResult = await manager.StopAsync("update");
                 if (!stopResult.Success)
                 {
                     Console.WriteLine($" failed: {stopResult.Message}");

--- a/src/Netclaw.Configuration/OperationalAlert.cs
+++ b/src/Netclaw.Configuration/OperationalAlert.cs
@@ -13,6 +13,8 @@ public enum AlertType
     ProviderUnreachable,
     ReminderExecutionFailed,
     ReminderAutoDisabled,
+    DaemonStarted,
+    DaemonStopping,
 }
 
 /// <summary>

--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -12,6 +12,7 @@ public sealed class ConfigWatcherServiceTests : IDisposable
     private readonly NetclawPaths _paths;
     private readonly DaemonRestartSignal _restartSignal;
     private readonly FakeApplicationLifetime _lifetime;
+    private readonly RecordingSink _sink;
     private readonly ConfigWatcherService _sut;
 
     public ConfigWatcherServiceTests()
@@ -24,12 +25,19 @@ public sealed class ConfigWatcherServiceTests : IDisposable
 
         _restartSignal = new DaemonRestartSignal();
         _lifetime = new FakeApplicationLifetime();
+        _sink = new RecordingSink();
+
+        var notifier = new DaemonLifecycleNotifier(
+            _sink,
+            TimeProvider.System,
+            NullLogger<DaemonLifecycleNotifier>.Instance);
 
         _sut = new ConfigWatcherService(
             _paths,
             TimeProvider.System,
             _lifetime,
             _restartSignal,
+            notifier,
             NullLogger<ConfigWatcherService>.Instance);
     }
 
@@ -70,6 +78,19 @@ public sealed class ConfigWatcherServiceTests : IDisposable
         Assert.True(_lifetime.StopRequested);
     }
 
+    [Fact]
+    public void ValidConfigChange_NotifiesShutdown()
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
+
+        _sut.ApplyReload();
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal(AlertType.DaemonStopping, alert.Category);
+        Assert.NotNull(alert.Context);
+        Assert.Equal("config-reload", alert.Context["reason"]);
+    }
+
     public void Dispose()
     {
         _sut.Dispose();
@@ -86,5 +107,12 @@ public sealed class ConfigWatcherServiceTests : IDisposable
         public CancellationToken ApplicationStopped => CancellationToken.None;
 
         public void StopApplication() => StopRequested = true;
+    }
+
+    private sealed class RecordingSink : IOperationalNotificationSink
+    {
+        public List<OperationalAlert> Alerts { get; } = [];
+
+        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/DaemonLifecycleNotifierTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/DaemonLifecycleNotifierTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class DaemonLifecycleNotifierTests
+{
+    private readonly RecordingSink _sink = new();
+    private readonly DaemonLifecycleNotifier _sut;
+
+    public DaemonLifecycleNotifierTests()
+    {
+        _sut = new DaemonLifecycleNotifier(
+            _sink,
+            TimeProvider.System,
+            NullLogger<DaemonLifecycleNotifier>.Instance);
+    }
+
+    [Fact]
+    public void NotifyStarted_EmitsDaemonStartedAlert()
+    {
+        _sut.NotifyStarted();
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("daemon.started", alert.Type);
+        Assert.Equal(AlertType.DaemonStarted, alert.Category);
+        Assert.Equal("info", alert.Severity);
+        Assert.NotNull(alert.Context);
+        Assert.True(alert.Context.ContainsKey("pid"));
+        Assert.Equal(Environment.ProcessId.ToString(), alert.Context["pid"]);
+    }
+
+    [Fact]
+    public void NotifyShutdown_EmitsDaemonStoppingAlert()
+    {
+        _sut.NotifyShutdown("cli-stop");
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("daemon.stopping", alert.Type);
+        Assert.Equal(AlertType.DaemonStopping, alert.Category);
+        Assert.Equal("info", alert.Severity);
+        Assert.NotNull(alert.Context);
+        Assert.Equal("cli-stop", alert.Context["reason"]);
+        Assert.Equal(Environment.ProcessId.ToString(), alert.Context["pid"]);
+        Assert.Contains("cli-stop", alert.Summary);
+    }
+
+    [Fact]
+    public void NotifyShutdown_IncludesReasonInSummary()
+    {
+        _sut.NotifyShutdown("update");
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("Netclaw daemon stopping: update", alert.Summary);
+    }
+
+    private sealed class RecordingSink : IOperationalNotificationSink
+    {
+        public List<OperationalAlert> Alerts { get; } = [];
+
+        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -186,11 +186,29 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     app.MapProviderOAuthEndpoints();
 
+    // Daemon lifecycle endpoint — CLI calls this before sending SIGTERM.
+    // Future #326 hook: add session drain before returning.
+    app.MapPost("/api/lifecycle/shutdown", (
+        DaemonLifecycleNotifier notifier,
+        HttpRequest request) =>
+    {
+        var reason = request.Query["reason"].ToString();
+        if (string.IsNullOrEmpty(reason))
+            return Results.BadRequest(new { error = "reason query parameter is required" });
+
+        notifier.NotifyShutdown(reason);
+        return Results.Ok(new { reason, pid = Environment.ProcessId });
+    });
+
     // Register channel-specific tools after DI is built (tools need resolved services).
     ChannelToolRegistration.RegisterChannelTools(app.Services);
 
     // Reminder REST API
     MapReminderEndpoints(app);
+
+    // Fire startup notification after all hosted services are ready
+    app.Lifetime.ApplicationStarted.Register(() =>
+        app.Services.GetRequiredService<DaemonLifecycleNotifier>().NotifyStarted());
 
     await app.RunAsync();
 }
@@ -415,6 +433,9 @@ static void ConfigureDaemonServices(
     {
         services.AddSingleton<IOperationalNotificationSink>(NullNotificationSink.Instance);
     }
+
+    // Daemon lifecycle notifier (startup/shutdown webhooks + logging)
+    services.AddSingleton<DaemonLifecycleNotifier>();
 
     // MCP server lifecycle management
     var mcpServers = configuration.GetSection("McpServers")

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -23,6 +23,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
     private readonly TimeProvider _timeProvider;
     private readonly IHostApplicationLifetime _appLifetime;
     private readonly DaemonRestartSignal _restartSignal;
+    private readonly DaemonLifecycleNotifier _lifecycleNotifier;
     private readonly ILogger<ConfigWatcherService> _logger;
 
     private FileSystemWatcher? _watcher;
@@ -34,12 +35,14 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
         TimeProvider timeProvider,
         IHostApplicationLifetime appLifetime,
         DaemonRestartSignal restartSignal,
+        DaemonLifecycleNotifier lifecycleNotifier,
         ILogger<ConfigWatcherService> logger)
     {
         _paths = paths;
         _timeProvider = timeProvider;
         _appLifetime = appLifetime;
         _restartSignal = restartSignal;
+        _lifecycleNotifier = lifecycleNotifier;
         _logger = logger;
     }
 
@@ -131,6 +134,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
             }
 
             _logger.LogInformation("Config valid. Requesting daemon restart.");
+            _lifecycleNotifier.NotifyShutdown("config-reload");
             _restartSignal.RequestRestart();
             _appLifetime.StopApplication();
         }

--- a/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
+++ b/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Fires operational webhook notifications for daemon lifecycle events (start/stop).
+/// Called directly by the shutdown endpoint, <see cref="ConfigWatcherService"/>, and
+/// the <see cref="Microsoft.Extensions.Hosting.IHostApplicationLifetime.ApplicationStarted"/> hook.
+/// </summary>
+public sealed class DaemonLifecycleNotifier
+{
+    private readonly IOperationalNotificationSink _sink;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DaemonLifecycleNotifier> _logger;
+
+    public DaemonLifecycleNotifier(
+        IOperationalNotificationSink sink,
+        TimeProvider timeProvider,
+        ILogger<DaemonLifecycleNotifier> logger)
+    {
+        _sink = sink;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Announces that the daemon has started and is ready to accept work.
+    /// </summary>
+    public void NotifyStarted()
+    {
+        var pid = Environment.ProcessId;
+        _logger.LogInformation("Netclaw daemon started (PID {Pid})", pid);
+
+        _sink.Emit(new OperationalAlert
+        {
+            AlertId = Guid.NewGuid().ToString("N")[..12],
+            Type = "daemon.started",
+            Category = AlertType.DaemonStarted,
+            Severity = "info",
+            Summary = "Netclaw daemon started",
+            Timestamp = _timeProvider.GetUtcNow(),
+            Source = pid.ToString(CultureInfo.InvariantCulture),
+            Context = new Dictionary<string, string>
+            {
+                ["pid"] = pid.ToString(CultureInfo.InvariantCulture),
+            },
+        });
+    }
+
+    /// <summary>
+    /// Announces that the daemon is about to stop, with a reason describing why.
+    /// </summary>
+    /// <param name="reason">
+    /// Human-readable reason string (e.g., "cli-stop", "update", "config-reload").
+    /// </param>
+    public void NotifyShutdown(string reason)
+    {
+        var pid = Environment.ProcessId;
+        _logger.LogInformation("Netclaw daemon stopping (PID {Pid}, reason: {Reason})", pid, reason);
+
+        _sink.Emit(new OperationalAlert
+        {
+            AlertId = Guid.NewGuid().ToString("N")[..12],
+            Type = "daemon.stopping",
+            Category = AlertType.DaemonStopping,
+            Severity = "info",
+            Summary = $"Netclaw daemon stopping: {reason}",
+            Timestamp = _timeProvider.GetUtcNow(),
+            Source = pid.ToString(CultureInfo.InvariantCulture),
+            Context = new Dictionary<string, string>
+            {
+                ["pid"] = pid.ToString(CultureInfo.InvariantCulture),
+                ["reason"] = reason,
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DaemonLifecycleNotifier` service that fires `daemon.started` and `daemon.stopping` operational webhook notifications with PID and shutdown reason
- Adds `POST /api/lifecycle/shutdown?reason=...` endpoint — CLI calls this before sending SIGTERM for graceful shutdown coordination
- All CLI shutdown paths (`daemon stop`, `update`, init wizard) now post a reason to the endpoint before killing the daemon
- Updates systemd unit template with `ExecStop` so `systemctl stop` routes through `netclaw daemon stop`
- Extracts `DaemonApi.ResolveEndpoint()` to eliminate hardcoded endpoint duplication

Groundwork for #326 (graceful session drain) — the shutdown endpoint is the future hook point where `SessionRegistry.DrainAsync()` will be called before returning.

Closes #356
Ref #326

## Test plan

- [x] `dotnet build` passes
- [x] `DaemonLifecycleNotifierTests` — verifies started/stopping alerts have correct type, severity, PID, and reason
- [x] `ConfigWatcherServiceTests` — verifies config reload fires stopping webhook with reason "config-reload"
- [x] `dotnet slopwatch analyze` — 0 new violations