### PR TITLE
fix(tui): support multiple provider instances of the same type

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ModelManagerViewModelTests.cs
@@ -291,6 +291,54 @@ public sealed class ModelManagerViewModelTests : IDisposable
         Assert.Equal(ModelManagerState.RoleOverview, vm.CurrentState.Value);
     }
 
+    [Fact]
+    public void Refresh_PopulatesDisplayNameFromRegistry()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-vllm"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai-compatible",
+                    ["Endpoint"] = "http://localhost:8080"
+                }
+            }
+        });
+
+        var registry = Netclaw.Cli.Provider.ProviderCommand.CreateDefaultRegistry();
+        using var vm = new ModelManagerViewModel(_paths, _fakeProbe, registry);
+        vm.Refresh();
+
+        Assert.Single(vm.Providers);
+        Assert.Equal("my-vllm", vm.Providers[0].Name);
+        Assert.Equal("llama.cpp / vLLM", vm.Providers[0].DisplayName);
+    }
+
+    [Fact]
+    public void Refresh_FallsBackToTypeWhenNoRegistry()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-ollama"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "ollama",
+                    ["Endpoint"] = "http://localhost:11434"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.Refresh();
+
+        Assert.Single(vm.Providers);
+        Assert.Equal("ollama", vm.Providers[0].DisplayName);
+    }
+
     private ModelManagerViewModel CreateViewModel()
     {
         return new ModelManagerViewModel(_paths, _fakeProbe);

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -626,6 +626,72 @@ public sealed class ProviderManagerViewModelTests : IDisposable
         vm.GoBack();
     }
 
+    [Fact]
+    public void DisplayProviders_ShowsMultipleInstancesOfSameType()
+    {
+        WriteConfig(new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Providers"] = new Dictionary<string, object>
+            {
+                ["my-vllm-local"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai-compatible",
+                    ["Endpoint"] = "http://localhost:8080"
+                },
+                ["my-vllm-remote"] = new Dictionary<string, object>
+                {
+                    ["Type"] = "openai-compatible",
+                    ["Endpoint"] = "http://192.168.1.50:8080"
+                }
+            }
+        });
+
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+
+        // Both instances should appear
+        var compatible = vm.DisplayProviders.Where(p => p.ProviderType == "openai-compatible").ToList();
+        Assert.Equal(2, compatible.Count);
+        Assert.Contains(compatible, p => p.ConfiguredName == "my-vllm-local");
+        Assert.Contains(compatible, p => p.ConfiguredName == "my-vllm-remote");
+        Assert.All(compatible, p => Assert.True(p.IsConfigured));
+
+        // openai-compatible should NOT appear as an unconfigured placeholder
+        Assert.DoesNotContain(vm.DisplayProviders,
+            p => p.ProviderType == "openai-compatible" && !p.IsConfigured);
+
+        // Other unconfigured types should still be present
+        Assert.Contains(vm.DisplayProviders, p => p.ProviderType == "ollama" && !p.IsConfigured);
+
+        // Total: 2 configured + 4 unconfigured types = 6
+        Assert.Equal(6, vm.DisplayProviders.Count);
+    }
+
+    [Fact]
+    public void StartAddNewProvider_TransitionsToAddSelectType()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+        vm.CurrentState.Value = ProviderManagerState.List;
+
+        vm.StartAddNewProvider();
+
+        Assert.Equal(ProviderManagerState.AddSelectType, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public void GoBack_FromAddSelectType_ReturnsToList()
+    {
+        using var vm = CreateViewModel();
+        vm.RefreshDisplayProviders();
+        vm.CurrentState.Value = ProviderManagerState.AddSelectType;
+
+        vm.GoBack();
+
+        Assert.Equal(ProviderManagerState.List, vm.CurrentState.Value);
+    }
+
     private ProviderManagerViewModel CreateViewModel()
     {
         return new ProviderManagerViewModel(_paths, ProviderCommand.CreateDefaultRegistry(), _fakeProbe);

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -23,7 +23,7 @@ internal static class ProviderCommand
 
         return subcommand switch
         {
-            "list" => Task.FromResult(RunList(paths, writer)),
+            "list" => Task.FromResult(RunList(paths, registry, writer)),
             "add" => RunAddAsync(args, paths, registry, writer),
             "remove" => Task.FromResult(RunRemove(args, paths, writer)),
             "help" or "-h" or "--help" => Task.FromResult(WriteHelp(registry, writer)),
@@ -31,7 +31,7 @@ internal static class ProviderCommand
         };
     }
 
-    private static int RunList(NetclawPaths paths, TextWriter writer)
+    private static int RunList(NetclawPaths paths, ProviderDescriptorRegistry registry, TextWriter writer)
     {
         var providers = LoadProviders(paths);
 
@@ -42,10 +42,13 @@ internal static class ProviderCommand
             return 0;
         }
 
-        writer.WriteLine($"{"Name",-20} {"Type",-12} {"Auth",-10} {"Endpoint"}");
+        writer.WriteLine($"{"Name",-20} {"Provider",-22} {"Auth",-10} {"Endpoint"}");
         foreach (var (name, entry) in providers.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
         {
-            writer.WriteLine($"{name,-20} {entry.Type,-12} {entry.AuthMethod,-10} {entry.Endpoint}");
+            var displayName = registry.TryGet(entry.Type, out var descriptor)
+                ? descriptor.DisplayName
+                : entry.Type;
+            writer.WriteLine($"{name,-20} {displayName,-22} {entry.AuthMethod,-10} {entry.Endpoint}");
         }
 
         return 0;

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -148,7 +148,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
 
         return Layouts.Vertical()
             .WithChild(new TextNode("  Model Role Assignments").WithForeground(Color.White).Bold())
-            .WithChild(new TextNode($"  {"Role",-12} {"Provider",-18} {"Model ID",-28} Status")
+            .WithChild(new TextNode($"  {"Role",-12} {"Provider",-28} {"Model ID",-28} Status")
                 .WithForeground(Color.Gray))
             .WithChild(_roleList)
             .WithChild(new TextNode("").Height(1))
@@ -156,17 +156,25 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
                 .WithForeground(Color.Gray));
     }
 
-    private static string FormatRoleItem(string role, ModelReference? model)
+    private string FormatRoleItem(string role, ModelReference? model)
     {
         if (model is null)
-            return $"{role,-12} {"(not set)",-18} {"\u2014",-28} \u2014";
+            return $"{role,-12} {"(not set)",-28} {"\u2014",-28} \u2014";
 
-        return $"{role,-12} {model.Provider,-18} {model.ModelId,-28} {(model.Provenance?.ToString() ?? "unknown")}";
+        var providerLabel = model.Provider;
+        var match = ViewModel.Providers.FirstOrDefault(p =>
+            string.Equals(p.Name, model.Provider, StringComparison.OrdinalIgnoreCase));
+        if (match.Name is not null)
+            providerLabel = $"{match.Name} ({match.DisplayName})";
+
+        return $"{role,-12} {providerLabel,-28} {model.ModelId,-28} {(model.Provenance?.ToString() ?? "unknown")}";
     }
 
     private ILayoutNode BuildProviderSelection()
     {
-        var items = ViewModel.Providers.Select(p => p.Name).ToList();
+        var items = ViewModel.Providers
+            .Select(p => $"{p.Name} ({p.DisplayName})")
+            .ToList();
 
         _providerList = Layouts.SelectionList(items)
             .WithMode(SelectionMode.Single)
@@ -179,7 +187,11 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
             .Subscribe(selected =>
             {
                 if (selected.Count > 0)
-                    ViewModel.SelectProvider(selected[0]);
+                {
+                    var idx = items.IndexOf(selected[0]);
+                    if (idx >= 0 && idx < ViewModel.Providers.Count)
+                        ViewModel.SelectProvider(ViewModel.Providers[idx].Name);
+                }
             })
             .DisposeWith(_stepSubs);
 
@@ -286,9 +298,15 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
             })
             .DisposeWith(_stepSubs);
 
+        var discoverProviderLabel = ViewModel.SelectedProvider ?? "";
+        var discoverMatch = ViewModel.Providers.FirstOrDefault(p =>
+            string.Equals(p.Name, ViewModel.SelectedProvider, StringComparison.OrdinalIgnoreCase));
+        if (discoverMatch.Name is not null)
+            discoverProviderLabel = $"{discoverMatch.Name} ({discoverMatch.DisplayName})";
+
         var title = ViewModel.SelectedRole is not null
-            ? $"  Select model for {ViewModel.SelectedRole} (from '{ViewModel.SelectedProvider}'):"
-            : $"  Models from '{ViewModel.SelectedProvider}' ({ViewModel.DiscoveredModels.Count} found):";
+            ? $"  Select model for {ViewModel.SelectedRole} (from '{discoverProviderLabel}'):"
+            : $"  Models from '{discoverProviderLabel}' ({ViewModel.DiscoveredModels.Count} found):";
 
         return Layouts.Vertical()
             .WithChild(new TextNode(title).WithForeground(Color.White))
@@ -315,10 +333,16 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
             })
             .DisposeWith(_stepSubs);
 
+        var providerLabel = ViewModel.SelectedProvider ?? "";
+        var providerMatch = ViewModel.Providers.FirstOrDefault(p =>
+            string.Equals(p.Name, ViewModel.SelectedProvider, StringComparison.OrdinalIgnoreCase));
+        if (providerMatch.Name is not null)
+            providerLabel = $"{providerMatch.Name} ({providerMatch.DisplayName})";
+
         return Layouts.Vertical()
             .WithChild(new TextNode($"  Assign {ViewModel.SelectedRole} model?")
                 .WithForeground(Color.White).Bold())
-            .WithChild(new TextNode($"    Provider: {ViewModel.SelectedProvider}")
+            .WithChild(new TextNode($"    Provider: {providerLabel}")
                 .WithForeground(Color.White))
             .WithChild(new TextNode($"    Model:    {ViewModel.SelectedModelId}")
                 .WithForeground(Color.White))

--- a/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerViewModel.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Diagnostics;
 using Netclaw.Cli.Config;
 using Netclaw.Configuration;
+using Netclaw.Providers;
 using R3;
 using Termina.Input;
 using Termina.Reactive;
@@ -30,6 +31,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
     private readonly NetclawPaths _paths;
     private readonly IProviderProbe _probe;
+    private readonly ProviderDescriptorRegistry? _registry;
     private CancellationTokenSource? _probeCts;
 
     public ReactiveProperty<ModelManagerState> CurrentState { get; } = new(ModelManagerState.RoleOverview);
@@ -45,7 +47,7 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
 
     // ── Loaded state ──
     public ModelSelection? Models { get; private set; }
-    public List<(string Name, ProviderEntry Entry)> Providers { get; } = [];
+    public List<(string Name, string DisplayName, ProviderEntry Entry)> Providers { get; } = [];
 
     // ── Assignment flow ──
     public string? SelectedRole { get; set; }
@@ -59,10 +61,12 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
     /// </summary>
     internal Task? ProbeCompletion { get; private set; }
 
-    public ModelManagerViewModel(NetclawPaths paths, IProviderProbe probe)
+    public ModelManagerViewModel(NetclawPaths paths, IProviderProbe probe,
+        ProviderDescriptorRegistry? registry = null)
     {
         _paths = paths;
         _probe = probe;
+        _registry = registry;
     }
 
     public override void OnActivated()
@@ -81,7 +85,12 @@ public sealed class ModelManagerViewModel : ReactiveViewModel
         Providers.Clear();
         var loaded = Provider.ProviderCommand.LoadProviders(_paths);
         foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
-            Providers.Add((name, entry));
+        {
+            var displayName = _registry is not null && _registry.TryGet(entry.Type, out var descriptor)
+                ? descriptor.DisplayName
+                : entry.Type;
+            Providers.Add((name, displayName, entry));
+        }
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -81,6 +81,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             {
                 ProviderManagerState.Loading => BuildLoadingView(),
                 ProviderManagerState.List => BuildProviderListView(),
+                ProviderManagerState.AddSelectType => BuildAddSelectTypeView(),
                 ProviderManagerState.AddSelectAuth => BuildAddAuthView(),
                 ProviderManagerState.AddCredentials => BuildCredentialsView(),
                 ProviderManagerState.AddOAuthDeviceFlow => BuildOAuthDeviceFlowView(),
@@ -139,6 +140,8 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                         " Checking providers...  [Ctrl+Q] Quit",
                     ProviderManagerState.List =>
                         " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
+                    ProviderManagerState.AddSelectType =>
+                        " [\u2191/\u2193] Navigate  [Enter] Select  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.Details =>
                         " [K] Update key  [R] Remove  [V] Re-validate  [Esc] Back  [Ctrl+Q] Quit",
                     ProviderManagerState.RemoveConfirm =>
@@ -181,29 +184,42 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
                 _ => (SpinnerFrames[elapsed % SpinnerFrames.Length], Color.Yellow)
             };
 
-            children.WithChild(new TextNode($"  {statusChar} {item.DisplayName}")
+            var label = item.ConfiguredName is not null
+                ? $"{item.ConfiguredName} ({item.DisplayName})"
+                : item.DisplayName;
+            children.WithChild(new TextNode($"  {statusChar} {label}")
                 .WithForeground(color));
         }
 
         return children;
     }
 
+    private const string AddNewProviderSentinel = "  + Add new provider...";
+
     private ILayoutNode BuildProviderListView()
     {
         var items = ViewModel.DisplayProviders
             .Select(p =>
             {
-                var statusChar = p switch
+                if (p.IsConfigured)
                 {
-                    { IsConfigured: true, Health: ProviderHealthStatus.Healthy } => "\u2713",
-                    { IsConfigured: true, Health: ProviderHealthStatus.Unhealthy } => "\u26a0",
-                    { IsConfigured: true, Health: ProviderHealthStatus.Probing } => "\u2026",
-                    _ => " "
-                };
+                    var statusChar = p.Health switch
+                    {
+                        ProviderHealthStatus.Healthy => "\u2713",
+                        ProviderHealthStatus.Unhealthy => "\u26a0",
+                        ProviderHealthStatus.Probing => "\u2026",
+                        _ => " "
+                    };
 
-                return $"{statusChar} {p.DisplayName,-20} {p.DisplayAuth,-12} {p.DisplayEndpoint}";
+                    var nameLabel = $"{p.ConfiguredName} ({p.DisplayName})";
+                    return $"{statusChar} {nameLabel,-36} {p.DisplayAuth,-12} {p.DisplayEndpoint}";
+                }
+
+                return $"  {p.DisplayName,-36} {"(not configured)",-12}";
             })
             .ToList();
+
+        items.Add(AddNewProviderSentinel);
 
         _providerList = Layouts.SelectionList(items)
             .WithMode(SelectionMode.Single)
@@ -217,19 +233,54 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
             {
                 if (selected.Count > 0)
                 {
-                    var idx = items.IndexOf(selected[0]);
-                    if (idx >= 0)
+                    if (selected[0] == AddNewProviderSentinel)
                     {
-                        ViewModel.SelectedProviderIndex = idx;
-                        ViewModel.ActivateSelectedProvider();
+                        ViewModel.StartAddNewProvider();
+                    }
+                    else
+                    {
+                        var idx = items.IndexOf(selected[0]);
+                        if (idx >= 0)
+                        {
+                            ViewModel.SelectedProviderIndex = idx;
+                            ViewModel.ActivateSelectedProvider();
+                        }
                     }
                 }
             })
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  {"",2}{"Provider",-20} {"Auth",-12} Endpoint")
+            .WithChild(new TextNode($"  {"",2}{"Provider",-36} {"Auth",-12} Endpoint")
                 .WithForeground(Color.White).Bold())
+            .WithChild(_providerList);
+    }
+
+    private ILayoutNode BuildAddSelectTypeView()
+    {
+        var registry = ViewModel.Registry;
+        var displayToTypeKey = registry.KnownTypeKeys
+            .ToDictionary(k => registry.Get(k).DisplayName, k => k);
+
+        _providerList = Layouts.SelectionList(displayToTypeKey.Keys.ToList())
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _providerList.OnFocused();
+        _lastFocusedList = _providerList;
+
+        _providerList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0 && displayToTypeKey.TryGetValue(selected[0], out var typeKey))
+                {
+                    ViewModel.StartAddForType(typeKey);
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Select provider type to add:").WithForeground(Color.White))
             .WithChild(_providerList);
     }
 

--- a/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerViewModel.cs
@@ -18,6 +18,7 @@ public enum ProviderManagerState
 {
     Loading,
     List,
+    AddSelectType,
     AddSelectAuth,
     AddCredentials,
     AddOAuthDeviceFlow,
@@ -168,48 +169,54 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
     /// <summary>
     /// Build DisplayProviders from known types merged with loaded config.
+    /// Shows all configured instances (including multiple of the same type),
+    /// followed by unconfigured type placeholders for types with no instances.
     /// </summary>
     public void RefreshDisplayProviders()
     {
         DisplayProviders.Clear();
         var loaded = Provider.ProviderCommand.LoadProviders(_paths);
 
+        // Pass 1: Add all configured instances
+        var configuredTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, entry) in loaded.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            configuredTypes.Add(entry.Type);
+            var displayName = _registry.TryGet(entry.Type, out var descriptor)
+                ? descriptor.DisplayName
+                : entry.Type;
+
+            var authStr = entry.AuthMethod == AuthMethod.None
+                ? "\u2014"
+                : entry.AuthMethod.ToString();
+
+            DisplayProviders.Add(new ProviderDisplayItem
+            {
+                ProviderType = entry.Type,
+                DisplayName = displayName,
+                IsConfigured = true,
+                ConfiguredName = name,
+                Entry = entry,
+                DisplayEndpoint = entry.Endpoint,
+                DisplayAuth = authStr
+            });
+        }
+
+        // Pass 2: Add unconfigured placeholders for types with no instances
         foreach (var typeKey in _registry.KnownTypeKeys)
         {
+            if (configuredTypes.Contains(typeKey))
+                continue;
+
             var descriptor = _registry.Get(typeKey);
-
-            // Find configured provider of this type
-            var configured = loaded
-                .FirstOrDefault(p => string.Equals(p.Value.Type, typeKey, StringComparison.OrdinalIgnoreCase));
-
-            if (configured.Key is not null)
+            DisplayProviders.Add(new ProviderDisplayItem
             {
-                var authStr = configured.Value.AuthMethod == AuthMethod.None
-                    ? "\u2014"
-                    : configured.Value.AuthMethod.ToString();
-
-                DisplayProviders.Add(new ProviderDisplayItem
-                {
-                    ProviderType = typeKey,
-                    DisplayName = descriptor.DisplayName,
-                    IsConfigured = true,
-                    ConfiguredName = configured.Key,
-                    Entry = configured.Value,
-                    DisplayEndpoint = configured.Value.Endpoint,
-                    DisplayAuth = authStr
-                });
-            }
-            else
-            {
-                DisplayProviders.Add(new ProviderDisplayItem
-                {
-                    ProviderType = typeKey,
-                    DisplayName = descriptor.DisplayName,
-                    IsConfigured = false,
-                    DisplayEndpoint = $"({descriptor.DefaultEndpoint})",
-                    DisplayAuth = "\u2014"
-                });
-            }
+                ProviderType = typeKey,
+                DisplayName = descriptor.DisplayName,
+                IsConfigured = false,
+                DisplayEndpoint = $"({descriptor.DefaultEndpoint})",
+                DisplayAuth = "\u2014"
+            });
         }
     }
 
@@ -309,6 +316,17 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
 
             // Probing or Unchecked — no-op
         }
+    }
+
+    /// <summary>
+    /// Start the add-new-provider flow by showing the type selection screen.
+    /// Called when the user selects the "+ Add new provider" sentinel row.
+    /// </summary>
+    public void StartAddNewProvider()
+    {
+        ClearAddState();
+        CurrentState.Value = ProviderManagerState.AddSelectType;
+        NotifyStateChanged();
     }
 
     /// <summary>
@@ -612,6 +630,9 @@ public sealed class ProviderManagerViewModel : ReactiveViewModel
     {
         switch (CurrentState.Value)
         {
+            case ProviderManagerState.AddSelectType:
+                GoBackToList();
+                break;
             case ProviderManagerState.AddSelectAuth:
                 GoBackToList();
                 break;


### PR DESCRIPTION
## Summary

Fixes #384. The provider manager TUI assumed one instance per provider type, breaking `netclaw provider` and `netclaw model` when two providers shared the same type (e.g., two `openai-compatible` entries with different endpoints).

- **Rewrite `RefreshDisplayProviders()`** — two-pass approach shows all configured instances followed by unconfigured type placeholders, instead of `FirstOrDefault` per type
- **Add "+ Add new provider" option** — allows adding additional instances of any type (including already-configured types) via the TUI
- **Show display names everywhere** — model manager provider selection, role overview, confirm screen, discover screen, and CLI `netclaw provider list` now show `Name (DisplayName)` format

## Test plan

- [x] `dotnet build` — full solution compiles
- [x] All 226 existing CLI tests pass unchanged
- [x] 5 new tests added:
  - `DisplayProviders_ShowsMultipleInstancesOfSameType`
  - `StartAddNewProvider_TransitionsToAddSelectType`
  - `GoBack_FromAddSelectType_ReturnsToList`
  - `Refresh_PopulatesDisplayNameFromRegistry`
  - `Refresh_FallsBackToTypeWhenNoRegistry`
- [ ] Manual: configure two `openai-compatible` entries → both appear in `netclaw provider` TUI
- [ ] Manual: `netclaw provider list` shows DisplayName column
- [ ] Manual: `netclaw model` shows `Name (DisplayName)` in provider selection