### PR TITLE
fix(status): unify daemon uptime into single DaemonStartClock singleton

### DIFF
--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -11,6 +11,7 @@ using Netclaw.Configuration;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Daemon.Services;
 using Netclaw.Providers.OAuth;
 using Xunit;
 
@@ -74,6 +75,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
     public async Task IncludesSlackConnectorAsDisabled_WhenNotEnabled()
     {
         var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
             slackOptions: new SlackChannelOptions { Enabled = false },
@@ -94,6 +96,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
     public async Task ReportsSlackAsDisconnected_WhenEnabledButMissingRuntimeChannel()
     {
         var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
             slackOptions: new SlackChannelOptions { Enabled = true, AllowedChannelIds = ["C1"] },
@@ -114,6 +117,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
     public async Task StatusIncludesModelCapabilities()
     {
         var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
             slackOptions: new SlackChannelOptions { Enabled = false },
@@ -172,6 +176,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         try
         {
             var service = new DaemonRuntimeStatusService(
+                new DaemonStartClock(TimeProvider.System),
                 TimeProvider.System,
                 channels: Array.Empty<IChannel>(),
                 slackOptions: new SlackChannelOptions { Enabled = false },
@@ -235,6 +240,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         await sqliteStore.InitializeAsync();
 
         var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
             slackOptions: new SlackChannelOptions { Enabled = false },
@@ -267,6 +273,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         ChannelTelemetry.RecordSlackReplyFailed(77);
 
         var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
             slackOptions: new SlackChannelOptions { Enabled = false },

--- a/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/PidFileServiceTests.cs
@@ -61,7 +61,7 @@ public sealed class PidFileServiceTests : IDisposable
         return new PidFileService(
             _paths,
             signal ?? new DaemonRestartSignal(),
-            TimeProvider.System,
+            new DaemonStartClock(TimeProvider.System),
             NullLogger<PidFileService>.Instance);
     }
 

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -12,10 +12,12 @@ using Netclaw.Configuration;
 using Netclaw.Configuration.Feeds;
 using Netclaw.Daemon.Configuration;
 using Netclaw.Daemon.Mcp;
+using Netclaw.Daemon.Services;
 
 namespace Netclaw.Daemon.Gateway;
 
 internal sealed class DaemonRuntimeStatusService(
+    DaemonStartClock startClock,
     TimeProvider timeProvider,
     IEnumerable<IChannel> channels,
     SlackChannelOptions slackOptions,
@@ -28,13 +30,11 @@ internal sealed class DaemonRuntimeStatusService(
     SQLiteMemoryStore? sqliteMemoryStore = null,
     IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
 {
-    private readonly DateTimeOffset _startedAt = timeProvider.GetUtcNow();
-
     public async Task<DaemonRuntimeStatus.Response> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         var process = Process.GetCurrentProcess();
         var now = timeProvider.GetUtcNow();
-        var uptime = now - _startedAt;
+        var uptime = now - startClock.StartedAt;
 
         var connectors = new List<DaemonRuntimeStatus.Connector>
         {
@@ -57,7 +57,7 @@ internal sealed class DaemonRuntimeStatusService(
             Process = new DaemonRuntimeStatus.Process
             {
                 Pid = process.Id,
-                StartedAtUtc = _startedAt,
+                StartedAtUtc = startClock.StartedAt,
                 UptimeSeconds = (long)uptime.TotalSeconds
             },
             Connectors = connectors,

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -6,10 +6,12 @@ using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Skills;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
 
 namespace Netclaw.Daemon.Gateway;
 
 internal sealed class DaemonStatsService(
+    DaemonStartClock startClock,
     TimeProvider timeProvider,
     SessionCatalogService sessionCatalog,
     SkillRegistry skillRegistry,
@@ -17,12 +19,10 @@ internal sealed class DaemonStatsService(
     SQLiteMemoryStore? sqliteMemoryStore = null,
     IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
 {
-    private readonly DateTimeOffset _startedAt = timeProvider.GetUtcNow();
-
     public async Task<DaemonStats.Response> GetStatsAsync(int? days = null, CancellationToken ct = default)
     {
         var now = timeProvider.GetUtcNow();
-        var uptime = now - _startedAt;
+        var uptime = now - startClock.StartedAt;
 
         var actorRef = await dailyStatsActor.GetAsync(ct);
 
@@ -45,7 +45,7 @@ internal sealed class DaemonStatsService(
             Process = new DaemonStats.Process
             {
                 UptimeSeconds = (long)uptime.TotalSeconds,
-                StartedAtUtc = _startedAt
+                StartedAtUtc = startClock.StartedAt
             },
             Tokens = new DaemonStats.Tokens
             {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -105,12 +105,16 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     builder.Services.AddSingleton<SessionCatalogService>();
     builder.Services.AddSingleton<ISessionLifecycleObserver>(sp => sp.GetRequiredService<SessionCatalogService>());
     builder.Services.AddSingleton<SessionRegistry>();
+    builder.Services.AddSingleton<DaemonStartClock>();
     builder.Services.AddSingleton<DaemonRuntimeStatusService>();
     builder.Services.AddSingleton<DailyStatsPublisher>();
     builder.Services.AddSingleton<Netclaw.Actors.Telemetry.ISessionMetrics>(sp => sp.GetRequiredService<DailyStatsPublisher>());
     builder.Services.AddSingleton<DaemonStatsService>();
 
     var app = builder.Build();
+
+    // Eagerly resolve so StartedAt reflects daemon startup, not first request.
+    app.Services.GetRequiredService<DaemonStartClock>();
 
     // Gateway surface
     app.MapHub<SessionHub>("/hub/session");

--- a/src/Netclaw.Daemon/Services/DaemonStartClock.cs
+++ b/src/Netclaw.Daemon/Services/DaemonStartClock.cs
@@ -1,0 +1,11 @@
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Captures the daemon's logical start time once at construction.
+/// Register as a singleton and eagerly resolve so the timestamp
+/// reflects actual startup, not first-request time.
+/// </summary>
+public sealed class DaemonStartClock(TimeProvider timeProvider)
+{
+    public DateTimeOffset StartedAt { get; } = timeProvider.GetUtcNow();
+}

--- a/src/Netclaw.Daemon/Services/PidFileService.cs
+++ b/src/Netclaw.Daemon/Services/PidFileService.cs
@@ -12,14 +12,14 @@ public sealed class PidFileService : IHostedService
 {
     private readonly NetclawPaths _paths;
     private readonly DaemonRestartSignal _restartSignal;
-    private readonly TimeProvider _timeProvider;
+    private readonly DaemonStartClock _startClock;
     private readonly ILogger<PidFileService> _logger;
 
-    public PidFileService(NetclawPaths paths, DaemonRestartSignal restartSignal, TimeProvider timeProvider, ILogger<PidFileService> logger)
+    public PidFileService(NetclawPaths paths, DaemonRestartSignal restartSignal, DaemonStartClock startClock, ILogger<PidFileService> logger)
     {
         _paths = paths;
         _restartSignal = restartSignal;
-        _timeProvider = timeProvider;
+        _startClock = startClock;
         _logger = logger;
     }
 
@@ -28,7 +28,7 @@ public sealed class PidFileService : IHostedService
         _paths.EnsureDirectoriesExist();
 
         var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        var startedAt = _timeProvider.GetUtcNow().ToString("o", CultureInfo.InvariantCulture);
+        var startedAt = _startClock.StartedAt.ToString("o", CultureInfo.InvariantCulture);
         File.WriteAllText(_paths.PidFilePath, $"{pid}\n{startedAt}");
         _logger.LogDebug("Wrote daemon PID file: {PidFilePath} -> {Pid}", _paths.PidFilePath, pid);
 


### PR DESCRIPTION
## Summary

- `DaemonRuntimeStatusService` and `DaemonStatsService` each independently captured `_startedAt` in their constructors, but .NET DI instantiates singletons lazily on first resolution — so each service's start time was set when its endpoint was first hit, not at daemon startup
- `netclaw status` and `netclaw stats` reported different uptimes depending on when each was first called
- Introduces `DaemonStartClock` as the single canonical source of daemon start time, eagerly resolved after `Build()`, and injected into both status services and `PidFileService`

## Test plan

- [x] `DaemonRuntimeStatusServiceTests` pass (6 tests)
- [x] `PidFileServiceTests` pass (3 tests)
- [x] Full solution build succeeds with zero warnings
- [ ] CI passes