### PR TITLE
fix(daemon): drain active sessions before config restart

### DIFF
--- a/docs/prd/PRD-001-netclaw-mvp.md
+++ b/docs/prd/PRD-001-netclaw-mvp.md
@@ -271,21 +271,20 @@ Before context compaction occurs, Netclaw shall trigger a silent agentic turn
 prompting the model to write durable memories to disk. This directly counters
 context rot — losing important information when context resets. See PRD-007.
 
-### FR-016 Config Hot-Reload
+### FR-016 Config Change Restart Coordination
 
-Netclaw shall monitor operational configuration files for changes and apply
-updates without process restart:
+Netclaw shall monitor operational configuration files for changes and validate
+them before they affect runtime behavior.
 
-- **Watched files** (hot-reloaded): ACL rules, provider config, MCP profiles,
-  schedule definitions
-- **Unwatched files** (require restart or session reboot): personality files,
-  project registry, environment inventory
+- **Watched files**: operational daemon config written to `netclaw.json`
+- **Session-scoped files** (require session reboot or fresh turn context):
+  personality files, project registry, environment inventory
 
-Mechanism: `FileSystemWatcher` + 500ms debounce + validate-before-apply.
-Invalid config changes SHALL be rejected with logged diagnostics. Valid changes
-SHALL notify owning actors (ACL changes → policy engine refresh, provider
-changes → `IChatClient` rebuild, MCP changes → reconnect/disconnect servers,
-schedule changes → timer reconfiguration).
+Mechanism: `FileSystemWatcher` + 500ms debounce + validate-before-restart.
+Invalid config changes SHALL be rejected with logged diagnostics and SHALL keep
+the current daemon instance running. Valid changes SHALL trigger coordinated
+daemon restart: close new ingress, drain active sessions, restart, relaunch the
+sessions that were active, and resume from the last durable checkpoint.
 
 ## Operational Requirements
 

--- a/docs/spec/SPEC-011-daemon-architecture.md
+++ b/docs/spec/SPEC-011-daemon-architecture.md
@@ -45,7 +45,7 @@ Netclaw.Daemon Process
 │   ├── Slack Socket Mode
 │   └── Internal Timer
 │
-├── ConfigWatcherService (FileSystemWatcher hot-reload)
+├── ConfigWatcherService + RestartCoordinator (FileSystemWatcher restart coordination)
 └── ISystemPromptProvider (layered soul files)
 ```
 
@@ -267,27 +267,36 @@ works for:
 The TUI is a presentation layer — it renders tool call/result output but does
 not execute tools.
 
-## Configuration Hot-Reload
+## Configuration Restart Coordination
 
 ### Trigger
 
 `FileSystemWatcher` on `~/.netclaw/config/` monitors for changes to
-`netclaw.json` and `secrets.json`.
+`netclaw.json`.
 
 ### Behavior
 
 1. File change event received
 2. 500ms debounce timer started (reset on additional events)
 3. After debounce: read and validate new configuration
-4. **Valid config**: rebuild `IChatClientProvider`, notify actor system
-5. **Invalid config**: log warning with validation errors, preserve previous config
+4. **Valid config**: close daemon-managed ingress, enumerate live session actors,
+   ask them to drain, persist a restart manifest, and request coordinated
+   daemon restart
+5. **After restart**: warm the sessions that were active when restart began and
+   inject a continuity notice for the next turn
+6. **Invalid config**: log warning with validation errors, preserve previous config
 
-### What Reloads
+### What Changes Take Effect After Restart
 
 - Provider credentials and endpoints
 - Model selections (main, fallback, compaction)
 - Session parameters (compaction threshold, tool iteration limits)
 - Tool configuration (shell timeout, output limits)
+
+### What Still Requires Manual Session Resume Or Reconnect
+
+- Live transport connections, SignalR sockets, and Slack delivery handles
+- New inbound work that arrives after restart drain begins
 
 ### What Does Not Reload (requires restart)
 

--- a/openspec/changes/graceful-config-restart-drain/tasks.md
+++ b/openspec/changes/graceful-config-restart-drain/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Restart coordination
 
-- [ ] 1.1 Add a daemon restart coordinator plus ingress gate and route `ConfigWatcherService` through it instead of calling `StopApplication()` directly.
-- [ ] 1.2 Persist a restart manifest for the active-session set captured after ingress closes, and raise the host shutdown budget so drain has enough time to finish.
+- [x] 1.1 Add a daemon restart coordinator plus ingress gate and route `ConfigWatcherService` through it instead of calling `StopApplication()` directly.
+- [x] 1.2 Persist a restart manifest for the active-session set captured after ingress closes, and raise the host shutdown budget so drain has enough time to finish.
 
 ## 2. Session drain behavior
 
-- [ ] 2.1 Add a restart-specific drain message path to `LlmSessionActor` that keeps idle passivation behavior separate from config-triggered restart drain.
-- [ ] 2.2 Make ready sessions passivate immediately, let processing/compacting sessions finish or fail their in-flight work within the drain window, and stop from the last durable checkpoint on timeout.
-- [ ] 2.3 Return a restart-in-progress rejection for new `SendUserMessage` and retry-inducing delivery feedback once restart drain has begun.
+- [x] 2.1 Add a restart-specific drain message path to `LlmSessionActor` that keeps idle passivation behavior separate from config-triggered restart drain.
+- [x] 2.2 Make ready sessions passivate immediately, let processing/compacting sessions finish or fail their in-flight work within the drain window, and stop from the last durable checkpoint on timeout.
+- [x] 2.3 Return a restart-in-progress rejection for new `SendUserMessage` and retry-inducing delivery feedback once restart drain has begun.
 
 ## 3. Startup recovery
 
-- [ ] 3.1 Add a startup recovery hosted service that reads the restart manifest, rewarms the previously active sessions through the session manager, and clears the manifest after recovery.
-- [ ] 3.2 Inject a transient restart continuity notice into warmed sessions so the next turn explains recovery from the last durable checkpoint.
+- [x] 3.1 Add a startup recovery hosted service that reads the restart manifest, rewarms the previously active sessions through the session manager, and clears the manifest after recovery.
+- [x] 3.2 Inject a transient restart continuity notice into warmed sessions so the next turn explains recovery from the last durable checkpoint.
 
 ## 4. Adapter and lifecycle integration
 
-- [ ] 4.1 Update daemon-managed ingress paths so Slack, SignalR, and other adapter entry points reject new work consistently while restart drain is active.
-- [ ] 4.2 Ensure lifecycle notifications, session catalog state, and restart logs distinguish successful drains from timeout-based restart completion.
+- [x] 4.1 Update daemon-managed ingress paths so Slack, SignalR, and other adapter entry points reject new work consistently while restart drain is active.
+- [x] 4.2 Ensure lifecycle notifications, session catalog state, and restart logs distinguish successful drains from timeout-based restart completion.
 
 ## 5. Verification and docs
 
-- [ ] 5.1 Add daemon/service tests covering valid config change drain, invalid config no-restart, ingress rejection during drain, and timeout-driven restart.
-- [ ] 5.2 Add actor integration tests covering restart drain from ready, processing, and compacting states plus recovery from the last durable checkpoint.
-- [ ] 5.3 Update `docs/spec/SPEC-011-daemon-architecture.md`, related PRD/spec references, and any user-facing diagnostics text to match the new coordinated restart behavior.
-- [ ] 5.4 Run `dotnet test` for affected projects and `dotnet slopwatch analyze` after implementation changes.
+- [x] 5.1 Add daemon/service tests covering valid config change drain, invalid config no-restart, ingress rejection during drain, and timeout-driven restart.
+- [x] 5.2 Add actor integration tests covering restart drain from ready, processing, and compacting states plus recovery from the last durable checkpoint.
+- [x] 5.3 Update `docs/spec/SPEC-011-daemon-architecture.md`, related PRD/spec references, and any user-facing diagnostics text to match the new coordinated restart behavior.
+- [x] 5.4 Run `dotnet test` for affected projects and `dotnet slopwatch analyze` after implementation changes.

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -189,6 +189,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     {
         return new SlackGatewayDependencies(
             Pipeline: null!,
+            IngressGate: null,
             ActorSystem: null!,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -107,6 +107,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -184,6 +185,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -252,6 +254,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -315,6 +318,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -363,6 +367,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -411,6 +416,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -481,6 +487,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -550,6 +557,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: feedbackPipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -604,6 +612,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: feedbackPipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -658,6 +667,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: feedbackPipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -715,6 +725,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: feedbackPipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -773,6 +784,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: feedbackPipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -817,6 +829,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions
@@ -874,6 +887,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,
+            IngressGate: null,
             ActorSystem: Sys,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions

--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -572,6 +572,7 @@ public sealed class SlackProactiveThreadActorTests(ITestOutputHelper output) : T
     {
         return new SlackGatewayDependencies(
             Pipeline: null!,
+            IngressGate: null,
             ActorSystem: null!,
             TimeProvider: TimeProvider.System,
             Options: new SlackChannelOptions

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -2,6 +2,7 @@ using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
+using Akka.Streams;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,6 +85,7 @@ public class LlmSessionIntegrationTests : TestKit
         services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
         services.AddSingleton<TimeProvider>(_timeProvider);
         services.AddSingleton<ISessionLifecycleObserver>(_lifecycleObserver);
+        services.AddSingleton<ISessionPipeline>(new UnusedSessionPipeline());
 
         // Composite records for LlmSessionActor constructor
         services.AddSingleton(sp => new SessionServices(
@@ -1802,4 +1804,17 @@ internal sealed class RecordingSessionLifecycleObserver : ISessionLifecycleObser
 
     public void OnSessionDeactivated(SessionId sessionId)
         => DeactivatedSessionIds.Add(sessionId.Value);
+}
+
+internal sealed class UnusedSessionPipeline : ISessionPipeline
+{
+    public Task<MaterializedSession> CreateAsync(
+        SessionId sessionId,
+        SessionPipelineOptions options,
+        IMaterializer? materializer = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromException<MaterializedSession>(new NotSupportedException("Session pipeline is not used by these tests."));
+
+    public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default)
+        => Task.CompletedTask;
 }

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -56,6 +56,7 @@ public class LlmSessionIntegrationTests : TestKit
                 DiscoveredToolMaxCount = 12,
             }
         });
+        services.AddSingleton(new ReminderConfig());
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
         services.AddSingleton<SidecarRecallPlanner>();
@@ -1084,6 +1085,194 @@ public class LlmSessionIntegrationTests : TestKit
         await ExpectTerminatedAsync(child, TimeSpan.FromSeconds(5));
 
         Assert.Contains(sessionId.Value, _lifecycleObserver.DeactivatedSessionIds);
+    }
+
+    [Fact]
+    public async Task Ready_session_drains_for_daemon_restart()
+    {
+        var sessionId = new SessionId("test-channel/restart-drain-ready");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("restart-drain-ready-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}").ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+
+        var ack = await sessionManager.Ask<CommandAck>(new PrepareForDaemonRestart
+        {
+            SessionId = sessionId,
+            Reason = "config-reload"
+        }, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(sessionId, ack.SessionId);
+        await ExpectTerminatedAsync(child, TimeSpan.FromSeconds(5));
+        Assert.Contains(sessionId.Value, _lifecycleObserver.DeactivatedSessionIds);
+    }
+
+    [Fact]
+    public async Task Processing_session_rejects_new_work_and_passivates_after_current_turn()
+    {
+        var sessionId = new SessionId("test-channel/restart-drain-processing");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("restart-drain-processing-sub");
+        var responseGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _fakeChatClient.NextResponseGate = responseGate;
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "First message"
+        }, TimeSpan.FromSeconds(3));
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}").ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+
+        var drainTask = sessionManager.Ask<CommandAck>(new PrepareForDaemonRestart
+        {
+            SessionId = sessionId,
+            Reason = "config-reload"
+        }, TimeSpan.FromSeconds(5));
+
+        var nack = await sessionManager.Ask<CommandNack>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Should be rejected"
+        }, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(SessionIngressGate.RestartInProgressMessage, nack.Reason);
+
+        sessionManager.Tell(new DeliveryFailed
+        {
+            SessionId = sessionId,
+            TurnNumber = 999,
+            ChannelType = ChannelType.Slack,
+            FailureKind = DeliveryFailureKind.MessageTooLarge,
+            ErrorMessage = "msg_too_long"
+        });
+
+        responseGate.TrySetResult();
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+        Assert.Equal(sessionId, (await drainTask).SessionId);
+        await ExpectTerminatedAsync(child, TimeSpan.FromSeconds(5));
+        Assert.DoesNotContain(_fakeChatClient.ReceivedMessages, conversation =>
+            conversation.Any(msg =>
+                msg.Text is not null
+                && msg.Text.Contains("msg_too_long", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task Compacting_session_rejects_new_work_and_passivates_after_compaction_finishes()
+    {
+        var sessionId = new SessionId("test-channel/restart-drain-compacting");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("restart-drain-compacting-sub");
+        _fakeChatClient.UsageOverride = new UsageDetails
+        {
+            InputTokenCount = 200_000,
+            OutputTokenCount = 1,
+            TotalTokenCount = 200_001
+        };
+        _fakeChatClient.HangingObservationCallsRemaining = 1;
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Trigger compaction"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        var escapedId = Uri.EscapeDataString(sessionId.Value);
+        var child = await Sys.ActorSelection($"/user/session-manager/{escapedId}").ResolveOne(TimeSpan.FromSeconds(3));
+        Watch(child);
+
+        var drainTask = sessionManager.Ask<CommandAck>(new PrepareForDaemonRestart
+        {
+            SessionId = sessionId,
+            Reason = "config-reload"
+        }, TimeSpan.FromSeconds(5));
+
+        var nack = await sessionManager.Ask<CommandNack>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Should be rejected during compaction"
+        }, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(SessionIngressGate.RestartInProgressMessage, nack.Reason);
+
+        child.Tell(new CompactionFailed
+        {
+            Cause = new InvalidOperationException("test compaction completion")
+        });
+
+        Assert.Equal(sessionId, (await drainTask).SessionId);
+        await ExpectTerminatedAsync(child, TimeSpan.FromSeconds(5));
+        Assert.Contains(sessionId.Value, _lifecycleObserver.DeactivatedSessionIds);
+    }
+
+    [Fact]
+    public async Task Warm_session_injects_restart_notice_on_next_turn()
+    {
+        var sessionId = new SessionId("test-channel/restart-warm-notice");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("restart-warm-notice-sub");
+
+        await sessionManager.Ask<CommandAck>(new WarmSession
+        {
+            SessionId = sessionId,
+            RestartNotice = "The daemon restarted due to a configuration change. Recovery resumed from the last durable checkpoint."
+        }, TimeSpan.FromSeconds(3));
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.TextOnly
+        }, TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Hello after restart"
+        }, TimeSpan.FromSeconds(3));
+
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+
+        Assert.Contains(_fakeChatClient.ReceivedMessages, conversation =>
+            conversation.Any(msg =>
+                msg.Role == Microsoft.Extensions.AI.ChatRole.System
+                && msg.Text is not null
+                && msg.Text.Contains("Recovery resumed from the last durable checkpoint", StringComparison.Ordinal)));
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -157,17 +157,20 @@ public sealed class SessionPipeline : ISessionPipeline
     private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
     private readonly ISessionLifecycleObserver? _lifecycleObserver;
     private readonly NetclawPaths? _paths;
+    private readonly SessionIngressGate? _ingressGate;
 
     public SessionPipeline(
         ActorSystem system,
         IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
         ISessionLifecycleObserver? lifecycleObserver = null,
-        NetclawPaths? paths = null)
+        NetclawPaths? paths = null,
+        SessionIngressGate? ingressGate = null)
     {
         _system = system;
         _sessionManagerProvider = sessionManagerProvider;
         _lifecycleObserver = lifecycleObserver;
         _paths = paths;
+        _ingressGate = ingressGate;
     }
 
     /// <summary>
@@ -188,6 +191,8 @@ public sealed class SessionPipeline : ISessionPipeline
         IMaterializer? materializer = null,
         CancellationToken cancellationToken = default)
     {
+        _ingressGate?.ThrowIfClosed();
+
         var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
         var killSwitch = KillSwitches.Shared($"session-{sessionId.Value}");
 

--- a/src/Netclaw.Actors/Channels/SessionIngressGate.cs
+++ b/src/Netclaw.Actors/Channels/SessionIngressGate.cs
@@ -1,0 +1,44 @@
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Thrown when daemon-managed session ingress is closed during coordinated restart.
+/// </summary>
+public sealed class SessionIngressBlockedException : InvalidOperationException
+{
+    public SessionIngressBlockedException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Thread-safe gate used to reject new daemon-managed session ingress while coordinated restart is in progress.
+/// </summary>
+public sealed class SessionIngressGate
+{
+    public const string RestartInProgressMessage = "Daemon restarting, try again in a minute.";
+
+    private string? _closedReason;
+
+    public bool IsClosed => _closedReason is not null;
+
+    public string? ClosedReason => Volatile.Read(ref _closedReason);
+
+    public bool TryClose(string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        return Interlocked.CompareExchange(ref _closedReason, reason, comparand: null) is null;
+    }
+
+    public void Reopen()
+    {
+        Interlocked.Exchange(ref _closedReason, null);
+    }
+
+    public void ThrowIfClosed()
+    {
+        var reason = ClosedReason;
+        if (reason is not null)
+            throw new SessionIngressBlockedException(reason);
+    }
+}

--- a/src/Netclaw.Actors/Hosting/GenericChildPerEntityMessages.cs
+++ b/src/Netclaw.Actors/Hosting/GenericChildPerEntityMessages.cs
@@ -1,0 +1,18 @@
+namespace Netclaw.Actors.Hosting;
+
+/// <summary>
+/// Queries the currently live entity IDs hosted by a <see cref="GenericChildPerEntityParent"/>.
+/// </summary>
+public sealed record GetActiveEntityIds
+{
+    public static readonly GetActiveEntityIds Instance = new();
+
+    private GetActiveEntityIds()
+    {
+    }
+}
+
+/// <summary>
+/// Response containing the currently live entity IDs for a <see cref="GenericChildPerEntityParent"/>.
+/// </summary>
+public sealed record ActiveEntityIds(IReadOnlyList<string> EntityIds);

--- a/src/Netclaw.Actors/Hosting/GenericChildPerEntityParent.cs
+++ b/src/Netclaw.Actors/Hosting/GenericChildPerEntityParent.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Sharding;
 
@@ -25,6 +26,17 @@ public sealed class GenericChildPerEntityParent : ReceiveActor
     {
         _extractor = extractor;
         _propsFactory = propsFactory;
+
+        Receive<GetActiveEntityIds>(_ =>
+        {
+            var entityIds = Context
+                .GetChildren()
+                .Select(child => Uri.UnescapeDataString(child.Path.Name))
+                .OrderBy(static id => id, StringComparer.Ordinal)
+                .ToArray();
+
+            Sender.Tell(new ActiveEntityIds(entityIds));
+        });
 
         ReceiveAny(o =>
         {

--- a/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
+++ b/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
@@ -1,0 +1,21 @@
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Requests that a live session stop accepting new work and passivate for coordinated daemon restart.
+/// </summary>
+public sealed record PrepareForDaemonRestart : IWithSessionId
+{
+    public required SessionId SessionId { get; init; }
+
+    public required string Reason { get; init; }
+}
+
+/// <summary>
+/// Rehydrates a session after coordinated daemon restart and primes a one-turn continuity notice.
+/// </summary>
+public sealed record WarmSession : IWithSessionId
+{
+    public required SessionId SessionId { get; init; }
+
+    public required string RestartNotice { get; init; }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -113,6 +113,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private readonly Telemetry.ISessionMetrics? _sessionMetrics;
 
+    private bool _restartDrainRequested;
+    private IActorRef? _restartDrainReplyTo;
+    private string? _pendingRestartNotice;
+    private string? _turnRestartNotice;
+
     // Persistent state (immutable — replaced on each event)
     private SessionState _state = SessionState.Empty;
 
@@ -306,6 +311,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         Command<CompactionWorkFailed>(_ => { });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
         Command<DeliveryFailed>(HandleDeliveryFailedWhenReady);
+        Command<PrepareForDaemonRestart>(_ => RequestRestartDrain());
 
         Command<SendUserMessage>(HandleIncomingUserMessage);
     }
@@ -319,6 +325,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<SendUserMessage>(cmd =>
         {
+            if (_restartDrainRequested)
+            {
+                _log.Info("Rejecting new user message while restart drain is pending");
+                TryReplyNack(SessionIngressGate.RestartInProgressMessage);
+                return;
+            }
+
             _deliveryRetry.Clear();
             _log.Info("Buffering user message (LLM call in progress)");
             _buffer.Add(cmd);
@@ -327,6 +340,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<DeliveryFailed>(msg =>
         {
+            if (_restartDrainRequested)
+            {
+                _log.Info("Ignoring delivery feedback while restart drain is pending");
+                return;
+            }
+
             if (!DeliveryRetryHandler.IsRetryable(msg))
             {
                 _log.Warning(
@@ -651,6 +670,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
+        Command<PrepareForDaemonRestart>(_ => RequestRestartDrain());
     }
 
     private void HandleDistillationResult(SessionDistillationCompleted msg)
@@ -718,6 +738,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // Buffer user messages during compaction (same as Processing)
         Command<SendUserMessage>(cmd =>
         {
+            if (_restartDrainRequested)
+            {
+                _log.Info("Rejecting new user message while restart drain is pending during compaction");
+                TryReplyNack(SessionIngressGate.RestartInProgressMessage);
+                return;
+            }
+
             _log.Info("Buffering user message (compaction in progress)");
             _buffer.Add(cmd);
             TryReplyAck();
@@ -746,6 +773,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             DrainBufferOrReady();
         });
         Command<SpawnChildActorRequest>(msg => Sender.Tell(Context.ActorOf(msg.Props, msg.ActorName)));
+        Command<PrepareForDaemonRestart>(_ => RequestRestartDrain());
 
         Command<CompactionTriggered>(msg =>
         {
@@ -901,6 +929,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void DrainBufferOrReady()
     {
+        if (_restartDrainRequested)
+        {
+            ClearBufferedMessagesForRestartDrain();
+            TransitionTo(SessionPhase.Ready);
+            TransitionTo(SessionPhase.Passivating);
+            return;
+        }
+
         if (_buffer.Count > 0)
         {
             _log.Info("Post-compaction: draining {BufferCount} buffered message(s)", _buffer.Count);
@@ -937,9 +973,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         CommandSubscriptionMessages();
         CommandSnapshotMessages();
+        Command<PrepareForDaemonRestart>(_ => RequestRestartDrain());
 
         Command<SendUserMessage>(cmd =>
         {
+            if (_restartDrainRequested)
+            {
+                _log.Info("Rejecting new user message while restart passivation is in progress");
+                TryReplyNack(SessionIngressGate.RestartInProgressMessage);
+                return;
+            }
+
             _log.Info("Aborting passivation due to new user message");
             Timers.Cancel(PassivationTimerKey);
             TransitionTo(SessionPhase.Ready);
@@ -961,6 +1005,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         Command<DeliveryFailed>(msg =>
         {
+            if (_restartDrainRequested)
+            {
+                _log.Info("Ignoring delivery feedback while restart passivation is in progress");
+                return;
+            }
+
             _log.Info("Aborting passivation due to delivery feedback");
             Timers.Cancel(PassivationTimerKey);
             TransitionTo(SessionPhase.Ready);
@@ -983,6 +1033,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         _lifecycleObserver?.OnSessionDeactivated(_sessionId);
         SaveSnapshot(_state.ToSnapshot());
+        _restartDrainReplyTo?.Tell(CommandAck.For(_sessionId));
+        _restartDrainReplyTo = null;
         Context.Stop(Self);
     }
 
@@ -1258,6 +1310,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void DrainBufferedMessagesOrBecomeReady()
     {
+        if (_restartDrainRequested)
+        {
+            ClearBufferedMessagesForRestartDrain();
+            TransitionTo(SessionPhase.Ready);
+            TransitionTo(SessionPhase.Passivating);
+            return;
+        }
+
         if (_buffer.Count > 0)
         {
             TurnLog().Info("turn_buffer_drain count={BufferCount}", _buffer.Count);
@@ -1392,7 +1452,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _state = _state.AddUserMessage(userContent, mediaRefs.Count > 0 ? mediaRefs : null);
         TryReplyAck();
         _recallManager.ResetForNewTurn();
-        FireLlmCall(userContent);
+        FireInitialTurnLlmCall(userContent);
         TransitionTo(SessionPhase.Processing);
     }
 
@@ -1501,6 +1561,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<SessionDistillationCompleted>(msg => HandleDistillationResult(msg));
+
+        Command<WarmSession>(cmd =>
+        {
+            _pendingRestartNotice = cmd.RestartNotice;
+            Sender.Tell(CommandAck.For(_sessionId));
+        });
 
         Command<JoinSession>(cmd =>
         {
@@ -1891,7 +1957,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
             // Inject skill content as a one-time system message for this turn
             _slashCommandSkillContent = skillBody;
-            FireLlmCall(effectiveUserContent);
+            FireInitialTurnLlmCall(effectiveUserContent);
             _slashCommandSkillContent = null;
 
             TransitionTo(SessionPhase.Processing);
@@ -1923,8 +1989,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// </summary>
     private void InjectDynamicContextLayers(List<AiChatMessage> messages)
     {
-        if (_contextLayers.Count == 0) return;
-
         var parts = new List<string>();
         foreach (var layer in _contextLayers)
         {
@@ -1940,6 +2004,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // inject the skill body as a system context part
         if (_slashCommandSkillContent is not null)
             parts.Add(_slashCommandSkillContent);
+
+        if (_turnRestartNotice is not null)
+            parts.Add(_turnRestartNotice);
 
         // Session identity — allows the agent to reference its own session and media directory
         var sessionBlock = $"[session]\nid: {_sessionId.Value}";
@@ -2205,12 +2272,55 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         return log;
     }
 
+    private void RequestRestartDrain()
+    {
+        _restartDrainRequested = true;
+        _restartDrainReplyTo = Sender;
+
+        if (_currentPhase == SessionPhase.Ready)
+            TransitionTo(SessionPhase.Passivating);
+    }
+
+    private void ClearBufferedMessagesForRestartDrain()
+    {
+        if (_buffer.Count == 0)
+            return;
+
+        _log.Warning(
+            "Dropping {BufferCount} buffered message(s) because coordinated restart drain is completing.",
+            _buffer.Count);
+        _buffer.Clear();
+    }
+
+    private void FireInitialTurnLlmCall(string? recallQuery)
+    {
+        _turnRestartNotice = _pendingRestartNotice;
+        _pendingRestartNotice = null;
+
+        try
+        {
+            FireLlmCall(recallQuery);
+        }
+        finally
+        {
+            _turnRestartNotice = null;
+        }
+    }
+
     private void TryReplyAck()
     {
         if (Sender.IsNobody() || Equals(Sender, Context.System.DeadLetters))
             return;
 
         Sender.Tell(CommandAck.For(_sessionId));
+    }
+
+    private void TryReplyNack(string reason)
+    {
+        if (Sender.IsNobody() || Equals(Sender, Context.System.DeadLetters))
+            return;
+
+        Sender.Tell(CommandNack.For(_sessionId, reason));
     }
 
 

--- a/src/Netclaw.Channels.Slack/SlackChannel.cs
+++ b/src/Netclaw.Channels.Slack/SlackChannel.cs
@@ -18,6 +18,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
     private readonly ISlackApiClient _slack;
     private readonly ISlackSocketModeClient _socketModeClient;
     private readonly ISlackReplyClient _replyClient;
+    private readonly SessionIngressGate _ingressGate;
     private readonly IContentScanner _contentScanner;
     private readonly IPromptInjectionDetector _promptInjectionDetector;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -37,6 +38,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         ISlackApiClient slack,
         ISlackSocketModeClient socketModeClient,
         ISlackReplyClient replyClient,
+        SessionIngressGate ingressGate,
         IContentScanner contentScanner,
         IPromptInjectionDetector? promptInjectionDetector,
         IHttpClientFactory httpClientFactory,
@@ -50,6 +52,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
         _slack = slack;
         _socketModeClient = socketModeClient;
         _replyClient = replyClient;
+        _ingressGate = ingressGate;
         _contentScanner = contentScanner;
         _promptInjectionDetector = promptInjectionDetector ?? new NullPromptInjectionDetector();
         _httpClientFactory = httpClientFactory;
@@ -109,6 +112,7 @@ public sealed class SlackChannel : IChannel, IEventHandler<MessageEvent>, IEvent
             _gateway = _system.ActorOf(
                 SlackGatewayActor.CreateProps(new SlackGatewayDependencies(
                     Pipeline: _pipeline,
+                    IngressGate: _ingressGate,
                     ActorSystem: _system,
                     TimeProvider: _timeProvider,
                     Options: _options,

--- a/src/Netclaw.Channels.Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackConversationActor.cs
@@ -75,6 +75,15 @@ public sealed class SlackConversationActor : ReceiveActor
                 return;
             }
 
+            if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
+            {
+                var replyThreadTs = message.ThreadTs ?? SlackThreadTs.FromEventTs(message.EventTs);
+                _log.Info("slack_event_filtered event={0} reason=restart_drain_active", message.EventId);
+                ChannelTelemetry.RecordSlackEventFiltered("restart_drain_active");
+                _ = PostIngressClosedReplyAsync(message.ChannelId, replyThreadTs, ingressClosedReason);
+                return;
+            }
+
             var thread = existingThread.IsNobody()
                 ? Context.ActorOf(CreateThreadProps(message.ChannelId, threadTs), threadActorName)
                 : existingThread;
@@ -119,6 +128,12 @@ public sealed class SlackConversationActor : ReceiveActor
 
         Receive<StartProactiveThread>(message =>
         {
+            if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
+            {
+                Sender.Tell(new Status.Failure(new InvalidOperationException(ingressClosedReason)));
+                return;
+            }
+
             // Defense-in-depth: validate channel ACL even though the tool already checked.
             // DM channels (D-prefixed) skip this — they were validated via user ACL + AllowDirectMessages.
             var isDmChannel = message.ChannelId.Value.StartsWith("D", StringComparison.Ordinal);
@@ -195,5 +210,19 @@ public sealed class SlackConversationActor : ReceiveActor
             channelId: channelId,
             threadTs: threadTs,
             dependencies: _dependencies);
+    }
+
+    private async Task PostIngressClosedReplyAsync(SlackChannelId channelId, SlackThreadTs threadTs, string message)
+    {
+        try
+        {
+            await _dependencies.ReplyClient.PostThreadReplyAsync(
+                new SlackPostMessage(channelId, threadTs, message),
+                CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to post restart-drain reply to Slack thread {0}", threadTs.Value);
+        }
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
@@ -82,6 +82,7 @@ public sealed class SlackGatewayActor : ReceiveActor
 
 public sealed record SlackGatewayDependencies(
     ISessionPipeline Pipeline,
+    SessionIngressGate? IngressGate,
     ActorSystem ActorSystem,
     TimeProvider TimeProvider,
     SlackChannelOptions Options,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -253,6 +253,13 @@ internal sealed class SlackThreadBindingActor : ReceiveActor, IWithUnboundedStas
                 return;
             }
 
+            if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
+            {
+                _log.Info("Rejecting Slack inbound message while restart drain is active");
+                await SafePostAsync(ingressClosedReason);
+                return;
+            }
+
             var writer = _inputQueue;
             if (writer is null)
             {

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -35,6 +35,7 @@ public sealed class NetclawPaths
 
     // ── Cache directory ──
     public string CacheDirectory => Path.Combine(BasePath, "cache");
+    public string RestartManifestPath => Path.Combine(CacheDirectory, "restart-manifest.json");
 
     // ── Memory ──
     public string MemorySqliteDbPath => SqliteDbPath;

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionRegistryTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionRegistryTests.cs
@@ -1,6 +1,7 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Daemon.Gateway;
 using Xunit;
@@ -15,9 +16,10 @@ namespace Netclaw.Daemon.Tests.Gateway;
 /// </summary>
 public sealed class SessionRegistryTests
 {
-    private SessionRegistry BuildRegistry()
+    private SessionRegistry BuildRegistry(SessionIngressGate? ingressGate = null)
         => new(
             new StubRequiredActor(),
+            ingressGate ?? new SessionIngressGate(),
             TimeProvider.System,
             NullLogger<SessionRegistry>.Instance);
 
@@ -128,6 +130,33 @@ public sealed class SessionRegistryTests
         var result = await registry.EnsureSessionAsync("conn-3", "signalr/any-old-id", "tui");
         // The old ID was unknown after shutdown, so it's created fresh
         Assert.Equal("signalr/any-old-id", result.SessionId);
+    }
+
+    [Fact]
+    public async Task EnsureSession_throws_when_ingress_closed()
+    {
+        var gate = new SessionIngressGate();
+        gate.TryClose(SessionIngressGate.RestartInProgressMessage);
+        var registry = BuildRegistry(gate);
+
+        var ex = await Assert.ThrowsAsync<Microsoft.AspNetCore.SignalR.HubException>(
+            () => registry.EnsureSessionAsync("conn-1", null, "tui"));
+
+        Assert.Equal(SessionIngressGate.RestartInProgressMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task SendMessage_throws_when_ingress_closed()
+    {
+        var gate = new SessionIngressGate();
+        var registry = BuildRegistry(gate);
+        var sessionId = await registry.CreateSessionAsync("conn-1", "tui");
+        gate.TryClose(SessionIngressGate.RestartInProgressMessage);
+
+        var ex = await Assert.ThrowsAsync<Microsoft.AspNetCore.SignalR.HubException>(
+            () => registry.SendMessageAsync("conn-1", sessionId, "hello"));
+
+        Assert.Equal(SessionIngressGate.RestartInProgressMessage, ex.Message);
     }
 
     /// <summary>

--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Services;
@@ -10,9 +9,7 @@ public sealed class ConfigWatcherServiceTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
-    private readonly DaemonRestartSignal _restartSignal;
-    private readonly FakeApplicationLifetime _lifetime;
-    private readonly RecordingSink _sink;
+    private readonly FakeRestartCoordinator _restartCoordinator;
     private readonly ConfigWatcherService _sut;
 
     public ConfigWatcherServiceTests()
@@ -23,33 +20,23 @@ public sealed class ConfigWatcherServiceTests : IDisposable
         _paths = new NetclawPaths(_tempDir);
         _paths.EnsureDirectoriesExist();
 
-        _restartSignal = new DaemonRestartSignal();
-        _lifetime = new FakeApplicationLifetime();
-        _sink = new RecordingSink();
-
-        var notifier = new DaemonLifecycleNotifier(
-            _sink,
-            TimeProvider.System,
-            NullLogger<DaemonLifecycleNotifier>.Instance);
+        _restartCoordinator = new FakeRestartCoordinator();
 
         _sut = new ConfigWatcherService(
             _paths,
             TimeProvider.System,
-            _lifetime,
-            _restartSignal,
-            notifier,
+            _restartCoordinator,
             NullLogger<ConfigWatcherService>.Instance);
     }
 
     [Fact]
-    public void ValidConfigChange_TriggersRestart()
+    public async Task ValidConfigChange_TriggersRestart()
     {
         File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
 
-        _sut.ApplyReload();
+        await _sut.ApplyReloadAsync(CancellationToken.None);
 
-        Assert.True(_restartSignal.RestartRequested);
-        Assert.True(_lifetime.StopRequested);
+        Assert.Equal(1, _restartCoordinator.RequestCount);
     }
 
     [Theory]
@@ -69,41 +56,37 @@ public sealed class ConfigWatcherServiceTests : IDisposable
     }
 
     [Fact]
-    public void InvalidJson_DoesNotTriggerRestart()
+    public async Task InvalidJson_DoesNotTriggerRestart()
     {
         File.WriteAllText(_paths.NetclawConfigPath, """{ broken json """);
         // secrets.json doesn't exist — that's fine (optional)
 
-        _sut.ApplyReload();
+        await _sut.ApplyReloadAsync(CancellationToken.None);
 
-        Assert.False(_restartSignal.RestartRequested);
-        Assert.False(_lifetime.StopRequested);
+        Assert.Equal(0, _restartCoordinator.RequestCount);
     }
 
     [Fact]
-    public void MissingConfigFiles_TriggersRestart()
+    public async Task MissingConfigFiles_TriggersRestart()
     {
         // Both files are optional in the config chain — missing = valid
         Assert.False(File.Exists(_paths.NetclawConfigPath));
         Assert.False(File.Exists(_paths.SecretsPath));
 
-        _sut.ApplyReload();
+        await _sut.ApplyReloadAsync(CancellationToken.None);
 
-        Assert.True(_restartSignal.RestartRequested);
-        Assert.True(_lifetime.StopRequested);
+        Assert.Equal(1, _restartCoordinator.RequestCount);
     }
 
     [Fact]
-    public void ValidConfigChange_NotifiesShutdown()
+    public async Task RestartCoordinatorFailure_DoesNotLeaveIngressClosed()
     {
         File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
+        _restartCoordinator.ThrowOnRequest = true;
 
-        _sut.ApplyReload();
+        await _sut.ApplyReloadAsync(CancellationToken.None);
 
-        var alert = Assert.Single(_sink.Alerts);
-        Assert.Equal(AlertType.DaemonStopping, alert.Category);
-        Assert.NotNull(alert.Context);
-        Assert.Equal("config-reload", alert.Context["reason"]);
+        Assert.Equal(1, _restartCoordinator.RequestCount);
     }
 
     public void Dispose()
@@ -113,21 +96,20 @@ public sealed class ConfigWatcherServiceTests : IDisposable
             Directory.Delete(_tempDir, recursive: true);
     }
 
-    private sealed class FakeApplicationLifetime : IHostApplicationLifetime
+    private sealed class FakeRestartCoordinator : IDaemonRestartCoordinator
     {
-        public bool StopRequested { get; private set; }
+        public int RequestCount { get; private set; }
 
-        public CancellationToken ApplicationStarted => CancellationToken.None;
-        public CancellationToken ApplicationStopping => CancellationToken.None;
-        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public bool ThrowOnRequest { get; set; }
 
-        public void StopApplication() => StopRequested = true;
-    }
+        public Task RequestConfigRestartAsync(CancellationToken cancellationToken)
+        {
+            RequestCount++;
 
-    private sealed class RecordingSink : IOperationalNotificationSink
-    {
-        public List<OperationalAlert> Alerts { get; } = [];
+            if (ThrowOnRequest)
+                throw new InvalidOperationException("boom");
 
-        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/DaemonRestartCoordinatorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/DaemonRestartCoordinatorTests.cs
@@ -1,0 +1,177 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class DaemonRestartCoordinatorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly ActorSystem _system;
+    private readonly NetclawPaths _paths;
+    private readonly SessionIngressGate _ingressGate = new();
+    private readonly DaemonRestartSignal _restartSignal = new();
+    private readonly FakeApplicationLifetime _appLifetime = new();
+    private readonly RecordingSink _sink = new();
+
+    public DaemonRestartCoordinatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-restart-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+        _system = ActorSystem.Create($"restart-tests-{Guid.NewGuid():N}");
+    }
+
+    [Fact]
+    public async Task RequestConfigRestartAsync_drains_active_sessions_and_requests_stop()
+    {
+        var coordinator = CreateCoordinator(["slack/C123.1", "slack/C123.2"], restartDrainTimeout: TimeSpan.FromMilliseconds(250));
+
+        await coordinator.RequestConfigRestartAsync(CancellationToken.None);
+
+        Assert.True(_restartSignal.RestartRequested);
+        Assert.True(_appLifetime.StopRequested);
+        Assert.Equal(SessionIngressGate.RestartInProgressMessage, _ingressGate.ClosedReason);
+
+        var manifest = await new RestartManifestStore(_paths).ReadAsync(CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Equal(["slack/C123.1", "slack/C123.2"], manifest!.SessionIds);
+        Assert.Empty(manifest.TimedOutSessionIds);
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("drained", alert.Context!["drainOutcome"]);
+        Assert.Equal("2", alert.Context["activeSessions"]);
+    }
+
+    [Fact]
+    public async Task RequestConfigRestartAsync_records_timed_out_sessions()
+    {
+        var coordinator = CreateCoordinator(
+            ["slack/C123.1", "slack/C123.2"],
+            timedOutSessionIds: ["slack/C123.2"],
+            restartDrainTimeout: TimeSpan.FromMilliseconds(100));
+
+        await coordinator.RequestConfigRestartAsync(CancellationToken.None);
+
+        Assert.True(_restartSignal.RestartRequested);
+        Assert.True(_appLifetime.StopRequested);
+
+        var manifest = await new RestartManifestStore(_paths).ReadAsync(CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Equal(["slack/C123.2"], manifest!.TimedOutSessionIds);
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("timeout", alert.Context!["drainOutcome"]);
+        Assert.Equal("1", alert.Context["timedOutSessions"]);
+    }
+
+    [Fact]
+    public async Task RequestConfigRestartAsync_reopens_ingress_when_coordination_fails()
+    {
+        var coordinator = CreateCoordinator([], throwOnEnumeration: true, restartDrainTimeout: TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => coordinator.RequestConfigRestartAsync(CancellationToken.None));
+
+        Assert.False(_restartSignal.RestartRequested);
+        Assert.False(_appLifetime.StopRequested);
+        Assert.Null(_ingressGate.ClosedReason);
+    }
+
+    public void Dispose()
+    {
+        _system.Terminate().GetAwaiter().GetResult();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private DaemonRestartCoordinator CreateCoordinator(
+        IReadOnlyList<string> activeSessionIds,
+        IReadOnlyList<string>? timedOutSessionIds = null,
+        bool throwOnEnumeration = false,
+        TimeSpan? restartDrainTimeout = null)
+    {
+        var sessionManager = _system.ActorOf(Props.Create(() => new StubSessionManagerActor(
+            activeSessionIds,
+            timedOutSessionIds ?? Array.Empty<string>(),
+            throwOnEnumeration)));
+        var notifier = new DaemonLifecycleNotifier(_sink, TimeProvider.System, NullLogger<DaemonLifecycleNotifier>.Instance);
+
+        return new DaemonRestartCoordinator(
+            _ingressGate,
+            new RestartManifestStore(_paths),
+            new StubRequiredActor(sessionManager),
+            _restartSignal,
+            _appLifetime,
+            notifier,
+            TimeProvider.System,
+            NullLogger<DaemonRestartCoordinator>.Instance,
+            restartDrainTimeout);
+    }
+
+    private sealed class StubRequiredActor : IRequiredActor<SessionManagerActorKey>
+    {
+        public StubRequiredActor(IActorRef actorRef)
+        {
+            ActorRef = actorRef;
+        }
+
+        public IActorRef ActorRef { get; }
+
+        public Task<IActorRef> GetAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ActorRef);
+    }
+
+    private sealed class StubSessionManagerActor : ReceiveActor
+    {
+        public StubSessionManagerActor(
+            IReadOnlyList<string> activeSessionIds,
+            IReadOnlyList<string> timedOutSessionIds,
+            bool throwOnEnumeration)
+        {
+            Receive<GetActiveEntityIds>(_ =>
+            {
+                if (throwOnEnumeration)
+                {
+                    Sender.Tell(new Status.Failure(new InvalidOperationException("enumeration failed")));
+                    return;
+                }
+
+                Sender.Tell(new ActiveEntityIds(activeSessionIds));
+            });
+
+            Receive<PrepareForDaemonRestart>(msg =>
+            {
+                if (timedOutSessionIds.Contains(msg.SessionId.Value, StringComparer.Ordinal))
+                    return;
+
+                Sender.Tell(CommandAck.For(msg.SessionId));
+            });
+        }
+    }
+
+    private sealed class FakeApplicationLifetime : IHostApplicationLifetime
+    {
+        public bool StopRequested { get; private set; }
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => StopRequested = true;
+    }
+
+    private sealed class RecordingSink : IOperationalNotificationSink
+    {
+        public List<OperationalAlert> Alerts { get; } = [];
+
+        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Gateway;
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class RestartRecoveryServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly ActorSystem _system;
+    private readonly NetclawPaths _paths;
+
+    public RestartRecoveryServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-recovery-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+        _system = ActorSystem.Create($"restart-recovery-tests-{Guid.NewGuid():N}");
+    }
+
+    [Fact]
+    public async Task StartAsync_warms_manifest_sessions_and_marks_catalog_active()
+    {
+        var warmedSessions = new ConcurrentQueue<WarmSession>();
+        var actor = _system.ActorOf(Props.Create(() => new WarmSessionActor(warmedSessions)));
+        var manifestStore = new RestartManifestStore(_paths);
+        var catalog = new SessionCatalogService(_paths, TimeProvider.System, NullLogger<SessionCatalogService>.Instance);
+        var sessionId = new SessionId("slack/C123/1710000000.000001");
+
+        catalog.OnSessionActivated(sessionId, Netclaw.Actors.Channels.ChannelType.Slack);
+        catalog.OnSessionDeactivated(sessionId);
+
+        await manifestStore.WriteAsync(new RestartManifest
+        {
+            Reason = "config-reload",
+            RequestedAt = TimeProvider.System.GetUtcNow(),
+            SessionIds = [sessionId.Value],
+            TimedOutSessionIds = [sessionId.Value]
+        }, CancellationToken.None);
+
+        var sut = new RestartRecoveryService(
+            manifestStore,
+            new StubRequiredActor(actor),
+            catalog,
+            NullLogger<RestartRecoveryService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        Assert.True(warmedSessions.TryDequeue(out var warmed));
+        Assert.Equal(sessionId, warmed!.SessionId);
+        Assert.Contains("last durable checkpoint", warmed.RestartNotice, StringComparison.Ordinal);
+        Assert.Null(await manifestStore.ReadAsync(CancellationToken.None));
+
+        var entry = Assert.Single(catalog.ListRecent());
+        Assert.Equal("active", entry.Status);
+    }
+
+    public void Dispose()
+    {
+        _system.Terminate().GetAwaiter().GetResult();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private sealed class StubRequiredActor : IRequiredActor<SessionManagerActorKey>
+    {
+        public StubRequiredActor(IActorRef actorRef)
+        {
+            ActorRef = actorRef;
+        }
+
+        public IActorRef ActorRef { get; }
+
+        public Task<IActorRef> GetAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ActorRef);
+    }
+
+    private sealed class WarmSessionActor : ReceiveActor
+    {
+        public WarmSessionActor(ConcurrentQueue<WarmSession> warmedSessions)
+        {
+            Receive<WarmSession>(msg =>
+            {
+                warmedSessions.Enqueue(msg);
+                Sender.Tell(CommandAck.For(msg.SessionId));
+            });
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -280,6 +280,29 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
         return entries;
     }
 
+    public void MarkSessionActive(SessionId sessionId)
+    {
+        var persistenceId = $"session-{sessionId.Value}";
+
+        try
+        {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            EnsureSchemaUpToDate(conn, _logger);
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "UPDATE sessions SET status = 'active' WHERE persistence_id = $pid";
+            cmd.Parameters.AddWithValue("$pid", persistenceId);
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to mark session {SessionId} active during restart recovery", sessionId.Value);
+        }
+    }
+
     private void UpdateSession(
         SqliteConnection conn,
         string persistenceId,

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -24,6 +24,7 @@ namespace Netclaw.Daemon.Gateway;
 public sealed class SessionRegistry
 {
     private readonly IRequiredActor<SignalRGatewayActorKey> _gatewayProvider;
+    private readonly SessionIngressGate _ingressGate;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<SessionRegistry> _logger;
 
@@ -35,10 +36,12 @@ public sealed class SessionRegistry
 
     public SessionRegistry(
         IRequiredActor<SignalRGatewayActorKey> gatewayProvider,
+        SessionIngressGate ingressGate,
         TimeProvider timeProvider,
         ILogger<SessionRegistry> logger)
     {
         _gatewayProvider = gatewayProvider;
+        _ingressGate = ingressGate;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -54,6 +57,7 @@ public sealed class SessionRegistry
         await _sessionMutationGate.WaitAsync();
         try
         {
+            ThrowIfIngressClosed();
             return await CreateSessionCoreAsync(callerConnectionId, ct);
         }
         finally
@@ -100,6 +104,8 @@ public sealed class SessionRegistry
         await _sessionMutationGate.WaitAsync();
         try
         {
+            ThrowIfIngressClosed();
+
             if (!string.IsNullOrWhiteSpace(sessionId))
             {
                 var requestedSessionId = ParseSessionId(sessionId);
@@ -162,6 +168,8 @@ public sealed class SessionRegistry
         await _sessionMutationGate.WaitAsync();
         try
         {
+            ThrowIfIngressClosed();
+
             if (!_knownSessions.TryGetValue(requestedSessionId, out var channelType))
                 throw new HubException($"Session '{sessionId}' not found.");
 
@@ -196,6 +204,8 @@ public sealed class SessionRegistry
 
         if (!_knownSessions.ContainsKey(attachedSessionId))
             throw new HubException($"Session '{sessionId}' not found.");
+
+        ThrowIfIngressClosed();
 
         var signalrMessageId = $"signalr:{callerConnectionId.Value}:{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}:{Guid.NewGuid():N}";
         if (signalrMessageId.Length > 128)
@@ -330,5 +340,12 @@ public sealed class SessionRegistry
             return parsed;
 
         throw new HubException($"Unknown channel type: '{channelType}'.");
+    }
+
+    private void ThrowIfIngressClosed()
+    {
+        var reason = _ingressGate.ClosedReason;
+        if (reason is not null)
+            throw new HubException(reason);
     }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -110,6 +110,10 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     builder.Services.AddSingleton<DailyStatsPublisher>();
     builder.Services.AddSingleton<Netclaw.Actors.Telemetry.ISessionMetrics>(sp => sp.GetRequiredService<DailyStatsPublisher>());
     builder.Services.AddSingleton<DaemonStatsService>();
+    builder.Services.AddSingleton<SessionIngressGate>();
+    builder.Services.AddSingleton<RestartManifestStore>();
+    builder.Services.AddSingleton<DaemonRestartCoordinator>();
+    builder.Services.AddSingleton<IDaemonRestartCoordinator>(sp => sp.GetRequiredService<DaemonRestartCoordinator>());
 
     var app = builder.Build();
 
@@ -219,7 +223,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     app.MapProviderOAuthEndpoints();
 
     // Daemon lifecycle endpoint — CLI calls this before sending SIGTERM.
-    // Future #326 hook: add session drain before returning.
+    // Config-triggered restart coordination happens inside DaemonRestartCoordinator.
     app.MapPost("/api/lifecycle/shutdown", (
         DaemonLifecycleNotifier notifier,
         HttpRequest request) =>
@@ -318,7 +322,7 @@ static void ConfigureDaemonServices(
 
     services.Configure<HostOptions>(options =>
     {
-        options.ShutdownTimeout = TimeSpan.FromSeconds(10);
+        options.ShutdownTimeout = TimeSpan.FromSeconds(30);
     });
 
     // Resolve models for session config
@@ -707,6 +711,10 @@ static void ConfigureDaemonServices(
     // Config hot-reload watcher
     services.AddSingleton<ConfigWatcherService>();
     services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<ConfigWatcherService>());
+
+    // Warm previously active sessions after a coordinated restart.
+    services.AddSingleton<RestartRecoveryService>();
+    services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<RestartRecoveryService>());
 
     // PID file authority for daemon lifecycle management
     services.AddSingleton<PidFileService>();

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -21,9 +21,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
 {
     private readonly NetclawPaths _paths;
     private readonly TimeProvider _timeProvider;
-    private readonly IHostApplicationLifetime _appLifetime;
-    private readonly DaemonRestartSignal _restartSignal;
-    private readonly DaemonLifecycleNotifier _lifecycleNotifier;
+    private readonly IDaemonRestartCoordinator _restartCoordinator;
     private readonly ILogger<ConfigWatcherService> _logger;
 
     private FileSystemWatcher? _watcher;
@@ -33,16 +31,12 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
     public ConfigWatcherService(
         NetclawPaths paths,
         TimeProvider timeProvider,
-        IHostApplicationLifetime appLifetime,
-        DaemonRestartSignal restartSignal,
-        DaemonLifecycleNotifier lifecycleNotifier,
+        IDaemonRestartCoordinator restartCoordinator,
         ILogger<ConfigWatcherService> logger)
     {
         _paths = paths;
         _timeProvider = timeProvider;
-        _appLifetime = appLifetime;
-        _restartSignal = restartSignal;
-        _lifecycleNotifier = lifecycleNotifier;
+        _restartCoordinator = restartCoordinator;
         _logger = logger;
     }
 
@@ -107,7 +101,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
                 await Task.Delay(_debounceInterval, token);
                 if (token.IsCancellationRequested) return;
 
-                ApplyReload();
+                await ApplyReloadAsync(CancellationToken.None);
             }
             catch (OperationCanceledException)
             {
@@ -116,7 +110,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
         }, CancellationToken.None);
     }
 
-    internal void ApplyReload()
+    internal async Task ApplyReloadAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -132,10 +126,8 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
                 return;
             }
 
-            _logger.LogInformation("Config valid. Requesting daemon restart.");
-            _lifecycleNotifier.NotifyShutdown("config-reload");
-            _restartSignal.RequestRestart();
-            _appLifetime.StopApplication();
+            _logger.LogInformation("Config valid. Starting coordinated daemon restart.");
+            await _restartCoordinator.RequestConfigRestartAsync(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -8,7 +8,7 @@ namespace Netclaw.Daemon.Services;
 /// <summary>
 /// Monitors <c>~/.netclaw/config/</c> for changes to <c>netclaw.json</c>.
 /// Debounces file system events and validates new config before applying.
-/// See SPEC-011 §Configuration Hot-Reload.
+/// See SPEC-011 §Configuration Restart Coordination.
 ///
 /// <para>
 /// Single reload trigger: all config changes go to disk first (TUI wizard,
@@ -118,7 +118,7 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
                 "[{Timestamp:o}] Config change detected, validating before restart...",
                 _timeProvider.GetUtcNow());
 
-            // Validate JSON structure of both config files before triggering restart.
+            // Validate JSON structure of the watched config file before triggering restart.
             // Full semantic validation happens during the next startup cycle.
             if (!ValidateConfigJson(_paths.NetclawConfigPath))
             {

--- a/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
+++ b/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
@@ -55,10 +55,22 @@ public sealed class DaemonLifecycleNotifier
     /// <param name="reason">
     /// Human-readable reason string (e.g., "cli-stop", "update", "config-reload").
     /// </param>
-    public void NotifyShutdown(string reason)
+    public void NotifyShutdown(string reason, IReadOnlyDictionary<string, string>? additionalContext = null)
     {
         var pid = Environment.ProcessId;
         _logger.LogInformation("Netclaw daemon stopping (PID {Pid}, reason: {Reason})", pid, reason);
+
+        var context = new Dictionary<string, string>
+        {
+            ["pid"] = pid.ToString(CultureInfo.InvariantCulture),
+            ["reason"] = reason,
+        };
+
+        if (additionalContext is not null)
+        {
+            foreach (var pair in additionalContext)
+                context[pair.Key] = pair.Value;
+        }
 
         _sink.Emit(new OperationalAlert
         {
@@ -69,11 +81,7 @@ public sealed class DaemonLifecycleNotifier
             Summary = $"Netclaw daemon stopping: {reason}",
             Timestamp = _timeProvider.GetUtcNow(),
             Source = pid.ToString(CultureInfo.InvariantCulture),
-            Context = new Dictionary<string, string>
-            {
-                ["pid"] = pid.ToString(CultureInfo.InvariantCulture),
-                ["reason"] = reason,
-            },
+            Context = context,
         });
     }
 }

--- a/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using System.Linq;
+using Akka.Actor;
+using Akka.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Daemon.Services;
+
+public interface IDaemonRestartCoordinator
+{
+    Task RequestConfigRestartAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Coordinates graceful daemon restart by closing ingress, draining active sessions,
+/// persisting restart recovery state, and only then requesting host shutdown.
+/// </summary>
+public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
+{
+    internal static readonly TimeSpan RestartDrainTimeout = TimeSpan.FromSeconds(20);
+
+    private readonly SessionIngressGate _ingressGate;
+    private readonly RestartManifestStore _manifestStore;
+    private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
+    private readonly DaemonRestartSignal _restartSignal;
+    private readonly IHostApplicationLifetime _appLifetime;
+    private readonly DaemonLifecycleNotifier _lifecycleNotifier;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DaemonRestartCoordinator> _logger;
+    private readonly TimeSpan _restartDrainTimeout;
+
+    public DaemonRestartCoordinator(
+        SessionIngressGate ingressGate,
+        RestartManifestStore manifestStore,
+        IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
+        DaemonRestartSignal restartSignal,
+        IHostApplicationLifetime appLifetime,
+        DaemonLifecycleNotifier lifecycleNotifier,
+        TimeProvider timeProvider,
+        ILogger<DaemonRestartCoordinator> logger,
+        TimeSpan? restartDrainTimeout = null)
+    {
+        _ingressGate = ingressGate;
+        _manifestStore = manifestStore;
+        _sessionManagerProvider = sessionManagerProvider;
+        _restartSignal = restartSignal;
+        _appLifetime = appLifetime;
+        _lifecycleNotifier = lifecycleNotifier;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _restartDrainTimeout = restartDrainTimeout ?? RestartDrainTimeout;
+    }
+
+    public async Task RequestConfigRestartAsync(CancellationToken cancellationToken)
+    {
+        if (!_ingressGate.TryClose(SessionIngressGate.RestartInProgressMessage))
+        {
+            _logger.LogInformation("Coordinated restart already in progress; ignoring duplicate config reload request.");
+            return;
+        }
+
+        try
+        {
+            var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
+            var activeIdsResponse = await sessionManager.Ask<ActiveEntityIds>(
+                GetActiveEntityIds.Instance,
+                timeout: _restartDrainTimeout,
+                cancellationToken: cancellationToken);
+
+            var sessionIds = activeIdsResponse.EntityIds
+                .Select(id => new SessionId(id))
+                .ToArray();
+
+            _logger.LogInformation(
+                "Starting coordinated config restart for {SessionCount} active session(s).",
+                sessionIds.Length);
+
+            var drainResult = await DrainSessionsAsync(sessionManager, sessionIds, cancellationToken);
+
+            var manifest = new RestartManifest
+            {
+                Reason = "config-reload",
+                RequestedAt = _timeProvider.GetUtcNow(),
+                SessionIds = sessionIds.Select(static id => id.Value).ToList(),
+                TimedOutSessionIds = drainResult.TimedOutSessionIds.Select(static id => id.Value).ToList()
+            };
+
+            if (manifest.SessionIds.Count == 0)
+                await _manifestStore.DeleteAsync();
+            else
+                await _manifestStore.WriteAsync(manifest, cancellationToken);
+
+            var notificationContext = new Dictionary<string, string>
+            {
+                ["drainOutcome"] = drainResult.TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
+                ["activeSessions"] = sessionIds.Length.ToString(CultureInfo.InvariantCulture),
+                ["drainedSessions"] = drainResult.DrainedSessionIds.Count.ToString(CultureInfo.InvariantCulture),
+                ["timedOutSessions"] = drainResult.TimedOutSessionIds.Count.ToString(CultureInfo.InvariantCulture)
+            };
+
+            _lifecycleNotifier.NotifyShutdown("config-reload", notificationContext);
+            _restartSignal.RequestRestart();
+            _appLifetime.StopApplication();
+        }
+        catch
+        {
+            _ingressGate.Reopen();
+            throw;
+        }
+    }
+
+    private async Task<DrainResult> DrainSessionsAsync(IActorRef sessionManager, IReadOnlyList<SessionId> sessionIds, CancellationToken cancellationToken)
+    {
+        if (sessionIds.Count == 0)
+            return DrainResult.Empty;
+
+        using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        drainCts.CancelAfter(_restartDrainTimeout);
+
+        var drainTasks = sessionIds.Select(async sessionId =>
+        {
+            try
+            {
+                var ack = await sessionManager.Ask<CommandAck>(
+                    new PrepareForDaemonRestart
+                    {
+                        SessionId = sessionId,
+                        Reason = "config-reload"
+                    },
+                    timeout: _restartDrainTimeout,
+                    cancellationToken: drainCts.Token);
+
+                return new DrainOutcome(sessionId, ack.SessionId == sessionId);
+            }
+            catch (OperationCanceledException)
+            {
+                return new DrainOutcome(sessionId, false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to drain session {SessionId} before restart.", sessionId.Value);
+                return new DrainOutcome(sessionId, false);
+            }
+        }).ToArray();
+
+        var outcomes = await Task.WhenAll(drainTasks);
+        var drained = outcomes.Where(static x => x.Drained).Select(static x => x.SessionId).ToArray();
+        var timedOut = outcomes.Where(static x => !x.Drained).Select(static x => x.SessionId).ToArray();
+
+        if (timedOut.Length == 0)
+        {
+            _logger.LogInformation("All {SessionCount} active session(s) drained before restart.", drained.Length);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Proceeding with restart after drain timeout; {DrainedCount} session(s) drained and {TimedOutCount} will recover from the last durable checkpoint.",
+                drained.Length,
+                timedOut.Length);
+        }
+
+        return new DrainResult(drained, timedOut);
+    }
+
+    private sealed record DrainOutcome(SessionId SessionId, bool Drained);
+
+    private sealed record DrainResult(IReadOnlyList<SessionId> DrainedSessionIds, IReadOnlyList<SessionId> TimedOutSessionIds)
+    {
+        public static readonly DrainResult Empty = new([], []);
+    }
+}

--- a/src/Netclaw.Daemon/Services/RestartManifestStore.cs
+++ b/src/Netclaw.Daemon/Services/RestartManifestStore.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+public sealed record RestartManifest
+{
+    public required string Reason { get; init; }
+
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    public required List<string> SessionIds { get; init; }
+
+    public List<string> TimedOutSessionIds { get; init; } = [];
+}
+
+/// <summary>
+/// Persists short-lived restart recovery state across a coordinated in-process host restart.
+/// </summary>
+public sealed class RestartManifestStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private readonly NetclawPaths _paths;
+
+    public RestartManifestStore(NetclawPaths paths)
+    {
+        _paths = paths;
+    }
+
+    public async Task WriteAsync(RestartManifest manifest, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        _paths.EnsureDirectoriesExist();
+
+        await using var stream = File.Create(_paths.RestartManifestPath);
+        await JsonSerializer.SerializeAsync(stream, manifest, JsonOptions, cancellationToken);
+    }
+
+    public async Task<RestartManifest?> ReadAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_paths.RestartManifestPath))
+            return null;
+
+        await using var stream = File.OpenRead(_paths.RestartManifestPath);
+        return await JsonSerializer.DeserializeAsync<RestartManifest>(stream, JsonOptions, cancellationToken);
+    }
+
+    public Task DeleteAsync()
+    {
+        if (File.Exists(_paths.RestartManifestPath))
+            File.Delete(_paths.RestartManifestPath);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Netclaw.Daemon/Services/RestartRecoveryService.cs
+++ b/src/Netclaw.Daemon/Services/RestartRecoveryService.cs
@@ -1,0 +1,84 @@
+using Akka.Actor;
+using Akka.Pattern;
+using Akka.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Daemon.Gateway;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Rehydrates the sessions that were active before coordinated restart began.
+/// </summary>
+public sealed class RestartRecoveryService : IHostedService
+{
+    private const string RestartNotice = "The daemon restarted due to a configuration change. Recovery resumed from the last durable checkpoint.";
+
+    private readonly RestartManifestStore _manifestStore;
+    private readonly IRequiredActor<SessionManagerActorKey> _sessionManagerProvider;
+    private readonly SessionCatalogService _sessionCatalog;
+    private readonly ILogger<RestartRecoveryService> _logger;
+
+    public RestartRecoveryService(
+        RestartManifestStore manifestStore,
+        IRequiredActor<SessionManagerActorKey> sessionManagerProvider,
+        SessionCatalogService sessionCatalog,
+        ILogger<RestartRecoveryService> logger)
+    {
+        _manifestStore = manifestStore;
+        _sessionManagerProvider = sessionManagerProvider;
+        _sessionCatalog = sessionCatalog;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var manifest = await _manifestStore.ReadAsync(cancellationToken);
+        if (manifest is null)
+            return;
+
+        try
+        {
+            if (manifest.SessionIds.Count == 0)
+                return;
+
+            var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
+            foreach (var sessionIdValue in manifest.SessionIds)
+            {
+                var sessionId = new SessionId(sessionIdValue);
+
+                try
+                {
+                    await sessionManager.Ask<CommandAck>(
+                        new WarmSession
+                        {
+                            SessionId = sessionId,
+                            RestartNotice = RestartNotice
+                        },
+                        timeout: TimeSpan.FromSeconds(10),
+                        cancellationToken: cancellationToken);
+
+                    _sessionCatalog.MarkSessionActive(sessionId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to warm session {SessionId} during restart recovery.", sessionIdValue);
+                }
+            }
+
+            _logger.LogInformation(
+                "Restart recovery warmed {SessionCount} session(s); {TimedOutCount} were previously timed out during drain.",
+                manifest.SessionIds.Count,
+                manifest.TimedOutSessionIds.Count);
+        }
+        finally
+        {
+            await _manifestStore.DeleteAsync();
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- coordinate config-triggered restarts through ingress gating, active-session drain, restart manifest persistence, and post-restart warmup
- add restart-aware session and adapter behavior so new work is rejected during drain and interrupted sessions resume from the last durable checkpoint
- cover the flow with daemon, Slack, and session integration tests, and align the PRD/spec/OpenSpec artifacts with coordinated restart behavior

## Testing
- dotnet test
- dotnet slopwatch analyze