### PR TITLE
fix(tools): web_fetch saves binary content with correct extension and raw bytes

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -362,9 +362,31 @@ public class WebFetchToolTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_saves_plain_text_as_is()
+    public async Task ExecuteAsync_saves_json_with_json_extension()
     {
         var json = """{"name": "test", "value": 42}""";
+
+        var handler = new FakeHttpHandler(json, "application/json");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://api.example.com/data.json" },
+            CancellationToken.None);
+
+        Assert.Contains("Saved to:", result);
+
+        var files = Directory.GetFiles(_tempDir, "*.json");
+        Assert.Single(files);
+
+        var fileContent = await File.ReadAllTextAsync(files[0]);
+        Assert.Contains("\"name\": \"test\"", fileContent);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_saves_json_without_url_extension_uses_content_type()
+    {
+        var json = """{"name": "test"}""";
 
         var handler = new FakeHttpHandler(json, "application/json");
         var httpClient = new HttpClient(handler);
@@ -376,11 +398,32 @@ public class WebFetchToolTests : IDisposable
 
         Assert.Contains("Saved to:", result);
 
-        var files = Directory.GetFiles(_tempDir, "*.txt");
+        // Should use .json from Content-Type fallback, not .txt
+        var files = Directory.GetFiles(_tempDir, "*.json");
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_preserves_shell_script_extension()
+    {
+        var script = "#!/bin/bash\necho 'hello world'";
+
+        var handler = new FakeHttpHandler(script, "text/plain");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/install.sh" },
+            CancellationToken.None);
+
+        Assert.Contains("Saved to:", result);
+        Assert.Contains(".sh", result);
+
+        var files = Directory.GetFiles(_tempDir, "*.sh");
         Assert.Single(files);
 
         var fileContent = await File.ReadAllTextAsync(files[0]);
-        Assert.Contains("\"name\": \"test\"", fileContent);
+        Assert.Contains("echo 'hello world'", fileContent);
     }
 
     [Fact]
@@ -500,6 +543,91 @@ public class WebFetchToolTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteAsync_saves_binary_image_with_correct_extension_and_bytes()
+    {
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xFE, 0x00, 0x01 };
+
+        var handler = new FakeHttpHandler(imageBytes, "image/png");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/photo.png" },
+            CancellationToken.None);
+
+        Assert.Contains("Fetched:", result);
+        Assert.Contains(".png", result);
+        Assert.Contains("Content-Type: image/png", result);
+        Assert.Contains("binary file", result);
+        Assert.Contains("attach_file", result);
+
+        var files = Directory.GetFiles(_tempDir, "*.png");
+        Assert.Single(files);
+
+        // Verify byte-perfect round-trip
+        var savedBytes = await File.ReadAllBytesAsync(files[0]);
+        Assert.Equal(imageBytes, savedBytes);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_saves_pdf_with_correct_extension()
+    {
+        // PDF magic bytes
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 };
+
+        var handler = new FakeHttpHandler(pdfBytes, "application/pdf");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://arxiv.org/pdf/2603.25414" },
+            CancellationToken.None);
+
+        Assert.Contains("Content-Type: application/pdf", result);
+
+        // URL has no extension, should fall back to .pdf from Content-Type
+        var files = Directory.GetFiles(_tempDir, "*.pdf");
+        Assert.Single(files);
+
+        var savedBytes = await File.ReadAllBytesAsync(files[0]);
+        Assert.Equal(pdfBytes, savedBytes);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_saves_binary_with_url_extension_over_fallback()
+    {
+        var bytes = new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }; // GIF89a
+
+        var handler = new FakeHttpHandler(bytes, "image/gif");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/animation.gif" },
+            CancellationToken.None);
+
+        var files = Directory.GetFiles(_tempDir, "*.gif");
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_binary_unknown_type_no_url_extension_saves_as_bin()
+    {
+        var bytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+
+        var handler = new FakeHttpHandler(bytes, "application/octet-stream");
+        var httpClient = new HttpClient(handler);
+        var tool = new WebFetchTool(httpClient: httpClient, fetchDirectory: _tempDir);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Url"] = "https://example.com/api/download" },
+            CancellationToken.None);
+
+        var files = Directory.GetFiles(_tempDir, "*.bin");
+        Assert.Single(files);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_rejects_ftp_url()
     {
         var tool = new WebFetchTool(fetchDirectory: _tempDir);
@@ -509,6 +637,48 @@ public class WebFetchToolTests : IDisposable
             CancellationToken.None);
 
         Assert.Contains("Error", result);
+    }
+
+    [Theory]
+    [InlineData("image/png", true)]
+    [InlineData("image/jpeg", true)]
+    [InlineData("image/webp", true)]
+    [InlineData("audio/mpeg", true)]
+    [InlineData("video/mp4", true)]
+    [InlineData("application/pdf", true)]
+    [InlineData("application/zip", true)]
+    [InlineData("application/octet-stream", true)]
+    [InlineData("text/html", false)]
+    [InlineData("text/plain", false)]
+    [InlineData("application/json", false)]
+    [InlineData("", false)]
+    public void IsBinaryContentType_classifies_correctly(string contentType, bool expected)
+    {
+        Assert.Equal(expected, WebFetchTool.IsBinaryContentType(contentType));
+    }
+
+    [Theory]
+    [InlineData("https://example.com/photo.png", ".png")]
+    [InlineData("https://example.com/install.sh", ".sh")]
+    [InlineData("https://example.com/data.json", ".json")]
+    [InlineData("https://example.com/api/data", null)]
+    [InlineData("https://example.com/", null)]
+    [InlineData("https://arxiv.org/pdf/2603.25414", null)] // numeric-only = not a real extension
+    public void GetExtensionFromUrl_extracts_extension(string url, string? expected)
+    {
+        var uri = new Uri(url);
+        Assert.Equal(expected, WebFetchTool.GetExtensionFromUrl(uri));
+    }
+
+    [Theory]
+    [InlineData("application/pdf", true, ".pdf")]
+    [InlineData("application/json", false, ".json")]
+    [InlineData("text/csv", false, ".csv")]
+    [InlineData("image/png", true, ".bin")]
+    [InlineData("text/plain", false, ".txt")]
+    public void GetFallbackExtension_returns_correct_extension(string contentType, bool isBinary, string expected)
+    {
+        Assert.Equal(expected, WebFetchTool.GetFallbackExtension(contentType, isBinary));
     }
 
     private static string LoadFixture(string filename)
@@ -522,25 +692,33 @@ public class WebFetchToolTests : IDisposable
     }
 
     /// <summary>
-    /// Fake HTTP handler that returns a canned response.
+    /// Fake HTTP handler that returns a canned response (text or binary).
     /// </summary>
     private sealed class FakeHttpHandler : HttpMessageHandler
     {
-        private readonly string _content;
+        private readonly byte[] _bytes;
         private readonly string _contentType;
 
         public FakeHttpHandler(string content, string contentType)
         {
-            _content = content;
+            _bytes = Encoding.UTF8.GetBytes(content);
+            _contentType = contentType;
+        }
+
+        public FakeHttpHandler(byte[] bytes, string contentType)
+        {
+            _bytes = bytes;
             _contentType = contentType;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken ct)
         {
+            var content = new ByteArrayContent(_bytes);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
             var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
             {
-                Content = new StringContent(_content, Encoding.UTF8, new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType))
+                Content = content
             };
             return Task.FromResult(response);
         }

--- a/src/Netclaw.Actors/Tools/WebFetchTool.cs
+++ b/src/Netclaw.Actors/Tools/WebFetchTool.cs
@@ -8,14 +8,15 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Tools;
 
 /// <summary>
-/// Fetches a web page and saves its content to a local file.
-/// Default format preserves HTML (links, images, structure); text mode
-/// extracts plain text only. Returns a summary with the file path so the
-/// agent can use file_read or shell_execute (grep) to selectively read
-/// the content without blowing out the context window.
+/// Fetches a URL and saves its content to a local file.
+/// For HTML: default format preserves structure; text mode extracts plain text.
+/// For binary content (images, PDFs, etc.): saves raw bytes with correct extension.
+/// For other text content: saves as-is with the URL's file extension preserved.
+/// Returns a summary with the file path so the agent can use file_read,
+/// grep, or attach_file to work with the content.
 /// </summary>
 [NetclawTool("web_fetch",
-    "Fetch a web page URL and save its content to a local file. Default format='raw' preserves HTML (links, images, structure); format='text' extracts plain text. Returns file path with preview. Use file_read to examine the full content.",
+    "Fetch a URL and save its content to a local file. HTML: format='raw' (default) preserves structure, format='text' extracts plain text. Binary (images, PDFs): saves raw bytes with correct extension. Returns file path with preview. Use file_read to examine content or attach_file to send binary files to the user.",
     Grant = "web")]
 public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
 {
@@ -84,15 +85,28 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             using var response = await _httpClient.SendAsync(request, ct);
             response.EnsureSuccessStatusCode();
 
-            var content = await ReadWithLimitAsync(response, ct);
             var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
+            var fetchDir = context.SessionDirectory ?? _fetchDirectory;
 
-            // Determine format: null or "raw" → raw HTML; "text" → text extraction
+            if (IsBinaryContentType(contentType))
+            {
+                var bytes = await ReadBytesWithLimitAsync(response, ct);
+                if (bytes.Length == 0)
+                    return $"Fetched {args.Url} but the response was empty.";
+
+                var extension = GetExtensionFromUrl(uri)
+                    ?? GetFallbackExtension(contentType, isBinary: true);
+                var filePath = SaveBytesToFile(bytes, uri, fetchDir, extension);
+
+                return FormatBinarySummary(uri.ToString(), filePath, bytes.Length, contentType);
+            }
+
+            var content = await ReadTextWithLimitAsync(response, ct);
             var useTextMode = string.Equals(args.Format, "text", StringComparison.OrdinalIgnoreCase);
 
             string savedContent;
             string title;
-            string extension;
+            string textExtension;
             string previewText;
 
             if (contentType.Contains("html", StringComparison.OrdinalIgnoreCase))
@@ -101,13 +115,13 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
                 if (useTextMode)
                 {
                     savedContent = ExtractTextFromHtml(content);
-                    extension = ".txt";
+                    textExtension = ".txt";
                     previewText = savedContent;
                 }
                 else
                 {
                     savedContent = SanitizeHtml(content);
-                    extension = ".html";
+                    textExtension = ".html";
                     previewText = ExtractMetadataSummary(content);
                 }
             }
@@ -115,22 +129,18 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
             {
                 title = uri.Host;
                 savedContent = content;
-                extension = ".txt";
+                textExtension = GetExtensionFromUrl(uri)
+                    ?? GetFallbackExtension(contentType, isBinary: false);
                 previewText = content;
             }
 
             if (string.IsNullOrWhiteSpace(savedContent))
                 return $"Fetched {args.Url} but the page contained no extractable content.";
 
-            // Use session-scoped directory if available, otherwise fall back to shared temp
-            var fetchDir = context.SessionDirectory ?? _fetchDirectory;
-
-            // Save to disk
-            var filePath = SaveToFile(savedContent, uri, fetchDir, extension);
+            var textFilePath = SaveToFile(savedContent, uri, fetchDir, textExtension);
             var lineCount = savedContent.Count(c => c == '\n') + 1;
 
-            // Build summary with preview
-            return FormatSummary(uri.ToString(), title, filePath, savedContent.Length, lineCount, previewText);
+            return FormatSummary(uri.ToString(), title, textFilePath, savedContent.Length, lineCount, previewText);
         }
         catch (HttpRequestException ex)
         {
@@ -142,24 +152,73 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         }
     }
 
-    private static async Task<string> ReadWithLimitAsync(HttpResponseMessage response, CancellationToken ct)
+    internal static bool IsBinaryContentType(string contentType)
+        => contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+        || contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase)
+        || contentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase)
+        || contentType is "application/pdf" or "application/zip"
+            or "application/gzip" or "application/octet-stream";
+
+    /// <summary>
+    /// Extract file extension from the URL path (e.g., /photo.png → .png).
+    /// Returns null if the URL has no recognizable extension.
+    /// Filters out numeric-only "extensions" like .25414 (version numbers, IDs).
+    /// </summary>
+    internal static string? GetExtensionFromUrl(Uri uri)
     {
-        // Read up to MaxResponseBytes to avoid memory issues
-        var stream = await response.Content.ReadAsStreamAsync(ct);
-        using var limited = new BinaryReader(stream);
-        var bytes = limited.ReadBytes(MaxResponseBytes);
-        return Encoding.UTF8.GetString(bytes);
+        var ext = Path.GetExtension(uri.AbsolutePath);
+        if (string.IsNullOrEmpty(ext))
+            return null;
+
+        // Filter out numeric-only extensions (e.g., .25414 from arxiv URLs)
+        if (ext.Length > 1 && ext.AsSpan(1).IndexOfAnyExceptInRange('0', '9') < 0)
+            return null;
+
+        return ext;
     }
 
-    private string SaveToFile(string content, Uri uri, string directory, string extension = ".txt")
+    /// <summary>
+    /// Fallback extension when the URL has no file extension.
+    /// Covers common Content-Types; defaults to .bin (binary) or .txt (text).
+    /// </summary>
+    internal static string GetFallbackExtension(string contentType, bool isBinary) => contentType switch
+    {
+        "application/pdf" => ".pdf",
+        "application/json" => ".json",
+        "text/csv" => ".csv",
+        "text/html" => ".html",
+        "text/markdown" => ".md",
+        _ => isBinary ? ".bin" : ".txt"
+    };
+
+    private static async Task<string> ReadTextWithLimitAsync(HttpResponseMessage response, CancellationToken ct)
+        => Encoding.UTF8.GetString(await ReadBytesWithLimitAsync(response, ct));
+
+    private static async Task<byte[]> ReadBytesWithLimitAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var limited = new BinaryReader(stream);
+        return limited.ReadBytes(MaxResponseBytes);
+    }
+
+    private string BuildFilePath(Uri uri, string directory, string extension)
     {
         Directory.CreateDirectory(directory);
-
-        // Generate a filename from the URL host + path + timestamp
         var sanitized = SanitizeForFilename(uri);
         var filename = $"{sanitized}-{_timeProvider.GetUtcNow().ToUnixTimeSeconds()}{extension}";
-        var filePath = Path.Combine(directory, filename);
+        return Path.Combine(directory, filename);
+    }
 
+    private string SaveBytesToFile(byte[] content, Uri uri, string directory, string extension)
+    {
+        var filePath = BuildFilePath(uri, directory, extension);
+        File.WriteAllBytes(filePath, content);
+        return filePath;
+    }
+
+    private string SaveToFile(string content, Uri uri, string directory, string extension)
+    {
+        var filePath = BuildFilePath(uri, directory, extension);
         File.WriteAllText(filePath, content, Encoding.UTF8);
         return filePath;
     }
@@ -186,6 +245,18 @@ public sealed partial class WebFetchTool : NetclawTool<WebFetchTool.Params>
         if (lines.Length > PreviewLines)
             sb.AppendLine($"... ({lines.Length - PreviewLines} more lines — use file_read or grep to search)");
 
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatBinarySummary(
+        string url, string filePath, int byteCount, string contentType)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Fetched: {url}");
+        sb.AppendLine($"Saved to: {filePath} ({byteCount:N0} bytes)");
+        sb.AppendLine($"Content-Type: {contentType}");
+        sb.AppendLine();
+        sb.AppendLine("This is a binary file. Use attach_file to send it to the user, or file_read if the format supports text extraction.");
         return sb.ToString().TrimEnd();
     }
 


### PR DESCRIPTION
## Summary

Fixes #386 — `web_fetch` was reading all HTTP responses as UTF-8 strings and saving non-HTML content with `.txt` extension. Binary files (images, PDFs) were mangled, breaking the `attach_file` workflow for Slack delivery.

- Add binary content detection via `Content-Type` header (`image/*`, `audio/*`, `video/*`, `application/pdf`, etc.) with raw `byte[]` save path
- Use URL path extension first (`.png`, `.sh`, `.json`), fall back to `Content-Type` mapping only when URL has no extension
- Filter out numeric-only "extensions" like `.25414` (arxiv version IDs)
- Extract shared `BuildFilePath` helper to deduplicate save methods
- Have `ReadTextWithLimitAsync` delegate to `ReadBytesWithLimitAsync`

## Test plan

- [x] Binary image round-trip: PNG bytes saved with `.png` extension, byte-perfect verification
- [x] PDF with no URL extension: falls back to `.pdf` from Content-Type
- [x] JSON/shell script: URL extension (`.json`, `.sh`) preserved instead of `.txt`
- [x] Unknown binary with no URL extension: saves as `.bin`
- [x] Theory tests for `IsBinaryContentType`, `GetExtensionFromUrl`, `GetFallbackExtension`
- [x] All 59 existing + new tests pass
- [x] No new slopwatch violations