### PR TITLE
fix(skills): recover orphaned skill files in skill_manage

### DIFF
--- a/feeds/skills/.system/files/skill-authoring/SKILL.md
+++ b/feeds/skills/.system/files/skill-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: skill-authoring
 description: "How to create, edit, and manage Netclaw skills. Read this when you need to synthesize a new skill from a session, understand the skill file format, or use the skill_manage tool."
 metadata:
   author: netclaw
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Skill Authoring
@@ -119,6 +119,13 @@ The skill body references these files explicitly: "See
 them on demand via `skill_read_resource`.
 
 ## Creating Skills with skill_manage
+
+**IMPORTANT: NEVER use `file_write` to create or modify skill files.** The
+`file_write` tool writes to disk but does NOT register the skill in the
+in-memory `SkillRegistry`. The skill will exist on disk but be invisible to
+`skill_load`, the skill index, and `netclaw stats` until the next daemon
+restart. Always use `skill_manage` — it validates frontmatter, writes
+atomically, and triggers an immediate registry rescan.
 
 Use the `skill_manage` tool for all skill mutations:
 

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -309,6 +309,100 @@ public class SkillToolTests : IDisposable
             Path.Combine(_paths.SkillsDirectory, "delete-me")));
     }
 
+    [Fact]
+    public async Task SkillManage_Create_OverwritesOrphanedFile()
+    {
+        // Simulate file_write creating a skill file without registry registration
+        var dir = Path.Combine(_paths.SkillsDirectory, "orphan-skill");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), "# No frontmatter");
+        // Intentionally NOT calling ScanSkills() — registry is empty
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "create",
+            ["Name"] = "orphan-skill",
+            ["Content"] = "---\nname: orphan-skill\ndescription: Fixed skill.\n---\n# Fixed"
+        });
+
+        Assert.Contains("orphan-skill", result);
+        Assert.Contains("orphaned", result);
+        // Verify skill is now registered
+        Assert.NotNull(_registry.GetAll().FirstOrDefault(s => s.Name == "orphan-skill"));
+    }
+
+    [Fact]
+    public async Task SkillManage_Create_BlocksWhenSkillProperlyRegistered()
+    {
+        WriteSkill("existing-skill", """
+            ---
+            name: existing-skill
+            description: Already registered.
+            ---
+            # Existing
+            """);
+        ScanSkills();
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "create",
+            ["Name"] = "existing-skill",
+            ["Content"] = "---\nname: existing-skill\ndescription: Duplicate.\n---\n# Dup"
+        });
+
+        Assert.Contains("already exists", result);
+        Assert.Contains("edit", result);
+    }
+
+    [Fact]
+    public async Task SkillManage_Edit_RescansOrphanedFile()
+    {
+        // Simulate file_write creating a valid skill file without registry registration
+        WriteSkill("orphan-edit", """
+            ---
+            name: orphan-edit
+            description: Orphaned but valid.
+            ---
+            # Original
+            """);
+        // Intentionally NOT calling ScanSkills() — registry is empty
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "edit",
+            ["Name"] = "orphan-edit",
+            ["Content"] = "---\nname: orphan-edit\ndescription: Updated.\n---\n# Updated"
+        });
+
+        Assert.Contains("updated", result, StringComparison.OrdinalIgnoreCase);
+        var content = File.ReadAllText(
+            Path.Combine(_paths.SkillsDirectory, "orphan-edit", "SKILL.md"));
+        Assert.Contains("# Updated", content);
+    }
+
+    [Fact]
+    public async Task SkillManage_Edit_OrphanWithInvalidFrontmatter_StillNotFound()
+    {
+        // file_write created a file without valid frontmatter — rescan won't register it
+        var dir = Path.Combine(_paths.SkillsDirectory, "bad-orphan");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), "# No frontmatter at all");
+        // Not calling ScanSkills()
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "edit",
+            ["Name"] = "bad-orphan",
+            ["Content"] = "---\nname: bad-orphan\ndescription: Fix.\n---\n# Fix"
+        });
+
+        Assert.Contains("not found", result);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private SkillManageTool CreateManageTool()

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -102,7 +102,18 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         var skillPath = Path.Combine(skillDir, "SKILL.md");
 
         if (File.Exists(skillPath))
-            return $"Skill '{name}' already exists. Use 'edit' to modify it.";
+        {
+            // If the file exists on disk but isn't in the registry (orphaned from file_write),
+            // allow create to overwrite it. Only block if the skill is properly registered.
+            var existing = FindSkill(name);
+            if (existing is not null)
+                return $"Skill '{name}' already exists. Use 'edit' to modify it.";
+
+            // Orphaned file — overwrite and register it
+            AtomicWrite(skillPath, args.Content);
+            RescanAndUpdateIndex();
+            return $"Skill '{name}' created at {skillDir} (replaced orphaned file)";
+        }
 
         Directory.CreateDirectory(skillDir);
         AtomicWrite(skillPath, args.Content);
@@ -126,7 +137,19 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
         var skill = FindSkill(name);
         if (skill is null)
-            return $"Skill '{name}' not found.";
+        {
+            // The skill might exist on disk but not be in the registry (orphaned from file_write).
+            // Rescan and retry before giving up.
+            var candidatePath = Path.Combine(_paths.SkillsDirectory, name, "SKILL.md");
+            if (File.Exists(candidatePath))
+            {
+                RescanAndUpdateIndex();
+                skill = FindSkill(name);
+            }
+
+            if (skill is null)
+                return $"Skill '{name}' not found.";
+        }
 
         if (skill.TrustTier == SkillTrustTier.System)
             return "Cannot edit system skills. System skills are read-only.";


### PR DESCRIPTION
## Summary
- Fix Catch-22 in `skill_manage` where `file_write`-created skill files block both `create` ("already exists") and `edit` ("not found") actions
- `create` now detects orphaned files (on disk but not in registry) and overwrites them
- `edit` now rescans orphaned files before returning "not found"
- Updated `skill-authoring` system skill (v1.1.0) with explicit warning against using `file_write` for skill files

## Test plan
- [x] `SkillManage_Create_OverwritesOrphanedFile` — create overwrites orphan and registers it
- [x] `SkillManage_Create_BlocksWhenSkillProperlyRegistered` — create still rejects duplicates
- [x] `SkillManage_Edit_RescansOrphanedFile` — edit recovers orphan via rescan
- [x] `SkillManage_Edit_OrphanWithInvalidFrontmatter_StillNotFound` — edit rejects unrecoverable orphans
- [x] All 17 existing `SkillToolTests` pass