### PR TITLE
fix(slack): consolidate TextContent into single TextOutput (#413)

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -855,6 +855,59 @@ public class LlmSessionIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Non_contiguous_TextContent_items_produce_single_TextOutput()
+    {
+        // Simulate a response where ToChatResponse() produces non-contiguous
+        // TextContent items: [text, tool_call, text]. This happens when the
+        // provider returns text both before and after tool calls in the same
+        // response message. Without consolidation, each TextContent would be
+        // emitted as a separate TextOutput → duplicate Slack posts.
+        _fakeChatClient.PlannedResponses.Enqueue(new AIContent[]
+        {
+            new TextContent("Part one"),
+            new FunctionCallContent("call-nc1", "browser_chrome_devtools/navigate_page",
+                new Dictionary<string, object?> { ["url"] = "https://example.com" }),
+            new TextContent("Part two")
+        });
+        _fakeToolExecutor.Results["browser_chrome_devtools/navigate_page"] = "page loaded";
+
+        var sessionId = new SessionId("test-channel/non-contiguous-text");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("nc-sub");
+
+        // Subscribe to Text + ToolCalls only (not TextStreaming) to match
+        // Slack adapter behavior and avoid streaming delta noise.
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Text | OutputFilter.ToolCalls
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Do something with tools"
+        }, TimeSpan.FromSeconds(3));
+
+        // Should receive exactly ONE consolidated TextOutput for the preamble
+        var preamble = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        Assert.Contains("Part one", preamble.Text);
+        Assert.Contains("Part two", preamble.Text);
+
+        // Tool call output
+        var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3));
+        Assert.Equal("browser_chrome_devtools/navigate_page", toolCall.ToolName);
+
+        // Final text response after tool execution
+        var finalText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        Assert.Contains("fake", finalText.Text, StringComparison.OrdinalIgnoreCase);
+
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
     public async Task Session_recovers_state_after_actor_is_killed()
     {
         var sessionId = new SessionId("test-channel/recovery-test");

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1078,23 +1078,21 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // TextDeltaOutput was emitted to subscribers.
         // BufferFlush tells streaming adapters to flush their accumulated buffer
         // so the preamble is visible to users before the potentially long tool phase.
-        var hasPreambleText = lastMessage.Contents
+        // Consolidate all TextContent items into a single TextOutput to avoid
+        // duplicate Slack posts when ToChatResponse() produces non-contiguous
+        // TextContent items (e.g. [text, tool_call, text]).
+        var preambleText = string.Join("\n\n", lastMessage.Contents
             .OfType<TextContent>()
-            .Any(t => !string.IsNullOrWhiteSpace(t.Text));
+            .Select(t => t.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t)));
 
-        if (hasPreambleText)
+        if (preambleText.Length > 0)
         {
-            foreach (var content in lastMessage.Contents)
+            EmitOutput(new TextOutput
             {
-                if (content is TextContent text && !string.IsNullOrWhiteSpace(text.Text))
-                {
-                    EmitOutput(new TextOutput
-                    {
-                        SessionId = _sessionId,
-                        Text = text.Text
-                    }, OutputFilter.Text);
-                }
-            }
+                SessionId = _sessionId,
+                Text = preambleText
+            }, OutputFilter.Text);
             EmitOutput(new BufferFlush { SessionId = _sessionId }, OutputFilter.TextStreaming);
         }
 
@@ -2041,14 +2039,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             switch (content)
             {
-                case TextContent text when includeText:
-                    EmitOutput(new TextOutput
-                    {
-                        SessionId = _sessionId,
-                        Text = text.Text ?? string.Empty
-                    }, OutputFilter.Text);
-                    break;
-
                 case TextReasoningContent thinking when includeThinking:
                     EmitOutput(new ThinkingOutput
                     {
@@ -2068,6 +2058,27 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                             : null
                     }, OutputFilter.ToolCalls);
                     break;
+            }
+        }
+
+        // Consolidate all TextContent items into a single TextOutput to avoid
+        // duplicate posts when ToChatResponse() produces non-contiguous
+        // TextContent items (e.g. [text, tool_call, text]). Emitted after
+        // thinking to preserve the original content ordering (thinking before text).
+        if (includeText)
+        {
+            var fullText = string.Join("\n\n", message.Contents
+                .OfType<TextContent>()
+                .Select(t => t.Text)
+                .Where(t => !string.IsNullOrWhiteSpace(t)));
+
+            if (fullText.Length > 0)
+            {
+                EmitOutput(new TextOutput
+                {
+                    SessionId = _sessionId,
+                    Text = fullText
+                }, OutputFilter.Text);
             }
         }
 


### PR DESCRIPTION
## Summary

- **Fixes duplicate Slack messages** where every assistant response was posted twice in threads
- Root cause: `ToChatResponse()` (Microsoft.Extensions.AI 10.4.1) preserves non-contiguous `TextContent` items separated by `FunctionCallContent` (e.g., `[text, tool_call, text]`). Both `HandleToolCallResponse` and `EmitResponseOutputs` emitted a separate `TextOutput` per `TextContent` item, each posted as a separate Slack message
- Consolidates all `TextContent` items into a single `TextOutput` emission via LINQ join in both code paths

## Root cause evidence

Daemon logs for session `D0AC6CKBK5K/1774412603.599179` confirmed:
- Every response doubled with ~130ms gap between posts
- Zero pipeline reinit events
- Exactly one subscriber at a time with clean join/leave lifecycle
- Systemic emission bug, not a race condition

## Test plan

- [x] New test: `Non_contiguous_TextContent_items_produce_single_TextOutput` — verifies `[TextContent, FunctionCallContent, TextContent]` response produces exactly one consolidated `TextOutput`
- [x] All 24 `LlmSessionIntegrationTests` pass (including existing preamble + filter tests)
- [x] All 14 `SlackFileFlowIntegrationTests` pass
- [x] All 8 `ToolExecutionIntegrationTests` pass
- [x] `dotnet slopwatch analyze` — no new violations

Closes #413