### PR TITLE
refactor(wizard): cleanup duplicated patterns, stringly-typed parsing, and wrapper type

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExternalSkillsStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExternalSkillsStepViewModelTests.cs
@@ -165,16 +165,16 @@ public sealed class ExternalSkillsStepViewModelTests : IDisposable
         var builder = new WizardConfigBuilder(_context.Paths);
         step.ContributeConfig(builder);
 
-        Assert.NotNull(builder.ExternalSkills);
-        Assert.Equal(2, builder.ExternalSkills!.Sources.Count);
+        Assert.NotNull(builder.ExternalSkillSources);
+        Assert.Equal(2, builder.ExternalSkillSources!.Count);
 
-        var claude = builder.ExternalSkills.Sources[0];
+        var claude = builder.ExternalSkillSources[0];
         Assert.Equal("claude-code", claude.Name);
         Assert.Equal("claude-code", claude.WellKnown);
         Assert.True(claude.Enabled);
         Assert.True(claude.AllowSymlinks);
 
-        var openCode = builder.ExternalSkills.Sources[1];
+        var openCode = builder.ExternalSkillSources[1];
         Assert.Equal("open-code", openCode.Name);
         Assert.Equal("open-code", openCode.WellKnown);
         Assert.False(openCode.Enabled);
@@ -191,10 +191,10 @@ public sealed class ExternalSkillsStepViewModelTests : IDisposable
         var builder = new WizardConfigBuilder(_context.Paths);
         step.ContributeConfig(builder);
 
-        Assert.NotNull(builder.ExternalSkills);
-        Assert.Equal(2, builder.ExternalSkills!.Sources.Count);
+        Assert.NotNull(builder.ExternalSkillSources);
+        Assert.Equal(2, builder.ExternalSkillSources!.Count);
 
-        var custom = builder.ExternalSkills.Sources[1];
+        var custom = builder.ExternalSkillSources[1];
         Assert.Equal("custom", custom.Name);
         Assert.Equal("/opt/team/skills", custom.Path);
         Assert.Null(custom.WellKnown);
@@ -210,6 +210,6 @@ public sealed class ExternalSkillsStepViewModelTests : IDisposable
         var builder = new WizardConfigBuilder(_context.Paths);
         step.ContributeConfig(builder);
 
-        Assert.Null(builder.ExternalSkills);
+        Assert.Null(builder.ExternalSkillSources);
     }
 }

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -216,26 +216,23 @@ public sealed class WizardConfigBuilderTests : IDisposable
     {
         var builder = new WizardConfigBuilder(_paths)
         {
-            ExternalSkills = new ExternalSkillsConfigSection
-            {
-                Sources =
-                [
-                    new ExternalSkillSource
-                    {
-                        Name = "claude-code",
-                        WellKnown = "claude-code",
-                        Enabled = true,
-                        AllowSymlinks = true
-                    },
-                    new ExternalSkillSource
-                    {
-                        Name = "custom",
-                        Path = "/opt/team/skills",
-                        Enabled = true,
-                        AllowSymlinks = false
-                    }
-                ]
-            }
+            ExternalSkillSources =
+            [
+                new ExternalSkillSource
+                {
+                    Name = "claude-code",
+                    WellKnown = "claude-code",
+                    Enabled = true,
+                    AllowSymlinks = true
+                },
+                new ExternalSkillSource
+                {
+                    Name = "custom",
+                    Path = "/opt/team/skills",
+                    Enabled = true,
+                    AllowSymlinks = false
+                }
+            ]
         };
 
         var config = builder.BuildConfigDictionary();

--- a/src/Netclaw.Cli/Tui/Wizard/IWizardStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/IWizardStepView.cs
@@ -27,6 +27,14 @@ public sealed class StepViewCallbacks
 
     /// <summary>Request a terminal redraw.</summary>
     public required Action RequestRedraw { get; init; }
+
+    /// <summary>Invalidate content and help, then request a redraw.</summary>
+    public void InvalidateAndRedraw()
+    {
+        InvalidateContent();
+        InvalidateHelp();
+        RequestRedraw();
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/BrowserAutomationStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/BrowserAutomationStepView.cs
@@ -34,9 +34,10 @@ public sealed class BrowserAutomationStepView : IWizardStepView
 
     private ILayoutNode BuildEnableSubStep(BrowserAutomationStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _enabledList = Layouts.SelectionList(
-                "No \u2014 skip browser automation for now",
-                "Yes \u2014 configure browser MCP tools")
+        var noLabel = "No \u2014 skip browser automation for now";
+        var yesLabel = "Yes \u2014 configure browser MCP tools";
+
+        _enabledList = Layouts.SelectionList(noLabel, yesLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -49,16 +50,8 @@ public sealed class BrowserAutomationStepView : IWizardStepView
                 if (selected.Count == 0)
                     return;
 
-                if (selected[0].StartsWith("Yes", StringComparison.Ordinal))
-                {
-                    vm.Enabled = true;
-                    callbacks.AdvanceStep(); // → sub-step 1 via TryAdvance
-                }
-                else
-                {
-                    vm.Enabled = false;
-                    callbacks.AdvanceStep(); // step complete
-                }
+                vm.Enabled = selected[0] == yesLabel;
+                callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
 
@@ -72,8 +65,9 @@ public sealed class BrowserAutomationStepView : IWizardStepView
         var chromeLabel = vm.IsChromeDevToolsAvailable
             ? "Chrome DevTools MCP"
             : $"Chrome DevTools MCP (disabled - {vm.ChromeDevToolsUnavailableReason})";
+        var playwrightLabel = "Playwright MCP";
 
-        _backendList = Layouts.SelectionList(chromeLabel, "Playwright MCP")
+        _backendList = Layouts.SelectionList(chromeLabel, playwrightLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -86,14 +80,13 @@ public sealed class BrowserAutomationStepView : IWizardStepView
                 if (selected.Count == 0)
                     return;
 
-                if (selected[0].StartsWith("Chrome DevTools", StringComparison.Ordinal)
-                    && !vm.IsChromeDevToolsAvailable)
+                if (selected[0] == chromeLabel && !vm.IsChromeDevToolsAvailable)
                 {
                     // Can't select disabled option — show error
                     return;
                 }
 
-                vm.SelectedBackend = selected[0].StartsWith("Playwright", StringComparison.Ordinal)
+                vm.SelectedBackend = selected[0] == playwrightLabel
                     ? BrowserAutomationBackend.Playwright
                     : BrowserAutomationBackend.ChromeDevTools;
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/BrowserAutomationStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/BrowserAutomationStepViewModel.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 public sealed class BrowserAutomationStepViewModel : IWizardStepViewModel
 {
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
 
     public string StepId => "browser-automation";
     public string DisplayTitle => "Browser Automation";
@@ -51,7 +51,7 @@ public sealed class BrowserAutomationStepViewModel : IWizardStepViewModel
         if (_currentSubStep == 0 && Enabled)
         {
             _currentSubStep = 1;
-            _completedSubStep = 1;
+            _highWaterSubStep = 1;
             return true;
         }
         return false;
@@ -70,7 +70,7 @@ public sealed class BrowserAutomationStepViewModel : IWizardStepViewModel
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
         else
             _currentSubStep = 0;
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
@@ -104,7 +104,7 @@ public sealed class ChannelsStepView : IWizardStepView
                 _addMode = false;
                 _addInput = null;
                 _lastFocusedInput = null;
-                InvalidateAndRedraw();
+                _callbacks?.InvalidateAndRedraw();
                 return true;
             }
 
@@ -132,7 +132,7 @@ public sealed class ChannelsStepView : IWizardStepView
                     _addMode = false;
                     _addInput = null;
                     _lastFocusedInput = null;
-                    InvalidateAndRedraw();
+                    _callbacks?.InvalidateAndRedraw();
                     return true;
                 }
 
@@ -197,7 +197,7 @@ public sealed class ChannelsStepView : IWizardStepView
                 return false;
         }
 
-        InvalidateAndRedraw();
+        _callbacks?.InvalidateAndRedraw();
         return true;
     }
 
@@ -214,10 +214,4 @@ public sealed class ChannelsStepView : IWizardStepView
         _cursorIndex = 0;
     }
 
-    private void InvalidateAndRedraw()
-    {
-        _callbacks?.InvalidateContent();
-        _callbacks?.InvalidateHelp();
-        _callbacks?.RequestRedraw();
-    }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepView.cs
@@ -112,9 +112,10 @@ public sealed class ExternalSkillsStepView : IWizardStepView
     {
         _lastFocusedInput = null;
 
-        _symlinkList = Layouts.SelectionList(
-                "No \u2014 stricter security (default)",
-                "Yes \u2014 needed if skill directory uses symlinks")
+        var noLabel = "No \u2014 stricter security (default)";
+        var yesLabel = "Yes \u2014 needed if skill directory uses symlinks";
+
+        _symlinkList = Layouts.SelectionList(noLabel, yesLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -127,7 +128,7 @@ public sealed class ExternalSkillsStepView : IWizardStepView
                 if (selected.Count == 0)
                     return;
 
-                _vm!.CustomPathAllowSymlinks = selected[0].StartsWith("Yes", StringComparison.Ordinal);
+                _vm!.CustomPathAllowSymlinks = selected[0] == yesLabel;
                 callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
@@ -180,7 +181,7 @@ public sealed class ExternalSkillsStepView : IWizardStepView
                 return false;
         }
 
-        InvalidateAndRedraw();
+        _callbacks?.InvalidateAndRedraw();
         return true;
     }
 
@@ -210,10 +211,4 @@ public sealed class ExternalSkillsStepView : IWizardStepView
         _cursorIndex = 0;
     }
 
-    private void InvalidateAndRedraw()
-    {
-        _callbacks?.InvalidateContent();
-        _callbacks?.InvalidateHelp();
-        _callbacks?.RequestRedraw();
-    }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExternalSkillsStepViewModel.cs
@@ -11,7 +11,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
 {
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
 
     private readonly IReadOnlyList<WellKnownProbeResult> _detectedSources;
     private readonly bool[] _enabledFlags;
@@ -70,14 +70,14 @@ public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
         if (_currentSubStep == 0)
         {
             _currentSubStep = 1;
-            _completedSubStep = 1;
+            _highWaterSubStep = 1;
             return true;
         }
 
         if (_currentSubStep == 1 && HasCustomPath)
         {
             _currentSubStep = 2;
-            _completedSubStep = 2;
+            _highWaterSubStep = 2;
             return true;
         }
 
@@ -98,7 +98,7 @@ public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
         else
             _currentSubStep = 0;
     }
@@ -134,10 +134,7 @@ public sealed class ExternalSkillsStepViewModel : IWizardStepViewModel
 
         if (sources.Count > 0)
         {
-            builder.ExternalSkills = new ExternalSkillsConfigSection
-            {
-                Sources = sources
-            };
+            builder.ExternalSkillSources = sources;
         }
     }
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
@@ -9,7 +9,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 public sealed class IdentityStepViewModel : IWizardStepViewModel
 {
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
     private WizardContext? _context;
 
     public string StepId => "identity";
@@ -45,7 +45,7 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
         if (_currentSubStep < SubStepCount - 1)
         {
             _currentSubStep++;
-            _completedSubStep = _currentSubStep;
+            _highWaterSubStep = _currentSubStep;
             return true;
         }
         return false; // step complete
@@ -67,7 +67,7 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
         if (direction == NavigationDirection.Forward)
             _currentSubStep = 0;
         else if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
     }
 
     public void OnLeave() { }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
@@ -88,9 +88,7 @@ public sealed class ProviderStepView : IWizardStepView
                     {
                         vm.SetSubStep(1);
                     }
-                    callbacks.InvalidateContent();
-                    callbacks.InvalidateHelp();
-                    callbacks.RequestRedraw();
+                    callbacks.InvalidateAndRedraw();
                 }
             })
             .DisposeWith(callbacks.Subscriptions);
@@ -136,9 +134,7 @@ public sealed class ProviderStepView : IWizardStepView
                     {
                         vm.SetSubStep(2);
                     }
-                    callbacks.InvalidateContent();
-                    callbacks.InvalidateHelp();
-                    callbacks.RequestRedraw();
+                    callbacks.InvalidateAndRedraw();
                 }
             })
             .DisposeWith(callbacks.Subscriptions);
@@ -170,9 +166,7 @@ public sealed class ProviderStepView : IWizardStepView
                     vm.EndpointInput = string.IsNullOrWhiteSpace(text) ? defaultEndpoint : text;
                     vm.SetSubStep(3);
                     vm.StartProbe();
-                    callbacks.InvalidateContent();
-                    callbacks.InvalidateHelp();
-                    callbacks.RequestRedraw();
+                    callbacks.InvalidateAndRedraw();
                 })
                 .DisposeWith(callbacks.Subscriptions);
 
@@ -203,9 +197,7 @@ public sealed class ProviderStepView : IWizardStepView
                 vm.ApiKeyInput = text;
                 vm.SetSubStep(3);
                 vm.StartProbe();
-                callbacks.InvalidateContent();
-                callbacks.InvalidateHelp();
-                callbacks.RequestRedraw();
+                callbacks.InvalidateAndRedraw();
             })
             .DisposeWith(callbacks.Subscriptions);
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepViewModel.cs
@@ -26,7 +26,7 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
 
     // Sub-step tracking: these map to the same values as the monolith's _providerSubStep
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
 
     public ProviderStepViewModel(
         ProviderDescriptorRegistry registry,
@@ -82,8 +82,8 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
     public void SetSubStep(int step)
     {
         _currentSubStep = step;
-        if (step > _completedSubStep)
-            _completedSubStep = step;
+        if (step > _highWaterSubStep)
+            _highWaterSubStep = step;
     }
 
     public bool TryAdvance()
@@ -132,7 +132,7 @@ public sealed class ProviderStepViewModel : IWizardStepViewModel
     {
         _context = context;
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
     }
 
     public void OnLeave() { }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SearchStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SearchStepView.cs
@@ -37,10 +37,11 @@ public sealed class SearchStepView : IWizardStepView
 
     private ILayoutNode BuildBackendSelection(SearchStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _backendList = Layouts.SelectionList(
-                "DuckDuckGo (default \u2014 no config needed, may hit bot detection)",
-                "Brave Search (API key required \u2014 reliable, fast)",
-                "SearXNG (self-hosted \u2014 endpoint required)")
+        var duckDuckGoLabel = "DuckDuckGo (default \u2014 no config needed, may hit bot detection)";
+        var braveLabel = "Brave Search (API key required \u2014 reliable, fast)";
+        var searxngLabel = "SearXNG (self-hosted \u2014 endpoint required)";
+
+        _backendList = Layouts.SelectionList(duckDuckGoLabel, braveLabel, searxngLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -54,17 +55,17 @@ public sealed class SearchStepView : IWizardStepView
                 if (selected.Count > 0)
                 {
                     var choice = selected[0];
-                    if (choice.StartsWith("DuckDuckGo", StringComparison.Ordinal))
+                    if (choice == duckDuckGoLabel)
                     {
                         vm.SelectedBackend = SearchBackend.DuckDuckGo;
                         callbacks.AdvanceStep(); // step complete, no credentials needed
                     }
-                    else if (choice.StartsWith("Brave", StringComparison.Ordinal))
+                    else if (choice == braveLabel)
                     {
                         vm.SelectedBackend = SearchBackend.Brave;
                         callbacks.AdvanceStep(); // → sub-step 1 (handled by TryAdvance)
                     }
-                    else if (choice.StartsWith("SearXNG", StringComparison.Ordinal))
+                    else if (choice == searxngLabel)
                     {
                         vm.SelectedBackend = SearchBackend.SearXng;
                         callbacks.AdvanceStep(); // → sub-step 1

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SearchStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SearchStepViewModel.cs
@@ -9,7 +9,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 public sealed class SearchStepViewModel : IWizardStepViewModel
 {
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
 
     public string StepId => "search";
     public string DisplayTitle => "Web Search";
@@ -40,7 +40,7 @@ public sealed class SearchStepViewModel : IWizardStepViewModel
         if (_currentSubStep == 0 && NeedsCredentials)
         {
             _currentSubStep = 1;
-            _completedSubStep = 1;
+            _highWaterSubStep = 1;
             return true;
         }
         return false; // step complete
@@ -59,7 +59,7 @@ public sealed class SearchStepViewModel : IWizardStepViewModel
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
         else
             _currentSubStep = 0;
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
@@ -45,7 +45,10 @@ public sealed class SlackStepView : IWizardStepView
 
     private ILayoutNode BuildEnableSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _enabledList = Layouts.SelectionList("Yes \u2014 configure Slack bot", "No \u2014 skip for now")
+        var yesLabel = "Yes \u2014 configure Slack bot";
+        var noLabel = "No \u2014 skip for now";
+
+        _enabledList = Layouts.SelectionList(yesLabel, noLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -58,7 +61,7 @@ public sealed class SlackStepView : IWizardStepView
             {
                 if (selected.Count > 0)
                 {
-                    vm.SlackEnabled = selected[0].StartsWith("Yes", StringComparison.Ordinal);
+                    vm.SlackEnabled = selected[0] == yesLabel;
                     callbacks.AdvanceStep();
                 }
             })
@@ -169,9 +172,10 @@ public sealed class SlackStepView : IWizardStepView
 
     private ILayoutNode BuildDmEnabledSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _dmEnabledList = Layouts.SelectionList(
-                "Yes \u2014 allow approved users to DM the bot",
-                "No \u2014 channel messages only (default)")
+        var dmYesLabel = "Yes \u2014 allow approved users to DM the bot";
+        var dmNoLabel = "No \u2014 channel messages only (default)";
+
+        _dmEnabledList = Layouts.SelectionList(dmYesLabel, dmNoLabel)
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -184,7 +188,7 @@ public sealed class SlackStepView : IWizardStepView
             {
                 if (selected.Count > 0)
                 {
-                    vm.AllowDirectMessages = selected[0].StartsWith("Yes", StringComparison.Ordinal);
+                    vm.AllowDirectMessages = selected[0] == dmYesLabel;
                     callbacks.AdvanceStep();
                 }
             })

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -15,7 +15,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
 
     private readonly ISlackProbe _slackProbe;
     private int _currentSubStep;
-    private int _completedSubStep;
+    private int _highWaterSubStep;
     private WizardContext? _context;
 
     public SlackStepViewModel(ISlackProbe slackProbe)
@@ -58,14 +58,14 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
         if (_currentSubStep == 0 && SlackEnabled)
         {
             _currentSubStep = 1;
-            _completedSubStep = 1;
+            _highWaterSubStep = 1;
             return true;
         }
 
         if (_currentSubStep >= 1 && _currentSubStep < 6 && SlackEnabled)
         {
             _currentSubStep++;
-            _completedSubStep = _currentSubStep;
+            _highWaterSubStep = _currentSubStep;
             return true;
         }
 
@@ -86,7 +86,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
     {
         _context = context;
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _completedSubStep;
+            _currentSubStep = _highWaterSubStep;
         else
             _currentSubStep = 0;
     }

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -318,4 +318,3 @@ public sealed class IdentityConfigSection
     public string? UserName { get; init; }
     public required string UserTimezone { get; init; }
 }
-

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -32,7 +32,7 @@ public sealed class WizardConfigBuilder
     public IdentityConfigSection? Identity { get; set; }
     public WorkspacesConfigSection? Workspaces { get; set; }
     public NotificationsConfigSection? Notifications { get; set; }
-    public ExternalSkillsConfigSection? ExternalSkills { get; set; }
+    public List<ExternalSkillSource>? ExternalSkillSources { get; set; }
 
     /// <summary>
     /// Assemble the typed sections into netclaw.json and write it.
@@ -164,9 +164,9 @@ public sealed class WizardConfigBuilder
         };
 
         // External skills
-        if (ExternalSkills is { Sources.Count: > 0 })
+        if (ExternalSkillSources is { Count: > 0 })
         {
-            var sourcesArray = ExternalSkills.Sources.Select(s =>
+            var sourcesArray = ExternalSkillSources.Select(s =>
             {
                 var entry = new Dictionary<string, object>
                 {
@@ -319,7 +319,3 @@ public sealed class IdentityConfigSection
     public required string UserTimezone { get; init; }
 }
 
-public sealed class ExternalSkillsConfigSection
-{
-    public List<ExternalSkillSource> Sources { get; init; } = [];
-}


### PR DESCRIPTION
## Summary

Addresses all four open `cleanup`-labeled issues:

- **#505** — Extract `InvalidateAndRedraw()` into `StepViewCallbacks`, removing duplicate private methods from `ChannelsStepView`, `ExternalSkillsStepView`, and inline triples from `ProviderStepView`
- **#506** — Replace `StartsWith` stringly-typed selection parsing with label variable equality across `BrowserAutomationStepView`, `SearchStepView`, `ExternalSkillsStepView`, and `SlackStepView`
- **#507** — Rename `_completedSubStep` → `_highWaterSubStep` across all 6 wizard step view models to accurately reflect high-water-mark semantics
- **#508** — Remove unnecessary `ExternalSkillsConfigSection` wrapper, replacing with `List<ExternalSkillSource>?` directly on `WizardConfigBuilder`

Closes #505, closes #506, closes #507, closes #508

## Test plan

- [x] `dotnet build` passes
- [x] All 118 wizard tests pass (`dotnet test --filter Wizard`)
- [ ] CI passes