### PR TITLE
feat(tools): cap MCP tool descriptions and evict discovered tools on compaction

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/DiscoveredToolCacheTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Sessions.Handlers;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public class DiscoveredToolCacheTests
+{
+    [Fact]
+    public void EvictAll_ClearsAllDiscoveredTools()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+        var availableTools = new List<AITool>();
+
+        // Register and load 3 MCP tools
+        var tool1 = RegisterAndRemember(registry, cache, availableTools, "server", "tool_a", retentionTurns: 3, maxCount: 12);
+        var tool2 = RegisterAndRemember(registry, cache, availableTools, "server", "tool_b", retentionTurns: 3, maxCount: 12);
+        var tool3 = RegisterAndRemember(registry, cache, availableTools, "server", "tool_c", retentionTurns: 3, maxCount: 12);
+
+        Assert.Equal(3, availableTools.Count);
+        Assert.True(cache.HasTool("server/tool_a"));
+        Assert.True(cache.HasTool("server/tool_b"));
+        Assert.True(cache.HasTool("server/tool_c"));
+
+        // Evict all — simulates compaction reset
+        cache.EvictAll(availableTools, baseToolCount: 0);
+
+        Assert.Empty(availableTools);
+        Assert.False(cache.HasTool("server/tool_a"));
+        Assert.False(cache.HasTool("server/tool_b"));
+        Assert.False(cache.HasTool("server/tool_c"));
+    }
+
+    [Fact]
+    public void EvictAll_PreservesBaseTools()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+
+        // Simulate 2 base tools + 1 discovered tool
+        var baseTool1 = AIFunctionFactory.Create(() => "result", "search_tools");
+        var baseTool2 = AIFunctionFactory.Create(() => "result", "load_tool");
+        var availableTools = new List<AITool> { baseTool1, baseTool2 };
+        var baseToolCount = 2;
+
+        RegisterAndRemember(registry, cache, availableTools, "notion", "search", retentionTurns: 3, maxCount: 12);
+
+        Assert.Equal(3, availableTools.Count);
+
+        cache.EvictAll(availableTools, baseToolCount);
+
+        Assert.Equal(2, availableTools.Count);
+        Assert.Contains(baseTool1, availableTools);
+        Assert.Contains(baseTool2, availableTools);
+    }
+
+    [Fact]
+    public void PrepareForNewTurn_AfterEvictAll_DoesNotRestoreEvictedTools()
+    {
+        var registry = new ToolRegistry();
+        var cache = new DiscoveredToolCache();
+        var availableTools = new List<AITool>();
+
+        RegisterAndRemember(registry, cache, availableTools, "notion", "search", retentionTurns: 5, maxCount: 12);
+        Assert.Single(availableTools);
+
+        cache.EvictAll(availableTools, baseToolCount: 0);
+        Assert.Empty(availableTools);
+
+        // Next turn — evicted tools should NOT come back
+        cache.PrepareForNewTurn(availableTools, baseToolCount: 0, retentionTurns: 5, maxCount: 12, registry);
+        Assert.Empty(availableTools);
+    }
+
+    private static McpToolAdapter RegisterAndRemember(
+        ToolRegistry registry,
+        DiscoveredToolCache cache,
+        List<AITool> availableTools,
+        string serverName,
+        string toolName,
+        int retentionTurns,
+        int maxCount)
+    {
+        var fake = AIFunctionFactory.Create(() => "result", toolName, $"Description for {toolName}");
+        var adapter = new McpToolAdapter(fake, serverName, toolName);
+        registry.Register(adapter);
+        cache.Remember(adapter.Name, adapter, retentionTurns, maxCount);
+        availableTools.Add(adapter.ToAITool());
+        return adapter;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -126,13 +126,6 @@ public class McpToolAdapterTests
     }
 
     [Fact]
-    public void ClampDescription_ShortDescription_PreservedAsIs()
-    {
-        var result = McpToolAdapter.ClampDescription("Search for items", 2048);
-        Assert.Equal("Search for items", result);
-    }
-
-    [Fact]
     public void ClampDescription_ExactlyAtLimit_PreservedAsIs()
     {
         var description = new string('a', 2048);
@@ -159,13 +152,6 @@ public class McpToolAdapterTests
     }
 
     [Fact]
-    public void ClampDescription_EmptyDescription_ReturnsEmpty()
-    {
-        var result = McpToolAdapter.ClampDescription("", 2048);
-        Assert.Equal("", result);
-    }
-
-    [Fact]
     public void Constructor_WithMaxDescriptionChars_TruncatesDescription()
     {
         var longDesc = new string('x', 5000);
@@ -181,16 +167,6 @@ public class McpToolAdapterTests
         Assert.Equal(adapter.Description, aiFunc.Description);
     }
 
-    [Fact]
-    public void Constructor_WithoutMaxDescriptionChars_PreservesFullDescription()
-    {
-        var longDesc = new string('x', 5000);
-        string FakeFunc() => "result";
-        var fakeTool = AIFunctionFactory.Create(FakeFunc, "verbose_tool", longDesc);
-        var adapter = new McpToolAdapter(fakeTool, "notion", "verbose_tool");
-
-        Assert.Equal(longDesc, adapter.Description);
-    }
 }
 
 internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -124,6 +124,73 @@ public class McpToolAdapterTests
         Assert.StartsWith("Error:", result);
         Assert.Contains("session transport failed", result);
     }
+
+    [Fact]
+    public void ClampDescription_ShortDescription_PreservedAsIs()
+    {
+        var result = McpToolAdapter.ClampDescription("Search for items", 2048);
+        Assert.Equal("Search for items", result);
+    }
+
+    [Fact]
+    public void ClampDescription_ExactlyAtLimit_PreservedAsIs()
+    {
+        var description = new string('a', 2048);
+        var result = McpToolAdapter.ClampDescription(description, 2048);
+        Assert.Equal(description, result);
+    }
+
+    [Fact]
+    public void ClampDescription_ExceedsLimit_Truncated()
+    {
+        var description = new string('a', 5000);
+        var result = McpToolAdapter.ClampDescription(description, 2048);
+        Assert.Equal(2048 + " [truncated]".Length, result.Length);
+        Assert.EndsWith(" [truncated]", result);
+        Assert.StartsWith(new string('a', 2048), result);
+    }
+
+    [Fact]
+    public void ClampDescription_DisabledWithZero_PreservesFullDescription()
+    {
+        var description = new string('a', 10000);
+        var result = McpToolAdapter.ClampDescription(description, 0);
+        Assert.Equal(description, result);
+    }
+
+    [Fact]
+    public void ClampDescription_EmptyDescription_ReturnsEmpty()
+    {
+        var result = McpToolAdapter.ClampDescription("", 2048);
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void Constructor_WithMaxDescriptionChars_TruncatesDescription()
+    {
+        var longDesc = new string('x', 5000);
+        string FakeFunc() => "result";
+        var fakeTool = AIFunctionFactory.Create(FakeFunc, "verbose_tool", longDesc);
+        var adapter = new McpToolAdapter(fakeTool, "notion", "verbose_tool", maxDescriptionChars: 100);
+
+        Assert.Equal(100 + " [truncated]".Length, adapter.Description.Length);
+        Assert.EndsWith(" [truncated]", adapter.Description);
+
+        // SanitizedAIFunction should also have the truncated description
+        var aiFunc = (AIFunction)adapter.ToAITool();
+        Assert.Equal(adapter.Description, aiFunc.Description);
+    }
+
+    [Fact]
+    public void Constructor_WithoutMaxDescriptionChars_PreservesFullDescription()
+    {
+        var longDesc = new string('x', 5000);
+        string FakeFunc() => "result";
+        var fakeTool = AIFunctionFactory.Create(FakeFunc, "verbose_tool", longDesc);
+        var adapter = new McpToolAdapter(fakeTool, "notion", "verbose_tool");
+
+        Assert.Equal(longDesc, adapter.Description);
+    }
 }
 
 internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker

--- a/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolRegistrationExtensionsTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+/// <summary>
+/// Tests for MCP tool registration with description truncation.
+/// Schema warning tests require real McpClientTool instances (MCP SDK) and are
+/// covered by integration tests in Netclaw.Daemon.Tests.
+/// </summary>
+public class ToolRegistrationExtensionsTests
+{
+    [Fact]
+    public void McpToolAdapter_Truncated_SanitizedAIFunction_UsesClampedDescription()
+    {
+        var longDescription = new string('y', 10000);
+        var fakeTool = AIFunctionFactory.Create(() => "result", "big_tool", longDescription);
+        var adapter = new McpToolAdapter(fakeTool, "notion", "big_tool", maxDescriptionChars: 2048);
+
+        // The AITool exposed to the LLM should have the truncated description
+        var aiTool = adapter.ToAITool();
+        var aiFunc = Assert.IsAssignableFrom<AIFunction>(aiTool);
+        Assert.Equal(2048 + " [truncated]".Length, aiFunc.Description.Length);
+        Assert.EndsWith(" [truncated]", aiFunc.Description);
+
+        // Verify adapter.Description matches what the LLM sees
+        Assert.Equal(adapter.Description, aiFunc.Description);
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -902,6 +902,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 _lastInputTokenCount = 0; // Reset — next LLM call will provide fresh count
                 _startupContextInjected = false; // Re-inject static layers on next LLM call
                 _recallManager.ResetForCompaction(); // Force fresh recall + progressive recall reset
+                _discoveredToolCache.EvictAll(_availableTools, _baseToolCount); // Reset to base tools — re-discover as needed
 
                 EnqueueCheckpointFireAndForget(new MemoryCheckpointRequest(
                     SessionId: _sessionId,

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -49,7 +49,7 @@ public sealed class McpToolAdapter : INetclawTool
 
     /// <summary>
     /// Truncates a tool description to fit within the configured character limit.
-    /// Matches Claude Code's 2KB cap on MCP tool descriptions.
+    /// Default 2KB matches Claude Code's cap: https://code.claude.com/docs/en/mcp
     /// </summary>
     internal static string ClampDescription(string description, int maxChars)
     {

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -32,7 +32,6 @@ public sealed class McpToolAdapter : INetclawTool
         Name = $"{serverName}/{toolName}";
         GrantCategory = grantCategory ?? $"mcp:{serverName}";
 
-        // Extract description and schema from the underlying AITool
         if (mcpTool is AIFunction func)
         {
             Description = ClampDescription(func.Description ?? "", maxDescriptionChars);

--- a/src/Netclaw.Actors/Tools/McpToolAdapter.cs
+++ b/src/Netclaw.Actors/Tools/McpToolAdapter.cs
@@ -22,7 +22,8 @@ public sealed class McpToolAdapter : INetclawTool
         string serverName,
         string toolName,
         string? grantCategory = null,
-        IMcpToolInvoker? invoker = null)
+        IMcpToolInvoker? invoker = null,
+        int maxDescriptionChars = 0)
     {
         _mcpTool = mcpTool;
         _toolName = toolName;
@@ -34,10 +35,10 @@ public sealed class McpToolAdapter : INetclawTool
         // Extract description and schema from the underlying AITool
         if (mcpTool is AIFunction func)
         {
-            Description = func.Description ?? "";
+            Description = ClampDescription(func.Description ?? "", maxDescriptionChars);
             // Sanitize schema for LLM compatibility (strips nullable unions, etc.)
             ParameterSchema = McpSchemaSanitizer.SanitizeSchema(func.JsonSchema);
-            _sanitizedTool = new SanitizedAIFunction(func, Name, ParameterSchema);
+            _sanitizedTool = new SanitizedAIFunction(func, Name, Description, ParameterSchema);
         }
         else
         {
@@ -45,6 +46,18 @@ public sealed class McpToolAdapter : INetclawTool
             ParameterSchema = default;
             _sanitizedTool = mcpTool;
         }
+    }
+
+    /// <summary>
+    /// Truncates a tool description to fit within the configured character limit.
+    /// Matches Claude Code's 2KB cap on MCP tool descriptions.
+    /// </summary>
+    internal static string ClampDescription(string description, int maxChars)
+    {
+        if (maxChars <= 0 || description.Length <= maxChars)
+            return description;
+
+        return description[..maxChars] + " [truncated]";
     }
 
     public string Name { get; }
@@ -114,19 +127,21 @@ public sealed class McpToolAdapter : INetclawTool
     {
         private readonly AIFunction _inner;
         private readonly string _namespacedName;
+        private readonly string _description;
         private readonly JsonElement _sanitizedSchema;
 
-        public SanitizedAIFunction(AIFunction inner, string namespacedName, JsonElement sanitizedSchema)
+        public SanitizedAIFunction(AIFunction inner, string namespacedName, string description, JsonElement sanitizedSchema)
         {
             _inner = inner;
             _namespacedName = namespacedName;
+            _description = description;
             _sanitizedSchema = sanitizedSchema;
         }
 
         // Use the namespaced name (e.g., "memorizer/search_memories") so the LLM
         // calls the tool by the same name it's registered under in ToolRegistry.
         public override string Name => _namespacedName;
-        public override string Description => _inner.Description;
+        public override string Description => _description;
         public override JsonElement JsonSchema => _sanitizedSchema;
 
         protected override ValueTask<object?> InvokeCoreAsync(

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -1,5 +1,6 @@
 using Akka.Actor;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Skills;
@@ -78,16 +79,36 @@ public static class ToolRegistrationExtensions
     /// <summary>
     /// Register MCP tools discovered from an MCP server into the tool registry.
     /// Tools are wrapped as <see cref="McpToolAdapter"/> with namespaced names.
+    /// Descriptions exceeding <paramref name="maxDescriptionChars"/> are truncated.
+    /// Schemas exceeding <paramref name="maxSchemaWarnChars"/> trigger a warning log.
     /// </summary>
     public static ToolRegistry WithMcpTools(
         this ToolRegistry registry,
         string serverName,
         IList<McpClientTool> tools,
         string? grantCategory = null,
-        IMcpToolInvoker? invoker = null)
+        IMcpToolInvoker? invoker = null,
+        int maxDescriptionChars = 0,
+        int maxSchemaWarnChars = 0,
+        ILogger? logger = null)
     {
         foreach (var tool in tools)
-            registry.Register(new McpToolAdapter(tool, serverName, tool.Name, grantCategory, invoker));
+        {
+            var adapter = new McpToolAdapter(tool, serverName, tool.Name, grantCategory, invoker, maxDescriptionChars);
+            registry.Register(adapter);
+
+            if (maxSchemaWarnChars > 0 && adapter.ParameterSchema.ValueKind != System.Text.Json.JsonValueKind.Undefined)
+            {
+                var schemaChars = adapter.ParameterSchema.GetRawText().Length;
+                if (schemaChars > maxSchemaWarnChars)
+                {
+                    logger?.LogWarning(
+                        "MCP tool '{ServerName}/{ToolName}' has an oversized schema ({SchemaChars} chars, threshold {Threshold}). " +
+                        "This wastes context window budget when the tool is loaded. Consider asking the MCP server author to reduce schema verbosity.",
+                        serverName, tool.Name, schemaChars, maxSchemaWarnChars);
+                }
+            }
+        }
 
         return registry;
     }

--- a/src/Netclaw.Configuration/SessionConfig.cs
+++ b/src/Netclaw.Configuration/SessionConfig.cs
@@ -129,6 +129,8 @@ public sealed record SessionConfig
             MemorySidecarsEnabled = ResolveValue(tuningSection, section, nameof(SessionTuning.MemorySidecarsEnabled), nested.MemorySidecarsEnabled),
             DeterministicRetrievalEnabled = ResolveValue(tuningSection, section, nameof(SessionTuning.DeterministicRetrievalEnabled), nested.DeterministicRetrievalEnabled),
             MemoryDistillationTurnInterval = ResolveValue(tuningSection, section, nameof(SessionTuning.MemoryDistillationTurnInterval), nested.MemoryDistillationTurnInterval),
+            MaxToolDescriptionChars = ResolveValue(tuningSection, section, nameof(SessionTuning.MaxToolDescriptionChars), nested.MaxToolDescriptionChars),
+            MaxToolSchemaWarnChars = ResolveValue(tuningSection, section, nameof(SessionTuning.MaxToolSchemaWarnChars), nested.MaxToolSchemaWarnChars),
         };
     }
 

--- a/src/Netclaw.Configuration/SessionTuning.cs
+++ b/src/Netclaw.Configuration/SessionTuning.cs
@@ -84,6 +84,22 @@ public sealed record SessionTuning
     public int MemoryDistillationTurnInterval { get; init; } = 5;
 
     /// <summary>
+    /// Maximum characters allowed in an MCP tool description before truncation.
+    /// Oversized descriptions (e.g., Notion tools at ~10K chars each) are truncated
+    /// at registration time to protect the context window. Matches Claude Code's
+    /// documented 2KB cap. Set to 0 to disable truncation.
+    /// </summary>
+    public int MaxToolDescriptionChars { get; init; } = 2048;
+
+    /// <summary>
+    /// Character threshold at which an MCP tool's JSON schema triggers a warning log.
+    /// Schemas cannot be safely truncated (would break invocation), so this is
+    /// observability only — alerts operators that an MCP server is shipping bloated
+    /// tool definitions. Set to 0 to disable warnings.
+    /// </summary>
+    public int MaxToolSchemaWarnChars { get; init; } = 8000;
+
+    /// <summary>
     /// Retry policy for transient streaming LLM failures (5xx, 429).
     /// Only applies when no data has been streamed yet — mid-stream failures
     /// are not retried because the partial response cannot be reconstructed.

--- a/src/Netclaw.Configuration/SessionTuning.cs
+++ b/src/Netclaw.Configuration/SessionTuning.cs
@@ -86,8 +86,9 @@ public sealed record SessionTuning
     /// <summary>
     /// Maximum characters allowed in an MCP tool description before truncation.
     /// Oversized descriptions (e.g., Notion tools at ~10K chars each) are truncated
-    /// at registration time to protect the context window. Matches Claude Code's
-    /// documented 2KB cap. Set to 0 to disable truncation.
+    /// at registration time to protect the context window. Default matches Claude Code's
+    /// documented 2KB cap (see https://code.claude.com/docs/en/mcp — "Scale with MCP
+    /// Tool Search" section). Set to 0 to disable truncation.
     /// </summary>
     public int MaxToolDescriptionChars { get; init; } = 2048;
 

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -20,6 +20,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     private readonly IOperationalNotificationSink _notificationSink;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<McpClientManager> _logger;
+    private readonly int _maxToolDescriptionChars;
+    private readonly int _maxToolSchemaWarnChars;
 
     private readonly ConcurrentDictionary<string, McpClient> _clients =
         new(StringComparer.OrdinalIgnoreCase);
@@ -47,7 +49,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         McpOAuthService oauthService,
         IOperationalNotificationSink notificationSink,
         TimeProvider timeProvider,
-        ILogger<McpClientManager> logger)
+        ILogger<McpClientManager> logger,
+        SessionConfig? sessionConfig = null)
     {
         _serverEntries = serverEntries;
         _toolRegistry = toolRegistry;
@@ -55,6 +58,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         _notificationSink = notificationSink;
         _timeProvider = timeProvider;
         _logger = logger;
+        _maxToolDescriptionChars = sessionConfig?.Tuning.MaxToolDescriptionChars ?? 0;
+        _maxToolSchemaWarnChars = sessionConfig?.Tuning.MaxToolSchemaWarnChars ?? 0;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -393,7 +398,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             _sharedToolFunctions[name] = CreateFunctionMap(tools);
             _sessionScopedServers[name] = RequiresSessionScopedClient(name, entry);
 
-            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, this);
+            _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, this,
+                _maxToolDescriptionChars, _maxToolSchemaWarnChars, _logger);
             _statuses[name] = new McpServerStatus(name, McpConnectionState.Connected, tools.Count, null);
 
             _logger.LogInformation("MCP server '{Name}' connected ({ToolCount} tools)", name, tools.Count);


### PR DESCRIPTION
## Summary

- **Cap MCP tool descriptions at 2KB** (matching Claude Code's documented limit) to prevent oversized descriptions from bloating the LLM context window. Truncation happens once at registration time via `McpToolAdapter.ClampDescription`.
- **Log warnings for oversized tool schemas** (>8KB default threshold) so operators know which MCP servers are shipping bloated tool definitions. Schemas can't be safely truncated, so this is observability only.
- **Evict discovered tools on compaction** — previously discovered tools survived compaction, continuing to consume context even after the conversation was summarized. Now `DiscoveredToolCache.EvictAll()` is called alongside the existing compaction resets, forcing re-discovery of only the tools actually needed.

Both limits are configurable via `SessionTuning.MaxToolDescriptionChars` (default 2048, 0 disables) and `SessionTuning.MaxToolSchemaWarnChars` (default 8000, 0 disables).

Addresses context window pollution from MCP servers like Notion that return ~10K chars per tool description (45K total for 10 tools). Follow-up to #492 which split search_tools from tool loading.

## Test plan

- [x] 7 new `McpToolAdapterTests` covering `ClampDescription` edge cases and constructor-level truncation
- [x] All 1,627 existing tests pass
- [ ] CI green