### PR TITLE
feat(security): integrate trust context policy with global read roots and channel audiences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,13 +109,12 @@ missing from the schema will be rejected by `ConfigSchemaDoctorCheck` at runtime
 - no north-star/deferred features in MVP without explicit PRD update
 - actor boundaries remain transport-agnostic (pub/sub over direct transport asks)
 - persistence types remain framework-owned and serialization-safe
-- **No fallback paths.** Do not add silent retries, plain-text downgrades, or
-  graceful degradation that hides errors. When the LLM produces output a channel
-  can't deliver, feed the full error back to the LLM session so it can
-  understand what went wrong and retry with corrected output. The only acceptable
-  error-handling pattern is: error occurs → error details propagated back to the
-  LLM → LLM retries with that context. If you believe a fallback is genuinely
-  needed, stop and ask for explicit approval first.
+- **No silent fallbacks.** When something fails or is misconfigured, fail
+  loudly — do not silently degrade to a default. Fallbacks hide bugs and
+  misconfigurations, and on security-relevant paths they can silently escalate
+  privileges. A fallback is only justified when partial failure is a normal
+  runtime condition (e.g., a network retry). If you think you need one, ask
+  first.
 - no new Slopwatch violations: run `/dotnet-skills:slopwatch` after code changes
 - use `TimeProvider` (not `DateTime.UtcNow` / `DateTimeOffset.UtcNow`) so time
   can be virtualized in tests. Inject `TimeProvider` via DI; default to

--- a/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
@@ -65,4 +65,94 @@ public sealed class SlackAclPolicyTests
         Assert.Equal("user_not_allowed", result.DenyReason);
         Assert.Equal(TrustAudience.Public, result.Audience);
     }
+
+    [Fact]
+    public void EvaluateInbound_dm_with_channel_audiences_dm_personal_returns_personal()
+    {
+        var message = CreateDm("U123");
+        var options = new SlackChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string> { ["dm"] = "personal" }
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal(TrustAudience.Personal, result.Audience);
+    }
+
+    [Fact]
+    public void EvaluateInbound_explicit_channel_id_override_takes_precedence()
+    {
+        var message = CreateChannelMessage("C456", "U123");
+        var options = new SlackChannelOptions
+        {
+            AllowedChannelIds = ["C456"],
+            ChannelAudiences = new Dictionary<string, string> { ["C456"] = "personal" }
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal(TrustAudience.Personal, result.Audience);
+    }
+
+    [Fact]
+    public void EvaluateInbound_missing_channel_audience_falls_back_to_heuristic()
+    {
+        var message = CreateChannelMessage("C789", "U123");
+        var options = new SlackChannelOptions
+        {
+            AllowedChannelIds = ["C789"],
+            ChannelAudiences = new Dictionary<string, string> { ["dm"] = "personal" }
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        // Explicit channel → Team via heuristic fallback
+        Assert.Equal(TrustAudience.Team, result.Audience);
+    }
+
+    [Fact]
+    public void EvaluateInbound_dm_without_channel_audiences_returns_team()
+    {
+        var message = CreateDm("U123");
+        var options = new SlackChannelOptions
+        {
+            AllowDirectMessages = true
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal(TrustAudience.Team, result.Audience);
+    }
+
+    private static SlackInboundMessage CreateDm(string userId) => new(
+        SlackInboundKind.Message,
+        new SlackEventId("evt-1"),
+        new SlackChannelId("D123"),
+        null,
+        new SlackEventTs("1708531200.000100"),
+        new SlackUserId(userId),
+        null,
+        "hello",
+        null,
+        false,
+        true);
+
+    private static SlackInboundMessage CreateChannelMessage(string channelId, string userId) => new(
+        SlackInboundKind.Message,
+        new SlackEventId("evt-1"),
+        new SlackChannelId(channelId),
+        null,
+        new SlackEventTs("1708531200.000100"),
+        new SlackUserId(userId),
+        null,
+        "hello",
+        null,
+        false,
+        false);
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
@@ -130,6 +130,45 @@ public sealed class SlackAclPolicyTests
         Assert.Equal(TrustAudience.Team, result.Audience);
     }
 
+    [Fact]
+    public void EvaluateInbound_dm_channel_id_in_audiences_takes_precedence_over_dm_key()
+    {
+        // DM channel ID "D123" is explicitly mapped to "public",
+        // while "dm" key says "personal" — explicit ID wins.
+        var message = CreateDm("U123");
+        var options = new SlackChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string>
+            {
+                ["D123"] = "public",
+                ["dm"] = "personal"
+            }
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal(TrustAudience.Public, result.Audience);
+    }
+
+    [Fact]
+    public void EvaluateInbound_invalid_channel_audience_value_falls_through_to_heuristic()
+    {
+        var message = CreateDm("U123");
+        var options = new SlackChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string> { ["dm"] = "persoanl" } // typo
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.True(result.IsAllowed);
+        // Invalid value → TryParseAudience fails → heuristic fallback → Team
+        Assert.Equal(TrustAudience.Team, result.Audience);
+    }
+
     private static SlackInboundMessage CreateDm(string userId) => new(
         SlackInboundKind.Message,
         new SlackEventId("evt-1"),

--- a/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAclPolicyTests.cs
@@ -153,7 +153,7 @@ public sealed class SlackAclPolicyTests
     }
 
     [Fact]
-    public void EvaluateInbound_invalid_channel_audience_value_falls_through_to_heuristic()
+    public void EvaluateInbound_invalid_channel_audience_value_denies_message()
     {
         var message = CreateDm("U123");
         var options = new SlackChannelOptions
@@ -164,9 +164,26 @@ public sealed class SlackAclPolicyTests
 
         var result = SlackAclPolicy.EvaluateInbound(message, options, null);
 
-        Assert.True(result.IsAllowed);
-        // Invalid value → TryParseAudience fails → heuristic fallback → Team
-        Assert.Equal(TrustAudience.Team, result.Audience);
+        Assert.False(result.IsAllowed);
+        Assert.Contains("invalid_channel_audience", result.DenyReason);
+        Assert.Contains("persoanl", result.DenyReason);
+    }
+
+    [Fact]
+    public void EvaluateInbound_invalid_channel_id_audience_value_denies_message()
+    {
+        var message = CreateChannelMessage("C456", "U123");
+        var options = new SlackChannelOptions
+        {
+            AllowedChannelIds = ["C456"],
+            ChannelAudiences = new Dictionary<string, string> { ["C456"] = "pubilc" } // typo
+        };
+
+        var result = SlackAclPolicy.EvaluateInbound(message, options, null);
+
+        Assert.False(result.IsAllowed);
+        Assert.Contains("invalid_channel_audience", result.DenyReason);
+        Assert.Contains("pubilc", result.DenyReason);
     }
 
     private static SlackInboundMessage CreateDm(string userId) => new(

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -143,12 +143,90 @@ public class FileReadToolTests : IDisposable
         Assert.DoesNotContain("do not read", result);
     }
 
+    [Fact]
+    public async Task Team_context_can_read_file_inside_skills_directory_via_global_read_roots()
+    {
+        var skillsDir = Path.Combine(_tempDir, "skills");
+        Directory.CreateDirectory(skillsDir);
+        var skillFile = Path.Combine(skillsDir, "test-skill", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(skillFile)!);
+        await File.WriteAllTextAsync(skillFile, "# Test Skill");
+
+        var paths = new NetclawPaths(_tempDir);
+        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+
+        var args = new Dictionary<string, object?> { ["Path"] = skillFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Equal("# Test Skill", result);
+    }
+
+    [Fact]
+    public async Task Team_context_can_read_file_inside_identity_directory_via_global_read_roots()
+    {
+        var identityDir = Path.Combine(_tempDir, "identity");
+        Directory.CreateDirectory(identityDir);
+        var soulFile = Path.Combine(identityDir, "SOUL.md");
+        await File.WriteAllTextAsync(soulFile, "# Soul");
+
+        var paths = new NetclawPaths(_tempDir);
+        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+
+        var args = new Dictionary<string, object?> { ["Path"] = soulFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Equal("# Soul", result);
+    }
+
+    [Fact]
+    public async Task Team_context_cannot_read_file_outside_session_and_global_roots()
+    {
+        var secretFile = Path.Combine(_tempDir, "config", "secrets.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(secretFile)!);
+        await File.WriteAllTextAsync(secretFile, "secret data");
+
+        var paths = new NetclawPaths(_tempDir);
+        var tool = new FileReadTool(new ToolConfig(), paths: paths);
+
+        var args = new Dictionary<string, object?> { ["Path"] = secretFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Contains("Team trust context", result);
+        Assert.DoesNotContain("secret data", result);
+    }
+
+    [Fact]
+    public async Task Team_context_without_paths_falls_back_to_session_only()
+    {
+        var skillsDir = Path.Combine(_tempDir, "skills");
+        Directory.CreateDirectory(skillsDir);
+        var skillFile = Path.Combine(skillsDir, "test-skill", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(skillFile)!);
+        await File.WriteAllTextAsync(skillFile, "# Test Skill");
+
+        // No paths injected — no global read roots
+        var tool = new FileReadTool(new ToolConfig());
+
+        var args = new Dictionary<string, object?> { ["Path"] = skillFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Contains("Team trust context", result);
+    }
+
     private ToolExecutionContext CreatePersonalContext()
         => new("signalr/thread-1", _sessionDir)
         {
             Audience = TrustAudience.Personal.ToWireValue(),
             Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
             ChannelType = "signalr"
+        };
+
+    private ToolExecutionContext CreateTeamContext()
+        => new("slack/thread-1", _sessionDir)
+        {
+            Audience = TrustAudience.Team.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.TeamBoundary,
+            ChannelType = "slack"
         };
 
     private ToolExecutionContext CreatePublicContext()

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -213,6 +213,54 @@ public class FileReadToolTests : IDisposable
         Assert.Contains("Team trust context", result);
     }
 
+    [Fact]
+    public async Task Team_context_can_read_file_inside_literal_global_read_root()
+    {
+        var sharedDir = Path.Combine(_tempDir, "shared-data");
+        Directory.CreateDirectory(sharedDir);
+        var dataFile = Path.Combine(sharedDir, "data.txt");
+        await File.WriteAllTextAsync(dataFile, "shared content");
+
+        var config = new ToolConfig
+        {
+            AudienceProfiles = new ToolAudienceProfiles
+            {
+                GlobalReadRoots = [sharedDir]
+            }
+        };
+        var paths = new NetclawPaths(_tempDir);
+        var tool = new FileReadTool(config, paths: paths);
+
+        var args = new Dictionary<string, object?> { ["Path"] = dataFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Equal("shared content", result);
+    }
+
+    [Fact]
+    public async Task Literal_global_read_root_works_without_netclaw_paths()
+    {
+        var sharedDir = Path.Combine(_tempDir, "shared-data");
+        Directory.CreateDirectory(sharedDir);
+        var dataFile = Path.Combine(sharedDir, "data.txt");
+        await File.WriteAllTextAsync(dataFile, "shared content");
+
+        var config = new ToolConfig
+        {
+            AudienceProfiles = new ToolAudienceProfiles
+            {
+                GlobalReadRoots = [sharedDir]
+            }
+        };
+        // No NetclawPaths injected — literal paths should still resolve
+        var tool = new FileReadTool(config);
+
+        var args = new Dictionary<string, object?> { ["Path"] = dataFile };
+        var result = await tool.ExecuteAsync(args, CreateTeamContext(), CancellationToken.None);
+
+        Assert.Equal("shared content", result);
+    }
+
     private ToolExecutionContext CreatePersonalContext()
         => new("signalr/thread-1", _sessionDir)
         {

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -23,11 +23,11 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         [property: Description("Line number to start reading from (1-based, optional)")] int? Offset = null,
         [property: Description("Maximum number of lines to read (optional)")] int? Limit = null);
 
-    public FileReadTool(ToolConfig config, ToolPathPolicy? pathPolicy = null)
+    public FileReadTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
     {
         _config = config;
         _pathPolicy = pathPolicy;
-        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -7,9 +7,9 @@ internal sealed class ScopedFileAccessPolicy
 {
     private readonly ToolAudienceProfileResolver _profileResolver;
 
-    public ScopedFileAccessPolicy(ToolConfig toolConfig)
+    public ScopedFileAccessPolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
     {
-        _profileResolver = new ToolAudienceProfileResolver(toolConfig);
+        _profileResolver = new ToolAudienceProfileResolver(toolConfig, paths);
     }
 
     public bool TryResolveReadPath(string rawPath, ToolExecutionContext context, out string fullPath, out string error)
@@ -32,10 +32,18 @@ internal sealed class ScopedFileAccessPolicy
             _ => profile.ReadFiles
         };
 
-        return _profileResolver.ResolveRoots(access, context)
+        var roots = _profileResolver.ResolveRoots(access, context)
             .Select(NormalizeDirectoryPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+            .ToList();
+
+        // Merge global read roots for read access
+        if (accessKind == AccessKind.Read)
+        {
+            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
+                roots.Add(globalRoot);
+        }
+
+        return roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private bool TryResolvePath(
@@ -79,16 +87,24 @@ internal sealed class ScopedFileAccessPolicy
 
         var roots = _profileResolver.ResolveRoots(access, context)
             .Select(NormalizeDirectoryPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+            .ToList();
 
-        if (roots.Length == 0)
+        // Merge global read roots for read access
+        if (accessKind == AccessKind.Read)
+        {
+            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
+                roots.Add(globalRoot);
+        }
+
+        var distinctRoots = roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+        if (distinctRoots.Length == 0)
         {
             error = $"Error: {GetAudienceLabel(context)} trust context does not have any configured local file roots for {accessKind.ToString().ToLowerInvariant()} access.";
             return false;
         }
 
-        foreach (var root in roots)
+        foreach (var root in distinctRoots)
         {
             if (!IsPathWithinDirectory(fullPath, root))
                 continue;
@@ -103,7 +119,7 @@ internal sealed class ScopedFileAccessPolicy
             return true;
         }
 
-        error = $"Error: {GetAudienceLabel(context)} trust context may only access files inside the current session directory or configured roots: {string.Join(", ", roots)}.";
+        error = $"Error: {GetAudienceLabel(context)} trust context may only access files inside the current session directory or configured roots: {string.Join(", ", distinctRoots)}.";
         return false;
     }
 

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -24,26 +24,8 @@ internal sealed class ScopedFileAccessPolicy
     public IReadOnlyList<string> GetRootsForContext(ToolExecutionContext context, AccessKind accessKind)
     {
         var profile = _profileResolver.ResolveProfile(context);
-        var access = accessKind switch
-        {
-            AccessKind.Read => profile.ReadFiles,
-            AccessKind.Write => profile.WriteFiles,
-            AccessKind.Attach => profile.AttachFiles,
-            _ => profile.ReadFiles
-        };
-
-        var roots = _profileResolver.ResolveRoots(access, context)
-            .Select(NormalizeDirectoryPath)
-            .ToList();
-
-        // Merge global read roots for read access
-        if (accessKind == AccessKind.Read)
-        {
-            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
-                roots.Add(globalRoot);
-        }
-
-        return roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var access = GetAccessProfile(profile, accessKind);
+        return ResolveAndMergeRoots(access, context, accessKind);
     }
 
     private bool TryResolvePath(
@@ -65,13 +47,7 @@ internal sealed class ScopedFileAccessPolicy
         }
 
         var profile = _profileResolver.ResolveProfile(context);
-        var access = accessKind switch
-        {
-            AccessKind.Read => profile.ReadFiles,
-            AccessKind.Write => profile.WriteFiles,
-            AccessKind.Attach => profile.AttachFiles,
-            _ => profile.ReadFiles
-        };
+        var access = GetAccessProfile(profile, accessKind);
 
         if (access.Mode == ToolFilesystemMode.All)
         {
@@ -85,26 +61,15 @@ internal sealed class ScopedFileAccessPolicy
             return false;
         }
 
-        var roots = _profileResolver.ResolveRoots(access, context)
-            .Select(NormalizeDirectoryPath)
-            .ToList();
+        var roots = ResolveAndMergeRoots(access, context, accessKind);
 
-        // Merge global read roots for read access
-        if (accessKind == AccessKind.Read)
-        {
-            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
-                roots.Add(globalRoot);
-        }
-
-        var distinctRoots = roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
-
-        if (distinctRoots.Length == 0)
+        if (roots.Count == 0)
         {
             error = $"Error: {GetAudienceLabel(context)} trust context does not have any configured local file roots for {accessKind.ToString().ToLowerInvariant()} access.";
             return false;
         }
 
-        foreach (var root in distinctRoots)
+        foreach (var root in roots)
         {
             if (!IsPathWithinDirectory(fullPath, root))
                 continue;
@@ -119,8 +84,40 @@ internal sealed class ScopedFileAccessPolicy
             return true;
         }
 
-        error = $"Error: {GetAudienceLabel(context)} trust context may only access files inside the current session directory or configured roots: {string.Join(", ", distinctRoots)}.";
+        error = $"Error: {GetAudienceLabel(context)} trust context may only access files inside the current session directory or configured roots: {string.Join(", ", roots)}.";
         return false;
+    }
+
+    private static ToolFilesystemAccessProfile GetAccessProfile(ToolAudienceProfile profile, AccessKind accessKind) =>
+        accessKind switch
+        {
+            AccessKind.Read => profile.ReadFiles,
+            AccessKind.Write => profile.WriteFiles,
+            AccessKind.Attach => profile.AttachFiles,
+            _ => profile.ReadFiles
+        };
+
+    /// <summary>
+    /// Resolves profile roots and merges global read roots for read access.
+    /// Single source of truth for root resolution — used by both
+    /// <see cref="GetRootsForContext"/> and <see cref="TryResolvePath"/>.
+    /// </summary>
+    private IReadOnlyList<string> ResolveAndMergeRoots(
+        ToolFilesystemAccessProfile access,
+        ToolExecutionContext context,
+        AccessKind accessKind)
+    {
+        var roots = _profileResolver.ResolveRoots(access, context)
+            .Select(NormalizeDirectoryPath)
+            .ToList();
+
+        if (accessKind == AccessKind.Read)
+        {
+            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
+                roots.Add(globalRoot);
+        }
+
+        return roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private static string GetAudienceLabel(ToolExecutionContext context)

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -6,10 +6,16 @@ namespace Netclaw.Actors.Tools;
 internal sealed class ScopedFileAccessPolicy
 {
     private readonly ToolAudienceProfileResolver _profileResolver;
+    private readonly Lazy<IReadOnlyList<string>> _cachedGlobalReadRoots;
 
     public ScopedFileAccessPolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
     {
         _profileResolver = new ToolAudienceProfileResolver(toolConfig, paths);
+        _cachedGlobalReadRoots = new Lazy<IReadOnlyList<string>>(() =>
+            _profileResolver.ResolveGlobalReadRoots()
+                .Select(NormalizeDirectoryPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray());
     }
 
     public bool TryResolveReadPath(string rawPath, ToolExecutionContext context, out string fullPath, out string error)
@@ -113,7 +119,7 @@ internal sealed class ScopedFileAccessPolicy
 
         if (accessKind == AccessKind.Read)
         {
-            foreach (var globalRoot in _profileResolver.ResolveGlobalReadRoots().Select(NormalizeDirectoryPath))
+            foreach (var globalRoot in _cachedGlobalReadRoots.Value)
                 roots.Add(globalRoot);
         }
 

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -53,23 +53,9 @@ internal sealed class ToolAudienceProfileResolver
         var roots = new List<string>();
         foreach (var root in profiles.GlobalReadRoots)
         {
-            if (string.IsNullOrWhiteSpace(root))
-                continue;
-
-            var trimmed = root.Trim();
-            if (string.Equals(trimmed, ToolAudienceProfileDefaults.SkillsDirectoryToken, StringComparison.OrdinalIgnoreCase))
-            {
-                roots.Add(_paths.SkillsDirectory);
-            }
-            else if (string.Equals(trimmed, ToolAudienceProfileDefaults.IdentityDirectoryToken, StringComparison.OrdinalIgnoreCase))
-            {
-                roots.Add(_paths.IdentityDirectory);
-            }
-            else
-            {
-                // Literal path
-                roots.Add(trimmed);
-            }
+            var resolved = ResolvePathToken(root);
+            if (resolved is not null)
+                roots.Add(resolved);
         }
 
         return roots;
@@ -100,6 +86,28 @@ internal sealed class ToolAudienceProfileResolver
         return IsMcpServerAllowed(serverName, profile);
     }
 
+    /// <summary>
+    /// Resolves a path token (e.g. <c>{skills_dir}</c>, <c>{identity_dir}</c>) to an absolute path.
+    /// Returns null for empty input or if <see cref="_paths"/> is not available for path-based tokens.
+    /// Unrecognized values are treated as literal paths.
+    /// </summary>
+    private string? ResolvePathToken(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        var trimmed = token.Trim();
+
+        if (string.Equals(trimmed, ToolAudienceProfileDefaults.SkillsDirectoryToken, StringComparison.OrdinalIgnoreCase))
+            return _paths?.SkillsDirectory;
+
+        if (string.Equals(trimmed, ToolAudienceProfileDefaults.IdentityDirectoryToken, StringComparison.OrdinalIgnoreCase))
+            return _paths?.IdentityDirectory;
+
+        // Literal path
+        return trimmed;
+    }
+
     private string? ResolveToken(string root, ToolExecutionContext context)
     {
         if (string.IsNullOrWhiteSpace(root))
@@ -107,22 +115,12 @@ internal sealed class ToolAudienceProfileResolver
 
         var trimmed = root.Trim();
 
+        // Session token requires context, not paths
         if (string.Equals(trimmed, ToolAudienceProfileDefaults.SessionDirectoryToken, StringComparison.OrdinalIgnoreCase))
-        {
             return string.IsNullOrWhiteSpace(context.SessionDirectory) ? null : context.SessionDirectory;
-        }
 
-        if (string.Equals(trimmed, ToolAudienceProfileDefaults.SkillsDirectoryToken, StringComparison.OrdinalIgnoreCase))
-        {
-            return _paths?.SkillsDirectory;
-        }
-
-        if (string.Equals(trimmed, ToolAudienceProfileDefaults.IdentityDirectoryToken, StringComparison.OrdinalIgnoreCase))
-        {
-            return _paths?.IdentityDirectory;
-        }
-
-        return trimmed;
+        // Delegate to shared path token resolver
+        return ResolvePathToken(trimmed);
     }
 
     private static TrustAudience ResolveAudience(ToolExecutionContext? context)

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -42,13 +42,11 @@ internal sealed class ToolAudienceProfileResolver
 
     /// <summary>
     /// Resolves <see cref="ToolAudienceProfiles.GlobalReadRoots"/> tokens into absolute paths.
-    /// Returns empty if paths are not available or no roots are configured.
+    /// Token-based roots (e.g. <c>{skills_dir}</c>) require <see cref="_paths"/> to resolve;
+    /// literal paths are always included.
     /// </summary>
     public IReadOnlyList<string> ResolveGlobalReadRoots()
     {
-        if (_paths is null)
-            return [];
-
         var profiles = _toolConfig.AudienceProfiles;
         var roots = new List<string>();
         foreach (var root in profiles.GlobalReadRoots)

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -6,10 +6,12 @@ namespace Netclaw.Actors.Tools;
 internal sealed class ToolAudienceProfileResolver
 {
     private readonly ToolConfig _toolConfig;
+    private readonly NetclawPaths? _paths;
 
-    public ToolAudienceProfileResolver(ToolConfig toolConfig)
+    public ToolAudienceProfileResolver(ToolConfig toolConfig, NetclawPaths? paths = null)
     {
         _toolConfig = toolConfig;
+        _paths = paths;
     }
 
     public ToolAudienceProfile ResolveProfile(ToolExecutionContext? context)
@@ -30,17 +32,44 @@ internal sealed class ToolAudienceProfileResolver
         var roots = new List<string>();
         foreach (var root in access.Roots)
         {
+            var resolved = ResolveToken(root, context);
+            if (resolved is not null)
+                roots.Add(resolved);
+        }
+
+        return roots;
+    }
+
+    /// <summary>
+    /// Resolves <see cref="ToolAudienceProfiles.GlobalReadRoots"/> tokens into absolute paths.
+    /// Returns empty if paths are not available or no roots are configured.
+    /// </summary>
+    public IReadOnlyList<string> ResolveGlobalReadRoots()
+    {
+        if (_paths is null)
+            return [];
+
+        var profiles = _toolConfig.AudienceProfiles;
+        var roots = new List<string>();
+        foreach (var root in profiles.GlobalReadRoots)
+        {
             if (string.IsNullOrWhiteSpace(root))
                 continue;
 
-            if (string.Equals(root.Trim(), ToolAudienceProfileDefaults.SessionDirectoryToken, StringComparison.OrdinalIgnoreCase))
+            var trimmed = root.Trim();
+            if (string.Equals(trimmed, ToolAudienceProfileDefaults.SkillsDirectoryToken, StringComparison.OrdinalIgnoreCase))
             {
-                if (!string.IsNullOrWhiteSpace(context.SessionDirectory))
-                    roots.Add(context.SessionDirectory!);
-                continue;
+                roots.Add(_paths.SkillsDirectory);
             }
-
-            roots.Add(root.Trim());
+            else if (string.Equals(trimmed, ToolAudienceProfileDefaults.IdentityDirectoryToken, StringComparison.OrdinalIgnoreCase))
+            {
+                roots.Add(_paths.IdentityDirectory);
+            }
+            else
+            {
+                // Literal path
+                roots.Add(trimmed);
+            }
         }
 
         return roots;
@@ -69,6 +98,31 @@ internal sealed class ToolAudienceProfileResolver
     {
         var profile = ResolveProfile(audience);
         return IsMcpServerAllowed(serverName, profile);
+    }
+
+    private string? ResolveToken(string root, ToolExecutionContext context)
+    {
+        if (string.IsNullOrWhiteSpace(root))
+            return null;
+
+        var trimmed = root.Trim();
+
+        if (string.Equals(trimmed, ToolAudienceProfileDefaults.SessionDirectoryToken, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.IsNullOrWhiteSpace(context.SessionDirectory) ? null : context.SessionDirectory;
+        }
+
+        if (string.Equals(trimmed, ToolAudienceProfileDefaults.SkillsDirectoryToken, StringComparison.OrdinalIgnoreCase))
+        {
+            return _paths?.SkillsDirectory;
+        }
+
+        if (string.Equals(trimmed, ToolAudienceProfileDefaults.IdentityDirectoryToken, StringComparison.OrdinalIgnoreCase))
+        {
+            return _paths?.IdentityDirectory;
+        }
+
+        return trimmed;
     }
 
     private static TrustAudience ResolveAudience(ToolExecutionContext? context)

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -19,10 +19,11 @@ public static class ToolRegistrationExtensions
         ToolConfig config,
         ISearchBackend? searchBackend = null,
         ToolPathPolicy? pathPolicy = null,
-        ToolAccessPolicy? toolAccessPolicy = null)
+        ToolAccessPolicy? toolAccessPolicy = null,
+        NetclawPaths? paths = null)
     {
         registry.Register(new ShellTool(config, pathPolicy));
-        registry.Register(new FileReadTool(config, pathPolicy));
+        registry.Register(new FileReadTool(config, pathPolicy, paths));
         registry.Register(new FileWriteTool(config, pathPolicy));
         registry.Register(new AttachFileTool(config));
         if (searchBackend is not null)

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -30,9 +30,8 @@ public static class SlackAclPolicy
 
         var isExplicitUser = options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
-        var audience = (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
-            ? TrustAudience.Team
-            : TrustAudience.Public;
+
+        var audience = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
 
         var principal = isExplicitUser
             ? PrincipalClassification.TrustedInternal
@@ -63,6 +62,36 @@ public static class SlackAclPolicy
             return true;
 
         return options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Resolves audience via: explicit channel ID → "dm" key → existing heuristic fallback.
+    /// </summary>
+    internal static TrustAudience ResolveAudience(
+        SlackInboundMessage message,
+        SlackChannelOptions options,
+        bool isExplicitUser,
+        bool isExplicitChannel)
+    {
+        // 1. Explicit channel ID mapping
+        if (options.ChannelAudiences.TryGetValue(message.ChannelId.Value, out var channelOverride)
+            && SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience))
+        {
+            return channelAudience;
+        }
+
+        // 2. DM key mapping
+        if (message.IsDirectMessage
+            && options.ChannelAudiences.TryGetValue("dm", out var dmOverride)
+            && SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience))
+        {
+            return dmAudience;
+        }
+
+        // 3. Existing heuristic fallback
+        return (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
+            ? TrustAudience.Team
+            : TrustAudience.Public;
     }
 
     /// <summary>

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -31,7 +31,11 @@ public static class SlackAclPolicy
         var isExplicitUser = options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
-        var audience = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
+        var audienceResult = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
+        if (audienceResult.Error is not null)
+            return SlackAclDecision.Deny(audienceResult.Error);
+
+        var audience = audienceResult.Audience;
 
         var principal = isExplicitUser
             ? PrincipalClassification.TrustedInternal
@@ -66,32 +70,44 @@ public static class SlackAclPolicy
 
     /// <summary>
     /// Resolves audience via: explicit channel ID → "dm" key → existing heuristic fallback.
+    /// Returns an error when a <see cref="SlackChannelOptions.ChannelAudiences"/> key matches
+    /// but the value is not a recognized audience string — this is a config error, not a
+    /// "fall through to default" situation.
     /// </summary>
-    internal static TrustAudience ResolveAudience(
+    internal static AudienceResult ResolveAudience(
         SlackInboundMessage message,
         SlackChannelOptions options,
         bool isExplicitUser,
         bool isExplicitChannel)
     {
         // 1. Explicit channel ID mapping
-        if (options.ChannelAudiences.TryGetValue(message.ChannelId.Value, out var channelOverride)
-            && SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience))
+        if (options.ChannelAudiences.TryGetValue(message.ChannelId.Value, out var channelOverride))
         {
-            return channelAudience;
+            return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
+                ? new AudienceResult(channelAudience)
+                : new AudienceResult($"invalid_channel_audience:{message.ChannelId.Value}={channelOverride}");
         }
 
         // 2. DM key mapping
         if (message.IsDirectMessage
-            && options.ChannelAudiences.TryGetValue("dm", out var dmOverride)
-            && SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience))
+            && options.ChannelAudiences.TryGetValue("dm", out var dmOverride))
         {
-            return dmAudience;
+            return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
+                ? new AudienceResult(dmAudience)
+                : new AudienceResult($"invalid_channel_audience:dm={dmOverride}");
         }
 
-        // 3. Existing heuristic fallback
-        return (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
+        // 3. Existing heuristic fallback (no key matched — this is the only legitimate fallback)
+        var audience = (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
             ? TrustAudience.Team
             : TrustAudience.Public;
+        return new AudienceResult(audience);
+    }
+
+    internal readonly record struct AudienceResult(TrustAudience Audience, string? Error)
+    {
+        public AudienceResult(TrustAudience audience) : this(audience, null) { }
+        public AudienceResult(string error) : this(default, error) { }
     }
 
     /// <summary>

--- a/src/Netclaw.Channels.Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannelOptions.cs
@@ -37,5 +37,5 @@ public sealed class SlackChannelOptions
     /// <c>"personal"</c>, <c>"team"</c>, or <c>"public"</c>.
     /// When a channel/DM is not mapped, the existing ACL heuristic applies.
     /// </summary>
-    public Dictionary<string, string> ChannelAudiences { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> ChannelAudiences { get; init; } = new(StringComparer.Ordinal);
 }

--- a/src/Netclaw.Channels.Slack/SlackChannelOptions.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannelOptions.cs
@@ -30,4 +30,12 @@ public sealed class SlackChannelOptions
     public string[] AllowedChannelIds { get; init; } = [];
 
     public string[] AllowedUserIds { get; init; } = [];
+
+    /// <summary>
+    /// Per-channel audience overrides. Keys are Slack channel IDs or the special
+    /// key <c>"dm"</c> for direct messages. Values are audience strings:
+    /// <c>"personal"</c>, <c>"team"</c>, or <c>"public"</c>.
+    /// When a channel/DM is not mapped, the existing ACL heuristic applies.
+    /// </summary>
+    public Dictionary<string, string> ChannelAudiences { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class SecurityPolicyDoctorCheckTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public SecurityPolicyDoctorCheckTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task MissingSecuritySection_IsError()
+    {
+        WriteConfig(new { configVersion = 1 });
+        var check = new SecurityPolicyDoctorCheck(_paths);
+
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Security section is missing", result.Message);
+    }
+
+    [Fact]
+    public async Task NullPosture_StrictDisabled_IsError()
+    {
+        WriteConfig("""
+            {
+              "configVersion": 1,
+              "Security": {
+                "StrictDefaults": false
+              }
+            }
+            """);
+
+        var check = new SecurityPolicyDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("silently assumes Personal posture", result.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitPersonalPosture_HostAllowed_Warns()
+    {
+        WriteConfig("""
+            {
+              "configVersion": 1,
+              "Security": {
+                "DeploymentPosture": "Personal",
+                "ShellExecutionMode": "HostAllowed",
+                "StrictDefaults": true
+              }
+            }
+            """);
+
+        var check = new SecurityPolicyDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("full host access", result.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitTeamPosture_ShellOff_Passes()
+    {
+        WriteConfig("""
+            {
+              "configVersion": 1,
+              "Security": {
+                "DeploymentPosture": "Team",
+                "ShellExecutionMode": "Off",
+                "StrictDefaults": true
+              }
+            }
+            """);
+
+        var check = new SecurityPolicyDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("Team", result.Message);
+    }
+
+    [Fact]
+    public async Task MissingConfigFile_IsError()
+    {
+        // Don't write any config
+        var check = new SecurityPolicyDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        // DoctorJsonConfigReader returns Warning for missing file,
+        // which the check propagates
+        Assert.True(result.Severity is DoctorSeverity.Warning or DoctorSeverity.Error);
+    }
+
+    private void WriteConfig(object config)
+    {
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        options.Converters.Add(new JsonStringEnumConverter());
+        File.WriteAllText(_paths.NetclawConfigPath, JsonSerializer.Serialize(config, options));
+    }
+
+    private void WriteConfig(string configText)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath, configText);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
@@ -98,15 +98,14 @@ public sealed class SecurityPolicyDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task MissingConfigFile_IsError()
+    public async Task MissingConfigFile_DelegatesToConfigReader_Warning()
     {
-        // Don't write any config
+        // Don't write any config — DoctorJsonConfigReader returns Warning for missing file
         var check = new SecurityPolicyDoctorCheck(_paths);
         var result = await check.RunAsync();
 
-        // DoctorJsonConfigReader returns Warning for missing file,
-        // which the check propagates
-        Assert.True(result.Severity is DoctorSeverity.Warning or DoctorSeverity.Error);
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Equal("Config File", result.Name);
     }
 
     private void WriteConfig(object config)

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -24,15 +24,15 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task MissingToolsSection_WarnsAboutStrictDefaults()
+    public async Task MissingToolsSection_IsError()
     {
         WriteConfig(new { configVersion = 1 });
         var check = new ToolAudienceProfilesDoctorCheck(_paths);
 
         var result = await check.RunAsync();
 
-        Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("strict", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Tools section is missing", result.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardViewModelTests.cs
@@ -1082,6 +1082,44 @@ public sealed class InitWizardViewModelTests : IDisposable
         Assert.Contains("Environment Capabilities", tooling, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PopulateChannelAudiences_personal_posture_dm_maps_to_personal()
+    {
+        using var vm = CreateViewModel();
+        vm.ExposureMode = "Local only";
+        vm.SlackAllowDirectMessages = true;
+
+        vm.PopulateChannelAudiences();
+
+        Assert.True(vm.ChannelAudiences.ContainsKey("dm"));
+        Assert.Equal("personal", vm.ChannelAudiences["dm"]);
+    }
+
+    [Fact]
+    public void PopulateChannelAudiences_team_posture_dm_maps_to_team()
+    {
+        using var vm = CreateViewModel();
+        vm.ExposureMode = "Private network";
+        vm.SlackAllowDirectMessages = true;
+
+        vm.PopulateChannelAudiences();
+
+        Assert.True(vm.ChannelAudiences.ContainsKey("dm"));
+        Assert.Equal("team", vm.ChannelAudiences["dm"]);
+    }
+
+    [Fact]
+    public void PopulateChannelAudiences_no_dm_enabled_has_no_dm_key()
+    {
+        using var vm = CreateViewModel();
+        vm.ExposureMode = "Local only";
+        vm.SlackAllowDirectMessages = false;
+
+        vm.PopulateChannelAudiences();
+
+        Assert.False(vm.ChannelAudiences.ContainsKey("dm"));
+    }
+
     private InitWizardViewModel CreateViewModel(IBrowserAutomationBootstrapper? browserBootstrapper = null)
     {
         return new InitWizardViewModel(_paths, _registry, _fakeProbe, _fakeSlackProbe, browserBootstrapper);

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -10,6 +10,7 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<DoctorFixService>();
         services.AddSingleton<IDoctorCheck, ConfigSchemaDoctorCheck>();
         services.AddSingleton<IDoctorCheck, ToolAudienceProfilesDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, SecurityPolicyDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SlackAclDoctorCheck>();
         services.AddSingleton<IDoctorCheck, TelemetryDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();

--- a/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class SecurityPolicyDoctorCheck(NetclawPaths paths) : IDoctorCheck
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var (root, error) = DoctorJsonConfigReader.TryReadConfig(paths);
+        if (error is not null)
+            return Task.FromResult(error);
+
+        if (root is null)
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Security Policy",
+                "Config file is missing; security policy cannot be evaluated.",
+                "Run `netclaw init` to scaffold a baseline config with security defaults."));
+
+        if (root["Security"] is not JsonObject securityObject)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Security Policy",
+                "Security section is missing; strict fallback defaults are active (Public posture, shell disabled).",
+                "Add a Security section with DeploymentPosture or run `netclaw init` again."));
+        }
+
+        SecurityPolicyConfig config;
+        try
+        {
+            config = JsonSerializer.Deserialize<SecurityPolicyConfig>(securityObject.ToJsonString(), JsonOptions)
+                     ?? new SecurityPolicyConfig();
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Security Policy",
+                $"Failed to parse Security configuration: {ex.Message}",
+                "Fix Security section values or rerun `netclaw init`."));
+        }
+
+        var effective = SecurityPolicyDefaults.Resolve(config);
+
+        if (!config.DeploymentPosture.HasValue && !config.StrictDefaults)
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                "Security Policy",
+                "DeploymentPosture is null with StrictDefaults disabled — this silently assumes Personal posture with full access.",
+                "Set an explicit DeploymentPosture value or enable StrictDefaults."));
+        }
+
+        var warnings = new List<string>();
+
+        if (effective.UsedStrictFallback && !config.DeploymentPosture.HasValue)
+        {
+            warnings.Add("DeploymentPosture not set; strict fallback resolved to Public.");
+        }
+
+        if (effective.DeploymentPosture == DeploymentPosture.Personal
+            && effective.ShellExecutionMode == ShellExecutionMode.HostAllowed)
+        {
+            warnings.Add("Personal posture with HostAllowed shell — full host access is enabled.");
+        }
+
+        if (warnings.Count > 0)
+        {
+            return Task.FromResult(DoctorCheckResult.Warning(
+                "Security Policy",
+                string.Join(" ", warnings),
+                "Review deployment posture and shell mode. Set explicit values to suppress this warning."));
+        }
+
+        return Task.FromResult(DoctorCheckResult.Pass(
+            "Security Policy",
+            $"Deployment posture: {effective.DeploymentPosture}, Shell: {effective.ShellExecutionMode}."));
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -26,9 +26,9 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
 
         if (root["Tools"] is not JsonObject toolsObject)
         {
-            return Task.FromResult(DoctorCheckResult.Warning(
+            return Task.FromResult(DoctorCheckResult.Error(
                 "Tool Audience Profiles",
-                "Tools section is missing; strict tool trust defaults are active.",
+                "Tools section is missing; tool trust policy cannot be evaluated.",
                 "Add a Tools section with AudienceProfiles or run `netclaw init` again."));
         }
 

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -129,7 +129,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
     /// Per-channel audience overrides generated from the wizard.
     /// Keys: channel IDs or "dm". Values: "personal", "team", "public".
     /// </summary>
-    public Dictionary<string, string> ChannelAudiences { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> ChannelAudiences { get; } = new(StringComparer.Ordinal);
 
     // ── Step 8: Identity ──
     public string AgentName { get; set; } = "Netclaw";

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1350,7 +1350,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
         {
             foreach (var channel in LastChannelResolution.Resolved)
             {
-                // Don't override if already set (shouldn't happen, but defensive)
+                // Channels are inherently shared spaces — always default to Team
+                // regardless of deployment posture. Personal posture only elevates
+                // DMs, not channels, because channel messages are visible to other
+                // workspace members. Operators who need Personal for a specific
+                // channel can override in netclaw.json directly.
                 ChannelAudiences.TryAdd(channel.Id, TrustAudience.Team.ToWireValue());
             }
         }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -124,6 +124,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
     public string? ExposureMode { get; set; }
     public string? WebhookUrl { get; set; }
 
+    // ── Channel trust (derived from exposure + Slack channels) ──
+    /// <summary>
+    /// Per-channel audience overrides generated from the wizard.
+    /// Keys: channel IDs or "dm". Values: "personal", "team", "public".
+    /// </summary>
+    public Dictionary<string, string> ChannelAudiences { get; } = new(StringComparer.OrdinalIgnoreCase);
+
     // ── Step 8: Identity ──
     public string AgentName { get; set; } = "Netclaw";
     public string? CommunicationStyle { get; set; }
@@ -884,6 +891,11 @@ public partial class InitWizardViewModel : ReactiveViewModel
                 slackSection["AllowedUserIds"] = userIds.ToArray();
             }
 
+            // Generate smart channel audience defaults
+            PopulateChannelAudiences();
+            if (ChannelAudiences.Count > 0)
+                slackSection["ChannelAudiences"] = new Dictionary<string, string>(ChannelAudiences);
+
             config["Slack"] = slackSection;
         }
 
@@ -900,6 +912,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
 
             config["Search"] = searchSection;
         }
+
+        // Security section — deployment posture derived from exposure mode
+        config["Security"] = new Dictionary<string, object>
+        {
+            ["DeploymentPosture"] = ResolveDeploymentPosture().ToString(),
+            ["ShellExecutionMode"] = ResolveRecommendedShellMode().ToString(),
+            ["StrictDefaults"] = true
+        };
 
         config["Tools"] = BuildRecommendedToolConfig();
 
@@ -1290,15 +1310,50 @@ public partial class InitWizardViewModel : ReactiveViewModel
         };
     }
 
-    private ShellExecutionMode ResolveRecommendedShellMode()
+    private DeploymentPosture ResolveDeploymentPosture()
     {
         if (string.IsNullOrWhiteSpace(ExposureMode)
             || ExposureMode.StartsWith("Local only", StringComparison.OrdinalIgnoreCase))
+            return DeploymentPosture.Personal;
+
+        if (ExposureMode.StartsWith("Private", StringComparison.OrdinalIgnoreCase))
+            return DeploymentPosture.Team;
+
+        return DeploymentPosture.Public;
+    }
+
+    private ShellExecutionMode ResolveRecommendedShellMode()
+    {
+        return ResolveDeploymentPosture() == DeploymentPosture.Personal
+            ? ShellExecutionMode.HostAllowed
+            : ShellExecutionMode.Off;
+    }
+
+    /// <summary>
+    /// Derives smart channel audience defaults from deployment posture.
+    /// DMs → Personal (if posture is Personal), Team otherwise.
+    /// Explicitly-added channels → Team.
+    /// </summary>
+    internal void PopulateChannelAudiences()
+    {
+        ChannelAudiences.Clear();
+        var posture = ResolveDeploymentPosture();
+
+        if (SlackAllowDirectMessages)
         {
-            return ShellExecutionMode.HostAllowed;
+            ChannelAudiences["dm"] = posture == DeploymentPosture.Personal
+                ? TrustAudience.Personal.ToWireValue()
+                : TrustAudience.Team.ToWireValue();
         }
 
-        return ShellExecutionMode.Off;
+        if (LastChannelResolution is { Resolved.Count: > 0 })
+        {
+            foreach (var channel in LastChannelResolution.Resolved)
+            {
+                // Don't override if already set (shouldn't happen, but defensive)
+                ChannelAudiences.TryAdd(channel.Id, TrustAudience.Team.ToWireValue());
+            }
+        }
     }
 
     public override void Dispose()

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -26,6 +26,14 @@
         "AllowedUserIds": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "ChannelAudiences": {
+          "type": "object",
+          "description": "Per-channel audience overrides. Keys are channel IDs or 'dm'. Values are 'personal', 'team', or 'public'.",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["personal", "team", "public"]
+          }
         }
       },
       "additionalProperties": false
@@ -74,6 +82,25 @@
     "Session": {
       "type": "object",
       "additionalProperties": true
+    },
+    "Security": {
+      "type": "object",
+      "description": "Trust-context security policy defaults.",
+      "properties": {
+        "DeploymentPosture": {
+          "type": ["string", "null"],
+          "enum": ["Public", "Team", "Personal", null]
+        },
+        "ShellExecutionMode": {
+          "type": ["string", "null"],
+          "enum": ["Off", "SandboxOnly", "HostAllowed", null]
+        },
+        "StrictDefaults": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
     },
     "Tools": {
       "type": "object",
@@ -308,7 +335,12 @@
       "properties": {
         "Public": { "$ref": "#/$defs/ToolAudienceProfile" },
         "Team": { "$ref": "#/$defs/ToolAudienceProfile" },
-        "Personal": { "$ref": "#/$defs/ToolAudienceProfile" }
+        "Personal": { "$ref": "#/$defs/ToolAudienceProfile" },
+        "GlobalReadRoots": {
+          "type": "array",
+          "description": "Filesystem roots readable by all audiences. Supports tokens: {skills_dir}, {identity_dir}.",
+          "items": { "type": "string" }
+        }
       },
       "additionalProperties": false
     },

--- a/src/Netclaw.Configuration/ToolAudienceProfiles.cs
+++ b/src/Netclaw.Configuration/ToolAudienceProfiles.cs
@@ -35,11 +35,25 @@ public sealed class ToolAudienceProfiles
     public ToolAudienceProfile Public { get; set; } = ToolAudienceProfileDefaults.CreatePublic();
     public ToolAudienceProfile Team { get; set; } = ToolAudienceProfileDefaults.CreateTeam();
     public ToolAudienceProfile Personal { get; set; } = ToolAudienceProfileDefaults.CreatePersonal();
+
+    /// <summary>
+    /// Filesystem roots that are always readable regardless of audience profile.
+    /// Supports tokens: <c>{skills_dir}</c>, <c>{identity_dir}</c>.
+    /// Defaults to skills and identity directories so skill loading and identity
+    /// file reads work even under Team/Public audiences.
+    /// </summary>
+    public List<string> GlobalReadRoots { get; set; } =
+    [
+        ToolAudienceProfileDefaults.SkillsDirectoryToken,
+        ToolAudienceProfileDefaults.IdentityDirectoryToken
+    ];
 }
 
 public static class ToolAudienceProfileDefaults
 {
     public const string SessionDirectoryToken = "{session_dir}";
+    public const string SkillsDirectoryToken = "{skills_dir}";
+    public const string IdentityDirectoryToken = "{identity_dir}";
 
     public static ToolAudienceProfiles CreateProfiles() => new()
     {

--- a/src/Netclaw.Configuration/ToolAudienceProfiles.cs
+++ b/src/Netclaw.Configuration/ToolAudienceProfiles.cs
@@ -59,7 +59,8 @@ public static class ToolAudienceProfileDefaults
     {
         Public = CreatePublic(),
         Team = CreateTeam(),
-        Personal = CreatePersonal()
+        Personal = CreatePersonal(),
+        GlobalReadRoots = [SkillsDirectoryToken, IdentityDirectoryToken]
     };
 
     public static ToolAudienceProfile CreatePublic() => new()

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -367,7 +367,7 @@ static void ConfigureDaemonServices(
     services.AddSingleton(toolAccessPolicy);
 
     var toolRegistry = new ToolRegistry();
-    toolRegistry.WithFirstPartyTools(toolConfig, searchBackend, toolPathPolicy, toolAccessPolicy);
+    toolRegistry.WithFirstPartyTools(toolConfig, searchBackend, toolPathPolicy, toolAccessPolicy, paths);
 
     // Skills system: seed built-in skills to .system/, register sync service
     CopyBuiltInSkills(paths.SystemSkillsDirectory);


### PR DESCRIPTION
## Summary

- Adds **GlobalReadRoots** to `ToolAudienceProfiles` with `{skills_dir}` and `{identity_dir}` tokens — skills and identity files are now readable regardless of audience profile, unblocking skill loading under Team/Public audiences
- Adds **ChannelAudiences** dictionary to `SlackChannelOptions` for per-channel audience overrides (resolution: explicit channel ID → `"dm"` key → existing heuristic fallback)
- Adds **Security section** to config schema (`DeploymentPosture`, `ShellExecutionMode`, `StrictDefaults`)
- Init wizard now emits `Security` section and `Slack.ChannelAudiences` with smart defaults derived from deployment posture
- Escalates missing `Tools` section from Warning → **Error** in doctor check
- Adds **SecurityPolicyDoctorCheck** (missing Security → Error; null posture with relaxed defaults → Error)

## Context

PRs #380 (memory quality overhaul) and #249 (trust context policy) both merged to dev, but the system was broken: Slack sessions default to Team audience with no Tools config section, blocking `shell_execute`, restricting `file_read` to session directory (can't load skills), and causing empty response loops.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1,311 tests pass (0 failures)
- [x] `dotnet slopwatch analyze` — 0 violations
- [ ] `netclaw init` generates Security + Tools + ChannelAudiences
- [ ] `netclaw doctor` passes with complete config, fails without Security/Tools
- [ ] Slack DM → Personal → `shell_execute` works, skills loadable
- [ ] Slack channel → Team → `shell_execute` blocked, skills readable via global roots