### PR TITLE
perf(providers): fix O(n²) ToolCallTextFilter scanning during streaming

### DIFF
--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -332,24 +332,84 @@ data: [DONE]
         Assert.False(filter.ShouldSuppress("Hello "));
         Assert.False(filter.IsActive);
 
-        Assert.True(filter.ShouldSuppress("Hello <tool_call><function=test>"));
+        // Delta containing the marker triggers suppression
+        Assert.True(filter.ShouldSuppress("<tool_call><function=test>"));
         Assert.True(filter.IsActive);
 
-        // Subsequent calls are also suppressed
-        Assert.True(filter.ShouldSuppress("Hello <tool_call><function=test></function></tool_call>"));
+        // Subsequent deltas are also suppressed
+        Assert.True(filter.ShouldSuppress("</function></tool_call>"));
     }
 
     [Fact]
     public void ToolCallTextFilter_ReturnsCleanedText()
     {
         var filter = new OpenAiCompatibleChatClient.ToolCallTextFilter();
-        var fullText = "Preamble text <tool_call><function=search><parameter=Query>test</parameter></function></tool_call> Done";
+        var accumulatedText = new StringBuilder();
 
-        filter.ShouldSuppress(fullText);
+        var delta1 = "Preamble text ";
+        accumulatedText.Append(delta1);
+        filter.ShouldSuppress(delta1);
 
-        var cleaned = filter.GetCleanedText();
+        var delta2 = "<tool_call><function=search><parameter=Query>test</parameter></function></tool_call> Done";
+        accumulatedText.Append(delta2);
+        filter.ShouldSuppress(delta2);
+
+        var cleaned = OpenAiCompatibleChatClient.ToolCallTextFilter.GetCleanedText(accumulatedText);
         Assert.Contains("Preamble text", cleaned, StringComparison.Ordinal);
         Assert.DoesNotContain("<tool_call>", cleaned, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToolCallTextFilter_DetectsMarkerSplitAcrossTwoDeltas()
+    {
+        var filter = new OpenAiCompatibleChatClient.ToolCallTextFilter();
+
+        Assert.False(filter.ShouldSuppress("some text <tool_"));
+        Assert.False(filter.IsActive);
+
+        // Second delta completes the marker
+        Assert.True(filter.ShouldSuppress("call><function=test>"));
+        Assert.True(filter.IsActive);
+    }
+
+    [Fact]
+    public void ToolCallTextFilter_DetectsMarkerSplitAcrossManySmallDeltas()
+    {
+        var filter = new OpenAiCompatibleChatClient.ToolCallTextFilter();
+        var marker = "<tool_call";
+
+        // Feed marker one character at a time
+        for (var i = 0; i < marker.Length - 1; i++)
+        {
+            Assert.False(filter.ShouldSuppress(marker[i].ToString()));
+            Assert.False(filter.IsActive);
+        }
+
+        // Last character completes the marker
+        Assert.True(filter.ShouldSuppress(marker[^1].ToString()));
+        Assert.True(filter.IsActive);
+    }
+
+    [Fact]
+    public void ToolCallTextFilter_HandlesEmptyDeltas()
+    {
+        var filter = new OpenAiCompatibleChatClient.ToolCallTextFilter();
+
+        Assert.False(filter.ShouldSuppress(""));
+        Assert.False(filter.ShouldSuppress("Hello "));
+        Assert.False(filter.ShouldSuppress(""));
+        Assert.False(filter.ShouldSuppress(""));
+        Assert.True(filter.ShouldSuppress("<tool_call>"));
+        Assert.True(filter.IsActive);
+    }
+
+    [Fact]
+    public void ToolCallTextFilter_MarkerAtStartOfStream()
+    {
+        var filter = new OpenAiCompatibleChatClient.ToolCallTextFilter();
+
+        Assert.True(filter.ShouldSuppress("<tool_call><function=foo>"));
+        Assert.True(filter.IsActive);
     }
 
     [Fact]

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -79,8 +79,13 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             using var document = JsonDocument.Parse(ssePayload);
             foreach (var update in ParseStreamingUpdates(document.RootElement, pendingToolCalls))
             {
+                var suppressThisUpdate = false;
                 foreach (var tc in update.Contents.OfType<TextContent>())
+                {
                     accumulatedText.Append(tc.Text);
+                    if (filter.ShouldSuppress(tc.Text))
+                        suppressThisUpdate = true;
+                }
 
                 if (update.Contents.OfType<FunctionCallContent>().Any())
                     hadStructuredToolCalls = true;
@@ -89,8 +94,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                     finalUpdate = update;
 
                 // Suppress text updates that contain tool call XML
-                if (update.Contents.OfType<TextContent>().Any()
-                    && filter.ShouldSuppress(accumulatedText.ToString()))
+                if (suppressThisUpdate)
                     continue;
 
                 yield return update;
@@ -108,7 +112,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             if (textToolCalls.Count > 0)
             {
                 // Emit any cleaned non-tool-call text that was suppressed
-                var cleaned = filter.GetCleanedText();
+                var cleaned = ToolCallTextFilter.GetCleanedText(accumulatedText);
                 if (!string.IsNullOrWhiteSpace(cleaned))
                 {
                     yield return new ChatResponseUpdate(ChatRole.Assistant, [new TextContent(cleaned)]);
@@ -635,23 +639,50 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
 
     internal sealed class ToolCallTextFilter
     {
-        private bool _suppressionActive;
-        private readonly StringBuilder _suppressedText = new();
+        private const string Marker = "<tool_call";
+        private const int OverlapSize = 9; // Marker.Length - 1
 
-        public bool ShouldSuppress(string accumulatedText)
+        private bool _suppressionActive;
+        private readonly char[] _overlap = new char[OverlapSize];
+        private int _overlapLength;
+
+        /// <summary>
+        /// Checks whether the given delta text (newest chunk only) should be suppressed.
+        /// Uses a small overlap buffer to detect the marker split across delta boundaries.
+        /// </summary>
+        public bool ShouldSuppress(string? delta)
         {
             if (_suppressionActive)
+                return true;
+
+            if (string.IsNullOrEmpty(delta))
+                return false;
+
+            // Search window = overlap tail from previous delta(s) + current delta
+            int windowLength = _overlapLength + delta.Length;
+            Span<char> window = windowLength <= 256
+                ? stackalloc char[windowLength]
+                : new char[windowLength];
+
+            _overlap.AsSpan(0, _overlapLength).CopyTo(window);
+            delta.AsSpan().CopyTo(window[_overlapLength..]);
+
+            if (window.IndexOf(Marker.AsSpan()) >= 0)
             {
-                _suppressedText.Clear();
-                _suppressedText.Append(accumulatedText);
+                _suppressionActive = true;
                 return true;
             }
 
-            if (accumulatedText.Contains("<tool_call", StringComparison.Ordinal))
+            // Retain the last OverlapSize chars for cross-boundary detection
+            if (windowLength >= OverlapSize)
             {
-                _suppressionActive = true;
-                _suppressedText.Append(accumulatedText);
-                return true;
+                window[(windowLength - OverlapSize)..].CopyTo(_overlap);
+                _overlapLength = OverlapSize;
+            }
+            else
+            {
+                window[..windowLength].CopyTo(_overlap);
+                _overlapLength = windowLength;
             }
 
             return false;
@@ -659,7 +690,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
 
         public bool IsActive => _suppressionActive;
 
-        public string GetCleanedText()
-            => TextToolCallParser.StripToolCallText(_suppressedText.ToString());
+        public static string GetCleanedText(StringBuilder accumulatedText)
+            => TextToolCallParser.StripToolCallText(accumulatedText.ToString());
     }
 }


### PR DESCRIPTION
## Summary

Closes #454

- Replace full-text rescanning in `ToolCallTextFilter.ShouldSuppress()` with incremental delta-based detection using a 9-char overlap buffer
- Eliminate redundant `_suppressedText` StringBuilder — `GetCleanedText` is now static and accepts the caller's `accumulatedText`
- Per-delta work drops from O(accumulated_length) to O(delta_length + 9) with zero heap allocations (stackalloc)

## Test plan

- [x] Existing `ToolCallTextFilter_SuppressesOnToolCallTag` updated to pass deltas
- [x] Existing `ToolCallTextFilter_ReturnsCleanedText` updated for static `GetCleanedText`
- [x] New: `DetectsMarkerSplitAcrossTwoDeltas` — marker split across 2 deltas
- [x] New: `DetectsMarkerSplitAcrossManySmallDeltas` — marker fed char-by-char (10 deltas)
- [x] New: `HandlesEmptyDeltas` — empty strings interspersed with content
- [x] New: `MarkerAtStartOfStream` — first delta starts with `<tool_call`
- [x] E2E `StreamingSuppressesToolCallXml_WhenModelEmitsTextToolCalls` passes unchanged