### PR TITLE
fix(tools): sanitize MCP tool schemas for llama.cpp compatibility

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -287,4 +287,175 @@ public class McpSchemaSanitizerTests
         Assert.False(normalized.ContainsKey("Url"));
         Assert.False(normalized.ContainsKey("Timeout"));
     }
+
+    [Fact]
+    public void SanitizeSchema_Strips_DollarSchema()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string" }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        Assert.False(sanitized.TryGetProperty("$schema", out _));
+        Assert.Equal("object", sanitized.GetProperty("type").GetString());
+        Assert.True(sanitized.TryGetProperty("properties", out _));
+    }
+
+    [Fact]
+    public void SanitizeSchema_Strips_DollarSchema_InNestedObjects()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" }
+                        }
+                    }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var filters = sanitized.GetProperty("properties").GetProperty("filters");
+
+        Assert.False(filters.TryGetProperty("$schema", out _));
+        Assert.Equal("object", filters.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void SanitizeSchema_NormalizesEmptyAdditionalProperties()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "additionalProperties": {}
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        var ap = sanitized.GetProperty("additionalProperties");
+        Assert.Equal(JsonValueKind.True, ap.ValueKind);
+    }
+
+    [Fact]
+    public void SanitizeSchema_PreservesBooleanAdditionalProperties()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "additionalProperties": false
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        var ap = sanitized.GetProperty("additionalProperties");
+        Assert.Equal(JsonValueKind.False, ap.ValueKind);
+    }
+
+    [Fact]
+    public void SanitizeSchema_PreservesNonEmptyAdditionalProperties()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "additionalProperties": { "type": "string" }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        var ap = sanitized.GetProperty("additionalProperties");
+        Assert.Equal(JsonValueKind.Object, ap.ValueKind);
+        Assert.Equal("string", ap.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void SanitizeSchema_PreservesActualNullValues()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "default": null
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        Assert.True(sanitized.TryGetProperty("default", out var defaultProp));
+        Assert.Equal(JsonValueKind.Null, defaultProp.ValueKind);
+    }
+
+    [Fact]
+    public void SanitizeSchema_HandlesNotionSearchSchema()
+    {
+        // Real-world Notion search schema that was causing 502 errors
+        var schema = JsonDocument.Parse("""
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Search query"
+                    },
+                    "filters": {
+                        "type": "object",
+                        "properties": {
+                            "created_date_range": {
+                                "type": "object",
+                                "properties": {
+                                    "start_date": { "type": "string" }
+                                },
+                                "additionalProperties": {}
+                            }
+                        },
+                        "additionalProperties": {}
+                    }
+                },
+                "required": ["query", "filters"]
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        // $schema stripped at top level
+        Assert.False(sanitized.TryGetProperty("$schema", out _));
+
+        // additionalProperties: {} normalized to true in nested objects
+        var filters = sanitized.GetProperty("properties").GetProperty("filters");
+        Assert.Equal(JsonValueKind.True, filters.GetProperty("additionalProperties").ValueKind);
+
+        var dateRange = filters.GetProperty("properties").GetProperty("created_date_range");
+        Assert.Equal(JsonValueKind.True, dateRange.GetProperty("additionalProperties").ValueKind);
+
+        // Core schema structure preserved
+        Assert.Equal("object", sanitized.GetProperty("type").GetString());
+        Assert.Equal(2, sanitized.GetProperty("required").GetArrayLength());
+    }
 }

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -131,8 +131,10 @@ public static class McpSchemaSanitizer
                 // Recursively sanitize anyOf/oneOf/allOf
                 "anyOf" or "oneOf" or "allOf" => SanitizeSchemaArray(property.Value),
 
-                // Pass through other properties
-                _ => JsonElementToObject(property.Value)
+                // Recursively sanitize all other properties so stripping
+                // rules (e.g. $schema) apply through unrecognized keywords
+                // like patternProperties, not, if/then/else, etc.
+                _ => JsonElementToObject(SanitizeElement(property.Value))
             };
 
             // Skip stripped fields (e.g. $schema)

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -107,9 +107,20 @@ public static class McpSchemaSanitizer
         {
             var value = property.Name switch
             {
+                // Strip $schema meta-reference — not a tool parameter, and it
+                // breaks llama.cpp's JSON-schema-to-GBNF grammar conversion.
+                "$schema" => (object?)null,
+
                 // Handle type arrays like ["string", "null"] -> "string"
                 "type" when property.Value.ValueKind == JsonValueKind.Array =>
                     SimplifyTypeArray(property.Value),
+
+                // Normalize additionalProperties: {} to true. An empty object is
+                // semantically equivalent to true in JSON Schema, but confuses
+                // grammar generators that expect a boolean.
+                "additionalProperties" when property.Value.ValueKind == JsonValueKind.Object
+                    && !property.Value.EnumerateObject().Any()
+                    => true,
 
                 // Recursively sanitize properties object
                 "properties" => SanitizePropertiesObject(property.Value),
@@ -123,6 +134,10 @@ public static class McpSchemaSanitizer
                 // Pass through other properties
                 _ => JsonElementToObject(property.Value)
             };
+
+            // Skip stripped fields (e.g. $schema)
+            if (value is null && property.Value.ValueKind != JsonValueKind.Null)
+                continue;
 
             dict[property.Name] = value;
         }


### PR DESCRIPTION
## Summary

- Strip `$schema` meta-references from MCP tool parameter schemas — these break llama.cpp's JSON-schema-to-GBNF grammar conversion, causing immediate 502 errors when Notion tools are loaded
- Normalize `additionalProperties: {}` (empty object) to `true` — semantically equivalent but compatible with grammar generators that expect a boolean
- Recursively sanitize all schema keywords (not just explicitly-listed ones) so stripping rules apply through `patternProperties`, `not`, `if`/`then`/`else`, etc.

## Test plan

- [x] New tests: `$schema` stripping (top-level and nested), `additionalProperties` normalization, boolean preservation, non-empty object preservation, null value preservation, real-world Notion search schema integration test
- [x] All 12 `McpSchemaSanitizerTests` pass
- [x] All 13 `McpToolAdapterTests` pass
- [ ] Manual: restart netclawd and attempt a Notion search to verify no more 502s