### PR TITLE
fix(config): add Format field to webhook schema + enforce schema sync rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ Before coding a capability, discover in this order:
 If planning and implementation artifacts conflict, fix planning artifacts first.
 If discovery artifacts conflict with each other, update them before implementing.
 
+## Configuration Schema Sync Rule
+
+When adding or changing properties on any `*Config` type in `Netclaw.Configuration`,
+update `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` in the same PR.
+The schema uses `"additionalProperties": false` throughout — any new property that is
+missing from the schema will be rejected by `ConfigSchemaDoctorCheck` at runtime.
+
 ## Universal Quality Bar
 
 - secure-by-default behavior for gateway and tools

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -169,6 +169,12 @@
               "Headers": {
                 "type": ["object", "null"],
                 "additionalProperties": { "type": "string" }
+              },
+              "Format": {
+                "type": "string",
+                "enum": ["Generic", "Slack"],
+                "default": "Generic",
+                "description": "Payload format for this webhook target. Generic = JSON envelope; Slack = Block Kit format."
               }
             },
             "required": ["Url"],


### PR DESCRIPTION
## Summary

- Adds `Format` enum (`Generic` | `Slack`) to the webhook item definition in `netclaw-config.v1.schema.json` — the property existed on `WebhookTarget` but was missing from the schema, causing `ConfigSchemaDoctorCheck` to reject any `netclaw.json` that set `"Format": "Slack"`
- Adds a **Configuration Schema Sync Rule** to `AGENTS.md`/`CLAUDE.md` so agents know to keep the schema in sync whenever a `*Config` property is added or changed

## Root cause

`WebhookFormat` was added in #363 (feat(slack): Block Kit webhook formatter) but the JSON schema was never updated. Because the schema uses `"additionalProperties": false` on webhook items, any config with `"Format": "Slack"` would be flagged as invalid by doctor.

## Related

Closes #368 is tracked separately for the `--fix` / remediation UX improvements.

## Test plan

- [ ] Verify `netclaw.json` with `"Format": "Slack"` on a webhook target passes `netclaw doctor` schema check
- [ ] Verify `netclaw.json` without `Format` field still passes (field is optional, defaults to `Generic`)
- [ ] Verify `netclaw.json` with an invalid format value (e.g. `"Format": "Discord"`) fails schema validation