### PR TITLE
feat(security): add minisign signature verification to netclaw update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
+    <PackageVersion Include="NSec.Cryptography" Version="24.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/design.md
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/design.md
@@ -1,0 +1,144 @@
+## Context
+
+The `netclaw update` command fetches `manifest.json` from
+`https://releases.netclaw.dev/manifest.json` over HTTPS. The manifest contains
+SHA-256 checksums for each binary asset. The client verifies downloaded binaries
+against these checksums, but never verifies that the manifest itself is
+authentic.
+
+The CI release pipeline already signs the manifest with minisign (Ed25519) and
+uploads `manifest.json.sig` and `manifest.pub` to R2. The public key is
+committed to the repo at `feeds/releases/manifest.pub`. The verification loop
+just needs to be closed on the client side.
+
+Current update check architecture:
+- `UpdateCheckService` (static, in `Netclaw.Configuration`) — shared manifest
+  fetch + evaluation logic with 1-hour cache
+- `UpdateCommand` (in `Netclaw.Cli`) — interactive CLI update flow
+- `BinaryUpdateCheckService` (in `Netclaw.Daemon`) — startup-only hosted service
+- `UpdateAvailableDoctorCheck` — doctor check (5s timeout)
+- `StatusUpdateChecker` / `BackgroundUpdateCheckAsync` — CLI background checks
+
+## Goals / Non-Goals
+
+**Goals:**
+- Verify minisign Ed25519 signature on the manifest before trusting it
+- Embed the public key in the binary so verification doesn't depend on CDN
+- Add periodic (24h) daemon-side update rechecks
+- Emit `UpdateAvailable` operational alert through existing notification infra
+- Zero new NuGet dependencies
+
+**Non-Goals:**
+- Signing individual binary assets (SHA-256 in the verified manifest is sufficient)
+- Key rotation mechanism (can be added later; requires a new binary release)
+- Configurable recheck interval (hardcoded 24h is fine for MVP)
+- Verifying the manifest during `install.sh` bootstrap (separate script, out of scope)
+
+## Decisions
+
+### 1. Minisign format parser as a standalone utility
+
+**Decision:** Create `MinisignVerifier` in `Netclaw.Configuration.Security` as a
+pure static utility that parses minisign signature files and verifies Ed25519
+signatures.
+
+**Rationale:** The minisign format is simple (2 lines: untrusted comment +
+base64-encoded signature blob). The signature blob is 74 bytes: 2-byte algorithm
+ID + 8-byte key ID + 64-byte Ed25519 signature. Parsing this is ~50 lines. The
+public key format is identical (2 lines: comment + 42 bytes: 2-byte algorithm +
+8-byte key ID + 32-byte Ed25519 public key).
+
+**Alternative considered:** Use a NuGet package for minisign. Rejected because
+no well-maintained .NET minisign library exists, and the format is trivial to
+parse. Adding a dependency for 50 lines of parsing is not justified.
+
+### 2. Ed25519 verification via System.Security.Cryptography
+
+**Decision:** Use `System.Security.Cryptography.Ed25519` (available in .NET 9+)
+for signature verification.
+
+**Rationale:** Built-in, no external dependencies, hardware-accelerated where
+available. The Ed25519 API is straightforward:
+`Ed25519.VerifyData(publicKey, data, signature)`.
+
+**Alternative considered:** `NSec.Cryptography` or `libsodium-net`. Rejected
+because .NET now has native Ed25519 support and we don't want external crypto
+dependencies.
+
+### 3. Public key embedded as a compiled constant
+
+**Decision:** Embed the raw public key bytes as a `ReadOnlySpan<byte>` constant
+in `MinisignVerifier`. The key value comes from `feeds/releases/manifest.pub`.
+
+**Rationale:** The public key must not be fetched from the CDN being verified
+(circular trust). Embedding it in the binary means it ships with every release
+and requires a new release to rotate. This is the standard approach (e.g.,
+Homebrew, Go toolchain).
+
+**Alternative considered:** Load from a local file in `~/.netclaw/`. Rejected
+because it adds a file-not-found failure mode and the key rarely changes.
+
+### 4. Signature verification in FetchManifestAsync
+
+**Decision:** Add signature verification inside `UpdateCheckService.FetchManifestAsync()`.
+After fetching the manifest JSON, fetch `manifest.json.sig`, parse it, and
+verify before deserializing the manifest. If verification fails, return `null`
+(same as any other fetch failure).
+
+**Rationale:** This is the single point through which all manifest access flows
+(CLI update, daemon check, doctor check, background check). Verifying here means
+every consumer gets verified manifests without code changes.
+
+The method already returns `null` on failure and callers handle it gracefully.
+For the interactive `netclaw update` command, we need to distinguish "no update"
+from "signature failure" — so `FetchManifestAsync` will be changed to return a
+result type that includes the failure reason. `UpdateCommand` can then display
+an appropriate error message.
+
+### 5. Periodic timer in BinaryUpdateCheckService
+
+**Decision:** Convert `BinaryUpdateCheckService` from `IHostedService` to
+`BackgroundService` with a periodic timer. Check at startup (existing behavior),
+then every 24 hours.
+
+**Rationale:** `BackgroundService.ExecuteAsync` is the standard pattern for
+long-running periodic work in ASP.NET Core. The 1-hour cache in
+`UpdateCheckService` will have long expired by the 24-hour mark, so each
+periodic check triggers a fresh manifest fetch.
+
+### 6. UpdateAvailable alert type and emission
+
+**Decision:** Add `UpdateAvailable` to the `AlertType` enum. Emit from
+`BinaryUpdateCheckService` when `result.IsUpdateAvailable` is true. Use
+`IOperationalNotificationSink` (already a registered singleton in the daemon).
+
+**Rationale:** The notification infrastructure (webhook delivery, Slack
+formatting, deduplication) already exists. The deduplication key will be
+`update.available:{latestVersion}`, so the same version doesn't spam. This is
+~10 lines of code.
+
+## Risks / Trade-offs
+
+**[Risk] Public key becomes stale after key rotation** → Mitigation: Key
+rotation requires publishing a new binary release with the updated key. This is
+acceptable because key rotation is a rare, deliberate event. Document the
+rotation procedure in the release runbook.
+
+**[Risk] Ed25519 API availability** → Mitigation: .NET 9+ includes Ed25519 in
+`System.Security.Cryptography`. Netclaw targets .NET 10, so this is available.
+Verify in CI.
+
+**[Risk] Signature check adds latency to update flow** → Mitigation: The `.sig`
+file is ~200 bytes. Fetching it is negligible compared to the manifest fetch.
+Ed25519 verification is sub-millisecond. No measurable impact.
+
+**[Risk] Older manifests published before signing was enabled** → Mitigation:
+The signing infrastructure has been in place since the first release. All
+published manifests have signatures. If a pre-signing manifest somehow exists,
+the signature fetch returns 404 and the update is rejected (fail-closed, as
+designed).
+
+**[Trade-off] Fail-closed on signature failure vs. graceful degradation** → We
+chose fail-closed. A missing or invalid signature means the manifest cannot be
+trusted. Silent fallback to unsigned manifests would defeat the purpose. The
+user sees a clear error message and can investigate.

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/proposal.md
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+Netclaw is distributed as a public open-source tool. The `netclaw update`
+command downloads a binary manifest from R2 and trusts its SHA-256 checksums to
+verify downloaded binaries — but the manifest itself is never verified for
+authenticity. A compromised CDN/R2 bucket could serve a tampered manifest with
+matching checksums pointing to malicious binaries and the client would accept it.
+
+The signing infrastructure already exists: CI signs the manifest with minisign,
+uploads `manifest.json.sig` and `manifest.pub` to R2 alongside the manifest,
+and the public key is committed to the repo. The client just never checks.
+
+Additionally, the daemon only checks for updates once at startup. Long-running
+daemons go stale — a periodic recheck with proactive notification via the
+existing operational alert system would close the loop on update awareness.
+
+## What Changes
+
+- Verify minisign Ed25519 signature on `manifest.json` before trusting its
+  contents during `netclaw update` and all background update checks.
+- Download `manifest.json.sig` alongside the manifest; fail loudly if signature
+  is missing or invalid.
+- Embed the minisign public key in the binary (compiled from
+  `feeds/releases/manifest.pub`) so verification works without fetching the key
+  from the same CDN being validated.
+- Add periodic update recheck to `BinaryUpdateCheckService` (default: every 24
+  hours while the daemon is running).
+- Emit an `UpdateAvailable` operational alert via `IOperationalNotificationSink`
+  when an update is detected, so configured webhooks (including Slack) receive
+  proactive notification.
+
+## Capabilities
+
+### New Capabilities
+
+- `manifest-signature-verification`: Minisign Ed25519 signature verification of
+  the binary feed manifest, including signature format parsing, public key
+  embedding, and fail-closed verification logic.
+
+### Modified Capabilities
+
+- `netclaw-cli`: Add signature verification requirement to the update command
+  flow and background update checks. Add periodic daemon-side recheck and
+  operational alert emission for update availability.
+
+## Impact
+
+- **Code:** `UpdateCheckService` (signature verification on manifest fetch),
+  `UpdateCommand` (no direct changes — inherits verified manifest),
+  `BinaryUpdateCheckService` (periodic timer + alert emission),
+  `OperationalAlert` (new `UpdateAvailable` alert type), new
+  `MinisignVerifier` utility class.
+- **Dependencies:** None new — Ed25519 verification available via
+  `System.Security.Cryptography` in .NET 10. No external NuGet packages needed.
+- **Build:** Public key embedded as a compiled constant or embedded resource;
+  no runtime dependency on `feeds/releases/manifest.pub` file.
+- **Security:** Closes a supply-chain verification gap. Fail-closed: if
+  signature is missing, invalid, or verification fails, the manifest is
+  rejected. No silent fallback to unsigned manifests.
+- **Wire compatibility:** No protocol changes. The `.sig` file is already
+  published by CI. Older clients that don't verify signatures continue to work
+  (they just ignore the `.sig` file).
+- **PRD traceability:** Extends PRD-004 (CLI onboarding and config) update
+  command security posture. Extends PRD-001 (MVP) default-deny security stance
+  to the update channel.

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/specs/manifest-signature-verification/spec.md
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/specs/manifest-signature-verification/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Minisign signature format parsing
+
+The system SHALL parse minisign detached signature files (`.sig`) into their
+component parts: untrusted comment line, signature algorithm identifier, key ID,
+and Ed25519 signature bytes. The parser SHALL reject signatures that do not
+conform to the minisign format.
+
+#### Scenario: Parse valid minisign signature file
+
+- **WHEN** a valid minisign `.sig` file is provided
+- **THEN** the parser extracts the Ed25519 signature bytes and key ID
+- **AND** the key ID matches the expected signing key
+
+#### Scenario: Reject malformed signature file
+
+- **WHEN** a `.sig` file with invalid format is provided (wrong line count,
+  missing header, invalid base64)
+- **THEN** the parser returns a failure result
+- **AND** no signature bytes are produced
+
+#### Scenario: Reject signature with wrong algorithm
+
+- **WHEN** a `.sig` file specifies an algorithm other than Ed25519 (pure)
+- **THEN** the parser returns a failure result indicating unsupported algorithm
+
+### Requirement: Ed25519 signature verification
+
+The system SHALL verify Ed25519 signatures against the manifest content using
+the embedded public key. Verification SHALL use `System.Security.Cryptography`
+built-in Ed25519 support with no external cryptography dependencies.
+
+#### Scenario: Valid signature accepted
+
+- **WHEN** a manifest and its corresponding valid `.sig` are provided
+- **THEN** Ed25519 verification succeeds
+- **AND** the manifest content is trusted
+
+#### Scenario: Tampered manifest rejected
+
+- **WHEN** a manifest has been modified after signing
+- **THEN** Ed25519 verification fails
+- **AND** the manifest content is rejected
+
+#### Scenario: Wrong key rejected
+
+- **WHEN** a valid signature was produced by a different signing key
+- **THEN** verification fails because the key ID does not match the embedded
+  public key
+
+### Requirement: Embedded public key
+
+The system SHALL embed the minisign public key as a compiled constant in the
+binary. The key SHALL NOT be fetched from the CDN at runtime, because the CDN
+is the untrusted channel being verified.
+
+#### Scenario: Public key available without network
+
+- **WHEN** signature verification is performed
+- **THEN** the public key is read from the compiled binary
+- **AND** no HTTP request is made to obtain the public key
+
+#### Scenario: Public key matches release infrastructure
+
+- **GIVEN** the CI pipeline signs with the private key corresponding to
+  `feeds/releases/manifest.pub`
+- **WHEN** the embedded public key is compared to the repo copy
+- **THEN** they are identical
+
+### Requirement: Fail-closed manifest verification
+
+The system SHALL reject the manifest and abort the update when signature
+verification fails. There SHALL be no fallback to unsigned manifest acceptance.
+
+#### Scenario: Missing signature file aborts update
+
+- **WHEN** `manifest.json.sig` cannot be downloaded (404, timeout, network error)
+- **THEN** the manifest is rejected
+- **AND** the update command exits with a non-zero code and an error message
+  explaining the signature is missing
+
+#### Scenario: Invalid signature aborts update
+
+- **WHEN** the signature does not verify against the manifest content
+- **THEN** the manifest is rejected
+- **AND** the update command exits with a non-zero code and an error message
+  warning of possible tampering
+
+#### Scenario: Background check with signature failure
+
+- **WHEN** a background update check encounters a signature verification failure
+- **THEN** the check returns a "no update" result (same as network failure)
+- **AND** the failure is logged at warning level

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/specs/netclaw-cli/spec.md
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/specs/netclaw-cli/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Signed manifest verification during update
+
+The `netclaw update` command SHALL verify the minisign signature of
+`manifest.json` before trusting its contents. The command SHALL download
+`manifest.json.sig` alongside the manifest and verify the Ed25519 signature
+against the embedded public key. The command SHALL reject the manifest and abort
+the update if signature verification fails.
+
+#### Scenario: Successful update with valid signature
+
+- **WHEN** operator runs `netclaw update`
+- **AND** the manifest signature verifies against the embedded public key
+- **THEN** the update proceeds normally using the verified manifest checksums
+
+#### Scenario: Update aborted on invalid signature
+
+- **WHEN** operator runs `netclaw update`
+- **AND** the manifest signature does not verify
+- **THEN** the command exits with a non-zero code
+- **AND** an error message warns of possible manifest tampering
+
+#### Scenario: Update aborted when signature file missing
+
+- **WHEN** operator runs `netclaw update`
+- **AND** `manifest.json.sig` cannot be downloaded
+- **THEN** the command exits with a non-zero code
+- **AND** an error message explains the signature file is missing
+
+### Requirement: Periodic daemon update check
+
+The daemon SHALL periodically recheck for available updates while running.
+The default recheck interval SHALL be 24 hours. The recheck SHALL use the same
+`UpdateCheckService` and signature verification as the CLI update command.
+
+#### Scenario: Daemon detects update after startup
+
+- **GIVEN** the daemon started with no update available
+- **WHEN** a new release is published and 24 hours elapse
+- **THEN** the daemon detects the available update on the next periodic check
+
+#### Scenario: Recheck interval respects cache
+
+- **GIVEN** the update check cache duration is 1 hour
+- **WHEN** the periodic timer fires at the 24-hour interval
+- **THEN** a fresh manifest fetch is performed (cache has long expired)
+
+### Requirement: Update availability operational alert
+
+The daemon SHALL emit an `UpdateAvailable` operational alert via
+`IOperationalNotificationSink` when an update is detected. The alert SHALL
+be emitted at most once per detected version (deduplicated by the existing
+webhook deduplication mechanism).
+
+#### Scenario: Alert emitted on update detection
+
+- **GIVEN** the daemon detects an available update
+- **WHEN** the update check result indicates `IsUpdateAvailable`
+- **THEN** an `UpdateAvailable` operational alert is emitted with severity
+  "info"
+- **AND** the alert summary includes the current and available versions
+
+#### Scenario: Alert delivered to configured webhooks
+
+- **GIVEN** a Slack webhook is configured in notifications config
+- **WHEN** an `UpdateAvailable` alert is emitted
+- **THEN** the webhook receives a notification formatted per the webhook format
+  (Generic JSON or Slack Block Kit)
+
+#### Scenario: Alert not duplicated within dedup window
+
+- **GIVEN** an `UpdateAvailable` alert was recently emitted for the same version
+- **WHEN** the periodic recheck runs again within the deduplication window
+- **THEN** no duplicate alert is emitted

--- a/openspec/changes/archive/2026-03-23-verify-update-signatures/tasks.md
+++ b/openspec/changes/archive/2026-03-23-verify-update-signatures/tasks.md
@@ -1,0 +1,31 @@
+## 1. Minisign Format Parser
+
+- [x] 1.1 Create `MinisignVerifier` static class in `Netclaw.Configuration/Security/` with public key parsing (2-byte algo + 8-byte key ID + 32-byte Ed25519 key from base64 line)
+- [x] 1.2 Add signature file parsing (2-byte algo + 8-byte key ID + 64-byte Ed25519 signature from base64 line)
+- [x] 1.3 Add Ed25519 signature verification method using `NSec.Cryptography` — accepts manifest bytes, signature bytes, and public key bytes
+- [x] 1.4 Embed the public key from `feeds/releases/manifest.pub` as a compiled `ReadOnlySpan<byte>` constant
+- [x] 1.5 Add unit tests for: valid signature accepted, tampered content rejected, malformed signature rejected, wrong key ID rejected
+
+## 2. Manifest Signature Verification
+
+- [x] 2.1 Add `FeedConstants.BinaryManifestSignatureUrl` for `manifest.json.sig` endpoint
+- [x] 2.2 Change `UpdateCheckService.FetchManifestAsync` return type to a result type that distinguishes success, network failure, and signature failure
+- [x] 2.3 In `FetchManifestAsync`, download `manifest.json.sig` after fetching the manifest, verify signature before deserializing, return signature failure result if verification fails
+- [x] 2.4 Update `UpdateCommand.RunAsync` to check the result type and display appropriate error messages for signature failures vs. network failures
+- [x] 2.5 Update `CheckForUpdateAsync` callers to handle the new result type (background checks treat signature failure same as network failure — log warning, return no-update)
+- [x] 2.6 Add integration-style tests with real minisign-signed test fixtures (sign a test manifest, verify round-trip)
+
+## 3. Periodic Daemon Update Check
+
+- [x] 3.1 Convert `BinaryUpdateCheckService` from `IHostedService` to `BackgroundService` with `ExecuteAsync` loop
+- [x] 3.2 Run initial check at startup (preserve existing behavior), then sleep 24 hours between rechecks
+- [x] 3.3 Add `UpdateAvailable` to `AlertType` enum with wire type `update.available`
+- [x] 3.4 Inject `IOperationalNotificationSink` into `BinaryUpdateCheckService` and emit `UpdateAvailable` alert when `result.IsUpdateAvailable` is true, with current/latest version in context
+- [x] 3.5 Add unit tests for: alert emitted on update detection, alert not emitted when up-to-date, periodic timer fires after interval
+
+## 4. Validation and Cleanup
+
+- [x] 4.1 Run `dotnet build` to verify no compilation errors
+- [x] 4.2 Run `dotnet test` to verify all tests pass (1,282 pass, 0 fail)
+- [x] 4.3 Run `dotnet slopwatch analyze` to verify no new violations (3 pre-existing warnings only)
+- [x] 4.4 Spec updates already in openspec/changes/verify-update-signatures/specs/netclaw-cli/spec.md (will sync at archive)

--- a/openspec/specs/manifest-signature-verification/spec.md
+++ b/openspec/specs/manifest-signature-verification/spec.md
@@ -1,0 +1,101 @@
+# manifest-signature-verification Specification
+
+## Purpose
+
+Define minisign Ed25519 signature verification behavior for the binary feed
+manifest, ensuring cryptographic authenticity before trusting manifest contents.
+
+## Requirements
+
+### Requirement: Minisign signature format parsing
+
+The system SHALL parse minisign detached signature files (`.sig`) into their
+component parts: untrusted comment line, signature algorithm identifier, key ID,
+and Ed25519 signature bytes. The parser SHALL reject signatures that do not
+conform to the minisign format.
+
+#### Scenario: Parse valid minisign signature file
+
+- **WHEN** a valid minisign `.sig` file is provided
+- **THEN** the parser extracts the Ed25519 signature bytes and key ID
+- **AND** the key ID matches the expected signing key
+
+#### Scenario: Reject malformed signature file
+
+- **WHEN** a `.sig` file with invalid format is provided (wrong line count,
+  missing header, invalid base64)
+- **THEN** the parser returns a failure result
+- **AND** no signature bytes are produced
+
+#### Scenario: Reject signature with wrong algorithm
+
+- **WHEN** a `.sig` file specifies an algorithm other than Ed25519 (pure)
+- **THEN** the parser returns a failure result indicating unsupported algorithm
+
+### Requirement: Ed25519 signature verification
+
+The system SHALL verify Ed25519 signatures against the manifest content using
+the embedded public key. Verification SHALL use NSec.Cryptography (libsodium
+wrapper) for Ed25519 support.
+
+#### Scenario: Valid signature accepted
+
+- **WHEN** a manifest and its corresponding valid `.sig` are provided
+- **THEN** Ed25519 verification succeeds
+- **AND** the manifest content is trusted
+
+#### Scenario: Tampered manifest rejected
+
+- **WHEN** a manifest has been modified after signing
+- **THEN** Ed25519 verification fails
+- **AND** the manifest content is rejected
+
+#### Scenario: Wrong key rejected
+
+- **WHEN** a valid signature was produced by a different signing key
+- **THEN** verification fails because the key ID does not match the embedded
+  public key
+
+### Requirement: Embedded public key
+
+The system SHALL embed the minisign public key as a compiled constant in the
+binary. The key SHALL NOT be fetched from the CDN at runtime, because the CDN
+is the untrusted channel being verified.
+
+#### Scenario: Public key available without network
+
+- **WHEN** signature verification is performed
+- **THEN** the public key is read from the compiled binary
+- **AND** no HTTP request is made to obtain the public key
+
+#### Scenario: Public key matches release infrastructure
+
+- **GIVEN** the CI pipeline signs with the private key corresponding to
+  `feeds/releases/manifest.pub`
+- **WHEN** the embedded public key is compared to the repo copy
+- **THEN** they are identical
+
+### Requirement: Fail-closed manifest verification
+
+The system SHALL reject the manifest and abort the update when signature
+verification fails. There SHALL be no fallback to unsigned manifest acceptance.
+
+#### Scenario: Missing signature file aborts update
+
+- **WHEN** `manifest.json.sig` cannot be downloaded (404, timeout, network error)
+- **THEN** the manifest is rejected
+- **AND** the update command exits with a non-zero code and an error message
+  explaining the signature is missing
+
+#### Scenario: Invalid signature aborts update
+
+- **WHEN** the signature does not verify against the manifest content
+- **THEN** the manifest is rejected
+- **AND** the update command exits with a non-zero code and an error message
+  warning of possible tampering
+
+#### Scenario: Background check with signature failure
+
+- **WHEN** a background update check encounters a signature verification failure
+- **THEN** the check returns a "no update" result (same as network failure)
+- **AND** the failure is logged at warning level

--- a/openspec/specs/netclaw-cli/spec.md
+++ b/openspec/specs/netclaw-cli/spec.md
@@ -336,3 +336,77 @@ its health status.
   - Health status (`healthy`, `degraded`, or `unavailable`)
   - For Memorizer: endpoint URL and tool count
   - For files: memory count and index path
+
+### Requirement: Signed manifest verification during update
+
+The `netclaw update` command SHALL verify the minisign signature of
+`manifest.json` before trusting its contents. The command SHALL download
+`manifest.json.sig` alongside the manifest and verify the Ed25519 signature
+against the embedded public key. The command SHALL reject the manifest and abort
+the update if signature verification fails.
+
+#### Scenario: Successful update with valid signature
+
+- **WHEN** operator runs `netclaw update`
+- **AND** the manifest signature verifies against the embedded public key
+- **THEN** the update proceeds normally using the verified manifest checksums
+
+#### Scenario: Update aborted on invalid signature
+
+- **WHEN** operator runs `netclaw update`
+- **AND** the manifest signature does not verify
+- **THEN** the command exits with a non-zero code
+- **AND** an error message warns of possible manifest tampering
+
+#### Scenario: Update aborted when signature file missing
+
+- **WHEN** operator runs `netclaw update`
+- **AND** `manifest.json.sig` cannot be downloaded
+- **THEN** the command exits with a non-zero code
+- **AND** an error message explains the signature file is missing
+
+### Requirement: Periodic daemon update check
+
+The daemon SHALL periodically recheck for available updates while running.
+The default recheck interval SHALL be 24 hours. The recheck SHALL use the same
+`UpdateCheckService` and signature verification as the CLI update command.
+
+#### Scenario: Daemon detects update after startup
+
+- **GIVEN** the daemon started with no update available
+- **WHEN** a new release is published and 24 hours elapse
+- **THEN** the daemon detects the available update on the next periodic check
+
+#### Scenario: Recheck interval respects cache
+
+- **GIVEN** the update check cache duration is 1 hour
+- **WHEN** the periodic timer fires at the 24-hour interval
+- **THEN** a fresh manifest fetch is performed (cache has long expired)
+
+### Requirement: Update availability operational alert
+
+The daemon SHALL emit an `UpdateAvailable` operational alert via
+`IOperationalNotificationSink` when an update is detected. The alert SHALL
+be emitted at most once per detected version (deduplicated by the existing
+webhook deduplication mechanism).
+
+#### Scenario: Alert emitted on update detection
+
+- **GIVEN** the daemon detects an available update
+- **WHEN** the update check result indicates `IsUpdateAvailable`
+- **THEN** an `UpdateAvailable` operational alert is emitted with severity
+  "info"
+- **AND** the alert summary includes the current and available versions
+
+#### Scenario: Alert delivered to configured webhooks
+
+- **GIVEN** a Slack webhook is configured in notifications config
+- **WHEN** an `UpdateAvailable` alert is emitted
+- **THEN** the webhook receives a notification formatted per the webhook format
+  (Generic JSON or Slack Block Kit)
+
+#### Scenario: Alert not duplicated within dedup window
+
+- **GIVEN** an `UpdateAvailable` alert was recently emitted for the same version
+- **WHEN** the periodic recheck runs again within the deduplication window
+- **THEN** no duplicate alert is emitted

--- a/src/Netclaw.Cli.Tests/Cli/StatusUpdateCheckerTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/StatusUpdateCheckerTests.cs
@@ -2,24 +2,45 @@ using System.Net;
 using System.Text.Json;
 using Netclaw.Cli.Update;
 using Netclaw.Configuration.Feeds;
+using Netclaw.Configuration.Security;
+using NSec.Cryptography;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Cli;
 
 public sealed class StatusUpdateCheckerTests : IDisposable
 {
+    private readonly Key _testSigningKey;
+    private readonly byte[] _testPublicKeyBlob;
+
+    public StatusUpdateCheckerTests()
+    {
+        _testSigningKey = Key.Create(SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        var pubKeyRaw = _testSigningKey.Export(KeyBlobFormat.RawPublicKey);
+        _testPublicKeyBlob = new byte[42];
+        _testPublicKeyBlob[0] = 0x45; _testPublicKeyBlob[1] = 0x64; // "Ed"
+        byte[] testKeyId = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        Array.Copy(testKeyId, 0, _testPublicKeyBlob, 2, 8);
+        Array.Copy(pubKeyRaw, 0, _testPublicKeyBlob, 10, 32);
+
+        MinisignVerifier.TestPublicKeyOverride = _testPublicKeyBlob;
+        UpdateCheckService.ResetCache();
+    }
+
     public void Dispose()
     {
-        // Reset static update cache to avoid cross-test interference
+        MinisignVerifier.TestPublicKeyOverride = null;
         UpdateCheckService.ResetCache();
+        _testSigningKey.Dispose();
     }
 
     [Fact]
     public async Task CheckAsync_ReturnsUpdateAvailable_WhenNewerVersionExists()
     {
         var manifest = CreateManifest("0.9.0", UpdateCheckService.GetCurrentRid());
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await StatusUpdateChecker.CheckAsync(httpClient, "0.1.0");
@@ -33,8 +54,7 @@ public sealed class StatusUpdateCheckerTests : IDisposable
     public async Task CheckAsync_ReturnsUpToDate_WhenAlreadyLatest()
     {
         var manifest = CreateManifest("0.1.0", UpdateCheckService.GetCurrentRid());
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await StatusUpdateChecker.CheckAsync(httpClient, "0.1.0");
@@ -75,8 +95,7 @@ public sealed class StatusUpdateCheckerTests : IDisposable
     {
         var manifest = CreateManifest("0.9.0", UpdateCheckService.GetCurrentRid(),
             releaseNotesUrl: "https://github.com/stannardlabs/netclaw/releases/tag/0.9.0");
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await StatusUpdateChecker.CheckAsync(httpClient, "0.1.0");
@@ -86,6 +105,31 @@ public sealed class StatusUpdateCheckerTests : IDisposable
     }
 
     // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private FakeHttpHandler CreateSignedHandler(BinaryFeedManifest manifest)
+    {
+        var handler = new FakeHttpHandler();
+        var json = JsonSerializer.Serialize(manifest);
+        handler.AddResponse(FeedConstants.BinaryManifestUrl, HttpStatusCode.OK, json, "application/json");
+
+        var sigContent = SignContent(json);
+        handler.AddResponse(FeedConstants.BinaryManifestSignatureUrl, HttpStatusCode.OK, sigContent, "text/plain");
+
+        return handler;
+    }
+
+    private string SignContent(string content)
+    {
+        var data = System.Text.Encoding.UTF8.GetBytes(content);
+        var signature = SignatureAlgorithm.Ed25519.Sign(_testSigningKey, data);
+
+        var sigBlob = new byte[74];
+        sigBlob[0] = 0x45; sigBlob[1] = 0x44; // "ED"
+        Array.Copy(_testPublicKeyBlob, 2, sigBlob, 2, 8);
+        Array.Copy(signature, 0, sigBlob, 10, 64);
+
+        return $"untrusted comment: test signature\n{Convert.ToBase64String(sigBlob)}\ntrusted comment: test\ndGVzdA==\n";
+    }
 
     private static BinaryFeedManifest CreateManifest(string version, string rid, string? releaseNotesUrl = null)
     {
@@ -124,6 +168,11 @@ public sealed class StatusUpdateCheckerTests : IDisposable
         {
             var json = JsonSerializer.Serialize(body);
             _responses[url] = (HttpStatusCode.OK, json, "application/json");
+        }
+
+        public void AddResponse(string url, HttpStatusCode status, string content, string contentType)
+        {
+            _responses[url] = (status, content, contentType);
         }
 
         public void AddErrorResponse(string url, HttpStatusCode status)

--- a/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
+++ b/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="Termina" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Netclaw.Cli/Update/StatusUpdateChecker.cs
+++ b/src/Netclaw.Cli/Update/StatusUpdateChecker.cs
@@ -25,11 +25,11 @@ internal static class StatusUpdateChecker
 
         try
         {
-            var manifest = await UpdateCheckService.FetchManifestAsync(httpClient, cts.Token);
-            if (manifest is null)
+            var fetchResult = await UpdateCheckService.FetchVerifiedManifestAsync(httpClient, cts.Token);
+            if (!fetchResult.IsSuccess)
                 return new StatusUpdateResult("unknown", currentVersion, null, null);
 
-            var result = UpdateCheckService.EvaluateManifest(manifest, currentVersion);
+            var result = UpdateCheckService.EvaluateManifest(fetchResult.Manifest!, currentVersion);
             return result.IsUpdateAvailable
                 ? new StatusUpdateResult("update-available", result.CurrentVersion, result.LatestVersion, result.ReleaseNotesUrl)
                 : new StatusUpdateResult("up-to-date", result.CurrentVersion, null, null);

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -39,8 +39,27 @@ internal static class UpdateCommand
         var currentVersion = BuildInfo.Version;
 
         using var httpClient = new HttpClient();
-        var result = await UpdateCheckService.CheckForUpdateAsync(
-            httpClient, currentVersion);
+
+        // Fetch manifest with signature verification
+        var fetchResult = await UpdateCheckService.FetchVerifiedManifestAsync(
+            httpClient);
+
+        if (!fetchResult.IsSuccess)
+        {
+            if (fetchResult.Status == ManifestFetchStatus.SignatureFailure)
+            {
+                Console.Error.WriteLine($"Error: {fetchResult.ErrorMessage}");
+                Console.Error.WriteLine("The update manifest could not be verified. This may indicate tampering.");
+                Console.Error.WriteLine("If this persists, report the issue at https://github.com/stannardlabs/netclaw/issues");
+                return 1;
+            }
+
+            // Network failure — could be transient
+            Console.Error.WriteLine($"Could not check for updates: {fetchResult.ErrorMessage}");
+            return 1;
+        }
+
+        var result = UpdateCheckService.EvaluateManifest(fetchResult.Manifest!, currentVersion);
 
         if (!result.IsUpdateAvailable)
         {

--- a/src/Netclaw.Configuration.Tests/Security/MinisignVerifierTests.cs
+++ b/src/Netclaw.Configuration.Tests/Security/MinisignVerifierTests.cs
@@ -1,0 +1,152 @@
+using Netclaw.Configuration.Security;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests.Security;
+
+public class MinisignVerifierTests
+{
+    // Test fixtures generated with NSec.Cryptography Ed25519 in minisign format.
+    // Key ID: 0102030405060708 (arbitrary test value)
+    private const string TestPublicKeyFile =
+        "untrusted comment: test key\n" +
+        "RWQBAgMEBQYHCE/ac1bsM6dMe4VmOpz4nsZ11O0gFdaINQw+wtqcqA7N\n";
+
+    private const string TestSignatureFile =
+        "untrusted comment: test signature\n" +
+        "RUQBAgMEBQYHCPkmuRAEYY6jkXIlXdUL0ECD0kJYh/IPELV1FUk9Jg3uMw4adHuycYOL9VAAUmY1exKfKMqyfhGgzjjZ9ejhZgg=\n" +
+        "trusted comment: test\n" +
+        "dGVzdA==\n";
+
+    // Signed content (must match exactly — no trailing newline)
+    private const string TestManifestContent = """{"schemaVersion":1,"latest":"1.0.0"}""";
+
+    [Fact]
+    public void ParsePublicKey_ValidKey_ReturnsComponents()
+    {
+        var parsed = MinisignVerifier.ParsePublicKey(TestPublicKeyFile);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(2, parsed.Algorithm.Length);
+        Assert.Equal(8, parsed.KeyId.Length);
+        Assert.Equal(32, parsed.Key.Length);
+        // "Ed" = 0x45, 0x64 (Ed25519 public key)
+        Assert.Equal(0x45, parsed.Algorithm[0]);
+        Assert.Equal(0x64, parsed.Algorithm[1]);
+    }
+
+    [Fact]
+    public void ParseSignature_ValidSignature_ReturnsComponents()
+    {
+        var parsed = MinisignVerifier.ParseSignature(TestSignatureFile);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(2, parsed.Algorithm.Length);
+        Assert.Equal(8, parsed.KeyId.Length);
+        Assert.Equal(64, parsed.Signature.Length);
+        // "ED" = Ed25519 standard (non-prehashed) signature
+        Assert.Equal(0x45, parsed.Algorithm[0]);
+        Assert.Equal(0x44, parsed.Algorithm[1]);
+    }
+
+    [Fact]
+    public void ParseSignature_MalformedBase64_ReturnsNull()
+    {
+        const string malformed = "untrusted comment: test\n!!!not-base64!!!\n";
+        Assert.Null(MinisignVerifier.ParseSignature(malformed));
+    }
+
+    [Fact]
+    public void ParseSignature_WrongBlobLength_ReturnsNull()
+    {
+        // base64 of 10 bytes (too short for 74-byte signature blob)
+        const string tooShort = "untrusted comment: test\nAAECAwQFBgcICQ==\n";
+        Assert.Null(MinisignVerifier.ParseSignature(tooShort));
+    }
+
+    [Fact]
+    public void ParseSignature_MissingUntrustedComment_ReturnsNull()
+    {
+        const string noComment = "some other header\nRUQBAgMEBQYHCPkmuRAEYY6jkXIlXdUL0ECD0kJYh/IPELV1FUk9Jg3uMw4adHuycYOL9VAAUmY1exKfKMqyfhGgzjjZ9ejhZgg=\n";
+        Assert.Null(MinisignVerifier.ParseSignature(noComment));
+    }
+
+    [Fact]
+    public void ParseSignature_EmptyString_ReturnsNull()
+    {
+        Assert.Null(MinisignVerifier.ParseSignature(""));
+    }
+
+    [Fact]
+    public void VerifyEd25519_ValidSignature_ReturnsTrue()
+    {
+        var pubKey = MinisignVerifier.ParsePublicKey(TestPublicKeyFile)!;
+        var sig = MinisignVerifier.ParseSignature(TestSignatureFile)!;
+        var data = System.Text.Encoding.UTF8.GetBytes(TestManifestContent);
+
+        var result = MinisignVerifier.VerifyEd25519(pubKey.Key, data, sig.Signature);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void VerifyEd25519_TamperedData_ReturnsFalse()
+    {
+        var pubKey = MinisignVerifier.ParsePublicKey(TestPublicKeyFile)!;
+        var sig = MinisignVerifier.ParseSignature(TestSignatureFile)!;
+        var data = System.Text.Encoding.UTF8.GetBytes(TestManifestContent + "TAMPERED");
+
+        var result = MinisignVerifier.VerifyEd25519(pubKey.Key, data, sig.Signature);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Verify_WithEmbeddedKey_ReturnsKeyMismatch_ForTestFixture()
+    {
+        // The test fixture was signed with a different key than the embedded production key,
+        // so verification with the embedded key should return KeyMismatch
+        var data = System.Text.Encoding.UTF8.GetBytes(TestManifestContent);
+
+        var result = MinisignVerifier.Verify(data, TestSignatureFile);
+
+        Assert.Equal(MinisignVerifier.VerifyResult.KeyMismatch, result);
+    }
+
+    [Fact]
+    public void Verify_MalformedSignature_ReturnsMalformedSignature()
+    {
+        var data = System.Text.Encoding.UTF8.GetBytes("test");
+
+        var result = MinisignVerifier.Verify(data, "garbage\ndata\n");
+
+        Assert.Equal(MinisignVerifier.VerifyResult.MalformedSignature, result);
+    }
+
+    [Fact]
+    public void EmbeddedPublicKey_HasCorrectLength()
+    {
+        Assert.Equal(32, MinisignVerifier.EmbeddedPublicKey.Length);
+    }
+
+    [Fact]
+    public void EmbeddedKeyId_HasCorrectLength()
+    {
+        Assert.Equal(8, MinisignVerifier.EmbeddedKeyId.Length);
+    }
+
+    [Fact]
+    public void ParsePublicKey_MatchesEmbeddedKey_ForProductionKeyFile()
+    {
+        // Verify the embedded key matches what ParsePublicKey would extract
+        // from the production manifest.pub file
+        const string productionPubKeyFile =
+            "untrusted comment: minisign public key C29536096818F582\n" +
+            "RWSC9RhoCTaVwiEndieBGwzLy8wWUSzm3p0FsgOEWhEHv95/B5R9WOTD\n";
+
+        var parsed = MinisignVerifier.ParsePublicKey(productionPubKeyFile);
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed.Key.AsSpan().SequenceEqual(MinisignVerifier.EmbeddedPublicKey));
+        Assert.True(parsed.KeyId.AsSpan().SequenceEqual(MinisignVerifier.EmbeddedKeyId));
+    }
+}

--- a/src/Netclaw.Configuration/Feeds/FeedConstants.cs
+++ b/src/Netclaw.Configuration/Feeds/FeedConstants.cs
@@ -24,6 +24,11 @@ public static class FeedConstants
     public const string BinaryManifestUrl = "https://releases.netclaw.dev/manifest.json";
 
     /// <summary>
+    /// URL for the binary releases manifest signature (minisign detached signature).
+    /// </summary>
+    public const string BinaryManifestSignatureUrl = "https://releases.netclaw.dev/manifest.json.sig";
+
+    /// <summary>
     /// Base URL for skill file downloads (Cloudflare R2 + custom domain).
     /// Skill files are immutable and cached indefinitely at versioned URLs.
     /// The manifest URL remains at <see cref="FeedBaseUrl"/> on Cloudflare Pages.

--- a/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
+++ b/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
@@ -1,5 +1,7 @@
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
+using Netclaw.Configuration.Security;
 
 namespace Netclaw.Configuration.Feeds;
 
@@ -13,6 +15,31 @@ public sealed class UpdateCheckResult
     public string LatestVersion { get; init; } = "";
     public string? ReleaseNotesUrl { get; init; }
     public List<BinaryAsset> MatchingAssets { get; init; } = [];
+}
+
+/// <summary>
+/// Result of fetching the binary feed manifest, distinguishing success from
+/// different failure modes so callers can display appropriate messages.
+/// </summary>
+public sealed class ManifestFetchResult
+{
+    public BinaryFeedManifest? Manifest { get; init; }
+    public ManifestFetchStatus Status { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public bool IsSuccess => Status == ManifestFetchStatus.Success && Manifest is not null;
+}
+
+public enum ManifestFetchStatus
+{
+    /// <summary>Manifest fetched, signature verified, deserialized successfully.</summary>
+    Success,
+
+    /// <summary>Network error, timeout, or HTTP error fetching manifest or signature.</summary>
+    NetworkFailure,
+
+    /// <summary>Manifest signature verification failed — possible tampering.</summary>
+    SignatureFailure,
 }
 
 /// <summary>
@@ -56,14 +83,14 @@ public static class UpdateCheckService
 
         try
         {
-            var manifest = await FetchManifestAsync(httpClient, cancellationToken);
-            if (manifest is null)
+            var fetchResult = await FetchVerifiedManifestAsync(httpClient, cancellationToken);
+            if (!fetchResult.IsSuccess)
             {
                 CacheResult(noUpdate);
                 return noUpdate;
             }
 
-            var result = EvaluateManifest(manifest, currentVersion);
+            var result = EvaluateManifest(fetchResult.Manifest!, currentVersion);
             CacheResult(result);
             return result;
         }
@@ -72,6 +99,93 @@ public static class UpdateCheckService
             CacheResult(noUpdate);
             return noUpdate;
         }
+    }
+
+    /// <summary>
+    /// Fetches the binary manifest with signature verification and returns a detailed result.
+    /// Used by <see cref="Netclaw.Cli.Update.UpdateCommand"/> to display appropriate error messages.
+    /// </summary>
+    public static async Task<ManifestFetchResult> FetchVerifiedManifestAsync(
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(FeedConstants.BinaryFeedHttpTimeout);
+
+        string json;
+        try
+        {
+            var response = await httpClient.GetAsync(
+                FeedConstants.BinaryManifestUrl, cts.Token);
+            response.EnsureSuccessStatusCode();
+            json = await response.Content.ReadAsStringAsync(cts.Token);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new ManifestFetchResult
+            {
+                Status = ManifestFetchStatus.NetworkFailure,
+                ErrorMessage = $"Failed to fetch manifest: {ex.Message}",
+            };
+        }
+
+        // Fetch and verify signature
+        string signatureContent;
+        try
+        {
+            var sigResponse = await httpClient.GetAsync(
+                FeedConstants.BinaryManifestSignatureUrl, cts.Token);
+            sigResponse.EnsureSuccessStatusCode();
+            signatureContent = await sigResponse.Content.ReadAsStringAsync(cts.Token);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new ManifestFetchResult
+            {
+                Status = ManifestFetchStatus.SignatureFailure,
+                ErrorMessage = $"Failed to fetch manifest signature: {ex.Message}",
+            };
+        }
+
+        var verifyResult = MinisignVerifier.Verify(
+            Encoding.UTF8.GetBytes(json), signatureContent);
+
+        if (verifyResult != MinisignVerifier.VerifyResult.Valid)
+        {
+            return new ManifestFetchResult
+            {
+                Status = ManifestFetchStatus.SignatureFailure,
+                ErrorMessage = verifyResult switch
+                {
+                    MinisignVerifier.VerifyResult.MalformedSignature =>
+                        "Manifest signature file is malformed",
+                    MinisignVerifier.VerifyResult.UnsupportedAlgorithm =>
+                        "Manifest signature uses an unsupported algorithm",
+                    MinisignVerifier.VerifyResult.KeyMismatch =>
+                        "Manifest was signed by an unrecognized key",
+                    MinisignVerifier.VerifyResult.InvalidSignature =>
+                        "Manifest signature is invalid — the manifest may have been tampered with",
+                    _ => "Manifest signature verification failed",
+                },
+            };
+        }
+
+        // Signature verified — safe to deserialize
+        var manifest = JsonSerializer.Deserialize<BinaryFeedManifest>(json);
+        if (manifest is null || manifest.SchemaVersion != 1)
+        {
+            return new ManifestFetchResult
+            {
+                Status = ManifestFetchStatus.NetworkFailure,
+                ErrorMessage = "Manifest deserialization failed or unsupported schema version",
+            };
+        }
+
+        return new ManifestFetchResult
+        {
+            Manifest = manifest,
+            Status = ManifestFetchStatus.Success,
+        };
     }
 
     private static void CacheResult(UpdateCheckResult result)
@@ -87,30 +201,6 @@ public static class UpdateCheckService
     {
         s_cachedResult = null;
         s_cachedAt = default;
-    }
-
-    /// <summary>
-    /// Fetches and deserializes the binary feed manifest.
-    /// Returns null on any failure (timeout, HTTP error, deserialization error).
-    /// </summary>
-    public static async Task<BinaryFeedManifest?> FetchManifestAsync(
-        HttpClient httpClient,
-        CancellationToken cancellationToken = default)
-    {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(FeedConstants.BinaryFeedHttpTimeout);
-
-        var response = await httpClient.GetAsync(
-            FeedConstants.BinaryManifestUrl, cts.Token);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsStringAsync(cts.Token);
-        var manifest = JsonSerializer.Deserialize<BinaryFeedManifest>(json);
-
-        if (manifest is null || manifest.SchemaVersion != 1)
-            return null;
-
-        return manifest;
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Netclaw.Configuration.Tests" />
+    <InternalsVisibleTo Include="Netclaw.Daemon.Tests" />
+    <InternalsVisibleTo Include="Netclaw.Cli.Tests" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="NSec.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Configuration/OperationalAlert.cs
+++ b/src/Netclaw.Configuration/OperationalAlert.cs
@@ -15,6 +15,7 @@ public enum AlertType
     ReminderAutoDisabled,
     DaemonStarted,
     DaemonStopping,
+    UpdateAvailable,
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/Security/MinisignVerifier.cs
+++ b/src/Netclaw.Configuration/Security/MinisignVerifier.cs
@@ -1,0 +1,205 @@
+using System.Buffers.Text;
+using NSec.Cryptography;
+
+namespace Netclaw.Configuration.Security;
+
+/// <summary>
+/// Verifies minisign Ed25519 signatures on binary feed manifests.
+/// Minisign format: https://jedisct1.github.io/minisign/
+/// </summary>
+public static class MinisignVerifier
+{
+    // Minisign algorithm identifiers for Ed25519:
+    // "ED" = standard (non-prehashed) detached signature — used by `minisign -S`
+    // "Ed" = prehashed mode — used by `minisign -SH`
+    // We accept both since the verification math is identical for Ed25519 pure.
+    private static ReadOnlySpan<byte> Ed25519Standard => "ED"u8;
+    private static ReadOnlySpan<byte> Ed25519Prehashed => "Ed"u8;
+
+    // Embedded public key from feeds/releases/manifest.pub
+    // Decoded from: RWSC9RhoCTaVwiEndieBGwzLy8wWUSzm3p0FsgOEWhEHv95/B5R9WOTD
+    // Format: 2-byte algorithm ("Ed") + 8-byte key ID + 32-byte Ed25519 public key
+    private static ReadOnlySpan<byte> EmbeddedPublicKeyBlob => [
+        0x45, 0x64, // "Ed" algorithm
+        0x82, 0xf5, 0x18, 0x68, 0x09, 0x36, 0x95, 0xc2, // Key ID: C29536096818F582 (little-endian in file, display is big-endian)
+        0x21, 0x27, 0x76, 0x27, 0x81, 0x1b, 0x0c, 0xcb, // Ed25519 public key (32 bytes)
+        0xcb, 0xcc, 0x16, 0x51, 0x2c, 0xe6, 0xde, 0x9d,
+        0x05, 0xb2, 0x03, 0x84, 0x5a, 0x11, 0x07, 0xbf,
+        0xde, 0x7f, 0x07, 0x94, 0x7d, 0x58, 0xe4, 0xc3,
+    ];
+
+    /// <summary>
+    /// Test seam: when set, overrides the embedded public key for verification.
+    /// Must be a 42-byte minisign public key blob (2 algo + 8 key ID + 32 key).
+    /// Reset to null after tests to restore production behavior.
+    /// </summary>
+    internal static byte[]? TestPublicKeyOverride { get; set; }
+
+    /// <summary>
+    /// The embedded Ed25519 public key ID (8 bytes) for matching against signatures.
+    /// </summary>
+    internal static ReadOnlySpan<byte> EmbeddedKeyId => EmbeddedPublicKeyBlob.Slice(2, 8);
+
+    /// <summary>
+    /// The embedded Ed25519 public key (32 bytes) for signature verification.
+    /// </summary>
+    internal static ReadOnlySpan<byte> EmbeddedPublicKey => EmbeddedPublicKeyBlob.Slice(10, 32);
+
+    /// <summary>
+    /// Result of a signature verification attempt.
+    /// </summary>
+    public enum VerifyResult
+    {
+        /// <summary>Signature is valid.</summary>
+        Valid,
+
+        /// <summary>Signature file format is malformed.</summary>
+        MalformedSignature,
+
+        /// <summary>Signature uses an unsupported algorithm (not Ed25519 pure).</summary>
+        UnsupportedAlgorithm,
+
+        /// <summary>Signature was produced by a different key than the embedded public key.</summary>
+        KeyMismatch,
+
+        /// <summary>Signature does not match the provided data.</summary>
+        InvalidSignature,
+    }
+
+    /// <summary>
+    /// Parses a minisign signature file into its components.
+    /// Format: line 1 = "untrusted comment: ...", line 2 = base64(2-byte algo + 8-byte key ID + 64-byte signature).
+    /// </summary>
+    /// <returns>The parsed signature, or null if the format is invalid.</returns>
+    internal static ParsedSignature? ParseSignature(string signatureFileContent)
+    {
+        var lines = signatureFileContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length < 2)
+            return null;
+
+        // Line 1 must start with "untrusted comment:"
+        if (!lines[0].StartsWith("untrusted comment:", StringComparison.Ordinal))
+            return null;
+
+        // Line 2 is base64-encoded signature blob
+        byte[] blob;
+        try
+        {
+            blob = Convert.FromBase64String(lines[1].Trim());
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        // Expected: 2 (algo) + 8 (key ID) + 64 (Ed25519 signature) = 74 bytes
+        if (blob.Length != 74)
+            return null;
+
+        return new ParsedSignature
+        {
+            Algorithm = blob.AsSpan(0, 2).ToArray(),
+            KeyId = blob.AsSpan(2, 8).ToArray(),
+            Signature = blob.AsSpan(10, 64).ToArray(),
+        };
+    }
+
+    /// <summary>
+    /// Parses a minisign public key file into its components.
+    /// Format: line 1 = "untrusted comment: ...", line 2 = base64(2-byte algo + 8-byte key ID + 32-byte key).
+    /// </summary>
+    internal static ParsedPublicKey? ParsePublicKey(string publicKeyFileContent)
+    {
+        var lines = publicKeyFileContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length < 2)
+            return null;
+
+        byte[] blob;
+        try
+        {
+            blob = Convert.FromBase64String(lines[1].Trim());
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        // Expected: 2 (algo) + 8 (key ID) + 32 (Ed25519 public key) = 42 bytes
+        if (blob.Length != 42)
+            return null;
+
+        return new ParsedPublicKey
+        {
+            Algorithm = blob.AsSpan(0, 2).ToArray(),
+            KeyId = blob.AsSpan(2, 8).ToArray(),
+            Key = blob.AsSpan(10, 32).ToArray(),
+        };
+    }
+
+    /// <summary>
+    /// Verifies a minisign signature against data using the embedded public key.
+    /// </summary>
+    /// <param name="data">The signed data (manifest content).</param>
+    /// <param name="signatureFileContent">The raw content of the .sig file.</param>
+    /// <returns>The verification result.</returns>
+    public static VerifyResult Verify(ReadOnlySpan<byte> data, string signatureFileContent)
+    {
+        var sig = ParseSignature(signatureFileContent);
+        if (sig is null)
+            return VerifyResult.MalformedSignature;
+
+        // Check algorithm is Ed25519 (standard or prehashed)
+        if (!sig.Algorithm.AsSpan().SequenceEqual(Ed25519Standard) &&
+            !sig.Algorithm.AsSpan().SequenceEqual(Ed25519Prehashed))
+            return VerifyResult.UnsupportedAlgorithm;
+
+        // Use test override if set, otherwise embedded production key
+        ReadOnlySpan<byte> activeKeyId;
+        ReadOnlySpan<byte> activePublicKey;
+        if (TestPublicKeyOverride is { Length: 42 } testBlob)
+        {
+            activeKeyId = testBlob.AsSpan(2, 8);
+            activePublicKey = testBlob.AsSpan(10, 32);
+        }
+        else
+        {
+            activeKeyId = EmbeddedKeyId;
+            activePublicKey = EmbeddedPublicKey;
+        }
+
+        // Check key ID matches active key
+        if (!sig.KeyId.AsSpan().SequenceEqual(activeKeyId))
+            return VerifyResult.KeyMismatch;
+
+        return VerifyEd25519(activePublicKey, data, sig.Signature)
+            ? VerifyResult.Valid
+            : VerifyResult.InvalidSignature;
+    }
+
+    /// <summary>
+    /// Verifies an Ed25519 signature using NSec.Cryptography.
+    /// </summary>
+    internal static bool VerifyEd25519(
+        ReadOnlySpan<byte> publicKeyBytes,
+        ReadOnlySpan<byte> data,
+        ReadOnlySpan<byte> signatureBytes)
+    {
+        var algorithm = SignatureAlgorithm.Ed25519;
+        var publicKey = PublicKey.Import(algorithm, publicKeyBytes, KeyBlobFormat.RawPublicKey);
+        return algorithm.Verify(publicKey, data, signatureBytes);
+    }
+
+    internal sealed class ParsedSignature
+    {
+        public required byte[] Algorithm { get; init; }
+        public required byte[] KeyId { get; init; }
+        public required byte[] Signature { get; init; }
+    }
+
+    internal sealed class ParsedPublicKey
+    {
+        public required byte[] Algorithm { get; init; }
+        public required byte[] KeyId { get; init; }
+        public required byte[] Key { get; init; }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
+++ b/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="ModelContextProtocol.Core" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
@@ -3,7 +3,9 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Feeds;
+using Netclaw.Configuration.Security;
 using Netclaw.Daemon.Services;
+using NSec.Cryptography;
 using Xunit;
 
 namespace Netclaw.Daemon.Tests.Services;
@@ -12,12 +14,29 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
+    private readonly Key _testSigningKey;
+    private readonly byte[] _testPublicKeyBlob;
 
     public BinaryUpdateCheckServiceTests()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
         _paths = new NetclawPaths(_tempDir);
         _paths.EnsureDirectoriesExist();
+
+        // Generate a test signing keypair for each test
+        _testSigningKey = Key.Create(SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        var pubKeyRaw = _testSigningKey.Export(KeyBlobFormat.RawPublicKey);
+        _testPublicKeyBlob = new byte[42];
+        _testPublicKeyBlob[0] = 0x45; _testPublicKeyBlob[1] = 0x64; // "Ed"
+        // Key ID: test bytes
+        byte[] testKeyId = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        Array.Copy(testKeyId, 0, _testPublicKeyBlob, 2, 8);
+        Array.Copy(pubKeyRaw, 0, _testPublicKeyBlob, 10, 32);
+
+        // Set test key override so MinisignVerifier uses our test key
+        MinisignVerifier.TestPublicKeyOverride = _testPublicKeyBlob;
 
         // Clear static cache between tests to avoid cross-test interference
         UpdateCheckService.ResetCache();
@@ -28,44 +47,72 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     // ═══════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task StartAsync_LogsWarningWhenUpdateAvailable()
+    public async Task CheckAndNotify_CachesResultWhenUpdateAvailable()
     {
         var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         var sut = CreateDaemonService(handler, currentVersion: "0.1.0");
-        await sut.StartAsync(CancellationToken.None);
+        await sut.CheckAndNotifyAsync(CancellationToken.None);
 
-        // Static cache should be populated
         var cached = UpdateCheckService.GetLastResult();
         Assert.NotNull(cached);
         Assert.True(cached!.IsUpdateAvailable);
     }
 
     [Fact]
-    public async Task StartAsync_GracefullyHandlesNetworkFailure()
+    public async Task CheckAndNotify_EmitsUpdateAvailableAlert()
+    {
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = CreateSignedHandler(manifest);
+        var sink = new FakeNotificationSink();
+
+        var sut = CreateDaemonService(handler, currentVersion: "0.1.0", sink: sink);
+        await sut.CheckAndNotifyAsync(CancellationToken.None);
+
+        Assert.Single(sink.Alerts);
+        var alert = sink.Alerts[0];
+        Assert.Equal(AlertType.UpdateAvailable, alert.Category);
+        Assert.Equal("update.available", alert.Type);
+        Assert.Equal("info", alert.Severity);
+        Assert.Contains("0.2.0", alert.Summary);
+    }
+
+    [Fact]
+    public async Task CheckAndNotify_DoesNotEmitAlertWhenUpToDate()
+    {
+        var manifest = CreateManifest("0.1.0", UpdateCheckService.GetCurrentRid());
+        var handler = CreateSignedHandler(manifest);
+        var sink = new FakeNotificationSink();
+
+        var sut = CreateDaemonService(handler, currentVersion: "0.1.0", sink: sink);
+        await sut.CheckAndNotifyAsync(CancellationToken.None);
+
+        Assert.Empty(sink.Alerts);
+    }
+
+    [Fact]
+    public async Task CheckAndNotify_GracefullyHandlesNetworkFailure()
     {
         var handler = new FakeHttpHandler();
         handler.AddErrorResponse(FeedConstants.BinaryManifestUrl, HttpStatusCode.ServiceUnavailable);
 
         var sut = CreateDaemonService(handler, currentVersion: "0.1.0");
-        await sut.StartAsync(CancellationToken.None);
+        await sut.CheckAndNotifyAsync(CancellationToken.None);
 
-        // UpdateCheckService never throws — returns "no update" on failure.
         var cached = UpdateCheckService.GetLastResult();
         Assert.NotNull(cached);
         Assert.False(cached!.IsUpdateAvailable);
     }
 
     [Fact]
-    public async Task StartAsync_HandlesTimeoutGracefully()
+    public async Task CheckAndNotify_HandlesTimeoutGracefully()
     {
         var handler = new FakeHttpHandler();
         // No response configured → 404, which triggers HttpRequestException
 
         var sut = CreateDaemonService(handler, currentVersion: "0.1.0");
-        await sut.StartAsync(CancellationToken.None);
+        await sut.CheckAndNotifyAsync(CancellationToken.None);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -76,8 +123,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     public async Task CheckForUpdateAsync_ReturnsUpdateWhenNewerVersionAvailable()
     {
         var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await UpdateCheckService.CheckForUpdateAsync(
@@ -93,8 +139,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     public async Task CheckForUpdateAsync_ReturnsNoUpdateWhenAlreadyLatest()
     {
         var manifest = CreateManifest("0.1.0", "linux-x64");
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await UpdateCheckService.CheckForUpdateAsync(
@@ -107,8 +152,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     public async Task CheckForUpdateAsync_ReturnsNoUpdateWhenNewerThanManifest()
     {
         var manifest = CreateManifest("0.1.0", "linux-x64");
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await UpdateCheckService.CheckForUpdateAsync(
@@ -135,8 +179,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     public async Task CheckForUpdateAsync_UsesDedicatedReleasesManifestEndpoint()
     {
         var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
-        var handler = new FakeHttpHandler();
-        handler.AddJsonResponse("https://releases.netclaw.dev/manifest.json", manifest);
+        var handler = CreateSignedHandler(manifest);
 
         using var httpClient = new HttpClient(handler);
         var result = await UpdateCheckService.CheckForUpdateAsync(
@@ -144,6 +187,57 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
 
         Assert.True(result.IsUpdateAvailable);
         Assert.Equal("0.2.0", result.LatestVersion);
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_ReturnsNoUpdateOnMissingSignature()
+    {
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = new FakeHttpHandler();
+        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        // No signature configured — will 404
+
+        using var httpClient = new HttpClient(handler);
+        var result = await UpdateCheckService.CheckForUpdateAsync(
+            httpClient, "0.1.0");
+
+        // Signature failure treated as network failure → no update
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task FetchVerifiedManifestAsync_ReturnsSignatureFailureOnMissingSignature()
+    {
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = new FakeHttpHandler();
+        handler.AddJsonResponse(FeedConstants.BinaryManifestUrl, manifest);
+        // No signature URL → 404
+
+        using var httpClient = new HttpClient(handler);
+        var result = await UpdateCheckService.FetchVerifiedManifestAsync(httpClient);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ManifestFetchStatus.SignatureFailure, result.Status);
+    }
+
+    [Fact]
+    public async Task FetchVerifiedManifestAsync_ReturnsSignatureFailureOnTamperedManifest()
+    {
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = new FakeHttpHandler();
+
+        // Return the manifest but sign different content
+        var json = JsonSerializer.Serialize(manifest);
+        handler.AddResponse(FeedConstants.BinaryManifestUrl, HttpStatusCode.OK, json, "application/json");
+
+        var wrongSig = SignContent("different content");
+        handler.AddResponse(FeedConstants.BinaryManifestSignatureUrl, HttpStatusCode.OK, wrongSig, "text/plain");
+
+        using var httpClient = new HttpClient(handler);
+        var result = await UpdateCheckService.FetchVerifiedManifestAsync(httpClient);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ManifestFetchStatus.SignatureFailure, result.Status);
     }
 
     [Fact]
@@ -300,7 +394,9 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
 
     public void Dispose()
     {
+        MinisignVerifier.TestPublicKeyOverride = null;
         UpdateCheckService.ResetCache();
+        _testSigningKey.Dispose();
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
     }
@@ -310,13 +406,48 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     // ═══════════════════════════════════════════════════════════════
 
     private static BinaryUpdateCheckService CreateDaemonService(
-        FakeHttpHandler handler, string currentVersion = "0.1.0")
+        FakeHttpHandler handler,
+        string currentVersion = "0.1.0",
+        FakeNotificationSink? sink = null)
     {
         var httpClient = new HttpClient(handler);
         return new BinaryUpdateCheckService(
             httpClient,
             NullLogger<BinaryUpdateCheckService>.Instance,
-            currentVersion);
+            currentVersion,
+            sink);
+    }
+
+    /// <summary>
+    /// Creates a FakeHttpHandler that returns a properly signed manifest.
+    /// </summary>
+    private FakeHttpHandler CreateSignedHandler(BinaryFeedManifest manifest)
+    {
+        var handler = new FakeHttpHandler();
+        var json = JsonSerializer.Serialize(manifest);
+        handler.AddResponse(FeedConstants.BinaryManifestUrl, HttpStatusCode.OK, json, "application/json");
+
+        var sigContent = SignContent(json);
+        handler.AddResponse(FeedConstants.BinaryManifestSignatureUrl, HttpStatusCode.OK, sigContent, "text/plain");
+
+        return handler;
+    }
+
+    /// <summary>
+    /// Signs content with the test key and returns minisign signature file content.
+    /// </summary>
+    private string SignContent(string content)
+    {
+        var data = System.Text.Encoding.UTF8.GetBytes(content);
+        var signature = SignatureAlgorithm.Ed25519.Sign(_testSigningKey, data);
+
+        // Build minisign signature blob: "ED" (2) + keyId (8) + signature (64) = 74 bytes
+        var sigBlob = new byte[74];
+        sigBlob[0] = 0x45; sigBlob[1] = 0x44; // "ED" (standard)
+        Array.Copy(_testPublicKeyBlob, 2, sigBlob, 2, 8); // Copy key ID
+        Array.Copy(signature, 0, sigBlob, 10, 64);
+
+        return $"untrusted comment: test signature\n{Convert.ToBase64String(sigBlob)}\ntrusted comment: test\ndGVzdA==\n";
     }
 
     private static BinaryFeedManifest CreateManifest(string version, string rid)
@@ -356,10 +487,16 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
         };
     }
 
+    private sealed class FakeNotificationSink : IOperationalNotificationSink
+    {
+        public List<OperationalAlert> Alerts { get; } = [];
+        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
+    }
+
     /// <summary>
     /// Reuses the same FakeHttpHandler pattern from <see cref="SystemSkillSyncServiceTests"/>.
     /// </summary>
-    private sealed class FakeHttpHandler : HttpMessageHandler
+    internal sealed class FakeHttpHandler : HttpMessageHandler
     {
         private readonly Dictionary<string, (HttpStatusCode Status, string Content, string ContentType)> _responses = new();
 
@@ -367,6 +504,11 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
         {
             var json = JsonSerializer.Serialize(body);
             _responses[url] = (HttpStatusCode.OK, json, "application/json");
+        }
+
+        public void AddResponse(string url, HttpStatusCode status, string content, string contentType)
+        {
+            _responses[url] = (status, content, contentType);
         }
 
         public void AddErrorResponse(string url, HttpStatusCode status)

--- a/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
+++ b/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
@@ -1,41 +1,69 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
 using Netclaw.Configuration.Feeds;
 
 namespace Netclaw.Daemon.Services;
 
 /// <summary>
-/// Checks for binary updates at daemon startup and logs a warning if one is available.
+/// Checks for binary updates at daemon startup and periodically thereafter.
+/// Emits an <see cref="AlertType.UpdateAvailable"/> operational alert when
+/// an update is detected, so configured webhooks (Slack, etc.) get notified.
 /// The result is cached in <see cref="UpdateCheckService"/> for 1 hour so
 /// <see cref="Gateway.DaemonRuntimeStatusService"/> can include update info in the status API.
 /// Never blocks startup, never downloads anything.
-/// Runs after <see cref="SystemSkillSyncService"/>.
 /// </summary>
-internal sealed class BinaryUpdateCheckService : IHostedService
+internal sealed class BinaryUpdateCheckService : BackgroundService
 {
+    /// <summary>
+    /// How often to recheck for updates after the initial startup check.
+    /// </summary>
+    internal static readonly TimeSpan RecheckInterval = TimeSpan.FromHours(24);
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<BinaryUpdateCheckService> _logger;
+    private readonly IOperationalNotificationSink? _notificationSink;
+    private readonly TimeProvider _timeProvider;
     private readonly string _currentVersion;
 
     public BinaryUpdateCheckService(
         HttpClient httpClient,
-        ILogger<BinaryUpdateCheckService> logger)
-        : this(httpClient, logger, BuildInfo.Version)
+        ILogger<BinaryUpdateCheckService> logger,
+        IOperationalNotificationSink? notificationSink = null,
+        TimeProvider? timeProvider = null)
+        : this(httpClient, logger, BuildInfo.Version, notificationSink, timeProvider)
     {
     }
 
-    // Internal constructor for testing — accepts HttpClient directly
+    // Internal constructor for testing
     internal BinaryUpdateCheckService(
         HttpClient httpClient,
         ILogger<BinaryUpdateCheckService> logger,
-        string currentVersion)
+        string currentVersion,
+        IOperationalNotificationSink? notificationSink = null,
+        TimeProvider? timeProvider = null)
     {
         _httpClient = httpClient;
         _logger = logger;
         _currentVersion = currentVersion;
+        _notificationSink = notificationSink;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Initial check at startup
+        await CheckAndNotifyAsync(stoppingToken);
+
+        // Periodic recheck
+        using var timer = new PeriodicTimer(RecheckInterval, _timeProvider);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await CheckAndNotifyAsync(stoppingToken);
+        }
+    }
+
+    internal async Task CheckAndNotifyAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -47,6 +75,8 @@ internal sealed class BinaryUpdateCheckService : IHostedService
                 _logger.LogWarning(
                     "Netclaw update available: {CurrentVersion} → {LatestVersion}. Run 'netclaw update' to upgrade.",
                     result.CurrentVersion, result.LatestVersion);
+
+                EmitUpdateAlert(result);
             }
             else
             {
@@ -59,5 +89,22 @@ internal sealed class BinaryUpdateCheckService : IHostedService
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    private void EmitUpdateAlert(UpdateCheckResult result)
+    {
+        _notificationSink?.Emit(new OperationalAlert
+        {
+            AlertId = Guid.NewGuid().ToString("N"),
+            Type = "update.available",
+            Category = AlertType.UpdateAvailable,
+            Summary = $"Netclaw update available: {result.CurrentVersion} → {result.LatestVersion}. Run 'netclaw update' to upgrade.",
+            Timestamp = _timeProvider.GetUtcNow(),
+            Severity = "info",
+            Source = result.LatestVersion,
+            Context = new Dictionary<string, string>
+            {
+                ["currentVersion"] = result.CurrentVersion,
+                ["latestVersion"] = result.LatestVersion,
+            },
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- Verifies minisign Ed25519 signature on `manifest.json` before trusting its contents during `netclaw update` and all background update checks
- Downloads `manifest.json.sig` alongside the manifest; fails loudly if signature is missing or invalid (fail-closed, no fallback to unsigned)
- Embeds the public key from `feeds/releases/manifest.pub` as a compiled constant — no CDN dependency for verification
- Converts `BinaryUpdateCheckService` from `IHostedService` to `BackgroundService` with 24-hour periodic recheck timer
- Emits `UpdateAvailable` operational alert via existing webhook notification infrastructure when updates are detected
- Adds `NSec.Cryptography` (libsodium wrapper) for Ed25519 verification — .NET 10 lacks built-in Ed25519

Closes #390

## Test plan

- [x] 13 MinisignVerifier unit tests (parse, verify, tampered, malformed, key mismatch, embedded key consistency)
- [x] 20 BinaryUpdateCheckService tests updated with Ed25519-signed test fixtures
- [x] 5 StatusUpdateChecker tests updated with signed manifests
- [x] New tests: signature failure returns appropriate `ManifestFetchStatus`, tampered manifest rejected, alert emitted/not emitted
- [x] Full suite: 1,282 tests pass, 0 failures
- [x] `dotnet slopwatch analyze` — no new violations