### PR TITLE
prepare release 0.9.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,40 +7,20 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.9.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.9.0 — Two-phase streaming timeout, FTS5 memory recall, turn-based distillation, and streaming performance fix
+    <VersionPrefix>0.9.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.9.1 — Configurable project workspaces, reminders upgrade, skill security scanning, and session reliability fixes
 
 **Features**
 
-* Added two-phase streaming timeout for LLM calls — introduces separate `FirstTokenTimeout` and `StreamIdleTimeout` settings, replacing the single monolithic timeout. The first-token window catches provider failures fast while the idle timeout tolerates long-running tool-use streams without premature cancellation. ([#460](https://github.com/Aaronontheweb/netclaw/pull/460))
-* Added turn-based memory distillation trigger alongside idle timeout — sessions now trigger memory distillation at turn boundaries in addition to the existing 90-second idle timer, so busy multi-turn conversations no longer defer all memory formation until the session goes quiet. ([#442](https://github.com/Aaronontheweb/netclaw/pull/442), [#463](https://github.com/Aaronontheweb/netclaw/pull/463))
-* Migrated memory recall search from LIKE to SQLite FTS5 full-text search with BM25 scoring — recall queries now use a dedicated FTS5 virtual table for relevance-ranked results instead of substring matching, significantly improving recall quality for multi-word queries. ([#436](https://github.com/Aaronontheweb/netclaw/pull/436))
-* Added token delta and cumulative logging to `LoggingChatClient` — each streaming chunk now logs its individual token delta alongside the running cumulative total, making it easier to diagnose token consumption during long tool-use loops. ([#443](https://github.com/Aaronontheweb/netclaw/pull/443), [#445](https://github.com/Aaronontheweb/netclaw/pull/445))
+* Added configurable project workspaces with AGENTS.md discovery — operators can now define named workspaces under `~/.netclaw/workspaces/`. Each workspace maps a name to a root directory, and `AGENTS.md` files found in the workspace tree are surfaced automatically as project context. The `netclaw init` wizard now prompts for a workspaces path during setup. ([#472](https://github.com/Aaronontheweb/netclaw/pull/472), [#482](https://github.com/Aaronontheweb/netclaw/pull/482))
+* Upgraded to Akka.Reminders v0.6.0-beta2 with envelope-based delivery — reminders now deliver via a typed envelope wrapper rather than raw message dispatch, improving type safety and routing clarity. **Breaking change:** the SQLite reminder store schema adds ack-tracking columns in this release. Existing reminder databases must be deleted and recreated after upgrading. ([#484](https://github.com/Aaronontheweb/netclaw/pull/484))
+* Added skill content security scanning with shared prompt injection detection — skill files are now scanned at load time using 22 regex patterns across 5 threat categories (prompt injection, role hijacking, instruction override, data exfiltration, and system escape). Skills that match a pattern are blocked from loading and logged with the specific pattern that triggered the rejection. ([#408](https://github.com/Aaronontheweb/netclaw/pull/408))
 
 **Bug Fixes**
 
-* Fixed daemon restarting active sessions during config reload — the config restart path now drains all active sessions gracefully before applying the new configuration, preventing mid-turn interruptions. ([#468](https://github.com/Aaronontheweb/netclaw/pull/468))
-* Fixed `web_fetch` saving binary content with incorrect extensions and corrupted bytes — binary responses (images, PDFs, etc.) are now saved with the correct file extension derived from the Content-Type header, and raw bytes are written without text encoding round-trips. ([#386](https://github.com/Aaronontheweb/netclaw/pull/386), [#461](https://github.com/Aaronontheweb/netclaw/pull/461))
-* Enforced HTTPS by default in the `web_fetch` tool — requests to plain HTTP URLs are now rejected unless explicitly allowed, hardening the default security posture for outbound fetches. ([#458](https://github.com/Aaronontheweb/netclaw/pull/458))
-* Fixed `netclaw init` auto-detecting Slack webhook format from URL — the init wizard now inspects the webhook URL to determine whether it is a Slack incoming webhook and sets `"Format": "Slack"` automatically, eliminating a common misconfiguration. ([#401](https://github.com/Aaronontheweb/netclaw/pull/401), [#462](https://github.com/Aaronontheweb/netclaw/pull/462))
-* Stopped persisting system prompt in Akka journal — the full system prompt was previously included in persisted session state, bloating the journal and slowing recovery. It is now excluded from persistence and reconstructed on recovery. ([#451](https://github.com/Aaronontheweb/netclaw/pull/451))
-* Enforced record-class storage for evidence memories — evidence memory proposals that arrived as plain strings are now normalized into the expected record-class format before storage, preventing downstream deserialization failures. ([#446](https://github.com/Aaronontheweb/netclaw/pull/446), [#452](https://github.com/Aaronontheweb/netclaw/pull/452))
-* Added `TurnOutcome` to prevent quick-exit paths from inflating turn count — tool-only and no-op turns that exit early without an LLM response no longer increment the turn counter, giving more accurate turn-based metrics. ([#450](https://github.com/Aaronontheweb/netclaw/pull/450))
-* Added singleton guard and PID file watchdog to prevent duplicate daemons — launching a second daemon instance now fails fast with a clear error instead of silently competing for resources. A PID file watchdog detects stale lock files from crashed processes. ([#433](https://github.com/Aaronontheweb/netclaw/pull/433))
-* Fixed console output leaks in CLI and daemon — stray `Console.Write` calls that bypassed the structured logging pipeline are now routed through the proper output channels. ([#425](https://github.com/Aaronontheweb/netclaw/pull/425))
-
-**Performance**
-
-* Fixed O(n^2) `ToolCallTextFilter` scanning during streaming — replaced the quadratic per-chunk scan with incremental delta detection, eliminating a hot path that caused visible latency on long tool-call sequences. ([#454](https://github.com/Aaronontheweb/netclaw/pull/454), [#457](https://github.com/Aaronontheweb/netclaw/pull/457))
-
-**Diagnostics**
-
-* Unified daemon uptime into a single `DaemonStartClock` singleton — previously uptime was computed from multiple inconsistent sources. All uptime queries now read from one authoritative clock. ([#456](https://github.com/Aaronontheweb/netclaw/pull/456))
-* Surfaced diagnostic detail when update check fails — `netclaw update` and background update checks now log the specific HTTP status and error body instead of a generic "check failed" message. ([#431](https://github.com/Aaronontheweb/netclaw/pull/431))
-
-**Dependencies**
-
-* Bumped ModelContextProtocol.Core from 1.0.0 to 1.1.0. ([#434](https://github.com/Aaronontheweb/netclaw/pull/434))</PackageReleaseNotes>
+* Fixed sessions requiring manual message resend after context overflow compaction — sessions now automatically resend the original user message after compaction completes, so users no longer see "Please resend your last message" prompts. Also added streaming retry for transient provider errors (5xx, 429) with configurable backoff via `SessionTuning.StreamingRetryPolicy`. ([#485](https://github.com/Aaronontheweb/netclaw/pull/485))
+* Fixed `HttpClient.Timeout` (default 100s) prematurely killing LLM calls for self-hosted models with large contexts — the session watchdog is now the sole timeout authority for LLM request lifetimes. `HttpClient.Timeout` is set to `Timeout.InfiniteTimeSpan` and all cancellation flows through the session watchdog's `CancellationToken`. ([#476](https://github.com/Aaronontheweb/netclaw/pull/476))
+* Fixed reminder execution actor using the wrong output filter — the actor was configured with `TextStreaming | ToolCalls` instead of the correct filter for reminder delivery, causing reminders to not stream output correctly. ([#475](https://github.com/Aaronontheweb/netclaw/pull/475))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+#### 0.9.1 2026-03-30 ####
+
+Netclaw v0.9.1 — Configurable project workspaces, reminders upgrade, skill security scanning, and session reliability fixes
+
+**Features**
+
+* Added configurable project workspaces with AGENTS.md discovery — operators can now define named workspaces under `~/.netclaw/workspaces/`. Each workspace maps a name to a root directory, and `AGENTS.md` files found in the workspace tree are surfaced automatically as project context. The `netclaw init` wizard now prompts for a workspaces path during setup. ([#472](https://github.com/Aaronontheweb/netclaw/pull/472), [#482](https://github.com/Aaronontheweb/netclaw/pull/482))
+* Upgraded to Akka.Reminders v0.6.0-beta2 with envelope-based delivery — reminders now deliver via a typed envelope wrapper rather than raw message dispatch, improving type safety and routing clarity. **Breaking change:** the SQLite reminder store schema adds ack-tracking columns in this release. Existing reminder databases must be deleted and recreated after upgrading. ([#484](https://github.com/Aaronontheweb/netclaw/pull/484))
+* Added skill content security scanning with shared prompt injection detection — skill files are now scanned at load time using 22 regex patterns across 5 threat categories (prompt injection, role hijacking, instruction override, data exfiltration, and system escape). Skills that match a pattern are blocked from loading and logged with the specific pattern that triggered the rejection. ([#408](https://github.com/Aaronontheweb/netclaw/pull/408))
+
+**Bug Fixes**
+
+* Fixed sessions requiring manual message resend after context overflow compaction — sessions now automatically resend the original user message after compaction completes, so users no longer see "Please resend your last message" prompts. Also added streaming retry for transient provider errors (5xx, 429) with configurable backoff via `SessionTuning.StreamingRetryPolicy`. ([#485](https://github.com/Aaronontheweb/netclaw/pull/485))
+* Fixed `HttpClient.Timeout` (default 100s) prematurely killing LLM calls for self-hosted models with large contexts — the session watchdog is now the sole timeout authority for LLM request lifetimes. `HttpClient.Timeout` is set to `Timeout.InfiniteTimeSpan` and all cancellation flows through the session watchdog's `CancellationToken`. ([#476](https://github.com/Aaronontheweb/netclaw/pull/476))
+* Fixed reminder execution actor using the wrong output filter — the actor was configured with `TextStreaming | ToolCalls` instead of the correct filter for reminder delivery, causing reminders to not stream output correctly. ([#475](https://github.com/Aaronontheweb/netclaw/pull/475))
+
 #### 0.9.0 2026-03-27 ####
 
 Netclaw v0.9.0 — Two-phase streaming timeout, FTS5 memory recall, turn-based distillation, and streaming performance fix


### PR DESCRIPTION
## Summary

- Bumps `VersionPrefix` to `0.9.1` in `Directory.Build.props`
- Adds 0.9.1 release notes to `RELEASE_NOTES.md` covering:
  - Configurable project workspaces with AGENTS.md discovery (#482)
  - Akka.Reminders v0.6.0-beta2 upgrade with envelope-based delivery (#484) — includes breaking SQLite schema change
  - Skill content security scanning with prompt injection detection (#408)
  - Session auto-resend after context overflow compaction + streaming retry (#485)
  - HttpClient.Timeout fix for self-hosted models with large contexts (#476)
  - Reminder execution actor output filter fix (#475)

## Test plan

- [ ] Verify `Directory.Build.props` reports `VersionPrefix` as `0.9.1`
- [ ] Verify release notes entry appears at the top of `RELEASE_NOTES.md` with date `2026-03-30`
- [ ] Confirm CI passes on this branch before merging
- [ ] After merge: sync local `dev`, create and push tag `0.9.1` — CI/CD will handle the GitHub Release