### PR TITLE
feat(init): add inbound webhook toggle to exposure-mode flow

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -168,10 +168,77 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
         Assert.False(config.ContainsKey("Daemon"));
     }
 
+    // ── ContributeConfig — Webhooks ─────────────────────────────────────────
+
+    [Fact]
+    public void ContributeConfig_WebhooksEnabled_WritesWebhooksSection()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.WebhooksEnabled = true;
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Webhooks);
+        Assert.True(builder.Webhooks.Enabled);
+    }
+
+    [Fact]
+    public void ContributeConfig_WebhooksDisabled_OmitsWebhooksSection()
+    {
+        using var step = new ExposureModeStepViewModel();
+        // WebhooksEnabled defaults to false
+
+        var builder = new WizardConfigBuilder(_context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.Null(builder.Webhooks);
+    }
+
+    // ── BuildConfigDictionary — Webhooks ─────────────────────────────────────
+
+    [Fact]
+    public void BuildConfigDictionary_WebhooksEnabled_WritesEnabledTrue()
+    {
+        var builder = new WizardConfigBuilder(_context.Paths)
+        {
+            Webhooks = new WebhooksConfigSection { Enabled = true }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.True(config.ContainsKey("Webhooks"));
+        var webhooks = (Dictionary<string, object>)config["Webhooks"];
+        Assert.Equal(true, webhooks["Enabled"]);
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_WebhooksDisabled_OmitsWebhooksKey()
+    {
+        var builder = new WizardConfigBuilder(_context.Paths)
+        {
+            Webhooks = new WebhooksConfigSection { Enabled = false }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.False(config.ContainsKey("Webhooks"));
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_NullWebhooks_OmitsWebhooksKey()
+    {
+        var builder = new WizardConfigBuilder(_context.Paths);
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.False(config.ContainsKey("Webhooks"));
+    }
+
     // ── Sub-step navigation ───────────────────────────────────────────────────
 
     [Fact]
-    public void TryAdvance_LocalMode_ReturnsFalse()
+    public void TryAdvance_LocalMode_AdvancesToWebhookSubStep()
     {
         using var step = new ExposureModeStepViewModel();
         step.OnEnter(_context, NavigationDirection.Forward);
@@ -179,12 +246,12 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
 
         var result = step.TryAdvance();
 
-        Assert.False(result);
-        Assert.Equal(0, step.CurrentSubStep);
+        Assert.True(result);
+        Assert.Equal(1, step.CurrentSubStep); // webhook toggle
     }
 
     [Fact]
-    public void TryAdvance_TailscaleServe_AdvancesToSubStep1()
+    public void TryAdvance_TailscaleServe_AdvancesToConfirmation()
     {
         using var step = new ExposureModeStepViewModel();
         step.OnEnter(_context, NavigationDirection.Forward);
@@ -193,11 +260,11 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
         var result = step.TryAdvance();
 
         Assert.True(result);
-        Assert.Equal(1, step.CurrentSubStep);
+        Assert.Equal(1, step.CurrentSubStep); // confirmation
     }
 
     [Fact]
-    public void TryAdvance_TailscaleFunnel_AdvancesToSubStep1()
+    public void TryAdvance_TailscaleFunnel_AdvancesToConfirmation()
     {
         using var step = new ExposureModeStepViewModel();
         step.OnEnter(_context, NavigationDirection.Forward);
@@ -206,16 +273,31 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
         var result = step.TryAdvance();
 
         Assert.True(result);
-        Assert.Equal(1, step.CurrentSubStep);
+        Assert.Equal(1, step.CurrentSubStep); // confirmation
     }
 
     [Fact]
-    public void TryAdvance_FromSubStep1_ReturnsFalse()
+    public void TryAdvance_NonLocal_FromConfirmation_AdvancesToWebhookSubStep()
     {
         using var step = new ExposureModeStepViewModel();
         step.OnEnter(_context, NavigationDirection.Forward);
         step.SelectedMode = ExposureMode.TailscaleFunnel;
-        step.TryAdvance(); // advance to sub-step 1
+        step.TryAdvance(); // → confirmation (sub-step 1)
+
+        var result = step.TryAdvance();
+
+        Assert.True(result);
+        Assert.Equal(2, step.CurrentSubStep); // webhook toggle
+    }
+
+    [Fact]
+    public void TryAdvance_FromWebhookSubStep_ReturnsFalse()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.TailscaleFunnel;
+        step.TryAdvance(); // → confirmation
+        step.TryAdvance(); // → webhook toggle
 
         var result = step.TryAdvance();
 
@@ -223,12 +305,40 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
     }
 
     [Fact]
-    public void TryGoBack_FromSubStep1_ReturnsTrue()
+    public void TryAdvance_Local_FromWebhookSubStep_ReturnsFalse()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.Local;
+        step.TryAdvance(); // → webhook toggle
+
+        var result = step.TryAdvance();
+
+        Assert.False(result); // step complete
+    }
+
+    [Fact]
+    public void TryGoBack_FromWebhookSubStep_ReturnsTrue()
     {
         using var step = new ExposureModeStepViewModel();
         step.OnEnter(_context, NavigationDirection.Forward);
         step.SelectedMode = ExposureMode.TailscaleServe;
-        step.TryAdvance(); // go to sub-step 1
+        step.TryAdvance(); // → confirmation
+        step.TryAdvance(); // → webhook toggle
+
+        var result = step.TryGoBack();
+
+        Assert.True(result);
+        Assert.Equal(1, step.CurrentSubStep); // back to confirmation
+    }
+
+    [Fact]
+    public void TryGoBack_FromConfirmation_ReturnsTrue()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.TailscaleServe;
+        step.TryAdvance(); // → confirmation
 
         var result = step.TryGoBack();
 
@@ -284,20 +394,38 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
     }
 
     [Fact]
-    public void SubStepCount_Local_IsOne()
+    public void SubStepCount_Local_IsTwo()
     {
         using var step = new ExposureModeStepViewModel();
         step.SelectedMode = ExposureMode.Local;
 
-        Assert.Equal(1, step.SubStepCount);
+        Assert.Equal(2, step.SubStepCount);
     }
 
     [Fact]
-    public void SubStepCount_NonLocal_IsTwo()
+    public void SubStepCount_NonLocal_IsThree()
     {
         using var step = new ExposureModeStepViewModel();
         step.SelectedMode = ExposureMode.TailscaleFunnel;
 
-        Assert.Equal(2, step.SubStepCount);
+        Assert.Equal(3, step.SubStepCount);
+    }
+
+    [Fact]
+    public void WebhookSubStep_Local_IsOne()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.Local;
+
+        Assert.Equal(1, step.WebhookSubStep);
+    }
+
+    [Fact]
+    public void WebhookSubStep_NonLocal_IsTwo()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.TailscaleFunnel;
+
+        Assert.Equal(2, step.WebhookSubStep);
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
@@ -11,8 +11,9 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// <summary>
 /// Termina view for the ExposureMode wizard step.
 /// Sub-step 0: mode selection list (four modes, local pre-selected).
-/// Sub-step 1: informational notice (tailscale-serve) or high-risk warning
+/// Sub-step 1 (non-local only): informational notice (tailscale-serve) or high-risk warning
 ///             with explicit confirmation (tailscale-funnel, cloudflare-tunnel).
+/// Last sub-step: inbound webhook enable/disable toggle.
 /// </summary>
 public sealed class ExposureModeStepView : IWizardStepView
 {
@@ -26,12 +27,14 @@ public sealed class ExposureModeStepView : IWizardStepView
     {
         var vm = (ExposureModeStepViewModel)stepVm;
 
-        return vm.CurrentSubStep switch
-        {
-            0 => BuildModeSelection(vm, callbacks),
-            1 => BuildConfirmation(vm, callbacks),
-            _ => Layouts.Empty()
-        };
+        if (vm.CurrentSubStep == 0)
+            return BuildModeSelection(vm, callbacks);
+
+        if (vm.CurrentSubStep == vm.WebhookSubStep)
+            return BuildWebhookToggle(vm, callbacks);
+
+        // Sub-step 1 confirmation (non-Local modes only)
+        return BuildConfirmation(vm, callbacks);
     }
 
     private ILayoutNode BuildModeSelection(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
@@ -138,6 +141,42 @@ public sealed class ExposureModeStepView : IWizardStepView
                 .WithForeground(Color.BrightBlack))
             .WithSpacing(1)
             .WithChild(_confirmList);
+    }
+
+    private ILayoutNode BuildWebhookToggle(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        const string enableLabel = "Yes \u2014 accept inbound webhook requests";
+        const string disableLabel = "No \u2014 do not accept inbound webhooks (default)";
+
+        _modeList = null;
+
+        _confirmList = Layouts.SelectionList(disableLabel, enableLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _confirmList.OnFocused();
+        _lastFocusedList = _confirmList;
+
+        _confirmList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0)
+                {
+                    vm.WebhooksEnabled = selected[0] == enableLabel;
+                    callbacks.AdvanceStep();
+                }
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Should this daemon accept inbound webhooks?").WithForeground(Color.White))
+            .WithSpacing(1)
+            .WithChild(_confirmList)
+            .WithSpacing(1)
+            .WithChild(new TextNode("  Inbound webhooks let external services trigger autonomous runs via HTTP POST.")
+                .WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("  This is separate from outbound notification webhooks.")
+                .WithForeground(Color.BrightBlack));
     }
 
     public bool HandleKeyPress(KeyPressed key)

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
@@ -3,8 +3,8 @@ using Netclaw.Configuration;
 namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
-/// Wizard step for selecting the daemon network exposure mode.
-/// Two sub-steps: mode selection, then a confirmation/notice screen for non-local modes.
+/// Wizard step for selecting the daemon network exposure mode and inbound webhook enablement.
+/// Sub-steps: mode selection → optional confirmation/notice → webhook toggle.
 /// </summary>
 public sealed class ExposureModeStepViewModel : IWizardStepViewModel
 {
@@ -17,39 +17,58 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
     /// <summary>The selected exposure mode. Defaults to <see cref="ExposureMode.Local"/>.</summary>
     public ExposureMode SelectedMode { get; set; } = ExposureMode.Local;
 
+    /// <summary>Whether inbound webhook ingestion is enabled.</summary>
+    public bool WebhooksEnabled { get; set; }
+
     public bool IsApplicable(WizardContext context) => true;
 
     public int CurrentSubStep => _currentSubStep;
 
     /// <summary>
-    /// Two sub-steps when a non-local mode is selected (confirmation/notice screen);
-    /// one sub-step for Local.
+    /// Sub-steps: mode selection + optional confirmation/notice + webhook toggle.
     /// </summary>
-    public int SubStepCount => NeedsSecondStep ? 2 : 1;
+    public int SubStepCount => NeedsConfirmation ? 3 : 2;
 
     /// <summary>True when the selected mode requires a confirmation or notice screen.</summary>
-    internal bool NeedsSecondStep => SelectedMode != ExposureMode.Local;
+    internal bool NeedsConfirmation => SelectedMode != ExposureMode.Local;
 
     /// <summary>True for modes that expose the daemon to the public internet.</summary>
     public bool IsHighRisk =>
         SelectedMode is ExposureMode.TailscaleFunnel or ExposureMode.CloudflareTunnel;
 
-    public string GetHelpText() => (_currentSubStep, IsHighRisk) switch
+    /// <summary>The sub-step index for the inbound webhook toggle (always last).</summary>
+    internal int WebhookSubStep => NeedsConfirmation ? 2 : 1;
+
+    public string GetHelpText()
     {
-        (0, _) => "  Local is safest — daemon only reachable from this machine. Use tunnels for remote access.",
-        (1, true) => "  This mode exposes your daemon beyond your tailnet. Ensure hub authentication is configured.",
-        (1, false) => "  Tailscale Serve limits access to your tailnet only. Press Enter to confirm.",
-        _ => ""
-    };
+        if (_currentSubStep == 0)
+            return "  Local is safest — daemon only reachable from this machine. Use tunnels for remote access.";
+
+        if (_currentSubStep == WebhookSubStep)
+            return "  Inbound webhooks let external services trigger autonomous runs via HTTP POST.";
+
+        // Sub-step 1 confirmation (non-Local modes only)
+        return IsHighRisk
+            ? "  This mode exposes your daemon beyond your tailnet. Ensure hub authentication is configured."
+            : "  Tailscale Serve limits access to your tailnet only. Press Enter to confirm.";
+    }
 
     public bool TryAdvance()
     {
-        if (_currentSubStep == 0 && NeedsSecondStep)
+        if (_currentSubStep == 0 && NeedsConfirmation)
         {
             _currentSubStep = 1;
             _highWaterSubStep = 1;
-            return true; // handled internally
+            return true; // mode selection → confirmation
         }
+
+        if (_currentSubStep < WebhookSubStep)
+        {
+            _currentSubStep = WebhookSubStep;
+            _highWaterSubStep = WebhookSubStep;
+            return true; // → webhook toggle
+        }
+
         return false; // step complete, orchestrator advances
     }
 
@@ -74,8 +93,7 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
     public void OnLeave() { }
 
     /// <summary>
-    /// Writes the Daemon section only when exposure mode is non-default (non-local).
-    /// Local mode is the schema default and is omitted to keep configs minimal.
+    /// Writes the Daemon section (non-local modes) and Webhooks section (when enabled).
     /// </summary>
     public void ContributeConfig(WizardConfigBuilder builder)
     {
@@ -85,6 +103,11 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
             {
                 ExposureMode = SelectedMode
             };
+        }
+
+        if (WebhooksEnabled)
+        {
+            builder.Webhooks = new WebhooksConfigSection { Enabled = true };
         }
     }
 

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -34,6 +34,7 @@ public sealed class WizardConfigBuilder
     public NotificationsConfigSection? Notifications { get; set; }
     public List<ExternalSkillSource>? ExternalSkillSources { get; set; }
     public DaemonConfigSection? Daemon { get; set; }
+    public WebhooksConfigSection? Webhooks { get; set; }
 
     /// <summary>
     /// Assemble the typed sections into netclaw.json and write it.
@@ -217,6 +218,15 @@ public sealed class WizardConfigBuilder
             };
         }
 
+        // Webhooks section — only written when enabled (disabled = default, omit)
+        if (Webhooks is { Enabled: true })
+        {
+            config["Webhooks"] = new Dictionary<string, object>
+            {
+                ["Enabled"] = true
+            };
+        }
+
         // Notifications
         if (Notifications is { WebhookUrl: not null })
         {
@@ -332,5 +342,10 @@ public sealed class IdentityConfigSection
 public sealed class DaemonConfigSection
 {
     public ExposureMode ExposureMode { get; init; } = ExposureMode.Local;
+}
+
+public sealed class WebhooksConfigSection
+{
+    public bool Enabled { get; init; }
 }
 


### PR DESCRIPTION
## Summary
- Adds an inbound webhook enable/disable sub-step to the exposure-mode wizard step in `netclaw init`
- The toggle appears after mode selection (and after confirmation for non-local modes)
- Copy clearly distinguishes inbound webhook ingestion from outbound notification webhooks
- When enabled, writes `Webhooks.Enabled = true` to `netclaw.json`; disabled configs omit the section

## Test plan
- [x] All 32 `ExposureModeStepViewModelTests` pass (including new webhook config, navigation, and sub-step count tests)
- [x] `dotnet build` succeeds
- [ ] Manual: run `netclaw init`, verify webhook toggle appears after exposure mode selection
- [ ] Manual: verify `netclaw.json` contains `"Webhooks": { "Enabled": true }` when enabled
- [ ] Manual: verify `netclaw.json` omits `Webhooks` section when disabled

Closes #530