### PR TITLE
feat: add token delta and cumulative logging

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
@@ -113,6 +113,118 @@ public sealed class LoggingChatClientTests
         Assert.Contains(logs, l => l.Contains("role=user"));
     }
 
+    [Fact]
+    public async Task LogsTokenDeltaAcrossMultipleCalls()
+    {
+        var logs = new List<string>();
+        var logger = new CapturingLogger(logs);
+        var callCount = 0;
+
+        var fake = new FakeChatClient((_, _, _) =>
+        {
+            callCount++;
+            // Return increasing input tokens: 100, 150, 200
+            var inputTokens = callCount * 50;
+            return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")])
+            {
+                Usage = new UsageDetails { InputTokenCount = inputTokens, OutputTokenCount = 10 }
+            });
+        });
+
+        var client = new LoggingChatClient(fake, logger);
+
+        // First call: 50 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+        // Second call: 100 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+        // Third call: 150 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        // Verify first call has delta of +50 (no previous)
+        Assert.Contains(logs, l => l.Contains("delta: +50"));
+        // Verify 2nd and 3rd calls have delta of +50 each
+        Assert.Equal(3, logs.Count(l => l.Contains("delta: +50")));
+    }
+
+    [Fact]
+    public async Task LogsCumulativeTokensAcrossMultipleCalls()
+    {
+        var logs = new List<string>();
+        var logger = new CapturingLogger(logs);
+        var callCount = 0;
+
+        var fake = new FakeChatClient((_, _, _) =>
+        {
+            callCount++;
+            // Return input tokens: 50, 100, 150
+            var inputTokens = callCount * 50;
+            return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")])
+            {
+                Usage = new UsageDetails { InputTokenCount = inputTokens, OutputTokenCount = 10 }
+            });
+        });
+
+        var client = new LoggingChatClient(fake, logger);
+
+        // First call: 50 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+        // Second call: 100 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+        // Third call: 150 tokens
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        // Verify cumulative: 50, 150, 300
+        Assert.Contains(logs, l => l.Contains("cumulative: 50"));
+        Assert.Contains(logs, l => l.Contains("cumulative: 150"));
+        Assert.Contains(logs, l => l.Contains("cumulative: 300"));
+    }
+
+    [Fact]
+    public async Task Streaming_LogsTokenDeltaAndCumulative()
+    {
+        var logs = new List<string>();
+        var logger = new CapturingLogger(logs);
+        var callCount = 0;
+
+        var fake = new FakeChatClient(streaming: true, streamHandler: (messages, options, ct) =>
+        {
+            callCount++;
+            // Return 100 input tokens on each call
+            return StreamWithUsage(messages, 100, 10);
+        });
+
+        var client = new LoggingChatClient(fake, logger);
+
+        // First streaming call
+        await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")])) { }
+        // Second streaming call
+        await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")])) { }
+
+        // Verify delta and cumulative appear in streaming logs
+        Assert.Contains(logs, l => l.Contains("delta:") && l.Contains("cumulative:"));
+        // First call should have delta +100, cumulative 100
+        Assert.Contains(logs, l => l.Contains("delta: +100") && l.Contains("cumulative: 100"));
+        // Second call should have delta 0, cumulative 200
+        Assert.Contains(logs, l => l.Contains("delta: 0") && l.Contains("cumulative: 200"));
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> StreamWithUsage(
+        IEnumerable<ChatMessage> messages, int inputTokens, int outputTokens)
+    {
+        await Task.CompletedTask;
+        // Yield a text update
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("response")]
+        };
+        // Yield usage details
+        yield return new ChatResponseUpdate
+        {
+            Contents = [new UsageContent(new UsageDetails { InputTokenCount = inputTokens, OutputTokenCount = outputTokens })]
+        };
+    }
+
     /// <summary>
     /// Minimal logger that captures formatted messages for assertion.
     /// </summary>

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -15,6 +15,10 @@ public sealed class LoggingChatClient : DelegatingChatClient
     private readonly ILogger _logger;
     private readonly TimeProvider _timeProvider;
 
+    // Track token usage across calls (single-threaded, no lock needed)
+    private long _lastInputTokens = 0;
+    private long _cumulativeInputTokens = 0;
+
     public LoggingChatClient(
         IChatClient innerClient,
         ILogger logger,
@@ -88,9 +92,13 @@ public sealed class LoggingChatClient : DelegatingChatClient
         var totalElapsed = _timeProvider.GetElapsedTime(start);
         if (inputTokens > 0 || outputTokens > 0)
         {
+            var delta = inputTokens - _lastInputTokens;
+            _cumulativeInputTokens += inputTokens;
+            _lastInputTokens = inputTokens;
+
             _logger.LogInformation(
-                "LLM streaming call completed in {ElapsedMs:F0}ms (input: {InputTokens}, output: {OutputTokens})",
-                totalElapsed.TotalMilliseconds, inputTokens, outputTokens);
+                "LLM streaming call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta:+#;-#;0}, cumulative: {Cumulative}, output: {OutputTokens})",
+                totalElapsed.TotalMilliseconds, inputTokens, delta, _cumulativeInputTokens, outputTokens);
         }
         else
         {
@@ -260,11 +268,19 @@ public sealed class LoggingChatClient : DelegatingChatClient
     {
         if (usage is not null)
         {
+            var inputTokens = usage.InputTokenCount ?? 0;
+            var outputTokens = usage.OutputTokenCount ?? 0;
+            var delta = inputTokens - _lastInputTokens;
+            _cumulativeInputTokens += inputTokens;
+            _lastInputTokens = inputTokens;
+
             _logger.LogInformation(
-                "LLM call completed in {ElapsedMs:F0}ms (input: {InputTokens}, output: {OutputTokens})",
+                "LLM call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta:+#;-#;0}, cumulative: {Cumulative}, output: {OutputTokens})",
                 elapsed.TotalMilliseconds,
-                usage.InputTokenCount ?? 0,
-                usage.OutputTokenCount ?? 0);
+                inputTokens,
+                delta,
+                _cumulativeInputTokens,
+                outputTokens);
         }
         else
         {


### PR DESCRIPTION
## Summary

Adds token delta and cumulative logging to LoggingChatClient to help track:

1. **Delta**: How many tokens were added/removed compared to the previous call
2. **Cumulative**: Running total of all input tokens consumed

## Log format

Before:
```
LLM call completed in 3284ms (input: 26062, output: 187)
```

After:
```
LLM call completed in 3284ms (input: 26062, delta: +256, cumulative: 812219, output: 187)
```

## Implementation

- Two simple fields: `_lastInputTokens` and `_cumulativeInputTokens`
- No locking needed (Akka actors are single-threaded per actor)
- Resets on daemon restart (acceptable for MVP)

## Tests

All 9 tests pass, including:
- Delta calculation across multiple calls
- Cumulative token tracking  
- Both streaming and non-streaming paths

Closes #441
