### PR TITLE
feat(memory): add turn-based distillation trigger alongside idle timeout

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -219,6 +219,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         _compactionClient,
                         TimeSpan.FromSeconds(Math.Max(10, _config.MemoryObserverIdleSeconds)),
                         distillationTimeout,
+                        _config.Tuning.MemoryDistillationTurnInterval,
                         _timeProvider),
                     "memory-observer");
             }

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -33,6 +33,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     private readonly IChatClient _client;
     private readonly TimeSpan _idleTimeout;
     private readonly TimeSpan _sidecarTimeout;
+    private readonly int _distillTurnInterval;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
@@ -45,6 +46,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     private DistillationRunState? _activeRun;
     private PendingPassivationRequest? _pendingPassivation;
     private int _turnCount;
+    private int _turnsSinceLastDistill;
 
     public override string PersistenceId { get; }
 
@@ -53,20 +55,23 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         IChatClient client,
         TimeSpan idleTimeout,
         TimeSpan sidecarTimeout,
+        int distillTurnInterval = 0,
         TimeProvider? timeProvider = null) =>
-        Props.Create(() => new SessionMemoryObserverActor(sessionId, client, idleTimeout, sidecarTimeout, timeProvider));
+        Props.Create(() => new SessionMemoryObserverActor(sessionId, client, idleTimeout, sidecarTimeout, distillTurnInterval, timeProvider));
 
     public SessionMemoryObserverActor(
         SessionId sessionId,
         IChatClient client,
         TimeSpan idleTimeout,
         TimeSpan sidecarTimeout,
+        int distillTurnInterval = 0,
         TimeProvider? timeProvider = null)
     {
         _sessionId = sessionId;
         _client = client;
         _idleTimeout = idleTimeout;
         _sidecarTimeout = sidecarTimeout;
+        _distillTurnInterval = distillTurnInterval;
         _timeProvider = timeProvider ?? TimeProvider.System;
 
         PersistenceId = $"memory-observer-{sessionId.Value}";
@@ -99,7 +104,19 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                 AppendTranscriptLine(line);
 
             if (msg is TurnCompleted tc && tc.Outcome != TurnOutcome.Skipped)
+            {
                 _turnCount = tc.TurnNumber;
+                _turnsSinceLastDistill++;
+
+                if (_distillTurnInterval > 0 && _hasNewContent && !_draining
+                    && _turnsSinceLastDistill >= _distillTurnInterval)
+                {
+                    _log.Info(
+                        "session_observer_turn_trigger turns_since_last={TurnsSince} interval={Interval}",
+                        _turnsSinceLastDistill, _distillTurnInterval);
+                    TriggerDistillation(Context.Parent, replyWhenNoWork: false);
+                }
+            }
         });
 
         Command<ReceiveTimeout>(_ => TriggerDistillation(Context.Parent, replyWhenNoWork: false));
@@ -161,6 +178,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     {
         var run = new DistillationRunState(++_nextRunId, _contentVersion, replyTo);
         _activeRun = run;
+        _turnsSinceLastDistill = 0;
 
         _ = RunDistillationAsync(
             _client,

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -189,7 +189,8 @@
             "KeepRecentMessages": { "type": "integer", "minimum": 1 },
             "TitleGenerationInterval": { "type": "integer", "minimum": 0 },
             "MemorySidecarsEnabled": { "type": "boolean" },
-            "DeterministicRetrievalEnabled": { "type": "boolean" }
+            "DeterministicRetrievalEnabled": { "type": "boolean" },
+            "MemoryDistillationTurnInterval": { "type": "integer", "minimum": 0 }
           },
           "additionalProperties": false
         }

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -128,6 +128,7 @@ public sealed record SessionConfig
             TitleGenerationInterval = ResolveValue(tuningSection, section, nameof(SessionTuning.TitleGenerationInterval), nested.TitleGenerationInterval),
             MemorySidecarsEnabled = ResolveValue(tuningSection, section, nameof(SessionTuning.MemorySidecarsEnabled), nested.MemorySidecarsEnabled),
             DeterministicRetrievalEnabled = ResolveValue(tuningSection, section, nameof(SessionTuning.DeterministicRetrievalEnabled), nested.DeterministicRetrievalEnabled),
+            MemoryDistillationTurnInterval = ResolveValue(tuningSection, section, nameof(SessionTuning.MemoryDistillationTurnInterval), nested.MemoryDistillationTurnInterval),
         };
     }
 

--- a/src/Netclaw.Configuration/SessionTuning.cs
+++ b/src/Netclaw.Configuration/SessionTuning.cs
@@ -73,4 +73,13 @@ public sealed record SessionTuning
     /// memory recall on each turn. Scheduled for removal — always true in production.
     /// </summary>
     public bool DeterministicRetrievalEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Number of completed turns between memory distillation triggers.
+    /// When set, the observer distills every N turns regardless of idle state,
+    /// ensuring memories form during long active sessions (e.g., 25-turn tool loops).
+    /// The idle timeout (<see cref="SessionConfig.MemoryObserverIdleSeconds"/>) remains
+    /// active as a fallback for partial-turn content. Set to 0 to disable.
+    /// </summary>
+    public int MemoryDistillationTurnInterval { get; init; } = 5;
 }


### PR DESCRIPTION
## Summary

Closes #442

- Adds `MemoryDistillationTurnInterval` tuning property (default 5) to trigger memory distillation every N completed turns, regardless of idle state
- Busy sessions with long tool loops (e.g., 25-turn scanner iterations) now form memories during active use instead of waiting for 90s of silence
- The idle timeout (`MemoryObserverIdleSeconds`) remains as a fallback for partial-turn content
- Set to 0 to disable turn-based triggering

## Test plan

- [x] All existing observer, distillation, watchdog, and config tests pass (128 tests)
- [x] Build succeeds with zero warnings
- [ ] Manual: run a multi-turn tool loop session and verify distillation fires mid-session (check logs for `session_observer_turn_trigger`)
- [ ] Manual: verify idle-timeout distillation still fires when session goes quiet between turn triggers