### PR TITLE
fix(daemon): add singleton guard and PID file watchdog to prevent duplicate daemons

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
@@ -94,6 +94,6 @@ public sealed class DaemonManagerSingletonGuardTests : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
+        catch (IOException) { /* test cleanup — directory may already be gone */ }
     }
 }

--- a/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
@@ -94,6 +94,6 @@ public sealed class DaemonManagerSingletonGuardTests : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch (IOException) { /* test cleanup — directory may already be gone */ }
+        catch (IOException) { } // slopwatch-ignore: SW003 test cleanup best-effort — directory may already be gone
     }
 }

--- a/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonManagerSingletonGuardTests.cs
@@ -1,0 +1,99 @@
+using Netclaw.Cli.Daemon;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+public sealed class DaemonManagerSingletonGuardTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly DaemonManager _sut;
+
+    public DaemonManagerSingletonGuardTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+        _sut = new DaemonManager(_paths, TimeProvider.System);
+    }
+
+    [Fact]
+    public void IsLockFileHeld_ReturnsFalse_WhenNoLock()
+    {
+        Assert.False(_sut.IsLockFileHeld());
+    }
+
+    [Fact]
+    public void IsLockFileHeld_ReturnsTrue_WhenLockHeld()
+    {
+        using var holder = new FileStream(
+            _paths.LockFilePath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        Assert.True(_sut.IsLockFileHeld());
+    }
+
+    [Fact]
+    public void IsLockFileHeld_ReturnsFalse_AfterLockReleased()
+    {
+        // Acquire and release
+        using (var holder = new FileStream(
+            _paths.LockFilePath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None))
+        {
+            Assert.True(_sut.IsLockFileHeld());
+        }
+
+        // After release, probe should succeed
+        Assert.False(_sut.IsLockFileHeld());
+    }
+
+    [Fact]
+    public void GetStatus_ReportsNotRunning_WhenNoPidFileAndNoLock()
+    {
+        var status = _sut.GetStatus();
+        Assert.False(status.IsRunning);
+        Assert.Null(status.Pid);
+    }
+
+    [Fact]
+    public void GetStatus_ReportsRunning_WhenLockHeldButNoPidFile()
+    {
+        using var holder = new FileStream(
+            _paths.LockFilePath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        var status = _sut.GetStatus();
+        Assert.True(status.IsRunning);
+        Assert.Null(status.Pid);
+        Assert.Contains("PID file missing", status.Message);
+    }
+
+    [Fact]
+    public void Start_RefusesToStart_WhenLockHeld()
+    {
+        using var holder = new FileStream(
+            _paths.LockFilePath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+
+        var result = _sut.Start();
+        Assert.False(result.Success);
+        Assert.Contains("already running", result.Message);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -59,6 +59,9 @@ public sealed partial class DaemonManager
             return new DaemonResult(false, $"Failed to start daemon: {ex.Message}");
         }
 
+        // Preliminary PID file for immediate status checks. The daemon's PidFileService
+        // overwrites with the authoritative two-line format. The lock file (acquired by
+        // the daemon in Program.cs) is the actual singleton guard.
         File.WriteAllText(_paths.PidFilePath, process.Id.ToString());
 
         return new DaemonResult(true, $"Daemon started (PID {process.Id}).");
@@ -75,8 +78,13 @@ public sealed partial class DaemonManager
     /// </param>
     public async Task<DaemonResult> StopAsync(string reason)
     {
-        if (!TryReadPid(out var pid))
-            return new DaemonResult(false, "Daemon is not running (no PID file).");
+        if (!TryGetRunningPid(out var pid))
+            return new DaemonResult(false, "Daemon is not running.");
+
+        if (pid == 0)
+            return new DaemonResult(false,
+                "Daemon appears running (lock file held) but PID file is missing. " +
+                "The daemon will self-terminate shortly, or use 'pkill netclawd' to stop it manually.");
 
         Process process;
         try
@@ -162,8 +170,16 @@ public sealed partial class DaemonManager
     /// </summary>
     public DaemonStatus GetStatus()
     {
-        if (!TryReadPid(out var pid))
+        if (!TryGetRunningPid(out var pid))
             return new DaemonStatus(IsRunning: false, Pid: null, Message: "Daemon is not running.");
+
+        if (pid == 0)
+        {
+            // Lock file is held but PID file is missing.
+            // The watchdog will terminate the daemon shortly.
+            return new DaemonStatus(IsRunning: true, Pid: null,
+                Message: "Daemon is running (PID file missing \u2014 daemon will self-terminate shortly).");
+        }
 
         try
         {
@@ -312,23 +328,56 @@ public sealed partial class DaemonManager
 
     private bool TryGetRunningPid(out int pid)
     {
-        if (!TryReadPid(out pid))
-            return false;
-
-        try
+        // Tier 1: PID file (fast path — covers normal operation)
+        if (TryReadPid(out pid))
         {
-            var process = Process.GetProcessById(pid);
-            if (process.HasExited || !IsDaemonProcess(process))
+            try
+            {
+                var process = Process.GetProcessById(pid);
+                if (!process.HasExited && IsDaemonProcess(process))
+                    return true;
+
+                CleanupPidFile();
+            }
+            catch (ArgumentException)
             {
                 CleanupPidFile();
-                return false;
             }
+        }
+
+        // Tier 2: Lock file probe (fast, OS-backed — covers PID file loss)
+        if (IsLockFileHeld())
+        {
+            // A daemon holds the lock but we have no (valid) PID file.
+            // Signal to callers via pid == 0 that we know a daemon exists
+            // but can't identify its PID.
+            pid = 0;
             return true;
         }
-        catch (ArgumentException)
+
+        return false;
+    }
+
+    /// <summary>
+    /// Probes whether the daemon lock file is currently held by another process.
+    /// Returns <c>true</c> if the lock cannot be acquired (a daemon is running).
+    /// The probe opens and immediately disposes the file — the CLI never holds the lock.
+    /// </summary>
+    internal bool IsLockFileHeld()
+    {
+        try
         {
-            CleanupPidFile();
+            using var probe = new FileStream(
+                _paths.LockFilePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: 1);
             return false;
+        }
+        catch (IOException)
+        {
+            return true;
         }
     }
 

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -64,6 +64,7 @@ public sealed class NetclawPaths
     public string DaemonLogPath => Path.Combine(LogsDirectory, "daemon.log");
     public string SessionsDirectory => Path.Combine(BasePath, "sessions");
     public string PidFilePath => Path.Combine(BasePath, "netclaw.pid");
+    public string LockFilePath => Path.Combine(BasePath, "netclaw.lock");
     public string SqliteDbPath => Path.Combine(BasePath, "netclaw.db");
     public string McpOAuthMetadataPath => Path.Combine(ConfigDirectory, "mcp-oauth-metadata.json");
     public string KeysDirectory => Path.Combine(BasePath, "keys");

--- a/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
@@ -68,6 +68,6 @@ public sealed class PidFileServiceTests : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch (IOException) { /* test cleanup — directory may already be gone */ }
+        catch (IOException) { } // slopwatch-ignore: SW003 test cleanup best-effort — directory may already be gone
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class PidFileServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public PidFileServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    [Fact]
+    public async Task StartAsync_WritesTwoLinePidFile()
+    {
+        var sut = CreateService();
+
+        await sut.StartAsync(CancellationToken.None);
+
+        Assert.True(File.Exists(_paths.PidFilePath));
+        var lines = File.ReadAllLines(_paths.PidFilePath);
+        Assert.Equal(2, lines.Length);
+        Assert.Equal(Environment.ProcessId.ToString(), lines[0].Trim());
+        Assert.True(DateTimeOffset.TryParse(lines[1].Trim(), out _));
+    }
+
+    [Fact]
+    public async Task StopAsync_DeletesPidFile_WhenNoRestartRequested()
+    {
+        var signal = new DaemonRestartSignal();
+        var sut = CreateService(signal);
+
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StopAsync(CancellationToken.None);
+
+        Assert.False(File.Exists(_paths.PidFilePath));
+    }
+
+    [Fact]
+    public async Task StopAsync_KeepsPidFile_WhenRestartRequested()
+    {
+        var signal = new DaemonRestartSignal();
+        var sut = CreateService(signal);
+
+        await sut.StartAsync(CancellationToken.None);
+        signal.RequestRestart();
+        await sut.StopAsync(CancellationToken.None);
+
+        Assert.True(File.Exists(_paths.PidFilePath));
+    }
+
+    private PidFileService CreateService(DaemonRestartSignal? signal = null)
+    {
+        return new PidFileService(
+            _paths,
+            signal ?? new DaemonRestartSignal(),
+            TimeProvider.System,
+            NullLogger<PidFileService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
@@ -68,6 +68,6 @@ public sealed class PidFileServiceTests : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
+        catch (IOException) { /* test cleanup — directory may already be gone */ }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class PidFileWatchdogServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly FakeApplicationLifetime _lifetime;
+
+    public PidFileWatchdogServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+        _lifetime = new FakeApplicationLifetime();
+    }
+
+    [Fact]
+    public async Task DoesNotShutdown_WhenPidFileExists()
+    {
+        // Write a PID file so the watchdog sees it
+        File.WriteAllText(_paths.PidFilePath, Environment.ProcessId.ToString());
+
+        var sut = CreateService();
+        await sut.StartAsync(CancellationToken.None);
+
+        // Wait longer than one poll interval
+        await Task.Delay(PidFileWatchdogService.PollInterval + TimeSpan.FromSeconds(1));
+
+        Assert.False(_lifetime.StopRequested);
+
+        await sut.StopAsync(CancellationToken.None);
+        sut.Dispose();
+    }
+
+    [Fact]
+    public async Task InitiatesShutdown_WhenPidFileDeleted()
+    {
+        // Write a PID file, start watchdog, then delete the file
+        File.WriteAllText(_paths.PidFilePath, Environment.ProcessId.ToString());
+
+        var sut = CreateService();
+        await sut.StartAsync(CancellationToken.None);
+
+        // Delete the PID file
+        File.Delete(_paths.PidFilePath);
+
+        // Wait for the watchdog to detect the deletion (up to 2 poll intervals)
+        var deadline = DateTime.UtcNow + PidFileWatchdogService.PollInterval * 3;
+        while (!_lifetime.StopRequested && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(200);
+        }
+
+        Assert.True(_lifetime.StopRequested);
+
+        await sut.StopAsync(CancellationToken.None);
+        sut.Dispose();
+    }
+
+    [Fact]
+    public async Task InitiatesShutdown_WhenPidFileNeverExisted()
+    {
+        // Don't write a PID file — watchdog should detect on first poll
+        var sut = CreateService();
+        await sut.StartAsync(CancellationToken.None);
+
+        var deadline = DateTime.UtcNow + PidFileWatchdogService.PollInterval * 3;
+        while (!_lifetime.StopRequested && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(200);
+        }
+
+        Assert.True(_lifetime.StopRequested);
+
+        await sut.StopAsync(CancellationToken.None);
+        sut.Dispose();
+    }
+
+    private PidFileWatchdogService CreateService()
+    {
+        return new PidFileWatchdogService(
+            _paths,
+            _lifetime,
+            NullLogger<PidFileWatchdogService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private sealed class FakeApplicationLifetime : IHostApplicationLifetime
+    {
+        public bool StopRequested { get; private set; }
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => StopRequested = true;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
@@ -92,17 +92,14 @@ public sealed class PidFileWatchdogServiceTests : IDisposable
                     return true;
             }
         }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested)
-        {
-            // Timeout expired — fall through to final check.
-        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 timeout expired — fall through to final condition check
         return condition();
     }
 
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch (IOException) { /* test cleanup — directory may already be gone */ }
+        catch (IOException) { } // slopwatch-ignore: SW003 test cleanup best-effort — directory may already be gone
     }
 
     private sealed class FakeApplicationLifetime : IHostApplicationLifetime

--- a/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileWatchdogServiceTests.cs
@@ -8,6 +8,8 @@ namespace Netclaw.Daemon.Tests.Services;
 
 public sealed class PidFileWatchdogServiceTests : IDisposable
 {
+    private static readonly TimeSpan FastPoll = TimeSpan.FromMilliseconds(100);
+
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
     private readonly FakeApplicationLifetime _lifetime;
@@ -23,14 +25,13 @@ public sealed class PidFileWatchdogServiceTests : IDisposable
     [Fact]
     public async Task DoesNotShutdown_WhenPidFileExists()
     {
-        // Write a PID file so the watchdog sees it
         File.WriteAllText(_paths.PidFilePath, Environment.ProcessId.ToString());
 
         var sut = CreateService();
         await sut.StartAsync(CancellationToken.None);
 
-        // Wait longer than one poll interval
-        await Task.Delay(PidFileWatchdogService.PollInterval + TimeSpan.FromSeconds(1));
+        // Let several poll cycles pass
+        await WaitUntilAsync(() => false, timeout: FastPoll * 8);
 
         Assert.False(_lifetime.StopRequested);
 
@@ -41,23 +42,14 @@ public sealed class PidFileWatchdogServiceTests : IDisposable
     [Fact]
     public async Task InitiatesShutdown_WhenPidFileDeleted()
     {
-        // Write a PID file, start watchdog, then delete the file
         File.WriteAllText(_paths.PidFilePath, Environment.ProcessId.ToString());
 
         var sut = CreateService();
         await sut.StartAsync(CancellationToken.None);
 
-        // Delete the PID file
         File.Delete(_paths.PidFilePath);
 
-        // Wait for the watchdog to detect the deletion (up to 2 poll intervals)
-        var deadline = DateTime.UtcNow + PidFileWatchdogService.PollInterval * 3;
-        while (!_lifetime.StopRequested && DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(200);
-        }
-
-        Assert.True(_lifetime.StopRequested);
+        Assert.True(await WaitUntilAsync(() => _lifetime.StopRequested, timeout: TimeSpan.FromSeconds(5)));
 
         await sut.StopAsync(CancellationToken.None);
         sut.Dispose();
@@ -66,17 +58,10 @@ public sealed class PidFileWatchdogServiceTests : IDisposable
     [Fact]
     public async Task InitiatesShutdown_WhenPidFileNeverExisted()
     {
-        // Don't write a PID file — watchdog should detect on first poll
         var sut = CreateService();
         await sut.StartAsync(CancellationToken.None);
 
-        var deadline = DateTime.UtcNow + PidFileWatchdogService.PollInterval * 3;
-        while (!_lifetime.StopRequested && DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(200);
-        }
-
-        Assert.True(_lifetime.StopRequested);
+        Assert.True(await WaitUntilAsync(() => _lifetime.StopRequested, timeout: TimeSpan.FromSeconds(5)));
 
         await sut.StopAsync(CancellationToken.None);
         sut.Dispose();
@@ -87,13 +72,37 @@ public sealed class PidFileWatchdogServiceTests : IDisposable
         return new PidFileWatchdogService(
             _paths,
             _lifetime,
-            NullLogger<PidFileWatchdogService>.Instance);
+            NullLogger<PidFileWatchdogService>.Instance,
+            FastPoll);
+    }
+
+    /// <summary>
+    /// Polls a condition until it becomes true or the timeout expires.
+    /// Returns true if the condition was met, false on timeout.
+    /// </summary>
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cts.Token))
+            {
+                if (condition())
+                    return true;
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Timeout expired — fall through to final check.
+        }
+        return condition();
     }
 
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
+        catch (IOException) { /* test cleanup — directory may already be gone */ }
     }
 
     private sealed class FakeApplicationLifetime : IHostApplicationLifetime

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -37,12 +37,39 @@ using static Microsoft.Extensions.Logging.LogLevel;
 
 try
 {
-    var restartSignal = new DaemonRestartSignal();
-    do
+    // Acquire an exclusive lock file before anything else. This is the OS-level
+    // singleton guard — a second netclawd instance will fail to open the file
+    // and exit immediately. The lock survives soft restarts (same process) and
+    // is released by the OS on crash (fd closed → flock released).
+    var paths = new NetclawPaths();
+    paths.EnsureDirectoriesExist();
+
+    FileStream lockFile;
+    try
     {
-        restartSignal.Reset();
-        await RunDaemonAsync(args, restartSignal);
-    } while (restartSignal.RestartRequested);
+        lockFile = new FileStream(
+            paths.LockFilePath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+    }
+    catch (IOException)
+    {
+        Console.Error.WriteLine(
+            "error: Another netclawd instance is already running (lock file held). Exiting.");
+        Environment.ExitCode = 1;
+        return;
+    }
+
+    await using (lockFile)
+    {
+        var restartSignal = new DaemonRestartSignal();
+        do
+        {
+            restartSignal.Reset();
+            await RunDaemonAsync(args, restartSignal);
+        } while (restartSignal.RestartRequested);
+    }
 }
 catch (Exception ex)
 {
@@ -680,6 +707,11 @@ static void ConfigureDaemonServices(
     // PID file authority for daemon lifecycle management
     services.AddSingleton<PidFileService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<PidFileService>());
+
+    // PID file watchdog — self-terminates daemon if PID file is deleted externally.
+    // Registered after PidFileService so it starts after the PID file is written
+    // and stops before PidFileService deletes it during graceful shutdown.
+    services.AddSingleton<IHostedService, PidFileWatchdogService>();
 
     // Active session cleanup during host shutdown
     services.AddSingleton<SessionRegistryShutdownService>();

--- a/src/Netclaw.Daemon/Services/PidFileWatchdogService.cs
+++ b/src/Netclaw.Daemon/Services/PidFileWatchdogService.cs
@@ -16,19 +16,30 @@ public sealed class PidFileWatchdogService : IHostedService, IDisposable
     private readonly NetclawPaths _paths;
     private readonly IHostApplicationLifetime _appLifetime;
     private readonly ILogger<PidFileWatchdogService> _logger;
+    private readonly TimeSpan _pollInterval;
     private CancellationTokenSource? _cts;
     private Task? _pollTask;
 
-    internal static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(5);
 
     public PidFileWatchdogService(
         NetclawPaths paths,
         IHostApplicationLifetime appLifetime,
         ILogger<PidFileWatchdogService> logger)
+        : this(paths, appLifetime, logger, DefaultPollInterval)
+    {
+    }
+
+    internal PidFileWatchdogService(
+        NetclawPaths paths,
+        IHostApplicationLifetime appLifetime,
+        ILogger<PidFileWatchdogService> logger,
+        TimeSpan pollInterval)
     {
         _paths = paths;
         _appLifetime = appLifetime;
         _logger = logger;
+        _pollInterval = pollInterval;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -40,24 +51,19 @@ public sealed class PidFileWatchdogService : IHostedService, IDisposable
 
     private async Task PollAsync(CancellationToken ct)
     {
-        using var timer = new PeriodicTimer(PollInterval);
-        try
+        using var timer = new PeriodicTimer(_pollInterval);
+        // OperationCanceledException from WaitForNextTickAsync on shutdown is
+        // expected and handled by StopAsync via ConfigureAwaitOptions.SuppressThrowing.
+        while (await timer.WaitForNextTickAsync(ct))
         {
-            while (await timer.WaitForNextTickAsync(ct))
+            if (!File.Exists(_paths.PidFilePath))
             {
-                if (!File.Exists(_paths.PidFilePath))
-                {
-                    _logger.LogWarning(
-                        "PID file missing ({PidFilePath}). Initiating shutdown to prevent orphan daemon.",
-                        _paths.PidFilePath);
-                    _appLifetime.StopApplication();
-                    return;
-                }
+                _logger.LogWarning(
+                    "PID file missing ({PidFilePath}). Initiating shutdown to prevent orphan daemon.",
+                    _paths.PidFilePath);
+                _appLifetime.StopApplication();
+                return;
             }
-        }
-        catch (OperationCanceledException)
-        {
-            // Normal shutdown — timer cancelled by StopAsync.
         }
     }
 

--- a/src/Netclaw.Daemon/Services/PidFileWatchdogService.cs
+++ b/src/Netclaw.Daemon/Services/PidFileWatchdogService.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Polls for PID file existence and initiates graceful shutdown when the file
+/// is missing. This prevents orphan daemons when the PID file is lost (crash,
+/// external deletion, filesystem issue). Uses periodic polling rather than
+/// <see cref="FileSystemWatcher"/> because inotify on Linux can miss events,
+/// and the daemon's lock file covers the detection gap.
+/// </summary>
+public sealed class PidFileWatchdogService : IHostedService, IDisposable
+{
+    private readonly NetclawPaths _paths;
+    private readonly IHostApplicationLifetime _appLifetime;
+    private readonly ILogger<PidFileWatchdogService> _logger;
+    private CancellationTokenSource? _cts;
+    private Task? _pollTask;
+
+    internal static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+
+    public PidFileWatchdogService(
+        NetclawPaths paths,
+        IHostApplicationLifetime appLifetime,
+        ILogger<PidFileWatchdogService> logger)
+    {
+        _paths = paths;
+        _appLifetime = appLifetime;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _pollTask = PollAsync(_cts.Token);
+        return Task.CompletedTask;
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(PollInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct))
+            {
+                if (!File.Exists(_paths.PidFilePath))
+                {
+                    _logger.LogWarning(
+                        "PID file missing ({PidFilePath}). Initiating shutdown to prevent orphan daemon.",
+                        _paths.PidFilePath);
+                    _appLifetime.StopApplication();
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown — timer cancelled by StopAsync.
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts is not null)
+        {
+            await _cts.CancelAsync();
+        }
+
+        if (_pollTask is not null)
+        {
+            await _pollTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #427 — `netclaw daemon status` reports "not running" while a `netclawd` process is alive because the PID file was lost. Without the PID file, `daemon start` would launch a second daemon, causing SQLite WAL corruption, double Slack connections, and double inference calls.

Adds three complementary defenses:

- **Exclusive file lock** (`netclaw.lock`) acquired in `Program.cs` before the restart loop — prevents a second `netclawd` from starting even if the PID file is missing. Released automatically by the OS on crash.
- **PID file watchdog** (`PidFileWatchdogService`) — polls every 5s and initiates graceful shutdown when the PID file disappears, preventing orphan daemons.
- **CLI lock file probe** — `GetStatus()`, `Start()`, and `StopAsync()` detect a running daemon via the lock file when the PID file is absent.

## Test plan

- [x] All 1,437 existing tests pass
- [x] New `DaemonManagerSingletonGuardTests` (6 tests) — lock probe correctness, status/start behavior with and without lock
- [x] New `PidFileServiceTests` (3 tests) — PID file write format, deletion on shutdown, preservation on restart
- [x] New `PidFileWatchdogServiceTests` (3 tests) — shutdown on PID deletion, no shutdown when PID exists, shutdown when PID never existed
- [ ] Manual: start daemon, delete PID file → daemon shuts down within ~5s
- [ ] Manual: start daemon, try `daemon start` again → refuses ("already running")
- [ ] Manual: `kill -9` daemon, then `daemon start` → succeeds (lock released by OS)
- [ ] Manual: delete PID file, immediately run `daemon status` → reports "running (PID file missing)" via lock probe