### PR TITLE
fix(cli): serialize enums as strings in config JSON output

### DIFF
--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -10,7 +10,11 @@ namespace Netclaw.Cli.Config;
 /// </summary>
 internal static class ConfigFileHelper
 {
-    internal static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
 
     /// <summary>
     /// Load both netclaw.json and secrets.json as mutable dictionaries.


### PR DESCRIPTION
## Summary
- Adds `JsonStringEnumConverter` to `ConfigFileHelper.JsonOptions` so enum properties (e.g. `McpCapabilityClass`) are serialized as string names instead of integers
- Fixes `netclaw doctor` schema validation failures where `CapabilityClass` was written as `0` instead of `"Unknown"`

## Test plan
- [ ] `dotnet build` succeeds
- [ ] `netclaw doctor` no longer reports `[FAIL] Config Schema` for `CapabilityClass`
- [ ] Existing CLI tests pass