### PR TITLE
refactor(security): remove McpCapabilityClass, rely on audience profiles

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -218,8 +218,7 @@ shape, confirm that strict-default fallback is active, or verify that
       "Command": "uvx",
       "Arguments": ["memorizer-mcp"],
       "Enabled": true,
-      "GrantCategory": "mcp:memorizer",
-      "CapabilityClass": "MemorySafe"
+      "GrantCategory": "mcp:memorizer"
     },
     "github": {
       "Transport": "http",
@@ -227,8 +226,7 @@ shape, confirm that strict-default fallback is active, or verify that
       "Headers": {
         "Authorization": "Bearer ${GITHUB_TOKEN}"
       },
-      "Enabled": true,
-      "CapabilityClass": "PublishExternal"
+      "Enabled": true
     }
   }
 }
@@ -244,7 +242,6 @@ shape, confirm that strict-default fallback is active, or verify that
 | `Headers` | object? | `null` | Additional headers for remote HTTP/SSE MCP servers. |
 | `Enabled` | bool | `true` | Whether the server is loaded at startup. |
 | `GrantCategory` | string? | `null` | Optional ACL grant category. Defaults to `mcp:{serverName}` when omitted. |
-| `CapabilityClass` | string | `"Unknown"` | Server-level trust classification (`Unknown`, `Information`, `MemorySafe`, `SensitiveRead`, `PublishExternal`, `HighImpact`). |
 | `OAuthClientId` | string? | `null` | Static OAuth client ID for servers without dynamic client registration. |
 | `OAuthScope` | string? | `null` | Optional OAuth scope override. |
 

--- a/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DispatchingToolExecutorTests.cs
@@ -329,7 +329,6 @@ public class DispatchingToolExecutorTests
             AIFunctionFactory.Create(() => "ok", "search_memories"),
             "memorizer",
             "search_memories",
-            capabilityClass: McpCapabilityClass.MemorySafe,
             invoker: new RecordingMcpToolInvoker("ok")));
 
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
@@ -355,39 +354,4 @@ public class DispatchingToolExecutorTests
         Assert.Equal("mcp_server_not_allowed_for_audience_profile", ex.DenyReason);
     }
 
-    [Fact]
-    public async Task Mcp_tool_is_denied_when_capability_exceeds_allowed_audience()
-    {
-        var registry = new ToolRegistry();
-        registry.Register(new McpToolAdapter(
-            AIFunctionFactory.Create(() => "ok", "read_inbox"),
-            "textforge",
-            "read_inbox",
-            capabilityClass: McpCapabilityClass.SensitiveRead,
-            invoker: new RecordingMcpToolInvoker("ok")));
-
-        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
-        config.AudienceProfiles.Team.AllowedMcpServers.Add("textforge");
-
-        var executor = new DispatchingToolExecutor(
-            registry,
-            new ToolAccessPolicy(
-                config,
-                new EffectivePolicyDefaults(
-                    DeploymentPosture.Personal,
-                    TrustAudience.Personal,
-                    ShellExecutionMode.HostAllowed,
-                    UsedStrictFallback: false)));
-
-        var toolCall = new FunctionCallContent("call-mcp-capability-deny", "textforge/read_inbox", new Dictionary<string, object?>());
-        var context = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", null)
-        {
-            Audience = TrustAudience.Team.ToWireValue(),
-            Boundary = SecurityPolicyDefaults.TeamBoundary,
-            ChannelType = "slack"
-        };
-
-        var ex = await Assert.ThrowsAsync<ToolAccessDeniedException>(() => executor.ExecuteAsync(toolCall, context));
-        Assert.Equal("mcp_capability_denied_for_audience", ex.DenyReason);
-    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SearchToolsToolTests.cs
@@ -199,54 +199,13 @@ public class SearchToolsToolTests
     }
 
     [Fact]
-    public async Task Search_FiltersSensitiveMcpTools_InTeamContext()
-    {
-        var registry = new ToolRegistry();
-        registry.Register(new McpToolAdapter(
-            CreateFakeAIFunction("search_memories", "Find stored memories"),
-            "memorizer",
-            "search_memories",
-            capabilityClass: McpCapabilityClass.MemorySafe));
-        registry.Register(new McpToolAdapter(
-            CreateFakeAIFunction("read_inbox", "Read email inbox"),
-            "textforge",
-            "read_inbox",
-            capabilityClass: McpCapabilityClass.SensitiveRead));
-
-        var tool = new SearchToolsTool(
-            registry,
-            new ToolAccessPolicy(
-                CreateProfileAwareToolConfig(allowedTeamServers: ["memorizer", "textforge"]),
-                new EffectivePolicyDefaults(
-                    DeploymentPosture.Personal,
-                    TrustAudience.Personal,
-                    ShellExecutionMode.HostAllowed,
-                    UsedStrictFallback: false)));
-
-        var context = new Netclaw.Tools.ToolExecutionContext("slack/thread-1", null)
-        {
-            Audience = TrustAudience.Team.ToWireValue(),
-            Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
-            ChannelType = "slack"
-        };
-
-        var result = await tool.ExecuteAsync(
-            new Dictionary<string, object?> { ["Query"] = "all", ["Server"] = "textforge" },
-            context,
-            CancellationToken.None);
-
-        Assert.Contains("No tools found", result);
-    }
-
-    [Fact]
     public async Task Search_AllowsMemorySafeMcpTools_InTeamContext()
     {
         var registry = new ToolRegistry();
         registry.Register(new McpToolAdapter(
             CreateFakeAIFunction("search_memories", "Find stored memories"),
             "memorizer",
-            "search_memories",
-            capabilityClass: McpCapabilityClass.MemorySafe));
+            "search_memories"));
 
         var tool = new SearchToolsTool(
             registry,
@@ -280,8 +239,7 @@ public class SearchToolsToolTests
         registry.Register(new McpToolAdapter(
             CreateFakeAIFunction("search_memories", "Find stored memories"),
             "memorizer",
-            "search_memories",
-            capabilityClass: McpCapabilityClass.MemorySafe));
+            "search_memories"));
 
         var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
         var tool = new SearchToolsTool(

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
-using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
@@ -23,7 +22,6 @@ public sealed class McpToolAdapter : INetclawTool
         string serverName,
         string toolName,
         string? grantCategory = null,
-        McpCapabilityClass capabilityClass = McpCapabilityClass.Unknown,
         IMcpToolInvoker? invoker = null)
     {
         _mcpTool = mcpTool;
@@ -32,7 +30,6 @@ public sealed class McpToolAdapter : INetclawTool
         ServerName = serverName;
         Name = $"{serverName}/{toolName}";
         GrantCategory = grantCategory ?? $"mcp:{serverName}";
-        CapabilityClass = capabilityClass;
 
         // Extract description and schema from the underlying AITool
         if (mcpTool is AIFunction func)
@@ -54,7 +51,6 @@ public sealed class McpToolAdapter : INetclawTool
     public string Description { get; }
     public string GrantCategory { get; }
     public string ServerName { get; }
-    public McpCapabilityClass CapabilityClass { get; }
     public JsonElement ParameterSchema { get; }
 
     /// <summary>The bare tool name without the server prefix.</summary>

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -53,8 +53,7 @@ public sealed class ToolAccessPolicy
     private bool IsToolExposed(INetclawTool tool, TrustAudience audience)
     {
         if (tool is McpToolAdapter mcp)
-            return _profileResolver.IsMcpServerAllowed(mcp.ServerName, audience)
-                && IsMcpToolExposed(mcp.CapabilityClass, audience);
+            return _profileResolver.IsMcpServerAllowed(mcp.ServerName, audience);
 
         if (!_profileResolver.IsToolAllowed(tool.Name, CreateContext(audience)))
             return false;
@@ -73,9 +72,7 @@ public sealed class ToolAccessPolicy
             if (!_profileResolver.IsMcpServerAllowed(mcp.ServerName, context))
                 return ToolAccessDecision.Deny("mcp_server_not_allowed_for_audience_profile");
 
-            return IsMcpToolExposed(mcp.CapabilityClass, audience)
-                ? ToolAccessDecision.Allow()
-                : ToolAccessDecision.Deny("mcp_capability_denied_for_audience");
+            return ToolAccessDecision.Allow();
         }
 
         if (!_profileResolver.IsToolAllowed(tool.Name, context))
@@ -116,17 +113,6 @@ public sealed class ToolAccessPolicy
 
     private static bool IsShellTool(INetclawTool tool)
         => string.Equals(tool.Name, "shell_execute", StringComparison.Ordinal);
-
-    private static bool IsMcpToolExposed(McpCapabilityClass capabilityClass, TrustAudience audience)
-        => capabilityClass switch
-        {
-            McpCapabilityClass.Information => true,
-            McpCapabilityClass.MemorySafe => audience is TrustAudience.Team or TrustAudience.Personal,
-            McpCapabilityClass.SensitiveRead => audience == TrustAudience.Personal,
-            McpCapabilityClass.PublishExternal => audience == TrustAudience.Personal,
-            McpCapabilityClass.HighImpact => audience == TrustAudience.Personal,
-            _ => audience == TrustAudience.Personal
-        };
 
     private static string? GetToolName(AITool tool)
         => tool is AIFunction function ? function.Name : null;

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -83,11 +83,10 @@ public static class ToolRegistrationExtensions
         string serverName,
         IList<McpClientTool> tools,
         string? grantCategory = null,
-        McpCapabilityClass capabilityClass = McpCapabilityClass.Unknown,
         IMcpToolInvoker? invoker = null)
     {
         foreach (var tool in tools)
-            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory, capabilityClass, invoker));
+            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory, invoker));
 
         return registry;
     }

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -135,7 +135,6 @@ public sealed class ConfigSchemaDoctorCheckTests
                   "Transport": "stdio",
                   "Command": "uvx",
                   "Arguments": ["memorizer-mcp"],
-                  "CapabilityClass": "MemorySafe",
                   "Enabled": false
                 }
               }

--- a/src/Netclaw.Configuration/McpServerEntry.cs
+++ b/src/Netclaw.Configuration/McpServerEntry.cs
@@ -1,15 +1,5 @@
 namespace Netclaw.Configuration;
 
-public enum McpCapabilityClass
-{
-    Unknown,
-    Information,
-    MemorySafe,
-    SensitiveRead,
-    PublishExternal,
-    HighImpact
-}
-
 /// <summary>
 /// Configuration for a single MCP server profile.
 /// Bound from the <c>McpServers</c> section of <c>netclaw.json</c> + <c>secrets.json</c>.
@@ -39,9 +29,6 @@ public sealed class McpServerEntry
 
     /// <summary>ACL grant category. Defaults to "mcp:{name}" when null.</summary>
     public string? GrantCategory { get; set; }
-
-    /// <summary>Capability classification used by trust policy and discovery filtering.</summary>
-    public McpCapabilityClass CapabilityClass { get; set; } = McpCapabilityClass.Unknown;
 
     /// <summary>Static OAuth client ID for servers that don't support dynamic client registration.</summary>
     public string? OAuthClientId { get; set; }

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -420,11 +420,6 @@
           },
           "Enabled": { "type": "boolean", "default": true },
           "GrantCategory": { "type": ["string", "null"] },
-          "CapabilityClass": {
-            "type": "string",
-            "enum": ["Unknown", "Information", "MemorySafe", "SensitiveRead", "PublishExternal", "HighImpact"],
-            "default": "Unknown"
-          },
           "OAuthClientId": { "type": ["string", "null"] },
           "OAuthScope": { "type": ["string", "null"] }
         },

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -393,7 +393,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             _sharedToolFunctions[name] = CreateFunctionMap(tools);
             _sessionScopedServers[name] = RequiresSessionScopedClient(name, entry);
 
-            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, entry.CapabilityClass, this);
+            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, this);
             _statuses[name] = new McpServerStatus(name, McpConnectionState.Connected, tools.Count, null);
 
             _logger.LogInformation("MCP server '{Name}' connected ({ToolCount} tools)", name, tools.Count);


### PR DESCRIPTION
## Summary
- Removes `McpCapabilityClass` enum and all references — MCP tool exposure is now gated solely by `AllowedMcpServers` in audience profiles
- The enum conflated access control with input trust signaling and was redundant with existing audience profile server allowlists
- Removes `CapabilityClass` from config schema, spec docs, and `McpServerEntry`
- Deletes tests that asserted capability-class gating behavior

## Follow-up
- #489 — MCP input trust signal (Trusted/Untrusted) for memory safety
- #490 — Per-tool audience gating for MCP servers

## Test plan
- [x] 26 actor tests pass (capability-specific tests removed)
- [x] 8 CLI schema doctor tests pass
- [ ] CI passes