### PR TITLE
fix(config): exclude secrets.json from config watcher restart trigger

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -45,12 +45,27 @@ public sealed class ConfigWatcherServiceTests : IDisposable
     public void ValidConfigChange_TriggersRestart()
     {
         File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
-        File.WriteAllText(_paths.SecretsPath, """{ "ApiKeys": {} }""");
 
         _sut.ApplyReload();
 
         Assert.True(_restartSignal.RestartRequested);
         Assert.True(_lifetime.StopRequested);
+    }
+
+    [Theory]
+    [InlineData("secrets.json")]
+    [InlineData("mcp-oauth-metadata.json")]
+    [InlineData("random.txt")]
+    [InlineData(null)]
+    public void NonConfigFiles_AreNotWatched(string? fileName)
+    {
+        Assert.False(ConfigWatcherService.IsWatchedFile(fileName));
+    }
+
+    [Fact]
+    public void NetclawJson_IsWatched()
+    {
+        Assert.True(ConfigWatcherService.IsWatchedFile("netclaw.json"));
     }
 
     [Fact]

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -6,9 +6,9 @@ using Netclaw.Configuration;
 namespace Netclaw.Daemon.Services;
 
 /// <summary>
-/// Monitors <c>~/.netclaw/config/</c> for changes to <c>netclaw.json</c> and
-/// <c>secrets.json</c>. Debounces file system events and validates new config
-/// before applying. See SPEC-011 §Configuration Hot-Reload.
+/// Monitors <c>~/.netclaw/config/</c> for changes to <c>netclaw.json</c>.
+/// Debounces file system events and validates new config before applying.
+/// See SPEC-011 §Configuration Hot-Reload.
 ///
 /// <para>
 /// Single reload trigger: all config changes go to disk first (TUI wizard,
@@ -126,8 +126,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
 
             // Validate JSON structure of both config files before triggering restart.
             // Full semantic validation happens during the next startup cycle.
-            if (!ValidateConfigJson(_paths.NetclawConfigPath) ||
-                !ValidateConfigJson(_paths.SecretsPath))
+            if (!ValidateConfigJson(_paths.NetclawConfigPath))
             {
                 _logger.LogWarning("Config validation failed. Keeping current config — no restart.");
                 return;
@@ -163,8 +162,8 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
         }
     }
 
-    private static bool IsWatchedFile(string? fileName) =>
-        fileName is "netclaw.json" or "secrets.json";
+    internal static bool IsWatchedFile(string? fileName) =>
+        fileName is "netclaw.json";
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary

Fixes #372.

- `ConfigWatcherService` watched both `netclaw.json` and `secrets.json`, so OAuth token refreshes (which write to `secrets.json`) triggered daemon restarts mid-session, killing active turns
- Narrowed `IsWatchedFile` to only `netclaw.json` — secret changes are loaded on-demand and never require a restart
- Removed the now-unnecessary `secrets.json` JSON validation from `ApplyReload`

## Test plan

- [x] Existing `ConfigWatcherServiceTests` pass (9 tests)
- [x] New `NonConfigFiles_AreNotWatched` theory covers `secrets.json`, `mcp-oauth-metadata.json`, `random.txt`, and `null`
- [x] New `NetclawJson_IsWatched` confirms `netclaw.json` still triggers restart