### PR TITLE
feat(memory): session-level memory observer actor (spike)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,14 @@ Update eval cases when:
 - Changing identity grounding rules — update identity assertion patterns
 - A production session exhibits a new failure pattern — add a regression case
 
+**Debugging eval failures:** Eval failures are VERY RARELY the model's fault.
+Almost always the root cause is an instrumentation issue — how we're parsing or
+asserting on the model's output (regex mismatch, output format change, assertion
+too brittle). If instrumentation checks out, the next most likely cause is a
+genuine alignment problem (system prompt, skill content, or context assembly not
+giving the model the right information). Only after ruling out both should you
+consider model capability as the cause.
+
 ## System Skills Sync Rule
 
 System skills in `feeds/skills/.system/files/` are the agent's operational

--- a/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
@@ -1,0 +1,47 @@
+using Netclaw.Actors.Memory;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+public sealed class MemoryRulesFirstExtractorTests
+{
+    private readonly MemoryRulesFirstExtractor _extractor = new(new MemoryPolicyEvaluator());
+
+    private static MemoryCheckpointPayload MakeTurnPayload(string userContent) => new(
+        SessionId: "D0AC6CKBK5K/1774370274.953879",
+        TriggerType: CheckpointTriggerType.TurnComplete.ToWireValue(),
+        Source: "session",
+        Content: userContent,
+        UserContent: userContent,
+        AssistantContent: null,
+        IsExplicitRequest: false,
+        HasVerifiedToolFinding: false,
+        IsCompactionBoundary: false,
+        HasAcceptedSubAgentFinding: false,
+        Domain: "project:d0ac6ckbk5k",
+        Sensitivity: "normal",
+        RecallMode: "auto",
+        Confidence: 0.88);
+
+    [Theory]
+    [InlineData("Well I was going to has You do some Netclaw work for me if")]
+    [InlineData("Want to know if I needs To edit that or not")]
+    [InlineData("I was just thinking about maybe doing something")]
+    [InlineData("You can uses The GH command line utility")]
+    public void Rejects_conversational_fragments_from_project_statement_pattern(string input)
+    {
+        var result = _extractor.Extract(MakeTurnPayload(input), new HashSet<string>());
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("Our deployment pipeline uses GitHub Actions for CI/CD and container builds")]
+    [InlineData("Netclaw requires Akka.NET 1.5.62 or later for cluster sharding support")]
+    public void Accepts_genuine_project_statements(string input)
+    {
+        var result = _extractor.Extract(MakeTurnPayload(input), new HashSet<string>());
+
+        Assert.NotEmpty(result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/DeterministicCandidateSelectorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/DeterministicCandidateSelectorTests.cs
@@ -1,0 +1,106 @@
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Sessions;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class DeterministicCandidateSelectorTests
+{
+    private static DeterministicRetrievalRequestPlan MakePlan(
+        string hardScope = "project:d0ac6ckbk5k",
+        IReadOnlyList<string>? lexicalTerms = null,
+        IReadOnlyList<string>? anchorHints = null,
+        IReadOnlyList<string>? facets = null,
+        IReadOnlyList<string>? softScopes = null) => new(
+        HardScope: hardScope,
+        SoftScopes: softScopes ?? [],
+        RetrievalMode: DeterministicRetrievalMode.Ranked,
+        LexicalTerms: lexicalTerms ?? [],
+        Facets: facets ?? [],
+        AnchorHints: anchorHints ?? [],
+        CandidateLimit: 30,
+        AllowedMemoryClasses: [MemoryClass.DurableFact.ToWireValue(), MemoryClass.Evidence.ToWireValue()],
+        ExcludedSensitivity: [MemorySensitivity.Secret.ToWireValue()],
+        ExcludeExpired: true);
+
+    private static SQLiteMemoryHydratedItem MakeItem(
+        string id,
+        string title,
+        string content,
+        string domain = "project:d0ac6ckbk5k",
+        string memoryClass = "durable_fact") => new(
+        Id: id,
+        Kind: "document",
+        MemoryClass: memoryClass,
+        Title: title,
+        Content: content,
+        AliasesJson: null,
+        FacetsJson: null,
+        SlotsJson: null,
+        Domain: domain,
+        Boundary: "boundary:trusted-instance",
+        Audience: "public",
+        Sensitivity: "normal",
+        RecallMode: "auto",
+        UpdateSemantics: "merge-document",
+        ExpiresAtMs: null,
+        UpdatedAtMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+    [Fact]
+    public void Candidate_with_no_lexical_overlap_survives_baseline_score()
+    {
+        var selector = new DeterministicCandidateSelector();
+        var plan = MakePlan(lexicalTerms: ["session"]);
+        var item = MakeItem("doc-1", "User Identity Profile", "Aaron runs Petabridge.");
+
+        var result = selector.Select(plan, [item]);
+
+        Assert.Single(result);
+        Assert.Equal("doc-1", result[0].Id);
+    }
+
+    [Fact]
+    public void Same_domain_candidate_ranks_higher_than_cross_domain()
+    {
+        var selector = new DeterministicCandidateSelector();
+        var plan = MakePlan(
+            hardScope: "project:d0ac6ckbk5k",
+            lexicalTerms: ["petabridge"]);
+
+        var sameDomain = MakeItem("doc-same", "Company: Petabridge", "Petabridge builds Akka.NET.", domain: "project:d0ac6ckbk5k");
+        var crossDomain = MakeItem("doc-cross", "Company: Petabridge", "Petabridge builds Akka.NET.", domain: "project:signalr");
+
+        var result = selector.Select(plan, [crossDomain, sameDomain]);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("doc-same", result[0].Id);
+    }
+
+    [Fact]
+    public void Cross_domain_candidate_not_excluded()
+    {
+        var selector = new DeterministicCandidateSelector();
+        var plan = MakePlan(
+            hardScope: "project:d0ac6ckbk5k",
+            lexicalTerms: ["petabridge"]);
+
+        var crossDomain = MakeItem("doc-cross", "Company: Petabridge", "Petabridge builds Akka.NET.", domain: "project:signalr");
+
+        var result = selector.Select(plan, [crossDomain]);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Evidence_class_candidates_are_selected()
+    {
+        var selector = new DeterministicCandidateSelector();
+        var plan = MakePlan(lexicalTerms: ["reelfarm"]);
+
+        var evidence = MakeItem("doc-evidence", "Reel.Farm Research", "ReelFarm costs $39/mo.", memoryClass: "evidence");
+
+        var result = selector.Select(plan, [evidence]);
+
+        Assert.Single(result);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/DeterministicRetrievalPlanningTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/DeterministicRetrievalPlanningTests.cs
@@ -131,6 +131,112 @@ public sealed class DeterministicRetrievalPlanningTests
     }
 
     [Fact]
+    public void Planner_includes_evidence_in_allowed_memory_classes()
+    {
+        var planner = new DeterministicRetrievalRequestPlanner();
+        var plan = planner.Plan(new AutomaticRecallRequest(
+            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            Query: "what did we find about Reel.Farm?",
+            RecentUserMessages: ["what did we find about Reel.Farm?"],
+            MaxItems: 3));
+
+        Assert.Contains(MemoryClass.DurableFact.ToWireValue(), plan.AllowedMemoryClasses);
+        Assert.Contains(MemoryClass.Evidence.ToWireValue(), plan.AllowedMemoryClasses);
+    }
+
+    [Fact]
+    public async Task Coordinator_recalls_evidence_class_memories()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "netclaw-evidence-recall-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var store = new SQLiteMemoryStore(Path.Combine(dir, "memory.db"), TimeProvider.System);
+        await store.InitializeAsync();
+
+        var anchor = store.CreateDefaultAnchor("reelfarm-research", "project:d0ac6ckbk5k");
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        await store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: "doc-reelfarm-research",
+            Anchor: anchor,
+            MemoryClass: "evidence",
+            Title: "Reel.Farm Marketing Tool Research",
+            MarkdownBody: "Reel.Farm costs $39/mo and generates AI-powered short-form videos for TikTok and Instagram Reels.",
+            AliasesJson: "[\"reelfarm\",\"reel farm\",\"marketing automation\"]",
+            FacetsJson: "[\"project_artifact\",\"marketing_tools\"]",
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Domain: "project:d0ac6ckbk5k",
+            Sensitivity: "normal",
+            RecallMode: "searchable",
+            Confidence: 0.85,
+            FreshnessAtMs: now,
+            ExpiresAtMs: now + 2_592_000_000,
+            CreatedAtMs: now,
+            UpdatedAtMs: now));
+
+        var coordinator = new SQLiteMemoryRecallCoordinator(
+            store,
+            NullLogger<SQLiteMemoryRecallCoordinator>.Instance,
+            sessionConfig: new SessionConfig { DeterministicRetrievalEnabled = true, MemorySidecarsEnabled = false });
+
+        var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
+            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            Query: "what did we find about Reel.Farm?",
+            RecentUserMessages: ["what did we find about Reel.Farm?"],
+            MaxItems: 3));
+
+        Assert.False(result.Degraded);
+        Assert.Contains(result.Items, x => x.Id == "doc-reelfarm-research");
+    }
+
+    [Fact]
+    public async Task Coordinator_recalls_cross_domain_memories_via_audience_primary_path()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "netclaw-audience-primary-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var store = new SQLiteMemoryStore(Path.Combine(dir, "memory.db"), TimeProvider.System);
+        await store.InitializeAsync();
+
+        // Store a memory under project:signalr (old domain)
+        var anchor = store.CreateDefaultAnchor("user-company", "project:signalr");
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        await store.UpsertDocumentAsync(new SQLiteMemoryDocument(
+            DocumentId: "doc-company-info",
+            Anchor: anchor,
+            MemoryClass: "durable_fact",
+            Title: "Company: Petabridge",
+            MarkdownBody: "Aaron works at Petabridge, an Akka.NET consultancy.",
+            AliasesJson: "[\"petabridge\",\"company\"]",
+            FacetsJson: "[\"personal_profile\"]",
+            SlotsJson: null,
+            UpdateSemantics: "merge-document",
+            Domain: "project:signalr",
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.94,
+            FreshnessAtMs: now,
+            ExpiresAtMs: null,
+            CreatedAtMs: now,
+            UpdatedAtMs: now));
+
+        var coordinator = new SQLiteMemoryRecallCoordinator(
+            store,
+            NullLogger<SQLiteMemoryRecallCoordinator>.Instance,
+            sessionConfig: new SessionConfig { DeterministicRetrievalEnabled = true, MemorySidecarsEnabled = false });
+
+        // Query from a different domain (project:d0ac6ckbk5k — Slack DM)
+        var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
+            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            Query: "what company does Aaron work at",
+            RecentUserMessages: ["what company does Aaron work at"],
+            MaxItems: 3));
+
+        Assert.False(result.Degraded);
+        Assert.Contains(result.Items, x => x.Id == "doc-company-info");
+    }
+
+    [Fact]
     public async Task Coordinator_widens_across_domains_for_named_project_entities()
     {
         var dir = Path.Combine(Path.GetTempPath(), "netclaw-deterministic-cross-domain-tests", Guid.NewGuid().ToString("N"));

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -355,6 +355,13 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
             return false;
         }
 
+        // Reject conversational fragments that accidentally match the regex
+        if (IsConversationalFragment(rawSubject) || IsConversationalFragment(rawObject))
+        {
+            candidate = null!;
+            return false;
+        }
+
         var subjectLabel = NormalizeSubject(rawSubject);
         var objectLabel = SummarizeObject(rawObject);
         var normalizedContent = NormalizeSentence($"{subjectLabel} {NormalizeVerb(rawVerb)} {rawObject}");
@@ -396,6 +403,22 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
             MemoryId: null);
         return true;
     }
+
+    private static readonly string[] ConversationalPrefixes =
+    [
+        "i ", "well ", "going to ", "want to ", "if that ", "i'm ",
+        "you ", "let me ", "maybe ", "just ", "so ", "anyway "
+    ];
+
+    private static bool IsConversationalFragment(string text)
+    {
+        var lower = text.Trim().ToLowerInvariant();
+        return ConversationalPrefixes.Any(p => lower.StartsWith(p, StringComparison.Ordinal));
+    }
+
+    private static int CountSubstantiveWords(string text)
+        => text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Count(w => w.Length >= 3);
 
     private static string CleanStatementTail(string value)
         => value.Trim().TrimEnd('.', '!', '?');

--- a/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
@@ -1349,10 +1349,10 @@ public sealed class SQLiteMemoryStore
             documentCmd.CommandText = """
                 INSERT INTO memory_documents(
                   document_id, anchor_id, memory_class, title, markdown_body, aliases_json, facets_json, slots_json, update_semantics,
-                  domain, sensitivity, recall_mode, confidence, freshness_at,
+                  domain, boundary, audience, sensitivity, recall_mode, confidence, freshness_at,
                   expires_at, created_at, updated_at)
                 VALUES($id, $anchorId, $memoryClass, $title, $body, $aliasesJson, $facetsJson, $slotsJson, $semantics,
-                  $domain, $sensitivity, $recallMode, $confidence, $freshnessAt,
+                  $domain, $boundary, $audience, $sensitivity, $recallMode, $confidence, $freshnessAt,
                   $expiresAt, $createdAt, $updatedAt)
                 ON CONFLICT(document_id) DO UPDATE SET
                   memory_class=excluded.memory_class,
@@ -1363,6 +1363,8 @@ public sealed class SQLiteMemoryStore
                   slots_json=excluded.slots_json,
                   update_semantics=excluded.update_semantics,
                   domain=excluded.domain,
+                  boundary=excluded.boundary,
+                  audience=excluded.audience,
                   sensitivity=excluded.sensitivity,
                   recall_mode=excluded.recall_mode,
                   confidence=excluded.confidence,
@@ -1380,6 +1382,8 @@ public sealed class SQLiteMemoryStore
             documentCmd.Parameters.AddWithValue("$slotsJson", (object?)operation.SlotsJson ?? DBNull.Value);
             documentCmd.Parameters.AddWithValue("$semantics", operation.UpdateSemantics);
             documentCmd.Parameters.AddWithValue("$domain", operation.Domain);
+            documentCmd.Parameters.AddWithValue("$boundary", (object?)operation.Boundary ?? DBNull.Value);
+            documentCmd.Parameters.AddWithValue("$audience", (object?)operation.Audience ?? DBNull.Value);
             documentCmd.Parameters.AddWithValue("$sensitivity", operation.Sensitivity);
             documentCmd.Parameters.AddWithValue("$recallMode", resolvedRecallMode);
             documentCmd.Parameters.AddWithValue("$confidence", operation.Confidence);

--- a/src/Netclaw.Actors/Sessions/DeterministicCandidateSelector.cs
+++ b/src/Netclaw.Actors/Sessions/DeterministicCandidateSelector.cs
@@ -24,7 +24,9 @@ public sealed class DeterministicCandidateSelector
 
     private static double Score(DeterministicRetrievalRequestPlan plan, SQLiteMemoryHydratedItem document)
     {
-        var score = 0.0;
+        // Baseline: candidates survived SQL pre-filtering (LIKE match), so they
+        // deserve a non-zero score. Lexical/facet/anchor matches boost above this.
+        var score = 1.0;
         var text = (document.Title + " " + document.Content + " " + (document.AliasesJson ?? string.Empty) + " " + (document.FacetsJson ?? string.Empty)).ToLowerInvariant();
         var tokens = TextTokenizer.Tokenize(text).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -45,6 +47,11 @@ public sealed class DeterministicCandidateSelector
         foreach (var scope in plan.SoftScopes)
             if (text.Contains(scope.Replace("scope:", string.Empty, StringComparison.OrdinalIgnoreCase), StringComparison.OrdinalIgnoreCase))
                 score += 3.5;
+
+        // Domain affinity: same-domain memories rank higher but cross-domain
+        // memories aren't excluded (audience+boundary are the security gates).
+        if (string.Equals(document.Domain, plan.HardScope, StringComparison.OrdinalIgnoreCase))
+            score += 5.0;
 
         return score;
     }

--- a/src/Netclaw.Actors/Sessions/DeterministicRetrievalPlanning.cs
+++ b/src/Netclaw.Actors/Sessions/DeterministicRetrievalPlanning.cs
@@ -45,7 +45,7 @@ public sealed class DeterministicRetrievalRequestPlanner
             Facets: facets,
             AnchorHints: anchorHints,
             CandidateLimit: retrievalMode == DeterministicRetrievalMode.Bundle ? 60 : 30,
-            AllowedMemoryClasses: [MemoryClass.DurableFact.ToWireValue()],
+            AllowedMemoryClasses: [MemoryClass.DurableFact.ToWireValue(), MemoryClass.Evidence.ToWireValue()],
             ExcludedSensitivity: [MemorySensitivity.Secret.ToWireValue()],
             ExcludeExpired: true);
     }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1946,6 +1946,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 var filtered = resolved.Items
                     .Where(i => !_injectedMemoryIds.Contains(i.Id))
                     .ToArray();
+
+                if (filtered.Length == 0 && resolved.Items.Count > 0)
+                {
+                    _log.Info(
+                        "progressive_recall_exhausted allCandidatesAlreadyInjected={0} totalInjected={1}",
+                        resolved.Items.Count,
+                        _injectedMemoryIds.Count);
+                }
+
                 resolved = new AutomaticRecallResult(filtered, resolved.Degraded, resolved.DegradeReason, resolved.DegradeStage);
             }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -247,12 +247,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     Memory.MemoryCurationActor.CreateProps(_memoryStore, _clientProvider),
                     "memory-curation");
 
+                // Distillation processes a full transcript — allow 2x normal sidecar timeout
+                var distillationTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds) * 2);
                 _observerActor = Context.ActorOf(
                     SessionMemoryObserverActor.CreateProps(
                         _sessionId,
                         _compactionClient,
                         TimeSpan.FromSeconds(Math.Max(10, _config.MemoryObserverIdleSeconds)),
-                        TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds))),
+                        distillationTimeout),
                     "memory-observer");
             }
         });

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -247,8 +247,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     Memory.MemoryCurationActor.CreateProps(_memoryStore, _clientProvider),
                     "memory-curation");
 
-                // Distillation processes a full transcript — allow 2x normal sidecar timeout
-                var distillationTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds) * 2);
+                // Distillation processes a full transcript — allow 5x normal sidecar timeout
+                // for slower local models (e.g., Qwen 3.5 27B)
+                var distillationTimeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds) * 5);
                 _observerActor = Context.ActorOf(
                     SessionMemoryObserverActor.CreateProps(
                         _sessionId,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -44,7 +44,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly IMemoryExtractor _memoryExtractor;
     private readonly IMemoryRecallCoordinator _memoryRecallCoordinator;
     private readonly IMemoryCheckpointSink _memoryCheckpointSink;
-    private readonly SidecarMemoryObserver _sidecarMemoryObserver = new();
     private readonly MemoryProposalGate _memoryProposalGate = new();
     private readonly TimeProvider _timeProvider;
     private readonly string? _sessionsBasePath;
@@ -108,6 +107,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     // Child actor for per-session memory curation (evaluate-before-write pipeline)
     private IActorRef? _curationActor;
+
+    // Child actor for session-level memory observation (distills transcript on idle)
+    private IActorRef? _observerActor;
 
     // Processing watchdog state (non-persistent)
     private static readonly object ProcessingWatchdogTimerKey = new();
@@ -244,6 +246,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 _curationActor = Context.ActorOf(
                     Memory.MemoryCurationActor.CreateProps(_memoryStore, _clientProvider),
                     "memory-curation");
+
+                _observerActor = Context.ActorOf(
+                    SessionMemoryObserverActor.CreateProps(
+                        _sessionId,
+                        _compactionClient,
+                        TimeSpan.FromSeconds(Math.Max(10, _config.MemoryObserverIdleSeconds)),
+                        TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds))),
+                    "memory-observer");
             }
         });
     }
@@ -296,6 +306,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 cmd.MediaReferences.Count > 0,
                 cmd.Content?.Length ?? 0);
             _logActor?.Tell(cmd);
+            _observerActor?.Tell(cmd);
 
             _toolCallCount = 0;
             _toolIterationCount = 0;
@@ -758,6 +769,57 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
+    }
+
+    private void HandleDistillationResult(SessionDistillationCompleted msg)
+    {
+        _log.Info(
+            "session_distillation_completed proposals={ProposalCount} inputTokens={InputTokens} outputTokens={OutputTokens} failure={Failure}",
+            msg.Proposals.Count,
+            msg.InputTokens,
+            msg.OutputTokens,
+            msg.FailureReason ?? "-");
+
+        // Emit sidecar token usage through the standard pipeline
+        if (msg.InputTokens.HasValue || msg.OutputTokens.HasValue)
+        {
+            _sessionMetrics?.RecordTokenUsage(msg.InputTokens ?? 0, msg.OutputTokens ?? 0);
+            EmitOutput(new UsageOutput
+            {
+                SessionId = _sessionId,
+                InputTokens = msg.InputTokens,
+                OutputTokens = msg.OutputTokens,
+                TotalTokens = (msg.InputTokens ?? 0) + (msg.OutputTokens ?? 0)
+            }, OutputFilter.Usage);
+        }
+
+        // Route proposals through the standard gate → curation pipeline
+        if (msg.Proposals.Count > 0 && _curationActor is not null)
+        {
+            var gateResult = _memoryProposalGate.Evaluate(
+                msg.Proposals,
+                _sessionId.ToMemoryDomain(),
+                Memory.MemorySensitivity.Normal.ToWireValue(),
+                NowMs(),
+                boundary: CurrentMemoryBoundary(),
+                audience: _currentTurnSource?.Audience ?? TrustAudience.Public);
+
+            var accepted = gateResult.MemoryOperations;
+
+            _log.Info(
+                "session_distillation_gate_result total={Total} accepted={Accepted} rejections={Rejections}",
+                gateResult.Summary.Total,
+                gateResult.Summary.Accepted,
+                gateResult.Summary.RejectionReasons.Count == 0
+                    ? "-"
+                    : string.Join("|", gateResult.Summary.RejectionReasons.Select(x => $"{x.Key}:{x.Value}")));
+
+            if (accepted.Count > 0)
+            {
+                _curationActor.Tell(new Memory.EvaluateProposals(accepted, _sessionId.ToMemoryDomain()));
+                _sessionMetrics?.RecordMemoriesFormed(accepted.Count);
+            }
+        }
     }
 
     private void Compacting()
@@ -1409,9 +1471,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             MaybeGenerateTitle();
             _activeRecall = recallResult;
 
-            if (_config.MemorySidecarsEnabled)
-                ObserveTurnForMemory(evt.UserMessage, evt.AssistantReply);
-
             EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                 SessionId: _sessionId,
                 TurnId: _activeTurnId,
@@ -1664,6 +1723,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             TurnLog().Warning("memory_curation_failed reason={Reason}", msg.Reason);
         });
+
+        Command<SessionDistillationCompleted>(msg => HandleDistillationResult(msg));
 
         Command<JoinSession>(cmd =>
         {
@@ -1972,6 +2033,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             {
                 var recallContent = FormatRecallForHistory(resolved);
                 _state = _state.AddSystemNudge(recallContent);
+                _observerActor?.Tell(new ObserverSystemContext("recalled-memory", recallContent));
             }
 
             var recallIds = resolved.Items.Count == 0
@@ -2869,84 +2931,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
     }
 
-    private void ObserveTurnForMemory(SerializableChatMessage userMessage, SerializableChatMessage assistantReply)
-    {
-        var userText = userMessage.Content ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(userText))
-            return;
-
-        var recentUser = _state.History
-            .Where(x => x.Role == Protocol.ChatRole.User && !SessionState.IsSystemNudge(x))
-            .Select(x => x.Content)
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .TakeLast(3)
-            .ToArray();
-
-        var recentAssistant = _state.History
-            .Where(x => x.Role == Protocol.ChatRole.Assistant)
-            .Select(x => x.Content)
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .TakeLast(3)
-            .ToArray();
-
-        var strongAssertions = BuildStrongAssertions(userText);
-        var request = _sidecarMemoryObserver.BuildRequest(
-            _sessionId.Value,
-            _activeTurnId ?? $"{_sessionId.Value}:{NowMs()}",
-            "turn_completed",
-            _sessionId.ToMemoryDomain(),
-            Memory.MemorySensitivity.Normal.ToWireValue(),
-            userText,
-            assistantReply.Content ?? string.Empty,
-            strongAssertions,
-            [],
-            recentUser,
-            recentAssistant,
-            [],
-            false,
-            _timeProvider.GetUtcNow());
-
-        var self = Self;
-        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.SidecarLlmTimeoutSeconds));
-        _ = ObserveMemoryAsync(_compactionClient, request, self, _log, timeout);
-    }
-
-    private static async Task ObserveMemoryAsync(
-        IChatClient client,
-        MemoryObservationRequest request,
-        IActorRef self,
-        ILoggingAdapter log,
-        TimeSpan timeout)
-    {
-        var proposals = await SessionSidecarRunner.RunJsonAsync<IReadOnlyList<MemoryProposal>>(
-            client,
-            MemorySidecarPromptBuilder.BuildMemoryObservationSystemPrompt(),
-            MemorySidecarPromptBuilder.BuildMemoryObservationUserPrompt(request),
-            timeout,
-            message => log.Warning("Memory observation sidecar failed: {0}", message));
-
-        if (proposals is null)
-        {
-            self.Tell(new MemoryObservationFailed { Reason = "sidecar failed or returned null" });
-            return;
-        }
-
-        self.Tell(new MemoryObservationCompleted { Proposals = proposals });
-    }
-
-    private static IReadOnlyList<string> BuildStrongAssertions(string userText)
-    {
-        var assertions = new List<string>();
-        var text = userText.Trim();
-        if (text.StartsWith("I ", StringComparison.OrdinalIgnoreCase)
-            || text.StartsWith("I'm ", StringComparison.OrdinalIgnoreCase)
-            || text.StartsWith("I’m ", StringComparison.OrdinalIgnoreCase))
-        {
-            assertions.Add(text);
-        }
-        return assertions;
-    }
-
     private void EmitUsageOutput(UsageDetails usage)
     {
         _sessionMetrics?.RecordTokenUsage(usage.InputTokenCount ?? 0, usage.OutputTokenCount ?? 0);
@@ -3051,6 +3035,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
 
         _logActor?.Tell(output);
+        _observerActor?.Tell(output);
     }
 
     private void BindTurnTelemetry(MessageSource? source)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -799,13 +799,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Route proposals through the standard gate → curation pipeline
         if (msg.Proposals.Count > 0 && _curationActor is not null)
         {
+            // Use session-derived audience when _currentTurnSource is null
+            // (distillation fires after idle, turn context is cleared)
+            var audience = _currentTurnSource?.Audience
+                ?? SecurityPolicyDefaults.ResolveAudienceFromSessionId(_sessionId.Value);
             var gateResult = _memoryProposalGate.Evaluate(
                 msg.Proposals,
                 _sessionId.ToMemoryDomain(),
                 Memory.MemorySensitivity.Normal.ToWireValue(),
                 NowMs(),
                 boundary: CurrentMemoryBoundary(),
-                audience: _currentTurnSource?.Audience ?? TrustAudience.Public);
+                audience: audience);
 
             var accepted = gateResult.MemoryOperations;
 

--- a/src/Netclaw.Actors/Sessions/MemorySidecarPromptBuilder.cs
+++ b/src/Netclaw.Actors/Sessions/MemorySidecarPromptBuilder.cs
@@ -61,13 +61,36 @@ public static class MemorySidecarPromptBuilder
               "rationale": "Stable user preference stated explicitly."
             }
 
+            Example evidence (agent-derived finding):
+            {
+              "operation": "append_record",
+              "memoryClass": "evidence",
+              "subjectKind": "project",
+              "subjectValue": "netclaw",
+              "anchor": { "canonicalName": "pr-394-review", "anchorType": "review" },
+              "title": "PR #394 Review: Skill Platform Hardening",
+              "content": "PR #394 adds skill management CRUD tooling and a five-tier trust system (System > User > Community > External > Agent). Key findings: content security scanning interface, atomic file writes, system directory write protection.",
+              "aliases": ["PR 394", "skill trust tiers", "skill management"],
+              "facets": ["code_review", "project_artifact"],
+              "slots": [],
+              "relations": [],
+              "recallMode": "searchable",
+              "sensitivity": "normal",
+              "confidence": 0.80,
+              "freshUntilMs": null,
+              "expiresAtMs": null,
+              "targetSurface": null,
+              "rationale": "Agent-derived findings from PR review — synthesized conclusions, not raw diff output."
+            }
+
             Rules:
             - Strong stable user assertions and durable working preferences become durable_fact.
-            - Search results, hotel/flight options, passages, prices, and transient research become evidence.
-            - Diagnostic chatter and execution breadcrumbs become trace or ignore.
+            - Conclusions, learnings, and discoveries that the agent arrived at through tool use, analysis, or research become evidence with moderate confidence (0.7-0.85). Examples: PR review findings, research comparisons, discovered constraints or errors, task outcomes.
+            - Raw search results, hotel/flight options, price lists, and transient research data become evidence only when the agent has drawn a conclusion from them. Do not store raw tool output.
+            - Routine tool invocation logs, raw API responses, raw search result listings, status checks, and execution breadcrumbs become trace or ignore. The key distinction: synthesized knowledge → evidence; raw output → trace.
             - Never write secrets as auto-recall memories.
             - Never use SOUL.md as a sink for project facts, research passages, or evidence.
-            - Be conservative.
+            - When in doubt between evidence and ignore, prefer evidence with moderate confidence (0.7-0.8) rather than suppressing the observation.
             """;
     }
 

--- a/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
+++ b/src/Netclaw.Actors/Sessions/SQLiteMemoryRecallCoordinator.cs
@@ -52,9 +52,11 @@ public sealed class SQLiteMemoryRecallCoordinator(
 
                 var effectiveBoundary = ResolveBoundary(normalizedRequest, deterministicPlan.HardScope);
 
-                var rawCandidates = await store.SearchByPlanAsync(
+                // Audience-primary recall: domain is a ranking preference (via
+                // DeterministicCandidateSelector domain affinity boost), not a
+                // security gate. Audience+boundary are the SQL security filters.
+                var rawCandidates = await store.SearchAcrossDomainsByPlanAsync(
                     deterministicPlan.LexicalTerms.Count > 0 ? deterministicPlan.LexicalTerms : [normalizedRequest.Query],
-                    deterministicPlan.HardScope,
                     deterministicPlan.AllowedMemoryClasses,
                     deterministicPlan.CandidateLimit,
                     effectiveBoundary,
@@ -62,25 +64,10 @@ public sealed class SQLiteMemoryRecallCoordinator(
                     allowExpiredEvidence: false,
                     ct);
 
-                var widened = false;
-                if (rawCandidates.Count == 0 && ShouldWidenAcrossDomains(deterministicPlan))
-                {
-                    rawCandidates = await store.SearchAcrossDomainsByPlanAsync(
-                        deterministicPlan.LexicalTerms.Count > 0 ? deterministicPlan.LexicalTerms : [request.Query],
-                        deterministicPlan.AllowedMemoryClasses,
-                        deterministicPlan.CandidateLimit,
-                        effectiveBoundary,
-                        normalizedRequest.Audience,
-                        allowExpiredEvidence: false,
-                        ct);
-                    widened = true;
-                }
-
                 var candidates = _candidateSelector.Select(deterministicPlan, rawCandidates);
                 logger.LogInformation(
-                    "memory_retrieval_candidate_selection hardScope={HardScope} widenedAcrossDomains={WidenedAcrossDomains} rawCount={RawCount} selectedCount={SelectedCount} ids={Ids}",
+                    "memory_retrieval_candidate_selection hardScope={HardScope} rawCount={RawCount} selectedCount={SelectedCount} ids={Ids}",
                     deterministicPlan.HardScope,
-                    widened,
                     rawCandidates.Count,
                     candidates.Count,
                     string.Join("|", candidates.Select(x => x.Id)));
@@ -217,9 +204,6 @@ public sealed class SQLiteMemoryRecallCoordinator(
         => !string.IsNullOrWhiteSpace(request.Boundary)
             ? request.Boundary!
             : SecurityPolicyDefaults.InferLegacyBoundaryFromDomain(domain);
-    private static bool ShouldWidenAcrossDomains(DeterministicRetrievalRequestPlan plan)
-        => plan.AnchorHints.Count > 0
-           || plan.Facets.Contains("project_fact", StringComparer.OrdinalIgnoreCase);
 
     private async Task<RecallQueryPlan?> BuildPlanAsync(
         AutomaticRecallRequest request,

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -246,7 +246,10 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             if (deserialized?.Proposals is not null)
                 return deserialized.Proposals;
         }
-        catch (JsonException) { }
+        catch (JsonException)
+        {
+            // Expected: sidecar may wrap JSON in markdown fences — fall through to extraction
+        }
 
         // Fallback: extract JSON from markdown fences
         var jsonStart = text.IndexOf('{', StringComparison.Ordinal);
@@ -259,7 +262,10 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                     text[jsonStart..(jsonEnd + 1)], JsonOptions);
                 return deserialized?.Proposals ?? [];
             }
-            catch (JsonException) { }
+            catch (JsonException)
+            {
+                // Both parse attempts failed — return empty
+            }
         }
 
         return [];

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -110,8 +110,13 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         // Explicit distillation request from parent (passivation)
         Command<DistillMemories>(msg => TriggerDistillation(Sender));
 
-        // Internal: mark distillation complete
-        Command<DistillationFinished>(_ => _distilling = false);
+        // Internal: mark distillation complete. On failure, re-enable hasNewContent for retry.
+        Command<DistillationFinished>(msg =>
+        {
+            _distilling = false;
+            if (msg.Success)
+                _hasNewContent = false;
+        });
 
         // Internal: persist proposed anchors to journal (arrives from async task via self.Tell)
         Command<PersistAnchors>(msg =>
@@ -153,7 +158,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         }
 
         _distilling = true;
-        _hasNewContent = false;
 
         var self = Self;
         var skipList = _proposedAnchors.ToArray();
@@ -224,11 +228,11 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                 OutputTokens = outputTokens,
                 FailureReason = ex.Message
             });
+            self.Tell(new DistillationFinished(false));
+            return;
         }
-        finally
-        {
-            self.Tell(DistillationFinished.Instance);
-        }
+
+        self.Tell(new DistillationFinished(true));
     }
 
     private static IReadOnlyList<MemoryProposal> ParseProposals(string text)
@@ -341,10 +345,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 
     // ── Internal messages ──
 
-    private sealed record DistillationFinished
-    {
-        public static readonly DistillationFinished Instance = new();
-    }
+    private sealed record DistillationFinished(bool Success);
 
     private sealed record PersistAnchors(IReadOnlyList<string> Anchors);
 }

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -1,0 +1,376 @@
+using System.Text;
+using System.Text.Json;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Persistence;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.SubAgents;
+
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Per-session persistent child actor that observes the conversation stream
+/// and distills memories when the session goes idle.
+///
+/// <para>The observer accumulates a transcript from forwarded messages:
+/// user input, assistant text, tool call names, recalled memories, loaded skills,
+/// and turn boundaries. When the stream goes quiet (ReceiveTimeout), it runs a
+/// sidecar LLM call to distill the transcript into memory proposals.</para>
+///
+/// <para>Proposals are sent to the parent (<see cref="LlmSessionActor"/>),
+/// which routes them to the <see cref="MemoryCurationActor"/> for dedup and
+/// persistence. Token usage from the sidecar call is included in the result
+/// so the parent can emit it through the standard usage pipeline.</para>
+///
+/// <para>Persistent: journals <see cref="MemoriesDistilled"/> events so the
+/// skip list of already-proposed anchors survives across session incarnations.</para>
+/// </summary>
+public sealed class SessionMemoryObserverActor : ReceivePersistentActor
+{
+    private readonly SessionId _sessionId;
+    private readonly IChatClient _client;
+    private readonly TimeSpan _sidecarTimeout;
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+
+    private readonly StringBuilder _transcript = new();
+    private readonly HashSet<string> _proposedAnchors = new(StringComparer.OrdinalIgnoreCase);
+    private bool _hasNewContent;
+    private bool _distilling;
+    private int _turnCount;
+
+    public override string PersistenceId { get; }
+
+    public static Props CreateProps(
+        SessionId sessionId,
+        IChatClient client,
+        TimeSpan idleTimeout,
+        TimeSpan sidecarTimeout) =>
+        Props.Create(() => new SessionMemoryObserverActor(sessionId, client, idleTimeout, sidecarTimeout));
+
+    public SessionMemoryObserverActor(
+        SessionId sessionId,
+        IChatClient client,
+        TimeSpan idleTimeout,
+        TimeSpan sidecarTimeout)
+    {
+        _sessionId = sessionId;
+        _client = client;
+        _sidecarTimeout = sidecarTimeout;
+
+        PersistenceId = $"memory-observer-{sessionId.Value}";
+
+        // Recovery: rebuild skip list from journaled events
+        Recover<MemoriesDistilled>(evt =>
+        {
+            foreach (var anchor in evt.Anchors)
+                _proposedAnchors.Add(anchor);
+        });
+
+        Recover<RecoveryCompleted>(_ =>
+        {
+            _log.Info(
+                "session_observer_recovery_complete proposedAnchors={Count}",
+                _proposedAnchors.Count);
+        });
+
+        // Stream messages from parent
+        Command<SendUserMessage>(msg =>
+        {
+            if (!string.IsNullOrWhiteSpace(msg.Content))
+            {
+                _transcript.AppendLine($"[user] {msg.Content}");
+                _hasNewContent = true;
+            }
+        });
+
+        Command<ObserverSystemContext>(msg =>
+        {
+            _transcript.AppendLine($"[{msg.Label}] {msg.Content}");
+            _hasNewContent = true;
+        });
+
+        Command<SessionOutput>(msg =>
+        {
+            var line = FormatOutput(msg);
+            if (line is not null)
+            {
+                _transcript.AppendLine(line);
+                _hasNewContent = true;
+            }
+
+            if (msg is TurnCompleted tc)
+                _turnCount = tc.TurnNumber;
+        });
+
+        // Idle timer: self-trigger distillation when stream goes quiet
+        Command<ReceiveTimeout>(_ => TriggerDistillation(Context.Parent));
+
+        // Explicit distillation request from parent (passivation)
+        Command<DistillMemories>(msg => TriggerDistillation(Sender));
+
+        // Internal: mark distillation complete
+        Command<DistillationFinished>(_ => _distilling = false);
+
+        // Internal: persist proposed anchors to journal (arrives from async task via self.Tell)
+        Command<PersistAnchors>(msg =>
+        {
+            var evt = new MemoriesDistilled(msg.Anchors, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            Persist(evt, e =>
+            {
+                foreach (var anchor in e.Anchors)
+                    _proposedAnchors.Add(anchor);
+                _log.Info("session_observer_anchors_persisted count={Count}", e.Anchors.Count);
+            });
+        });
+
+        // Set the idle timer
+        Context.SetReceiveTimeout(idleTimeout);
+    }
+
+    private void TriggerDistillation(IActorRef replyTo)
+    {
+        if (_distilling)
+        {
+            _log.Info("session_observer_distill_skipped reason=already_in_progress");
+            return;
+        }
+
+        if (!_hasNewContent)
+        {
+            _log.Info("session_observer_distill_skipped reason=no_new_content");
+            replyTo.Tell(SessionDistillationCompleted.Empty);
+            return;
+        }
+
+        var transcriptText = _transcript.ToString();
+        if (string.IsNullOrWhiteSpace(transcriptText))
+        {
+            _log.Info("session_observer_distill_skipped reason=empty_transcript");
+            replyTo.Tell(SessionDistillationCompleted.Empty);
+            return;
+        }
+
+        _distilling = true;
+        _hasNewContent = false;
+
+        var self = Self;
+        var skipList = _proposedAnchors.ToArray();
+
+        _ = RunDistillationAsync(
+            _client, _sessionId.Value, _sessionId.ToMemoryDomain(),
+            _turnCount, transcriptText, skipList, _sidecarTimeout, self, replyTo);
+    }
+
+    private async Task RunDistillationAsync(
+        IChatClient client,
+        string sessionId,
+        string domain,
+        int turnCount,
+        string transcript,
+        IReadOnlyList<string> skipAnchors,
+        TimeSpan timeout,
+        IActorRef self,
+        IActorRef replyTo)
+    {
+        long? inputTokens = null;
+        long? outputTokens = null;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var messages = new List<ChatMessage>
+            {
+                new(Microsoft.Extensions.AI.ChatRole.System, BuildDistillationSystemPrompt()),
+                new(Microsoft.Extensions.AI.ChatRole.User, BuildDistillationUserPrompt(
+                    sessionId, domain, turnCount, transcript, skipAnchors))
+            };
+
+            var response = await client.GetResponseAsync(messages, cancellationToken: cts.Token);
+            var text = response.Messages[^1].Text ?? string.Empty;
+
+            inputTokens = response.Usage?.InputTokenCount;
+            outputTokens = response.Usage?.OutputTokenCount;
+
+            var proposals = ParseProposals(text);
+
+            // Persist proposed anchors to journal for skip list durability
+            var newAnchors = proposals
+                .Where(p => p.Anchor is not null)
+                .Select(p => p.Anchor!.CanonicalName)
+                .Where(a => !string.IsNullOrWhiteSpace(a))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (newAnchors.Length > 0)
+            {
+                self.Tell(new PersistAnchors(newAnchors));
+            }
+
+            replyTo.Tell(new SessionDistillationCompleted
+            {
+                Proposals = proposals,
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens
+            });
+        }
+        catch (Exception ex)
+        {
+            replyTo.Tell(new SessionDistillationCompleted
+            {
+                Proposals = [],
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
+                FailureReason = ex.Message
+            });
+        }
+        finally
+        {
+            self.Tell(DistillationFinished.Instance);
+        }
+    }
+
+    private static IReadOnlyList<MemoryProposal> ParseProposals(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return [];
+
+        try
+        {
+            var deserialized = JsonSerializer.Deserialize<DistillationResponse>(text, JsonOptions);
+            if (deserialized?.Proposals is not null)
+                return deserialized.Proposals;
+        }
+        catch (JsonException) { }
+
+        // Fallback: extract JSON from markdown fences
+        var jsonStart = text.IndexOf('{', StringComparison.Ordinal);
+        var jsonEnd = text.LastIndexOf('}');
+        if (jsonStart >= 0 && jsonEnd > jsonStart)
+        {
+            try
+            {
+                var deserialized = JsonSerializer.Deserialize<DistillationResponse>(
+                    text[jsonStart..(jsonEnd + 1)], JsonOptions);
+                return deserialized?.Proposals ?? [];
+            }
+            catch (JsonException) { }
+        }
+
+        return [];
+    }
+
+    private static string? FormatOutput(SessionOutput output) => output switch
+    {
+        TextOutput text when !string.IsNullOrWhiteSpace(text.Text)
+            => $"[assistant] {text.Text}",
+        ToolCallOutput toolCall
+            => $"[tool] {toolCall.ToolName}({Truncate(toolCall.ArgumentsJson ?? "", 200)})",
+        TurnCompleted tc
+            => $"[turn {tc.TurnNumber} completed]",
+        CompactionOutput
+            => "[session compacted]",
+        SubAgentOutput sa when sa.Phase == SubAgentPhase.Completed
+            => $"[subagent] {sa.AgentName} completed (findings={sa.FindingsCount})",
+        ErrorOutput error
+            => $"[error] {error.Message}",
+        _ => null
+    };
+
+    internal static string BuildDistillationSystemPrompt() => """
+        You are a session memory distillation sidecar.
+        You receive the full transcript of a conversation session.
+        Return JSON only: { "proposals": [ ... ] }
+
+        Your job: identify the 2-5 most valuable things learned in this session.
+
+        What to extract:
+        - Stable user preferences, decisions, or assertions → durable_fact (recallMode: "auto")
+        - Agent conclusions from research, analysis, or tool use → evidence (recallMode: "searchable")
+        - Project facts, constraints, or architectural decisions → durable_fact (recallMode: "auto")
+        - Task outcomes and significant results → evidence (recallMode: "searchable")
+
+        What to skip:
+        - Greetings, pleasantries, task coordination ("can you do X" / "sure")
+        - Intermediate reasoning superseded by a later conclusion
+        - Information already present in [recalled-memory] entries — those are already stored
+        - Information from [loaded-skill] entries — those are system knowledge, not memories
+        - Raw data or tool output that was summarized later (keep the summary, skip the raw)
+        - Anything the user corrected or walked back
+        - Anchors listed in the "skipAnchors" field — those were already proposed
+
+        Focus on the narrative arc: What did this session accomplish?
+        What would be useful to know in a future session?
+
+        For each proposal, include:
+        - operation: "upsert_document" or "append_record"
+        - memoryClass: "durable_fact" or "evidence"
+        - subjectKind: "user" or "project"
+        - subjectValue: the subject identifier
+        - anchor: { "canonicalName": "slug-name", "anchorType": "type" }
+        - title, content, aliases (non-empty array), facets (non-empty array)
+        - recallMode: "auto" for durable_fact, "searchable" for evidence
+        - sensitivity: "normal"
+        - confidence: 0.7-0.95
+
+        If nothing is worth remembering, return { "proposals": [] }.
+        """;
+
+    internal static string BuildDistillationUserPrompt(
+        string sessionId,
+        string domain,
+        int turnCount,
+        string transcript,
+        IReadOnlyList<string> skipAnchors) => JsonSerializer.Serialize(new
+    {
+        sessionId,
+        domain,
+        turnCount,
+        skipAnchors,
+        transcript
+    });
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // ── Internal messages ──
+
+    private sealed record DistillationFinished
+    {
+        public static readonly DistillationFinished Instance = new();
+    }
+
+    private sealed record PersistAnchors(IReadOnlyList<string> Anchors);
+}
+
+// ── Journal event ──
+
+/// <summary>Journaled event recording which anchors were proposed in a distillation.</summary>
+public sealed record MemoriesDistilled(IReadOnlyList<string> Anchors, long TimestampMs);
+
+// ── Messages ──
+
+/// <summary>System context injection forwarded to the observer (recalled memories, loaded skills).</summary>
+public sealed record ObserverSystemContext(string Label, string Content);
+
+/// <summary>Signal from parent: distill now (used during passivation).</summary>
+public sealed record DistillMemories;
+
+/// <summary>Observer's response with memory proposals and token usage for billing.</summary>
+public sealed record SessionDistillationCompleted
+{
+    public static readonly SessionDistillationCompleted Empty = new() { Proposals = [] };
+
+    public required IReadOnlyList<MemoryProposal> Proposals { get; init; }
+    public long? InputTokens { get; init; }
+    public long? OutputTokens { get; init; }
+    public string? FailureReason { get; init; }
+}
+
+internal sealed record DistillationResponse(IReadOnlyList<MemoryProposal>? Proposals);

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -240,35 +240,34 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         if (string.IsNullOrWhiteSpace(text))
             return [];
 
-        try
-        {
-            var deserialized = JsonSerializer.Deserialize<DistillationResponse>(text, JsonOptions);
-            if (deserialized?.Proposals is not null)
-                return deserialized.Proposals;
-        }
-        catch (JsonException)
-        {
-            // Expected: sidecar may wrap JSON in markdown fences — fall through to extraction
-        }
+        // Try direct parse first, then extract from markdown fences
+        var direct = TryDeserialize(text);
+        if (direct is not null)
+            return direct;
 
-        // Fallback: extract JSON from markdown fences
         var jsonStart = text.IndexOf('{', StringComparison.Ordinal);
         var jsonEnd = text.LastIndexOf('}');
         if (jsonStart >= 0 && jsonEnd > jsonStart)
         {
-            try
-            {
-                var deserialized = JsonSerializer.Deserialize<DistillationResponse>(
-                    text[jsonStart..(jsonEnd + 1)], JsonOptions);
-                return deserialized?.Proposals ?? [];
-            }
-            catch (JsonException)
-            {
-                // Both parse attempts failed — return empty
-            }
+            var extracted = TryDeserialize(text[jsonStart..(jsonEnd + 1)]);
+            if (extracted is not null)
+                return extracted;
         }
 
         return [];
+    }
+
+    private static IReadOnlyList<MemoryProposal>? TryDeserialize(string json)
+    {
+        try
+        {
+            var result = JsonSerializer.Deserialize<DistillationResponse>(json, JsonOptions);
+            return result?.Proposals;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     private static string? FormatOutput(SessionOutput output) => output switch

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -107,6 +107,13 @@ public sealed record SessionConfig
     public bool MemorySidecarsEnabled { get; init; } = true;
 
     /// <summary>
+    /// Idle seconds before the session memory observer triggers distillation.
+    /// The observer watches the conversation stream and distills memories
+    /// when the session goes quiet for this duration.
+    /// </summary>
+    public int MemoryObserverIdleSeconds { get; init; } = 90;
+
+    /// <summary>
     /// Enables deterministic retrieval request planning for automatic
     /// memory recall on each turn.
     /// </summary>


### PR DESCRIPTION
## Summary

Spike: adds `SessionMemoryObserverActor` — a persistent child actor that watches the
conversation stream and distills memories when the session goes idle. Replaces per-turn
observation which produced `proposalCount=0` on every prompt.

- Observer subscribes to same stream as SessionLogActor (user messages, assistant text,
  tool call names, recalled memories, turn boundaries)
- Runs sidecar LLM call with full transcript + skip list of already-proposed anchors
- Proposals flow through existing gate → curation actor pipeline
- Token usage emitted through standard pipeline for accurate billing
- Persistent: journals proposed anchors so skip list survives across incarnations

Builds on PR #409 (Phase 1 recall fixes).

## Known limitation

No passivation-triggered distillation. The observer's idle timer (90s) fires before
the session's passivation timeout (~5min), so memories form during normal pauses.
Final distillation before session death requires formalizing the session actor's state
machine — tracked in #TBD.

## Test plan

- [x] All 1,202 existing tests pass (including passivation test)
- [x] `dotnet slopwatch analyze` clean
- [ ] Binary swap → `netclaw -p` exercises → verify `proposalCount>0` in daemon logs
- [ ] Memory documents grow in SQLite after idle distillation