### PR TITLE
fix(sessions): trigger compaction during tool-loop iterations

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
@@ -1,0 +1,159 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Configuration;
+using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Regression test for #424: compaction never triggers during tool-loop iterations.
+/// Verifies that _lastInputTokenCount is updated from tool-call responses and that
+/// ShouldCompact() is checked before firing follow-up LLM calls in the tool loop.
+/// </summary>
+public class ToolLoopCompactionTests : TestKit
+{
+    private readonly FakeChatClient _fakeChatClient = new();
+    private readonly FakeToolExecutor _fakeToolExecutor = new();
+    private readonly FakeToolAuditLogger _fakeAuditLogger = new();
+
+    public ToolLoopCompactionTests(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
+        services.AddSingleton(new ModelCapabilities
+        {
+            ModelId = "fake-model",
+            ContextWindowTokens = 1000,
+        });
+        services.AddSingleton(new SessionConfig
+        {
+            MaxToolCallsPerTurn = 10, // High enough that budget doesn't interfere
+            Tuning = new SessionTuning
+            {
+                CompactionThreshold = 0.75, // 750 tokens triggers compaction
+                SnapshotInterval = 5,
+                KeepRecentToolResults = 1,
+                KeepRecentMessages = 0,
+                TitleGenerationInterval = 0,
+                MemorySidecarsEnabled = false,
+            }
+        });
+        services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
+            "You are a test assistant with tools."));
+        services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
+        services.AddSingleton<IToolAuditLogger>(_fakeAuditLogger);
+
+        var registry = new ToolRegistry();
+        registry.Register(
+            AIFunctionFactory.Create(() => "search result", "web_search"),
+            "web_search");
+        services.AddSingleton(registry);
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+
+        services.AddSingleton(sp => new SessionServices(
+            sp.GetRequiredService<IChatClientProvider>(),
+            sp.GetRequiredService<ISystemPromptProvider>(),
+            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
+            sp.GetService<TimeProvider>() ?? TimeProvider.System,
+            sp.GetService<NetclawPaths>()));
+        services.AddSingleton(sp => new SessionToolServices(
+            sp.GetRequiredService<IToolExecutor>(),
+            sp.GetService<IToolAuditLogger>(),
+            sp.GetRequiredService<ToolRegistry>(),
+            sp.GetService<ToolAccessPolicy>(),
+            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
+            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
+        services.AddSingleton(sp => new SessionMemoryServices(
+            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
+            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
+            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
+            sp.GetService<SQLiteMemoryStore>()));
+        services.AddSingleton(new SessionObservability(null, null));
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    [Fact]
+    public async Task Compaction_triggers_during_tool_loop_when_token_threshold_exceeded()
+    {
+        // Configure: LLM always returns tool calls with usage exceeding compaction threshold.
+        // Before the fix, _lastInputTokenCount was never updated during tool-call responses,
+        // so ShouldCompact() would never fire mid-loop.
+        _fakeChatClient.ToolCallsOnFirstCall =
+        [
+            new FunctionCallContent("call-1", "web_search",
+                new Dictionary<string, object?> { ["query"] = "test" })
+        ];
+        _fakeChatClient.AlwaysReturnToolCalls = true;
+        _fakeChatClient.UsageOverride = new UsageDetails
+        {
+            InputTokenCount = 800, // Exceeds 750 threshold (0.75 * 1000)
+            OutputTokenCount = 50,
+            TotalTokenCount = 850
+        };
+
+        var sessionId = new SessionId("test-channel/tool-loop-compaction");
+        var sessionManager = ActorRegistry.Get<SessionManagerActorKey>();
+        var subscriber = CreateTestProbe("tool-compact-sub");
+
+        await sessionManager.Ask<SessionJoined>(new JoinSession
+        {
+            SessionId = sessionId,
+            Subscriber = subscriber,
+            Filter = OutputFilter.Full
+        });
+        await subscriber.ExpectMsgAsync<SessionJoined>();
+
+        await sessionManager.Ask<CommandAck>(new SendUserMessage
+        {
+            SessionId = sessionId,
+            Content = "Search for something"
+        });
+
+        // The first LLM call returns a tool call (with 800 token usage).
+        // After tool execution completes, the actor should detect that
+        // _lastInputTokenCount >= threshold and trigger compaction instead
+        // of firing another LLM call.
+        await subscriber.ExpectMsgAsync<ToolCallOutput>();
+        await subscriber.ExpectMsgAsync<UsageOutput>();
+
+        // Compaction should trigger after the tool execution completes.
+        // Lower usage for post-compaction calls so we don't loop forever.
+        _fakeChatClient.UsageOverride = new UsageDetails
+        {
+            InputTokenCount = 100,
+            OutputTokenCount = 20,
+            TotalTokenCount = 120
+        };
+        _fakeChatClient.AlwaysReturnToolCalls = false;
+
+        var compaction = await subscriber.ExpectMsgAsync<CompactionOutput>(TimeSpan.FromSeconds(5));
+        Assert.True(compaction.MessagesAfter < compaction.MessagesBefore,
+            "Compaction should have reduced message count");
+
+        // After compaction, the session drains the buffer and completes the turn.
+        await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5));
+        await subscriber.ExpectMsgAsync<UsageOutput>(TimeSpan.FromSeconds(3));
+        await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3));
+    }
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -71,6 +71,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     // Last observed input token count from LLM response (for compaction trigger)
     private long _lastInputTokenCount;
 
+    // When compaction triggers mid-tool-loop, the turn is still in-progress.
+    // After compaction completes, we need to fire a follow-up LLM call to
+    // continue the turn instead of transitioning to Ready. See #424.
+    private bool _resumeToolLoopAfterCompaction;
+
     // Per-turn transient counters (tool budget, duplicate detection, empty-response retries)
     private readonly TurnStateTracker _turnState = new();
 
@@ -625,6 +630,20 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     break;
             }
 
+            // Check if compaction should trigger before the next LLM call.
+            // Without this, tool-loop iterations never trigger compaction because
+            // HandleToolCallResponse updates _lastInputTokenCount but only
+            // HandleTextResponse checked ShouldCompact(). See #424.
+            if (ShouldCompact())
+            {
+                _log.Info("Compaction threshold reached during tool loop ({InputTokens} tokens >= {Threshold} limit), starting compaction",
+                    _lastInputTokenCount, _model.CompactionTokenLimit(_config.Tuning.CompactionThreshold));
+                _resumeToolLoopAfterCompaction = true;
+                Self.Tell(new CompactionTriggered { InputTokenCount = _lastInputTokenCount });
+                TransitionTo(SessionPhase.Compacting);
+                return;
+            }
+
             // Fire follow-up LLM call with tool results in context
             TurnLog().Info("turn_tool_execution_complete iteration={Iteration} callCount={CallCount} max={Max} resultCount={ResultCount}",
                 _turnState.ToolIterationCount, _turnState.ToolCallCount, _config.MaxToolCallsPerTurn, msg.ToolResults.Count);
@@ -1043,8 +1062,33 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (_restartDrainRequested)
         {
             ClearBufferedMessagesForRestartDrain();
+            _resumeToolLoopAfterCompaction = false;
             TransitionTo(SessionPhase.Ready);
             TransitionTo(SessionPhase.Passivating);
+            return;
+        }
+
+        // Mid-tool-loop compaction: the turn is still in-progress with tool
+        // results in the history. Resume the LLM call to continue the turn. #424
+        if (_resumeToolLoopAfterCompaction)
+        {
+            _resumeToolLoopAfterCompaction = false;
+            _log.Info("Post-compaction: resuming tool loop with follow-up LLM call");
+
+            // Drain any mid-loop buffered messages before the follow-up call
+            if (_buffer.Count > 0)
+            {
+                foreach (var buffered in _buffer)
+                {
+                    var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
+                    _state = _state.AddUserMessage(buffered.Content, refs);
+                }
+                _buffer.Clear();
+            }
+
+            _streamingRetryAttempt = 0;
+            FireLlmCall();
+            TransitionTo(SessionPhase.Processing);
             return;
         }
 
@@ -1280,10 +1324,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             _turnState.TrackToolCall(tc.Name, argsJson);
         }
 
-        // Emit usage if present (intermediate turn)
+        // Emit usage if present (intermediate turn) and track for compaction
         if (usage is not null)
         {
             EmitUsageOutput(usage);
+
+            if (usage.InputTokenCount is > 0)
+            {
+                _lastInputTokenCount = usage.InputTokenCount.Value;
+            }
         }
 
         // Execute tools async — results come back as ToolExecutionCompleted

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -630,10 +630,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     break;
             }
 
-            // Check if compaction should trigger before the next LLM call.
-            // Without this, tool-loop iterations never trigger compaction because
-            // HandleToolCallResponse updates _lastInputTokenCount but only
-            // HandleTextResponse checked ShouldCompact(). See #424.
+            // Compaction check before follow-up LLM call (#424)
             if (ShouldCompact())
             {
                 _log.Info("Compaction threshold reached during tool loop ({InputTokens} tokens >= {Threshold} limit), starting compaction",
@@ -1068,31 +1065,16 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        // Mid-tool-loop compaction: the turn is still in-progress with tool
-        // results in the history. Resume the LLM call to continue the turn. #424
-        if (_resumeToolLoopAfterCompaction)
-        {
-            _resumeToolLoopAfterCompaction = false;
+        // Mid-tool-loop compaction (#424): the turn is still in-progress,
+        // so we must fire a follow-up LLM call even if the buffer is empty.
+        var resumeToolLoop = _resumeToolLoopAfterCompaction;
+        _resumeToolLoopAfterCompaction = false;
+
+        if (resumeToolLoop)
             _log.Info("Post-compaction: resuming tool loop with follow-up LLM call");
 
-            // Drain any mid-loop buffered messages before the follow-up call
-            if (_buffer.Count > 0)
-            {
-                foreach (var buffered in _buffer)
-                {
-                    var refs = buffered.MediaReferences.Count > 0 ? buffered.MediaReferences : null;
-                    _state = _state.AddUserMessage(buffered.Content, refs);
-                }
-                _buffer.Clear();
-            }
-
-            _streamingRetryAttempt = 0;
-            FireLlmCall();
-            TransitionTo(SessionPhase.Processing);
-            return;
-        }
-
-        if (_buffer.Count > 0)
+        var hadBufferedMessages = _buffer.Count > 0;
+        if (hadBufferedMessages)
         {
             _log.Info("Post-compaction: draining {BufferCount} buffered message(s)", _buffer.Count);
             foreach (var buffered in _buffer)
@@ -1101,6 +1083,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 _state = _state.AddUserMessage(buffered.Content, refs);
             }
             _buffer.Clear();
+        }
+
+        if (resumeToolLoop || hadBufferedMessages)
+        {
             _streamingRetryAttempt = 0;
             FireLlmCall();
             TransitionTo(SessionPhase.Processing);


### PR DESCRIPTION
## Summary

Fixes #424 — compaction never triggers during tool-loop iterations.

- **Track `_lastInputTokenCount` in `HandleToolCallResponse`** — usage was emitted to metrics but the compaction threshold field was never updated, so `ShouldCompact()` saw stale values during tool loops
- **Check `ShouldCompact()` in `ToolExecutionCompleted`** before firing the next LLM call — compaction can now trigger mid-loop instead of waiting for a text response that may never come
- **Resume the tool loop after mid-loop compaction** — `_resumeToolLoopAfterCompaction` flag tells `DrainBufferOrReady()` to fire a follow-up LLM call to complete the in-progress turn

Also addresses the llama.cpp silent context shifting problem noted in the issue: if proactive compaction fires before hitting the context limit, the emergency path is never needed.

## Test plan

- [x] New `ToolLoopCompactionTests.Compaction_triggers_during_tool_loop_when_token_threshold_exceeded` — verifies compaction fires mid-tool-loop and the turn completes afterward
- [x] All 9 existing `CompactionIntegrationTests` pass
- [x] All 4 existing `MaxToolIterationTests` pass