### PR TITLE
fix: address review feedback on token delta logging

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/LoggingChatClientTests.cs
@@ -140,10 +140,10 @@ public sealed class LoggingChatClientTests
         // Third call: 150 tokens
         await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
 
-        // Verify first call has delta of +50 (no previous)
-        Assert.Contains(logs, l => l.Contains("delta: +50"));
-        // Verify 2nd and 3rd calls have delta of +50 each
-        Assert.Equal(3, logs.Count(l => l.Contains("delta: +50")));
+        // First call has no previous, so delta is N/A
+        Assert.Contains(logs, l => l.Contains("delta: N/A"));
+        // Second and third calls have delta of +50 each
+        Assert.Equal(2, logs.Count(l => l.Contains("delta: +50")));
     }
 
     [Fact]
@@ -202,8 +202,8 @@ public sealed class LoggingChatClientTests
 
         // Verify delta and cumulative appear in streaming logs
         Assert.Contains(logs, l => l.Contains("delta:") && l.Contains("cumulative:"));
-        // First call should have delta +100, cumulative 100
-        Assert.Contains(logs, l => l.Contains("delta: +100") && l.Contains("cumulative: 100"));
+        // First call should have delta N/A (no previous), cumulative 100
+        Assert.Contains(logs, l => l.Contains("delta: N/A") && l.Contains("cumulative: 100"));
         // Second call should have delta 0, cumulative 200
         Assert.Contains(logs, l => l.Contains("delta: 0") && l.Contains("cumulative: 200"));
     }

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -8,7 +8,9 @@ namespace Netclaw.Daemon.Configuration;
 
 /// <summary>
 /// Decorates an <see cref="IChatClient"/> with logging for elapsed time,
-/// token usage, and errors.
+/// token usage, and errors. This class is <b>not</b> thread-safe and is
+/// intended to be scoped per-actor or per-session (Akka actors are
+/// single-threaded, so no synchronization is needed).
 /// </summary>
 public sealed class LoggingChatClient : DelegatingChatClient
 {
@@ -16,8 +18,8 @@ public sealed class LoggingChatClient : DelegatingChatClient
     private readonly TimeProvider _timeProvider;
 
     // Track token usage across calls (single-threaded, no lock needed)
-    private long _lastInputTokens = 0;
-    private long _cumulativeInputTokens = 0;
+    private long? _lastInputTokens;
+    private long _cumulativeInputTokens;
 
     public LoggingChatClient(
         IChatClient innerClient,
@@ -92,13 +94,12 @@ public sealed class LoggingChatClient : DelegatingChatClient
         var totalElapsed = _timeProvider.GetElapsedTime(start);
         if (inputTokens > 0 || outputTokens > 0)
         {
-            var delta = inputTokens - _lastInputTokens;
-            _cumulativeInputTokens += inputTokens;
-            _lastInputTokens = inputTokens;
+            var delta = RecordInputTokens(inputTokens);
+            var deltaFormatted = delta is null ? "N/A" : FormatDelta(delta.Value);
 
             _logger.LogInformation(
-                "LLM streaming call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta:+#;-#;0}, cumulative: {Cumulative}, output: {OutputTokens})",
-                totalElapsed.TotalMilliseconds, inputTokens, delta, _cumulativeInputTokens, outputTokens);
+                "LLM streaming call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta}, cumulative: {Cumulative}, output: {OutputTokens})",
+                totalElapsed.TotalMilliseconds, inputTokens, deltaFormatted, _cumulativeInputTokens, outputTokens);
         }
         else
         {
@@ -264,21 +265,40 @@ public sealed class LoggingChatClient : DelegatingChatClient
         int BrowserToolOptionCount,
         string PromptHash);
 
+    /// <summary>
+    /// Records input token usage and returns the delta from the previous call,
+    /// or <c>null</c> if this is the first call.
+    /// </summary>
+    private long? RecordInputTokens(long inputTokens)
+    {
+        var delta = _lastInputTokens.HasValue
+            ? inputTokens - _lastInputTokens.Value
+            : (long?)null;
+        _cumulativeInputTokens += inputTokens;
+        _lastInputTokens = inputTokens;
+        return delta;
+    }
+
+    private static string FormatDelta(long delta) => delta switch
+    {
+        > 0 => $"+{delta}",
+        _ => delta.ToString()
+    };
+
     private void LogCompletion(TimeSpan elapsed, UsageDetails? usage)
     {
         if (usage is not null)
         {
             var inputTokens = usage.InputTokenCount ?? 0;
             var outputTokens = usage.OutputTokenCount ?? 0;
-            var delta = inputTokens - _lastInputTokens;
-            _cumulativeInputTokens += inputTokens;
-            _lastInputTokens = inputTokens;
+            var delta = RecordInputTokens(inputTokens);
+            var deltaFormatted = delta is null ? "N/A" : FormatDelta(delta.Value);
 
             _logger.LogInformation(
-                "LLM call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta:+#;-#;0}, cumulative: {Cumulative}, output: {OutputTokens})",
+                "LLM call completed in {ElapsedMs:F0}ms (input: {InputTokens}, delta: {Delta}, cumulative: {Cumulative}, output: {OutputTokens})",
                 elapsed.TotalMilliseconds,
                 inputTokens,
-                delta,
+                deltaFormatted,
                 _cumulativeInputTokens,
                 outputTokens);
         }


### PR DESCRIPTION
## Summary

Follow-up to #443 — addresses review feedback on the token delta/cumulative logging feature.

- **Extract `RecordInputTokens` helper** — deduplicates the 3-line delta/cumulative/last-update pattern between the streaming path and `LogCompletion`
- **First-call delta is now `N/A`** — changed `_lastInputTokens` from `long` to `long?` so the first call logs `delta: N/A` instead of showing the full token count as a misleading delta
- **Explicit `FormatDelta` helper** — replaces `{Delta:+#;-#;0}` format specifier (which structured logging sinks ignore) with explicit string formatting that works across all backends
- **Thread-safety doc comment** — documents that `LoggingChatClient` is not thread-safe and is scoped per-actor/per-session

## Test plan

- [x] All 9 `LoggingChatClientTests` pass
- [x] Delta tests updated to assert `N/A` on first call
- [x] Streaming tests updated for same first-call behavior