### PR TITLE
feat(doctor): schema-driven config migration via doctor --fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ update `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` in the 
 The schema uses `"additionalProperties": false` throughout — any new property that is
 missing from the schema will be rejected by `ConfigSchemaDoctorCheck` at runtime.
 
+**Migration-friendly schema changes:** `netclaw doctor --fix` uses `SchemaFixResolver` to
+auto-fix common schema validation errors. To ensure smooth upgrades for existing configs:
+- When adding a new **required** property, include a `"default"` value in the schema so
+  the fix resolver can insert it automatically.
+- When adding an **enum** property, always use `"type": "string"` with named values (not
+  integers) so the resolver can coerce stale numeric values.
+- When **removing** a property, no special action is needed — the resolver detects and
+  removes properties disallowed by `additionalProperties: false`.
+
 ## Universal Quality Bar
 
 - secure-by-default behavior for gateway and tools

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Netclaw Operations
@@ -62,7 +62,9 @@ When something seems wrong with Netclaw itself:
 
 1. Run `netclaw doctor` via `shell_execute` — validates config, providers,
    MCP connections, memory health
-2. Run `netclaw status` via `shell_execute` — live runtime state from daemon
+2. If doctor reports fixable issues, run `netclaw doctor --fix --dry-run` to
+   preview auto-repairs (schema-driven: stale properties, enum coercion, missing defaults)
+3. Run `netclaw status` via `shell_execute` — live runtime state from daemon
 3. Check daemon logs at `~/.netclaw/logs/daemon-{yyyy-MM-dd}.log`
 4. Check session logs at `~/.netclaw/sessions/{session-id}/logs/`
 

--- a/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DoctorFixServiceTests.cs
@@ -84,6 +84,66 @@ public sealed class DoctorFixServiceTests
         Assert.Contains("\"Format\": \"Slack\"", plan.Fixes[0].UpdatedText, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task RemovesStalePropertyViaSchemaFix()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        // Config with a stale property that the schema no longer defines
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "McpServers": {
+                "memorizer": {
+                  "Transport": "stdio",
+                  "Command": "uvx",
+                  "Enabled": true,
+                  "CapabilityClass": "MemorySafe"
+                }
+              }
+            }
+            """);
+
+        var service = new DoctorFixService(paths);
+        var plan = await service.BuildPlanAsync();
+
+        Assert.True(plan.HasChanges);
+        Assert.Single(plan.Fixes);
+        // CapabilityClass was removed from schema — should be cleaned up
+        Assert.DoesNotContain("CapabilityClass", plan.Fixes[0].UpdatedText, StringComparison.Ordinal);
+        // Other properties should be preserved
+        Assert.Contains("memorizer", plan.Fixes[0].UpdatedText, StringComparison.Ordinal);
+        Assert.Contains("stdio", plan.Fixes[0].UpdatedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DynamicDescriptionReflectsAppliedFixes()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "Slack": {
+                "Enabled": true
+              }
+            }
+            """);
+
+        var service = new DoctorFixService(paths);
+        var plan = await service.BuildPlanAsync();
+
+        Assert.True(plan.HasChanges);
+        // Description should mention what was actually fixed
+        Assert.Contains("configVersion", plan.Fixes[0].Description, StringComparison.Ordinal);
+        Assert.Contains("Slack ACL defaults", plan.Fixes[0].Description, StringComparison.Ordinal);
+    }
+
     private static string CreateTempBasePath()
     {
         var path = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));

--- a/src/Netclaw.Cli.Tests/Doctor/SchemaFixResolverTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SchemaFixResolverTests.cs
@@ -7,30 +7,32 @@ namespace Netclaw.Cli.Tests.Doctor;
 
 public sealed class SchemaFixResolverTests
 {
+    private const string ServerLevelEnumSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "Servers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "Level": {
+                    "type": "string",
+                    "enum": ["Low", "Medium", "High"],
+                    "default": "Low"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+        """;
+
     [Fact]
     public void FixesIntegerEnumToString()
     {
-        var (schema, schemaJson) = ParseSchema("""
-            {
-              "type": "object",
-              "properties": {
-                "Servers": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "Level": {
-                        "type": "string",
-                        "enum": ["Low", "Medium", "High"],
-                        "default": "Low"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              }
-            }
-            """);
+        var (schema, schemaJson) = ParseSchema(ServerLevelEnumSchema);
 
         var config = JsonNode.Parse("""
             {
@@ -51,27 +53,7 @@ public sealed class SchemaFixResolverTests
     [Fact]
     public void SkipsAlreadyCorrectStringEnum()
     {
-        var (schema, schemaJson) = ParseSchema("""
-            {
-              "type": "object",
-              "properties": {
-                "Servers": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "Level": {
-                        "type": "string",
-                        "enum": ["Low", "Medium", "High"],
-                        "default": "Low"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              }
-            }
-            """);
+        var (schema, schemaJson) = ParseSchema(ServerLevelEnumSchema);
 
         var config = JsonNode.Parse("""
             {
@@ -90,27 +72,7 @@ public sealed class SchemaFixResolverTests
     [Fact]
     public void SkipsOutOfRangeIntegerEnum()
     {
-        var (schema, schemaJson) = ParseSchema("""
-            {
-              "type": "object",
-              "properties": {
-                "Servers": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "Level": {
-                        "type": "string",
-                        "enum": ["Low", "Medium", "High"],
-                        "default": "Low"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              }
-            }
-            """);
+        var (schema, schemaJson) = ParseSchema(ServerLevelEnumSchema);
 
         var config = JsonNode.Parse("""
             {
@@ -131,27 +93,7 @@ public sealed class SchemaFixResolverTests
     [Fact]
     public void FixesMultipleServerEntries()
     {
-        var (schema, schemaJson) = ParseSchema("""
-            {
-              "type": "object",
-              "properties": {
-                "Servers": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "Level": {
-                        "type": "string",
-                        "enum": ["Low", "Medium", "High"],
-                        "default": "Low"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              }
-            }
-            """);
+        var (schema, schemaJson) = ParseSchema(ServerLevelEnumSchema);
 
         var config = JsonNode.Parse("""
             {

--- a/src/Netclaw.Cli.Tests/Doctor/SchemaFixResolverTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SchemaFixResolverTests.cs
@@ -1,0 +1,344 @@
+using System.Text.Json.Nodes;
+using Json.Schema;
+using Netclaw.Cli.Doctor;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class SchemaFixResolverTests
+{
+    [Fact]
+    public void FixesIntegerEnumToString()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Servers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "Level": {
+                        "type": "string",
+                        "enum": ["Low", "Medium", "High"],
+                        "default": "Low"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Servers": {
+                "alpha": { "Level": 2 }
+              }
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.True(result);
+        Assert.Single(fixes);
+        Assert.Contains("High", fixes[0]);
+        Assert.Equal("High", config["Servers"]!["alpha"]!["Level"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SkipsAlreadyCorrectStringEnum()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Servers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "Level": {
+                        "type": "string",
+                        "enum": ["Low", "Medium", "High"],
+                        "default": "Low"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Servers": {
+                "alpha": { "Level": "Medium" }
+              }
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.False(result);
+        Assert.Empty(fixes);
+    }
+
+    [Fact]
+    public void SkipsOutOfRangeIntegerEnum()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Servers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "Level": {
+                        "type": "string",
+                        "enum": ["Low", "Medium", "High"],
+                        "default": "Low"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Servers": {
+                "alpha": { "Level": 99 }
+              }
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        // Should not fix — integer is out of enum range.
+        // The type+enum error is still raised but we can't map 99 to a valid value.
+        Assert.False(result);
+        Assert.Empty(fixes);
+    }
+
+    [Fact]
+    public void FixesMultipleServerEntries()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Servers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "Level": {
+                        "type": "string",
+                        "enum": ["Low", "Medium", "High"],
+                        "default": "Low"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Servers": {
+                "alpha": { "Level": 0 },
+                "beta": { "Level": "High" },
+                "gamma": { "Level": 1 }
+              }
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.True(result);
+        Assert.Equal(2, fixes.Count);
+        Assert.Equal("Low", config["Servers"]!["alpha"]!["Level"]!.GetValue<string>());
+        Assert.Equal("High", config["Servers"]!["beta"]!["Level"]!.GetValue<string>());
+        Assert.Equal("Medium", config["Servers"]!["gamma"]!["Level"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void InsertsDefaultForMissingRequiredProperty()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "required": ["configVersion"],
+              "properties": {
+                "configVersion": {
+                  "type": "integer",
+                  "default": 1
+                },
+                "Name": {
+                  "type": "string"
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Name": "test"
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.True(result);
+        Assert.Single(fixes);
+        Assert.Contains("configVersion", fixes[0]);
+        Assert.Equal(1, config["configVersion"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void SkipsMissingRequiredWithoutDefault()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "required": ["configVersion"],
+              "properties": {
+                "configVersion": {
+                  "type": "integer"
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Name": "test"
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.False(result);
+        Assert.Empty(fixes);
+    }
+
+    [Fact]
+    public void RemovesDisallowedAdditionalProperty()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Servers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "Transport": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Servers": {
+                "alpha": {
+                  "Transport": "stdio",
+                  "CapabilityClass": "MemorySafe"
+                }
+              }
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.True(result);
+        Assert.Single(fixes);
+        Assert.Contains("CapabilityClass", fixes[0]);
+        Assert.Null(config["Servers"]!["alpha"]!["CapabilityClass"]);
+        Assert.Equal("stdio", config["Servers"]!["alpha"]!["Transport"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void LeavesAllowedPropertiesUntouched()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Name": { "type": "string" },
+                "Value": { "type": "integer" }
+              },
+              "additionalProperties": true
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Name": "test",
+              "Value": 42,
+              "Extra": "custom"
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.False(result);
+        Assert.Empty(fixes);
+    }
+
+    [Fact]
+    public void HandlesRefBasedEnumSchema()
+    {
+        var (schema, schemaJson) = ParseSchema("""
+            {
+              "type": "object",
+              "properties": {
+                "Mode": { "$ref": "#/$defs/AccessMode" }
+              },
+              "additionalProperties": false,
+              "$defs": {
+                "AccessMode": {
+                  "type": "string",
+                  "enum": ["ReadOnly", "ReadWrite", "Admin"]
+                }
+              }
+            }
+            """);
+
+        var config = JsonNode.Parse("""
+            {
+              "Mode": 1
+            }
+            """)!.AsObject();
+
+        var result = SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var fixes);
+
+        Assert.True(result);
+        Assert.Single(fixes);
+        Assert.Equal("ReadWrite", config["Mode"]!.GetValue<string>());
+    }
+
+    private static (JsonSchema Schema, JsonObject Json) ParseSchema(string schemaText)
+    {
+        var schema = JsonSchema.FromText(schemaText);
+        var json = JsonNode.Parse(schemaText)!.AsObject();
+        return (schema, json);
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -101,7 +101,7 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
             return Task.FromResult(DoctorCheckResult.Error(
                 "Config Schema",
                 $"Config does not match schema (loaded from: {schemaPath}).{errorDetails}",
-                "Run `netclaw config validate` (planned) or check configVersion/schema fields in netclaw.json."));
+                "Run `netclaw doctor --fix --dry-run` to preview auto-repairs, or check configVersion/schema fields in netclaw.json."));
         }
 
         if (syntheticVersion)
@@ -117,7 +117,7 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
             $"Config matches schema v{version}."));
     }
 
-    private static string ResolveSchemaPath(int version)
+    internal static string ResolveSchemaPath(int version)
     {
         var fileName = $"netclaw-config.v{version}.schema.json";
         var runtimePath = Path.Combine(AppContext.BaseDirectory, "Schemas", fileName);

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Json.Schema;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -28,12 +29,14 @@ public sealed class DoctorFixService(NetclawPaths paths)
         if (obj is null)
             return Task.FromResult(new DoctorFixPlan(fixes));
 
-        var changed = false;
+        var appliedFixes = new List<string>();
+
+        // --- Manual fixes (not derivable from schema alone) ---
 
         if (obj["configVersion"] is null)
         {
             obj["configVersion"] = 1;
-            changed = true;
+            appliedFixes.Add("configVersion");
         }
 
         if (obj["Slack"] is JsonObject slack && ReadBool(slack, "Enabled"))
@@ -45,7 +48,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
             if (!hasAllowedChannels && !hasDefaultChannel)
             {
                 slack["AllowedChannelIds"] = new JsonArray();
-                changed = true;
+                appliedFixes.Add("Slack ACL defaults");
             }
         }
 
@@ -56,7 +59,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
                 && string.IsNullOrWhiteSpace(otlp["Endpoint"]?.GetValue<string>()))
             {
                 otlp["Endpoint"] = "http://127.0.0.1:4317";
-                changed = true;
+                appliedFixes.Add("telemetry endpoint");
             }
         }
 
@@ -80,12 +83,15 @@ public sealed class DoctorFixService(NetclawPaths paths)
                 if (existing is null || existing.Equals(nameof(WebhookFormat.Generic), StringComparison.OrdinalIgnoreCase))
                 {
                     wh["Format"] = nameof(WebhookFormat.Slack);
-                    changed = true;
+                    appliedFixes.Add("webhook format");
                 }
             }
         }
 
-        if (changed)
+        // --- Schema-driven fixes ---
+        TryApplySchemaFixes(obj, appliedFixes);
+
+        if (appliedFixes.Count > 0)
         {
             var normalized = obj.ToJsonString(new JsonSerializerOptions
             {
@@ -98,12 +104,46 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
             fixes.Add(new DoctorFileFix(
                 FilePath: paths.NetclawConfigPath,
-                Description: "Apply safe configuration autofixes (schema version, ACL defaults, telemetry endpoint, webhook format).",
+                Description: $"Apply safe configuration autofixes ({string.Join(", ", appliedFixes)}).",
                 OriginalText: original,
                 UpdatedText: replacement));
         }
 
         return Task.FromResult(new DoctorFixPlan(fixes));
+    }
+
+    private void TryApplySchemaFixes(JsonObject config, List<string> appliedFixes)
+    {
+        // Resolve schema version (default to 1 if not present or invalid)
+        var version = 1;
+        if (config["configVersion"] is JsonValue versionValue
+            && versionValue.TryGetValue<int>(out var parsedVersion))
+        {
+            version = parsedVersion;
+        }
+
+        var schemaPath = ConfigSchemaDoctorCheck.ResolveSchemaPath(version);
+        if (!File.Exists(schemaPath))
+            return;
+
+        JsonSchema schema;
+        JsonObject? schemaJson;
+        try
+        {
+            var schemaText = File.ReadAllText(schemaPath);
+            schema = JsonSchema.FromText(schemaText);
+            schemaJson = JsonNode.Parse(schemaText) as JsonObject;
+        }
+        catch
+        {
+            return;
+        }
+
+        if (schemaJson is null)
+            return;
+
+        if (SchemaFixResolver.TryApplySchemaFixes(schema, schemaJson, config, out var schemaFixes))
+            appliedFixes.AddRange(schemaFixes);
     }
 
     public async Task ApplyAsync(DoctorFixPlan plan, CancellationToken cancellationToken = default)

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Schema;
+using Netclaw.Cli.Config;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -93,10 +93,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
         if (appliedFixes.Count > 0)
         {
-            var normalized = obj.ToJsonString(new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
+            var normalized = obj.ToJsonString(ConfigFileHelper.JsonOptions);
 
             var replacement = normalized.EndsWith(Environment.NewLine, StringComparison.Ordinal)
                 ? normalized

--- a/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
+++ b/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
@@ -73,17 +73,15 @@ public static class SchemaFixResolver
             if (segments.Length == 0)
                 continue;
 
-            // Get the current value from config — must be an integer
             if (ResolveConfigValue(config, segments) is not JsonValue jsonVal
                 || !jsonVal.TryGetValue<int>(out var intValue))
                 continue;
 
-            // Get the enum values from the schema at this path
             var propertySchema = ResolvePropertySchema(schemaJson, segments);
             if (propertySchema?["enum"] is not JsonArray enumArray || enumArray.Count == 0)
                 continue;
 
-            // Map integer index to enum string
+            // Map integer index to enum string — C# enums serialize as 0-based ordinals
             if (intValue < 0 || intValue >= enumArray.Count)
                 continue;
 
@@ -91,7 +89,6 @@ public static class SchemaFixResolver
             if (enumStr is null)
                 continue;
 
-            // Apply the fix
             if (SetConfigValue(config, segments, JsonValue.Create(enumStr)))
             {
                 appliedFixes.Add($"{instancePath}: {intValue} → \"{enumStr}\"");
@@ -170,7 +167,7 @@ public static class SchemaFixResolver
             if (detail.Errors is not { } errors)
                 continue;
 
-            if (!errors.TryGetValue("required", out var requiredMessage))
+            if (!errors.ContainsKey("required"))
                 continue;
 
             var instancePath = detail.InstanceLocation.ToString();
@@ -178,7 +175,6 @@ public static class SchemaFixResolver
                 ? Array.Empty<string>()
                 : ParseJsonPointer(instancePath);
 
-            // Get the parent object's schema to find which properties are required and have defaults
             var parentSchema = parentSegments.Length == 0
                 ? schemaJson
                 : ResolvePropertySchema(schemaJson, parentSegments);
@@ -194,7 +190,6 @@ public static class SchemaFixResolver
             if (properties is null || requiredProps.Count == 0)
                 continue;
 
-            // Get the config object at this path
             var configParent = parentSegments.Length == 0
                 ? config
                 : ResolveConfigNode(config, parentSegments) as JsonObject;
@@ -207,12 +202,10 @@ public static class SchemaFixResolver
                 if (configParent.ContainsKey(propName!))
                     continue; // already present
 
-                // Check if the property schema has a default
                 var propSchema = FollowRef(schemaJson, properties[propName!] as JsonObject);
                 if (propSchema?["default"] is not { } defaultNode)
                     continue;
 
-                // Insert the default value
                 configParent[propName!] = defaultNode.DeepClone();
                 var fullPath = parentSegments.Length == 0
                     ? $"/{propName}"

--- a/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
+++ b/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+
+namespace Netclaw.Cli.Doctor;
+
+/// <summary>
+/// Schema-driven config fix resolver. Runs JSON Schema validation against the config,
+/// then pattern-matches known error types to apply safe, idempotent fixes.
+/// </summary>
+public static class SchemaFixResolver
+{
+    /// <summary>
+    /// Validates config against schema and applies safe fixes for known error patterns.
+    /// Returns true if any fixes were applied; <paramref name="appliedFixes"/> lists descriptions.
+    /// </summary>
+    public static bool TryApplySchemaFixes(
+        JsonSchema schema,
+        JsonObject schemaJson,
+        JsonObject config,
+        out List<string> appliedFixes)
+    {
+        appliedFixes = [];
+
+        var evaluation = schema.Evaluate(config, new EvaluationOptions
+        {
+            OutputFormat = OutputFormat.List
+        });
+
+        if (evaluation.IsValid)
+            return false;
+
+        if (evaluation.Details is null)
+            return false;
+
+        var failingDetails = evaluation.Details
+            .Where(d => !d.IsValid && d.Errors is not null)
+            .ToList();
+
+        var changed = false;
+        changed |= TryFixIntegerEnumValues(schemaJson, config, failingDetails, appliedFixes);
+        changed |= TryRemoveDisallowedProperties(schemaJson, config, failingDetails, appliedFixes);
+        changed |= TryInsertMissingDefaults(schemaJson, config, failingDetails, appliedFixes);
+        return changed;
+    }
+
+    /// <summary>
+    /// Fixes integer values where the schema expects a string enum.
+    /// Common cause: C# enums serialized as their numeric value instead of name.
+    /// </summary>
+    private static bool TryFixIntegerEnumValues(
+        JsonObject schemaJson,
+        JsonObject config,
+        List<EvaluationResults> failingDetails,
+        List<string> appliedFixes)
+    {
+        var changed = false;
+
+        foreach (var detail in failingDetails)
+        {
+            if (detail.Errors is not { } errors)
+                continue;
+
+            // Must have both type and enum errors — indicates integer where string enum expected
+            if (!errors.ContainsKey("type") || !errors.ContainsKey("enum"))
+                continue;
+
+            var instancePath = detail.InstanceLocation.ToString();
+            if (string.IsNullOrEmpty(instancePath))
+                continue;
+
+            var segments = ParseJsonPointer(instancePath);
+            if (segments.Length == 0)
+                continue;
+
+            // Get the current value from config — must be an integer
+            if (ResolveConfigValue(config, segments) is not JsonValue jsonVal
+                || !jsonVal.TryGetValue<int>(out var intValue))
+                continue;
+
+            // Get the enum values from the schema at this path
+            var propertySchema = ResolvePropertySchema(schemaJson, segments);
+            if (propertySchema?["enum"] is not JsonArray enumArray || enumArray.Count == 0)
+                continue;
+
+            // Map integer index to enum string
+            if (intValue < 0 || intValue >= enumArray.Count)
+                continue;
+
+            var enumStr = enumArray[intValue]?.GetValue<string>();
+            if (enumStr is null)
+                continue;
+
+            // Apply the fix
+            if (SetConfigValue(config, segments, JsonValue.Create(enumStr)))
+            {
+                appliedFixes.Add($"{instancePath}: {intValue} → \"{enumStr}\"");
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Removes properties that are disallowed by <c>additionalProperties: false</c>.
+    /// Common cause: a property was removed from the schema in a newer version.
+    /// </summary>
+    /// <remarks>
+    /// When <c>additionalProperties: false</c> rejects a property, json-everything emits
+    /// an error detail at the full instance path of the rejected property with an empty
+    /// string error key and evaluation path ending in <c>/additionalProperties</c>.
+    /// </remarks>
+    private static bool TryRemoveDisallowedProperties(
+        JsonObject schemaJson,
+        JsonObject config,
+        List<EvaluationResults> failingDetails,
+        List<string> appliedFixes)
+    {
+        var changed = false;
+
+        foreach (var detail in failingDetails)
+        {
+            // Detect additionalProperties: false violations by evaluation path
+            var evalPath = detail.EvaluationPath.ToString();
+            if (!evalPath.EndsWith("/additionalProperties", StringComparison.Ordinal))
+                continue;
+
+            var instancePath = detail.InstanceLocation.ToString();
+            if (string.IsNullOrEmpty(instancePath))
+                continue;
+
+            var segments = ParseJsonPointer(instancePath);
+            if (segments.Length < 2)
+                continue;
+
+            // Verify this property is genuinely not in the schema
+            var propertySchema = ResolvePropertySchema(schemaJson, segments);
+            if (propertySchema is not null)
+                continue; // schema recognizes this property — don't remove
+
+            // Remove the property from its parent
+            var parentSegments = segments[..^1];
+            var propertyName = segments[^1];
+            if (ResolveConfigNode(config, parentSegments) is JsonObject parent
+                && parent.ContainsKey(propertyName))
+            {
+                parent.Remove(propertyName);
+                appliedFixes.Add($"Removed disallowed property {instancePath}");
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Inserts default values for missing required properties when the schema defines a default.
+    /// </summary>
+    private static bool TryInsertMissingDefaults(
+        JsonObject schemaJson,
+        JsonObject config,
+        List<EvaluationResults> failingDetails,
+        List<string> appliedFixes)
+    {
+        var changed = false;
+
+        foreach (var detail in failingDetails)
+        {
+            if (detail.Errors is not { } errors)
+                continue;
+
+            if (!errors.TryGetValue("required", out var requiredMessage))
+                continue;
+
+            var instancePath = detail.InstanceLocation.ToString();
+            var parentSegments = string.IsNullOrEmpty(instancePath)
+                ? Array.Empty<string>()
+                : ParseJsonPointer(instancePath);
+
+            // Get the parent object's schema to find which properties are required and have defaults
+            var parentSchema = parentSegments.Length == 0
+                ? schemaJson
+                : ResolvePropertySchema(schemaJson, parentSegments);
+
+            if (parentSchema is null)
+                continue;
+
+            var requiredProps = parentSchema["required"] is JsonArray reqArr
+                ? reqArr.Select(n => n?.GetValue<string>()).Where(s => s is not null).ToHashSet()
+                : [];
+
+            var properties = parentSchema["properties"] as JsonObject;
+            if (properties is null || requiredProps.Count == 0)
+                continue;
+
+            // Get the config object at this path
+            var configParent = parentSegments.Length == 0
+                ? config
+                : ResolveConfigNode(config, parentSegments) as JsonObject;
+
+            if (configParent is null)
+                continue;
+
+            foreach (var propName in requiredProps)
+            {
+                if (configParent.ContainsKey(propName!))
+                    continue; // already present
+
+                // Check if the property schema has a default
+                var propSchema = FollowRef(schemaJson, properties[propName!] as JsonObject);
+                if (propSchema?["default"] is not { } defaultNode)
+                    continue;
+
+                // Insert the default value
+                configParent[propName!] = defaultNode.DeepClone();
+                var fullPath = parentSegments.Length == 0
+                    ? $"/{propName}"
+                    : $"{instancePath}/{propName}";
+                appliedFixes.Add($"Inserted default for {fullPath}");
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    #region Schema navigation helpers
+
+    /// <summary>
+    /// Navigate the schema JSON object to resolve the sub-schema for a given config path.
+    /// Handles <c>properties</c>, <c>additionalProperties</c>, <c>items</c>, and <c>$ref</c>.
+    /// </summary>
+    internal static JsonObject? ResolvePropertySchema(JsonObject schemaRoot, ReadOnlySpan<string> pathSegments)
+    {
+        JsonObject? current = schemaRoot;
+
+        foreach (var segment in pathSegments)
+        {
+            if (current is null) return null;
+            current = FollowRef(schemaRoot, current);
+            if (current is null) return null;
+
+            // Try named property first
+            if (current["properties"] is JsonObject props && props[segment] is JsonNode propNode)
+            {
+                current = FollowRef(schemaRoot, propNode as JsonObject);
+                continue;
+            }
+
+            // Try additionalProperties (for dynamic keys like MCP server names)
+            if (current["additionalProperties"] is JsonObject addProps)
+            {
+                current = FollowRef(schemaRoot, addProps);
+                continue;
+            }
+
+            // Try array items
+            if (current["items"] is JsonObject items
+                && int.TryParse(segment, out _))
+            {
+                current = FollowRef(schemaRoot, items);
+                continue;
+            }
+
+            return null; // can't resolve further
+        }
+
+        return current is not null ? FollowRef(schemaRoot, current) : null;
+    }
+
+    /// <summary>
+    /// Resolve <c>$ref</c> to the referenced schema object. Only handles local <c>#/</c> references.
+    /// </summary>
+    private static JsonObject? FollowRef(JsonObject root, JsonObject? schema)
+    {
+        if (schema is null) return null;
+        if (schema["$ref"]?.GetValue<string>() is not { } refStr) return schema;
+        if (!refStr.StartsWith("#/", StringComparison.Ordinal)) return schema;
+
+        JsonNode? current = root;
+        foreach (var part in refStr[2..].Split('/'))
+        {
+            current = (current as JsonObject)?[part];
+            if (current is null) return null;
+        }
+
+        return current as JsonObject;
+    }
+
+    #endregion
+
+    #region Config navigation helpers
+
+    private static string[] ParseJsonPointer(string pointer)
+    {
+        if (string.IsNullOrEmpty(pointer) || pointer == "/")
+            return [];
+
+        return pointer.TrimStart('/').Split('/');
+    }
+
+    private static JsonNode? ResolveConfigNode(JsonObject root, ReadOnlySpan<string> segments)
+    {
+        JsonNode? current = root;
+        foreach (var segment in segments)
+        {
+            current = current switch
+            {
+                JsonObject obj => obj[segment],
+                JsonArray arr when int.TryParse(segment, out var idx) => arr[idx],
+                _ => null
+            };
+            if (current is null) return null;
+        }
+
+        return current;
+    }
+
+    private static JsonValue? ResolveConfigValue(JsonObject root, ReadOnlySpan<string> segments)
+        => ResolveConfigNode(root, segments) as JsonValue;
+
+    private static bool SetConfigValue(JsonObject root, ReadOnlySpan<string> segments, JsonNode newValue)
+    {
+        if (segments.Length == 0) return false;
+
+        var parentSegments = segments[..^1];
+        var propertyName = segments[^1];
+
+        if (ResolveConfigNode(root, parentSegments) is JsonObject parent)
+        {
+            parent[propertyName] = newValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+}

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -214,6 +214,16 @@ static async Task RunAsync(string[] args)
         else
             WriteDoctorResult(result);
 
+        // Hint about --fix when there are issues and fix wasn't requested
+        if (!doctorOptions.Fix
+            && result.ExitCode != 0
+            && doctorOptions.Format is DoctorOutputFormat.Text)
+        {
+            fixPlan ??= await fixService.BuildPlanAsync();
+            if (fixPlan.HasChanges)
+                Console.WriteLine("hint: Some issues may be auto-fixable. Run `netclaw doctor --fix --dry-run` to preview.");
+        }
+
         Environment.ExitCode = result.ExitCode;
         return;
     }


### PR DESCRIPTION
## Summary
- Adds `SchemaFixResolver` that validates config against the JSON schema and auto-fixes three error patterns:
  - **Integer→string enum coercion** — maps stale numeric enum values to their schema-defined string names
  - **Missing required defaults** — inserts `default` values from the schema for missing required properties
  - **Stale property removal** — removes properties disallowed by `additionalProperties: false` (e.g., `CapabilityClass` after #491)
- Integrates into `DoctorFixService` alongside existing manual fixes, with dynamic descriptions showing exactly which fixes fired
- Updates `ConfigSchemaDoctorCheck` remediation to point users to `--fix --dry-run`
- Adds post-check hint when `netclaw doctor` detects fixable issues without `--fix`
- Updates AGENTS.md Configuration Schema Sync Rule with migration-friendly guidance

Closes #481

## Test plan
- [x] 8 unit tests for `SchemaFixResolver` (enum coercion, out-of-range skip, defaults, stale removal, $ref handling)
- [x] 6 integration tests for `DoctorFixService` (existing + new dynamic description + stale property removal)
- [x] All 65 existing doctor tests pass
- [ ] CI passes