### PR TITLE
fix(sessions): persist delivery retry eligibility in snapshot

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -1432,7 +1432,10 @@ public class LlmSessionIntegrationTests : TestKit
         });
 
         child.Tell(ReceiveTimeout.Instance);
-        sessionManager.Tell(new DeliveryFailed
+        // Send directly to child (not via sessionManager) so Akka's single-sender
+        // ordering guarantee ensures the message arrives during Passivating, not
+        // after the actor has stopped and been re-created by the entity parent.
+        child.Tell(new DeliveryFailed
         {
             SessionId = sessionId,
             TurnNumber = completed.TurnNumber,

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -17,4 +17,12 @@ public sealed class SessionSnapshot
 
     [ProtoMember(3)]
     public string? Title { get; set; }
+
+    /// <summary>
+    /// Persisted so a recovered session can handle late-arriving
+    /// <see cref="DeliveryFailed"/> feedback after passivation.
+    /// Null when no turn is eligible (initial state or retries exhausted).
+    /// </summary>
+    [ProtoMember(4)]
+    public int? EligibleDeliveryTurnNumber { get; set; }
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -209,6 +209,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (offer.Snapshot is SessionSnapshot snapshot)
             {
                 _state = SessionState.FromSnapshot(snapshot);
+                if (snapshot.EligibleDeliveryTurnNumber is { } eligibleTurn)
+                    _deliveryRetry.MarkEligible(eligibleTurn);
                 _log.Info("Recovered from snapshot (turns={TurnCount})", _state.TurnCount);
             }
         });
@@ -932,7 +934,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                         Title: "compaction-boundary",
                         UpdateSemantics: "append-document")));
 
-                SaveSnapshot(_state.ToSnapshot());
+                SaveSnapshot(BuildSnapshot());
 
                 EmitOutput(new CompactionOutput
                 {
@@ -1142,7 +1144,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void CompletePassivation()
     {
         _lifecycleObserver?.OnSessionDeactivated(_sessionId);
-        SaveSnapshot(_state.ToSnapshot());
+        SaveSnapshot(BuildSnapshot());
         _restartDrainReplyTo?.Tell(CommandAck.For(_sessionId));
         _restartDrainReplyTo = null;
         Context.Stop(Self);
@@ -2243,11 +2245,18 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _log.Info("Dynamically loaded tool '{ToolName}' into session", toolName);
     }
 
+    private SessionSnapshot BuildSnapshot()
+    {
+        var snapshot = _state.ToSnapshot();
+        snapshot.EligibleDeliveryTurnNumber = _deliveryRetry.EligibleTurnNumber;
+        return snapshot;
+    }
+
     private void MaybeSnapshot()
     {
         if (_config.Tuning.SnapshotInterval > 0 && LastSequenceNr % _config.Tuning.SnapshotInterval == 0)
         {
-            SaveSnapshot(_state.ToSnapshot());
+            SaveSnapshot(BuildSnapshot());
         }
     }
 


### PR DESCRIPTION
## Summary

- **Production bug fix**: `DeliveryRetryHandler._eligibleTurnNumber` was pure in-memory state lost on passivation. If a channel reported delivery failure (e.g. `MessageTooLarge`) after the session stopped, the recovered instance discarded the feedback as stale (`eligibleTurn=none`), silently dropping the retry.
- **Snapshot persistence**: Added `EligibleDeliveryTurnNumber` (`int?`, `[ProtoMember(4)]`) to `SessionSnapshot`. Restored via `MarkEligible()` during `SnapshotOffer` recovery. Backward-compatible — old snapshots deserialize with `null`.
- **Test race fix**: Changed `Delivery_feedback_during_passivation_aborts_shutdown_and_retries_latest_turn` to send `DeliveryFailed` directly to the child actor instead of through `sessionManager`, leveraging Akka's single-sender ordering guarantee to eliminate the cross-mailbox race.

## Test plan

- [x] Specific test passes 10/10 runs locally (was flaky before)
- [x] Full `Netclaw.Actors.Tests` suite passes (761/761)
- [ ] CI passes