### PR TITLE
fix(sessions): split search_tools from tool loading to prevent schema overload

### DIFF
--- a/openspec/specs/netclaw-mcp/spec.md
+++ b/openspec/specs/netclaw-mcp/spec.md
@@ -113,10 +113,19 @@ removed tools from MCP servers.
 
 To avoid context window bloat with large tool catalogs (see
 `docs/research/dynamic-context-discovery.md` §1–2), the system SHALL use a
-two-layer discovery strategy: a compressed tool index injected into the system
-prompt for agent awareness, and a `search_tools` meta-tool for on-demand
-loading of full tool definitions. Core tools (shell, file operations) SHALL
-remain always-loaded; MCP tools SHALL be deferred by default.
+three-step discovery strategy: a compressed tool index injected into the system
+prompt for agent awareness, a `search_tools` meta-tool for browsing available
+tools (names and descriptions only), and a `load_tool` meta-tool for
+on-demand activation of individual tool definitions. `search_tools` SHALL NOT
+load tool schemas into the session — it SHALL return a discovery menu only.
+The agent SHALL call `load_tool` to activate each tool it needs. Core tools
+(shell, file operations) SHALL remain always-loaded; MCP tools SHALL be
+deferred by default.
+
+When an LLM call fails after tools have been dynamically loaded, the system
+SHALL evict all discovered tools from the session's available tool set. This
+prevents a tool set that caused the failure (e.g., oversized schemas) from
+poisoning subsequent turns.
 
 #### Scenario: Startup tool discovery
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -79,6 +79,7 @@ public class LlmSessionIntegrationTests : TestKit
             "browser_chrome_devtools",
             "navigate_page"));
         registry.Register(new SearchToolsTool(registry));
+        registry.Register(new LoadToolTool(registry));
 
         services.AddSingleton(registry);
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
@@ -758,14 +759,11 @@ public class LlmSessionIntegrationTests : TestKit
     {
         _fakeChatClient.ToolCallsOnFirstCall =
         [
-            new FunctionCallContent("call-search", "search_tools",
-                new Dictionary<string, object?> { ["Query"] = "browser_chrome_devtools" })
+            new FunctionCallContent("call-load", "load_tool",
+                new Dictionary<string, object?> { ["Name"] = "browser_chrome_devtools/navigate_page" })
         ];
 
-        _fakeToolExecutor.Results["search_tools"] =
-            "Found 1 tool(s):\n\n"
-            + "  browser_chrome_devtools/navigate_page — Navigate to URL (params: url)\n\n"
-            + "Call any tool above by its full name. Tools are now loaded and available.";
+        _fakeToolExecutor.Results["load_tool"] = "browser_chrome_devtools/navigate_page";
 
         var sessionId = new SessionId("channel-discovery/thread-retention");
         var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -99,6 +99,17 @@ internal sealed class DiscoveredToolCache
     }
 
     /// <summary>
+    /// Evict all discovered tools and trim the available tools list back to base tools.
+    /// Used when an LLM call fails to prevent a bad tool set from poisoning subsequent turns.
+    /// </summary>
+    public void EvictAll(List<AITool> availableTools, int baseToolCount)
+    {
+        _leases.Clear();
+        _order.Clear();
+        TrimToBase(availableTools, baseToolCount);
+    }
+
+    /// <summary>
     /// Check whether the cache contains a tool with an active lease.
     /// </summary>
     public bool HasTool(string toolName)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -554,15 +554,17 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     result.Name ?? "unknown", result.ToolCallId ?? "?", preview);
             }
 
-            // Dynamic tool loading: if search_tools was called, load discovered tools
-            // into the available tools list so they can be called in subsequent turns
+            // Dynamic tool loading: if load_tool was called, activate the requested tool.
+            // LoadToolTool returns the canonical tool name on success; the actor looks it
+            // up in the registry. Error messages won't match any entry, so only valid
+            // tool names trigger activation — no string parsing required.
             if (_fullRegistry is not null)
             {
                 foreach (var result in msg.ToolResults)
                 {
-                    if (result.Name is "search_tools" && result.Content is not null)
+                    if (result.Name is "load_tool" && result.Content is not null)
                     {
-                        LoadDiscoveredTools(result.Content);
+                        TryActivateDiscoveredTool(result.Content.Trim());
                     }
                 }
             }
@@ -703,6 +705,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             TurnLog().Error(msg.Cause, "turn_llm_call_failed");
+
+            // Evict discovered tools to prevent a poisoned tool set from cascading
+            // across turns (e.g., oversized Notion schemas causing repeated 502s).
+            _discoveredToolCache.EvictAll(_availableTools, _baseToolCount);
+            TurnLog().Info("turn_discovered_tools_evicted — tool list reset to base tools after LLM call failure");
 
             var errorMessage = ExtractLlmErrorMessage(msg.Cause);
             var category = msg.Cause is TimeoutException ? ErrorCategory.Timeout : ErrorCategory.ProviderFailure;
@@ -2204,38 +2211,25 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     /// <summary>
-    /// Parse tool names from search_tools output and add their AITool definitions
-    /// to <see cref="_availableTools"/> so the LLM can call them in subsequent iterations.
+    /// Attempt to activate a single discovered tool by name.
+    /// Checks registry, access policy, and adds to the available tools cache.
     /// </summary>
-    private void LoadDiscoveredTools(string searchToolOutput)
+    private bool TryActivateDiscoveredTool(string toolName)
     {
-        if (_fullRegistry is null) return;
+        if (_fullRegistry is null) return false;
 
-        // Parse tool names from the search output format: "  server/toolname — description"
-        foreach (var line in searchToolOutput.Split('\n'))
-        {
-            var trimmed = line.TrimStart();
-            var separatorIndex = trimmed.IndexOf(" — ", StringComparison.Ordinal);
-            if (separatorIndex < 0)
-                continue;
+        var registration = _fullRegistry.GetRegistrationByToolName(toolName);
+        if (registration is null) return false;
 
-            var toolName = trimmed[..separatorIndex].Trim();
-            if (string.IsNullOrEmpty(toolName))
-                continue;
+        if (_toolAccessPolicy is not null && !_toolAccessPolicy.IsToolExposed(registration, _currentTrustContext))
+            return false;
 
-            var registration = _fullRegistry.GetRegistrationByToolName(toolName);
-            if (registration is null)
-                continue;
-
-            if (_toolAccessPolicy is not null && !_toolAccessPolicy.IsToolExposed(registration, _currentTrustContext))
-                continue;
-
-            var tool = registration.Tool;
-            _discoveredToolCache.Remember(toolName, tool,
-                _config.Tuning.DiscoveredToolRetentionTurns,
-                _config.Tuning.DiscoveredToolMaxCount);
-            AddAvailableToolIfMissing(toolName, tool.ToAITool());
-        }
+        var tool = registration.Tool;
+        _discoveredToolCache.Remember(toolName, tool,
+            _config.Tuning.DiscoveredToolRetentionTurns,
+            _config.Tuning.DiscoveredToolMaxCount);
+        AddAvailableToolIfMissing(toolName, tool.ToAITool());
+        return true;
     }
 
     private void AddAvailableToolIfMissing(string toolName, AITool aiTool)

--- a/src/Netclaw.Actors/Tools/LoadToolTool.cs
+++ b/src/Netclaw.Actors/Tools/LoadToolTool.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Activates a discovered MCP tool by name so the LLM can call it.
+/// Tools must first be found via <see cref="SearchToolsTool"/> before loading.
+/// The session actor intercepts this tool by name and reads the tool call
+/// arguments to activate the requested tool — the output is LLM-facing only.
+/// </summary>
+[NetclawTool("load_tool",
+    "Activate a tool by name so you can call it. Use search_tools first to find tool names, then load_tool to activate one.",
+    Grant = "builtin")]
+public sealed partial class LoadToolTool : NetclawTool<LoadToolTool.Params>
+{
+    private readonly ToolRegistry _registry;
+    private readonly ToolAccessPolicy? _policy;
+
+    public record Params(
+        [property: Description("Full tool name to activate (e.g., 'notion/notion-search'). Use search_tools to find available tool names.")]
+        string Name);
+
+    public LoadToolTool(ToolRegistry registry, ToolAccessPolicy? policy = null)
+    {
+        _registry = registry;
+        _policy = policy;
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    {
+        var name = args.Name.Trim();
+
+        if (string.IsNullOrEmpty(name))
+            return Task.FromResult("Error: tool name is required.");
+
+        var registration = _registry.GetRegistrationByToolName(name);
+        if (registration is null)
+        {
+            var suggestions = _registry.SearchTools(name, null, 3);
+            if (suggestions.Count > 0)
+            {
+                var names = string.Join(", ", suggestions.Select(s => s.Name));
+                return Task.FromResult($"Tool '{name}' not found. Did you mean: {names}?");
+            }
+
+            return Task.FromResult($"Tool '{name}' not found. Use search_tools to find available tools.");
+        }
+
+        if (_policy is not null && !_policy.IsToolExposed(registration.Tool, context))
+            return Task.FromResult($"Tool '{name}' is not available in the current trust context.");
+
+        // Return the canonical tool name. The session actor intercepts load_tool
+        // results and attempts a registry lookup on the content to activate the tool.
+        // Error messages above will not match any registry entry, so only successful
+        // loads trigger activation — no string parsing required.
+        return Task.FromResult(registration.Tool.Name);
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
+}

--- a/src/Netclaw.Actors/Tools/SearchToolsTool.cs
+++ b/src/Netclaw.Actors/Tools/SearchToolsTool.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Actors.Tools;
 /// to load dynamically. Used as part of the two-layer discovery architecture.
 /// </summary>
 [NetclawTool("search_tools",
-    "Search for available tools by keyword. Returns tool names, descriptions, and parameter names. "
+    "Search for available tools by keyword. Returns tool names and descriptions — tools are NOT loaded until you call load_tool. "
     + "Use query='servers' to list MCP servers and query='all' with a server filter to browse one server.",
     Grant = "builtin")]
 public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params>
@@ -122,7 +122,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
 
         sb.AppendLine();
         sb.AppendLine("To browse one server, call search_tools(query: \"all\", server: \"<server_name>\").");
-        sb.AppendLine("To load specific tools, call search_tools(query: \"<intent>\", server: \"<server_name>\").");
+        sb.AppendLine("To find tools, call search_tools(query: \"<intent>\", server: \"<server_name>\"), then load_tool(\"<name>\") to activate.");
         sb.AppendLine("Detailed generated catalogs are on disk at identity/tooling/shadow/mcp/<server>.md.");
 
         if (!string.IsNullOrWhiteSpace(trailingHint))
@@ -153,7 +153,7 @@ public sealed partial class SearchToolsTool : NetclawTool<SearchToolsTool.Params
         }
 
         sb.AppendLine();
-        sb.AppendLine("Call any tool above by its full name. Tools are now loaded and available.");
+        sb.AppendLine("To use a tool, call load_tool(\"<tool_name>\") to activate it first.");
         return sb.ToString();
     }
 

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -33,8 +33,9 @@ public static class ToolRegistrationExtensions
             registry.Register(new WebSearchTool(searchBackend));
         registry.Register(new WebFetchTool(config));
 
-        // Register search_tools meta-tool (always loaded, "builtin" grant)
+        // Register search_tools and load_tool meta-tools (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry, toolAccessPolicy));
+        registry.Register(new LoadToolTool(registry, toolAccessPolicy));
 
         return registry;
     }


### PR DESCRIPTION
## Summary

Fixes #487. `search_tools` previously auto-loaded **all** returned MCP tool schemas into the session. When Notion tools were discovered (45K chars of schema across 10 tools), the inference server immediately returned 502 on every subsequent LLM call — and the tools persisted via lease cache, poisoning all future turns.

- **`search_tools` is now discovery-only** — returns tool names and descriptions without loading schemas
- **New `load_tool` built-in** — LLM explicitly activates individual tools by name (e.g., `load_tool("notion/notion-search")`)
- **Evict discovered tools on `LlmCallFailed`** — prevents cascading failures from poisoned tool sets
- **`TryActivateDiscoveredTool`** — shared method replaces duplicated registry lookup / policy check / cache logic

The session actor reads the canonical tool name from `load_tool` output and does a direct registry lookup — no magic string parsing. `LoadToolTool` checks `ToolAccessPolicy` via the context-aware `ExecuteAsync` overload.

## Test plan

- [ ] `search_tools("notion")` returns tool list but does NOT add them to `_availableTools`
- [ ] `load_tool("notion/notion-search")` activates only that tool
- [ ] LLM call succeeds with 1-2 Notion tools loaded (~8K chars vs 45K)
- [ ] If LLM call fails after tool load, tools are evicted from next turn
- [ ] Existing `Discovered_tools_are_retained_then_expire_after_lease_window` test passes with new flow