### PR TITLE
release: 0.9.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,39 @@
+#### 0.9.0 2026-03-27 ####
+
+Netclaw v0.9.0 — Two-phase streaming timeout, FTS5 memory recall, turn-based distillation, and streaming performance fix
+
+**Features**
+
+* Added two-phase streaming timeout for LLM calls — introduces separate `FirstTokenTimeout` and `StreamIdleTimeout` settings, replacing the single monolithic timeout. The first-token window catches provider failures fast while the idle timeout tolerates long-running tool-use streams without premature cancellation. ([#460](https://github.com/Aaronontheweb/netclaw/pull/460))
+* Added turn-based memory distillation trigger alongside idle timeout — sessions now trigger memory distillation at turn boundaries in addition to the existing 90-second idle timer, so busy multi-turn conversations no longer defer all memory formation until the session goes quiet. ([#442](https://github.com/Aaronontheweb/netclaw/pull/442), [#463](https://github.com/Aaronontheweb/netclaw/pull/463))
+* Migrated memory recall search from LIKE to SQLite FTS5 full-text search with BM25 scoring — recall queries now use a dedicated FTS5 virtual table for relevance-ranked results instead of substring matching, significantly improving recall quality for multi-word queries. ([#436](https://github.com/Aaronontheweb/netclaw/pull/436))
+* Added token delta and cumulative logging to `LoggingChatClient` — each streaming chunk now logs its individual token delta alongside the running cumulative total, making it easier to diagnose token consumption during long tool-use loops. ([#443](https://github.com/Aaronontheweb/netclaw/pull/443), [#445](https://github.com/Aaronontheweb/netclaw/pull/445))
+
+**Bug Fixes**
+
+* Fixed daemon restarting active sessions during config reload — the config restart path now drains all active sessions gracefully before applying the new configuration, preventing mid-turn interruptions. ([#468](https://github.com/Aaronontheweb/netclaw/pull/468))
+* Fixed `web_fetch` saving binary content with incorrect extensions and corrupted bytes — binary responses (images, PDFs, etc.) are now saved with the correct file extension derived from the Content-Type header, and raw bytes are written without text encoding round-trips. ([#386](https://github.com/Aaronontheweb/netclaw/pull/386), [#461](https://github.com/Aaronontheweb/netclaw/pull/461))
+* Enforced HTTPS by default in the `web_fetch` tool — requests to plain HTTP URLs are now rejected unless explicitly allowed, hardening the default security posture for outbound fetches. ([#458](https://github.com/Aaronontheweb/netclaw/pull/458))
+* Fixed `netclaw init` auto-detecting Slack webhook format from URL — the init wizard now inspects the webhook URL to determine whether it is a Slack incoming webhook and sets `"Format": "Slack"` automatically, eliminating a common misconfiguration. ([#401](https://github.com/Aaronontheweb/netclaw/pull/401), [#462](https://github.com/Aaronontheweb/netclaw/pull/462))
+* Stopped persisting system prompt in Akka journal — the full system prompt was previously included in persisted session state, bloating the journal and slowing recovery. It is now excluded from persistence and reconstructed on recovery. ([#451](https://github.com/Aaronontheweb/netclaw/pull/451))
+* Enforced record-class storage for evidence memories — evidence memory proposals that arrived as plain strings are now normalized into the expected record-class format before storage, preventing downstream deserialization failures. ([#446](https://github.com/Aaronontheweb/netclaw/pull/446), [#452](https://github.com/Aaronontheweb/netclaw/pull/452))
+* Added `TurnOutcome` to prevent quick-exit paths from inflating turn count — tool-only and no-op turns that exit early without an LLM response no longer increment the turn counter, giving more accurate turn-based metrics. ([#450](https://github.com/Aaronontheweb/netclaw/pull/450))
+* Added singleton guard and PID file watchdog to prevent duplicate daemons — launching a second daemon instance now fails fast with a clear error instead of silently competing for resources. A PID file watchdog detects stale lock files from crashed processes. ([#433](https://github.com/Aaronontheweb/netclaw/pull/433))
+* Fixed console output leaks in CLI and daemon — stray `Console.Write` calls that bypassed the structured logging pipeline are now routed through the proper output channels. ([#425](https://github.com/Aaronontheweb/netclaw/pull/425))
+
+**Performance**
+
+* Fixed O(n^2) `ToolCallTextFilter` scanning during streaming — replaced the quadratic per-chunk scan with incremental delta detection, eliminating a hot path that caused visible latency on long tool-call sequences. ([#454](https://github.com/Aaronontheweb/netclaw/pull/454), [#457](https://github.com/Aaronontheweb/netclaw/pull/457))
+
+**Diagnostics**
+
+* Unified daemon uptime into a single `DaemonStartClock` singleton — previously uptime was computed from multiple inconsistent sources. All uptime queries now read from one authoritative clock. ([#456](https://github.com/Aaronontheweb/netclaw/pull/456))
+* Surfaced diagnostic detail when update check fails — `netclaw update` and background update checks now log the specific HTTP status and error body instead of a generic "check failed" message. ([#431](https://github.com/Aaronontheweb/netclaw/pull/431))
+
+**Dependencies**
+
+* Bumped ModelContextProtocol.Core from 1.0.0 to 1.1.0. ([#434](https://github.com/Aaronontheweb/netclaw/pull/434))
+
 #### 0.8.1 2026-03-25 ####
 
 Netclaw v0.8.1 — Slack duplicate message fix, memory passivation hardening, file_edit tool, and LlmSessionActor decomposition

--- a/feeds/skills/.system/files/skill-authoring/SKILL.md
+++ b/feeds/skills/.system/files/skill-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: skill-authoring
 description: "How to create, edit, and manage Netclaw skills. Read this when you need to synthesize a new skill from a session, understand the skill file format, or use the skill_manage tool."
 metadata:
   author: netclaw
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Skill Authoring
@@ -119,6 +119,13 @@ The skill body references these files explicitly: "See
 them on demand via `skill_read_resource`.
 
 ## Creating Skills with skill_manage
+
+**IMPORTANT: NEVER use `file_write` to create or modify skill files.** The
+`file_write` tool writes to disk but does NOT register the skill in the
+in-memory `SkillRegistry`. The skill will exist on disk but be invisible to
+`skill_load`, the skill index, and `netclaw stats` until the next daemon
+restart. Always use `skill_manage` — it validates frontmatter, writes
+atomically, and triggers an immediate registry rescan.
 
 Use the `skill_manage` tool for all skill mutations:
 

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -309,6 +309,100 @@ public class SkillToolTests : IDisposable
             Path.Combine(_paths.SkillsDirectory, "delete-me")));
     }
 
+    [Fact]
+    public async Task SkillManage_Create_OverwritesOrphanedFile()
+    {
+        // Simulate file_write creating a skill file without registry registration
+        var dir = Path.Combine(_paths.SkillsDirectory, "orphan-skill");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), "# No frontmatter");
+        // Intentionally NOT calling ScanSkills() — registry is empty
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "create",
+            ["Name"] = "orphan-skill",
+            ["Content"] = "---\nname: orphan-skill\ndescription: Fixed skill.\n---\n# Fixed"
+        });
+
+        Assert.Contains("orphan-skill", result);
+        Assert.Contains("orphaned", result);
+        // Verify skill is now registered
+        Assert.NotNull(_registry.GetAll().FirstOrDefault(s => s.Name == "orphan-skill"));
+    }
+
+    [Fact]
+    public async Task SkillManage_Create_BlocksWhenSkillProperlyRegistered()
+    {
+        WriteSkill("existing-skill", """
+            ---
+            name: existing-skill
+            description: Already registered.
+            ---
+            # Existing
+            """);
+        ScanSkills();
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "create",
+            ["Name"] = "existing-skill",
+            ["Content"] = "---\nname: existing-skill\ndescription: Duplicate.\n---\n# Dup"
+        });
+
+        Assert.Contains("already exists", result);
+        Assert.Contains("edit", result);
+    }
+
+    [Fact]
+    public async Task SkillManage_Edit_RescansOrphanedFile()
+    {
+        // Simulate file_write creating a valid skill file without registry registration
+        WriteSkill("orphan-edit", """
+            ---
+            name: orphan-edit
+            description: Orphaned but valid.
+            ---
+            # Original
+            """);
+        // Intentionally NOT calling ScanSkills() — registry is empty
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "edit",
+            ["Name"] = "orphan-edit",
+            ["Content"] = "---\nname: orphan-edit\ndescription: Updated.\n---\n# Updated"
+        });
+
+        Assert.Contains("updated", result, StringComparison.OrdinalIgnoreCase);
+        var content = File.ReadAllText(
+            Path.Combine(_paths.SkillsDirectory, "orphan-edit", "SKILL.md"));
+        Assert.Contains("# Updated", content);
+    }
+
+    [Fact]
+    public async Task SkillManage_Edit_OrphanWithInvalidFrontmatter_StillNotFound()
+    {
+        // file_write created a file without valid frontmatter — rescan won't register it
+        var dir = Path.Combine(_paths.SkillsDirectory, "bad-orphan");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), "# No frontmatter at all");
+        // Not calling ScanSkills()
+
+        var tool = CreateManageTool();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Action"] = "edit",
+            ["Name"] = "bad-orphan",
+            ["Content"] = "---\nname: bad-orphan\ndescription: Fix.\n---\n# Fix"
+        });
+
+        Assert.Contains("not found", result);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private SkillManageTool CreateManageTool()

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -102,7 +102,18 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         var skillPath = Path.Combine(skillDir, "SKILL.md");
 
         if (File.Exists(skillPath))
-            return $"Skill '{name}' already exists. Use 'edit' to modify it.";
+        {
+            // If the file exists on disk but isn't in the registry (orphaned from file_write),
+            // allow create to overwrite it. Only block if the skill is properly registered.
+            var existing = FindSkill(name);
+            if (existing is not null)
+                return $"Skill '{name}' already exists. Use 'edit' to modify it.";
+
+            // Orphaned file — overwrite and register it
+            AtomicWrite(skillPath, args.Content);
+            RescanAndUpdateIndex();
+            return $"Skill '{name}' created at {skillDir} (replaced orphaned file)";
+        }
 
         Directory.CreateDirectory(skillDir);
         AtomicWrite(skillPath, args.Content);
@@ -126,7 +137,19 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
         var skill = FindSkill(name);
         if (skill is null)
-            return $"Skill '{name}' not found.";
+        {
+            // The skill might exist on disk but not be in the registry (orphaned from file_write).
+            // Rescan and retry before giving up.
+            var candidatePath = Path.Combine(_paths.SkillsDirectory, name, "SKILL.md");
+            if (File.Exists(candidatePath))
+            {
+                RescanAndUpdateIndex();
+                skill = FindSkill(name);
+            }
+
+            if (skill is null)
+                return $"Skill '{name}' not found.";
+        }
 
         if (skill.TrustTier == SkillTrustTier.System)
             return "Cannot edit system skills. System skills are read-only.";


### PR DESCRIPTION
## Summary

Release preparation for Netclaw 0.9.0.

- **Features:** Two-phase streaming timeout, turn-based memory distillation, FTS5 full-text search for memory recall, token delta/cumulative logging
- **Bug Fixes:** Drain sessions before config restart, binary content save fix, HTTPS enforcement in web_fetch, Slack webhook auto-detect, journal prompt bloat fix, evidence memory storage fix, turn count inflation fix, duplicate daemon guard, console output leak fix
- **Performance:** O(n^2) ToolCallTextFilter scanning replaced with incremental delta detection
- **Diagnostics:** Unified DaemonStartClock singleton, improved update check error reporting
- **Dependencies:** ModelContextProtocol.Core 1.0.0 to 1.1.0

## Test plan

- [ ] `dotnet build` succeeds (verified locally)
- [ ] `dotnet test` passes all 1,549 tests (verified locally)
- [ ] Review RELEASE_NOTES.md formatting and content accuracy
- [ ] Merge to dev, then tag 0.9.0 from dev and push tag to trigger release workflow