### PR TITLE
feat(tools): add file_edit tool for surgical text replacements

### DIFF
--- a/openspec/specs/netclaw-tools/spec.md
+++ b/openspec/specs/netclaw-tools/spec.md
@@ -166,6 +166,64 @@ SHALL be truncated to a configurable limit.
 - **WHEN** the shell tool executes a command
 - **THEN** the working directory is set to the project's registered path
 
+### Requirement: File edit tool
+
+The system SHALL provide a file edit tool that performs targeted text
+replacements in existing files without rewriting the entire file. The tool
+SHALL require the target file to already exist. The tool SHALL match literal
+text (not regex) and fail loudly if the specified text is not found. When
+multiple matches exist and replace-all is not specified, the tool SHALL fail
+with an ambiguity error to prevent accidental edits. OldString and NewString
+SHALL both be required and must differ. The tool uses the `file` grant
+category and respects the same security policies as file_write.
+
+#### Scenario: Single replacement in existing file
+
+- **GIVEN** the `file` grant is available and a file exists at the specified path
+- **WHEN** the agent invokes file_edit with OldString and NewString
+- **AND** OldString matches exactly once in the file
+- **THEN** the first occurrence is replaced with NewString
+- **AND** the rest of the file content is preserved
+
+#### Scenario: Replace all occurrences
+
+- **GIVEN** a file contains multiple occurrences of OldString
+- **WHEN** the agent invokes file_edit with ReplaceAll=true
+- **THEN** all occurrences are replaced with NewString
+
+#### Scenario: Ambiguous match rejected
+
+- **GIVEN** a file contains multiple occurrences of OldString
+- **WHEN** the agent invokes file_edit without ReplaceAll
+- **THEN** the tool returns an error indicating the match is ambiguous
+- **AND** the file is not modified
+
+#### Scenario: Text not found returns error
+
+- **GIVEN** a file does not contain OldString
+- **WHEN** the agent invokes file_edit
+- **THEN** the tool returns an error that the text was not found
+- **AND** the file is not modified
+
+#### Scenario: File must exist
+
+- **GIVEN** the specified file path does not exist
+- **WHEN** the agent invokes file_edit
+- **THEN** the tool returns a file-not-found error
+
+#### Scenario: Empty replacement performs deletion
+
+- **GIVEN** a file contains OldString
+- **WHEN** the agent invokes file_edit with NewString as empty string
+- **THEN** the matched text is deleted from the file
+
+#### Scenario: OldString and NewString must differ
+
+- **GIVEN** the agent invokes file_edit with OldString equal to NewString
+- **WHEN** the tool validates parameters
+- **THEN** the tool returns an error that OldString and NewString must differ
+- **AND** the file is not modified
+
 ### Requirement: GitHub CLI tool
 
 The system SHALL provide a GitHub tool that shells out to the `gh` CLI for

--- a/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileEditToolTests.cs
@@ -1,0 +1,219 @@
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class FileEditToolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileEditTool _tool = new(new ToolConfig());
+    private readonly string _sessionDir;
+
+    public FileEditToolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _sessionDir = Path.Combine(_tempDir, "session");
+        Directory.CreateDirectory(_sessionDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Edit_single_occurrence_replaces_text()
+    {
+        var filePath = Path.Combine(_tempDir, "test.cs");
+        await File.WriteAllTextAsync(filePath, "using System;\nusing Xunit;\n\nclass Foo { }");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "using Xunit;",
+            ["NewString"] = "using NUnit.Framework;"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully edited", result);
+        Assert.Contains("replaced 1 occurrence", result);
+        var content = await File.ReadAllTextAsync(filePath);
+        Assert.Equal("using System;\nusing NUnit.Framework;\n\nclass Foo { }", content);
+    }
+
+    [Fact]
+    public async Task ReplaceAll_replaces_all_occurrences()
+    {
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        await File.WriteAllTextAsync(filePath, "foo bar foo baz foo");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "foo",
+            ["NewString"] = "qux",
+            ["ReplaceAll"] = true
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("replaced 3 occurrence", result);
+        Assert.Equal("qux bar qux baz qux", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Non_unique_match_without_ReplaceAll_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        var original = "foo bar foo baz foo";
+        await File.WriteAllTextAsync(filePath, original);
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "foo",
+            ["NewString"] = "qux"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("matches 3 locations", result);
+        Assert.Equal(original, await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task OldString_not_found_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        var original = "hello world";
+        await File.WriteAllTextAsync(filePath, original);
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "goodbye",
+            ["NewString"] = "farewell"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("not found", result);
+        Assert.Equal(original, await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task OldString_equals_NewString_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        await File.WriteAllTextAsync(filePath, "hello world");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "hello",
+            ["NewString"] = "hello"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("must be different", result);
+    }
+
+    [Fact]
+    public async Task Empty_NewString_performs_deletion()
+    {
+        var filePath = Path.Combine(_tempDir, "test.cs");
+        await File.WriteAllTextAsync(filePath, "line1\nDELETE_ME\nline3");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "DELETE_ME\n",
+            ["NewString"] = ""
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully edited", result);
+        Assert.Equal("line1\nline3", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task File_does_not_exist_returns_error()
+    {
+        var filePath = Path.Combine(_tempDir, "nonexistent.txt");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "foo",
+            ["NewString"] = "bar"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("File not found", result);
+    }
+
+    [Fact]
+    public async Task Edit_denied_path_returns_access_denied()
+    {
+        var filePath = Path.Combine(_tempDir, "secrets.json");
+        await File.WriteAllTextAsync(filePath, "secret data");
+        var policy = new ToolPathPolicy([filePath]);
+        var tool = new FileEditTool(new ToolConfig(), policy);
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "secret",
+            ["NewString"] = "public"
+        }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("Access denied", result);
+        Assert.Equal("secret data", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Public_context_can_edit_inside_session_directory()
+    {
+        var filePath = Path.Combine(_sessionDir, "note.txt");
+        await File.WriteAllTextAsync(filePath, "old text");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "old text",
+            ["NewString"] = "new text"
+        }, CreatePublicContext(), CancellationToken.None);
+
+        Assert.Contains("Successfully edited", result);
+        Assert.Equal("new text", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task Public_context_cannot_edit_outside_session_directory()
+    {
+        var filePath = Path.Combine(_tempDir, "host-file.txt");
+        await File.WriteAllTextAsync(filePath, "original");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Path"] = filePath,
+            ["OldString"] = "original",
+            ["NewString"] = "modified"
+        }, CreatePublicContext(), CancellationToken.None);
+
+        Assert.Contains("Public trust context", result);
+        Assert.Contains("session directory", result);
+        Assert.Equal("original", await File.ReadAllTextAsync(filePath));
+    }
+
+    private ToolExecutionContext CreatePersonalContext()
+        => new("signalr/thread-1", _sessionDir)
+        {
+            Audience = TrustAudience.Personal.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
+            ChannelType = "signalr"
+        };
+
+    private ToolExecutionContext CreatePublicContext()
+        => new("slack/thread-1", _sessionDir)
+        {
+            Audience = TrustAudience.Public.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.PublicBoundary,
+            ChannelType = "slack"
+        };
+}

--- a/src/Netclaw.Actors/Tools/FileEditTool.cs
+++ b/src/Netclaw.Actors/Tools/FileEditTool.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using System.Text;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Makes targeted text replacements in an existing file without rewriting the entire file.
+/// Matches literal text (not regex). Fails if OldString is not found or is ambiguous.
+/// </summary>
+[NetclawTool("file_edit",
+    "Make targeted text replacements in an existing file without rewriting the entire file",
+    Grant = "file")]
+public sealed partial class FileEditTool : NetclawTool<FileEditTool.Params>
+{
+    private readonly ToolPathPolicy? _pathPolicy;
+    private readonly ScopedFileAccessPolicy _fileAccessPolicy;
+
+    public record Params(
+        [property: Description("Absolute path to the file to edit")] string Path,
+        [property: Description("The exact text to find in the file")] string OldString,
+        [property: Description("The text to replace it with (must differ from OldString; use empty string to delete)")] string NewString,
+        [property: Description("Replace all occurrences instead of just the first (default: false)")] bool? ReplaceAll = null);
+
+    public FileEditTool(ToolPathPolicy? pathPolicy = null)
+    {
+        _pathPolicy = pathPolicy;
+        _fileAccessPolicy = new ScopedFileAccessPolicy(new ToolConfig());
+    }
+
+    public FileEditTool(ToolConfig config, ToolPathPolicy? pathPolicy = null)
+    {
+        _pathPolicy = pathPolicy;
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
+
+    protected override async Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(args.Path))
+            return "Error: 'Path' parameter is required.";
+
+        if (string.IsNullOrEmpty(args.OldString))
+            return "Error: 'OldString' parameter is required and must not be empty.";
+
+        if (args.NewString == args.OldString)
+            return "Error: 'NewString' must be different from 'OldString'.";
+
+        if (!_fileAccessPolicy.TryResolveWritePath(args.Path, context, out var authorizedPath, out var accessError))
+            return accessError;
+
+        if (_pathPolicy?.IsDenied(authorizedPath) == true)
+            return "Error: Access denied — this file is protected by security policy.";
+
+        if (!File.Exists(authorizedPath))
+            return $"Error: File not found: {authorizedPath}";
+
+        try
+        {
+            var content = await File.ReadAllTextAsync(authorizedPath, Encoding.UTF8, ct);
+
+            var replaceAll = args.ReplaceAll == true;
+            var occurrences = CountOccurrences(content, args.OldString);
+
+            if (occurrences == 0)
+                return $"Error: The specified text was not found in {authorizedPath}";
+
+            if (occurrences > 1 && !replaceAll)
+                return $"Error: OldString matches {occurrences} locations in {authorizedPath}. " +
+                       "Provide more surrounding context to create a unique match, or set ReplaceAll=true.";
+
+            string newContent;
+            int replacementCount;
+
+            if (replaceAll)
+            {
+                newContent = content.Replace(args.OldString, args.NewString, StringComparison.Ordinal);
+                replacementCount = occurrences;
+            }
+            else
+            {
+                // Single replacement at first occurrence
+                var index = content.IndexOf(args.OldString, StringComparison.Ordinal);
+                newContent = string.Concat(
+                    content.AsSpan(0, index),
+                    args.NewString,
+                    content.AsSpan(index + args.OldString.Length));
+                replacementCount = 1;
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(newContent);
+            await File.WriteAllBytesAsync(authorizedPath, bytes, ct);
+
+            return $"Successfully edited {authorizedPath}: replaced {replacementCount} occurrence(s)";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return $"Error: Permission denied: {authorizedPath}";
+        }
+        catch (IOException ex)
+        {
+            return $"Error editing file: {ex.Message}";
+        }
+    }
+
+    private static int CountOccurrences(string content, string search)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = content.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+        return count;
+    }
+}

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -27,6 +27,7 @@ public static class ToolRegistrationExtensions
         registry.Register(new ShellTool(config, pathPolicy));
         registry.Register(new FileReadTool(config, pathPolicy, paths));
         registry.Register(new FileWriteTool(config, pathPolicy));
+        registry.Register(new FileEditTool(config, pathPolicy));
         registry.Register(new AttachFileTool(config));
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));

--- a/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
+++ b/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
@@ -214,8 +214,8 @@ public sealed class NetclawToolGenerator : IIncrementalGenerator
                 sb.AppendLine($"        var __{p.Name} = Netclaw.Tools.ToolArgumentHelper.GetString(arguments, \"{p.Name}\");");
                 if (p.IsRequired)
                 {
-                    sb.AppendLine($"        if (string.IsNullOrWhiteSpace(__{p.Name}))");
-                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing or empty.\");");
+                    sb.AppendLine($"        if (__{p.Name} is null)");
+                    sb.AppendLine($"            throw new System.ArgumentException(\"Required parameter '{p.Name}' is missing.\");");
                 }
             }
             else if (p.JsonType == "integer")


### PR DESCRIPTION
## Summary

Closes #404.

- Adds a new `file_edit` tool for targeted text replacements in existing files, modeled after Claude Code's Edit tool
- Parameters: `Path`, `OldString`, `NewString` (all required, OldString/NewString must differ), `ReplaceAll` (optional bool)
- Literal text matching with ambiguity guard — fails if OldString matches multiple locations without `ReplaceAll=true`
- Empty `NewString` performs deletion
- Same security enforcement as `file_write` (`ScopedFileAccessPolicy` + `ToolPathPolicy`)
- Fixes source generator to use null check instead of `IsNullOrWhiteSpace` for required string params — "required" means "must be provided," not "must be non-empty"

## Test plan

- [x] 10 new tests in `FileEditToolTests` (single replace, replace-all, ambiguity, not-found, must-differ, deletion, file-not-found, denied path, public context in/out of session dir)
- [x] All 676 existing tests pass (no regressions from generator change)
- [x] Full solution build clean (0 warnings, 0 errors)