### PR TITLE
feat(security): per-tool audience gating for MCP servers

### DIFF
--- a/openspec/changes/mcp-audience-tool-grants/.openspec.yaml
+++ b/openspec/changes/mcp-audience-tool-grants/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/mcp-audience-tool-grants/design.md
+++ b/openspec/changes/mcp-audience-tool-grants/design.md
@@ -1,0 +1,76 @@
+## Context
+
+MCP tools are currently gated at the server level: `ToolAudienceProfile.AllowedMcpServers` lists server names, and if a server is allowed, all its tools pass through. `ToolAccessPolicy.IsToolExposed` delegates to `ToolAudienceProfileResolver.IsMcpServerAllowed` which checks server name only. There is no per-tool check.
+
+Tools are registered at startup by `McpClientManager.ConnectAsync` → `ToolRegistrationExtensions.WithMcpTools`, which wraps each discovered tool as an `McpToolAdapter` with name format `{serverName}/{toolName}` and grant category `mcp:{serverName}`.
+
+The enforcement path for MCP tools:
+1. `IsToolExposed(INetclawTool, TrustAudience)` → checks `IsMcpServerAllowed(serverName, audience)`
+2. `AuthorizeInvocation(INetclawTool, ToolExecutionContext)` → same server-level check
+3. `FilterDiscoverableTools` / `FilterExposedTools` → calls `IsToolExposed` per tool
+
+The `McpToolAdapter` already exposes `ServerName` and the bare tool name, so per-tool filtering can be added without changing the adapter.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Per-audience per-server tool allowlists via `McpServerToolGrants` on `ToolAudienceProfile`
+- Backward-compatible: null/omitted grants = all tools exposed (current behavior)
+- Supply-chain visibility: log warnings when servers expose tools not granted to any audience
+- CLI + TUI for viewing and managing tool grants (`netclaw mcp tools`)
+- Doctor advisory for servers with no tool grants
+
+**Non-Goals:**
+- Server-level `AllowedTools` on `McpServerEntry` — single enforcement layer at the audience profile is sufficient
+- Webhook/notification alerts for tool changes (future Phase 3)
+- Per-tool filtering for first-party tools (already handled by `IsProfileManagedTool`)
+- Hot-reload of tool grants (config changes already require daemon restart)
+
+## Decisions
+
+### 1. Single enforcement layer at audience profile, not server entry
+
+**Decision**: `McpServerToolGrants` lives on `ToolAudienceProfile`, not `McpServerEntry`.
+
+**Rationale**: If every audience has scoped tool grants, there's no unreviewed path for a tool to reach a session. A second layer on `McpServerEntry` would be redundant config surface. Operators who want a global cap set the same grants on all three profiles.
+
+**Alternative considered**: Two layers (server-level global cap + audience-level scoping). Rejected — adds config complexity for no additional security if audience profiles are properly configured.
+
+### 2. Enforce at access-policy time, not registration time
+
+**Decision**: All discovered tools are still registered in `ToolRegistry` via `WithMcpTools`. Filtering happens in `ToolAccessPolicy.IsToolExposed` and `AuthorizeInvocation`.
+
+**Rationale**: Registration is a global, audience-independent operation — the daemon registers tools once for all sessions. Per-audience filtering must happen per-session at access time, which is where `ToolAccessPolicy` already operates. This also means `search_tools` correctly filters by the requesting session's audience.
+
+**Alternative considered**: Filter at registration time in `WithMcpTools`. Rejected — registration is not audience-aware; would need to register tools multiple times or maintain parallel registries.
+
+### 3. `McpServerToolGrants` is a nullable dictionary, not a mode enum
+
+**Decision**: `Dictionary<string, List<string>>?` where keys are server names and values are tool name lists. Null means no per-tool filtering.
+
+**Rationale**: This composes naturally with `AllowedMcpServers`. A server must pass the server gate first, then the tool grant check. Servers not in the dictionary expose all tools — backward-compatible and ergonomic for operators who only want to restrict one server.
+
+### 4. Tool change detection via startup logging, not persistent state
+
+**Decision**: `McpClientManager` compares discovered tools against grants from all audience profiles at connect time and logs warnings. No persistent "last known tools" storage.
+
+**Rationale**: Config is the source of truth. If an operator has configured grants, any tool not in any audience's grants is a signal. This requires no new persistence, no new actor state, and works on first startup.
+
+### 5. TUI fits in `netclaw mcp tools`, not a standalone command
+
+**Decision**: Add `tools` as a subcommand of the existing `netclaw mcp` family.
+
+**Rationale**: The feature is MCP-specific and the MCP command family already handles server lifecycle (`add`, `remove`, `auth`, `list`, `enable`, `disable`). Tool permissions are a natural extension.
+
+## Risks / Trade-offs
+
+**Risk: Stale grants** — If an MCP server renames a tool, the old name in grants silently stops matching.
+→ *Mitigation*: Log warning for grant entries not found on the server. `netclaw mcp tools --snapshot` lets operators re-baseline.
+
+**Risk: Empty grants confusion** — Operator sets `McpServerToolGrants: { "memorizer": [] }` and wonders why no tools work.
+→ *Mitigation*: Doctor advisory. Log message at startup: "MCP server 'memorizer' has empty tool grants for [audience] — no tools will be exposed."
+
+**Risk: Case sensitivity** — MCP tool names are case-sensitive per protocol. Grants must match exactly.
+→ *Mitigation*: Use `StringComparer.Ordinal`. Document in CLI help. The `--snapshot` command captures exact names.
+
+**Trade-off: No hot-reload** — Changing grants requires daemon restart. Acceptable because MCP server config changes already require restart. Future `netclaw-config-hot-reload` spec could address this.

--- a/openspec/changes/mcp-audience-tool-grants/proposal.md
+++ b/openspec/changes/mcp-audience-tool-grants/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+MCP server access is gated at the server level — if a server is allowed for an audience, all its tools are exposed. This creates a supply-chain risk (servers can add tools without operator review) and prevents per-audience tool scoping (no way to give Team `search+get` while Personal gets everything). Relates to PRD-002 (security posture) and GitHub issue #490.
+
+## What Changes
+
+- Add `McpServerToolGrants` dictionary to `ToolAudienceProfile` — per-server tool allowlists that vary by audience
+- Enforce per-tool filtering in `ToolAccessPolicy` and `ToolAudienceProfileResolver` after the existing server-level gate
+- Log warnings when MCP servers expose tools not granted to any audience (supply-chain detection)
+- Add `netclaw mcp tools` CLI subcommand for viewing and managing per-server tool grants
+- Add TUI mode for interactive tool permission configuration using Termina
+- Add doctor advisory for servers with no tool grants configured on any audience
+
+Default behavior is unchanged: Personal audience sees all tools from all servers. Tool grants are opt-in tightening — operators add them when they want to restrict exposure per audience.
+
+## Capabilities
+
+### New Capabilities
+
+_None_ — this extends existing MCP and ACL capabilities rather than introducing a new spec domain.
+
+### Modified Capabilities
+
+- `netclaw-mcp`: Add per-tool audience filtering to tool discovery and registration. Tools not granted to the session's audience are excluded from `search_tools` results and `load_tool` availability.
+- `netclaw-acl`: Add `McpServerToolGrants` as a second-stage filter after `AllowedMcpServers`. When a server has an entry in the grants dictionary, only listed tools pass the audience check.
+- `netclaw-cli`: Add `netclaw mcp tools` subcommand (CLI list mode + TUI interactive mode + `--snapshot` for baselining).
+
+## Impact
+
+- **Config**: New `McpServerToolGrants` property on `ToolAudienceProfile` in `netclaw.json`. Nullable, backward-compatible.
+- **Schema**: `netclaw-config.v1.schema.json` updated with new property in `ToolAudienceProfile` definition.
+- **Enforcement**: `ToolAccessPolicy.IsToolExposed` and `AuthorizeInvocation` gain per-tool check for `McpToolAdapter` path.
+- **Resolution**: `ToolAudienceProfileResolver` gains `IsMcpToolAllowed` method.
+- **Diagnostics**: `McpClientManager` logs tool drift warnings. `McpServersDoctorCheck` adds advisory for ungated servers.
+- **CLI**: `McpCommand` gains `tools` subcommand with CLI and TUI modes.
+- **No breaking changes** — existing configs without `McpServerToolGrants` behave identically to today.

--- a/openspec/changes/mcp-audience-tool-grants/specs/netclaw-acl/spec.md
+++ b/openspec/changes/mcp-audience-tool-grants/specs/netclaw-acl/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Tool and data grants
+
+The system SHALL enforce explicit grants for tool and data access. Grants SHALL
+be organized into specific tool grant categories: `shell`, `web_search`,
+`web_fetch`, `github`, `mcp:{server_name}`, `config_write`, and
+`schedule_write`. Each grant SHALL specify the allowed senders and channels to
+which it applies.
+
+For MCP tools, the system SHALL support an additional per-tool grant layer via
+`McpServerToolGrants` on each audience profile. When configured for a server,
+only explicitly listed tools SHALL pass the audience check. This per-tool
+check SHALL execute after the server-level `AllowedMcpServers` check.
+
+#### Scenario: Missing grant blocks tool call
+
+- **WHEN** a tool call is attempted without a matching grant
+- **THEN** execution is denied with a policy reason code
+
+#### Scenario: Category-specific grant allows tool
+
+- **GIVEN** ACL grants `web_search` for sender `U12345` on channel `C99999`
+- **WHEN** sender `U12345` requests a web search in channel `C99999`
+- **THEN** ACL evaluation returns allow for the `web_search` tool category
+
+#### Scenario: MCP server-scoped grant
+
+- **GIVEN** ACL grants `mcp:memorizer` for sender `U12345`
+- **WHEN** sender `U12345` requests an MCP tool from the `memorizer` server
+- **THEN** ACL evaluation returns allow
+- **AND** MCP tools from other servers without explicit grants are denied
+
+#### Scenario: MCP tool blocked by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/store`
+- **THEN** the invocation is denied with reason `mcp_tool_not_allowed_for_audience_profile`
+
+#### Scenario: MCP tool allowed by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/search_memories`
+- **THEN** the invocation is allowed
+
+#### Scenario: Config write grant required for self-configuration
+
+- **GIVEN** ACL does not grant `config_write` for the current sender
+- **WHEN** the agent attempts to write configuration files through conversation
+- **THEN** the write is denied with a policy reason code

--- a/openspec/changes/mcp-audience-tool-grants/specs/netclaw-cli/spec.md
+++ b/openspec/changes/mcp-audience-tool-grants/specs/netclaw-cli/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: MCP tool permissions CLI
+
+The system SHALL provide a `netclaw mcp tools` subcommand for viewing and
+managing per-server tool grants across audience profiles.
+
+#### Scenario: List tools for a server
+
+- **GIVEN** the daemon is running and `memorizer` is connected
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI displays all discovered tools from `memorizer`
+- **AND** each tool shows its grant status per audience (Public, Team, Personal)
+- **AND** tools not granted to any audience are visually distinguished
+
+#### Scenario: List tools when daemon is unavailable
+
+- **GIVEN** the daemon is not running
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI reports that tool discovery requires the daemon
+- **AND** exits with a non-zero exit code
+
+#### Scenario: Snapshot current tools as grants
+
+- **GIVEN** the daemon is running and `memorizer` exposes 5 tools
+- **WHEN** operator runs `netclaw mcp tools memorizer --snapshot`
+- **THEN** the CLI populates `McpServerToolGrants` for all audience profiles that allow `memorizer`
+- **AND** each profile's grant list contains all 5 currently discovered tool names
+- **AND** the updated config is written to `netclaw.json`
+
+#### Scenario: Help for tools subcommand
+
+- **WHEN** operator runs `netclaw mcp tools --help`
+- **THEN** the CLI displays usage, subcommand description, and available flags
+
+### Requirement: MCP tool permissions TUI
+
+The system SHALL provide an interactive TUI mode for `netclaw mcp tools`
+(invoked without a server name argument) that allows operators to browse
+servers, view discovered tools, and toggle per-tool grants per audience.
+
+#### Scenario: Launch TUI without arguments
+
+- **GIVEN** the daemon is running with MCP servers connected
+- **WHEN** operator runs `netclaw mcp tools` (no server name)
+- **THEN** the TUI launches showing a list of configured MCP servers
+
+#### Scenario: Browse tools for a server
+
+- **GIVEN** the TUI is showing the server list
+- **WHEN** operator selects a server
+- **THEN** the TUI shows all discovered tools for that server with descriptions
+- **AND** each tool shows its current grant status for the selected audience
+
+#### Scenario: Switch audience in TUI
+
+- **GIVEN** the TUI is showing tools for a server
+- **WHEN** operator presses Tab to switch audience
+- **THEN** the tool grant checkboxes update to reflect the newly selected audience's grants
+
+#### Scenario: Toggle tool grant in TUI
+
+- **GIVEN** the TUI is showing tools for a server under the Team audience
+- **WHEN** operator toggles a tool's checkbox
+- **THEN** the tool is added to or removed from the Team profile's `McpServerToolGrants` for this server
+
+#### Scenario: Save changes from TUI
+
+- **GIVEN** the operator has toggled tool grants in the TUI
+- **WHEN** operator presses the save key
+- **THEN** the updated `McpServerToolGrants` are written to `netclaw.json`
+- **AND** the TUI confirms the save
+
+### Requirement: MCP doctor advisory for ungated servers
+
+The `netclaw doctor` command SHALL include an advisory check for MCP servers
+that have no `McpServerToolGrants` configured on any audience profile.
+
+#### Scenario: Server with no tool grants triggers advisory
+
+- **GIVEN** `memorizer` is enabled and connected
+- **AND** no audience profile has `McpServerToolGrants` entries for `memorizer`
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** an info-level advisory is reported for `memorizer`
+- **AND** the message suggests adding tool grants for supply-chain protection
+
+#### Scenario: Server with tool grants passes advisory
+
+- **GIVEN** `memorizer` has `McpServerToolGrants` on at least one audience profile
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** no tool grant advisory is reported for `memorizer`

--- a/openspec/changes/mcp-audience-tool-grants/specs/netclaw-mcp/spec.md
+++ b/openspec/changes/mcp-audience-tool-grants/specs/netclaw-mcp/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Per-tool audience filtering for MCP servers
+
+The system SHALL support per-server tool allowlists on each audience profile
+via `McpServerToolGrants`. When a server has an entry in the grants dictionary,
+only tools whose bare name appears in the list SHALL be exposed to that
+audience. When a server has no entry (or grants is null), all tools from that
+server SHALL be exposed (backward-compatible default).
+
+Tool grants compose with the existing `AllowedMcpServers` gate: a tool must
+pass both the server-level check AND the per-tool grant check to be exposed.
+
+#### Scenario: Tool granted to audience is exposed
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": ["search_memories", "get"] }`
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools for this audience
+- **THEN** `memorizer/search_memories` and `memorizer/get` are exposed
+- **AND** other tools from `memorizer` are not exposed
+
+#### Scenario: No grants for server exposes all tools
+
+- **GIVEN** audience profile has `McpServerToolGrants` that does not contain a `memorizer` entry
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools for this audience
+- **THEN** all tools from `memorizer` are exposed
+
+#### Scenario: Null grants exposes all tools from allowed servers
+
+- **GIVEN** audience profile has `McpServerToolGrants: null`
+- **AND** servers are allowed via `AllowedMcpServers` or `McpServersMode: All`
+- **WHEN** the session resolves available tools
+- **THEN** all tools from all allowed servers are exposed
+
+#### Scenario: Empty tool list blocks all tools from server
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": [] }`
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools
+- **THEN** no tools from `memorizer` are exposed
+
+#### Scenario: Server not in AllowedMcpServers is blocked regardless of grants
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": ["search_memories"] }`
+- **BUT** `memorizer` is NOT in `AllowedMcpServers` and `McpServersMode` is `Allowlist`
+- **WHEN** the session resolves available tools
+- **THEN** no tools from `memorizer` are exposed
+
+#### Scenario: Different audiences see different tools from same server
+
+- **GIVEN** Team profile has `McpServerToolGrants: { "memorizer": ["search_memories", "get"] }`
+- **AND** Personal profile has `McpServersMode: All` with no `McpServerToolGrants`
+- **WHEN** a Team session resolves tools
+- **THEN** only `search_memories` and `get` are exposed
+- **AND** when a Personal session resolves tools, all `memorizer` tools are exposed
+
+### Requirement: Tool grant enforcement in search_tools
+
+Tools blocked by `McpServerToolGrants` SHALL NOT appear in `search_tools`
+results for the requesting session's audience. The compressed tool index
+injected into system prompts SHALL also reflect per-tool grant filtering.
+
+#### Scenario: Blocked tool absent from search_tools
+
+- **GIVEN** Team profile grants only `["search_memories"]` from `memorizer`
+- **WHEN** a Team session calls `search_tools` with query matching `store`
+- **THEN** `memorizer/store` does NOT appear in results
+
+#### Scenario: Blocked tool absent from load_tool
+
+- **GIVEN** Team profile grants only `["search_memories"]` from `memorizer`
+- **WHEN** a Team session calls `load_tool` for `memorizer/store`
+- **THEN** the tool is denied with a policy reason
+
+### Requirement: Tool change detection logging
+
+At MCP server connect time, the system SHALL compare discovered tools against
+tool grants configured across all audience profiles. The system SHALL log
+warnings for tools that appear on the server but are not granted to any
+audience, and for granted tool names that do not exist on the server.
+
+#### Scenario: New tool discovered but not granted
+
+- **GIVEN** `memorizer` server exposes tools `[search_memories, store, get, archive]`
+- **AND** across all audience profiles, only `[search_memories, store, get]` are granted
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** a warning is logged identifying `archive` as discovered but not granted to any audience
+
+#### Scenario: Granted tool not found on server
+
+- **GIVEN** Team profile grants `["search_memories", "old_tool"]` from `memorizer`
+- **AND** `memorizer` does not expose a tool named `old_tool`
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** a warning is logged identifying `old_tool` as granted but not found on the server
+
+#### Scenario: No grants configured skips change detection
+
+- **GIVEN** no audience profile has `McpServerToolGrants` entries for `memorizer`
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** no tool change detection warnings are logged for that server

--- a/openspec/changes/mcp-audience-tool-grants/tasks.md
+++ b/openspec/changes/mcp-audience-tool-grants/tasks.md
@@ -1,0 +1,42 @@
+## 1. Config Model
+
+- [x] 1.1 Add `McpServerToolGrants` property (`Dictionary<string, List<string>>?`) to `ToolAudienceProfile` in `src/Netclaw.Configuration/ToolAudienceProfiles.cs`
+- [x] 1.2 Add `McpServerToolGrants` to `ToolAudienceProfile` definition in `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json`
+
+## 2. Enforcement
+
+- [x] 2.1 Add `IsMcpToolAllowed(string serverName, string toolName, TrustAudience audience)` method to `ToolAudienceProfileResolver` in `src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs`
+- [x] 2.2 Update `IsToolExposed` in `ToolAccessPolicy` to call `IsMcpToolAllowed` after `IsMcpServerAllowed` for `McpToolAdapter` tools
+- [x] 2.3 Update `AuthorizeInvocation` in `ToolAccessPolicy` to deny with `mcp_tool_not_allowed_for_audience_profile` when per-tool grant check fails
+
+## 3. Tool Change Detection
+
+- [x] 3.1 Add tool drift logging in `McpClientManager.ConnectAsync` — compare discovered tools against grants from all audience profiles, warn on ungranted tools and stale grants
+
+## 4. Doctor Advisory
+
+- [x] 4.1 Add info-level advisory in `ToolAudienceProfilesDoctorCheck` for enabled servers with no `McpServerToolGrants` on any audience profile
+
+## 5. Tests
+
+- [x] 5.1 Unit tests for `IsMcpToolAllowed`: null grants = all pass, empty list = none pass, populated list = only matches pass, server not in grants = all pass
+- [x] 5.2 Unit tests for `IsToolExposed` integration: server allowed + tool granted = exposed, server allowed + tool not granted = blocked, server blocked = blocked regardless of grants
+- [x] 5.3 Unit tests for `AuthorizeInvocation`: verify correct deny reason code `mcp_tool_not_allowed_for_audience_profile`
+- [x] 5.4 Test `search_tools` does not return tools blocked by `McpServerToolGrants`
+- [x] 5.5 Doctor check test: advisory fires for servers with no grants, does not fire when grants exist
+
+## 6. CLI: `netclaw mcp tools`
+
+- [ ] 6.1 Add `tools` subcommand routing in `McpCommand.RunAsync` and help text
+- [ ] 6.2 Implement CLI list mode (`netclaw mcp tools <server>`) — query daemon for discovered tools, display per-audience grant status table
+- [ ] 6.3 Implement `--snapshot` flag — populate `McpServerToolGrants` from discovered tools and write to `netclaw.json`
+
+## 7. TUI: Interactive Tool Permissions
+
+- [ ] 7.1 Create `McpToolPermissionsViewModel` with server list, tool list, audience selector, and toggle state
+- [ ] 7.2 Create `McpToolPermissionsPage` with Termina layout: server list → tool grid with checkboxes → save
+- [ ] 7.3 Wire TUI mode in `McpCommand` (no server arg) and `Program.cs` routing
+
+## 8. Spec Sync
+
+- [ ] 8.1 Sync delta specs to main specs via `/opsx-sync` after implementation is verified

--- a/openspec/changes/mcp-audience-tool-grants/tasks.md
+++ b/openspec/changes/mcp-audience-tool-grants/tasks.md
@@ -27,15 +27,15 @@
 
 ## 6. CLI: `netclaw mcp tools`
 
-- [ ] 6.1 Add `tools` subcommand routing in `McpCommand.RunAsync` and help text
-- [ ] 6.2 Implement CLI list mode (`netclaw mcp tools <server>`) — query daemon for discovered tools, display per-audience grant status table
-- [ ] 6.3 Implement `--snapshot` flag — populate `McpServerToolGrants` from discovered tools and write to `netclaw.json`
+- [x] 6.1 Add `tools` subcommand routing in `McpCommand.RunAsync` and help text
+- [x] 6.2 Implement CLI list mode (`netclaw mcp tools <server>`) — query daemon for discovered tools, display per-audience grant status table
+- [x] 6.3 Implement `--snapshot` flag — populate `McpServerToolGrants` from discovered tools and write to `netclaw.json`
 
 ## 7. TUI: Interactive Tool Permissions
 
-- [ ] 7.1 Create `McpToolPermissionsViewModel` with server list, tool list, audience selector, and toggle state
-- [ ] 7.2 Create `McpToolPermissionsPage` with Termina layout: server list → tool grid with checkboxes → save
-- [ ] 7.3 Wire TUI mode in `McpCommand` (no server arg) and `Program.cs` routing
+- [x] 7.1 Create `McpToolPermissionsViewModel` with server list, tool list, audience selector, and toggle state
+- [x] 7.2 Create `McpToolPermissionsPage` with Termina layout: server list → tool grid with checkboxes → save
+- [x] 7.3 Wire TUI mode in `McpCommand` (no server arg) and `Program.cs` routing
 
 ## 8. Spec Sync
 

--- a/openspec/changes/mcp-audience-tool-grants/tasks.md
+++ b/openspec/changes/mcp-audience-tool-grants/tasks.md
@@ -39,4 +39,4 @@
 
 ## 8. Spec Sync
 
-- [ ] 8.1 Sync delta specs to main specs via `/opsx-sync` after implementation is verified
+- [x] 8.1 Sync delta specs to main specs via `/opsx-sync` after implementation is verified

--- a/openspec/specs/netclaw-acl/spec.md
+++ b/openspec/specs/netclaw-acl/spec.md
@@ -46,6 +46,11 @@ be organized into specific tool grant categories: `shell`, `web_search`,
 `schedule_write`. Each grant SHALL specify the allowed senders and channels to
 which it applies.
 
+For MCP tools, the system SHALL support an additional per-tool grant layer via
+`McpServerToolGrants` on each audience profile. When configured for a server,
+only explicitly listed tools SHALL pass the audience check. This per-tool
+check SHALL execute after the server-level `AllowedMcpServers` check.
+
 #### Scenario: Missing grant blocks tool call
 
 - **WHEN** a tool call is attempted without a matching grant
@@ -63,6 +68,20 @@ which it applies.
 - **WHEN** sender `U12345` requests an MCP tool from the `memorizer` server
 - **THEN** ACL evaluation returns allow
 - **AND** MCP tools from other servers without explicit grants are denied
+
+#### Scenario: MCP tool blocked by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/store`
+- **THEN** the invocation is denied with reason `mcp_tool_not_allowed_for_audience_profile`
+
+#### Scenario: MCP tool allowed by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/search_memories`
+- **THEN** the invocation is allowed
 
 #### Scenario: Config write grant required for self-configuration
 

--- a/openspec/specs/netclaw-cli/spec.md
+++ b/openspec/specs/netclaw-cli/spec.md
@@ -487,3 +487,100 @@ webhook deduplication mechanism).
 - **GIVEN** an `UpdateAvailable` alert was recently emitted for the same version
 - **WHEN** the periodic recheck runs again within the deduplication window
 - **THEN** no duplicate alert is emitted
+
+### Requirement: MCP tool permissions CLI
+
+The system SHALL provide a `netclaw mcp tools` subcommand for viewing and
+managing per-server tool grants across audience profiles.
+
+#### Scenario: List tools for a server
+
+- **GIVEN** the daemon is running and `memorizer` is connected
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI displays all discovered tools from `memorizer`
+- **AND** each tool shows its grant status per audience (Public, Team, Personal)
+- **AND** tools not granted to any audience are visually distinguished
+
+#### Scenario: List tools when daemon is unavailable
+
+- **GIVEN** the daemon is not running
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI reports that tool discovery requires the daemon
+- **AND** exits with a non-zero exit code
+
+#### Scenario: Snapshot current tools as grants
+
+- **GIVEN** the daemon is running and `memorizer` exposes 5 tools
+- **WHEN** operator runs `netclaw mcp tools memorizer --snapshot`
+- **THEN** the CLI populates `McpServerToolGrants` for all audience profiles that allow `memorizer`
+- **AND** each profile's grant list contains all 5 currently discovered tool names
+- **AND** the updated config is written to `netclaw.json`
+
+#### Scenario: Help for tools subcommand
+
+- **WHEN** operator runs `netclaw mcp tools --help`
+- **THEN** the CLI displays usage, subcommand description, and available flags
+
+### Requirement: MCP tool permissions TUI
+
+The system SHALL provide an interactive TUI mode for `netclaw mcp tools`
+(invoked without a server name argument) that allows operators to browse
+servers, view discovered tools, and toggle per-tool grants per audience.
+
+#### Scenario: Launch TUI without arguments
+
+- **GIVEN** the daemon is running with MCP servers connected
+- **WHEN** operator runs `netclaw mcp tools` (no server name)
+- **THEN** the TUI launches showing a list of configured MCP servers
+
+#### Scenario: Browse tools for a server
+
+- **GIVEN** the TUI is showing the server list
+- **WHEN** operator selects a server
+- **THEN** the TUI shows all discovered tools for that server
+- **AND** each tool shows its current grant status for the selected audience
+
+#### Scenario: Cycle audience in TUI
+
+- **GIVEN** the TUI is showing tools for a server
+- **WHEN** operator presses left/right arrow to cycle audience
+- **THEN** the tool grant checkboxes update to reflect the selected audience's grants
+
+#### Scenario: Toggle tool grant in TUI
+
+- **GIVEN** the TUI is showing tools for a server under the Team audience
+- **WHEN** operator toggles a tool's checkbox
+- **THEN** the tool is added to or removed from the Team profile's `McpServerToolGrants` for this server
+
+#### Scenario: Toggle server access in TUI
+
+- **GIVEN** the TUI is showing tools for a server not allowed for the Team audience
+- **WHEN** operator presses the enable/disable key
+- **THEN** the server is added to the Team profile's `AllowedMcpServers`
+- **AND** all tools start unchecked (secure by default)
+
+#### Scenario: Save changes from TUI
+
+- **GIVEN** the operator has toggled tool grants or server access in the TUI
+- **WHEN** operator presses the save key
+- **THEN** the updated `AllowedMcpServers` and `McpServerToolGrants` are written to `netclaw.json`
+- **AND** the TUI confirms the save
+
+### Requirement: MCP doctor advisory for ungated servers
+
+The `netclaw doctor` command SHALL include an advisory check for MCP servers
+that have no `McpServerToolGrants` configured on any audience profile.
+
+#### Scenario: Server with no tool grants triggers advisory
+
+- **GIVEN** `memorizer` is enabled and connected
+- **AND** no audience profile has `McpServerToolGrants` entries for `memorizer`
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** an info-level advisory is reported for `memorizer`
+- **AND** the message suggests adding tool grants for supply-chain protection
+
+#### Scenario: Server with tool grants passes advisory
+
+- **GIVEN** `memorizer` has `McpServerToolGrants` on at least one audience profile
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** no tool grant advisory is reported for `memorizer`

--- a/openspec/specs/netclaw-mcp/spec.md
+++ b/openspec/specs/netclaw-mcp/spec.md
@@ -165,3 +165,103 @@ unavailable server.
 - **WHEN** a session initializes
 - **THEN** tools from the reachable server are available
 - **AND** tools from the unreachable server are marked as unavailable
+
+### Requirement: Per-tool audience filtering for MCP servers
+
+The system SHALL support per-server tool allowlists on each audience profile
+via `McpServerToolGrants`. When a server has an entry in the grants dictionary,
+only tools whose bare name appears in the list SHALL be exposed to that
+audience. When a server has no entry (or grants is null), all tools from that
+server SHALL be exposed (backward-compatible default).
+
+Tool grants compose with the existing `AllowedMcpServers` gate: a tool must
+pass both the server-level check AND the per-tool grant check to be exposed.
+
+#### Scenario: Tool granted to audience is exposed
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": ["search_memories", "get"] }`
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools for this audience
+- **THEN** `memorizer/search_memories` and `memorizer/get` are exposed
+- **AND** other tools from `memorizer` are not exposed
+
+#### Scenario: No grants for server exposes all tools
+
+- **GIVEN** audience profile has `McpServerToolGrants` that does not contain a `memorizer` entry
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools for this audience
+- **THEN** all tools from `memorizer` are exposed
+
+#### Scenario: Null grants exposes all tools from allowed servers
+
+- **GIVEN** audience profile has `McpServerToolGrants: null`
+- **AND** servers are allowed via `AllowedMcpServers` or `McpServersMode: All`
+- **WHEN** the session resolves available tools
+- **THEN** all tools from all allowed servers are exposed
+
+#### Scenario: Empty tool list blocks all tools from server
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": [] }`
+- **AND** the `memorizer` server is in `AllowedMcpServers`
+- **WHEN** the session resolves available tools
+- **THEN** no tools from `memorizer` are exposed
+
+#### Scenario: Server not in AllowedMcpServers is blocked regardless of grants
+
+- **GIVEN** audience profile has `McpServerToolGrants: { "memorizer": ["search_memories"] }`
+- **BUT** `memorizer` is NOT in `AllowedMcpServers` and `McpServersMode` is `Allowlist`
+- **WHEN** the session resolves available tools
+- **THEN** no tools from `memorizer` are exposed
+
+#### Scenario: Different audiences see different tools from same server
+
+- **GIVEN** Team profile has `McpServerToolGrants: { "memorizer": ["search_memories", "get"] }`
+- **AND** Personal profile has `McpServersMode: All` with no `McpServerToolGrants`
+- **WHEN** a Team session resolves tools
+- **THEN** only `search_memories` and `get` are exposed
+- **AND** when a Personal session resolves tools, all `memorizer` tools are exposed
+
+### Requirement: Tool grant enforcement in search_tools
+
+Tools blocked by `McpServerToolGrants` SHALL NOT appear in `search_tools`
+results for the requesting session's audience. The compressed tool index
+injected into system prompts SHALL also reflect per-tool grant filtering.
+
+#### Scenario: Blocked tool absent from search_tools
+
+- **GIVEN** Team profile grants only `["search_memories"]` from `memorizer`
+- **WHEN** a Team session calls `search_tools` with query matching `store`
+- **THEN** `memorizer/store` does NOT appear in results
+
+#### Scenario: Blocked tool absent from load_tool
+
+- **GIVEN** Team profile grants only `["search_memories"]` from `memorizer`
+- **WHEN** a Team session calls `load_tool` for `memorizer/store`
+- **THEN** the tool is denied with a policy reason
+
+### Requirement: Tool change detection logging
+
+At MCP server connect time, the system SHALL compare discovered tools against
+tool grants configured across all audience profiles. The system SHALL log
+warnings for tools that appear on the server but are not granted to any
+audience, and for granted tool names that do not exist on the server.
+
+#### Scenario: New tool discovered but not granted
+
+- **GIVEN** `memorizer` server exposes tools `[search_memories, store, get, archive]`
+- **AND** across all audience profiles, only `[search_memories, store, get]` are granted
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** a warning is logged identifying `archive` as discovered but not granted to any audience
+
+#### Scenario: Granted tool not found on server
+
+- **GIVEN** Team profile grants `["search_memories", "old_tool"]` from `memorizer`
+- **AND** `memorizer` does not expose a tool named `old_tool`
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** a warning is logged identifying `old_tool` as granted but not found on the server
+
+#### Scenario: No grants configured skips change detection
+
+- **GIVEN** no audience profile has `McpServerToolGrants` entries for `memorizer`
+- **WHEN** the daemon connects to `memorizer`
+- **THEN** no tool change detection warnings are logged for that server

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
@@ -201,6 +201,170 @@ public sealed class McpToolAudienceGrantsTests
         Assert.DoesNotContain("memorizer/delete", result);
     }
 
+    // ── FilterExposedTools (session hot path) ──
+
+    [Fact]
+    public void FilterExposedTools_RemovesToolsBlockedByGrants()
+    {
+        var registry = new ToolRegistry();
+        var granted = CreateMcpTool("memorizer", "search_memories");
+        var blocked = CreateMcpTool("memorizer", "store");
+        registry.Register(granted);
+        registry.Register(blocked);
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        var trustContext = new EffectiveTrustContext(
+            DeploymentPosture.Personal,
+            TrustAudience.Team,
+            TrustAudience.Team,
+            TrustAudience.Team,
+            SecurityPolicyDefaults.TrustedInstanceBoundary,
+            PrincipalClassification.TrustedInternal,
+            TransportAuthenticity.Verified,
+            PayloadTaint.Trusted,
+            null, null, false, false, null);
+
+        var aiTools = new[] { granted.ToAITool(), blocked.ToAITool() };
+        var filtered = policy.FilterExposedTools(aiTools, registry, trustContext);
+
+        Assert.Single(filtered);
+        Assert.Equal("memorizer/search_memories", ((AIFunction)filtered[0]).Name);
+    }
+
+    // ── load_tool denial ──
+
+    [Fact]
+    public async Task LoadTool_DeniesBlockedTool()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateMcpTool("memorizer", "search_memories"));
+        registry.Register(CreateMcpTool("memorizer", "store"));
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = new LoadToolTool(registry, policy);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Name"] = "memorizer/store" },
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Contains("not available", result);
+    }
+
+    [Fact]
+    public async Task LoadTool_AllowsGrantedTool()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateMcpTool("memorizer", "search_memories"));
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = new LoadToolTool(registry, policy);
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Name"] = "memorizer/search_memories" },
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Equal("memorizer/search_memories", result);
+    }
+
+    // ── Public audience ──
+
+    [Fact]
+    public void PublicAudience_WithGrants_OnlyExposesGrantedTools()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Public.AllowedMcpServers.Add("memorizer");
+        config.AudienceProfiles.Public.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        Assert.True(policy.IsToolExposed(
+            CreateMcpTool("memorizer", "search_memories"),
+            CreateExecutionContext(TrustAudience.Public)));
+        Assert.False(policy.IsToolExposed(
+            CreateMcpTool("memorizer", "store"),
+            CreateExecutionContext(TrustAudience.Public)));
+    }
+
+    // ── Multiple servers with independent grants ──
+
+    [Fact]
+    public void MultipleServers_GrantsAreIndependent()
+    {
+        var config = CreateConfigWithTeamServer("memorizer", "github");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"],
+            ["github"] = ["create_issue", "list_issues"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        // memorizer grants don't affect github
+        Assert.True(policy.IsToolExposed(CreateMcpTool("github", "create_issue"), TeamContext()));
+        Assert.True(policy.IsToolExposed(CreateMcpTool("github", "list_issues"), TeamContext()));
+        Assert.False(policy.IsToolExposed(CreateMcpTool("github", "delete_repo"), TeamContext()));
+
+        // github grants don't affect memorizer
+        Assert.True(policy.IsToolExposed(CreateMcpTool("memorizer", "search_memories"), TeamContext()));
+        Assert.False(policy.IsToolExposed(CreateMcpTool("memorizer", "store"), TeamContext()));
+    }
+
+    // ── Config deserialization round-trip ──
+
+    [Fact]
+    public void McpServerToolGrants_DeserializesFromJson()
+    {
+        var json = """
+        {
+            "ShellMode": "HostAllowed",
+            "AudienceProfiles": {
+                "Team": {
+                    "McpServersMode": "Allowlist",
+                    "AllowedMcpServers": ["memorizer"],
+                    "McpServerToolGrants": {
+                        "memorizer": ["search_memories", "get"]
+                    }
+                }
+            }
+        }
+        """;
+
+        var config = System.Text.Json.JsonSerializer.Deserialize<ToolConfig>(json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+            });
+
+        Assert.NotNull(config);
+        Assert.NotNull(config.AudienceProfiles.Team.McpServerToolGrants);
+        Assert.True(config.AudienceProfiles.Team.McpServerToolGrants.ContainsKey("memorizer"));
+        Assert.Equal(["search_memories", "get"], config.AudienceProfiles.Team.McpServerToolGrants["memorizer"]);
+
+        // Verify it actually enforces correctly when wired through the policy
+        var policy = new ToolAccessPolicy(config, Defaults);
+        Assert.True(policy.IsToolExposed(CreateMcpTool("memorizer", "search_memories"), TeamContext()));
+        Assert.False(policy.IsToolExposed(CreateMcpTool("memorizer", "store"), TeamContext()));
+    }
+
     // ── Helpers ──
 
     private static McpToolAdapter CreateMcpTool(string serverName, string toolName, string? description = null)

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs
@@ -1,0 +1,232 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class McpToolAudienceGrantsTests
+{
+    private static readonly EffectivePolicyDefaults Defaults = new(
+        DeploymentPosture.Personal,
+        TrustAudience.Personal,
+        ShellExecutionMode.HostAllowed,
+        UsedStrictFallback: false);
+
+    // ── IsMcpToolAllowed (via ToolAccessPolicy.IsToolExposed) ──
+
+    [Fact]
+    public void NullGrants_AllToolsExposed()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        // McpServerToolGrants is null by default
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateMcpTool("memorizer", "store");
+
+        Assert.True(policy.IsToolExposed(tool, TeamContext()));
+    }
+
+    [Fact]
+    public void EmptyGrantList_NoToolsExposed()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = []
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateMcpTool("memorizer", "store");
+
+        Assert.False(policy.IsToolExposed(tool, TeamContext()));
+    }
+
+    [Fact]
+    public void GrantedTool_IsExposed()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories", "get"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        Assert.True(policy.IsToolExposed(CreateMcpTool("memorizer", "search_memories"), TeamContext()));
+        Assert.True(policy.IsToolExposed(CreateMcpTool("memorizer", "get"), TeamContext()));
+    }
+
+    [Fact]
+    public void UngrantedTool_IsBlocked()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories", "get"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        Assert.False(policy.IsToolExposed(CreateMcpTool("memorizer", "store"), TeamContext()));
+        Assert.False(policy.IsToolExposed(CreateMcpTool("memorizer", "delete"), TeamContext()));
+    }
+
+    [Fact]
+    public void ServerNotInGrants_AllToolsExposed()
+    {
+        var config = CreateConfigWithTeamServer("memorizer", "github");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        // github has no entry in grants → all tools pass
+        Assert.True(policy.IsToolExposed(CreateMcpTool("github", "create_issue"), TeamContext()));
+    }
+
+    [Fact]
+    public void ServerBlocked_ToolBlockedRegardlessOfGrants()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        // memorizer is allowed for Team, but github is NOT
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["github"] = ["create_issue"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        // github server is not in AllowedMcpServers → blocked at server level
+        Assert.False(policy.IsToolExposed(CreateMcpTool("github", "create_issue"), TeamContext()));
+    }
+
+    [Fact]
+    public void DifferentAudiences_SeeDifferentTools()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Team.AllowedMcpServers.Add("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories", "get"]
+        };
+        // Personal has McpServersMode=All by default, no grants → sees everything
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        var storeTool = CreateMcpTool("memorizer", "store");
+
+        // Team can't see store
+        Assert.False(policy.IsToolExposed(storeTool, TeamContext()));
+        // Personal can see store (no grants = all tools)
+        Assert.True(policy.IsToolExposed(storeTool, PersonalContext()));
+    }
+
+    // ── AuthorizeInvocation deny reason ──
+
+    [Fact]
+    public void AuthorizeInvocation_DeniesWithCorrectReason_WhenToolNotGranted()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        var decision = policy.AuthorizeInvocation(
+            CreateMcpTool("memorizer", "store"),
+            CreateExecutionContext(TrustAudience.Team));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("mcp_tool_not_allowed_for_audience_profile", decision.DenyReason);
+    }
+
+    [Fact]
+    public void AuthorizeInvocation_AllowsGrantedTool()
+    {
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        var decision = policy.AuthorizeInvocation(
+            CreateMcpTool("memorizer", "search_memories"),
+            CreateExecutionContext(TrustAudience.Team));
+
+        Assert.True(decision.Allowed);
+    }
+
+    [Fact]
+    public void AuthorizeInvocation_ServerDeny_TakesPrecedenceOverToolDeny()
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        // Team has no AllowedMcpServers → server-level deny
+        var policy = new ToolAccessPolicy(config, Defaults);
+
+        var decision = policy.AuthorizeInvocation(
+            CreateMcpTool("memorizer", "search_memories"),
+            CreateExecutionContext(TrustAudience.Team));
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("mcp_server_not_allowed_for_audience_profile", decision.DenyReason);
+    }
+
+    // ── search_tools filtering ──
+
+    [Fact]
+    public async Task SearchTools_ExcludesToolsBlockedByGrants()
+    {
+        var registry = new ToolRegistry();
+        registry.Register(CreateMcpTool("memorizer", "search_memories", "Find stored memories"));
+        registry.Register(CreateMcpTool("memorizer", "store", "Store a value"));
+        registry.Register(CreateMcpTool("memorizer", "delete", "Delete a memory"));
+
+        var config = CreateConfigWithTeamServer("memorizer");
+        config.AudienceProfiles.Team.McpServerToolGrants = new Dictionary<string, List<string>>
+        {
+            ["memorizer"] = ["search_memories"]
+        };
+
+        var tool = new SearchToolsTool(
+            registry,
+            new ToolAccessPolicy(config, Defaults));
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Query"] = "memor" },
+            CreateExecutionContext(TrustAudience.Team),
+            CancellationToken.None);
+
+        Assert.Contains("search_memories", result);
+        Assert.DoesNotContain("memorizer/store", result);
+        Assert.DoesNotContain("memorizer/delete", result);
+    }
+
+    // ── Helpers ──
+
+    private static McpToolAdapter CreateMcpTool(string serverName, string toolName, string? description = null)
+    {
+        var func = AIFunctionFactory.Create(() => "result", toolName, description ?? toolName);
+        return new McpToolAdapter(func, serverName, toolName);
+    }
+
+    private static ToolConfig CreateConfigWithTeamServer(params string[] servers)
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        foreach (var server in servers)
+            config.AudienceProfiles.Team.AllowedMcpServers.Add(server);
+        return config;
+    }
+
+    private static ToolExecutionContext CreateExecutionContext(TrustAudience audience)
+    {
+        return new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = audience.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
+            ChannelType = "slack"
+        };
+    }
+
+    private static ToolExecutionContext TeamContext() => CreateExecutionContext(TrustAudience.Team);
+    private static ToolExecutionContext PersonalContext() => CreateExecutionContext(TrustAudience.Personal);
+}

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -53,7 +53,8 @@ public sealed class ToolAccessPolicy
     private bool IsToolExposed(INetclawTool tool, TrustAudience audience)
     {
         if (tool is McpToolAdapter mcp)
-            return _profileResolver.IsMcpServerAllowed(mcp.ServerName, audience);
+            return _profileResolver.IsMcpServerAllowed(mcp.ServerName, audience)
+                && _profileResolver.IsMcpToolAllowed(mcp.ServerName, mcp.BareToolName, audience);
 
         if (!_profileResolver.IsToolAllowed(tool.Name, CreateContext(audience)))
             return false;
@@ -68,9 +69,11 @@ public sealed class ToolAccessPolicy
     {
         if (tool is McpToolAdapter mcp)
         {
-            var audience = ResolveAudience(context);
             if (!_profileResolver.IsMcpServerAllowed(mcp.ServerName, context))
                 return ToolAccessDecision.Deny("mcp_server_not_allowed_for_audience_profile");
+
+            if (!_profileResolver.IsMcpToolAllowed(mcp.ServerName, mcp.BareToolName, context))
+                return ToolAccessDecision.Deny("mcp_tool_not_allowed_for_audience_profile");
 
             return ToolAccessDecision.Allow();
         }

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -85,6 +85,25 @@ internal sealed class ToolAudienceProfileResolver
     }
 
     /// <summary>
+    /// Checks whether a specific tool from an MCP server is allowed for the given audience.
+    /// Returns true if:
+    /// - The profile has no <see cref="ToolAudienceProfile.McpServerToolGrants"/> (null), or
+    /// - The server has no entry in the grants dictionary, or
+    /// - The tool name appears in the server's grant list.
+    /// </summary>
+    public bool IsMcpToolAllowed(string serverName, string toolName, TrustAudience audience)
+    {
+        var profile = ResolveProfile(audience);
+        return IsMcpToolAllowed(serverName, toolName, profile);
+    }
+
+    public bool IsMcpToolAllowed(string serverName, string toolName, ToolExecutionContext? context)
+    {
+        var profile = ResolveProfile(context);
+        return IsMcpToolAllowed(serverName, toolName, profile);
+    }
+
+    /// <summary>
     /// Resolves a path token (e.g. <c>{skills_dir}</c>, <c>{identity_dir}</c>, <c>{workspaces_dir}</c>) to an absolute path.
     /// Returns null for empty input or if <see cref="_paths"/> is not available for path-based tokens.
     /// Unrecognized values are treated as literal paths.
@@ -135,6 +154,17 @@ internal sealed class ToolAudienceProfileResolver
             return true;
 
         return profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool IsMcpToolAllowed(string serverName, string toolName, ToolAudienceProfile profile)
+    {
+        if (profile.McpServerToolGrants is not { } grants)
+            return true;
+
+        if (!grants.TryGetValue(serverName, out var allowedTools))
+            return true;
+
+        return allowedTools.Contains(toolName, StringComparer.Ordinal);
     }
 
     private static bool IsProfileManagedTool(string toolName)

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -116,6 +116,80 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
     }
 
     [Fact]
+    public async Task McpServerWithNoToolGrants_WarnsAboutSupplyChain()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "memorizer": {
+                  "Transport": "stdio",
+                  "Command": "npx",
+                  "Enabled": true
+                }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("memorizer", result.Message);
+        Assert.Contains("McpServerToolGrants", result.Message);
+    }
+
+    [Fact]
+    public async Task McpServerWithToolGrants_NoSupplyChainWarning()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "McpServerToolGrants": {
+                      "memorizer": ["search_memories", "store"]
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "memorizer": {
+                  "Transport": "stdio",
+                  "Command": "npx",
+                  "Enabled": true
+                }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync();
+
+        // Should still warn about unrestricted personal, but NOT about tool grants
+        Assert.DoesNotContain("McpServerToolGrants", result.Message);
+    }
+
+    [Fact]
     public async Task RecommendedProfiles_Pass()
     {
         var toolConfig = new ToolConfig

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -197,6 +197,14 @@ public sealed class DaemonApi
         return await JsonSerializer.DeserializeAsync<JsonElement>(stream, WebJsonOptions, cts.Token);
     }
 
+    public async Task<List<string>> GetMcpToolNamesAsync(string serverName, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var client = _factory.CreateClient();
+        return await client.GetFromJsonAsync<List<string>>(
+            $"{_endpoint}/api/mcp/tools/{Uri.EscapeDataString(serverName)}", cts.Token) ?? [];
+    }
+
     // ── Provider OAuth ─────────────────────────────────────────────────
 
     public async Task<HttpResponseMessage> StartProviderOAuthAsync(string providerType, CancellationToken ct = default)

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -145,7 +145,7 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         var allowedServers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var grantedServers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var profile in new[] { profiles.Public, profiles.Team, profiles.Personal })
+        foreach (var profile in profiles.GetAllProfiles())
         {
             if (profile.McpServersMode == ToolProfileMode.All)
             {

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -86,6 +86,15 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
                 warnings.Add("Personal profile also enables host shell, which has a high blast radius.");
         }
 
+        // Advisory: MCP servers allowed by any audience but with no McpServerToolGrants
+        var ungatedServers = FindUngatedMcpServers(toolConfig.AudienceProfiles, root);
+        if (ungatedServers.Count > 0)
+        {
+            warnings.Add(
+                $"MCP server(s) {string.Join(", ", ungatedServers)} have no McpServerToolGrants on any audience — " +
+                "all discovered tools are exposed. Consider adding per-tool grants for supply-chain protection.");
+        }
+
         if (warnings.Count > 0)
         {
             return Task.FromResult(DoctorCheckResult.Warning(
@@ -124,5 +133,42 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
             && profile.ReadFiles.Mode == ToolFilesystemMode.All
             && profile.WriteFiles.Mode == ToolFilesystemMode.All
             && profile.AttachFiles.Mode == ToolFilesystemMode.All;
+    }
+
+    /// <summary>
+    /// Finds MCP servers that are allowed by at least one audience profile
+    /// but have no <see cref="ToolAudienceProfile.McpServerToolGrants"/> on any profile.
+    /// </summary>
+    private static List<string> FindUngatedMcpServers(ToolAudienceProfiles profiles, JsonObject root)
+    {
+        // Collect all server names that are allowed by any audience
+        var allowedServers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var grantedServers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var profile in new[] { profiles.Public, profiles.Team, profiles.Personal })
+        {
+            if (profile.McpServersMode == ToolProfileMode.All)
+            {
+                // All servers allowed — collect from config
+                if (root["McpServers"] is JsonObject mcpServers)
+                {
+                    foreach (var prop in mcpServers)
+                        allowedServers.Add(prop.Key);
+                }
+            }
+            else
+            {
+                foreach (var server in profile.AllowedMcpServers)
+                    allowedServers.Add(server);
+            }
+
+            if (profile.McpServerToolGrants is { } grants)
+            {
+                foreach (var server in grants.Keys)
+                    grantedServers.Add(server);
+            }
+        }
+
+        return allowedServers.Except(grantedServers, StringComparer.OrdinalIgnoreCase).Order().ToList();
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -48,6 +48,7 @@ internal static class McpCommand
             "remove" => RunRemove(args, paths, writer),
             "enable" => RunToggle(args, paths, enabled: true, writer),
             "disable" => RunToggle(args, paths, enabled: false, writer),
+            "tools" => await RunToolsAsync(args, paths, daemonApi, writer),
             "help" or "-h" or "--help" => WriteHelp(writer),
             _ => WriteHelp(writer)
         };
@@ -837,6 +838,188 @@ internal static class McpCommand
         return doc.RootElement.Clone();
     }
 
+    private static async Task<int> RunToolsAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi, TextWriter writer)
+    {
+        // Parse: netclaw mcp tools [<server>] [--snapshot]
+        string? serverName = null;
+        var snapshot = false;
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            if (args[i] is "--snapshot")
+                snapshot = true;
+            else if (args[i] is "--help" or "-h")
+            {
+                writer.WriteLine("Usage: netclaw mcp tools <server> [--snapshot]");
+                writer.WriteLine();
+                writer.WriteLine("  <server>     Show discovered tools and per-audience grant status");
+                writer.WriteLine("  --snapshot   Populate McpServerToolGrants from currently discovered tools");
+                return 0;
+            }
+            else if (serverName is null)
+                serverName = args[i];
+        }
+
+        if (serverName is null)
+        {
+            writer.WriteLine("Usage: netclaw mcp tools <server> [--snapshot]");
+            writer.WriteLine("Specify a server name. Use `netclaw mcp list` to see configured servers.");
+            return 1;
+        }
+
+        if (daemonApi is null)
+        {
+            writer.WriteLine("Error: daemon API not available. Is the daemon running?");
+            return 1;
+        }
+
+        // Get discovered tools from daemon
+        List<string> discoveredTools;
+        try
+        {
+            discoveredTools = await daemonApi.GetMcpToolNamesAsync(serverName, CancellationToken.None);
+        }
+        catch (HttpRequestException)
+        {
+            writer.WriteLine($"Error: could not reach daemon. Is it running?");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            writer.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+
+        if (discoveredTools.Count == 0)
+        {
+            writer.WriteLine($"No tools discovered for server '{serverName}'.");
+            writer.WriteLine("The server may be disconnected or have no tools. Check `netclaw mcp list`.");
+            return 1;
+        }
+
+        // Load audience profiles for grant status
+        var toolConfig = LoadToolConfig(paths);
+        var profiles = toolConfig.AudienceProfiles;
+
+        if (snapshot)
+            return RunToolsSnapshot(serverName, discoveredTools, profiles, paths, writer);
+
+        return RunToolsList(serverName, discoveredTools, profiles, writer);
+    }
+
+    private static int RunToolsList(
+        string serverName, List<string> discoveredTools, ToolAudienceProfiles profiles, TextWriter writer)
+    {
+        writer.WriteLine($"Tools for server '{serverName}' ({discoveredTools.Count} discovered):");
+        writer.WriteLine();
+
+        // Column headers
+        var maxNameLen = Math.Max(discoveredTools.Max(t => t.Length), 4);
+        writer.Write("  ");
+        writer.Write("Tool".PadRight(maxNameLen + 2));
+        writer.Write("Public   Team     Personal");
+        writer.WriteLine();
+        writer.Write("  ");
+        writer.WriteLine(new string('\u2500', maxNameLen + 2 + 26));
+
+        foreach (var tool in discoveredTools)
+        {
+            writer.Write("  ");
+            writer.Write(tool.PadRight(maxNameLen + 2));
+
+            writer.Write(FormatGrantStatus(serverName, tool, profiles.Public));
+            writer.Write(FormatGrantStatus(serverName, tool, profiles.Team));
+            writer.Write(FormatGrantStatus(serverName, tool, profiles.Personal));
+            writer.WriteLine();
+        }
+
+        return 0;
+    }
+
+    private static string FormatGrantStatus(string serverName, string toolName, ToolAudienceProfile profile)
+    {
+        if (profile.McpServerToolGrants is null)
+            return "\u2731        "; // ✱ = all (no grants configured)
+
+        if (!profile.McpServerToolGrants.TryGetValue(serverName, out var allowedTools))
+            return "\u2731        "; // ✱ = server not in grants, all tools pass
+
+        return allowedTools.Contains(toolName, StringComparer.Ordinal)
+            ? "\u2713        " // ✓ = granted
+            : "-        ";    // - = blocked
+    }
+
+    private static int RunToolsSnapshot(
+        string serverName, List<string> discoveredTools, ToolAudienceProfiles profiles,
+        NetclawPaths paths, TextWriter writer)
+    {
+        var (config, _) = LoadConfigFiles(paths);
+        var toolsSection = GetOrCreateSection(config, "Tools");
+        var profilesSection = GetOrCreateSection(toolsSection, "AudienceProfiles");
+
+        var updated = 0;
+        foreach (var audienceName in new[] { "Public", "Team", "Personal" })
+        {
+            var profile = audienceName switch
+            {
+                "Public" => profiles.Public,
+                "Team" => profiles.Team,
+                _ => profiles.Personal
+            };
+
+            // Only snapshot for audiences that allow this server
+            var serverAllowed = profile.McpServersMode == ToolProfileMode.All
+                || profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+
+            if (!serverAllowed)
+                continue;
+
+            var audienceSection = GetOrCreateSection(profilesSection, audienceName);
+            var grants = audienceSection.TryGetValue("McpServerToolGrants", out var existing)
+                && existing is Dictionary<string, object> dict
+                    ? dict
+                    : new Dictionary<string, object>();
+
+            grants[serverName] = discoveredTools;
+            audienceSection["McpServerToolGrants"] = grants;
+            updated++;
+        }
+
+        if (updated == 0)
+        {
+            writer.WriteLine($"Server '{serverName}' is not allowed by any audience profile. Nothing to snapshot.");
+            return 1;
+        }
+
+        WriteConfigFile(paths.NetclawConfigPath, config);
+        writer.WriteLine($"Snapshot complete: {discoveredTools.Count} tools from '{serverName}' written to McpServerToolGrants for {updated} audience profile(s).");
+        writer.WriteLine("New tools added by the server will not be exposed until you update the grants.");
+        return 0;
+    }
+
+    private static ToolConfig LoadToolConfig(NetclawPaths paths)
+    {
+        if (!File.Exists(paths.NetclawConfigPath))
+            return new ToolConfig();
+
+        try
+        {
+            var text = File.ReadAllText(paths.NetclawConfigPath);
+            using var doc = JsonDocument.Parse(text);
+
+            if (!doc.RootElement.TryGetProperty("Tools", out var toolsSection))
+                return new ToolConfig();
+
+            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(),
+                new JsonSerializerOptions { Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() } })
+                ?? new ToolConfig();
+        }
+        catch
+        {
+            return new ToolConfig();
+        }
+    }
+
     private static int WriteHelp(TextWriter writer)
     {
         writer.WriteLine("Usage: netclaw mcp <subcommand>");
@@ -849,6 +1032,7 @@ internal static class McpCommand
         writer.WriteLine("  remove     Remove an MCP server profile");
         writer.WriteLine("  enable     Enable a disabled MCP server");
         writer.WriteLine("  disable    Disable an MCP server without removing it");
+        writer.WriteLine("  tools      Show discovered tools and per-audience grant status");
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
@@ -856,6 +1040,8 @@ internal static class McpCommand
         writer.WriteLine("  netclaw mcp add --transport http textforge https://textforge.net/mcp");
         writer.WriteLine("  netclaw mcp auth forge");
         writer.WriteLine("  netclaw mcp list");
+        writer.WriteLine("  netclaw mcp tools memorizer");
+        writer.WriteLine("  netclaw mcp tools memorizer --snapshot");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -840,31 +840,56 @@ internal static class McpCommand
 
     private static async Task<int> RunToolsAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi, TextWriter writer)
     {
-        // Parse: netclaw mcp tools [<server>] [--snapshot]
+        // Parse: netclaw mcp tools <server> [--snapshot] [--audience <name>] [--grant t1,t2] [--revoke t1,t2]
         string? serverName = null;
+        string? audienceFilter = null;
         var snapshot = false;
+        List<string>? grantTools = null;
+        List<string>? revokeTools = null;
 
         for (var i = 2; i < args.Length; i++)
         {
-            if (args[i] is "--snapshot")
-                snapshot = true;
-            else if (args[i] is "--help" or "-h")
+            switch (args[i])
             {
-                writer.WriteLine("Usage: netclaw mcp tools <server> [--snapshot]");
-                writer.WriteLine();
-                writer.WriteLine("  <server>     Show discovered tools and per-audience grant status");
-                writer.WriteLine("  --snapshot   Populate McpServerToolGrants from currently discovered tools");
-                return 0;
+                case "--snapshot":
+                    snapshot = true;
+                    break;
+                case "--audience" when i + 1 < args.Length:
+                    audienceFilter = args[++i];
+                    break;
+                case "--grant" when i + 1 < args.Length:
+                    grantTools = args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList();
+                    break;
+                case "--revoke" when i + 1 < args.Length:
+                    revokeTools = args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList();
+                    break;
+                case "--help" or "-h":
+                    WriteToolsHelp(writer);
+                    return 0;
+                default:
+                    if (serverName is null && !args[i].StartsWith('-'))
+                        serverName = args[i];
+                    break;
             }
-            else if (serverName is null)
-                serverName = args[i];
         }
 
         if (serverName is null)
         {
-            writer.WriteLine("Usage: netclaw mcp tools <server> [--snapshot]");
-            writer.WriteLine("Specify a server name. Use `netclaw mcp list` to see configured servers.");
+            WriteToolsHelp(writer);
             return 1;
+        }
+
+        // Validate audience name if provided
+        TrustAudience? targetAudience = null;
+        if (audienceFilter is not null)
+        {
+            if (!SecurityPolicyDefaults.TryParseAudience(audienceFilter, out var parsed))
+            {
+                writer.WriteLine($"Error: unknown audience '{audienceFilter}'. Use public, team, or personal.");
+                return 1;
+            }
+
+            targetAudience = parsed;
         }
 
         if (daemonApi is null)
@@ -881,7 +906,7 @@ internal static class McpCommand
         }
         catch (HttpRequestException)
         {
-            writer.WriteLine($"Error: could not reach daemon. Is it running?");
+            writer.WriteLine("Error: could not reach daemon. Is it running?");
             return 1;
         }
         catch (Exception ex)
@@ -901,36 +926,90 @@ internal static class McpCommand
         var toolConfig = LoadToolConfig(paths);
         var profiles = toolConfig.AudienceProfiles;
 
-        if (snapshot)
-            return RunToolsSnapshot(serverName, discoveredTools, profiles, paths, writer);
+        // Surgical grant/revoke
+        if (grantTools is not null || revokeTools is not null)
+        {
+            if (targetAudience is null)
+            {
+                writer.WriteLine("Error: --grant and --revoke require --audience.");
+                return 1;
+            }
 
-        return RunToolsList(serverName, discoveredTools, profiles, writer);
+            return RunToolsGrantRevoke(serverName, targetAudience.Value, discoveredTools,
+                grantTools, revokeTools, profiles, paths, writer);
+        }
+
+        if (snapshot)
+            return RunToolsSnapshot(serverName, targetAudience, discoveredTools, profiles, paths, writer);
+
+        return RunToolsList(serverName, targetAudience, discoveredTools, profiles, writer);
+    }
+
+    private static void WriteToolsHelp(TextWriter writer)
+    {
+        writer.WriteLine("Usage: netclaw mcp tools <server> [options]");
+        writer.WriteLine();
+        writer.WriteLine("Options:");
+        writer.WriteLine("  --audience <name>     Filter to a specific audience (public, team, personal)");
+        writer.WriteLine("  --snapshot            Populate McpServerToolGrants from currently discovered tools");
+        writer.WriteLine("  --grant <tools>       Grant comma-separated tools (requires --audience)");
+        writer.WriteLine("  --revoke <tools>      Revoke comma-separated tools (requires --audience)");
+        writer.WriteLine();
+        writer.WriteLine("Examples:");
+        writer.WriteLine("  netclaw mcp tools memorizer                             Show all tools and grants");
+        writer.WriteLine("  netclaw mcp tools memorizer --audience team             Show Team grants only");
+        writer.WriteLine("  netclaw mcp tools memorizer --snapshot                  Baseline all audiences");
+        writer.WriteLine("  netclaw mcp tools memorizer --snapshot --audience team  Baseline Team only");
+        writer.WriteLine("  netclaw mcp tools memorizer --grant search_memories,get --audience team");
+        writer.WriteLine("  netclaw mcp tools memorizer --revoke delete,archive_memory --audience personal");
     }
 
     private static int RunToolsList(
-        string serverName, List<string> discoveredTools, ToolAudienceProfiles profiles, TextWriter writer)
+        string serverName, TrustAudience? audienceFilter, List<string> discoveredTools,
+        ToolAudienceProfiles profiles, TextWriter writer)
     {
         writer.WriteLine($"Tools for server '{serverName}' ({discoveredTools.Count} discovered):");
         writer.WriteLine();
 
-        // Column headers
         var maxNameLen = Math.Max(discoveredTools.Max(t => t.Length), 4);
-        writer.Write("  ");
-        writer.Write("Tool".PadRight(maxNameLen + 2));
-        writer.Write("Public   Team     Personal");
-        writer.WriteLine();
-        writer.Write("  ");
-        writer.WriteLine(new string('\u2500', maxNameLen + 2 + 26));
 
-        foreach (var tool in discoveredTools)
+        if (audienceFilter is { } single)
         {
+            // Single audience view
+            var profile = ResolveProfile(single, profiles);
+            var label = single.ToString();
             writer.Write("  ");
-            writer.Write(tool.PadRight(maxNameLen + 2));
+            writer.Write("Tool".PadRight(maxNameLen + 2));
+            writer.WriteLine(label);
+            writer.Write("  ");
+            writer.WriteLine(new string('\u2500', maxNameLen + 2 + label.Length));
 
-            writer.Write(FormatGrantStatus(serverName, tool, profiles.Public));
-            writer.Write(FormatGrantStatus(serverName, tool, profiles.Team));
-            writer.Write(FormatGrantStatus(serverName, tool, profiles.Personal));
+            foreach (var tool in discoveredTools)
+            {
+                writer.Write("  ");
+                writer.Write(tool.PadRight(maxNameLen + 2));
+                writer.WriteLine(FormatGrantStatus(serverName, tool, profile).TrimEnd());
+            }
+        }
+        else
+        {
+            // All audiences view
+            writer.Write("  ");
+            writer.Write("Tool".PadRight(maxNameLen + 2));
+            writer.Write("Public   Team     Personal");
             writer.WriteLine();
+            writer.Write("  ");
+            writer.WriteLine(new string('\u2500', maxNameLen + 2 + 26));
+
+            foreach (var tool in discoveredTools)
+            {
+                writer.Write("  ");
+                writer.Write(tool.PadRight(maxNameLen + 2));
+                writer.Write(FormatGrantStatus(serverName, tool, profiles.Public));
+                writer.Write(FormatGrantStatus(serverName, tool, profiles.Team));
+                writer.Write(FormatGrantStatus(serverName, tool, profiles.Personal));
+                writer.WriteLine();
+            }
         }
 
         return 0;
@@ -950,15 +1029,23 @@ internal static class McpCommand
     }
 
     private static int RunToolsSnapshot(
-        string serverName, List<string> discoveredTools, ToolAudienceProfiles profiles,
-        NetclawPaths paths, TextWriter writer)
+        string serverName, TrustAudience? targetAudience, List<string> discoveredTools,
+        ToolAudienceProfiles profiles, NetclawPaths paths, TextWriter writer)
     {
         var (config, _) = LoadConfigFiles(paths);
         var toolsSection = GetOrCreateSection(config, "Tools");
         var profilesSection = GetOrCreateSection(toolsSection, "AudienceProfiles");
 
+        var audienceNames = targetAudience switch
+        {
+            TrustAudience.Public => new[] { "Public" },
+            TrustAudience.Team => new[] { "Team" },
+            TrustAudience.Personal => new[] { "Personal" },
+            _ => new[] { "Public", "Team", "Personal" }
+        };
+
         var updated = 0;
-        foreach (var audienceName in new[] { "Public", "Team", "Personal" })
+        foreach (var audienceName in audienceNames)
         {
             var profile = audienceName switch
             {
@@ -967,12 +1054,19 @@ internal static class McpCommand
                 _ => profiles.Personal
             };
 
-            // Only snapshot for audiences that allow this server
             var serverAllowed = profile.McpServersMode == ToolProfileMode.All
                 || profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
 
             if (!serverAllowed)
+            {
+                if (targetAudience is not null)
+                {
+                    writer.WriteLine($"Server '{serverName}' is not allowed by the {audienceName} audience profile.");
+                    return 1;
+                }
+
                 continue;
+            }
 
             var audienceSection = GetOrCreateSection(profilesSection, audienceName);
             var grants = audienceSection.TryGetValue("McpServerToolGrants", out var existing)
@@ -995,6 +1089,88 @@ internal static class McpCommand
         writer.WriteLine($"Snapshot complete: {discoveredTools.Count} tools from '{serverName}' written to McpServerToolGrants for {updated} audience profile(s).");
         writer.WriteLine("New tools added by the server will not be exposed until you update the grants.");
         return 0;
+    }
+
+    private static int RunToolsGrantRevoke(
+        string serverName, TrustAudience audience, List<string> discoveredTools,
+        List<string>? grantTools, List<string>? revokeTools,
+        ToolAudienceProfiles profiles, NetclawPaths paths, TextWriter writer)
+    {
+        var audienceName = audience switch
+        {
+            TrustAudience.Public => "Public",
+            TrustAudience.Team => "Team",
+            _ => "Personal"
+        };
+
+        var profile = ResolveProfile(audience, profiles);
+
+        // Validate tool names exist on the server
+        var unknownGrants = grantTools?.Except(discoveredTools, StringComparer.Ordinal).ToList() ?? [];
+        var unknownRevokes = revokeTools?.Except(discoveredTools, StringComparer.Ordinal).ToList() ?? [];
+        if (unknownGrants.Count > 0 || unknownRevokes.Count > 0)
+        {
+            var unknown = unknownGrants.Concat(unknownRevokes).Distinct().ToList();
+            writer.WriteLine($"Error: tool(s) not found on server '{serverName}': {string.Join(", ", unknown)}");
+            writer.WriteLine("Use `netclaw mcp tools <server>` to see available tools.");
+            return 1;
+        }
+
+        // Build the updated tool set
+        HashSet<string> currentTools;
+        if (profile.McpServerToolGrants is { } existing
+            && existing.TryGetValue(serverName, out var currentList))
+        {
+            currentTools = new HashSet<string>(currentList, StringComparer.Ordinal);
+        }
+        else
+        {
+            // No grants configured yet — start from all discovered tools
+            currentTools = new HashSet<string>(discoveredTools, StringComparer.Ordinal);
+        }
+
+        if (grantTools is not null)
+            foreach (var tool in grantTools)
+                currentTools.Add(tool);
+
+        if (revokeTools is not null)
+            foreach (var tool in revokeTools)
+                currentTools.Remove(tool);
+
+        // Write to config
+        var (config, _) = LoadConfigFiles(paths);
+        var toolsSection = GetOrCreateSection(config, "Tools");
+        var profilesSection = GetOrCreateSection(toolsSection, "AudienceProfiles");
+        var audienceSection = GetOrCreateSection(profilesSection, audienceName);
+
+        var grants = audienceSection.TryGetValue("McpServerToolGrants", out var ex)
+            && ex is Dictionary<string, object> dict
+                ? dict
+                : new Dictionary<string, object>();
+
+        grants[serverName] = currentTools.Order(StringComparer.Ordinal).ToList();
+        audienceSection["McpServerToolGrants"] = grants;
+
+        WriteConfigFile(paths.NetclawConfigPath, config);
+
+        var changes = new List<string>();
+        if (grantTools is { Count: > 0 })
+            changes.Add($"granted {grantTools.Count}");
+        if (revokeTools is { Count: > 0 })
+            changes.Add($"revoked {revokeTools.Count}");
+
+        writer.WriteLine($"Updated {audienceName} profile for '{serverName}': {string.Join(", ", changes)} tool(s). {currentTools.Count} total granted.");
+        return 0;
+    }
+
+    private static ToolAudienceProfile ResolveProfile(TrustAudience audience, ToolAudienceProfiles profiles)
+    {
+        return audience switch
+        {
+            TrustAudience.Public => profiles.Public,
+            TrustAudience.Team => profiles.Team,
+            _ => profiles.Personal
+        };
     }
 
     private static ToolConfig LoadToolConfig(NetclawPaths paths)
@@ -1032,7 +1208,7 @@ internal static class McpCommand
         writer.WriteLine("  remove     Remove an MCP server profile");
         writer.WriteLine("  enable     Enable a disabled MCP server");
         writer.WriteLine("  disable    Disable an MCP server without removing it");
-        writer.WriteLine("  tools      Show discovered tools and per-audience grant status");
+        writer.WriteLine("  tools      Show and manage per-audience tool grants");
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
@@ -1041,7 +1217,8 @@ internal static class McpCommand
         writer.WriteLine("  netclaw mcp auth forge");
         writer.WriteLine("  netclaw mcp list");
         writer.WriteLine("  netclaw mcp tools memorizer");
-        writer.WriteLine("  netclaw mcp tools memorizer --snapshot");
+        writer.WriteLine("  netclaw mcp tools memorizer --snapshot --audience team");
+        writer.WriteLine("  netclaw mcp tools memorizer --grant search_memories,get --audience team");
         return 0;
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -11,9 +11,10 @@ namespace Netclaw.Cli.Mcp;
 
 public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsViewModel>
 {
-    private SelectionListNode<string>? _activeList;
+    private SelectionListNode<string>? _serverList;
     private DynamicLayoutNode? _contentNode;
     private readonly CompositeDisposable _stepSubs = new();
+    private int _toolCursor;
 
     protected override void OnBound()
     {
@@ -45,7 +46,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
     {
         _contentNode = new DynamicLayoutNode(() =>
         {
-            _activeList = null;
+            _serverList = null;
             _stepSubs.Clear();
 
             return ViewModel.CurrentState.Value switch
@@ -83,12 +84,12 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             .Select(s => $"{s.Name}  ({s.Status}, {s.ToolCount} tools)")
             .ToList();
 
-        _activeList = Layouts.SelectionList(items)
+        _serverList = Layouts.SelectionList(items)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
-        _activeList.OnFocused();
+        _serverList.OnFocused();
 
-        _activeList.SelectionConfirmed
+        _serverList.SelectionConfirmed
             .Subscribe(selected =>
             {
                 if (selected.Count > 0)
@@ -101,71 +102,90 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         return Layouts.Vertical()
             .WithChild(new TextNode("Select a server:").WithForeground(Color.White))
-            .WithChild(_activeList);
+            .WithChild(_serverList);
     }
 
+    /// <summary>
+    /// Manual cursor rendering — matches the channel wizard pattern.
+    /// Preserves cursor position across rebuilds (no SelectionListNode reset).
+    /// </summary>
     private ILayoutNode BuildToolGrid()
     {
         var server = ViewModel.SelectedServer ?? "?";
         var audienceLabel = ViewModel.SelectedAudience.ToWireValue();
-
-        // Audience selector matching the channel wizard pattern: [◀ personal ▶]
         var audienceSelector = $"[\u25c0 {audienceLabel,-8} \u25b6]";
 
-        var items = ViewModel.DiscoveredTools
-            .Select(tool =>
-            {
-                var granted = ViewModel.IsToolGranted(tool);
-                var marker = granted ? "\u2713" : " ";
-                return $"[{marker}] {tool}";
-            })
-            .ToList();
+        var tools = ViewModel.DiscoveredTools;
+        if (_toolCursor >= tools.Count) _toolCursor = tools.Count - 1;
+        if (_toolCursor < 0) _toolCursor = 0;
 
-        _activeList = Layouts.SelectionList(items)
-            .WithMode(SelectionMode.Single)
-            .WithHighlightColors(Color.Black, Color.Cyan);
-        _activeList.OnFocused();
-
-        _activeList.SelectionConfirmed
-            .Subscribe(selected =>
-            {
-                if (selected.Count > 0)
-                {
-                    // Extract tool name from "[✓] tool_name" or "[ ] tool_name"
-                    var raw = selected[0];
-                    var toolName = raw.Length > 4 ? raw[4..].Trim() : raw;
-                    ViewModel.ToggleTool(toolName);
-                }
-            })
-            .DisposeWith(_stepSubs);
+        var serverAllowed = ViewModel.IsServerAllowedForSelectedAudience();
 
         var layout = Layouts.Vertical()
             .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold())
             .WithChild(new TextNode($"  Audience: {audienceSelector}").WithForeground(Color.Cyan).Bold())
-            .WithSpacing(1)
-            .WithChild(_activeList);
+            .WithSpacing(1);
+
+        if (!serverAllowed)
+        {
+            layout = layout
+                .WithChild(new TextNode($"  Server '{server}' is not allowed for the {audienceLabel} audience.")
+                    .WithForeground(Color.Yellow))
+                .WithChild(new TextNode("  Add it to AllowedMcpServers or set McpServersMode to All first.")
+                    .WithForeground(Color.BrightBlack));
+        }
+        else
+        {
+            for (var i = 0; i < tools.Count; i++)
+            {
+                var tool = tools[i];
+                var isFocused = i == _toolCursor;
+                var granted = ViewModel.IsToolGranted(tool);
+                var prefix = isFocused ? " \u25b6 " : "   ";
+                var marker = granted ? "\u2713" : " ";
+                var line = $"{prefix}[{marker}] {tool}";
+
+                var node = new TextNode(line);
+                node = isFocused
+                    ? node.WithForeground(Color.Cyan).Bold()
+                    : granted
+                        ? node.WithForeground(Color.White)
+                        : node.WithForeground(Color.BrightBlack);
+                layout = layout.WithChild(node);
+            }
+        }
 
         if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
-            layout.WithChild(new TextNode(ViewModel.StatusMessage.Value).WithForeground(Color.Green));
+        {
+            layout = layout.WithSpacing(1)
+                .WithChild(new TextNode($"  {ViewModel.StatusMessage.Value}").WithForeground(Color.Green));
+        }
 
         return layout;
     }
 
     private LayoutNode BuildFooter()
     {
-        return new DynamicLayoutNode(() =>
+        var footerNode = new DynamicLayoutNode(() =>
         {
             var hints = ViewModel.CurrentState.Value switch
             {
                 ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    "[\u2190/\u2192] Audience  [Enter] Toggle  [S] Save  [Esc] Back  [Ctrl+Q] Quit" +
+                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [S] Save  [Esc] Back  [Ctrl+Q] Quit" +
                     (ViewModel.HasUnsavedChanges ? "  *unsaved*" : ""),
                 _ => ""
             };
 
             return new TextNode(hints).WithForeground(Color.BrightBlack);
         });
+
+        // Footer must invalidate on state changes to show correct hints
+        ViewModel.StateVersion
+            .Subscribe(_ => footerNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return footerNode;
     }
 
     private void HandleKeyPress(KeyPressed key)
@@ -181,43 +201,79 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         if (keyInfo.Key == ConsoleKey.Escape)
         {
-            // From server list, Esc quits the app
             if (ViewModel.CurrentState.Value == ToolPermissionsState.ServerList)
             {
                 ViewModel.RequestQuit();
                 return;
             }
 
+            _toolCursor = 0;
             ViewModel.GoBack();
             return;
         }
 
         if (ViewModel.CurrentState.Value == ToolPermissionsState.ToolGrid)
         {
-            if (keyInfo.Key == ConsoleKey.RightArrow)
+            switch (keyInfo.Key)
             {
-                ViewModel.CycleAudience();
-                return;
+                case ConsoleKey.UpArrow:
+                    if (_toolCursor > 0) _toolCursor--;
+                    InvalidateAndRedraw();
+                    return;
+
+                case ConsoleKey.DownArrow:
+                    if (_toolCursor < ViewModel.DiscoveredTools.Count - 1) _toolCursor++;
+                    InvalidateAndRedraw();
+                    return;
+
+                case ConsoleKey.RightArrow:
+                    ViewModel.CycleAudience();
+                    return;
+
+                case ConsoleKey.LeftArrow:
+                    ViewModel.CycleAudienceBack();
+                    return;
+
+                case ConsoleKey.Enter:
+                    if (ViewModel.DiscoveredTools.Count > 0)
+                        ViewModel.ToggleTool(ViewModel.DiscoveredTools[_toolCursor]);
+                    return;
+
+                case ConsoleKey.S:
+                    ViewModel.Save();
+                    return;
+
+                case ConsoleKey.A:
+                    ViewModel.ToggleAll();
+                    return;
             }
 
-            if (keyInfo.Key == ConsoleKey.LeftArrow)
-            {
-                ViewModel.CycleAudienceBack();
-                return;
-            }
-
-            if (keyInfo.Key == ConsoleKey.S || keyInfo.KeyChar == 's')
+            if (keyInfo.KeyChar == 's')
             {
                 ViewModel.Save();
                 return;
             }
+
+            if (keyInfo.KeyChar == 'a')
+            {
+                ViewModel.ToggleAll();
+                return;
+            }
+
+            return;
         }
 
-        // Route to active list
-        if (_activeList is not null)
+        // Server list — route to SelectionListNode
+        if (_serverList is not null)
         {
-            _activeList.HandleInput(keyInfo);
+            _serverList.HandleInput(keyInfo);
             ViewModel.RequestRedraw();
         }
+    }
+
+    private void InvalidateAndRedraw()
+    {
+        _contentNode?.Invalidate();
+        ViewModel.RequestRedraw();
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -1,0 +1,206 @@
+using Netclaw.Configuration;
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Mcp;
+
+public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsViewModel>
+{
+    private SelectionListNode<string>? _activeList;
+    private DynamicLayoutNode? _contentNode;
+    private readonly CompositeDisposable _stepSubs = new();
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(BuildHeader())
+            .WithChild(BuildContent())
+            .WithChild(BuildFooter());
+    }
+
+    private static LayoutNode BuildHeader()
+    {
+        return new PanelNode()
+            .WithBorder(BorderStyle.Rounded)
+            .WithBorderColor(Color.Cyan)
+            .WithContent(new TextNode("MCP Tool Permissions")
+                .WithForeground(Color.White)
+                .Bold());
+    }
+
+    private LayoutNode BuildContent()
+    {
+        _contentNode = new DynamicLayoutNode(() =>
+        {
+            _activeList = null;
+            _stepSubs.Clear();
+
+            return ViewModel.CurrentState.Value switch
+            {
+                ToolPermissionsState.Loading => BuildLoading(),
+                ToolPermissionsState.ServerList => BuildServerList(),
+                ToolPermissionsState.ToolGrid => BuildToolGrid(),
+                ToolPermissionsState.Saving => BuildLoading(),
+                _ => Layouts.Empty()
+            };
+        });
+
+        ViewModel.StateVersion
+            .Subscribe(_ => _contentNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return _contentNode;
+    }
+
+    private ILayoutNode BuildLoading()
+    {
+        var msg = string.IsNullOrEmpty(ViewModel.StatusMessage.Value)
+            ? "Loading..."
+            : ViewModel.StatusMessage.Value;
+
+        return new TextNode(msg).WithForeground(Color.BrightBlack);
+    }
+
+    private ILayoutNode BuildServerList()
+    {
+        if (ViewModel.Servers.Count == 0)
+            return new TextNode("No MCP servers connected.").WithForeground(Color.BrightBlack);
+
+        var items = ViewModel.Servers
+            .Select(s => $"{s.Name}  ({s.Status}, {s.ToolCount} tools)")
+            .ToList();
+
+        _activeList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+        _activeList.OnFocused();
+
+        _activeList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    var serverName = selected[0].Split("  (", 2)[0].Trim();
+                    ViewModel.SelectServer(serverName);
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("Select a server:").WithForeground(Color.White))
+            .WithChild(_activeList);
+    }
+
+    private ILayoutNode BuildToolGrid()
+    {
+        var server = ViewModel.SelectedServer ?? "?";
+        var audience = ViewModel.SelectedAudience;
+        var audienceLabel = audience switch
+        {
+            TrustAudience.Public => "Public",
+            TrustAudience.Team => "Team",
+            _ => "Personal"
+        };
+
+        var items = ViewModel.DiscoveredTools
+            .Select(tool =>
+            {
+                var granted = ViewModel.IsToolGranted(tool);
+                var marker = granted ? "\u2713" : " ";
+                return $"[{marker}] {tool}";
+            })
+            .ToList();
+
+        _activeList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+        _activeList.OnFocused();
+
+        _activeList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    // Extract tool name from "[✓] tool_name" or "[ ] tool_name"
+                    var raw = selected[0];
+                    var toolName = raw.Length > 4 ? raw[4..].Trim() : raw;
+                    ViewModel.ToggleTool(toolName);
+                }
+            })
+            .DisposeWith(_stepSubs);
+
+        var layout = Layouts.Vertical()
+            .WithChild(new TextNode($"Server: {server}  |  Audience: {audienceLabel}")
+                .WithForeground(Color.White)
+                .Bold())
+            .WithChild(_activeList);
+
+        if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
+            layout.WithChild(new TextNode(ViewModel.StatusMessage.Value).WithForeground(Color.Green));
+
+        return layout;
+    }
+
+    private LayoutNode BuildFooter()
+    {
+        return new DynamicLayoutNode(() =>
+        {
+            var hints = ViewModel.CurrentState.Value switch
+            {
+                ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit",
+                ToolPermissionsState.ToolGrid =>
+                    $"[Enter] Toggle  [Tab] Audience  [S] Save  [Esc] Back" +
+                    (ViewModel.HasUnsavedChanges ? "  *unsaved*" : ""),
+                _ => ""
+            };
+
+            return new TextNode(hints).WithForeground(Color.BrightBlack);
+        });
+    }
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            ViewModel.GoBack();
+            return;
+        }
+
+        if (ViewModel.CurrentState.Value == ToolPermissionsState.ToolGrid)
+        {
+            if (keyInfo.Key == ConsoleKey.Tab)
+            {
+                ViewModel.CycleAudience();
+                return;
+            }
+
+            if (keyInfo.Key == ConsoleKey.S || keyInfo.KeyChar == 's')
+            {
+                ViewModel.Save();
+                return;
+            }
+        }
+
+        // Route to active list
+        if (_activeList is not null)
+        {
+            _activeList.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+        }
+    }
+}

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -120,39 +120,35 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         if (_toolCursor < 0) _toolCursor = 0;
 
         var serverAllowed = ViewModel.IsServerAllowedForSelectedAudience();
+        var accessMarker = serverAllowed ? "\u2713" : " ";
 
         var layout = Layouts.Vertical()
             .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold())
             .WithChild(new TextNode($"  Audience: {audienceSelector}").WithForeground(Color.Cyan).Bold())
+            .WithSpacing(1)
+            .WithChild(new TextNode($"  [{accessMarker}] Server enabled for {audienceLabel}")
+                .WithForeground(serverAllowed ? Color.White : Color.Yellow))
             .WithSpacing(1);
 
-        if (!serverAllowed)
+        for (var i = 0; i < tools.Count; i++)
         {
-            layout = layout
-                .WithChild(new TextNode($"  Server '{server}' is not allowed for the {audienceLabel} audience.")
-                    .WithForeground(Color.Yellow))
-                .WithChild(new TextNode("  Add it to AllowedMcpServers or set McpServersMode to All first.")
-                    .WithForeground(Color.BrightBlack));
-        }
-        else
-        {
-            for (var i = 0; i < tools.Count; i++)
-            {
-                var tool = tools[i];
-                var isFocused = i == _toolCursor;
-                var granted = ViewModel.IsToolGranted(tool);
-                var prefix = isFocused ? " \u25b6 " : "   ";
-                var marker = granted ? "\u2713" : " ";
-                var line = $"{prefix}[{marker}] {tool}";
+            var tool = tools[i];
+            var isFocused = i == _toolCursor;
+            var granted = serverAllowed && ViewModel.IsToolGranted(tool);
+            var prefix = isFocused ? " \u25b6 " : "   ";
+            var marker = granted ? "\u2713" : " ";
+            var line = $"{prefix}[{marker}] {tool}";
 
-                var node = new TextNode(line);
-                node = isFocused
-                    ? node.WithForeground(Color.Cyan).Bold()
-                    : granted
-                        ? node.WithForeground(Color.White)
-                        : node.WithForeground(Color.BrightBlack);
-                layout = layout.WithChild(node);
-            }
+            var node = new TextNode(line);
+            if (!serverAllowed)
+                node = node.WithForeground(Color.BrightBlack);
+            else if (isFocused)
+                node = node.WithForeground(Color.Cyan).Bold();
+            else if (granted)
+                node = node.WithForeground(Color.White);
+            else
+                node = node.WithForeground(Color.BrightBlack);
+            layout = layout.WithChild(node);
         }
 
         if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
@@ -172,7 +168,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             {
                 ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [S] Save  [Esc] Back  [Ctrl+Q] Quit" +
+                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [E] Enable/Disable  [S] Save  [Esc] Back" +
                     (ViewModel.HasUnsavedChanges ? "  *unsaved*" : ""),
                 _ => ""
             };
@@ -235,7 +231,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                     return;
 
                 case ConsoleKey.Enter:
-                    if (ViewModel.DiscoveredTools.Count > 0)
+                    if (ViewModel.IsServerAllowedForSelectedAudience()
+                        && ViewModel.DiscoveredTools.Count > 0)
                         ViewModel.ToggleTool(ViewModel.DiscoveredTools[_toolCursor]);
                     return;
 
@@ -244,7 +241,12 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                     return;
 
                 case ConsoleKey.A:
-                    ViewModel.ToggleAll();
+                    if (ViewModel.IsServerAllowedForSelectedAudience())
+                        ViewModel.ToggleAll();
+                    return;
+
+                case ConsoleKey.E:
+                    ViewModel.ToggleServerAccess();
                     return;
             }
 
@@ -254,9 +256,15 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 return;
             }
 
-            if (keyInfo.KeyChar == 'a')
+            if (keyInfo.KeyChar == 'a' && ViewModel.IsServerAllowedForSelectedAudience())
             {
                 ViewModel.ToggleAll();
+                return;
+            }
+
+            if (keyInfo.KeyChar == 'e')
+            {
+                ViewModel.ToggleServerAccess();
                 return;
             }
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -107,13 +107,10 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
     private ILayoutNode BuildToolGrid()
     {
         var server = ViewModel.SelectedServer ?? "?";
-        var audience = ViewModel.SelectedAudience;
-        var audienceLabel = audience switch
-        {
-            TrustAudience.Public => "Public",
-            TrustAudience.Team => "Team",
-            _ => "Personal"
-        };
+        var audienceLabel = ViewModel.SelectedAudience.ToWireValue();
+
+        // Audience selector matching the channel wizard pattern: [◀ personal ▶]
+        var audienceSelector = $"[\u25c0 {audienceLabel,-8} \u25b6]";
 
         var items = ViewModel.DiscoveredTools
             .Select(tool =>
@@ -143,9 +140,9 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             .DisposeWith(_stepSubs);
 
         var layout = Layouts.Vertical()
-            .WithChild(new TextNode($"Server: {server}  |  Audience: {audienceLabel}")
-                .WithForeground(Color.White)
-                .Bold())
+            .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold())
+            .WithChild(new TextNode($"  Audience: {audienceSelector}").WithForeground(Color.Cyan).Bold())
+            .WithSpacing(1)
             .WithChild(_activeList);
 
         if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
@@ -160,9 +157,9 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         {
             var hints = ViewModel.CurrentState.Value switch
             {
-                ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit",
+                ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    $"[Enter] Toggle  [Tab] Audience  [S] Save  [Esc] Back" +
+                    "[\u2190/\u2192] Audience  [Enter] Toggle  [S] Save  [Esc] Back  [Ctrl+Q] Quit" +
                     (ViewModel.HasUnsavedChanges ? "  *unsaved*" : ""),
                 _ => ""
             };
@@ -175,17 +172,37 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
     {
         var keyInfo = key.KeyInfo;
 
+        // Ctrl+Q always quits
+        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.RequestQuit();
+            return;
+        }
+
         if (keyInfo.Key == ConsoleKey.Escape)
         {
+            // From server list, Esc quits the app
+            if (ViewModel.CurrentState.Value == ToolPermissionsState.ServerList)
+            {
+                ViewModel.RequestQuit();
+                return;
+            }
+
             ViewModel.GoBack();
             return;
         }
 
         if (ViewModel.CurrentState.Value == ToolPermissionsState.ToolGrid)
         {
-            if (keyInfo.Key == ConsoleKey.Tab)
+            if (keyInfo.Key == ConsoleKey.RightArrow)
             {
                 ViewModel.CycleAudience();
+                return;
+            }
+
+            if (keyInfo.Key == ConsoleKey.LeftArrow)
+            {
+                ViewModel.CycleAudienceBack();
                 return;
             }
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -47,7 +47,9 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
     // Track pending changes
     private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _pendingGrants = new();
-    public bool HasUnsavedChanges => _pendingGrants.Count > 0;
+    // Track pending server access changes: (audience, server) → allowed
+    private readonly Dictionary<(string Audience, string Server), bool> _pendingServerAccess = new();
+    public bool HasUnsavedChanges => _pendingGrants.Count > 0 || _pendingServerAccess.Count > 0;
 
     public override void OnActivated()
     {
@@ -190,9 +192,17 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             _ => Profiles.Personal
         };
 
-        // Server must be allowed by this audience first
-        if (!IsServerAllowed(SelectedServer, profile))
+        // Check pending server access, then config
+        var audName = AudienceName(SelectedAudience);
+        if (_pendingServerAccess.TryGetValue((audName, SelectedServer), out var pendingAccess))
+        {
+            if (!pendingAccess)
+                return false;
+        }
+        else if (!IsServerAllowed(SelectedServer, profile))
+        {
             return false;
+        }
 
         // No grants dictionary at all = no per-tool filtering, all tools pass
         if (profile.McpServerToolGrants is null)
@@ -291,6 +301,42 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         var toolsSection = ConfigFileHelper.GetOrCreateSection(config, "Tools");
         var profilesSection = ConfigFileHelper.GetOrCreateSection(toolsSection, "AudienceProfiles");
 
+        // Write server access changes (AllowedMcpServers)
+        foreach (var ((audienceName, serverName), allowed) in _pendingServerAccess)
+        {
+            var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
+
+            var serverList = audienceSection.TryGetValue("AllowedMcpServers", out var existingList)
+                && existingList is List<object> list
+                    ? list.Select(o => o.ToString()!).ToList()
+                    : [];
+
+            if (allowed && !serverList.Contains(serverName, StringComparer.OrdinalIgnoreCase))
+            {
+                serverList.Add(serverName);
+            }
+            else if (!allowed)
+            {
+                serverList.RemoveAll(s => s.Equals(serverName, StringComparison.OrdinalIgnoreCase));
+            }
+
+            audienceSection["AllowedMcpServers"] = serverList;
+
+            // Also update the in-memory profile so the UI reflects changes immediately
+            var profile = audienceName switch
+            {
+                "Public" => Profiles.Public,
+                "Team" => Profiles.Team,
+                _ => Profiles.Personal
+            };
+
+            if (allowed && !profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase))
+                profile.AllowedMcpServers.Add(serverName);
+            else if (!allowed)
+                profile.AllowedMcpServers.RemoveAll(s => s.Equals(serverName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Write tool grant changes (McpServerToolGrants)
         foreach (var (serverName, audienceGrants) in _pendingGrants)
         {
             foreach (var (audienceName, tools) in audienceGrants)
@@ -309,6 +355,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
         _pendingGrants.Clear();
+        _pendingServerAccess.Clear();
 
         StatusMessage.Value = "Saved to netclaw.json. Restart daemon to apply changes.";
         CurrentState.Value = ToolPermissionsState.ToolGrid;
@@ -320,14 +367,40 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         if (SelectedServer is null)
             return false;
 
-        var profile = SelectedAudience switch
-        {
-            TrustAudience.Public => Profiles.Public,
-            TrustAudience.Team => Profiles.Team,
-            _ => Profiles.Personal
-        };
+        var audienceName = AudienceName(SelectedAudience);
 
+        // Check pending changes first
+        if (_pendingServerAccess.TryGetValue((audienceName, SelectedServer), out var pending))
+            return pending;
+
+        var profile = ResolveProfile(SelectedAudience);
         return IsServerAllowed(SelectedServer, profile);
+    }
+
+    public void ToggleServerAccess()
+    {
+        if (SelectedServer is null)
+            return;
+
+        var allowed = IsServerAllowedForSelectedAudience();
+        var audienceName = AudienceName(SelectedAudience);
+        _pendingServerAccess[(audienceName, SelectedServer)] = !allowed;
+
+        if (!allowed)
+        {
+            // Enabling server for this audience — start with empty tool grants
+            // so the operator explicitly selects which tools to expose
+            if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
+            {
+                serverGrants = new Dictionary<string, HashSet<string>>();
+                _pendingGrants[SelectedServer] = serverGrants;
+            }
+
+            if (!serverGrants.ContainsKey(audienceName))
+                serverGrants[audienceName] = new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        NotifyStateChanged();
     }
 
     private static bool IsServerAllowed(string serverName, ToolAudienceProfile profile)
@@ -337,6 +410,20 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         return profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
     }
+
+    private ToolAudienceProfile ResolveProfile(TrustAudience audience) => audience switch
+    {
+        TrustAudience.Public => Profiles.Public,
+        TrustAudience.Team => Profiles.Team,
+        _ => Profiles.Personal
+    };
+
+    private static string AudienceName(TrustAudience audience) => audience switch
+    {
+        TrustAudience.Public => "Public",
+        TrustAudience.Team => "Team",
+        _ => "Personal"
+    };
 
     public void RequestQuit() => Shutdown();
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -166,7 +166,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     public bool IsToolGranted(string toolName)
     {
         if (SelectedServer is null)
-            return true;
+            return false;
 
         var audienceName = SelectedAudience switch
         {
@@ -190,13 +190,47 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             _ => Profiles.Personal
         };
 
-        if (profile.McpServerToolGrants is null)
-            return true; // No grants = all tools
+        // Server must be allowed by this audience first
+        if (!IsServerAllowed(SelectedServer, profile))
+            return false;
 
+        // No grants dictionary at all = no per-tool filtering, all tools pass
+        if (profile.McpServerToolGrants is null)
+            return true;
+
+        // Server not in grants = not yet configured, all tools pass
         if (!profile.McpServerToolGrants.TryGetValue(SelectedServer, out var configTools))
-            return true; // Server not in grants = all tools
+            return true;
 
         return configTools.Contains(toolName, StringComparer.Ordinal);
+    }
+
+    public void ToggleAll()
+    {
+        if (SelectedServer is null)
+            return;
+
+        // If any tool is granted, deselect all. Otherwise select all.
+        var anyGranted = DiscoveredTools.Any(IsToolGranted);
+
+        var audienceName = SelectedAudience switch
+        {
+            TrustAudience.Public => "Public",
+            TrustAudience.Team => "Team",
+            _ => "Personal"
+        };
+
+        if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
+        {
+            serverGrants = new Dictionary<string, HashSet<string>>();
+            _pendingGrants[SelectedServer] = serverGrants;
+        }
+
+        serverGrants[audienceName] = anyGranted
+            ? new HashSet<string>(StringComparer.Ordinal) // deselect all
+            : new HashSet<string>(DiscoveredTools, StringComparer.Ordinal); // select all
+
+        NotifyStateChanged();
     }
 
     public void ToggleTool(string toolName)
@@ -213,17 +247,32 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
         {
-            // First edit: snapshot all tools as granted
             serverGrants = new Dictionary<string, HashSet<string>>();
-            var allTools = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
-            serverGrants[audienceName] = allTools;
             _pendingGrants[SelectedServer] = serverGrants;
         }
 
         if (!serverGrants.TryGetValue(audienceName, out var tools))
         {
-            // First edit for this audience: snapshot all tools as granted
-            tools = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
+            // Initialize from config if grants exist for this server,
+            // otherwise start from all tools (matches IsToolGranted behavior)
+            var profile = SelectedAudience switch
+            {
+                TrustAudience.Public => Profiles.Public,
+                TrustAudience.Team => Profiles.Team,
+                _ => Profiles.Personal
+            };
+
+            if (profile.McpServerToolGrants is { } existing
+                && existing.TryGetValue(SelectedServer, out var configTools))
+            {
+                tools = new HashSet<string>(configTools, StringComparer.Ordinal);
+            }
+            else
+            {
+                // Server not yet configured — start with all tools granted
+                tools = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
+            }
+
             serverGrants[audienceName] = tools;
         }
 
@@ -264,6 +313,29 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         StatusMessage.Value = "Saved to netclaw.json. Restart daemon to apply changes.";
         CurrentState.Value = ToolPermissionsState.ToolGrid;
         NotifyStateChanged();
+    }
+
+    public bool IsServerAllowedForSelectedAudience()
+    {
+        if (SelectedServer is null)
+            return false;
+
+        var profile = SelectedAudience switch
+        {
+            TrustAudience.Public => Profiles.Public,
+            TrustAudience.Team => Profiles.Team,
+            _ => Profiles.Personal
+        };
+
+        return IsServerAllowed(SelectedServer, profile);
+    }
+
+    private static bool IsServerAllowed(string serverName, ToolAudienceProfile profile)
+    {
+        if (profile.McpServersMode == ToolProfileMode.All)
+            return true;
+
+        return profile.AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
     }
 
     public void RequestQuit() => Shutdown();

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Netclaw.Cli.Config;
+using Netclaw.Cli.Daemon;
+using Netclaw.Configuration;
+using R3;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Mcp;
+
+public enum ToolPermissionsState
+{
+    Loading,
+    ServerList,
+    ToolGrid,
+    Saving
+}
+
+public sealed class McpToolPermissionsViewModel : ReactiveViewModel
+{
+    private static readonly JsonSerializerOptions EnumJsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly NetclawPaths _paths;
+    private readonly DaemonApi _daemonApi;
+
+    public McpToolPermissionsViewModel(NetclawPaths paths, DaemonApi daemonApi)
+    {
+        _paths = paths;
+        _daemonApi = daemonApi;
+    }
+
+    public ReactiveProperty<ToolPermissionsState> CurrentState { get; } = new(ToolPermissionsState.Loading);
+    internal ReactiveProperty<int> StateVersion { get; } = new(0);
+    public ReactiveProperty<string> StatusMessage { get; } = new("");
+
+    // Server list state
+    public List<(string Name, string Status, int ToolCount)> Servers { get; } = [];
+
+    // Tool grid state
+    public string? SelectedServer { get; private set; }
+    public List<string> DiscoveredTools { get; } = [];
+    public TrustAudience SelectedAudience { get; private set; } = TrustAudience.Personal;
+    public ToolAudienceProfiles Profiles { get; private set; } = ToolAudienceProfileDefaults.CreateProfiles();
+
+    // Track pending changes
+    private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _pendingGrants = new();
+    public bool HasUnsavedChanges => _pendingGrants.Count > 0;
+
+    public override void OnActivated()
+    {
+        base.OnActivated();
+        _ = LoadServersAsync();
+    }
+
+    private async Task LoadServersAsync()
+    {
+        StatusMessage.Value = "Loading MCP server statuses...";
+
+        try
+        {
+            var statuses = await _daemonApi.GetMcpServerStatusesAsync(CancellationToken.None);
+            Servers.Clear();
+
+            foreach (var prop in statuses.EnumerateObject())
+            {
+                var state = prop.Value.GetProperty("state").GetString() ?? "unknown";
+                var toolCount = prop.Value.TryGetProperty("toolCount", out var tc) ? tc.GetInt32() : 0;
+                Servers.Add((prop.Name, state, toolCount));
+            }
+
+            Profiles = LoadToolConfig().AudienceProfiles;
+
+            if (Servers.Count == 0)
+            {
+                StatusMessage.Value = "No MCP servers connected. Start the daemon and configure servers first.";
+            }
+            else
+            {
+                StatusMessage.Value = "";
+                CurrentState.Value = ToolPermissionsState.ServerList;
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusMessage.Value = $"Could not reach daemon: {ex.Message}";
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void SelectServer(string serverName)
+    {
+        SelectedServer = serverName;
+        _ = LoadToolsForServerAsync(serverName);
+    }
+
+    private async Task LoadToolsForServerAsync(string serverName)
+    {
+        StatusMessage.Value = $"Loading tools for {serverName}...";
+        NotifyStateChanged();
+
+        try
+        {
+            var tools = await _daemonApi.GetMcpToolNamesAsync(serverName, CancellationToken.None);
+            DiscoveredTools.Clear();
+            DiscoveredTools.AddRange(tools);
+
+            // Initialize pending grants from current config if not already edited
+            if (!_pendingGrants.ContainsKey(serverName))
+                InitializePendingGrantsFromConfig(serverName);
+
+            StatusMessage.Value = "";
+            CurrentState.Value = ToolPermissionsState.ToolGrid;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage.Value = $"Error loading tools: {ex.Message}";
+        }
+
+        NotifyStateChanged();
+    }
+
+    private void InitializePendingGrantsFromConfig(string serverName)
+    {
+        var audienceGrants = new Dictionary<string, HashSet<string>>();
+
+        foreach (var (name, profile) in new[]
+        {
+            ("Public", Profiles.Public),
+            ("Team", Profiles.Team),
+            ("Personal", Profiles.Personal)
+        })
+        {
+            if (profile.McpServerToolGrants is { } grants
+                && grants.TryGetValue(serverName, out var tools))
+            {
+                audienceGrants[name] = new HashSet<string>(tools, StringComparer.Ordinal);
+            }
+            // If no grants configured, don't add an entry (null = all tools)
+        }
+
+        if (audienceGrants.Count > 0)
+            _pendingGrants[serverName] = audienceGrants;
+    }
+
+    public void CycleAudience()
+    {
+        SelectedAudience = SelectedAudience switch
+        {
+            TrustAudience.Public => TrustAudience.Team,
+            TrustAudience.Team => TrustAudience.Personal,
+            _ => TrustAudience.Public
+        };
+        NotifyStateChanged();
+    }
+
+    public bool IsToolGranted(string toolName)
+    {
+        if (SelectedServer is null)
+            return true;
+
+        var audienceName = SelectedAudience switch
+        {
+            TrustAudience.Public => "Public",
+            TrustAudience.Team => "Team",
+            _ => "Personal"
+        };
+
+        // Check pending grants first
+        if (_pendingGrants.TryGetValue(SelectedServer, out var serverGrants)
+            && serverGrants.TryGetValue(audienceName, out var tools))
+        {
+            return tools.Contains(toolName);
+        }
+
+        // No pending grants = check config
+        var profile = SelectedAudience switch
+        {
+            TrustAudience.Public => Profiles.Public,
+            TrustAudience.Team => Profiles.Team,
+            _ => Profiles.Personal
+        };
+
+        if (profile.McpServerToolGrants is null)
+            return true; // No grants = all tools
+
+        if (!profile.McpServerToolGrants.TryGetValue(SelectedServer, out var configTools))
+            return true; // Server not in grants = all tools
+
+        return configTools.Contains(toolName, StringComparer.Ordinal);
+    }
+
+    public void ToggleTool(string toolName)
+    {
+        if (SelectedServer is null)
+            return;
+
+        var audienceName = SelectedAudience switch
+        {
+            TrustAudience.Public => "Public",
+            TrustAudience.Team => "Team",
+            _ => "Personal"
+        };
+
+        if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
+        {
+            // First edit: snapshot all tools as granted
+            serverGrants = new Dictionary<string, HashSet<string>>();
+            var allTools = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
+            serverGrants[audienceName] = allTools;
+            _pendingGrants[SelectedServer] = serverGrants;
+        }
+
+        if (!serverGrants.TryGetValue(audienceName, out var tools))
+        {
+            // First edit for this audience: snapshot all tools as granted
+            tools = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
+            serverGrants[audienceName] = tools;
+        }
+
+        if (!tools.Remove(toolName))
+            tools.Add(toolName);
+
+        NotifyStateChanged();
+    }
+
+    public void Save()
+    {
+        if (!HasUnsavedChanges)
+            return;
+
+        var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
+        var toolsSection = ConfigFileHelper.GetOrCreateSection(config, "Tools");
+        var profilesSection = ConfigFileHelper.GetOrCreateSection(toolsSection, "AudienceProfiles");
+
+        foreach (var (serverName, audienceGrants) in _pendingGrants)
+        {
+            foreach (var (audienceName, tools) in audienceGrants)
+            {
+                var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
+
+                var grants = audienceSection.TryGetValue("McpServerToolGrants", out var existing)
+                    && existing is Dictionary<string, object> dict
+                        ? dict
+                        : new Dictionary<string, object>();
+
+                grants[serverName] = tools.Order(StringComparer.Ordinal).ToList();
+                audienceSection["McpServerToolGrants"] = grants;
+            }
+        }
+
+        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+        _pendingGrants.Clear();
+
+        StatusMessage.Value = "Saved to netclaw.json. Restart daemon to apply changes.";
+        CurrentState.Value = ToolPermissionsState.ToolGrid;
+        NotifyStateChanged();
+    }
+
+    public void GoBack()
+    {
+        switch (CurrentState.Value)
+        {
+            case ToolPermissionsState.ToolGrid:
+                SelectedServer = null;
+                DiscoveredTools.Clear();
+                CurrentState.Value = ToolPermissionsState.ServerList;
+                break;
+            default:
+                return;
+        }
+
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged()
+    {
+        StateVersion.Value++;
+        RequestRedraw();
+    }
+
+    private ToolConfig LoadToolConfig()
+    {
+        if (!File.Exists(_paths.NetclawConfigPath))
+            return new ToolConfig();
+
+        try
+        {
+            var text = File.ReadAllText(_paths.NetclawConfigPath);
+            using var doc = JsonDocument.Parse(text);
+
+            if (!doc.RootElement.TryGetProperty("Tools", out var toolsSection))
+                return new ToolConfig();
+
+            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(), EnumJsonOptions)
+                ?? new ToolConfig();
+        }
+        catch
+        {
+            return new ToolConfig();
+        }
+    }
+}

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -146,14 +146,20 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             _pendingGrants[serverName] = audienceGrants;
     }
 
+    private static readonly TrustAudience[] AudienceValues =
+        [TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public];
+
     public void CycleAudience()
     {
-        SelectedAudience = SelectedAudience switch
-        {
-            TrustAudience.Public => TrustAudience.Team,
-            TrustAudience.Team => TrustAudience.Personal,
-            _ => TrustAudience.Public
-        };
+        var idx = Array.IndexOf(AudienceValues, SelectedAudience);
+        SelectedAudience = AudienceValues[(idx + 1) % AudienceValues.Length];
+        NotifyStateChanged();
+    }
+
+    public void CycleAudienceBack()
+    {
+        var idx = Array.IndexOf(AudienceValues, SelectedAudience);
+        SelectedAudience = AudienceValues[(idx - 1 + AudienceValues.Length) % AudienceValues.Length];
         NotifyStateChanged();
     }
 
@@ -259,6 +265,8 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         CurrentState.Value = ToolPermissionsState.ToolGrid;
         NotifyStateChanged();
     }
+
+    public void RequestQuit() => Shutdown();
 
     public void GoBack()
     {

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -474,9 +474,27 @@ static async Task RunAsync(string[] args)
     {
         var mcpSubcommand = args.Length > 1 ? args[1] : "help";
 
-        if (mcpSubcommand is "auth" or "list")
+        if (mcpSubcommand is "tools" && args.Length <= 2)
         {
-            // auth/list need the daemon — spin up DI to get DaemonApi
+            // Bare `netclaw mcp tools` → TUI mode
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-mcp-tools-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+
+            builder.Services.AddTermina("/mcp-tools", t =>
+                t.RegisterRoute<McpToolPermissionsPage, McpToolPermissionsViewModel>("/mcp-tools"));
+
+            await builder.Build().RunAsync();
+            return;
+        }
+
+        if (mcpSubcommand is "auth" or "list" or "tools")
+        {
+            // auth/list/tools need the daemon — spin up DI to get DaemonApi
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
             builder.Logging.ClearProviders();

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -461,6 +461,14 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "McpServerToolGrants": {
+          "type": ["object", "null"],
+          "description": "Per-server tool allowlists. Keys are server names, values are arrays of allowed tool names. Servers not listed expose all tools.",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
         "ReadFiles": { "$ref": "#/$defs/ToolFilesystemAccessProfile" },
         "WriteFiles": { "$ref": "#/$defs/ToolFilesystemAccessProfile" },
         "AttachFiles": { "$ref": "#/$defs/ToolFilesystemAccessProfile" }

--- a/src/Netclaw.Configuration/ToolAudienceProfiles.cs
+++ b/src/Netclaw.Configuration/ToolAudienceProfiles.cs
@@ -25,6 +25,15 @@ public sealed class ToolAudienceProfile
     public List<string> AllowedTools { get; set; } = [];
     public ToolProfileMode McpServersMode { get; set; } = ToolProfileMode.Allowlist;
     public List<string> AllowedMcpServers { get; set; } = [];
+
+    /// <summary>
+    /// Per-server tool allowlists for this audience.
+    /// When a server appears here, only listed tools are exposed to this audience.
+    /// Servers not listed expose all their registered tools (subject to AllowedMcpServers gate).
+    /// Null means no per-tool filtering.
+    /// </summary>
+    public Dictionary<string, List<string>>? McpServerToolGrants { get; set; }
+
     public ToolFilesystemAccessProfile ReadFiles { get; set; } = new();
     public ToolFilesystemAccessProfile WriteFiles { get; set; } = new();
     public ToolFilesystemAccessProfile AttachFiles { get; set; } = new();

--- a/src/Netclaw.Configuration/ToolAudienceProfiles.cs
+++ b/src/Netclaw.Configuration/ToolAudienceProfiles.cs
@@ -46,6 +46,17 @@ public sealed class ToolAudienceProfiles
     public ToolAudienceProfile Personal { get; set; } = ToolAudienceProfileDefaults.CreatePersonal();
 
     /// <summary>
+    /// Returns all audience profiles (Public, Team, Personal) for enumeration.
+    /// Use this instead of manually constructing arrays to avoid missing a tier.
+    /// </summary>
+    public IEnumerable<ToolAudienceProfile> GetAllProfiles()
+    {
+        yield return Public;
+        yield return Team;
+        yield return Personal;
+    }
+
+    /// <summary>
     /// Filesystem roots that are always readable regardless of audience profile.
     /// Supports tokens: <c>{skills_dir}</c>, <c>{identity_dir}</c>, <c>{workspaces_dir}</c>.
     /// Defaults to skills, identity, and workspaces directories so skill loading,

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -167,6 +167,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         var manager = new McpClientManager(
             mcpServers,
             new ToolRegistry(),
+            new ToolConfig(),
             oauthService,
             NullNotificationSink.Instance,
             TimeProvider.System,

--- a/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpStdioSmokeTests.cs
@@ -160,7 +160,7 @@ public class McpStdioSmokeTests : IAsyncDisposable
             NullLogger<McpOAuthService>.Instance,
             pkceService,
             NullNotificationSink.Instance);
-        var manager = new McpClientManager(serverEntries, registry, oauthService, NullNotificationSink.Instance, TimeProvider.System, logger);
+        var manager = new McpClientManager(serverEntries, registry, new ToolConfig(), oauthService, NullNotificationSink.Instance, TimeProvider.System, logger);
 
         try
         {

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -110,6 +110,17 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
     public IReadOnlyDictionary<string, McpServerStatus> GetServerStatuses() => _statuses;
 
+    /// <summary>
+    /// Returns discovered tool names for a connected MCP server.
+    /// </summary>
+    public IReadOnlyList<string> GetToolNames(string serverName)
+    {
+        if (!_sharedToolFunctions.TryGetValue(serverName, out var tools))
+            return [];
+
+        return tools.Keys.Order(StringComparer.Ordinal).ToList();
+    }
+
     public async Task<bool> TryReconnectAsync(string serverName, CancellationToken ct = default)
     {
         if (!_serverEntries.TryGetValue(serverName, out var entry) || !entry.Enabled)

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -741,9 +741,9 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         var allGrantedTools = new HashSet<string>(StringComparer.Ordinal);
         var hasAnyGrants = false;
 
-        foreach (var profile in new[] { profiles.Public, profiles.Team, profiles.Personal })
+        foreach (var profile in profiles.GetAllProfiles())
         {
-            if (profile?.McpServerToolGrants is not { } grants)
+            if (profile.McpServerToolGrants is not { } grants)
                 continue;
 
             if (!grants.TryGetValue(serverName, out var tools))

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -16,6 +16,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
     private readonly Dictionary<string, McpServerEntry> _serverEntries;
     private readonly ToolRegistry _toolRegistry;
+    private readonly ToolConfig _toolConfig;
     private readonly McpOAuthService _oauthService;
     private readonly IOperationalNotificationSink _notificationSink;
     private readonly TimeProvider _timeProvider;
@@ -44,6 +45,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     public McpClientManager(
         Dictionary<string, McpServerEntry> serverEntries,
         ToolRegistry toolRegistry,
+        ToolConfig toolConfig,
         McpOAuthService oauthService,
         IOperationalNotificationSink notificationSink,
         TimeProvider timeProvider,
@@ -51,6 +53,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
     {
         _serverEntries = serverEntries;
         _toolRegistry = toolRegistry;
+        _toolConfig = toolConfig;
         _oauthService = oauthService;
         _notificationSink = notificationSink;
         _timeProvider = timeProvider;
@@ -396,6 +399,8 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             _toolRegistry.WithMcpTools(name, tools, entry.GrantCategory, this);
             _statuses[name] = new McpServerStatus(name, McpConnectionState.Connected, tools.Count, null);
 
+            LogToolDrift(name, tools);
+
             _logger.LogInformation("MCP server '{Name}' connected ({ToolCount} tools)", name, tools.Count);
             return true;
         }
@@ -725,6 +730,55 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
 
     private static string BuildScopedClientKey(string serverName, string scopeId)
         => $"{serverName}::{scopeId}";
+
+    /// <summary>
+    /// Compares discovered tools against <see cref="ToolAudienceProfile.McpServerToolGrants"/>
+    /// across all audience profiles and logs warnings for drift.
+    /// </summary>
+    private void LogToolDrift(string serverName, IList<McpClientTool> discoveredTools)
+    {
+        var profiles = _toolConfig.AudienceProfiles;
+        var allGrantedTools = new HashSet<string>(StringComparer.Ordinal);
+        var hasAnyGrants = false;
+
+        foreach (var profile in new[] { profiles.Public, profiles.Team, profiles.Personal })
+        {
+            if (profile?.McpServerToolGrants is not { } grants)
+                continue;
+
+            if (!grants.TryGetValue(serverName, out var tools))
+                continue;
+
+            hasAnyGrants = true;
+            foreach (var tool in tools)
+                allGrantedTools.Add(tool);
+        }
+
+        if (!hasAnyGrants)
+            return;
+
+        var discoveredNames = new HashSet<string>(
+            discoveredTools.Select(t => t.Name), StringComparer.Ordinal);
+
+        var ungranted = discoveredNames.Except(allGrantedTools).ToList();
+        var stale = allGrantedTools.Except(discoveredNames).ToList();
+
+        if (ungranted.Count > 0)
+        {
+            _logger.LogWarning(
+                "MCP server '{Name}' exposes {Count} tool(s) not granted to any audience: {Tools}. " +
+                "Review and add to McpServerToolGrants if intended.",
+                serverName, ungranted.Count, string.Join(", ", ungranted));
+        }
+
+        if (stale.Count > 0)
+        {
+            _logger.LogWarning(
+                "McpServerToolGrants for '{Name}' contains {Count} tool(s) not found on server: {Tools}. " +
+                "These may have been removed or renamed.",
+                serverName, stale.Count, string.Join(", ", stale));
+        }
+    }
 
     public void Dispose()
     {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -206,6 +206,12 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         return Results.Ok(result);
     });
 
+    app.MapGet("/api/mcp/tools/{name}", (string name, McpClientManager mcpManager) =>
+    {
+        var tools = mcpManager.GetToolNames(name);
+        return Results.Ok(tools);
+    });
+
     app.MapGet("/api/mcp/oauth/status/{name}", (string name, McpOAuthService oauthService) =>
     {
         var status = oauthService.GetFlowStatus(name);


### PR DESCRIPTION
## Summary

- Add `McpServerToolGrants` to `ToolAudienceProfile` for per-server tool allowlists that vary by audience. When a server has an entry in the grants dictionary, only listed tools are exposed to that audience. Composes with the existing `AllowedMcpServers` gate. Backward-compatible — null/omitted grants means all tools exposed (current behavior). Closes #490.
- Enforce per-tool check in `ToolAccessPolicy.IsToolExposed` and `AuthorizeInvocation` with deny reason `mcp_tool_not_allowed_for_audience_profile`
- Log tool drift warnings in `McpClientManager` when discovered tools diverge from configured grants
- Add doctor advisory for MCP servers with no tool grants on any audience profile
- Add `netclaw mcp tools <server>` CLI command showing per-audience grant status table
- Add `netclaw mcp tools <server> --snapshot` to baseline grants from discovered tools
- Add `netclaw mcp tools` TUI mode for interactive tool permission management
- Add `ToolAudienceProfiles.GetAllProfiles()` to centralize audience tier enumeration
- 17 unit tests covering enforcement, deny reasons, search_tools/load_tool filtering, config deserialization, and cross-audience behavior

## Test plan

- [x] 17 new `McpToolAudienceGrantsTests` covering all enforcement paths
- [x] 2 new `ToolAudienceProfilesDoctorCheckTests` for grant advisory
- [x] All existing tests pass (including daemon constructor changes)
- [x] Manual binary swap test: `netclaw mcp tools memorizer` displays grant table, `--snapshot` writes config correctly
- [ ] CI green
- [ ] TUI mode manual test (`netclaw mcp tools` with no args)