### PR TITLE
fix(slack): validate Slack API responses and fix silent delivery drops

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -670,6 +670,122 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Content_rejection_msg_too_long_sends_message_too_large_feedback()
+    {
+        var feedbackPipeline = new RecordingSessionPipeline([
+            new TextOutput
+            {
+                SessionId = new SessionId("D7/9200.1"),
+                TimestampMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+                Text = new string('x', 50_000)
+            },
+            new TurnCompleted
+            {
+                SessionId = new SessionId("D7/9200.1"),
+                TurnNumber = 1
+            }
+        ]);
+
+        _replyClient.PostFailures.Enqueue(new SlackMessageDeliveryException(
+            errorCode: "msg_too_long",
+            failureKind: DeliveryFailureKind.MessageTooLarge,
+            message: "msg_too_long"));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: feedbackPipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var actor = Sys.ActorOf(SlackThreadBindingActor.CreateProps(
+            new SessionId("D7/9200.1"),
+            new SlackChannelId("D7"),
+            new SlackThreadTs("9200.1"),
+            deps), "slack-thread-msg-too-long-test");
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = Assert.Single(feedbackPipeline.Feedback);
+            var failure = Assert.IsType<DeliveryFailed>(feedback);
+            Assert.Equal(DeliveryFailureKind.MessageTooLarge, failure.FailureKind);
+            Assert.Equal(1, failure.TurnNumber);
+            Assert.Contains("msg_too_long", failure.ErrorMessage);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Watch(actor);
+        Sys.Stop(actor);
+        await ExpectTerminatedAsync(actor);
+    }
+
+    [Fact]
+    public async Task Content_rejection_invalid_blocks_sends_content_rejected_feedback()
+    {
+        var feedbackPipeline = new RecordingSessionPipeline([
+            new TextOutput
+            {
+                SessionId = new SessionId("D7/9300.1"),
+                TimestampMs = TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+                Text = "Some text with bad formatting"
+            },
+            new TurnCompleted
+            {
+                SessionId = new SessionId("D7/9300.1"),
+                TurnNumber = 1
+            }
+        ]);
+
+        _replyClient.PostFailures.Enqueue(new SlackMessageDeliveryException(
+            errorCode: "invalid_blocks",
+            failureKind: DeliveryFailureKind.ContentRejected,
+            message: "invalid_blocks"));
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: feedbackPipeline,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = false,
+                AllowDirectMessages = true,
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner());
+
+        var actor = Sys.ActorOf(SlackThreadBindingActor.CreateProps(
+            new SessionId("D7/9300.1"),
+            new SlackChannelId("D7"),
+            new SlackThreadTs("9300.1"),
+            deps), "slack-thread-invalid-blocks-test");
+
+        await AwaitAssertAsync(() =>
+        {
+            var feedback = Assert.Single(feedbackPipeline.Feedback);
+            var failure = Assert.IsType<DeliveryFailed>(feedback);
+            Assert.Equal(DeliveryFailureKind.ContentRejected, failure.FailureKind);
+            Assert.Equal(1, failure.TurnNumber);
+            Assert.Contains("invalid_blocks", failure.ErrorMessage);
+        }, duration: TimeSpan.FromSeconds(10));
+
+        Watch(actor);
+        Sys.Stop(actor);
+        await ExpectTerminatedAsync(actor);
+    }
+
+    [Fact]
     public async Task Inbound_image_with_real_scanner_flows_to_llm()
     {
         // Uses the production MagicByteContentScanner instead of NullContentScanner

--- a/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
@@ -101,6 +101,8 @@ public sealed class SlackReplyClientTests
     [InlineData("too_many_attachments", DeliveryFailureKind.UnsupportedContent)]
     [InlineData("not_in_channel", DeliveryFailureKind.PermissionDenied)]
     [InlineData("channel_not_found", DeliveryFailureKind.PermissionDenied)]
+    [InlineData("missing_scope", DeliveryFailureKind.PermissionDenied)]
+    [InlineData("no_permission", DeliveryFailureKind.PermissionDenied)]
     [InlineData("rate_limited", DeliveryFailureKind.TransportFailure)]
     [InlineData("some_unknown_error", DeliveryFailureKind.Unknown)]
     public void MapFailureKind_classifies_error_codes_correctly(string errorCode, DeliveryFailureKind expected)

--- a/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
@@ -1,0 +1,202 @@
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Slack;
+using SlackNet;
+using SlackNet.Blocks;
+using SlackNet.Events;
+using SlackNet.WebApi;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackReplyClientTests
+{
+    private static SlackException CreateSlackException(string errorCode) =>
+        new(new ErrorResponse { Error = errorCode });
+
+    [Fact]
+    public async Task PostThreadReplyAsync_null_response_throws_phantom_success()
+    {
+        var fakeChat = new FakeChatApi(response: null);
+        var fakeClient = new FakeSlackApiClient(fakeChat);
+        var client = new SlackReplyClient(fakeClient);
+
+        var ex = await Assert.ThrowsAsync<SlackMessageDeliveryException>(() =>
+            client.PostThreadReplyAsync(new SlackPostMessage(
+                ChannelId: new SlackChannelId("C123"),
+                ThreadTs: new SlackThreadTs("1234.5678"),
+                Text: "hello")));
+
+        Assert.Equal("phantom_success", ex.ErrorCode);
+        Assert.Equal(DeliveryFailureKind.TransportFailure, ex.FailureKind);
+    }
+
+    [Fact]
+    public async Task PostThreadReplyAsync_empty_ts_throws_phantom_success()
+    {
+        var fakeChat = new FakeChatApi(response: new PostMessageResponse { Ts = "" });
+        var fakeClient = new FakeSlackApiClient(fakeChat);
+        var client = new SlackReplyClient(fakeClient);
+
+        var ex = await Assert.ThrowsAsync<SlackMessageDeliveryException>(() =>
+            client.PostThreadReplyAsync(new SlackPostMessage(
+                ChannelId: new SlackChannelId("C123"),
+                ThreadTs: new SlackThreadTs("1234.5678"),
+                Text: "hello")));
+
+        Assert.Equal("phantom_success", ex.ErrorCode);
+        Assert.Equal(DeliveryFailureKind.TransportFailure, ex.FailureKind);
+    }
+
+    [Fact]
+    public async Task PostThreadReplyAsync_slack_exception_wraps_to_delivery_exception()
+    {
+        var fakeChat = new FakeChatApi(throwOnPost: CreateSlackException("msg_too_long"));
+        var fakeClient = new FakeSlackApiClient(fakeChat);
+        var client = new SlackReplyClient(fakeClient);
+
+        var ex = await Assert.ThrowsAsync<SlackMessageDeliveryException>(() =>
+            client.PostThreadReplyAsync(new SlackPostMessage(
+                ChannelId: new SlackChannelId("C123"),
+                ThreadTs: new SlackThreadTs("1234.5678"),
+                Text: new string('x', 50_000))));
+
+        Assert.Equal("msg_too_long", ex.ErrorCode);
+        Assert.Equal(DeliveryFailureKind.MessageTooLarge, ex.FailureKind);
+    }
+
+    [Fact]
+    public async Task PostThreadReplyAsync_rate_limited_maps_to_transport_failure()
+    {
+        var fakeChat = new FakeChatApi(throwOnPost: CreateSlackException("rate_limited"));
+        var fakeClient = new FakeSlackApiClient(fakeChat);
+        var client = new SlackReplyClient(fakeClient);
+
+        var ex = await Assert.ThrowsAsync<SlackMessageDeliveryException>(() =>
+            client.PostThreadReplyAsync(new SlackPostMessage(
+                ChannelId: new SlackChannelId("C123"),
+                ThreadTs: new SlackThreadTs("1234.5678"),
+                Text: "hello")));
+
+        Assert.Equal("rate_limited", ex.ErrorCode);
+        Assert.Equal(DeliveryFailureKind.TransportFailure, ex.FailureKind);
+    }
+
+    [Fact]
+    public async Task PostThreadReplyAsync_valid_response_succeeds()
+    {
+        var fakeChat = new FakeChatApi(response: new PostMessageResponse { Ts = "1234.5678", Channel = "C123" });
+        var fakeClient = new FakeSlackApiClient(fakeChat);
+        var client = new SlackReplyClient(fakeClient);
+
+        await client.PostThreadReplyAsync(new SlackPostMessage(
+            ChannelId: new SlackChannelId("C123"),
+            ThreadTs: new SlackThreadTs("1234.5678"),
+            Text: "hello"));
+    }
+
+    [Theory]
+    [InlineData("invalid_blocks", DeliveryFailureKind.ContentRejected)]
+    [InlineData("invalid_arguments", DeliveryFailureKind.ContentRejected)]
+    [InlineData("msg_too_long", DeliveryFailureKind.MessageTooLarge)]
+    [InlineData("too_many_attachments", DeliveryFailureKind.UnsupportedContent)]
+    [InlineData("not_in_channel", DeliveryFailureKind.PermissionDenied)]
+    [InlineData("channel_not_found", DeliveryFailureKind.PermissionDenied)]
+    [InlineData("rate_limited", DeliveryFailureKind.TransportFailure)]
+    [InlineData("some_unknown_error", DeliveryFailureKind.Unknown)]
+    public void MapFailureKind_classifies_error_codes_correctly(string errorCode, DeliveryFailureKind expected)
+    {
+        Assert.Equal(expected, SlackReplyClient.MapFailureKind(errorCode));
+    }
+
+    /// <summary>
+    /// Minimal fake that only implements PostMessage for testing SlackReplyClient.
+    /// </summary>
+    private sealed class FakeChatApi(PostMessageResponse? response = null, SlackException? throwOnPost = null) : IChatApi
+    {
+        public Task<PostMessageResponse> PostMessage(Message message, CancellationToken cancellationToken = default)
+        {
+            if (throwOnPost is not null)
+                throw throwOnPost;
+            return Task.FromResult(response!);
+        }
+
+        public Task<MessageTsResponse> Delete(string ts, string channelId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<MessageTsResponse> MeMessage(string channel, string text, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ScheduleMessageResponse> ScheduleMessage(Message message, DateTime postAt, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteScheduledMessage(string messageId, string channelId, bool? asUser = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<PostEphemeralResponse> PostEphemeral(string userId, Message message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task Unfurl(string channelId, string ts, IDictionary<string, Attachment>? unfurls = null, bool userAuthRequired = false, IEnumerable<Block>? userAuthBlocks = null, string? userAuthMessage = null, string? userAuthUrl = null, UnfurlMetadata? metadata = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task Unfurl(LinkSource source, string unfurlId, IDictionary<string, Attachment>? unfurls = null, bool userAuthRequired = false, IEnumerable<Block>? userAuthBlocks = null, string? userAuthMessage = null, string? userAuthUrl = null, UnfurlMetadata? metadata = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<MessageUpdateResponse> Update(MessageUpdate messageUpdate, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<PermalinkResponse> GetPermalink(string channelId, string messageTs, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ScheduledMessageListResponse> ScheduledMessagesList(string? channel = null, DateTime? latestDateTime = null, DateTime? oldestDateTime = null, string? cursor = null, int limit = 100, string? teamId = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<MessageTsResponse> StartStream(string channel, string threadTs, string? markdownText = null, string? recipientUserId = null, string? recipientTeamId = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<MessageTsResponse> AppendStream(string channel, string ts, string markdownText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<PostMessageResponse> StopStream(string channel, string ts, string? markdownText = null, IEnumerable<Block>? blocks = null, object? metadataObject = null, MessageMetadata? metadataJson = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<PostMessageResponse> UpdateStream(string channel, string ts, IEnumerable<Block>? newBlocks = null, string? markdownText = null, object? metadataObject = null, MessageMetadata? metadataJson = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Minimal fake ISlackApiClient that exposes only Chat property for testing.
+    /// </summary>
+    private sealed class FakeSlackApiClient(IChatApi chat) : ISlackApiClient
+    {
+        public IChatApi Chat => chat;
+
+        public IApiApi Api => throw new NotImplementedException();
+        public IAppsConnectionsApi AppsConnectionsApi => throw new NotImplementedException();
+        public IAppsEventAuthorizationsApi AppsEventAuthorizations => throw new NotImplementedException();
+        public IAssistantSearchApi AssistantSearch => throw new NotImplementedException();
+        public IAssistantThreadsApi AssistantThreads => throw new NotImplementedException();
+        public IAuthApi Auth => throw new NotImplementedException();
+        public IBookmarksApi Bookmarks => throw new NotImplementedException();
+        public IBotsApi Bots => throw new NotImplementedException();
+        public ICallParticipantsApi CallParticipants => throw new NotImplementedException();
+        public ICallsApi Calls => throw new NotImplementedException();
+        public ICanvasesApi Canvases => throw new NotImplementedException();
+        public IConversationsApi Conversations => throw new NotImplementedException();
+        public IDialogApi Dialog => throw new NotImplementedException();
+        public IDndApi Dnd => throw new NotImplementedException();
+        public IEmojiApi Emoji => throw new NotImplementedException();
+        public IEntityApi Entity => throw new NotImplementedException();
+        public IExternalTeamsApi ExternalTeams => throw new NotImplementedException();
+        public IFileCommentsApi FileComments => throw new NotImplementedException();
+        public IFilesApi Files => throw new NotImplementedException();
+        public IListApi List => throw new NotImplementedException();
+        public IListDownloadApi ListDownload => throw new NotImplementedException();
+        public IListItemsApi ListItems => throw new NotImplementedException();
+        public IListAccessApi ListAccess => throw new NotImplementedException();
+        public IMigrationApi Migration => throw new NotImplementedException();
+        public IOAuthApi OAuth => throw new NotImplementedException();
+        public IOAuthV2Api OAuthV2 => throw new NotImplementedException();
+        public IOpenIdApi OpenIdApi => throw new NotImplementedException();
+        public IPinsApi Pins => throw new NotImplementedException();
+        public IReactionsApi Reactions => throw new NotImplementedException();
+        public IRemindersApi Reminders => throw new NotImplementedException();
+        public IRemoteFilesApi RemoteFiles => throw new NotImplementedException();
+        public IRtmApi Rtm => throw new NotImplementedException();
+        public IScheduledMessagesApi ScheduledMessages => throw new NotImplementedException();
+        public ISearchApi Search => throw new NotImplementedException();
+        public ITeamApi Team => throw new NotImplementedException();
+        public ITeamBillingApi TeamBilling => throw new NotImplementedException();
+        public ITeamPreferencesApi TeamPreferences => throw new NotImplementedException();
+        public ITeamProfileApi TeamProfile => throw new NotImplementedException();
+        public IToolingApi Tooling => throw new NotImplementedException();
+        public IUserGroupsApi UserGroups => throw new NotImplementedException();
+        public IUserGroupUsersApi UserGroupUsers => throw new NotImplementedException();
+        public IUserProfileApi UserProfile => throw new NotImplementedException();
+        public IUsersApi Users => throw new NotImplementedException();
+        public IViewsApi Views => throw new NotImplementedException();
+        public bool DisableRetryOnRateLimit { get; set; }
+        public bool WarningsAsErrors { get; set; }
+        public ISlackApiClient WithAccessToken(string accessToken) => throw new NotImplementedException();
+        public Task Get(string apiMethod, Dictionary<string, object> args, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<T> Get<T>(string apiMethod, Dictionary<string, object> args, CancellationToken cancellationToken) where T : class => throw new NotImplementedException();
+        public Task Post(string apiMethod, Dictionary<string, object> args, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<T> Post<T>(string apiMethod, Dictionary<string, object> args, CancellationToken cancellationToken) where T : class => throw new NotImplementedException();
+        public Task Post(string apiMethod, Dictionary<string, object> args, HttpContent content, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<T> Post<T>(string apiMethod, Dictionary<string, object> args, HttpContent content, CancellationToken cancellationToken) where T : class => throw new NotImplementedException();
+        public Task Respond(string responseUrl, IReadOnlyMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task PostToWebhook(string webhookUrl, Message message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+}

--- a/src/Netclaw.Channels.Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackConversationActor.cs
@@ -38,7 +38,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (IsBotMessage(message))
             {
                 _log.Debug("Ignoring Slack event {0}: bot/self message", message.EventId);
-                ChannelTelemetry.RecordSlackEventDropped("bot_message");
+                ChannelTelemetry.RecordSlackEventFiltered("bot_message");
                 return;
             }
 
@@ -66,7 +66,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (decision is SlackRoutingDecision.Ignore)
             {
                 _log.Debug("Ignoring Slack event {0}: routing policy decision ignore", message.EventId);
-                ChannelTelemetry.RecordSlackEventDropped("routing_policy_ignore");
+                ChannelTelemetry.RecordSlackEventFiltered("routing_policy_ignore");
                 return;
             }
 

--- a/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
@@ -28,7 +28,7 @@ public sealed class SlackGatewayActor : ReceiveActor
             if (!TryMarkEventProcessed(message.EventId))
             {
                 _log.Debug("Dropping duplicate Slack event {0}", message.EventId);
-                ChannelTelemetry.RecordSlackEventDropped("duplicate_event");
+                ChannelTelemetry.RecordSlackEventFiltered("duplicate_event");
                 return;
             }
 

--- a/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
@@ -1,3 +1,4 @@
+using Netclaw.Actors.Protocol;
 using SlackNet;
 using SlackNet.WebApi;
 
@@ -7,21 +8,52 @@ public sealed class SlackOutboundClient(ISlackApiClient slackApiClient) : ISlack
 {
     public async Task<SlackChannelId> OpenDmChannelAsync(SlackUserId userId, CancellationToken ct = default)
     {
-        var channelId = await slackApiClient.Conversations.Open(new[] { userId.Value }, ct);
-        return new SlackChannelId(channelId);
+        try
+        {
+            var channelId = await slackApiClient.Conversations.Open(new[] { userId.Value }, ct);
+            return new SlackChannelId(channelId);
+        }
+        catch (SlackException ex)
+        {
+            throw new SlackMessageDeliveryException(
+                ex.ErrorCode,
+                SlackReplyClient.MapFailureKind(ex.ErrorCode),
+                ex.Message,
+                ex);
+        }
     }
 
     public async Task<SlackNewThread> PostNewThreadAsync(SlackChannelId channelId, string text, CancellationToken ct = default)
     {
         var blocks = SlackBlockConverter.Convert(text);
-        var response = await slackApiClient.Chat.PostMessage(new Message
-        {
-            Channel = channelId.Value,
-            Text = text,
-            Blocks = blocks
-        }, ct);
 
-        var threadTs = new SlackThreadTs(response.Ts);
-        return new SlackNewThread(channelId, threadTs);
+        try
+        {
+            var response = await slackApiClient.Chat.PostMessage(new Message
+            {
+                Channel = channelId.Value,
+                Text = text,
+                Blocks = blocks
+            }, ct);
+
+            if (response is null || string.IsNullOrEmpty(response.Ts))
+            {
+                throw new SlackMessageDeliveryException(
+                    "phantom_success",
+                    DeliveryFailureKind.TransportFailure,
+                    "Slack returned no message timestamp — the message was not delivered");
+            }
+
+            var threadTs = new SlackThreadTs(response.Ts);
+            return new SlackNewThread(channelId, threadTs);
+        }
+        catch (SlackException ex)
+        {
+            throw new SlackMessageDeliveryException(
+                ex.ErrorCode,
+                SlackReplyClient.MapFailureKind(ex.ErrorCode),
+                ex.Message,
+                ex);
+        }
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
@@ -25,10 +25,10 @@ public sealed class SlackOutboundClient(ISlackApiClient slackApiClient) : ISlack
 
     public async Task<SlackNewThread> PostNewThreadAsync(SlackChannelId channelId, string text, CancellationToken ct = default)
     {
-        var blocks = SlackBlockConverter.Convert(text);
-
         try
         {
+            var blocks = SlackBlockConverter.Convert(text);
+
             var response = await slackApiClient.Chat.PostMessage(new Message
             {
                 Channel = channelId.Value,

--- a/src/Netclaw.Channels.Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackReplyClient.cs
@@ -12,13 +12,21 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
 
         try
         {
-            await slackApiClient.Chat.PostMessage(new Message
+            var response = await slackApiClient.Chat.PostMessage(new Message
             {
                 Channel = message.ChannelId.Value,
                 ThreadTs = message.ThreadTs.Value,
                 Text = message.Text,
                 Blocks = blocks
             }, cancellationToken);
+
+            if (response is null || string.IsNullOrEmpty(response.Ts))
+            {
+                throw new SlackMessageDeliveryException(
+                    "phantom_success",
+                    DeliveryFailureKind.TransportFailure,
+                    "Slack returned no message timestamp — the message was not delivered");
+            }
         }
         catch (SlackException ex)
         {
@@ -30,13 +38,14 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
         }
     }
 
-    private static DeliveryFailureKind MapFailureKind(string? errorCode)
+    internal static DeliveryFailureKind MapFailureKind(string? errorCode)
         => errorCode switch
         {
             "invalid_blocks" or "invalid_arguments" => DeliveryFailureKind.ContentRejected,
             "msg_too_long" => DeliveryFailureKind.MessageTooLarge,
             "too_many_attachments" => DeliveryFailureKind.UnsupportedContent,
             "not_in_channel" or "channel_not_found" or "missing_scope" or "no_permission" => DeliveryFailureKind.PermissionDenied,
+            "rate_limited" => DeliveryFailureKind.TransportFailure,
             _ => DeliveryFailureKind.Unknown
         };
 
@@ -53,12 +62,20 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             await using var stream = System.IO.File.OpenRead(filePath);
             var upload = new FileUpload(resolvedFilename, stream);
 
-            await slackApiClient.Files.Upload(
+            var response = await slackApiClient.Files.Upload(
                 upload,
                 channelId.Value,
                 threadTs.Value,
                 initialComment: null,
                 cancellationToken);
+
+            if (response is null)
+            {
+                throw new SlackMessageDeliveryException(
+                    "phantom_success",
+                    DeliveryFailureKind.TransportFailure,
+                    "Slack returned no file reference — the upload was not delivered");
+            }
         }
         catch (SlackException ex)
         {

--- a/src/Netclaw.Channels.Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackReplyClient.cs
@@ -8,10 +8,10 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
 {
     public async Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
     {
-        var blocks = SlackBlockConverter.Convert(message.Text);
-
         try
         {
+            var blocks = SlackBlockConverter.Convert(message.Text);
+
             var response = await slackApiClient.Chat.PostMessage(new Message
             {
                 Channel = message.ChannelId.Value,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -522,8 +522,9 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         }
         catch (SlackMessageDeliveryException ex)
         {
-            _log.Error(ex, "Slack rejected reply for session {0} with error code {1}", _sessionId.Value, ex.ErrorCode ?? "unknown");
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            _log.Warning("Slack delivery rejected for session {SessionId} error={ErrorCode} kind={FailureKind}",
+                _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
+            ChannelTelemetry.RecordSlackReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)
@@ -594,11 +595,9 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
         }
         catch (SlackMessageDeliveryException ex)
         {
-            _log.Error(ex, "Slack rejected file upload {FileName} for session {SessionId} with error code {ErrorCode}",
-                file.FileName,
-                _sessionId.Value,
-                ex.ErrorCode ?? "unknown");
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            _log.Warning("Slack delivery rejected for file upload {FileName} session={SessionId} error={ErrorCode} kind={FailureKind}",
+                file.FileName, _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
+            ChannelTelemetry.RecordSlackReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)

--- a/src/Netclaw.Channels.Slack/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels.Slack/Telemetry/ChannelTelemetry.cs
@@ -15,6 +15,9 @@ public static class ChannelTelemetry
     private static readonly Counter<long> SlackEventsDropped =
         Meter.CreateCounter<long>("netclaw.slack.events.dropped");
 
+    private static readonly Counter<long> SlackEventsFiltered =
+        Meter.CreateCounter<long>("netclaw.slack.events.filtered");
+
     private static readonly Counter<long> SlackEventsRouted =
         Meter.CreateCounter<long>("netclaw.slack.events.routed");
 
@@ -24,31 +27,33 @@ public static class ChannelTelemetry
     private static readonly Counter<long> SlackRepliesPosted =
         Meter.CreateCounter<long>("netclaw.slack.replies.posted");
 
+    private static readonly Counter<long> SlackRepliesRejected =
+        Meter.CreateCounter<long>("netclaw.slack.replies.rejected");
+
     private static readonly Counter<long> SlackRepliesFailed =
         Meter.CreateCounter<long>("netclaw.slack.replies.failed");
-
-    private static readonly Counter<long> SlackRepliesPlainTextFallback =
-        Meter.CreateCounter<long>("netclaw.slack.replies.plain_text_fallback");
 
     private static readonly Histogram<double> SlackReplyDurationMs =
         Meter.CreateHistogram<double>("netclaw.slack.reply.duration.ms", unit: "ms");
 
     private static long _slackEventsReceivedTotal;
     private static long _slackEventsDroppedTotal;
+    private static long _slackEventsFilteredTotal;
     private static long _slackEventsRoutedTotal;
     private static long _slackMessagesEnqueuedTotal;
     private static long _slackRepliesPostedTotal;
+    private static long _slackRepliesRejectedTotal;
     private static long _slackRepliesFailedTotal;
-    private static long _slackRepliesPlainTextFallbackTotal;
 
     public sealed record Snapshot(
         long SlackEventsReceived,
         long SlackEventsDropped,
+        long SlackEventsFiltered,
         long SlackEventsRouted,
         long SlackMessagesEnqueued,
         long SlackRepliesPosted,
-        long SlackRepliesFailed,
-        long SlackRepliesPlainTextFallback);
+        long SlackRepliesRejected,
+        long SlackRepliesFailed);
 
     public static void RecordSlackEventReceived(string kind)
     {
@@ -60,6 +65,12 @@ public static class ChannelTelemetry
     {
         Interlocked.Increment(ref _slackEventsDroppedTotal);
         SlackEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    public static void RecordSlackEventFiltered(string reason)
+    {
+        Interlocked.Increment(ref _slackEventsFilteredTotal);
+        SlackEventsFiltered.Add(1, new KeyValuePair<string, object?>("reason", reason));
     }
 
     public static void RecordSlackEventRouted(string kind)
@@ -81,6 +92,12 @@ public static class ChannelTelemetry
         SlackReplyDurationMs.Record(durationMs);
     }
 
+    public static void RecordSlackReplyRejected(string? errorCode)
+    {
+        Interlocked.Increment(ref _slackRepliesRejectedTotal);
+        SlackRepliesRejected.Add(1, new KeyValuePair<string, object?>("error_code", errorCode ?? "unknown"));
+    }
+
     public static void RecordSlackReplyFailed(double durationMs)
     {
         Interlocked.Increment(ref _slackRepliesFailedTotal);
@@ -88,30 +105,26 @@ public static class ChannelTelemetry
         SlackReplyDurationMs.Record(durationMs);
     }
 
-    public static void RecordSlackReplyPlainTextFallback()
-    {
-        Interlocked.Increment(ref _slackRepliesPlainTextFallbackTotal);
-        SlackRepliesPlainTextFallback.Add(1);
-    }
-
     public static Snapshot GetSnapshot()
         => new(
             SlackEventsReceived: Interlocked.Read(ref _slackEventsReceivedTotal),
             SlackEventsDropped: Interlocked.Read(ref _slackEventsDroppedTotal),
+            SlackEventsFiltered: Interlocked.Read(ref _slackEventsFilteredTotal),
             SlackEventsRouted: Interlocked.Read(ref _slackEventsRoutedTotal),
             SlackMessagesEnqueued: Interlocked.Read(ref _slackMessagesEnqueuedTotal),
             SlackRepliesPosted: Interlocked.Read(ref _slackRepliesPostedTotal),
-            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal),
-            SlackRepliesPlainTextFallback: Interlocked.Read(ref _slackRepliesPlainTextFallbackTotal));
+            SlackRepliesRejected: Interlocked.Read(ref _slackRepliesRejectedTotal),
+            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal));
 
     internal static void ResetForTests()
     {
         Interlocked.Exchange(ref _slackEventsReceivedTotal, 0);
         Interlocked.Exchange(ref _slackEventsDroppedTotal, 0);
+        Interlocked.Exchange(ref _slackEventsFilteredTotal, 0);
         Interlocked.Exchange(ref _slackEventsRoutedTotal, 0);
         Interlocked.Exchange(ref _slackMessagesEnqueuedTotal, 0);
         Interlocked.Exchange(ref _slackRepliesPostedTotal, 0);
+        Interlocked.Exchange(ref _slackRepliesRejectedTotal, 0);
         Interlocked.Exchange(ref _slackRepliesFailedTotal, 0);
-        Interlocked.Exchange(ref _slackRepliesPlainTextFallbackTotal, 0);
     }
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1108,7 +1108,7 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
     if (status.Telemetry.SlackCounters is { } counters)
     {
         Console.WriteLine(
-            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} reply_failed={counters.RepliesFailed} plain_text_fallback={counters.RepliesPlainTextFallback}");
+            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} rejected={counters.RepliesRejected} reply_failed={counters.RepliesFailed}");
     }
 
     if (status.Model is { } model)
@@ -1253,7 +1253,7 @@ static void WriteStatsResult(DaemonStats.Response stats, int? days)
 
     Console.WriteLine("slack:");
     Console.WriteLine($"  events: recv={stats.SlackActivity.EventsReceived} routed={stats.SlackActivity.EventsRouted} dropped={stats.SlackActivity.EventsDropped}");
-    Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} failed={stats.SlackActivity.RepliesFailed} plain_text_fallback={stats.SlackActivity.RepliesPlainTextFallback}");
+    Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} rejected={stats.SlackActivity.RepliesRejected} failed={stats.SlackActivity.RepliesFailed}");
 
     if (stats.Reminders is { } reminders)
     {

--- a/src/Netclaw.Cli/Tui/StatsPage.cs
+++ b/src/Netclaw.Cli/Tui/StatsPage.cs
@@ -172,7 +172,7 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         var sl = stats.SlackActivity;
         var content = Layouts.Vertical();
         content.WithChild(new TextNode($"  Events: recv={sl.EventsReceived} routed={sl.EventsRouted} dropped={sl.EventsDropped}").WithForeground(Color.White).Height(1));
-        content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} failed={sl.RepliesFailed} plain_text_fallback={sl.RepliesPlainTextFallback}").WithForeground(sl.RepliesFailed > 0 ? Color.Yellow : Color.White).Height(1));
+        content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} rejected={sl.RepliesRejected} failed={sl.RepliesFailed}").WithForeground(sl.RepliesFailed > 0 || sl.RepliesRejected > 0 ? Color.Yellow : Color.White).Height(1));
         return content;
     }
 

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -86,9 +86,9 @@ public static class DaemonRuntimeStatus
 
         public long RepliesPosted { get; init; }
 
-        public long RepliesFailed { get; init; }
+        public long RepliesRejected { get; init; }
 
-        public long RepliesPlainTextFallback { get; init; }
+        public long RepliesFailed { get; init; }
     }
 
     public sealed class Model : IWireType

--- a/src/Netclaw.Configuration/DaemonStats.cs
+++ b/src/Netclaw.Configuration/DaemonStats.cs
@@ -98,9 +98,9 @@ public static class DaemonStats
 
         public long RepliesPosted { get; init; }
 
-        public long RepliesFailed { get; init; }
+        public long RepliesRejected { get; init; }
 
-        public long RepliesPlainTextFallback { get; init; }
+        public long RepliesFailed { get; init; }
     }
 
     public sealed class Reminders : IWireType

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -96,8 +96,8 @@ internal sealed class DaemonRuntimeStatusService(
             EventsRouted = snapshot.SlackEventsRouted,
             MessagesEnqueued = snapshot.SlackMessagesEnqueued,
             RepliesPosted = snapshot.SlackRepliesPosted,
-            RepliesFailed = snapshot.SlackRepliesFailed,
-            RepliesPlainTextFallback = snapshot.SlackRepliesPlainTextFallback
+            RepliesRejected = snapshot.SlackRepliesRejected,
+            RepliesFailed = snapshot.SlackRepliesFailed
         };
     }
 

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -75,8 +75,8 @@ internal sealed class DaemonStatsService(
                 EventsRouted = slackSnapshot.SlackEventsRouted,
                 EventsDropped = slackSnapshot.SlackEventsDropped,
                 RepliesPosted = slackSnapshot.SlackRepliesPosted,
-                RepliesFailed = slackSnapshot.SlackRepliesFailed,
-                RepliesPlainTextFallback = slackSnapshot.SlackRepliesPlainTextFallback
+                RepliesRejected = slackSnapshot.SlackRepliesRejected,
+                RepliesFailed = slackSnapshot.SlackRepliesFailed
             },
             Reminders = await BuildReminderStatsAsync(ct),
             DailyBreakdown = dailyBreakdown


### PR DESCRIPTION
## Summary

Fixes #371 — Slack delivery errors silently swallowed in production.

- **Root cause**: `SlackReplyClient.PostThreadReplyAsync()` discarded the return value of `Chat.PostMessage()`, relying entirely on SlackNet to throw on `ok:false`. SlackNet 0.17.9's internal null-coalescing creates phantom `Ok=true` responses when the HTTP body is empty, causing delivery failures to be silently counted as successes.
- **Core fix**: Capture and validate `PostMessage`/`Upload` responses — null or empty `Ts` throws `SlackMessageDeliveryException` with `phantom_success` error code
- **Outbound hardening**: Added `SlackException` catch + response validation to `SlackOutboundClient` (previously had zero error handling)
- **Error classification**: Added `rate_limited` → `TransportFailure` mapping; moved `SlackBlockConverter.Convert()` inside try blocks so block conversion errors are properly wrapped
- **Metrics fix**: Replaced dead `PlainTextFallback` counter with `Rejected` counter for `ok:false` responses; separated `Filtered` (bot self-messages, duplicates) from `Dropped` (real message drops)
- **CLI**: `netclaw stats` now shows `posted`/`rejected`/`failed` instead of `posted`/`failed`/`plain_text_fallback`

## Breaking changes

- `DaemonStats.SlackActivity` and `DaemonRuntimeStatus.SlackCounters` wire types: removed `RepliesPlainTextFallback`, added `RepliesRejected`. CLI and daemon ship together so version skew is not a concern.

## Test plan

- [x] 15 new tests (13 unit + 2 integration), all passing
- [x] 1,221 total tests pass across all 7 test projects
- [x] `dotnet slopwatch analyze` — zero violations
- [ ] Manual: trigger `msg_too_long` in production → verify `rejected` counter increments, `DeliveryFailed` reaches session, LLM retries with shorter output