### PR TITLE
fix(tui): rename OpenAI-Compatible provider to "llama.cpp / vLLM"

### DIFF
--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -332,8 +332,13 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private ILayoutNode BuildProviderSelectionSubStep()
     {
         var registry = ViewModel.Registry;
+
+        // Map display names back to type keys for selection resolution
+        var displayToTypeKey = registry.KnownTypeKeys
+            .ToDictionary(k => registry.Get(k).DisplayName, k => k);
+
         _providerList = Layouts.SelectionList(
-                registry.KnownTypeKeys.ToList())
+                displayToTypeKey.Keys.ToList())
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -343,10 +348,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         _providerList.SelectionConfirmed
             .Subscribe(selected =>
             {
-                if (selected.Count > 0)
+                if (selected.Count > 0 && displayToTypeKey.TryGetValue(selected[0], out var typeKey))
                 {
-                    ViewModel.SelectedProviderType = selected[0];
-                    var descriptor = registry.Get(selected[0]);
+                    ViewModel.SelectedProviderType = typeKey;
+                    var descriptor = registry.Get(typeKey);
                     if (descriptor.Auth.SupportedAuthMethods is [AuthMethod.None])
                     {
                         ViewModel.SelectedAuthMethod = AuthMethod.None;
@@ -412,15 +417,16 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  Authentication for {providerType}:").WithForeground(Color.White))
+            .WithChild(new TextNode($"  Authentication for {descriptor.DisplayName}:").WithForeground(Color.White))
             .WithChild(_authMethodList);
     }
 
     private ILayoutNode BuildCredentialInputSubStep()
     {
         var providerType = ViewModel.SelectedProviderType ?? "unknown";
-
         var credDescriptor = ViewModel.Registry.Get(providerType);
+        var displayName = credDescriptor.DisplayName;
+
         if (credDescriptor.Auth is EndpointOnlyAuth)
         {
             var defaultEndpoint = credDescriptor.DefaultEndpoint;
@@ -443,7 +449,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 .DisposeWith(_stepSubs);
 
             return Layouts.Vertical()
-                .WithChild(new TextNode($"  {providerType} endpoint:").WithForeground(Color.White))
+                .WithChild(new TextNode($"  {displayName} endpoint:").WithForeground(Color.White))
                 .WithChild(new PanelNode()
                     .WithTitle("Endpoint")
                     .WithBorder(BorderStyle.Rounded)
@@ -454,7 +460,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
         _apiKeyInput = new TextInputNode()
             .AsPassword()
-            .WithPlaceholder($"Enter {providerType} API key...");
+            .WithPlaceholder($"Enter {displayName} API key...");
 
         if (!string.IsNullOrWhiteSpace(ViewModel.ApiKeyInput))
             _apiKeyInput.Text = ViewModel.ApiKeyInput;
@@ -474,7 +480,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  {providerType} API key:").WithForeground(Color.White))
+            .WithChild(new TextNode($"  {displayName} API key:").WithForeground(Color.White))
             .WithChild(new PanelNode()
                 .WithTitle("API Key")
                 .WithBorder(BorderStyle.Rounded)
@@ -615,9 +621,10 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     {
         var children = Layouts.Vertical();
         var providerType = ViewModel.SelectedProviderType ?? "unknown";
+        var descriptor = ViewModel.Registry.Get(providerType);
         var flowState = ViewModel.OAuth.FlowState.Value;
 
-        children.WithChild(new TextNode($"  OAuth Device Flow for {providerType}")
+        children.WithChild(new TextNode($"  OAuth Device Flow for {descriptor.DisplayName}")
             .WithForeground(Color.White).Bold());
         children.WithChild(new TextNode("").Height(1));
 
@@ -681,8 +688,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
 
     private ILayoutNode BuildBrowserOAuthFlowSubStep()
     {
+        var wizardProviderType = ViewModel.SelectedProviderType ?? "unknown";
         var result = OAuthFlowViews.BuildBrowserOAuthFlow(
-            ViewModel.SelectedProviderType ?? "unknown",
+            ViewModel.Registry.Get(wizardProviderType).DisplayName,
             ViewModel.OAuth.FlowState.Value,
             ViewModel.OAuth.BrowserOpenFailed,
             ViewModel.OAuth.VerificationUri,

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -529,8 +529,9 @@ public partial class InitWizardViewModel : ReactiveViewModel
         await Task.Delay(200, ct); // simulate validation
 
         var providerOk = !string.IsNullOrWhiteSpace(SelectedProviderType);
+        var providerLabel = providerOk ? Registry.Get(SelectedProviderType!).DisplayName : "none";
         HealthCheckResults[^1] = new HealthCheckItem(
-            $"LLM provider configured ({SelectedProviderType ?? "none"})",
+            $"LLM provider configured ({providerLabel})",
             providerOk);
         NotifyHealthCheckChanged();
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -181,7 +181,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                 _ => (SpinnerFrames[elapsed % SpinnerFrames.Length], Color.Yellow)
             };
 
-            children.WithChild(new TextNode($"  {statusChar} {item.ProviderType}")
+            children.WithChild(new TextNode($"  {statusChar} {item.DisplayName}")
                 .WithForeground(color));
         }
 
@@ -201,7 +201,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                     _ => " "
                 };
 
-                return $"{statusChar} {p.ProviderType,-16} {p.DisplayAuth,-12} {p.DisplayEndpoint}";
+                return $"{statusChar} {p.DisplayName,-20} {p.DisplayAuth,-12} {p.DisplayEndpoint}";
             })
             .ToList();
 
@@ -228,7 +228,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  {"",2}{"Type",-16} {"Auth",-12} Endpoint")
+            .WithChild(new TextNode($"  {"",2}{"Provider",-20} {"Auth",-12} Endpoint")
                 .WithForeground(Color.White).Bold())
             .WithChild(_providerList);
     }
@@ -257,7 +257,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  Authentication for {providerType}:")
+            .WithChild(new TextNode($"  Authentication for {descriptor.DisplayName}:")
                 .WithForeground(Color.White))
             .WithChild(_authList);
     }
@@ -268,7 +268,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         var providerType = ViewModel.NewProviderType ?? "unknown";
         var descriptor = ViewModel.Registry.Get(providerType);
 
-        children.WithChild(new TextNode($"  Provider: {providerType} (name: {ViewModel.NewProviderName})")
+        children.WithChild(new TextNode($"  Provider: {descriptor.DisplayName} (name: {ViewModel.NewProviderName})")
             .WithForeground(Color.White));
 
         if (descriptor.Auth is ApiKeyAuth or MultiAuth)
@@ -344,7 +344,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         var providerType = ViewModel.NewProviderType ?? "unknown";
         var flowState = ViewModel.OAuth.FlowState.Value;
 
-        children.WithChild(new TextNode($"  OAuth Device Flow for {providerType}")
+        children.WithChild(new TextNode($"  OAuth Device Flow for {ViewModel.Registry.Get(providerType).DisplayName}")
             .WithForeground(Color.White).Bold());
         children.WithChild(new TextNode("").Height(1));
 
@@ -406,8 +406,9 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
     private ILayoutNode BuildBrowserOAuthFlowView()
     {
+        var oauthProviderType = ViewModel.NewProviderType ?? "unknown";
         var result = OAuthFlowViews.BuildBrowserOAuthFlow(
-            ViewModel.NewProviderType ?? "unknown",
+            ViewModel.Registry.Get(oauthProviderType).DisplayName,
             ViewModel.OAuth.FlowState.Value,
             ViewModel.OAuth.BrowserOpenFailed,
             ViewModel.OAuth.VerificationUri,
@@ -472,7 +473,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         return Layouts.Vertical()
             .WithChild(new TextNode($"  \u2714 Provider '{ViewModel.NewProviderName}' ready to save")
                 .WithForeground(Color.Green))
-            .WithChild(new TextNode($"    Type: {ViewModel.NewProviderType}")
+            .WithChild(new TextNode($"    Type: {ViewModel.Registry.Get(ViewModel.NewProviderType ?? "unknown").DisplayName}")
                 .WithForeground(Color.White))
             .WithChild(new TextNode($"    Auth: {ViewModel.NewAuthMethod}")
                 .WithForeground(Color.White))
@@ -509,7 +510,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         return Layouts.Vertical()
             .WithChild(new TextNode($"  Provider: {item.ConfiguredName}").WithForeground(Color.White).Bold())
             .WithChild(new TextNode("").Height(1))
-            .WithChild(new TextNode($"    Type:     {item.ProviderType}").WithForeground(Color.White))
+            .WithChild(new TextNode($"    Type:     {item.DisplayName}").WithForeground(Color.White))
             .WithChild(new TextNode($"    Auth:     {item.DisplayAuth}").WithForeground(Color.White))
             .WithChild(new TextNode($"    Endpoint: {item.DisplayEndpoint}").WithForeground(Color.White))
             .WithChild(new TextNode($"    Status:   {healthStr}").WithForeground(healthColor))
@@ -525,7 +526,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
         var descriptor = ViewModel.Registry.Get(item.ProviderType);
         var children = Layouts.Vertical();
 
-        children.WithChild(new TextNode($"  Fix credentials for: {item.ConfiguredName} ({item.ProviderType})")
+        children.WithChild(new TextNode($"  Fix credentials for: {item.ConfiguredName} ({item.DisplayName})")
             .WithForeground(Color.White).Bold());
 
         if (item.ProbeResult is { Success: false, ErrorMessage: not null })
@@ -596,7 +597,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
 
             _apiKeyInput = new TextInputNode()
                 .AsPassword()
-                .WithPlaceholder($"Enter new {item.ProviderType} API key...");
+                .WithPlaceholder($"Enter new {item.DisplayName} API key...");
             _apiKeyInput.OnFocused();
             _lastFocusedInput = _apiKeyInput;
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -47,6 +47,7 @@ public enum ProviderHealthStatus
 public sealed class ProviderDisplayItem
 {
     public string ProviderType { get; init; } = "";
+    public string DisplayName { get; init; } = "";
     public bool IsConfigured { get; init; }
     public string? ConfiguredName { get; init; }
     public ProviderEntry? Entry { get; init; }
@@ -190,6 +191,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 DisplayProviders.Add(new ProviderDisplayItem
                 {
                     ProviderType = typeKey,
+                    DisplayName = descriptor.DisplayName,
                     IsConfigured = true,
                     ConfiguredName = configured.Key,
                     Entry = configured.Value,
@@ -202,6 +204,7 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
                 DisplayProviders.Add(new ProviderDisplayItem
                 {
                     ProviderType = typeKey,
+                    DisplayName = descriptor.DisplayName,
                     IsConfigured = false,
                     DisplayEndpoint = $"({descriptor.DefaultEndpoint})",
                     DisplayAuth = "\u2014"

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleDescriptor.cs
@@ -4,7 +4,8 @@ using Netclaw.Configuration;
 namespace Netclaw.Providers.SelfHosted;
 
 /// <summary>
-/// Provider descriptor for OpenAI-compatible endpoints such as vLLM or Lemonade.
+/// Provider descriptor for OpenAI-compatible endpoints such as llama.cpp,
+/// llama-server, vLLM, or Lemonade.
 /// </summary>
 public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
 {
@@ -16,7 +17,7 @@ public sealed class OpenAiCompatibleDescriptor : IProviderDescriptor
     }
 
     public string TypeKey => "openai-compatible";
-    public string DisplayName => "OpenAI-Compatible";
+    public string DisplayName => "llama.cpp / vLLM";
     public string DefaultEndpoint => "http://localhost:11434";
     public string ModelListingPath => "/v1/models";
     public IProviderAuth Auth { get; } = new EndpointOnlyAuth();


### PR DESCRIPTION
## Summary

- Renames the `openai-compatible` provider's `DisplayName` from "OpenAI-Compatible" to "llama.cpp / vLLM" to better describe the actual servers it supports (llama.cpp, llama-server, vLLM, Lemonade)
- Wires `DisplayName` through `ProviderDisplayItem` so all TUI views (provider manager, init wizard, OAuth flows) show the friendly name instead of the raw type key
- Column header changed from "Type" to "Provider" in the provider list view

No changes to config format, CLI commands, or internal `TypeKey` — this is purely a display rename.

## Test plan

- [x] All 24 ProviderManager TUI tests pass
- [x] All 47 InitWizard TUI tests pass
- [ ] Visual check: `netclaw provider` list shows "llama.cpp / vLLM" instead of "openai-compatible"
- [ ] Visual check: `netclaw init` provider selection shows display names