### PR TITLE
feat(skills): support loading skills from external directories

### DIFF
--- a/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
@@ -244,4 +244,46 @@ public class SkillRegistryTests
 
         Assert.False(registry.TryResolveSlashCommand("/ops", out _, out _));
     }
+
+    // --- Multi-root index tests ---
+
+    [Fact]
+    public void GenerateIndex_with_external_sources_uses_roots_header()
+    {
+        var registry = new SkillRegistry();
+        registry.Register(MakeEntry("my-skill", "desc"));
+
+        var externalSources = new[]
+        {
+            new ResolvedExternalSource("claude-code", "/home/user/.claude/skills", true)
+        };
+
+        var index = registry.GenerateIndex("/home/user/.netclaw/skills", externalSources);
+
+        Assert.Contains("roots: native=/home/user/.netclaw/skills,claude-code=/home/user/.claude/skills", index);
+        Assert.DoesNotContain("[skills]|root:", index);
+    }
+
+    [Fact]
+    public void GenerateIndex_without_external_sources_uses_single_root_header()
+    {
+        var registry = new SkillRegistry();
+        registry.Register(MakeEntry("my-skill", "desc"));
+
+        var index = registry.GenerateIndex("/home/user/.netclaw/skills");
+
+        Assert.Contains("[skills]|root: /home/user/.netclaw/skills", index);
+        Assert.DoesNotContain("roots:", index);
+    }
+
+    [Fact]
+    public void GenerateIndex_with_empty_external_sources_uses_single_root_header()
+    {
+        var registry = new SkillRegistry();
+        registry.Register(MakeEntry("my-skill", "desc"));
+
+        var index = registry.GenerateIndex("/home/user/.netclaw/skills", Array.Empty<ResolvedExternalSource>());
+
+        Assert.Contains("[skills]|root: /home/user/.netclaw/skills", index);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
@@ -430,6 +430,47 @@ public class SkillScannerTests : IDisposable
         Assert.Contains(result.Issues, issue => issue.Kind == SkillScanIssueKind.SymlinkNotAllowed);
     }
 
+    [Fact]
+    public void Symlinked_resource_tree_accepted_when_allowSymlinks_is_true()
+    {
+        WriteSkill("linked-skill", """
+            ---
+            name: linked-skill
+            description: Has linked resources.
+            ---
+
+            # Linked
+            """);
+
+        var targetDir = Path.Combine(_skillsDir, "external-resources");
+        Directory.CreateDirectory(targetDir);
+        File.WriteAllText(Path.Combine(targetDir, "guide.md"), "# Guide");
+        Directory.CreateSymbolicLink(Path.Combine(_skillsDir, "linked-skill", "references"), targetDir);
+
+        var result = SkillScanner.Scan(_skillsDir, allowSymlinks: true);
+
+        Assert.Single(result.AcceptedSkills);
+        Assert.Equal("linked-skill", result.AcceptedSkills[0].Name);
+    }
+
+    [Fact]
+    public void AllowSymlinks_does_not_affect_normal_skills()
+    {
+        WriteSkill("normal-skill", """
+            ---
+            name: normal-skill
+            description: A normal skill.
+            ---
+
+            # Normal
+            """);
+
+        var result = SkillScanner.Scan(_skillsDir, allowSymlinks: true);
+
+        Assert.Single(result.AcceptedSkills);
+        Assert.Equal("normal-skill", result.AcceptedSkills[0].Name);
+    }
+
     /// <summary>
     /// Creates a skill directory with SKILL.md containing the given content.
     /// </summary>

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -561,7 +561,7 @@ public class SkillToolTests : IDisposable
     }
 
     private SkillManageTool CreateManageTool(ISkillContentScanner? scanner = null)
-        => new(_registry, _indexLayer, _paths, scanner ?? new NoOpSkillContentScanner());
+        => new(_registry, _indexLayer, _paths, scanner ?? new NoOpSkillContentScanner(), Array.Empty<ResolvedExternalSource>());
 
     private static ISkillContentScanner CreateRegexScanner()
         => new RegexSkillContentScanner(
@@ -600,5 +600,81 @@ public class SkillToolTests : IDisposable
     {
         var result = SkillScanner.Scan(_paths.SkillsDirectory);
         _registry.ReplaceAll(result.AcceptedSkills, result.Issues);
+    }
+
+    [Fact]
+    public async Task Edit_rejects_external_skill()
+    {
+        // Create a skill in an "external" directory (outside native skills root)
+        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
+        try
+        {
+            var skillDir = Path.Combine(externalDir, "ext-skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+                ---
+                name: ext-skill
+                description: External skill.
+                ---
+
+                # External
+                """);
+
+            // Register the external skill in the registry
+            var externalScan = SkillScanner.Scan(externalDir);
+            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
+
+            var tool = CreateManageTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Action"] = "edit",
+                ["Name"] = "ext-skill",
+                ["Content"] = "---\nname: ext-skill\ndescription: Hacked.\n---\n# Hacked"
+            });
+
+            Assert.Contains("External skill directories are read-only", result);
+        }
+        finally
+        {
+            if (Directory.Exists(externalDir))
+                Directory.Delete(externalDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_rejects_external_skill()
+    {
+        var externalDir = Path.Combine(Path.GetTempPath(), $"netclaw-external-test-{Guid.NewGuid():N}");
+        try
+        {
+            var skillDir = Path.Combine(externalDir, "ext-skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+                ---
+                name: ext-skill
+                description: External skill.
+                ---
+
+                # External
+                """);
+
+            var externalScan = SkillScanner.Scan(externalDir);
+            _registry.ReplaceAll(externalScan.AcceptedSkills, externalScan.Issues);
+
+            var tool = CreateManageTool();
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Action"] = "delete",
+                ["Name"] = "ext-skill"
+            });
+
+            Assert.Contains("External skill directories are read-only", result);
+            Assert.True(Directory.Exists(skillDir), "External skill directory should not be deleted");
+        }
+        finally
+        {
+            if (Directory.Exists(externalDir))
+                Directory.Delete(externalDir, recursive: true);
+        }
     }
 }

--- a/src/Netclaw.Actors/Skills/SkillRegistry.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistry.cs
@@ -75,7 +75,7 @@ public sealed class SkillRegistry
     /// Skills with <c>DisableModelInvocation</c> are excluded from the index
     /// (they remain invokable via slash commands).
     /// </summary>
-    public string GenerateIndex(string skillsRoot)
+    public string GenerateIndex(string skillsRoot, IReadOnlyList<ResolvedExternalSource>? externalSources = null)
     {
         if (_skills.Count == 0)
             return string.Empty;
@@ -85,7 +85,21 @@ public sealed class SkillRegistry
             return string.Empty;
 
         var sb = new StringBuilder();
-        sb.AppendLine($"[skills]|root: {skillsRoot}|invoke via /name");
+
+        // Build roots header — single root for backward compat, multi-root when external sources exist
+        var hasExternal = externalSources is { Count: > 0 };
+        if (hasExternal)
+        {
+            sb.Append($"[skills]|roots: native={skillsRoot}");
+            foreach (var src in externalSources!)
+                sb.Append($",{src.Name}={src.Path}");
+            sb.AppendLine("|invoke via /name");
+        }
+        else
+        {
+            sb.AppendLine($"[skills]|root: {skillsRoot}|invoke via /name");
+        }
+
         sb.AppendLine("|IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning");
 
         // Group by category, null category = root-level user skills

--- a/src/Netclaw.Actors/Skills/SkillRegistryUpdater.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistryUpdater.cs
@@ -13,4 +13,15 @@ public static class SkillRegistryUpdater
         skillRegistry.ReplaceAll(scanResult.AcceptedSkills, scanResult.Issues);
         skillIndexLayer.Update(skillRegistry.GenerateIndex(skillsRoot));
     }
+
+    public static void ApplyMergedScanResult(
+        SkillRegistry skillRegistry,
+        SkillIndexContextLayer skillIndexLayer,
+        MergedSkillScanResult mergedResult,
+        string nativeSkillsRoot,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
+    {
+        skillRegistry.ReplaceAll(mergedResult.AcceptedSkills, mergedResult.Issues);
+        skillIndexLayer.Update(skillRegistry.GenerateIndex(nativeSkillsRoot, externalSources));
+    }
 }

--- a/src/Netclaw.Actors/Skills/SkillScanResult.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanResult.cs
@@ -40,3 +40,10 @@ public sealed record SkillScanResult(
             yield return $"... and {Issues.Count - maxIssues} more issue(s)";
     }
 }
+
+/// <summary>
+/// Merged skill scan result from native + external sources.
+/// </summary>
+public sealed record MergedSkillScanResult(
+    IReadOnlyList<SkillEntry> AcceptedSkills,
+    IReadOnlyList<SkillScanIssue> Issues);

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -39,7 +39,13 @@ public static partial class SkillScanner
     /// Scan the skills directory and return metadata for each skill found.
     /// Returns accepted skills plus explicit issues for rejected items.
     /// </summary>
-    public static SkillScanResult Scan(string skillsDirectory)
+    /// <param name="skillsDirectory">Root directory to scan for skills.</param>
+    /// <param name="allowSymlinks">
+    /// When <c>true</c>, symlinks within the directory are followed instead of rejected.
+    /// Resolved paths are still validated to stay within the root. Used for external
+    /// skill directories (e.g., Claude Code) that rely on symlinks.
+    /// </param>
+    public static SkillScanResult Scan(string skillsDirectory, bool allowSymlinks = false)
     {
         if (!Directory.Exists(skillsDirectory))
             return SkillScanResult.Empty;
@@ -55,7 +61,7 @@ public static partial class SkillScanner
             if (!File.Exists(skillMdPath))
                 continue;
 
-            var entry = ParseSkillFile(skillMdPath, rootFull, issues);
+            var entry = ParseSkillFile(skillMdPath, rootFull, issues, allowSymlinks);
             if (entry is not null)
                 acceptedCandidates.Add(entry);
         }
@@ -79,7 +85,7 @@ public static partial class SkillScanner
                 if (!File.Exists(skillMdPath))
                     continue;
 
-                var entry = ParseSkillFile(skillMdPath, rootFull, issues);
+                var entry = ParseSkillFile(skillMdPath, rootFull, issues, allowSymlinks);
                 if (entry is not null)
                     acceptedCandidates.Add(entry);
             }
@@ -111,15 +117,55 @@ public static partial class SkillScanner
         return new SkillScanResult(accepted, issues);
     }
 
-    private static SkillEntry? ParseSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues)
+    /// <summary>
+    /// Scans the native skills directory and all external sources, merging results.
+    /// Native skills take highest precedence; external sources follow config order.
+    /// Duplicate names from lower-precedence sources are logged as issues and skipped.
+    /// </summary>
+    public static MergedSkillScanResult ScanAndMerge(
+        string nativeSkillsDirectory,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
+    {
+        var nativeScan = Scan(nativeSkillsDirectory);
+        var allAccepted = new List<SkillEntry>(nativeScan.AcceptedSkills);
+        var allIssues = new List<SkillScanIssue>(nativeScan.Issues);
+
+        var knownNames = new HashSet<string>(
+            nativeScan.AcceptedSkills.Select(s => s.Name), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var source in externalSources)
+        {
+            var externalScan = Scan(source.Path, allowSymlinks: source.AllowSymlinks);
+            allIssues.AddRange(externalScan.Issues);
+
+            foreach (var skill in externalScan.AcceptedSkills)
+            {
+                if (!knownNames.Add(skill.Name))
+                {
+                    allIssues.Add(new SkillScanIssue(
+                        Path: skill.FilePath,
+                        Kind: SkillScanIssueKind.DuplicateName,
+                        Message: $"Skill '{skill.Name}' from external source '{source.Name}' is shadowed by a higher-precedence skill.",
+                        SkillName: skill.Name));
+                    continue;
+                }
+
+                allAccepted.Add(skill);
+            }
+        }
+
+        return new MergedSkillScanResult(allAccepted, allIssues);
+    }
+
+    private static SkillEntry? ParseSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false)
     {
         var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
-        var canonicalSkillFilePath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "skill file");
+        var canonicalSkillFilePath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "skill file", allowSymlinks);
         if (canonicalSkillFilePath is null)
             return null;
 
         var skillDirectory = Path.GetDirectoryName(canonicalSkillFilePath)!;
-        var canonicalSkillDirectory = ValidateCanonicalPath(skillDirectory, canonicalRoot, issues, "skill directory");
+        var canonicalSkillDirectory = ValidateCanonicalPath(skillDirectory, canonicalRoot, issues, "skill directory", allowSymlinks);
         if (canonicalSkillDirectory is null)
             return null;
 
@@ -151,7 +197,7 @@ public static partial class SkillScanner
             return null;
         }
 
-        return BuildEntryFromFrontmatter(frontmatter, content, canonicalSkillFilePath, canonicalSkillDirectory, canonicalRoot, issues);
+        return BuildEntryFromFrontmatter(frontmatter, content, canonicalSkillFilePath, canonicalSkillDirectory, canonicalRoot, issues, allowSymlinks);
     }
 
     /// <summary>
@@ -198,16 +244,9 @@ public static partial class SkillScanner
         string content,
         string filePath,
         string skillDirectory,
-        string rootDirectory)
-        => BuildEntryFromFrontmatter(fm, content, filePath, skillDirectory, rootDirectory, []);
-
-    private static SkillEntry? BuildEntryFromFrontmatter(
-        SkillFrontmatter fm,
-        string content,
-        string filePath,
-        string skillDirectory,
         string rootDirectory,
-        List<SkillScanIssue> issues)
+        List<SkillScanIssue> issues,
+        bool allowSymlinks = false)
     {
         // Description is required per AgentSkills.io spec
         if (string.IsNullOrWhiteSpace(fm.Description))
@@ -257,7 +296,7 @@ public static partial class SkillScanner
             version = versionValue;
 
         var issueCountBeforeResourceScan = issues.Count;
-        var resourcePaths = EnumerateResources(skillDirectory, rootDirectory, issues);
+        var resourcePaths = EnumerateResources(skillDirectory, rootDirectory, issues, allowSymlinks);
         if (issues.Count > issueCountBeforeResourceScan)
             return null;
 
@@ -284,7 +323,7 @@ public static partial class SkillScanner
     /// Enumerates resource files in standard subdirectories of a skill directory.
     /// Returns null if no resources are found.
     /// </summary>
-    private static IReadOnlyList<string>? EnumerateResources(string skillDirectory, string rootDirectory, List<SkillScanIssue> issues)
+    private static IReadOnlyList<string>? EnumerateResources(string skillDirectory, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false)
     {
         List<string>? resources = null;
         var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
@@ -295,7 +334,7 @@ public static partial class SkillScanner
             if (!Directory.Exists(subDir))
                 continue;
 
-            if (ValidateCanonicalPath(subDir, canonicalRoot, issues, $"resource directory '{subDirName}'") is null)
+            if (ValidateCanonicalPath(subDir, canonicalRoot, issues, $"resource directory '{subDirName}'", allowSymlinks) is null)
                 return null;
 
             string[] files;
@@ -314,7 +353,7 @@ public static partial class SkillScanner
 
             foreach (var file in files)
             {
-                if (ValidateCanonicalPath(file, canonicalRoot, issues, "resource file") is null)
+                if (ValidateCanonicalPath(file, canonicalRoot, issues, "resource file", allowSymlinks) is null)
                     return null;
 
                 var relativePath = Path.GetRelativePath(skillDirectory, file)
@@ -355,14 +394,15 @@ public static partial class SkillScanner
     internal static string NormalizeSkillName(string value)
         => value.Trim().ToLowerInvariant();
 
-    private static string NormalizeDirectoryPath(string path)
+    internal static string NormalizeDirectoryPath(string path)
         => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     private static string? ValidateCanonicalPath(
         string path,
         string canonicalRoot,
         List<SkillScanIssue> issues,
-        string label)
+        string label,
+        bool allowSymlinks = false)
     {
         var normalizedPath = Path.GetFullPath(path);
         var normalizedDirectoryPath = NormalizeDirectoryPath(normalizedPath);
@@ -376,7 +416,7 @@ public static partial class SkillScanner
             return null;
         }
 
-        if (ContainsSymlink(normalizedPath, canonicalRoot))
+        if (!allowSymlinks && ContainsSymlink(normalizedPath, canonicalRoot))
         {
             issues.Add(new SkillScanIssue(
                 Path: normalizedPath,
@@ -388,7 +428,7 @@ public static partial class SkillScanner
         return normalizedPath;
     }
 
-    private static bool IsUnderRoot(string path, string canonicalRoot)
+    internal static bool IsUnderRoot(string path, string canonicalRoot)
         => path.Equals(canonicalRoot, StringComparison.Ordinal)
             || path.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
             || path.StartsWith(canonicalRoot + Path.AltDirectorySeparatorChar, StringComparison.Ordinal);

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -31,6 +31,7 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
     private readonly SkillIndexContextLayer _skillIndexLayer;
     private readonly NetclawPaths _paths;
     private readonly ISkillContentScanner _scanner;
+    private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
 
     public record Params(
         [property: Description("Action to perform: create, edit, patch, delete, write_file, remove_file")]
@@ -54,12 +55,14 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         SkillRegistry skillRegistry,
         SkillIndexContextLayer skillIndexLayer,
         NetclawPaths paths,
-        ISkillContentScanner scanner)
+        ISkillContentScanner scanner,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
     {
         _skillRegistry = skillRegistry;
         _skillIndexLayer = skillIndexLayer;
         _paths = paths;
         _scanner = scanner;
+        _externalSources = externalSources;
     }
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
@@ -161,6 +164,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (IsSystemCategory(skill))
             return "Cannot edit system skills. System skills are read-only.";
 
+        if (IsExternalSkill(skill))
+            return "Cannot edit external skills. External skill directories are read-only.";
+
         var contentError = ValidateFrontmatter(args.Content);
         if (contentError is not null) return contentError;
 
@@ -198,6 +204,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
         if (IsSystemCategory(skill))
             return "Cannot patch system skills. System skills are read-only.";
+
+        if (IsExternalSkill(skill))
+            return "Cannot patch external skills. External skill directories are read-only.";
 
         // Determine target file
         var targetPath = skill.FilePath;
@@ -271,6 +280,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (IsSystemCategory(skill))
             return "Cannot delete system skills. System skills are read-only.";
 
+        if (IsExternalSkill(skill))
+            return "Cannot delete external skills. External skill directories are read-only.";
+
         Directory.Delete(skill.SkillDirectory, recursive: true);
 
         // Clean empty parent category directories
@@ -301,6 +313,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
         if (IsSystemCategory(skill))
             return "Cannot write files in system skills. System skills are read-only.";
+
+        if (IsExternalSkill(skill))
+            return "Cannot write files in external skills. External skill directories are read-only.";
 
         var fileError = ValidateResourcePath(args.FilePath);
         if (fileError is not null) return fileError;
@@ -343,6 +358,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
         if (IsSystemCategory(skill))
             return "Cannot remove files from system skills. System skills are read-only.";
+
+        if (IsExternalSkill(skill))
+            return "Cannot remove files from external skills. External skill directories are read-only.";
 
         var fileError = ValidateResourcePath(args.FilePath);
         if (fileError is not null) return fileError;
@@ -446,6 +464,13 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
     private static bool IsSystemCategory(SkillEntry skill)
         => string.Equals(skill.Category, SkillScanner.SystemCategory, StringComparison.Ordinal);
 
+    private bool IsExternalSkill(SkillEntry skill)
+    {
+        var nativeRoot = SkillScanner.NormalizeDirectoryPath(_paths.SkillsDirectory);
+        var skillPath = SkillScanner.NormalizeDirectoryPath(Path.GetDirectoryName(skill.FilePath)!);
+        return !SkillScanner.IsUnderRoot(skillPath, nativeRoot);
+    }
+
     private static void AtomicWrite(string path, string content)
     {
         var tempPath = path + ".tmp";
@@ -455,9 +480,12 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
     private Netclaw.Actors.Skills.SkillScanResult RescanAndUpdateIndex()
     {
-        var scanResult = SkillScanner.Scan(_paths.SkillsDirectory);
-        SkillRegistryUpdater.ApplyScanResult(_skillRegistry, _skillIndexLayer, scanResult, _paths.SkillsDirectory);
-        return scanResult;
+        var mergedResult = SkillScanner.ScanAndMerge(_paths.SkillsDirectory, _externalSources);
+        SkillRegistryUpdater.ApplyMergedScanResult(
+            _skillRegistry, _skillIndexLayer, mergedResult, _paths.SkillsDirectory, _externalSources);
+
+        // Return as SkillScanResult for AppendScanWarnings compatibility
+        return new Netclaw.Actors.Skills.SkillScanResult(mergedResult.AcceptedSkills, mergedResult.Issues);
     }
 
     private static string AppendScanWarnings(string message, Netclaw.Actors.Skills.SkillScanResult scanResult)

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -50,11 +50,12 @@ public static class ToolRegistrationExtensions
         SkillRegistry skillRegistry,
         SkillIndexContextLayer skillIndexLayer,
         NetclawPaths paths,
-        ISkillContentScanner scanner)
+        ISkillContentScanner scanner,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
     {
         registry.Register(new SkillLoadTool(skillRegistry, scanner));
         registry.Register(new SkillReadResourceTool(skillRegistry, scanner));
-        registry.Register(new SkillManageTool(skillRegistry, skillIndexLayer, paths, scanner));
+        registry.Register(new SkillManageTool(skillRegistry, skillIndexLayer, paths, scanner, externalSources));
         return registry;
     }
 

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -1,0 +1,99 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for loading skills from external directories
+/// (e.g., Claude Code, Open Code, or custom team skill directories).
+/// </summary>
+public sealed class ExternalSkillsConfig
+{
+    /// <summary>
+    /// Ordered list of external skill sources. Precedence follows list order —
+    /// earlier sources win on name collisions (native Netclaw skills always take
+    /// highest precedence regardless of order).
+    /// </summary>
+    public List<ExternalSkillSource> Sources { get; set; } = [];
+
+    /// <summary>
+    /// Resolves well-known aliases to absolute paths, filters to enabled sources
+    /// whose directories exist, and returns the resolved list.
+    /// </summary>
+    public IReadOnlyList<ResolvedExternalSource> ResolveEnabledSources()
+    {
+        var results = new List<ResolvedExternalSource>();
+
+        foreach (var source in Sources)
+        {
+            if (!source.Enabled)
+                continue;
+
+            var resolvedPath = source.WellKnown is not null
+                ? ResolveWellKnownPath(source.WellKnown)
+                : source.Path;
+
+            if (string.IsNullOrWhiteSpace(resolvedPath))
+                continue;
+
+            var fullPath = Path.GetFullPath(resolvedPath);
+            if (!Directory.Exists(fullPath))
+                continue;
+
+            results.Add(new ResolvedExternalSource(source.Name, fullPath, source.AllowSymlinks));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Maps well-known source aliases to their standard directory paths.
+    /// </summary>
+    internal static string? ResolveWellKnownPath(string wellKnown)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return wellKnown.ToLowerInvariant() switch
+        {
+            "claude-code" => Path.Combine(home, ".claude", "skills"),
+            "open-code" => Path.Combine(home, ".open-code", "skills"),
+            _ => null
+        };
+    }
+}
+
+/// <summary>
+/// Configuration for a single external skill source.
+/// </summary>
+public sealed class ExternalSkillSource
+{
+    /// <summary>
+    /// Unique identifier for this source (e.g., "claude-code", "team-skills").
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Absolute path to the skill directory. Mutually exclusive with <see cref="WellKnown"/>.
+    /// </summary>
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Well-known source alias that resolves to a standard path.
+    /// Supported values: "claude-code", "open-code".
+    /// Mutually exclusive with <see cref="Path"/>.
+    /// </summary>
+    public string? WellKnown { get; set; }
+
+    /// <summary>
+    /// Whether this source is active. Default: <c>true</c>.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Whether to allow symlinks within this external directory.
+    /// Resolved paths are still validated to stay within the source root.
+    /// Default: <c>false</c>.
+    /// </summary>
+    public bool AllowSymlinks { get; set; }
+}
+
+/// <summary>
+/// A resolved external skill source with an absolute path ready for scanning.
+/// </summary>
+public sealed record ResolvedExternalSource(string Name, string Path, bool AllowSymlinks);

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -303,6 +303,47 @@
       },
       "additionalProperties": false
     },
+    "ExternalSkills": {
+      "type": "object",
+      "description": "External skill directory sources (Claude Code, Open Code, custom paths).",
+      "properties": {
+        "Sources": {
+          "type": "array",
+          "description": "Ordered list of external skill sources. Precedence follows list order; native Netclaw skills always win.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Name": {
+                "type": "string",
+                "description": "Unique identifier for this source (e.g., 'claude-code', 'team-skills')."
+              },
+              "Path": {
+                "type": ["string", "null"],
+                "description": "Absolute path to the skill directory. Mutually exclusive with WellKnown."
+              },
+              "WellKnown": {
+                "type": ["string", "null"],
+                "enum": ["claude-code", "open-code", null],
+                "description": "Well-known source alias. Resolves to a standard path automatically."
+              },
+              "Enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this source is active."
+              },
+              "AllowSymlinks": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to follow symlinks in this directory. Resolved paths are still validated to stay within the source root."
+              }
+            },
+            "required": ["Name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "SubAgents": {
       "type": "object",
       "description": "Timeout configuration for subagent execution (seconds).",

--- a/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
@@ -21,7 +21,8 @@ internal static class SkillToolRegistration
         var skillIndexLayer = services.GetRequiredService<SkillIndexContextLayer>();
         var paths = services.GetRequiredService<NetclawPaths>();
         var scanner = services.GetRequiredService<ISkillContentScanner>();
+        var externalSources = services.GetRequiredService<IReadOnlyList<ResolvedExternalSource>>();
 
-        registry.WithSkillTools(skillRegistry, skillIndexLayer, paths, scanner);
+        registry.WithSkillTools(skillRegistry, skillIndexLayer, paths, scanner, externalSources);
     }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -410,7 +410,16 @@ static void ConfigureDaemonServices(
     // Skills system: seed built-in skills to .system/, register sync service
     CopyBuiltInSkills(paths.SystemSkillsDirectory);
     var skillRegistry = new SkillRegistry();
-    var initialSkillScan = SkillScanner.Scan(paths.SkillsDirectory);
+
+    // External skill sources (Claude Code, Open Code, custom paths)
+    var externalSkillsConfig = configuration.GetSection("ExternalSkills")
+        .Get<ExternalSkillsConfig>() ?? new ExternalSkillsConfig();
+    var resolvedExternalSources = externalSkillsConfig.ResolveEnabledSources();
+    services.AddSingleton(externalSkillsConfig);
+    services.AddSingleton(resolvedExternalSources);
+
+    // Scan native skills first (highest precedence), then external sources
+    var initialSkillScan = SkillScanner.ScanAndMerge(paths.SkillsDirectory, resolvedExternalSources);
     skillRegistry.ReplaceAll(initialSkillScan.AcceptedSkills, initialSkillScan.Issues);
     services.AddSingleton(skillRegistry);
 
@@ -520,13 +529,13 @@ static void ConfigureDaemonServices(
 
     // Skill index context layer — compressed format pointing at files on disk, rebuilt by sync service
     var skillIndexLayer = new SkillIndexContextLayer();
-    skillIndexLayer.Update(skillRegistry.GenerateIndex(paths.SkillsDirectory));
+    skillIndexLayer.Update(skillRegistry.GenerateIndex(paths.SkillsDirectory, resolvedExternalSources));
     services.AddSingleton(skillIndexLayer);
     services.AddSingleton<IContextLayerProvider>(skillIndexLayer);
 
     // Skill tools are registered post-build so ISkillContentScanner resolves from DI.
     // See SkillToolRegistration call after app.Build().
-    if (initialSkillScan.HasIssues)
+    if (initialSkillScan.Issues.Count > 0)
     {
         using var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(daemonLogLevel));
         var startupLogger = loggerFactory.CreateLogger("Netclaw.Startup");
@@ -871,8 +880,7 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(
 }
 
 /// <summary>
-/// Copies built-in skill files from the output directory to the skills directory.
-/// Skills are sourced from <c>feeds/skills/.system/files/</c> and copied to the
+/// Copies built-in system skills from the daemon's embedded resources into
 /// build output as <c>BuiltInSkills/{skill-name}/SKILL.md</c> (with companion files).
 /// Only writes files that do not already exist (feed updates are preserved).
 /// </summary>

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -30,6 +30,7 @@ internal sealed class SystemSkillSyncService : IHostedService
     private readonly ILogger<SystemSkillSyncService> _logger;
     private readonly string _daemonVersion;
     private readonly ISkillContentScanner _scanner;
+    private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
 
     public SystemSkillSyncService(
         HttpClient httpClient,
@@ -40,9 +41,10 @@ internal sealed class SystemSkillSyncService : IHostedService
         TimeProvider timeProvider,
         ISkillContentScanner scanner,
         ILogger<SystemSkillSyncService> logger,
+        IReadOnlyList<ResolvedExternalSource> externalSources,
         IChatClientProvider? chatClientProvider = null)
         : this(httpClient, paths, skillSyncConfig, skillRegistry, skillIndexLayer,
-            timeProvider, scanner, logger, BuildInfo.Version)
+            timeProvider, scanner, logger, BuildInfo.Version, externalSources)
     {
     }
 
@@ -56,7 +58,8 @@ internal sealed class SystemSkillSyncService : IHostedService
         TimeProvider timeProvider,
         ISkillContentScanner scanner,
         ILogger<SystemSkillSyncService> logger,
-        string daemonVersion)
+        string daemonVersion,
+        IReadOnlyList<ResolvedExternalSource>? externalSources = null)
     {
         _httpClient = httpClient;
         _paths = paths;
@@ -67,6 +70,7 @@ internal sealed class SystemSkillSyncService : IHostedService
         _scanner = scanner;
         _logger = logger;
         _daemonVersion = daemonVersion;
+        _externalSources = externalSources ?? [];
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -343,17 +347,18 @@ internal sealed class SystemSkillSyncService : IHostedService
     /// </summary>
     private void RescanAndUpdateIndex()
     {
-        var scanResult = SkillScanner.Scan(_paths.SkillsDirectory);
-        SkillRegistryUpdater.ApplyScanResult(_skillRegistry, _skillIndexLayer, scanResult, _paths.SkillsDirectory);
+        var mergedResult = SkillScanner.ScanAndMerge(_paths.SkillsDirectory, _externalSources);
+        SkillRegistryUpdater.ApplyMergedScanResult(
+            _skillRegistry, _skillIndexLayer, mergedResult, _paths.SkillsDirectory, _externalSources);
 
-        if (scanResult.HasIssues)
+        if (mergedResult.Issues.Count > 0)
         {
             _logger.LogWarning(
                 "Skill inventory is degraded after sync rebuild: accepted={AcceptedSkillCount} rejected={RejectedIssueCount}",
-                scanResult.AcceptedSkills.Count,
-                scanResult.Issues.Count);
+                mergedResult.AcceptedSkills.Count,
+                mergedResult.Issues.Count);
 
-            foreach (var issue in scanResult.Issues)
+            foreach (var issue in mergedResult.Issues)
             {
                 _logger.LogWarning(
                     "Rejected skill item during sync rebuild: kind={IssueKind} path={Path} message={Message}",
@@ -364,7 +369,7 @@ internal sealed class SystemSkillSyncService : IHostedService
         }
         else
         {
-            _logger.LogInformation("Skill description menu updated ({SkillCount} skills)", scanResult.AcceptedSkills.Count);
+            _logger.LogInformation("Skill description menu updated ({SkillCount} skills)", mergedResult.AcceptedSkills.Count);
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `ExternalSkills.Sources` config section for loading skills from Claude Code (`~/.claude/skills/`), Open Code, or custom team directories alongside native Netclaw skills
- Per-source `AllowSymlinks` policy — external dirs like Claude Code can opt in while native `~/.netclaw/skills/` stays locked down
- External directories are read-only — `skill_manage` guards all write operations
- Multi-source merge with native-wins precedence on name collisions
- Multi-root LLM index format so the agent knows where to `file_read` skills from each source

### Example config

```json
{
  "ExternalSkills": {
    "Sources": [
      {
        "Name": "claude-code",
        "WellKnown": "claude-code",
        "AllowSymlinks": true
      },
      {
        "Name": "team-skills",
        "Path": "/shared/team-skills"
      }
    ]
  }
}
```

## Test plan

- [x] All 1,654 existing tests pass
- [x] New tests: symlink allow/deny scanning, multi-root index generation, external skill write rejection
- [ ] Manual: add `ExternalSkills` config pointing to `~/.claude/skills/`, restart daemon, verify skills appear
- [ ] Manual: verify `skill_manage` rejects edits to external skills

## Follow-up

- Init wizard step to detect and suggest external skill directories: #502