### PR TITLE
fix(stats): parse token usage from empty-choices streaming chunk

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -534,6 +534,39 @@ data: [DONE]
     }
 
     [Fact]
+    public async Task StreamingResponse_EmitsUsageContent_WhenInSeparateEmptyChoicesChunk()
+    {
+        // Real-world OpenAI-compatible APIs send usage in a final chunk with empty choices array
+        const string sse = """
+            data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}
+
+            data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+            data: {"id":"abc","model":"test","choices":[],"usage":{"prompt_tokens":50,"completion_tokens":10,"total_tokens":60}}
+
+            data: [DONE]
+
+            """;
+
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sse, Encoding.UTF8, "text/event-stream")
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hello")]))
+            updates.Add(update);
+
+        var usageContents = updates.SelectMany(u => u.Contents.OfType<UsageContent>()).ToList();
+        Assert.Single(usageContents);
+        Assert.Equal(50, usageContents[0].Details.InputTokenCount);
+        Assert.Equal(10, usageContents[0].Details.OutputTokenCount);
+    }
+
+    [Fact]
     public void ParseUsage_ReturnsNull_WhenUsageFieldMissing()
     {
         using var doc = JsonDocument.Parse("""{"id":"1","model":"test","choices":[]}""");

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -467,7 +467,13 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
     private static IEnumerable<ChatResponseUpdate> ParseStreamingUpdates(JsonElement root, Dictionary<int, PendingToolCall> pendingToolCalls)
     {
         if (!root.TryGetProperty("choices", out var choices) || choices.GetArrayLength() == 0)
+        {
+            // The final usage-only chunk has an empty choices array — still parse usage
+            var usageOnly = ParseUsage(root);
+            if (usageOnly is not null)
+                yield return new ChatResponseUpdate(ChatRole.Assistant, [new UsageContent(usageOnly)]);
             yield break;
+        }
 
         var choice = choices[0];
         if (!choice.TryGetProperty("delta", out var delta))


### PR DESCRIPTION
## Summary

- OpenAI-compatible providers send token usage in a final SSE chunk with an **empty `choices` array**. `ParseStreamingUpdates` returned early on empty choices before reaching `ParseUsage`, silently discarding all token data.
- Added handling for the usage-only chunk before the early return so token statistics flow through to `DailyStatsActor`.
- Added regression test that reproduces the real-world SSE format (usage in a separate chunk with empty choices).

**Verified via binary swap**: `netclaw stats` now reports `tokens: in=33,131 out=353` after the fix.

## Test plan

- [x] Existing `OpenAiCompatibleChatClientTests` pass (28/28)
- [x] New test `StreamingResponse_EmitsUsageContent_WhenInSeparateEmptyChoicesChunk` passes
- [x] Binary swap test confirms `netclaw stats` reports token usage on live daemon