### PR TITLE
fix(security): enforce HTTPS by default in web_fetch tool

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Tools;
@@ -273,7 +274,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient, _tempDir);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
 
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?> { ["Url"] = "https://example.com/test" },
@@ -313,7 +314,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient, _tempDir);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
 
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?> { ["Url"] = "https://example.com/test", ["Format"] = "text" },
@@ -344,7 +345,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(html, "text/html");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient, _tempDir);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
 
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?> { ["Url"] = "https://example.com/page" },
@@ -367,7 +368,7 @@ public class WebFetchToolTests : IDisposable
 
         var handler = new FakeHttpHandler(json, "application/json");
         var httpClient = new HttpClient(handler);
-        var tool = new WebFetchTool(httpClient, _tempDir);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
 
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?> { ["Url"] = "https://api.example.com/data" },
@@ -393,6 +394,109 @@ public class WebFetchToolTests : IDisposable
 
         Assert.Contains("Error", result);
         Assert.Contains("Invalid URL", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_rejects_http_when_https_required()
+    {
+        var tool = new WebFetchTool(fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://example.com/page" },
+            CancellationToken.None);
+
+        Assert.Contains("HTTPS is required", result);
+        Assert.Contains("Tools.WebFetch.RequireHttps", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_allows_http_when_not_required()
+    {
+        var config = new ToolConfig { WebFetch = new WebFetchConfig { RequireHttps = false } };
+        var handler = new FakeHttpHandler("<html><body><p>OK</p></body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(config, httpClient, _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://example.com/page" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_allows_http_localhost_by_default()
+    {
+        var handler = new FakeHttpHandler("<html><body><p>Local</p></body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://localhost:8080/api" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_allows_http_127_0_0_1_by_default()
+    {
+        var handler = new FakeHttpHandler("<html><body><p>Loopback</p></body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://127.0.0.1:3000/" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_allows_http_ipv6_loopback_by_default()
+    {
+        var handler = new FakeHttpHandler("<html><body><p>IPv6</p></body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://[::1]:5000/" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.DoesNotContain("Error", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_rejects_http_localhost_when_not_in_allow_list()
+    {
+        var config = new ToolConfig { WebFetch = new WebFetchConfig { HttpAllowList = [] } };
+        var tool = new WebFetchTool(config, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://localhost:8080/" },
+            CancellationToken.None);
+
+        Assert.Contains("HTTPS is required", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_allows_http_for_custom_allow_list_host()
+    {
+        var config = new ToolConfig { WebFetch = new WebFetchConfig { HttpAllowList = ["internal.corp"] } };
+        var handler = new FakeHttpHandler("<html><body><p>Internal</p></body></html>", "text/html");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(config, httpClient, _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "http://internal.corp/api" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.DoesNotContain("Error", result);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -31,7 +31,7 @@ public static class ToolRegistrationExtensions
         registry.Register(new AttachFileTool(config));
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));
-        registry.Register(new WebFetchTool());
+        registry.Register(new WebFetchTool(config));
 
         // Register search_tools meta-tool (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry, toolAccessPolicy));

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Net;
 using System.Text;
 using HtmlAgilityPack;
+using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
@@ -28,6 +29,7 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     ];
 
+    private readonly WebFetchConfig _webFetchConfig;
     private readonly HttpClient _httpClient;
     private readonly string _fetchDirectory;
     private readonly TimeProvider _timeProvider;
@@ -38,13 +40,20 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         [property: Description("Output format: 'raw' (default) preserves HTML structure (links, images, tables); 'text' extracts plain text only")]
         string? Format = null);
 
-    public WebFetchTool(HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
+    public WebFetchTool(ToolConfig config, HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
     {
+        _webFetchConfig = config.WebFetch;
         _httpClient = httpClient ?? new HttpClient();
         _fetchDirectory = fetchDirectory
             ?? Path.Combine(Path.GetTempPath(), "netclaw-fetch");
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
+
+    /// <summary>
+    /// Test convenience constructor — uses default config.
+    /// </summary>
+    public WebFetchTool(HttpClient? httpClient = null, string? fetchDirectory = null, TimeProvider? timeProvider = null)
+        : this(new ToolConfig(), httpClient, fetchDirectory, timeProvider) { }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
         => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
@@ -57,6 +66,15 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         if (!Uri.TryCreate(args.Url, UriKind.Absolute, out var uri)
             || uri.Scheme is not ("http" or "https"))
             return "Error: Invalid URL. Must be an absolute HTTP or HTTPS URL.";
+
+        if (_webFetchConfig.RequireHttps
+            && uri.Scheme == "http"
+            && !_webFetchConfig.HttpAllowList.Any(h => h.Equals(uri.Host, StringComparison.OrdinalIgnoreCase)))
+        {
+            return $"Error: HTTPS is required by security policy. The URL '{args.Url}' uses plain HTTP. "
+                 + "Use https:// instead, or ask the operator to add the host to Tools.WebFetch.HttpAllowList "
+                 + "or set Tools.WebFetch.RequireHttps to false in the configuration.";
+        }
 
         try
         {

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -234,6 +234,23 @@
         },
         "AudienceProfiles": {
           "$ref": "#/$defs/ToolAudienceProfiles"
+        },
+        "WebFetch": {
+          "type": "object",
+          "properties": {
+            "RequireHttps": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, web_fetch rejects plain HTTP URLs unless the host is in HttpAllowList."
+            },
+            "HttpAllowList": {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": ["localhost", "127.0.0.1", "::1", "[::1]"],
+              "description": "Hosts allowed to use plain HTTP when RequireHttps is true. Default includes loopback addresses."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/Netclaw.Configuration/ToolConfig.cs
+++ b/src/Netclaw.Configuration/ToolConfig.cs
@@ -9,4 +9,5 @@ public sealed class ToolConfig
     public int ShellTimeoutSeconds { get; set; } = 60;
     public int MaxOutputChars { get; set; } = 32_000;
     public ToolAudienceProfiles AudienceProfiles { get; set; } = new();
+    public WebFetchConfig WebFetch { get; set; } = new();
 }

--- a/src/Netclaw.Configuration/WebFetchConfig.cs
+++ b/src/Netclaw.Configuration/WebFetchConfig.cs
@@ -1,0 +1,18 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for the web_fetch tool's HTTP/HTTPS policy.
+/// </summary>
+public sealed class WebFetchConfig
+{
+    /// <summary>
+    /// When true, web_fetch rejects plain HTTP URLs unless the host is in <see cref="HttpAllowList"/>.
+    /// </summary>
+    public bool RequireHttps { get; set; } = true;
+
+    /// <summary>
+    /// Hosts allowed to use plain HTTP when <see cref="RequireHttps"/> is true.
+    /// Default includes loopback addresses (localhost, 127.0.0.1, ::1).
+    /// </summary>
+    public List<string> HttpAllowList { get; set; } = ["localhost", "127.0.0.1", "::1", "[::1]"];
+}


### PR DESCRIPTION
## Summary

- **web_fetch now rejects plain HTTP URLs by default** to prevent MITM content injection attacks against the autonomous agent
- Adds `Tools.WebFetch` config section with `RequireHttps` (bool, default `true`) and `HttpAllowList` (string[], default loopback addresses)
- Localhost/loopback (`localhost`, `127.0.0.1`, `::1`) are exempt from HTTPS enforcement by default since traffic never leaves the machine
- Error messages guide the LLM to either use `https://` or request an operator config change

## Security Rationale

Plain HTTP fetches are vulnerable to man-in-the-middle content injection. For an autonomous agent that acts on fetched content without human review, a tampered response could influence agent decisions. This matches the HTTPS-only approach used by Claude Code's WebFetch tool.

## Config Examples

```jsonc
// Default: HTTPS enforced, loopback exempt
{ "Tools": {} }

// Add an internal host
{ "Tools": { "WebFetch": { "HttpAllowList": ["localhost", "127.0.0.1", "::1", "[::1]", "internal.mycompany.com"] } } }

// Allow all HTTP (disable enforcement)
{ "Tools": { "WebFetch": { "RequireHttps": false } } }

// Strict: no HTTP at all, not even localhost
{ "Tools": { "WebFetch": { "HttpAllowList": [] } } }
```

## Test plan

- [x] `dotnet build` passes (daemon + test projects)
- [x] All 30 WebFetchTool tests pass (23 existing + 7 new)
- [x] HTTP URL rejected with default config
- [x] HTTP allowed when `RequireHttps = false`
- [x] HTTP localhost/127.0.0.1/[::1] allowed by default
- [x] HTTP localhost rejected when `HttpAllowList = []`
- [x] Custom allow-list hosts work
- [x] Schema updated with `additionalProperties: false`