### PR TITLE
Init wizard: detect and suggest external skill directories

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExternalSkillsStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExternalSkillsStepViewModelTests.cs
@@ -1,0 +1,215 @@
+using Netclaw.Cli.Tui.Wizard;
+using Netclaw.Cli.Tui.Wizard.Steps;
+using Netclaw.Configuration;
+using Netclaw.Providers;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui.Wizard;
+
+public sealed class ExternalSkillsStepViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly WizardContext _context;
+
+    private static readonly IReadOnlyList<WellKnownProbeResult> TwoSources =
+    [
+        new("claude-code", "Claude Code", "/home/user/.claude/skills", true),
+        new("open-code", "Open Code", "/home/user/.open-code/skills", false)
+    ];
+
+    private static readonly IReadOnlyList<WellKnownProbeResult> OnlyClaudeCode =
+    [
+        new("claude-code", "Claude Code", "/home/user/.claude/skills", true)
+    ];
+
+    private static readonly IReadOnlyList<WellKnownProbeResult> NoSources = [];
+
+    public ExternalSkillsStepViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        var paths = new NetclawPaths(_tempDir);
+        paths.EnsureDirectoriesExist();
+        _context = new WizardContext
+        {
+            Paths = paths,
+            Registry = new ProviderDescriptorRegistry([]),
+            RequestRedraw = () => { }
+        };
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void IsApplicable_True_WhenSourcesDetected()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        Assert.True(step.IsApplicable(_context));
+    }
+
+    [Fact]
+    public void IsApplicable_False_WhenNoSourcesDetected()
+    {
+        using var step = new ExternalSkillsStepViewModel(NoSources);
+        Assert.False(step.IsApplicable(_context));
+    }
+
+    [Fact]
+    public void AllSourcesEnabledByDefault()
+    {
+        using var step = new ExternalSkillsStepViewModel(TwoSources);
+        Assert.True(step.IsSourceEnabled(0));
+        Assert.True(step.IsSourceEnabled(1));
+    }
+
+    [Fact]
+    public void ToggleSource_FlipsEnabled()
+    {
+        using var step = new ExternalSkillsStepViewModel(TwoSources);
+
+        step.ToggleSource(0);
+        Assert.False(step.IsSourceEnabled(0));
+        Assert.True(step.IsSourceEnabled(1));
+
+        step.ToggleSource(0);
+        Assert.True(step.IsSourceEnabled(0));
+    }
+
+    [Fact]
+    public void SubStepCount_IsTwo_WithoutCustomPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        Assert.Equal(2, step.SubStepCount);
+    }
+
+    [Fact]
+    public void SubStepCount_IsThree_WithCustomPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.CustomPath = "/opt/team/skills";
+        Assert.Equal(3, step.SubStepCount);
+    }
+
+    [Fact]
+    public void TryAdvance_FromChecklist_GoesToCustomPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(1, step.CurrentSubStep);
+    }
+
+    [Fact]
+    public void TryAdvance_FromCustomPath_GoesToSymlink_WhenPathSet()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.TryAdvance(); // → sub-step 1
+        step.CustomPath = "/opt/team/skills";
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(2, step.CurrentSubStep);
+    }
+
+    [Fact]
+    public void TryAdvance_FromCustomPath_Completes_WhenNoPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.TryAdvance(); // → sub-step 1
+
+        Assert.False(step.TryAdvance());
+    }
+
+    [Fact]
+    public void TryGoBack_FromCustomPath_ReturnsToChecklist()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.TryAdvance(); // → sub-step 1
+
+        Assert.True(step.TryGoBack());
+        Assert.Equal(0, step.CurrentSubStep);
+    }
+
+    [Fact]
+    public void TryGoBack_FromChecklist_ReturnsFalse()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+
+        Assert.False(step.TryGoBack());
+    }
+
+    [Fact]
+    public void OnEnter_Back_ResumesAtLastSubStep()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.TryAdvance(); // → sub-step 1
+
+        step.OnEnter(_context, NavigationDirection.Back);
+        Assert.Equal(1, step.CurrentSubStep);
+    }
+
+    [Fact]
+    public void ContributeConfig_WritesEnabledSources()
+    {
+        using var step = new ExternalSkillsStepViewModel(TwoSources);
+        step.ToggleSource(1); // disable Open Code
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.ExternalSkills);
+        Assert.Equal(2, builder.ExternalSkills!.Sources.Count);
+
+        var claude = builder.ExternalSkills.Sources[0];
+        Assert.Equal("claude-code", claude.Name);
+        Assert.Equal("claude-code", claude.WellKnown);
+        Assert.True(claude.Enabled);
+        Assert.True(claude.AllowSymlinks);
+
+        var openCode = builder.ExternalSkills.Sources[1];
+        Assert.Equal("open-code", openCode.Name);
+        Assert.Equal("open-code", openCode.WellKnown);
+        Assert.False(openCode.Enabled);
+        Assert.False(openCode.AllowSymlinks);
+    }
+
+    [Fact]
+    public void ContributeConfig_IncludesCustomPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(OnlyClaudeCode);
+        step.CustomPath = "/opt/team/skills";
+        step.CustomPathAllowSymlinks = true;
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.ExternalSkills);
+        Assert.Equal(2, builder.ExternalSkills!.Sources.Count);
+
+        var custom = builder.ExternalSkills.Sources[1];
+        Assert.Equal("custom", custom.Name);
+        Assert.Equal("/opt/team/skills", custom.Path);
+        Assert.Null(custom.WellKnown);
+        Assert.True(custom.Enabled);
+        Assert.True(custom.AllowSymlinks);
+    }
+
+    [Fact]
+    public void ContributeConfig_NoSection_WhenNoSourcesAndNoCustomPath()
+    {
+        using var step = new ExternalSkillsStepViewModel(NoSources);
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.Null(builder.ExternalSkills);
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -210,4 +210,61 @@ public sealed class WizardConfigBuilderTests : IDisposable
 
         Assert.False(config.ContainsKey("Notifications"));
     }
+
+    [Fact]
+    public void BuildConfigDictionary_IncludesExternalSkills_WhenSet()
+    {
+        var builder = new WizardConfigBuilder(_paths)
+        {
+            ExternalSkills = new ExternalSkillsConfigSection
+            {
+                Sources =
+                [
+                    new ExternalSkillSource
+                    {
+                        Name = "claude-code",
+                        WellKnown = "claude-code",
+                        Enabled = true,
+                        AllowSymlinks = true
+                    },
+                    new ExternalSkillSource
+                    {
+                        Name = "custom",
+                        Path = "/opt/team/skills",
+                        Enabled = true,
+                        AllowSymlinks = false
+                    }
+                ]
+            }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.True(config.ContainsKey("ExternalSkills"));
+        var section = (Dictionary<string, object>)config["ExternalSkills"];
+        var sources = (object[])section["Sources"];
+        Assert.Equal(2, sources.Length);
+
+        var first = (Dictionary<string, object>)sources[0];
+        Assert.Equal("claude-code", first["Name"]);
+        Assert.Equal("claude-code", first["WellKnown"]);
+        Assert.Equal(true, first["Enabled"]);
+        Assert.Equal(true, first["AllowSymlinks"]);
+        Assert.False(first.ContainsKey("Path"));
+
+        var second = (Dictionary<string, object>)sources[1];
+        Assert.Equal("custom", second["Name"]);
+        Assert.Equal("/opt/team/skills", second["Path"]);
+        Assert.False(second.ContainsKey("WellKnown"));
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_OmitsExternalSkills_WhenNull()
+    {
+        var builder = new WizardConfigBuilder(_paths);
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.False(config.ContainsKey("ExternalSkills"));
+    }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -88,6 +88,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var searchStep = new SearchStepViewModel();
         var browserStep = new BrowserAutomationStepViewModel();
         var identityStep = new IdentityStepViewModel();
+        var externalSkillsStep = new ExternalSkillsStepViewModel();
         _healthCheckStep = new HealthCheckStepViewModel(daemonManager, daemonApi, navigationState);
 
         var steps = new List<IWizardStepViewModel>
@@ -99,6 +100,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             searchStep,
             browserStep,
             identityStep,
+            externalSkillsStep,
             _healthCheckStep
         };
 
@@ -124,6 +126,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             ["search"] = new SearchStepView(),
             ["browser-automation"] = new BrowserAutomationStepView(),
             ["identity"] = new IdentityStepView(),
+            ["external-skills"] = new ExternalSkillsStepView(),
             ["health-check"] = new HealthCheckStepView()
         };
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
@@ -140,54 +140,60 @@ public sealed class ExternalSkillsStepView : IWizardStepView
 
     public bool HandleKeyPress(KeyPressed key)
     {
+        if (_vm is null)
+            return false;
+
         var keyInfo = key.KeyInfo;
 
-        // Sub-step 0: custom checklist navigation
-        if (_vm is { CurrentSubStep: 0 })
+        return _vm.CurrentSubStep switch
         {
-            var sources = _vm.DetectedSources;
-            switch (keyInfo.Key)
-            {
-                case ConsoleKey.UpArrow:
-                    if (_cursorIndex > 0) _cursorIndex--;
-                    break;
+            0 => HandleChecklistKey(keyInfo),
+            1 when _lastFocusedInput is not null => HandleDelegatedInput(keyInfo),
+            2 when _lastFocusedList is not null => HandleDelegatedList(keyInfo),
+            _ => false
+        };
+    }
 
-                case ConsoleKey.DownArrow:
-                    if (_cursorIndex < sources.Count - 1) _cursorIndex++;
-                    break;
+    private bool HandleChecklistKey(ConsoleKeyInfo keyInfo)
+    {
+        var sources = _vm!.DetectedSources;
+        switch (keyInfo.Key)
+        {
+            case ConsoleKey.UpArrow:
+                if (_cursorIndex > 0) _cursorIndex--;
+                break;
 
-                case ConsoleKey.Spacebar:
-                    if (sources.Count > 0)
-                        _vm.ToggleSource(_cursorIndex);
-                    break;
+            case ConsoleKey.DownArrow:
+                if (_cursorIndex < sources.Count - 1) _cursorIndex++;
+                break;
 
-                case ConsoleKey.Enter:
-                    _callbacks?.AdvanceStep();
-                    return true;
+            case ConsoleKey.Spacebar:
+                if (sources.Count > 0)
+                    _vm.ToggleSource(_cursorIndex);
+                break;
 
-                default:
-                    return false;
-            }
+            case ConsoleKey.Enter:
+                _callbacks?.AdvanceStep();
+                return true;
 
-            InvalidateAndRedraw();
-            return true;
+            default:
+                return false;
         }
 
-        // Sub-step 1: text input
-        if (_lastFocusedInput is not null)
-        {
-            _lastFocusedInput.HandleInput(keyInfo);
-            return true;
-        }
+        InvalidateAndRedraw();
+        return true;
+    }
 
-        // Sub-step 2: selection list
-        if (_lastFocusedList is not null)
-        {
-            _lastFocusedList.HandleInput(keyInfo);
-            return true;
-        }
+    private bool HandleDelegatedInput(ConsoleKeyInfo keyInfo)
+    {
+        _lastFocusedInput!.HandleInput(keyInfo);
+        return true;
+    }
 
-        return false;
+    private bool HandleDelegatedList(ConsoleKeyInfo keyInfo)
+    {
+        _lastFocusedList!.HandleInput(keyInfo);
+        return true;
     }
 
     public void HandlePaste(PasteEvent paste)

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
@@ -1,0 +1,213 @@
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui.Wizard.Steps;
+
+/// <summary>
+/// Termina view for the External Skills wizard step.
+/// Sub-step 0: checklist of detected well-known sources (custom keyboard nav).
+/// Sub-step 1: optional custom path text input.
+/// Sub-step 2: symlink toggle for custom path.
+/// </summary>
+public sealed class ExternalSkillsStepView : IWizardStepView
+{
+    private int _cursorIndex;
+    private TextInputNode? _customPathInput;
+    private SelectionListNode<string>? _symlinkList;
+    private IFocusable? _lastFocusedList;
+    private TextInputBaseNode? _lastFocusedInput;
+    private StepViewCallbacks? _callbacks;
+    private ExternalSkillsStepViewModel? _vm;
+
+    public string StepId => "external-skills";
+
+    public ILayoutNode BuildContent(IWizardStepViewModel stepVm, StepViewCallbacks callbacks)
+    {
+        _callbacks = callbacks;
+        _vm = (ExternalSkillsStepViewModel)stepVm;
+
+        return _vm.CurrentSubStep switch
+        {
+            0 => BuildSourceChecklist(),
+            1 => BuildCustomPathInput(callbacks),
+            2 => BuildSymlinkToggle(callbacks),
+            _ => Layouts.Empty()
+        };
+    }
+
+    private ILayoutNode BuildSourceChecklist()
+    {
+        _lastFocusedList = null;
+        _lastFocusedInput = null;
+
+        var sources = _vm!.DetectedSources;
+        if (_cursorIndex >= sources.Count) _cursorIndex = sources.Count - 1;
+        if (_cursorIndex < 0) _cursorIndex = 0;
+
+        var layout = Layouts.Vertical()
+            .WithChild(new TextNode("  External skill directories detected:").WithForeground(Color.White))
+            .WithSpacing(1);
+
+        for (var i = 0; i < sources.Count; i++)
+        {
+            var source = sources[i];
+            var isFocused = i == _cursorIndex;
+            var isEnabled = _vm.IsSourceEnabled(i);
+            var prefix = isFocused ? " \u25b6 " : "   ";
+            var checkbox = isEnabled ? "[x]" : "[ ]";
+            var line = $"{prefix}{checkbox} {source.DisplayName} ({source.ResolvedPath})";
+
+            var node = new TextNode(line);
+            node = isFocused
+                ? node.WithForeground(Color.Cyan).Bold()
+                : node.WithForeground(Color.White);
+            layout = layout.WithChild(node);
+        }
+
+        layout = layout.WithSpacing(1)
+            .WithChild(new TextNode("  Space to toggle, Enter to continue.")
+                .WithForeground(Color.BrightBlack));
+
+        return layout;
+    }
+
+    private ILayoutNode BuildCustomPathInput(StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+
+        _customPathInput = new TextInputNode()
+            .WithPlaceholder("/path/to/team-skills");
+
+        if (!string.IsNullOrWhiteSpace(_vm!.CustomPath))
+            _customPathInput.Text = _vm.CustomPath;
+
+        _customPathInput.OnFocused();
+        _lastFocusedInput = _customPathInput;
+
+        _customPathInput.Submitted
+            .Subscribe(text =>
+            {
+                _vm.CustomPath = string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Add a custom skill directory (optional, Enter to skip):")
+                .WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Path")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_customPathInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildSymlinkToggle(StepViewCallbacks callbacks)
+    {
+        _lastFocusedInput = null;
+
+        _symlinkList = Layouts.SelectionList(
+                "No \u2014 stricter security (default)",
+                "Yes \u2014 needed if skill directory uses symlinks")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _symlinkList.OnFocused();
+        _lastFocusedList = _symlinkList;
+
+        _symlinkList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                _vm!.CustomPathAllowSymlinks = selected[0].StartsWith("Yes", StringComparison.Ordinal);
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Allow symlinks in custom skill directory?")
+                .WithForeground(Color.White))
+            .WithChild(_symlinkList);
+    }
+
+    public bool HandleKeyPress(KeyPressed key)
+    {
+        var keyInfo = key.KeyInfo;
+
+        // Sub-step 0: custom checklist navigation
+        if (_vm is { CurrentSubStep: 0 })
+        {
+            var sources = _vm.DetectedSources;
+            switch (keyInfo.Key)
+            {
+                case ConsoleKey.UpArrow:
+                    if (_cursorIndex > 0) _cursorIndex--;
+                    break;
+
+                case ConsoleKey.DownArrow:
+                    if (_cursorIndex < sources.Count - 1) _cursorIndex++;
+                    break;
+
+                case ConsoleKey.Spacebar:
+                    if (sources.Count > 0)
+                        _vm.ToggleSource(_cursorIndex);
+                    break;
+
+                case ConsoleKey.Enter:
+                    _callbacks?.AdvanceStep();
+                    return true;
+
+                default:
+                    return false;
+            }
+
+            InvalidateAndRedraw();
+            return true;
+        }
+
+        // Sub-step 1: text input
+        if (_lastFocusedInput is not null)
+        {
+            _lastFocusedInput.HandleInput(keyInfo);
+            return true;
+        }
+
+        // Sub-step 2: selection list
+        if (_lastFocusedList is not null)
+        {
+            _lastFocusedList.HandleInput(keyInfo);
+            return true;
+        }
+
+        return false;
+    }
+
+    public void HandlePaste(PasteEvent paste)
+    {
+        _lastFocusedInput?.HandlePaste(paste);
+    }
+
+    public void ClearFocusState()
+    {
+        _lastFocusedList = null;
+        _lastFocusedInput = null;
+        _customPathInput = null;
+        _symlinkList = null;
+        _cursorIndex = 0;
+    }
+
+    private void InvalidateAndRedraw()
+    {
+        _callbacks?.InvalidateContent();
+        _callbacks?.InvalidateHelp();
+        _callbacks?.RequestRedraw();
+    }
+}

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
@@ -1,0 +1,150 @@
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Tui.Wizard.Steps;
+
+/// <summary>
+/// Wizard step for detecting and enabling external skill directories.
+/// Sub-step 0: checklist of detected well-known sources.
+/// Sub-step 1: optional custom path text input.
+/// Sub-step 2 (conditional): symlink toggle for the custom path.
+/// </summary>
+public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
+{
+    private int _currentSubStep;
+    private int _completedSubStep;
+
+    private readonly IReadOnlyList<WellKnownProbeResult> _detectedSources;
+    private readonly bool[] _enabledFlags;
+
+    public string StepId => "external-skills";
+    public string DisplayTitle => "External Skills";
+
+    /// <summary>Custom skill directory path (optional, entered in sub-step 1).</summary>
+    public string? CustomPath { get; set; }
+
+    /// <summary>Whether to allow symlinks in the custom path directory.</summary>
+    public bool CustomPathAllowSymlinks { get; set; }
+
+    public ExternalSkillsStepViewModel()
+    {
+        _detectedSources = ExternalSkillsConfig.ProbeWellKnownSources();
+        _enabledFlags = new bool[_detectedSources.Count];
+        Array.Fill(_enabledFlags, true);
+    }
+
+    /// <summary>Test constructor for injecting fake probe results.</summary>
+    internal ExternalSkillsStepViewModel(IReadOnlyList<WellKnownProbeResult> detectedSources)
+    {
+        _detectedSources = detectedSources;
+        _enabledFlags = new bool[_detectedSources.Count];
+        Array.Fill(_enabledFlags, true);
+    }
+
+    /// <summary>Well-known sources detected on disk.</summary>
+    public IReadOnlyList<WellKnownProbeResult> DetectedSources => _detectedSources;
+
+    /// <summary>Whether the source at the given index is enabled.</summary>
+    public bool IsSourceEnabled(int index) => _enabledFlags[index];
+
+    /// <summary>Toggle the enabled state of the source at the given index.</summary>
+    public void ToggleSource(int index) => _enabledFlags[index] = !_enabledFlags[index];
+
+    public bool IsApplicable(WizardContext context) => _detectedSources.Count > 0;
+
+    public int CurrentSubStep => _currentSubStep;
+
+    public int SubStepCount => HasCustomPath ? 3 : 2;
+
+    private bool HasCustomPath => !string.IsNullOrWhiteSpace(CustomPath);
+
+    public string GetHelpText() => _currentSubStep switch
+    {
+        0 => "  Use Space to toggle, Enter to confirm. Detected skill directories from other AI tools.",
+        1 => "  Optional. Enter a path to a shared team skill directory, or press Enter to skip.",
+        2 => "  Some skill directories use symlinks. Allow symlinks for this custom path?",
+        _ => ""
+    };
+
+    public bool TryAdvance()
+    {
+        if (_currentSubStep == 0)
+        {
+            _currentSubStep = 1;
+            _completedSubStep = 1;
+            return true;
+        }
+
+        if (_currentSubStep == 1 && HasCustomPath)
+        {
+            _currentSubStep = 2;
+            _completedSubStep = 2;
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryGoBack()
+    {
+        if (_currentSubStep > 0)
+        {
+            _currentSubStep--;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void OnEnter(WizardContext context, NavigationDirection direction)
+    {
+        if (direction == NavigationDirection.Forward)
+            _currentSubStep = 0;
+        else
+            _currentSubStep = _completedSubStep;
+    }
+
+    public void OnLeave() { }
+
+    public void ContributeConfig(WizardConfigBuilder builder)
+    {
+        var sources = new List<ExternalSkillSource>();
+
+        for (var i = 0; i < _detectedSources.Count; i++)
+        {
+            var probe = _detectedSources[i];
+            sources.Add(new ExternalSkillSource
+            {
+                Name = probe.WellKnownAlias,
+                WellKnown = probe.WellKnownAlias,
+                Enabled = _enabledFlags[i],
+                AllowSymlinks = probe.DefaultAllowSymlinks
+            });
+        }
+
+        if (HasCustomPath)
+        {
+            sources.Add(new ExternalSkillSource
+            {
+                Name = "custom",
+                Path = CustomPath,
+                Enabled = true,
+                AllowSymlinks = CustomPathAllowSymlinks
+            });
+        }
+
+        if (sources.Count > 0)
+        {
+            builder.ExternalSkills = new ExternalSkillsConfigSection
+            {
+                Sources = sources
+            };
+        }
+    }
+
+    public void ContributeSecrets(WizardSecretsBuilder builder) { }
+
+    public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
+        => Task.CompletedTask;
+
+    public void Dispose() { }
+}

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
@@ -97,10 +97,10 @@ public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
 
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
-        if (direction == NavigationDirection.Forward)
-            _currentSubStep = 0;
-        else
+        if (direction == NavigationDirection.Back)
             _currentSubStep = _completedSubStep;
+        else
+            _currentSubStep = 0;
     }
 
     public void OnLeave() { }

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -32,6 +32,7 @@ public sealed class WizardConfigBuilder
     public IdentityConfigSection? Identity { get; set; }
     public WorkspacesConfigSection? Workspaces { get; set; }
     public NotificationsConfigSection? Notifications { get; set; }
+    public ExternalSkillsConfigSection? ExternalSkills { get; set; }
 
     /// <summary>
     /// Assemble the typed sections into netclaw.json and write it.
@@ -162,6 +163,32 @@ public sealed class WizardConfigBuilder
             ["DisableSystemSkillSync"] = false
         };
 
+        // External skills
+        if (ExternalSkills is { Sources.Count: > 0 })
+        {
+            var sourcesArray = ExternalSkills.Sources.Select(s =>
+            {
+                var entry = new Dictionary<string, object>
+                {
+                    ["Name"] = s.Name,
+                    ["Enabled"] = s.Enabled,
+                    ["AllowSymlinks"] = s.AllowSymlinks
+                };
+
+                if (s.WellKnown is not null)
+                    entry["WellKnown"] = s.WellKnown;
+                else if (s.Path is not null)
+                    entry["Path"] = s.Path;
+
+                return (object)entry;
+            }).ToArray();
+
+            config["ExternalSkills"] = new Dictionary<string, object>
+            {
+                ["Sources"] = sourcesArray
+            };
+        }
+
         // MCP servers (browser automation)
         if (BrowserAutomation is { Enabled: true })
         {
@@ -290,4 +317,9 @@ public sealed class IdentityConfigSection
     public required string CommunicationStyle { get; init; }
     public string? UserName { get; init; }
     public required string UserTimezone { get; init; }
+}
+
+public sealed class ExternalSkillsConfigSection
+{
+    public List<ExternalSkillSource> Sources { get; init; } = [];
 }

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -44,9 +44,32 @@ public sealed class ExternalSkillsConfig
     }
 
     /// <summary>
+    /// Probes the filesystem for well-known external skill directories and returns
+    /// those that exist on disk, with their default configuration values.
+    /// </summary>
+    public static IReadOnlyList<WellKnownProbeResult> ProbeWellKnownSources()
+    {
+        ReadOnlySpan<(string Alias, string DisplayName, bool AllowSymlinks)> wellKnowns =
+        [
+            ("claude-code", "Claude Code", true),
+            ("open-code", "Open Code", false)
+        ];
+
+        var results = new List<WellKnownProbeResult>();
+        foreach (var (alias, displayName, allowSymlinks) in wellKnowns)
+        {
+            var path = ResolveWellKnownPath(alias);
+            if (path is not null && Directory.Exists(path))
+                results.Add(new WellKnownProbeResult(alias, displayName, path, allowSymlinks));
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Maps well-known source aliases to their standard directory paths.
     /// </summary>
-    internal static string? ResolveWellKnownPath(string wellKnown)
+    public static string? ResolveWellKnownPath(string wellKnown)
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         return wellKnown.ToLowerInvariant() switch
@@ -97,3 +120,16 @@ public sealed class ExternalSkillSource
 /// A resolved external skill source with an absolute path ready for scanning.
 /// </summary>
 public sealed record ResolvedExternalSource(string Name, string Path, bool AllowSymlinks);
+
+/// <summary>
+/// Result of probing for a well-known external skill directory.
+/// </summary>
+/// <param name="WellKnownAlias">The alias used in config (e.g., "claude-code").</param>
+/// <param name="DisplayName">Human-readable name (e.g., "Claude Code").</param>
+/// <param name="ResolvedPath">Absolute path on disk.</param>
+/// <param name="DefaultAllowSymlinks">Whether this source should allow symlinks by default.</param>
+public sealed record WellKnownProbeResult(
+    string WellKnownAlias,
+    string DisplayName,
+    string ResolvedPath,
+    bool DefaultAllowSymlinks);

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -7,6 +7,17 @@ namespace Netclaw.Configuration;
 public sealed class ExternalSkillsConfig
 {
     /// <summary>
+    /// Single catalog of well-known external skill sources. Both
+    /// <see cref="ResolveWellKnownPath"/> and <see cref="ProbeWellKnownSources"/>
+    /// consume this so alias/display/symlink metadata stays in one place.
+    /// </summary>
+    private static readonly (string Alias, string DisplayName, string RelativePath, bool DefaultAllowSymlinks)[] WellKnownCatalog =
+    [
+        ("claude-code", "Claude Code", Path.Combine(".claude", "skills"), true),
+        ("open-code", "Open Code", Path.Combine(".open-code", "skills"), false)
+    ];
+
+    /// <summary>
     /// Ordered list of external skill sources. Precedence follows list order —
     /// earlier sources win on name collisions (native Netclaw skills always take
     /// highest precedence regardless of order).
@@ -49,17 +60,13 @@ public sealed class ExternalSkillsConfig
     /// </summary>
     public static IReadOnlyList<WellKnownProbeResult> ProbeWellKnownSources()
     {
-        ReadOnlySpan<(string Alias, string DisplayName, bool AllowSymlinks)> wellKnowns =
-        [
-            ("claude-code", "Claude Code", true),
-            ("open-code", "Open Code", false)
-        ];
-
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var results = new List<WellKnownProbeResult>();
-        foreach (var (alias, displayName, allowSymlinks) in wellKnowns)
+
+        foreach (var (alias, displayName, relativePath, allowSymlinks) in WellKnownCatalog)
         {
-            var path = ResolveWellKnownPath(alias);
-            if (path is not null && Directory.Exists(path))
+            var path = Path.Combine(home, relativePath);
+            if (Directory.Exists(path))
                 results.Add(new WellKnownProbeResult(alias, displayName, path, allowSymlinks));
         }
 
@@ -72,12 +79,15 @@ public sealed class ExternalSkillsConfig
     public static string? ResolveWellKnownPath(string wellKnown)
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return wellKnown.ToLowerInvariant() switch
+        var normalized = wellKnown.ToLowerInvariant();
+
+        foreach (var (alias, _, relativePath, _) in WellKnownCatalog)
         {
-            "claude-code" => Path.Combine(home, ".claude", "skills"),
-            "open-code" => Path.Combine(home, ".open-code", "skills"),
-            _ => null
-        };
+            if (alias == normalized)
+                return Path.Combine(home, relativePath);
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #502

- Adds an **External Skills** wizard step to `netclaw init` that probes for well-known skill directories (`~/.claude/skills`, `~/.open-code/skills`) and lets users toggle each detected source on/off
- Supports optional custom path entry with per-source symlink policy configuration
- Auto-skips when no well-known directories exist on disk (`IsApplicable` returns false)
- Detected sources default to sensible `AllowSymlinks` values (true for Claude Code, false for Open Code)
- Writes selected sources into `ExternalSkills.Sources` config section

### Changes

- **`ExternalSkillsConfig`**: Added `WellKnownCatalog` static registry, `ProbeWellKnownSources()` method, made `ResolveWellKnownPath` public
- **`WizardConfigBuilder`**: Added `ExternalSkillsConfigSection` and serialization for `ExternalSkills` config section
- **New `ExternalSkillsStepViewModel`**: 3 sub-steps (checklist → custom path → symlink toggle), test constructor for deterministic testing
- **New `ExternalSkillsStepView`**: Custom cursor navigation checklist (sub-step 0), text input (sub-step 1), selection list (sub-step 2)
- **`InitWizardViewModel`**: Registered new step between identity and health-check

## Test plan

- [x] `dotnet build` compiles without errors
- [x] All 333 CLI tests pass (including 16 new tests)
- [x] All 112 Configuration tests pass
- [ ] Manual: run `netclaw init` with `~/.claude/skills` present — step appears with Claude Code pre-checked
- [ ] Manual: run `netclaw init` without either directory — step auto-skips
- [ ] Inspect generated `netclaw.json` — `ExternalSkills.Sources` section present with correct structure