### PR TITLE
fix(reminders): soft-delete one-shot reminders to preserve history

### DIFF
--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -261,7 +261,8 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
     /// <summary>
     /// Permanently removes a reminder definition, its schedule, history, and any
-    /// in-memory tracking state. Used for automatic cleanup of fired one-shot reminders.
+    /// in-memory tracking state. Used during startup reconciliation to clean up
+    /// stale one-shot reminders whose fire time has passed.
     /// </summary>
     private async Task DeleteReminderInternalAsync(ReminderId id)
     {
@@ -501,11 +502,13 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             }
         }
 
-        // One-shot reminders cannot fire again — delete after execution
+        // One-shot reminders cannot fire again — soft-delete by disabling.
+        // The definition stays on disk so history remains queryable.
+        // Startup reconciliation will hard-delete stale disabled one-shots.
         if (definition is { Schedule.Type: ReminderScheduleType.OneShot })
         {
-            _log.Info("One-shot reminder '{0}' completed, deleting", completed.Id.Value);
-            await DeleteReminderInternalAsync(completed.Id);
+            _log.Info("One-shot reminder '{0}' completed, disabling (soft-delete)", completed.Id.Value);
+            await DisableReminderInternalAsync(completed.Id);
         }
 
         await ProcessDeferredQueueAsync();

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -777,7 +777,7 @@ static void MapReminderEndpoints(WebApplication app)
     {
         var manager = await actor.GetAsync(ct);
         var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderListResponse>(
-            new Netclaw.Actors.Reminders.ListRemindersCommand(), TimeSpan.FromSeconds(10), ct);
+            new Netclaw.Actors.Reminders.ListRemindersCommand(IncludeDisabled: false), TimeSpan.FromSeconds(10), ct);
         var projected = response.Reminders.Select(r => new
         {
             id = r.Id.Value,


### PR DESCRIPTION
## Summary

- One-shot reminders are now **disabled** (soft-deleted) after execution instead of hard-deleted, so the definition stays on disk and history remains queryable
- The `/api/reminders` list endpoint now passes `IncludeDisabled: false`, hiding completed one-shots from the visible list
- Startup reconciliation still hard-deletes stale disabled one-shots, preventing zombie accumulation

## Root cause

Commit 225ede5 changed one-shot post-execution cleanup from disable to hard-delete (`DeleteReminderInternalAsync`), which removed both the definition file and the history file. The history API endpoint gates on `definitionStore.Exists()` — with the definition gone, it returned 404. The smoke sandbox reminder lifecycle test polls `reminder history` for `fired_at` but the 404 was swallowed by `2>/dev/null || true`, so the test timed out after 150s on every CI run since that merge.

## Test plan

- [ ] All existing reminder unit tests pass (verified locally — 55/55)
- [ ] Smoke sandbox reminder lifecycle test should now pass (reminder fires → history queryable → cancel cleans up)
- [ ] Verify `netclaw reminder list` does not show completed disabled one-shots
- [ ] Verify startup reconciliation still cleans up stale one-shots on daemon restart