### PR TITLE
chore(deps): bump Akka.Hosting to 1.5.64 + xUnit v2 → v3 migration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,15 @@ dotnet_diagnostic.IDE0072.severity = suggestion
 dotnet_diagnostic.CA1307.severity = suggestion
 dotnet_diagnostic.CA1309.severity = suggestion
 dotnet_diagnostic.CA1310.severity = suggestion
+# xUnit1051 requires TestContext.Current.CancellationToken — defer migration to follow-up PR (#517).
+dotnet_diagnostic.xUnit1051.severity = suggestion
+
+[**/*Tests/*.cs]
+# Same suppressions for test files at the root of a *.Tests project folder.
+dotnet_diagnostic.CA1307.severity = suggestion
+dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1310.severity = suggestion
+dotnet_diagnostic.xUnit1051.severity = suggestion
 
 [*.{md,json,yml,yaml}]
 trim_trailing_whitespace = false

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <AkkaHostingVersion>1.5.63</AkkaHostingVersion>
+    <AkkaHostingVersion>1.5.64</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.62</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.6.0-beta2</AkkaRemindersVersion>
     <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
@@ -54,7 +54,7 @@
   <!-- Test dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
   </ItemGroup>

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -8,7 +8,6 @@ using Netclaw.Actors.Tests.Channels.TestHelpers;
 using Netclaw.Channels.Slack;
 using Netclaw.Security;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Channels;
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -20,7 +20,6 @@ using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Channels;
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackProactiveThreadTests.cs
@@ -13,7 +13,6 @@ using Netclaw.Security;
 using SlackNet;
 using SlackNet.WebApi;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Channels;
 

--- a/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
@@ -327,9 +327,9 @@ public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
         Assert.True(elapsed <= TimeSpan.FromMilliseconds(300));
     }
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await TryDeleteDirectoryAsync(_baseDir);
     }

--- a/src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs
@@ -285,9 +285,9 @@ public sealed class SQLiteMemoryStoreTests : IAsyncLifetime
         Assert.Contains(personalResults, x => x.Id == "doc-personal");
     }
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await TryDeleteDirectoryAsync(_baseDir);
     }

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Akka.Persistence.Hosting" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -9,7 +9,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Reminders;
 

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -9,7 +9,6 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Reminders;
 

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -6,7 +6,6 @@ using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Reminders;
 

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -11,7 +11,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -16,7 +16,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTwoPhaseTimeoutTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTwoPhaseTimeoutTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 
 namespace Netclaw.Actors.Tests.Sessions;

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -11,7 +11,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
@@ -8,7 +8,6 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -15,7 +15,6 @@ using Netclaw.Actors.Tests.Memory;
 using Netclaw.Actors.Tests.SubAgents;
 using Netclaw.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
@@ -12,7 +12,6 @@ using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.Sessions;
 

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -9,7 +9,6 @@ using Netclaw.Actors.Tools;
 using Netclaw.Actors.Tests.Memory;
 using Netclaw.Tools;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Actors.Tests.SubAgents;
 

--- a/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
+++ b/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="Termina" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj
+++ b/src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -36,9 +36,9 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
 
     private NetclawPaths CreatePaths() => new(_tempBase);
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await TryDeleteDirectoryAsync(_tempBase);
     }

--- a/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
+++ b/src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="ModelContextProtocol.Core" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Netclaw.Daemon.Tests/Providers/OpenRouterStreamingSmokeTest.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenRouterStreamingSmokeTest.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.AI;
 using Netclaw.Providers.OpenRouter;
 using OpenAI;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Netclaw.Daemon.Tests.Providers;
 

--- a/src/Netclaw.MemoryRetrievalPoC.Tests/Netclaw.MemoryRetrievalPoC.Tests.csproj
+++ b/src/Netclaw.MemoryRetrievalPoC.Tests/Netclaw.MemoryRetrievalPoC.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
+++ b/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
   </ItemGroup>
 

--- a/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
+++ b/src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Bumps `Akka.Hosting`, `Akka.Persistence.Hosting`, and `Akka.Hosting.TestKit` from **1.5.63 → 1.5.64**
- `Akka.Hosting.TestKit` 1.5.64 dropped xUnit v2 in favour of xUnit v3, so this PR includes the required test migration
- Replaces the two Dependabot PRs #514 and #515 (both closed — they had broken builds and CPM violations)

## Changes

| Area | Change |
|---|---|
| `Directory.Packages.props` | `AkkaHostingVersion` 1.5.63 → 1.5.64; `xunit` 2.9.3 → `xunit.v3` 3.2.2 |
| 7 test `.csproj` files | `xunit` → `xunit.v3` reference |
| 20 test `.cs` files | Remove `using Xunit.Abstractions;` (`ITestOutputHelper` moved to `Xunit` namespace in v3) |
| 3 `IAsyncLifetime` implementations | Return type `Task` → `ValueTask` (xUnit v3 breaking change) |
| `.editorconfig` | Suppress `xUnit1051` at suggestion level for test files while migration is pending |

## xUnit1051 follow-up

xUnit v3 introduces analyzer rule `xUnit1051` — calls that accept `CancellationToken` should use `TestContext.Current.CancellationToken`. There are ~388 call sites across 4 test projects. Rather than expanding this PR's scope, the suppression is tracked for removal in #517.

## Test plan

- [ ] CI build passes (no `xUnit.core` vs `xunit.v3.core` type conflict)
- [ ] Slopwatch passes (no new violations)
- [ ] Smoke sandbox passes