### PR TITLE
fix(update): surface diagnostic detail when update check fails

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.16" />
+    <PackageVersion Include="SauceControl.Blake2Fast" Version="2.0.0" />
     <PackageVersion Include="SlackNet" Version="$(SlackNetVersion)" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.8.4" />

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1155,7 +1155,9 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
             Console.WriteLine($"update: up-to-date (v{updateCurrentVersion})");
             break;
         default:
-            Console.WriteLine("update: unknown (check failed — run 'netclaw update --check' to retry)");
+            var errorHint = cliUpdate?.ErrorDetail ?? status.Update?.ErrorDetail;
+            var detail = errorHint is not null ? $" [{errorHint}]" : "";
+            Console.WriteLine($"update: unknown (check failed{detail} — run 'netclaw update --check' to retry)");
             break;
     }
 }

--- a/src/Netclaw.Cli/Update/StatusUpdateChecker.cs
+++ b/src/Netclaw.Cli/Update/StatusUpdateChecker.cs
@@ -27,17 +27,21 @@ internal static class StatusUpdateChecker
         {
             var fetchResult = await UpdateCheckService.FetchVerifiedManifestAsync(httpClient, cts.Token);
             if (!fetchResult.IsSuccess)
-                return new StatusUpdateResult("unknown", currentVersion, null, null);
+                return new StatusUpdateResult("unknown", currentVersion, null, null,
+                    $"{fetchResult.Status}: {fetchResult.ErrorMessage}");
 
             var result = UpdateCheckService.EvaluateManifest(fetchResult.Manifest!, currentVersion);
             return result.IsUpdateAvailable
                 ? new StatusUpdateResult("update-available", result.CurrentVersion, result.LatestVersion, result.ReleaseNotesUrl)
                 : new StatusUpdateResult("up-to-date", result.CurrentVersion, null, null);
         }
-        catch (Exception)
+        catch (OperationCanceledException)
         {
-            // OperationCanceledException (3s timeout) or HttpRequestException (network failure)
-            return new StatusUpdateResult("unknown", currentVersion, null, null);
+            return new StatusUpdateResult("unknown", currentVersion, null, null, "timed out");
+        }
+        catch (Exception ex)
+        {
+            return new StatusUpdateResult("unknown", currentVersion, null, null, ex.Message);
         }
     }
 }
@@ -46,4 +50,5 @@ internal sealed record StatusUpdateResult(
     string State,
     string CurrentVersion,
     string? LatestVersion,
-    string? ReleaseNotesUrl);
+    string? ReleaseNotesUrl,
+    string? ErrorDetail = null);

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -124,6 +124,12 @@ public static class DaemonRuntimeStatus
         public string? LatestVersion { get; init; }
 
         public string? ReleaseNotesUrl { get; init; }
+
+        /// <summary>
+        /// Diagnostic detail when <see cref="State"/> is "unknown" — e.g. the specific
+        /// error that caused the check to fail.
+        /// </summary>
+        public string? ErrorDetail { get; init; }
     }
 
     public sealed class Memory : IWireType

--- a/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
+++ b/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json;
 using Netclaw.Configuration.Security;
 
@@ -136,13 +135,16 @@ public static class UpdateCheckService
         // Start both requests in parallel — halves network time for the CLI's 3s timeout
         var sigTask = httpClient.GetAsync(FeedConstants.BinaryManifestSignatureUrl, cts.Token);
 
-        string json;
+        // Read raw bytes for signature verification — avoids encoding round-trip
+        // (ReadAsStringAsync → UTF8.GetBytes can alter bytes if the response charset
+        // differs from UTF-8, breaking the Ed25519 signature).
+        byte[] manifestBytes;
         try
         {
             var response = await httpClient.GetAsync(
                 FeedConstants.BinaryManifestUrl, cts.Token);
             response.EnsureSuccessStatusCode();
-            json = await response.Content.ReadAsStringAsync(cts.Token);
+            manifestBytes = await response.Content.ReadAsByteArrayAsync(cts.Token);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -170,8 +172,7 @@ public static class UpdateCheckService
             };
         }
 
-        var verifyResult = MinisignVerifier.Verify(
-            Encoding.UTF8.GetBytes(json), signatureContent);
+        var verifyResult = MinisignVerifier.Verify(manifestBytes, signatureContent);
 
         if (verifyResult != MinisignVerifier.VerifyResult.Valid)
         {
@@ -194,7 +195,7 @@ public static class UpdateCheckService
         }
 
         // Signature verified — safe to deserialize
-        var manifest = JsonSerializer.Deserialize<BinaryFeedManifest>(json);
+        var manifest = JsonSerializer.Deserialize<BinaryFeedManifest>(manifestBytes);
         if (manifest is null || manifest.SchemaVersion != 1)
         {
             return new ManifestFetchResult

--- a/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
+++ b/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
@@ -11,6 +11,18 @@ namespace Netclaw.Configuration.Feeds;
 public sealed class UpdateCheckResult
 {
     public bool IsUpdateAvailable { get; init; }
+
+    /// <summary>
+    /// Whether the check completed successfully (manifest fetched and verified).
+    /// When false, <see cref="IsUpdateAvailable"/> is meaningless — the check failed.
+    /// </summary>
+    public bool CheckSucceeded { get; init; } = true;
+
+    /// <summary>
+    /// Human-readable error detail when <see cref="CheckSucceeded"/> is false.
+    /// </summary>
+    public string? ErrorDetail { get; init; }
+
     public string CurrentVersion { get; init; } = "";
     public string LatestVersion { get; init; } = "";
     public string? ReleaseNotesUrl { get; init; }
@@ -74,20 +86,21 @@ public static class UpdateCheckService
         if (cached is not null && DateTimeOffset.UtcNow - s_cachedAt < CacheDuration)
             return cached;
 
-        var noUpdate = new UpdateCheckResult
-        {
-            IsUpdateAvailable = false,
-            CurrentVersion = currentVersion,
-            LatestVersion = currentVersion,
-        };
-
         try
         {
             var fetchResult = await FetchVerifiedManifestAsync(httpClient, cancellationToken);
             if (!fetchResult.IsSuccess)
             {
-                CacheResult(noUpdate);
-                return noUpdate;
+                var failed = new UpdateCheckResult
+                {
+                    IsUpdateAvailable = false,
+                    CheckSucceeded = false,
+                    ErrorDetail = $"{fetchResult.Status}: {fetchResult.ErrorMessage}",
+                    CurrentVersion = currentVersion,
+                    LatestVersion = currentVersion,
+                };
+                CacheResult(failed);
+                return failed;
             }
 
             var result = EvaluateManifest(fetchResult.Manifest!, currentVersion);
@@ -96,8 +109,16 @@ public static class UpdateCheckService
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            CacheResult(noUpdate);
-            return noUpdate;
+            var failed = new UpdateCheckResult
+            {
+                IsUpdateAvailable = false,
+                CheckSucceeded = false,
+                ErrorDetail = ex.Message,
+                CurrentVersion = currentVersion,
+                LatestVersion = currentVersion,
+            };
+            CacheResult(failed);
+            return failed;
         }
     }
 
@@ -111,6 +132,9 @@ public static class UpdateCheckService
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(FeedConstants.BinaryFeedHttpTimeout);
+
+        // Start both requests in parallel — halves network time for the CLI's 3s timeout
+        var sigTask = httpClient.GetAsync(FeedConstants.BinaryManifestSignatureUrl, cts.Token);
 
         string json;
         try
@@ -129,12 +153,11 @@ public static class UpdateCheckService
             };
         }
 
-        // Fetch and verify signature
+        // Await the already-in-flight signature request
         string signatureContent;
         try
         {
-            var sigResponse = await httpClient.GetAsync(
-                FeedConstants.BinaryManifestSignatureUrl, cts.Token);
+            var sigResponse = await sigTask;
             sigResponse.EnsureSuccessStatusCode();
             signatureContent = await sigResponse.Content.ReadAsStringAsync(cts.Token);
         }

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="NSec.Cryptography" />
+    <PackageReference Include="SauceControl.Blake2Fast" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Configuration/Security/MinisignVerifier.cs
+++ b/src/Netclaw.Configuration/Security/MinisignVerifier.cs
@@ -171,7 +171,17 @@ public static class MinisignVerifier
         if (!sig.KeyId.AsSpan().SequenceEqual(activeKeyId))
             return VerifyResult.KeyMismatch;
 
-        return VerifyEd25519(activePublicKey, data, sig.Signature)
+        // Try raw Ed25519 first (works with test keys and legacy minisign).
+        if (VerifyEd25519(activePublicKey, data, sig.Signature))
+            return VerifyResult.Valid;
+
+        // Modern minisign (1.0.18+) always prehashes with BLAKE2b-512 before
+        // signing, even when algorithm bytes say "ED" (nominally "standard").
+        // Fall back to prehashed verification.
+        Span<byte> hash = stackalloc byte[64];
+        Blake2b512(data, hash);
+
+        return VerifyEd25519(activePublicKey, hash, sig.Signature)
             ? VerifyResult.Valid
             : VerifyResult.InvalidSignature;
     }
@@ -187,6 +197,15 @@ public static class MinisignVerifier
         var algorithm = SignatureAlgorithm.Ed25519;
         var publicKey = PublicKey.Import(algorithm, publicKeyBytes, KeyBlobFormat.RawPublicKey);
         return algorithm.Verify(publicKey, data, signatureBytes);
+    }
+
+    /// <summary>
+    /// Computes unkeyed BLAKE2b-512 (64-byte output) using Blake2Fast.
+    /// This is the same hash minisign uses for prehashing before Ed25519 signing.
+    /// </summary>
+    private static void Blake2b512(ReadOnlySpan<byte> data, Span<byte> hash)
+    {
+        Blake2Fast.Blake2b.ComputeAndWriteHash(64, data, hash);
     }
 
     internal sealed class ParsedSignature

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -252,13 +252,21 @@ internal sealed class DaemonRuntimeStatusService(
             };
         }
 
+        var state = result switch
+        {
+            { CheckSucceeded: false } => "unknown",
+            { IsUpdateAvailable: true } => "update-available",
+            _ => "up-to-date",
+        };
+
         return new DaemonRuntimeStatus.Update
         {
             Available = result.IsUpdateAvailable,
-            State = result.IsUpdateAvailable ? "update-available" : "up-to-date",
+            State = state,
             CurrentVersion = result.CurrentVersion,
             LatestVersion = result.IsUpdateAvailable ? result.LatestVersion : null,
             ReleaseNotesUrl = result.IsUpdateAvailable ? result.ReleaseNotesUrl : null,
+            ErrorDetail = result.CheckSucceeded ? null : result.ErrorDetail,
         };
     }
 


### PR DESCRIPTION
## Summary

The `netclaw status` update check was broken — always showed "unknown (check failed)" even though the CDN manifest and signature were valid. Root cause: modern minisign (1.0.18+) always prehashes data with BLAKE2b-512 before Ed25519 signing, even in "standard" mode. Our verifier passed raw manifest bytes to Ed25519.Verify, which failed because the signature covers the 64-byte BLAKE2b-512 hash, not the raw bytes.

Confirmed via LD_PRELOAD interception: minisign passes `mlen=64` (the hash), not the full 29KB manifest.

### Changes
- **BLAKE2b-512 prehash verification** — try raw Ed25519 first (backward compat), fall back to prehash (modern minisign). Uses `SauceControl.Blake2Fast` (pure managed, cross-platform)
- **Raw byte verification** — `ReadAsByteArrayAsync` instead of string round-trip
- **Parallel HTTP requests** — manifest + signature fetches concurrently
- **Diagnostic error detail** — error details surfaced in status line
- **Daemon no longer masks failures** — reports "unknown" not "up-to-date" on failure

Unblocks #419 (update notifications require a working update check).

## Test plan
- [x] All 1,425 tests pass
- [x] Live binary swap: `netclaw status` shows `update: up-to-date (v0.8.1)`
- [x] Daemon API returns correct update state