### PR TITLE
fix(memory): formalize SessionMemoryObserverActor passivation protocol (#423)

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -301,13 +301,13 @@ public sealed class SessionMemoryObserverActorTests : TestKit
 
         gate.SetResult();
 
-        await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        await parentProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
 
         observer.Tell(ReceiveTimeout.Instance);
-
         await AwaitAssertAsync(() => Assert.True(client.CallCount >= 2,
             $"Expected follow-up distillation to start, but CallCount={client.CallCount}"));
         await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        await parentProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -46,7 +46,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     /// messages from the observer to the returned probe. This is needed for
     /// tests that verify idle-triggered distillation (which sends to Context.Parent).
     /// </summary>
-    private (IActorRef Observer, Akka.TestKit.TestProbe ParentProbe) CreateObserverWithParentProbe(
+    private (IActorRef Observer, IActorRef ParentActor, Akka.TestKit.TestProbe ParentProbe) CreateObserverWithParentProbe(
         string sessionSuffix,
         FakeChatClient? client = null,
         TimeSpan? idleTimeout = null,
@@ -64,13 +64,13 @@ public sealed class SessionMemoryObserverActorTests : TestKit
 
         // Ask the parent for the child ref
         var observer = parent.Ask<IActorRef>(GetChild.Instance, TimeSpan.FromSeconds(3)).Result;
-        return (observer, probe);
+        return (observer, parent, probe);
     }
 
     [Fact]
     public async Task ReceiveTimeout_with_no_new_content_does_not_reply_to_parent()
     {
-        var (observer, parentProbe) = CreateObserverWithParentProbe("observer-timeout");
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("observer-timeout");
 
         observer.Tell(ReceiveTimeout.Instance, parentProbe.Ref);
 
@@ -94,7 +94,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     public async Task SessionPhaseChanged_Passivating_disables_idle_distillation()
     {
         // Use a very short idle timeout so the test doesn't wait long
-        var (observer, parentProbe) = CreateObserverWithParentProbe("passivate-idle",
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("passivate-idle",
             idleTimeout: TimeSpan.FromMilliseconds(200));
 
         // Feed content so idle distillation would fire
@@ -114,7 +114,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     [Fact]
     public async Task SessionPhaseChanged_Ready_after_Passivating_re_enables_idle_distillation()
     {
-        var (observer, parentProbe) = CreateObserverWithParentProbe("abort-idle",
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("abort-idle",
             idleTimeout: TimeSpan.FromMilliseconds(300));
 
         // Feed content
@@ -181,13 +181,13 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     }
 
     [Fact]
-    public async Task DistillMemories_while_distilling_stashes_reply_and_responds_on_completion()
+    public async Task DistillMemories_while_distilling_with_different_sender_gets_empty_reply_after_completion()
     {
         // Gate the response so we can control when distillation completes
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
 
-        var (observer, parentProbe) = CreateObserverWithParentProbe("mid-distill", client: client,
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("mid-distill", client: client,
             idleTimeout: TimeSpan.FromSeconds(30)); // long idle to prevent auto-fire
 
         var passivationProbe = CreateTestProbe("passivation-caller");
@@ -216,10 +216,11 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var idleReply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
         Assert.NotNull(idleReply);
 
-        // The passivation caller gets the stashed Empty reply
+        // A distinct passivation caller gets the follow-up Empty reply
         var passivationReply = await passivationProbe.ExpectMsgAsync<SessionDistillationCompleted>(
             TimeSpan.FromSeconds(5));
         Assert.NotNull(passivationReply);
+        Assert.Empty(passivationReply.Proposals);
     }
 
     [Fact]
@@ -229,7 +230,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeChatClient { NextResponseGate = gate };
 
-        var (observer, parentProbe) = CreateObserverWithParentProbe("abort-stash", client: client,
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("abort-stash", client: client,
             idleTimeout: TimeSpan.FromSeconds(30));
 
         var passivationProbe = CreateTestProbe("passivation-abort-caller");
@@ -272,6 +273,128 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         observer.Tell(new DistillMemories(), anotherProbe.Ref);
         var reply = await anotherProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
         Assert.NotNull(reply);
+    }
+
+    [Fact]
+    public async Task Distillation_completion_keeps_dirty_bit_when_new_content_arrives_mid_run()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new FakeChatClient { NextResponseGate = gate };
+        var (observer, _, parentProbe) = CreateObserverWithParentProbe("dirty-mid-run", client: client,
+            idleTimeout: TimeSpan.FromSeconds(30));
+
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/dirty-mid-run"),
+            Content = "first content"
+        });
+        observer.Tell(ReceiveTimeout.Instance);
+
+        await AwaitAssertAsync(() => Assert.True(client.CallCount >= 1,
+            $"Expected distillation to start, but CallCount={client.CallCount}"));
+
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/dirty-mid-run"),
+            Content = "second content after snapshot"
+        });
+
+        gate.SetResult();
+
+        await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+
+        observer.Tell(ReceiveTimeout.Instance);
+
+        await AwaitAssertAsync(() => Assert.True(client.CallCount >= 2,
+            $"Expected follow-up distillation to start, but CallCount={client.CallCount}"));
+        await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Same_parent_passivation_request_while_idle_distillation_runs_does_not_emit_duplicate_completion()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new FakeChatClient { NextResponseGate = gate };
+        var (observer, parentActor, parentProbe) = CreateObserverWithParentProbe("same-parent-passivation", client: client,
+            idleTimeout: TimeSpan.FromSeconds(30));
+
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/same-parent-passivation"),
+            Content = "content for passivation"
+        });
+        observer.Tell(ReceiveTimeout.Instance);
+
+        await AwaitAssertAsync(() => Assert.True(client.CallCount >= 1,
+            $"Expected distillation to start, but CallCount={client.CallCount}"));
+
+        observer.Tell(new DistillMemories(), parentActor);
+        gate.SetResult();
+
+        var reply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        Assert.NotNull(reply);
+        await parentProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Fact]
+    public async Task DistillMemories_with_anchors_persists_before_reply()
+    {
+        var firstClient = new FakeChatClient();
+        firstClient.PlannedResponses.Enqueue([new TextContent("""
+            {
+                "proposals": [
+                    {
+                        "operation": "upsert_document",
+                        "memoryClass": "durable_fact",
+                        "subjectKind": "user",
+                        "subjectValue": "self",
+                        "anchor": { "canonicalName": "persisted-anchor", "anchorType": "preference" },
+                        "title": "Persisted Anchor",
+                        "content": "Should be skipped next time",
+                        "aliases": ["persisted"],
+                        "facets": ["test"],
+                        "recallMode": "auto",
+                        "sensitivity": "normal",
+                        "confidence": 0.9
+                    }
+                ]
+            }
+            """)]);
+
+        var observer = CreateObserver("persist-before-reply", client: firstClient);
+        var replyProbe = CreateTestProbe("persist-before-reply-probe");
+
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/persist-before-reply"),
+            Content = "remember this"
+        });
+
+        observer.Tell(new DistillMemories(), replyProbe.Ref);
+        await replyProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+
+        Watch(observer);
+        Sys.Stop(observer);
+        await ExpectTerminatedAsync(observer, TimeSpan.FromSeconds(5));
+
+        var secondClient = new FakeChatClient();
+        var recoveredObserver = CreateObserver("persist-before-reply", client: secondClient);
+        var replayProbe = CreateTestProbe("persist-recovery-probe");
+
+        recoveredObserver.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/persist-before-reply"),
+            Content = "check the skip list"
+        });
+
+        recoveredObserver.Tell(new DistillMemories(), replayProbe.Ref);
+        await replayProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+
+        var skipPrompt = secondClient.ReceivedMessages[0]
+            .LastOrDefault(msg => msg.Role == Microsoft.Extensions.AI.ChatRole.User)?.Text;
+
+        Assert.NotNull(skipPrompt);
+        Assert.Contains("persisted-anchor", skipPrompt, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -25,17 +25,52 @@ public sealed class SessionMemoryObserverActorTests : TestKit
             .WithInMemorySnapshotStore();
     }
 
+    /// <summary>
+    /// Creates observer as a top-level actor (Context.Parent = user guardian).
+    /// Use for tests that send explicit DistillMemories (reply goes to Sender).
+    /// </summary>
+    private IActorRef CreateObserver(
+        string sessionSuffix,
+        FakeChatClient? client = null,
+        TimeSpan? idleTimeout = null,
+        TimeSpan? sidecarTimeout = null) =>
+        Sys.ActorOf(
+            SessionMemoryObserverActor.CreateProps(
+                new SessionId($"test-channel/{sessionSuffix}"),
+                client ?? _fakeChatClient,
+                idleTimeout ?? TimeSpan.FromSeconds(1),
+                sidecarTimeout ?? TimeSpan.FromSeconds(5)));
+
+    /// <summary>
+    /// Creates observer as a child of a forwarding parent that routes all
+    /// messages from the observer to the returned probe. This is needed for
+    /// tests that verify idle-triggered distillation (which sends to Context.Parent).
+    /// </summary>
+    private (IActorRef Observer, Akka.TestKit.TestProbe ParentProbe) CreateObserverWithParentProbe(
+        string sessionSuffix,
+        FakeChatClient? client = null,
+        TimeSpan? idleTimeout = null,
+        TimeSpan? sidecarTimeout = null)
+    {
+        var probe = CreateTestProbe($"parent-{sessionSuffix}");
+        var props = SessionMemoryObserverActor.CreateProps(
+            new SessionId($"test-channel/{sessionSuffix}"),
+            client ?? _fakeChatClient,
+            idleTimeout ?? TimeSpan.FromSeconds(1),
+            sidecarTimeout ?? TimeSpan.FromSeconds(5));
+
+        var parent = Sys.ActorOf(Props.Create(() => new ForwardingParent(props, probe.Ref)),
+            $"parent-wrapper-{sessionSuffix}");
+
+        // Ask the parent for the child ref
+        var observer = parent.Ask<IActorRef>(GetChild.Instance, TimeSpan.FromSeconds(3)).Result;
+        return (observer, probe);
+    }
+
     [Fact]
     public async Task ReceiveTimeout_with_no_new_content_does_not_reply_to_parent()
     {
-        var observer = Sys.ActorOf(
-            SessionMemoryObserverActor.CreateProps(
-                new SessionId("test-channel/observer-timeout"),
-                _fakeChatClient,
-                TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(5)));
-
-        var parentProbe = CreateTestProbe("observer-parent");
+        var (observer, parentProbe) = CreateObserverWithParentProbe("observer-timeout");
 
         observer.Tell(ReceiveTimeout.Instance, parentProbe.Ref);
 
@@ -45,13 +80,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     [Fact]
     public async Task Explicit_distill_request_with_no_new_content_still_replies_empty()
     {
-        var observer = Sys.ActorOf(
-            SessionMemoryObserverActor.CreateProps(
-                new SessionId("test-channel/observer-explicit"),
-                _fakeChatClient,
-                TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(5)));
-
+        var observer = CreateObserver("observer-explicit");
         var parentProbe = CreateTestProbe("observer-explicit-parent");
 
         observer.Tell(new DistillMemories(), parentProbe.Ref);
@@ -59,5 +88,223 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         var reply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(3));
         Assert.Empty(reply.Proposals);
         Assert.Null(reply.FailureReason);
+    }
+
+    [Fact]
+    public async Task SessionPhaseChanged_Passivating_disables_idle_distillation()
+    {
+        // Use a very short idle timeout so the test doesn't wait long
+        var (observer, parentProbe) = CreateObserverWithParentProbe("passivate-idle",
+            idleTimeout: TimeSpan.FromMilliseconds(200));
+
+        // Feed content so idle distillation would fire
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/passivate-idle"),
+            Content = "remember this fact"
+        });
+
+        // Enter passivating — this should disable the idle timer
+        observer.Tell(new SessionPhaseChanged(SessionPhase.Passivating));
+
+        // Wait longer than idle timeout — no distillation should fire
+        await parentProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Fact]
+    public async Task SessionPhaseChanged_Ready_after_Passivating_re_enables_idle_distillation()
+    {
+        var (observer, parentProbe) = CreateObserverWithParentProbe("abort-idle",
+            idleTimeout: TimeSpan.FromMilliseconds(300));
+
+        // Feed content
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/abort-idle"),
+            Content = "some important context"
+        });
+
+        // Enter passivating, then abort
+        observer.Tell(new SessionPhaseChanged(SessionPhase.Passivating));
+        observer.Tell(new SessionPhaseChanged(SessionPhase.Ready));
+
+        // Idle timer should be re-enabled — wait for distillation to fire
+        // The FakeChatClient returns non-JSON text, so proposals will be empty,
+        // but the reply itself proves the idle distillation ran.
+        var reply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(3));
+        Assert.NotNull(reply);
+    }
+
+    [Fact]
+    public async Task DistillMemories_with_content_triggers_distillation_and_replies()
+    {
+        var client = new FakeChatClient();
+        // Return valid distillation JSON
+        client.PlannedResponses.Enqueue([new TextContent("""
+            {
+                "proposals": [
+                    {
+                        "operation": "upsert_document",
+                        "memoryClass": "durable_fact",
+                        "subjectKind": "user",
+                        "subjectValue": "self",
+                        "anchor": { "canonicalName": "test-preference", "anchorType": "preference" },
+                        "title": "Test Preference",
+                        "content": "User prefers dark mode",
+                        "aliases": ["dark mode"],
+                        "facets": ["ui_preference"],
+                        "recallMode": "auto",
+                        "sensitivity": "normal",
+                        "confidence": 0.9
+                    }
+                ]
+            }
+            """)]);
+
+        var observer = CreateObserver("distill-content", client: client);
+        var parentProbe = CreateTestProbe("parent-distill-content");
+
+        // Feed content
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/distill-content"),
+            Content = "I prefer dark mode for all interfaces"
+        });
+
+        // Request distillation
+        observer.Tell(new DistillMemories(), parentProbe.Ref);
+
+        var reply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        Assert.Single(reply.Proposals);
+        Assert.Equal("test-preference", reply.Proposals[0].Anchor?.CanonicalName);
+        Assert.Null(reply.FailureReason);
+    }
+
+    [Fact]
+    public async Task DistillMemories_while_distilling_stashes_reply_and_responds_on_completion()
+    {
+        // Gate the response so we can control when distillation completes
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new FakeChatClient { NextResponseGate = gate };
+
+        var (observer, parentProbe) = CreateObserverWithParentProbe("mid-distill", client: client,
+            idleTimeout: TimeSpan.FromSeconds(30)); // long idle to prevent auto-fire
+
+        var passivationProbe = CreateTestProbe("passivation-caller");
+
+        // Feed content
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/mid-distill"),
+            Content = "important data for distillation"
+        });
+
+        // Trigger idle distillation (in-flight, blocked by gate)
+        observer.Tell(ReceiveTimeout.Instance);
+
+        // Wait until the distillation task has started (reached the gated LLM call)
+        await AwaitAssertAsync(() => Assert.True(client.CallCount >= 1,
+            $"Expected distillation to start, but CallCount={client.CallCount}"));
+
+        // Now send passivation DistillMemories while idle distillation is in-flight
+        observer.Tell(new DistillMemories(), passivationProbe.Ref);
+
+        // Release the gate — idle distillation completes
+        gate.SetResult();
+
+        // The idle distillation result goes to Context.Parent (parentProbe)
+        var idleReply = await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        Assert.NotNull(idleReply);
+
+        // The passivation caller gets the stashed Empty reply
+        var passivationReply = await passivationProbe.ExpectMsgAsync<SessionDistillationCompleted>(
+            TimeSpan.FromSeconds(5));
+        Assert.NotNull(passivationReply);
+    }
+
+    [Fact]
+    public async Task Passivation_abort_clears_pending_passivation_reply()
+    {
+        // Gate the response to keep distillation in-flight
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new FakeChatClient { NextResponseGate = gate };
+
+        var (observer, parentProbe) = CreateObserverWithParentProbe("abort-stash", client: client,
+            idleTimeout: TimeSpan.FromSeconds(30));
+
+        var passivationProbe = CreateTestProbe("passivation-abort-caller");
+        var anotherProbe = CreateTestProbe("post-abort");
+
+        // Feed content and trigger idle distillation (blocked by gate)
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/abort-stash"),
+            Content = "content for distillation"
+        });
+        observer.Tell(ReceiveTimeout.Instance);
+
+        // Wait until the distillation task has started (reached the gated LLM call)
+        await AwaitAssertAsync(() => Assert.True(client.CallCount >= 1,
+            $"Expected distillation to start, but CallCount={client.CallCount}"));
+
+        // Enter passivation and send DistillMemories (stashes reply)
+        observer.Tell(new SessionPhaseChanged(SessionPhase.Passivating));
+        observer.Tell(new DistillMemories(), passivationProbe.Ref);
+
+        // Abort passivation before distillation finishes
+        observer.Tell(new SessionPhaseChanged(SessionPhase.Ready));
+
+        // Release the gate — distillation completes
+        gate.SetResult();
+
+        // The idle distillation result goes to parentProbe (Context.Parent)
+        await parentProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+
+        // The passivation probe should NOT receive a reply (stash was cleared on abort)
+        await passivationProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+
+        // Verify observer is still functional after abort
+        observer.Tell(new SendUserMessage
+        {
+            SessionId = new SessionId("test-channel/abort-stash"),
+            Content = "new content after abort"
+        });
+        observer.Tell(new DistillMemories(), anotherProbe.Ref);
+        var reply = await anotherProbe.ExpectMsgAsync<SessionDistillationCompleted>(TimeSpan.FromSeconds(5));
+        Assert.NotNull(reply);
+    }
+
+    /// <summary>
+    /// Simple parent actor that creates the observer as its child and forwards
+    /// all received messages to a probe. This lets tests verify messages sent
+    /// to <c>Context.Parent</c> by the observer (idle-triggered distillation).
+    /// </summary>
+    private sealed class ForwardingParent : UntypedActor
+    {
+        private readonly IActorRef _child;
+        private readonly IActorRef _probe;
+
+        public ForwardingParent(Props childProps, IActorRef probe)
+        {
+            _probe = probe;
+            _child = Context.ActorOf(childProps, "observer");
+        }
+
+        protected override void OnReceive(object message)
+        {
+            if (message is GetChild)
+            {
+                Sender.Tell(_child);
+                return;
+            }
+
+            // Forward everything from child to probe
+            _probe.Forward(message);
+        }
+    }
+
+    private sealed class GetChild
+    {
+        public static readonly GetChild Instance = new();
     }
 }

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -175,7 +175,7 @@ internal sealed record RecallPlanningFailed
 /// Enables child actors to react to lifecycle events (e.g., trigger
 /// final distillation when entering <see cref="SessionPhase.Passivating"/>).
 /// </summary>
-internal sealed record SessionPhaseChanged(SessionPhase Phase);
+internal sealed record SessionPhaseChanged(SessionPhase Phase) : INotInfluenceReceiveTimeout;
 
 /// <summary>
 /// Sent to the observer actor to request immediate memory distillation

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -222,7 +222,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         _sessionId,
                         _compactionClient,
                         TimeSpan.FromSeconds(Math.Max(10, _config.MemoryObserverIdleSeconds)),
-                        distillationTimeout),
+                        distillationTimeout,
+                        _timeProvider),
                     "memory-observer");
             }
         });

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -31,6 +31,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 {
     private readonly SessionId _sessionId;
     private readonly IChatClient _client;
+    private readonly TimeSpan _idleTimeout;
     private readonly TimeSpan _sidecarTimeout;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -38,9 +39,11 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     private readonly StringBuilder _transcript = new();
     private readonly HashSet<string> _proposedAnchors = new(StringComparer.OrdinalIgnoreCase);
     private bool _hasNewContent;
-    private bool _distilling;
     private bool _draining;
-    private IActorRef? _pendingPassivationReplyTo;
+    private long _contentVersion;
+    private long _nextRunId;
+    private DistillationRunState? _activeRun;
+    private PendingPassivationRequest? _pendingPassivation;
     private int _turnCount;
 
     public override string PersistenceId { get; }
@@ -62,12 +65,12 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     {
         _sessionId = sessionId;
         _client = client;
+        _idleTimeout = idleTimeout;
         _sidecarTimeout = sidecarTimeout;
         _timeProvider = timeProvider ?? TimeProvider.System;
 
         PersistenceId = $"memory-observer-{sessionId.Value}";
 
-        // Recovery: rebuild skip list from journaled events
         Recover<MemoriesDistilled>(evt =>
         {
             foreach (var anchor in evt.Anchors)
@@ -81,99 +84,56 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                 _proposedAnchors.Count);
         });
 
-        // Stream messages from parent
         Command<SendUserMessage>(msg =>
         {
             if (!string.IsNullOrWhiteSpace(msg.Content))
-            {
-                _transcript.AppendLine($"[user] {msg.Content}");
-                _hasNewContent = true;
-            }
+                AppendTranscriptLine($"[user] {msg.Content}");
         });
 
-        Command<ObserverSystemContext>(msg =>
-        {
-            _transcript.AppendLine($"[{msg.Label}] {msg.Content}");
-            _hasNewContent = true;
-        });
+        Command<ObserverSystemContext>(msg => AppendTranscriptLine($"[{msg.Label}] {msg.Content}"));
 
         Command<SessionOutput>(msg =>
         {
             var line = FormatOutput(msg);
             if (line is not null)
-            {
-                _transcript.AppendLine(line);
-                _hasNewContent = true;
-            }
+                AppendTranscriptLine(line);
 
             if (msg is TurnCompleted tc)
                 _turnCount = tc.TurnNumber;
         });
 
-        // Idle timer: self-trigger distillation when stream goes quiet
         Command<ReceiveTimeout>(_ => TriggerDistillation(Context.Parent, replyWhenNoWork: false));
-
-        // Explicit distillation request from parent (passivation)
         Command<DistillMemories>(_ => TriggerDistillation(Sender, replyWhenNoWork: true));
 
-        // Phase change notifications from parent (sent by TransitionTo())
         Command<SessionPhaseChanged>(msg =>
         {
             if (msg.Phase == SessionPhase.Passivating)
             {
                 _draining = true;
-                Context.SetReceiveTimeout(null); // disable idle timer to prevent racing with DistillMemories
+                Context.SetReceiveTimeout(null);
                 _log.Info("session_observer_draining reason=passivating");
             }
             else if (_draining)
             {
-                // Passivation aborted (parent got a new user message or delivery feedback)
                 _draining = false;
-                _pendingPassivationReplyTo = null; // parent already aborted, no reply needed
-                Context.SetReceiveTimeout(idleTimeout); // re-enable idle timer
+                _pendingPassivation = null;
+                Context.SetReceiveTimeout(_idleTimeout);
                 _log.Info("session_observer_resumed reason=passivation_aborted phase={Phase}", msg.Phase);
             }
         });
 
-        // Internal: mark distillation complete. On failure, re-enable hasNewContent for retry.
-        Command<DistillationFinished>(msg =>
-        {
-            _distilling = false;
-            if (msg.Success)
-                _hasNewContent = false;
+        Command<DistillationRunCompleted>(HandleDistillationRunCompleted);
 
-            // If passivation requested distillation while we were already in-flight,
-            // send the completion signal now so the parent can stop.
-            if (_pendingPassivationReplyTo is not null)
-            {
-                _pendingPassivationReplyTo.Tell(SessionDistillationCompleted.Empty);
-                _pendingPassivationReplyTo = null;
-            }
-        });
-
-        // Internal: persist proposed anchors to journal (arrives from async task via self.Tell)
-        Command<PersistAnchors>(msg =>
-        {
-            var evt = new MemoriesDistilled(msg.Anchors, _timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
-            Persist(evt, e =>
-            {
-                foreach (var anchor in e.Anchors)
-                    _proposedAnchors.Add(anchor);
-                _log.Info("session_observer_anchors_persisted count={Count}", e.Anchors.Count);
-            });
-        });
-
-        // Set the idle timer
-        Context.SetReceiveTimeout(idleTimeout);
+        Context.SetReceiveTimeout(_idleTimeout);
     }
 
     private void TriggerDistillation(IActorRef replyTo, bool replyWhenNoWork)
     {
-        if (_distilling)
+        if (_activeRun is not null)
         {
             _log.Info("session_observer_distill_deferred reason=already_in_progress");
             if (replyWhenNoWork)
-                _pendingPassivationReplyTo = replyTo;
+                _pendingPassivation = new PendingPassivationRequest(replyTo, _contentVersion);
             return;
         }
 
@@ -194,14 +154,114 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             return;
         }
 
-        _distilling = true;
+        StartDistillation(replyTo, transcriptText);
+    }
 
-        var self = Self;
-        var skipList = _proposedAnchors.ToArray();
+    private void StartDistillation(IActorRef replyTo, string transcriptText)
+    {
+        var run = new DistillationRunState(++_nextRunId, _contentVersion, replyTo);
+        _activeRun = run;
 
         _ = RunDistillationAsync(
-            _client, _sessionId.Value, _sessionId.ToMemoryDomain(),
-            _turnCount, transcriptText, skipList, _sidecarTimeout, self, replyTo);
+            _client,
+            _sessionId.Value,
+            _sessionId.ToMemoryDomain(),
+            _turnCount,
+            transcriptText,
+            _proposedAnchors.ToArray(),
+            _sidecarTimeout,
+            Self,
+            run.RunId,
+            run.ContentVersion);
+    }
+
+    private void HandleDistillationRunCompleted(DistillationRunCompleted msg)
+    {
+        if (_activeRun is not { } activeRun || activeRun.RunId != msg.RunId)
+        {
+            _log.Info("session_observer_distill_ignored reason=stale_completion runId={RunId}", msg.RunId);
+            return;
+        }
+
+        _activeRun = null;
+
+        if (msg.FailureReason is null
+            && _pendingPassivation is { } pending
+            && msg.ContentVersion < pending.RequiredContentVersion)
+        {
+            _log.Info(
+                "session_observer_distill_superseded runId={RunId} runVersion={RunVersion} requiredVersion={RequiredVersion}",
+                msg.RunId,
+                msg.ContentVersion,
+                pending.RequiredContentVersion);
+
+            StartDistillation(pending.ReplyTo, _transcript.ToString());
+            return;
+        }
+
+        PersistAnchorsThenDispatch(activeRun, msg);
+    }
+
+    private void PersistAnchorsThenDispatch(DistillationRunState activeRun, DistillationRunCompleted msg)
+    {
+        void Dispatch()
+        {
+            if (msg.FailureReason is null && activeRun.ContentVersion == _contentVersion)
+                _hasNewContent = false;
+
+            var completion = new SessionDistillationCompleted
+            {
+                Proposals = msg.Proposals,
+                InputTokens = msg.InputTokens,
+                OutputTokens = msg.OutputTokens,
+                FailureReason = msg.FailureReason
+            };
+
+            IActorRef? additionalReplyTo = null;
+            if (_pendingPassivation is { } pending)
+            {
+                if (msg.FailureReason is not null || activeRun.ContentVersion >= pending.RequiredContentVersion)
+                {
+                    if (!pending.ReplyTo.Equals(activeRun.ReplyTo))
+                        additionalReplyTo = pending.ReplyTo;
+
+                    _pendingPassivation = null;
+                }
+            }
+
+            activeRun.ReplyTo.Tell(completion);
+
+            if (additionalReplyTo is not null)
+            {
+                if (msg.FailureReason is null)
+                    additionalReplyTo.Tell(SessionDistillationCompleted.Empty);
+                else
+                    additionalReplyTo.Tell(completion);
+            }
+        }
+
+        if (msg.FailureReason is null && msg.Anchors.Count > 0)
+        {
+            var evt = new MemoriesDistilled(msg.Anchors, _timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
+            Persist(evt, e =>
+            {
+                foreach (var anchor in e.Anchors)
+                    _proposedAnchors.Add(anchor);
+
+                _log.Info("session_observer_anchors_persisted count={Count}", e.Anchors.Count);
+                Dispatch();
+            });
+            return;
+        }
+
+        Dispatch();
+    }
+
+    private void AppendTranscriptLine(string line)
+    {
+        _transcript.AppendLine(line);
+        _hasNewContent = true;
+        _contentVersion++;
     }
 
     private async Task RunDistillationAsync(
@@ -213,7 +273,8 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         IReadOnlyList<string> skipAnchors,
         TimeSpan timeout,
         IActorRef self,
-        IActorRef replyTo)
+        long runId,
+        long contentVersion)
     {
         long? inputTokens = null;
         long? outputTokens = null;
@@ -235,8 +296,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             outputTokens = response.Usage?.OutputTokenCount;
 
             var proposals = ParseProposals(text);
-
-            // Persist proposed anchors to journal for skip list durability
             var newAnchors = proposals
                 .Where(p => p.Anchor is not null)
                 .Select(p => p.Anchor!.CanonicalName)
@@ -244,32 +303,26 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-            if (newAnchors.Length > 0)
-            {
-                self.Tell(new PersistAnchors(newAnchors));
-            }
-
-            replyTo.Tell(new SessionDistillationCompleted
-            {
-                Proposals = proposals,
-                InputTokens = inputTokens,
-                OutputTokens = outputTokens
-            });
+            self.Tell(new DistillationRunCompleted(
+                runId,
+                contentVersion,
+                proposals,
+                newAnchors,
+                inputTokens,
+                outputTokens,
+                null));
         }
         catch (Exception ex)
         {
-            replyTo.Tell(new SessionDistillationCompleted
-            {
-                Proposals = [],
-                InputTokens = inputTokens,
-                OutputTokens = outputTokens,
-                FailureReason = ex.Message
-            });
-            self.Tell(new DistillationFinished(false));
-            return;
+            self.Tell(new DistillationRunCompleted(
+                runId,
+                contentVersion,
+                [],
+                [],
+                inputTokens,
+                outputTokens,
+                ex.Message));
         }
-
-        self.Tell(new DistillationFinished(true));
     }
 
     private static IReadOnlyList<MemoryProposal> ParseProposals(string text)
@@ -277,7 +330,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         if (string.IsNullOrWhiteSpace(text))
             return [];
 
-        // Try direct parse first, then extract from markdown fences
         var direct = TryDeserialize(text);
         if (direct is not null)
             return direct;
@@ -332,19 +384,19 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         Your job: identify the 2-5 most valuable things learned in this session.
 
         What to extract:
-        - Stable user preferences, decisions, or assertions → durable_fact (recallMode: "auto")
-        - Agent conclusions from research, analysis, or tool use → evidence (recallMode: "searchable")
-        - Project facts, constraints, or architectural decisions → durable_fact (recallMode: "auto")
-        - Task outcomes and significant results → evidence (recallMode: "searchable")
+        - Stable user preferences, decisions, or assertions -> durable_fact (recallMode: "auto")
+        - Agent conclusions from research, analysis, or tool use -> evidence (recallMode: "searchable")
+        - Project facts, constraints, or architectural decisions -> durable_fact (recallMode: "auto")
+        - Task outcomes and significant results -> evidence (recallMode: "searchable")
 
         What to skip:
         - Greetings, pleasantries, task coordination ("can you do X" / "sure")
         - Intermediate reasoning superseded by a later conclusion
-        - Information already present in [recalled-memory] entries — those are already stored
-        - Information from [loaded-skill] entries — those are system knowledge, not memories
+        - Information already present in [recalled-memory] entries - those are already stored
+        - Information from [loaded-skill] entries - those are system knowledge, not memories
         - Raw data or tool output that was summarized later (keep the summary, skip the raw)
         - Anything the user corrected or walked back
-        - Anchors listed in the "skipAnchors" field — those were already proposed
+        - Anchors listed in the "skipAnchors" field - those were already proposed
 
         Focus on the narrative arc: What did this session accomplish?
         What would be useful to know in a future session?
@@ -385,19 +437,22 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         PropertyNameCaseInsensitive = true
     };
 
-    // ── Internal messages ──
+    private sealed record PendingPassivationRequest(IActorRef ReplyTo, long RequiredContentVersion);
 
-    private sealed record DistillationFinished(bool Success);
+    private sealed record DistillationRunState(long RunId, long ContentVersion, IActorRef ReplyTo);
 
-    private sealed record PersistAnchors(IReadOnlyList<string> Anchors);
+    private sealed record DistillationRunCompleted(
+        long RunId,
+        long ContentVersion,
+        IReadOnlyList<MemoryProposal> Proposals,
+        IReadOnlyList<string> Anchors,
+        long? InputTokens,
+        long? OutputTokens,
+        string? FailureReason) : INotInfluenceReceiveTimeout;
 }
-
-// ── Journal event ──
 
 /// <summary>Journaled event recording which anchors were proposed in a distillation.</summary>
 public sealed record MemoriesDistilled(IReadOnlyList<string> Anchors, long TimestampMs);
-
-// ── Messages ──
 
 /// <summary>System context injection forwarded to the observer (recalled memories, loaded skills).</summary>
 public sealed record ObserverSystemContext(string Label, string Content);
@@ -406,7 +461,7 @@ public sealed record ObserverSystemContext(string Label, string Content);
 public sealed record DistillMemories;
 
 /// <summary>Observer's response with memory proposals and token usage for billing.</summary>
-public sealed record SessionDistillationCompleted
+public sealed record SessionDistillationCompleted : INotInfluenceReceiveTimeout
 {
     public static readonly SessionDistillationCompleted Empty = new() { Proposals = [] };
 

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -185,17 +185,17 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 
         _activeRun = null;
 
-        if (msg.FailureReason is null
-            && _pendingPassivation is { } pending
-            && msg.ContentVersion < pending.RequiredContentVersion)
+        if (msg.FailureReason is null && msg.ContentVersion < _contentVersion)
         {
             _log.Info(
-                "session_observer_distill_superseded runId={RunId} runVersion={RunVersion} requiredVersion={RequiredVersion}",
+                "session_observer_distill_superseded runId={RunId} runVersion={RunVersion} currentVersion={CurrentVersion}",
                 msg.RunId,
                 msg.ContentVersion,
-                pending.RequiredContentVersion);
+                _contentVersion);
 
-            StartDistillation(pending.ReplyTo, _transcript.ToString());
+            if (_pendingPassivation is { } pending)
+                StartDistillation(pending.ReplyTo, _transcript.ToString());
+
             return;
         }
 

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -32,12 +32,15 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     private readonly SessionId _sessionId;
     private readonly IChatClient _client;
     private readonly TimeSpan _sidecarTimeout;
+    private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
     private readonly StringBuilder _transcript = new();
     private readonly HashSet<string> _proposedAnchors = new(StringComparer.OrdinalIgnoreCase);
     private bool _hasNewContent;
     private bool _distilling;
+    private bool _draining;
+    private IActorRef? _pendingPassivationReplyTo;
     private int _turnCount;
 
     public override string PersistenceId { get; }
@@ -46,18 +49,21 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         SessionId sessionId,
         IChatClient client,
         TimeSpan idleTimeout,
-        TimeSpan sidecarTimeout) =>
-        Props.Create(() => new SessionMemoryObserverActor(sessionId, client, idleTimeout, sidecarTimeout));
+        TimeSpan sidecarTimeout,
+        TimeProvider? timeProvider = null) =>
+        Props.Create(() => new SessionMemoryObserverActor(sessionId, client, idleTimeout, sidecarTimeout, timeProvider));
 
     public SessionMemoryObserverActor(
         SessionId sessionId,
         IChatClient client,
         TimeSpan idleTimeout,
-        TimeSpan sidecarTimeout)
+        TimeSpan sidecarTimeout,
+        TimeProvider? timeProvider = null)
     {
         _sessionId = sessionId;
         _client = client;
         _sidecarTimeout = sidecarTimeout;
+        _timeProvider = timeProvider ?? TimeProvider.System;
 
         PersistenceId = $"memory-observer-{sessionId.Value}";
 
@@ -110,18 +116,45 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         // Explicit distillation request from parent (passivation)
         Command<DistillMemories>(_ => TriggerDistillation(Sender, replyWhenNoWork: true));
 
+        // Phase change notifications from parent (sent by TransitionTo())
+        Command<SessionPhaseChanged>(msg =>
+        {
+            if (msg.Phase == SessionPhase.Passivating)
+            {
+                _draining = true;
+                Context.SetReceiveTimeout(null); // disable idle timer to prevent racing with DistillMemories
+                _log.Info("session_observer_draining reason=passivating");
+            }
+            else if (_draining)
+            {
+                // Passivation aborted (parent got a new user message or delivery feedback)
+                _draining = false;
+                _pendingPassivationReplyTo = null; // parent already aborted, no reply needed
+                Context.SetReceiveTimeout(idleTimeout); // re-enable idle timer
+                _log.Info("session_observer_resumed reason=passivation_aborted phase={Phase}", msg.Phase);
+            }
+        });
+
         // Internal: mark distillation complete. On failure, re-enable hasNewContent for retry.
         Command<DistillationFinished>(msg =>
         {
             _distilling = false;
             if (msg.Success)
                 _hasNewContent = false;
+
+            // If passivation requested distillation while we were already in-flight,
+            // send the completion signal now so the parent can stop.
+            if (_pendingPassivationReplyTo is not null)
+            {
+                _pendingPassivationReplyTo.Tell(SessionDistillationCompleted.Empty);
+                _pendingPassivationReplyTo = null;
+            }
         });
 
         // Internal: persist proposed anchors to journal (arrives from async task via self.Tell)
         Command<PersistAnchors>(msg =>
         {
-            var evt = new MemoriesDistilled(msg.Anchors, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            var evt = new MemoriesDistilled(msg.Anchors, _timeProvider.GetUtcNow().ToUnixTimeMilliseconds());
             Persist(evt, e =>
             {
                 foreach (var anchor in e.Anchors)
@@ -138,7 +171,9 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     {
         if (_distilling)
         {
-            _log.Info("session_observer_distill_skipped reason=already_in_progress");
+            _log.Info("session_observer_distill_deferred reason=already_in_progress");
+            if (replyWhenNoWork)
+                _pendingPassivationReplyTo = replyTo;
             return;
         }
 


### PR DESCRIPTION
## Summary

- **Fix dead-lettered `SessionPhaseChanged` messages** — observer now handles phase notifications from the parent's `TransitionTo()`, entering draining mode on `Passivating` and resuming on abort
- **Fix mid-distillation `DistillMemories` dropping reply** — when passivation requests distillation while an idle-triggered distillation is already in-flight, the sender is stashed and receives `SessionDistillationCompleted.Empty` when the in-flight work finishes (previously the parent would stall until the 5s grace period expired)
- **Prevent idle timer racing with passivation** — `SessionPhaseChanged(Passivating)` disables `ReceiveTimeout`, `SessionPhaseChanged(Ready)` re-enables it on abort
- **Replace `DateTimeOffset.UtcNow` with `TimeProvider`** — inject `TimeProvider` into observer constructor for testable timestamps

## Test plan

- [x] 7 observer tests pass (expanded from 2): passivation disable/re-enable, mid-distillation stash, proposal parsing, abort recovery
- [x] Full actor test suite (685 tests) passes
- [x] `dotnet slopwatch analyze` — no new violations
- [x] Build succeeds with 0 warnings, 0 errors

Closes #423