### PR TITLE
fix(ci): bundle CLI native libs in single-file publish and validate via packaged binary

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -58,12 +58,32 @@ jobs:
         shell: bash
         run: dotnet test -c Release
 
+      - name: "Publish CLI (single-file, self-contained)"
+        if: runner.os == 'Linux'
+        run: >
+          dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj
+          -c Release
+          -r linux-x64
+          --self-contained true
+          /p:PublishSingleFile=true
+          /p:EnableCompressionInSingleFile=true
+          /p:IncludeNativeLibrariesForSelfExtract=true
+          -o ./publish/cli
+
+      - name: "Package and stage CLI binary (simulate release install)"
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          mkdir -p ./archives ./install-test
+          tar czf ./archives/netclaw-test.tar.gz -C ./publish/cli netclaw
+          tar xzf ./archives/netclaw-test.tar.gz -C ./install-test
+
       - name: "CLI smoke tests"
         if: runner.os == 'Linux'
         shell: bash
         run: bash scripts/smoke/cli-smoke.sh
         env:
-          BUILD_CONFIG: Release
+          NETCLAW_CLI: ./install-test/netclaw
 
   slopwatch:
     name: Slopwatch

--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -106,6 +106,7 @@ jobs:
         --self-contained true
         /p:PublishSingleFile=true
         /p:EnableCompressionInSingleFile=true
+        /p:IncludeNativeLibrariesForSelfExtract=true
         /p:Version=${{ github.ref_name }}
         -o ./publish/cli
 

--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -49,6 +49,7 @@ jobs:
           --self-contained true
           /p:PublishSingleFile=true
           /p:EnableCompressionInSingleFile=true
+          /p:IncludeNativeLibrariesForSelfExtract=true
           -o ./publish/cli
 
       - name: Publish Daemon


### PR DESCRIPTION
## Summary

- Added `IncludeNativeLibrariesForSelfExtract=true` to the CLI publish step in all three workflows (`publish_release_binaries.yml`, `smoke_sandbox.yml`, `pr_validation.yml`) — the daemon already had this flag but the CLI was missing it, causing `libe_sqlite3.so` to be excluded from the packaged archive and triggering a type initializer exception in `netclaw doctor` on installed binaries
- Rewired the PR validation CLI smoke test to publish with full release flags, tar only the binary (exactly as the release pipeline does), extract to a clean directory, and run `cli-smoke.sh` from there — so the smoke test now faithfully catches packaging issues instead of testing via `dotnet run`

## Root cause

`a21a147` added `IncludeNativeLibrariesForSelfExtract=true` to the daemon publish but not the CLI. Without it, `libe_sqlite3.so` is left alongside the publish output rather than bundled in the single-file binary. Since the release archive only tars the `netclaw` executable, the native lib never ships. Users with leftover files from older non-single-file installations were masked from the issue until installed binaries diverged from the on-disk layout.

## Test plan

- [ ] `pr_validation` CI passes — smoke test runs against packaged binary, not `dotnet run`
- [ ] `netclaw doctor` Memory Checkpoint Health check passes on a clean install of the next release