### PR TITLE
feat: skill management CLI, directory watcher, and flat-file support

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Netclaw Operations
@@ -19,6 +19,7 @@ problems, how to update preferences, or how to maintain itself.
 |-------------|---------------|
 | Schedule reminders, cron jobs | [Scheduling](#scheduling) |
 | Discover MCP tools | [Tool Discovery](#tool-discovery) |
+| Manage skills and sources | [Skill Management](#skill-management) |
 | Something is broken, debug it | [Diagnostics](#diagnostics) |
 | Update preferences, tone, profile | [Identity](#identity) |
 | Pair remote devices, manage access | [Device Pairing](#device-pairing) |
@@ -57,6 +58,36 @@ After discovery, matched tools become callable for the session.
 Sessions receive granted tool categories. `builtin` is always granted.
 Other categories (`web`, `file`, `shell`, `scheduling`) depend on ACL
 config. If a tool is missing, it may not be granted for this session.
+
+## Skill Management
+
+The `netclaw skill` CLI manages skills and skill sources. All subcommands
+are offline — no daemon required.
+
+| Command | What it does |
+|---------|--------------|
+| `netclaw skill list` | List all discovered skills with source, version, status |
+| `netclaw skill show <name>` | Show skill metadata and full content |
+| `netclaw skill validate <path>` | Validate a SKILL.md file's frontmatter format |
+| `netclaw skill remove <name>` | Remove a native skill (refuses system/external) |
+| `netclaw skill issues` | Show only scanner issues (rejected items with reasons) |
+| `netclaw skill search <query>` | Search skills by name or description |
+
+### External skill sources
+
+Register additional skill directories (e.g. `~/.claude/skills/`):
+
+| Command | What it does |
+|---------|--------------|
+| `netclaw skill source list` | Show configured external sources |
+| `netclaw skill source add <name> --well-known claude-code` | Add Claude Code skills |
+| `netclaw skill source add <name> --path /shared/skills` | Add a custom directory |
+| `netclaw skill source remove <name>` | Remove a source |
+| `netclaw skill source enable <name>` | Enable a disabled source |
+| `netclaw skill source disable <name>` | Disable without removing |
+
+The daemon's `SkillDirectoryWatcherService` automatically rescans all skill
+directories (native + external) when files change on disk. No restart needed.
 
 ## Webhook Management
 
@@ -136,6 +167,7 @@ file. If it should be recalled when relevant → SQLite memory.
 | Self-diagnose | `netclaw doctor` |
 | Runtime health | `netclaw status` |
 | Memory/token stats | `netclaw stats` |
+| List/manage skills | `netclaw skill list` |
 | List past sessions | `netclaw sessions --once` |
 | Inspect reminder history | `netclaw reminder history <id> --last 5` |
 

--- a/feeds/skills/.system/files/skill-authoring/SKILL.md
+++ b/feeds/skills/.system/files/skill-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: skill-authoring
 description: "How to create, edit, and manage Netclaw skills. Read this when you need to synthesize a new skill from a session, understand the skill file format, or use the skill_manage tool."
 metadata:
   author: netclaw
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Skill Authoring
@@ -26,7 +26,9 @@ Do **not** create a skill for:
 
 ## Skill File Format
 
-Skills follow the [AgentSkills.io](https://agentskills.io) directory layout:
+Skills support two layouts:
+
+### Directory layout (recommended)
 
 ```
 skill-name/
@@ -35,6 +37,18 @@ skill-name/
   scripts/          # Optional: executable helpers
   assets/           # Optional: templates, static resources
 ```
+
+### Flat-file layout
+
+```
+skill-name.md       # YAML frontmatter + markdown instructions (no resources)
+```
+
+Flat `.md` files with valid YAML frontmatter are accepted as skills for
+compatibility with Claude Code and other platforms. The frontmatter `name`
+must match the filename (without `.md`). Flat-file skills cannot have
+resource subdirectories. If both `skill-name/SKILL.md` and `skill-name.md`
+exist, the directory version takes precedence.
 
 ### YAML Frontmatter (Required)
 
@@ -120,12 +134,14 @@ them on demand via `skill_read_resource`.
 
 ## Creating Skills with skill_manage
 
-**IMPORTANT: NEVER use `file_write` to create or modify skill files.** The
-`file_write` tool writes to disk but does NOT register the skill in the
-in-memory `SkillRegistry`. The skill will exist on disk but be invisible to
-`skill_load`, the skill index, and `netclaw stats` until the next daemon
-restart. Always use `skill_manage` — it validates frontmatter, writes
-atomically, and triggers an immediate registry rescan.
+**Always use `skill_manage` to create or modify skill files.** The
+`skill_manage` tool validates frontmatter, scans for prompt injection,
+writes atomically, and triggers an immediate registry rescan.
+
+If `file_write` is used instead, the `SkillDirectoryWatcherService` will
+detect the change and trigger a rescan automatically (within ~500ms). However,
+`skill_manage` is still preferred because it validates content *before*
+writing — the watcher only rescans after the fact.
 
 Use the `skill_manage` tool for all skill mutations:
 

--- a/src/Netclaw.Actors/Skills/SkillScanResult.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanResult.cs
@@ -13,6 +13,8 @@ public enum SkillScanIssueKind
     DuplicateName,
     FrontmatterNameMismatch,
     ResourceEnumerationFailed,
+    FlatFileMissingFrontmatter,
+    FlatFileNoDescription,
 }
 
 public sealed record SkillScanIssue(

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -294,7 +294,6 @@ public static partial class SkillScanner
             ? NormalizeSkillName(frontmatter.Name)
             : NormalizeSkillName(fileNameWithoutExt);
 
-        // Validate frontmatter name matches filename if explicitly specified
         if (!string.IsNullOrWhiteSpace(frontmatter.Name))
         {
             var expectedName = NormalizeSkillName(fileNameWithoutExt);
@@ -309,36 +308,8 @@ public static partial class SkillScanner
             }
         }
 
-        // Extract display name from first # heading in the body
-        var body = ExtractBody(content);
-        var headingMatch = HeadingRegex().Match(body);
-        var displayName = headingMatch.Success
-            ? headingMatch.Groups[1].Value.Trim()
-            : TitleCase(name);
-
-        // Extract version from metadata
-        string? version = null;
-        if (frontmatter.Metadata is not null && frontmatter.Metadata.TryGetValue("version", out var versionValue))
-            version = versionValue;
-
-        return new SkillEntry(
-            Name: name,
-            DisplayName: displayName,
-            Description: Truncate(frontmatter.Description.Trim(), MaxDescriptionLength),
-            FilePath: canonicalPath,
-            SkillDirectory: canonicalRoot, // flat files use the skills root as their directory
-            Category: null) // flat files are always root-level
-        {
-            Version = version,
-            License = frontmatter.License,
-            Compatibility = frontmatter.Compatibility,
-            AllowedTools = frontmatter.AllowedTools,
-            ResourcePaths = null, // flat files cannot have resources
-            DisableModelInvocation = frontmatter.DisableModelInvocation,
-            UserInvocable = frontmatter.UserInvocable,
-            ArgumentHint = frontmatter.ArgumentHint,
-            IsFlatFile = true
-        };
+        return BuildSkillEntry(frontmatter, content, name, canonicalPath, canonicalRoot, category: null)
+            with { ResourcePaths = null, IsFlatFile = true };
     }
 
     /// <summary>
@@ -415,36 +386,44 @@ public static partial class SkillScanner
             return null;
         }
 
-        // Extract display name from first # heading in the body
-        var body = ExtractBody(content);
-        var headingMatch = HeadingRegex().Match(body);
-        var displayName = headingMatch.Success
-            ? headingMatch.Groups[1].Value.Trim()
-            : TitleCase(name);
-
         // Resolve category from directory structure
-        // For skill at root/skill-name/SKILL.md → category is null
-        // For skill at root/category/skill-name/SKILL.md → category is "category"
         var relativePath = Path.GetRelativePath(rootDirectory, filePath);
         string? category = null;
         var parentOfSkillDir = Path.GetDirectoryName(Path.GetDirectoryName(relativePath));
         if (!string.IsNullOrEmpty(parentOfSkillDir) && parentOfSkillDir != ".")
             category = parentOfSkillDir.Replace(Path.DirectorySeparatorChar, '/');
 
-        // Extract version from metadata
-        string? version = null;
-        if (fm.Metadata is not null && fm.Metadata.TryGetValue("version", out var versionValue))
-            version = versionValue;
-
         var issueCountBeforeResourceScan = issues.Count;
         var resourcePaths = EnumerateResources(skillDirectory, rootDirectory, issues, allowSymlinks);
         if (issues.Count > issueCountBeforeResourceScan)
             return null;
 
+        return BuildSkillEntry(fm, content, name, filePath, skillDirectory, category)
+            with { ResourcePaths = resourcePaths };
+    }
+
+    /// <summary>
+    /// Shared SkillEntry construction from validated frontmatter. Used by both
+    /// directory-based and flat-file parsing paths.
+    /// </summary>
+    private static SkillEntry BuildSkillEntry(
+        SkillFrontmatter fm, string content, string name,
+        string filePath, string skillDirectory, string? category)
+    {
+        var body = ExtractBody(content);
+        var headingMatch = HeadingRegex().Match(body);
+        var displayName = headingMatch.Success
+            ? headingMatch.Groups[1].Value.Trim()
+            : TitleCase(name);
+
+        string? version = null;
+        if (fm.Metadata is not null && fm.Metadata.TryGetValue("version", out var versionValue))
+            version = versionValue;
+
         return new SkillEntry(
             Name: name,
             DisplayName: displayName,
-            Description: Truncate(fm.Description.Trim(), MaxDescriptionLength),
+            Description: Truncate(fm.Description!.Trim(), MaxDescriptionLength),
             FilePath: filePath,
             SkillDirectory: skillDirectory,
             Category: category)
@@ -453,7 +432,6 @@ public static partial class SkillScanner
             License = fm.License,
             Compatibility = fm.Compatibility,
             AllowedTools = fm.AllowedTools,
-            ResourcePaths = resourcePaths,
             DisableModelInvocation = fm.DisableModelInvocation,
             UserInvocable = fm.UserInvocable,
             ArgumentHint = fm.ArgumentHint

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -54,6 +54,22 @@ public static partial class SkillScanner
         var acceptedCandidates = new List<SkillEntry>();
         var issues = new List<SkillScanIssue>();
 
+        // Pass 0: flat-file skills (root-level .md files with valid frontmatter)
+        // Claude Code and other platforms allow skill-name.md as a skill without a directory wrapper.
+        foreach (var mdFile in Directory.GetFiles(rootFull, "*.md"))
+        {
+            var fileName = Path.GetFileName(mdFile);
+
+            // Skip README and hidden files
+            if (fileName.Equals("README.md", StringComparison.OrdinalIgnoreCase)
+                || fileName.StartsWith('.'))
+                continue;
+
+            var entry = ParseFlatSkillFile(mdFile, rootFull, issues, allowSymlinks);
+            if (entry is not null)
+                acceptedCandidates.Add(entry);
+        }
+
         // Pass 1: root-level directory skills (skill-name/SKILL.md)
         foreach (var dir in Directory.GetDirectories(rootFull))
         {
@@ -91,26 +107,53 @@ public static partial class SkillScanner
             }
         }
 
-        var duplicateNames = acceptedCandidates
-            .GroupBy(static s => s.Name, StringComparer.OrdinalIgnoreCase)
-            .Where(static g => g.Count() > 1)
-            .ToDictionary(static g => g.Key, static g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+        // Resolve duplicates: directory skills take precedence over flat-file skills.
+        // If both are the same type (both directories or both flat files), reject all duplicates.
+        var groups = acceptedCandidates
+            .GroupBy(static s => s.Name, StringComparer.OrdinalIgnoreCase);
 
-        foreach (var duplicate in duplicateNames)
+        var resolved = new List<SkillEntry>();
+        foreach (var group in groups)
         {
-            var conflictingPaths = string.Join(", ", duplicate.Value.Select(static s => s.FilePath));
-            foreach (var skill in duplicate.Value)
+            var entries = group.ToList();
+            if (entries.Count == 1)
             {
-                issues.Add(new SkillScanIssue(
-                    Path: skill.FilePath,
-                    Kind: SkillScanIssueKind.DuplicateName,
-                    Message: $"Skill name '{skill.Name}' is duplicated across: {conflictingPaths}",
-                    SkillName: skill.Name));
+                resolved.Add(entries[0]);
+                continue;
+            }
+
+            var directoryEntries = entries.Where(static e => !e.IsFlatFile).ToList();
+            var flatEntries = entries.Where(static e => e.IsFlatFile).ToList();
+
+            if (directoryEntries.Count == 1 && flatEntries.Count >= 1)
+            {
+                // Directory skill wins; flat file(s) are shadowed
+                resolved.Add(directoryEntries[0]);
+                foreach (var flat in flatEntries)
+                {
+                    issues.Add(new SkillScanIssue(
+                        Path: flat.FilePath,
+                        Kind: SkillScanIssueKind.DuplicateName,
+                        Message: $"Flat file '{flat.FilePath}' is shadowed by directory skill '{directoryEntries[0].FilePath}'.",
+                        SkillName: flat.Name));
+                }
+            }
+            else
+            {
+                // Multiple directory skills or multiple flat files with same name — reject all
+                var conflictingPaths = string.Join(", ", entries.Select(static s => s.FilePath));
+                foreach (var skill in entries)
+                {
+                    issues.Add(new SkillScanIssue(
+                        Path: skill.FilePath,
+                        Kind: SkillScanIssueKind.DuplicateName,
+                        Message: $"Skill name '{skill.Name}' is duplicated across: {conflictingPaths}",
+                        SkillName: skill.Name));
+                }
             }
         }
 
-        var accepted = acceptedCandidates
-            .Where(skill => !duplicateNames.ContainsKey(skill.Name))
+        var accepted = resolved
             .OrderBy(static s => s.Name, StringComparer.Ordinal)
             .ToList();
 
@@ -201,10 +244,108 @@ public static partial class SkillScanner
     }
 
     /// <summary>
+    /// Parses a flat <c>.md</c> file as a skill. Flat files are root-level markdown
+    /// files with valid YAML frontmatter — supported for compatibility with Claude Code
+    /// and other platforms that allow skills without the directory wrapper.
+    /// </summary>
+    private static SkillEntry? ParseFlatSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false)
+    {
+        var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
+        var canonicalPath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "flat skill file", allowSymlinks);
+        if (canonicalPath is null)
+            return null;
+
+        string content;
+        try
+        {
+            content = File.ReadAllText(canonicalPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            issues.Add(new SkillScanIssue(
+                Path: canonicalPath,
+                Kind: SkillScanIssueKind.UnreadableFile,
+                Message: $"Failed to read flat skill file: {ex.Message}"));
+            return null;
+        }
+
+        var frontmatter = ExtractFrontmatter(content);
+        if (frontmatter is null)
+        {
+            issues.Add(new SkillScanIssue(
+                Path: canonicalPath,
+                Kind: SkillScanIssueKind.FlatFileMissingFrontmatter,
+                Message: "Flat .md file found but lacks valid YAML frontmatter. Add frontmatter with name and description, or move into a skill-name/SKILL.md directory."));
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(frontmatter.Description))
+        {
+            issues.Add(new SkillScanIssue(
+                Path: canonicalPath,
+                Kind: SkillScanIssueKind.FlatFileNoDescription,
+                Message: "Flat .md file has frontmatter but missing description field."));
+            return null;
+        }
+
+        // Derive skill name from frontmatter or filename
+        var fileNameWithoutExt = Path.GetFileNameWithoutExtension(canonicalPath);
+        var name = !string.IsNullOrWhiteSpace(frontmatter.Name)
+            ? NormalizeSkillName(frontmatter.Name)
+            : NormalizeSkillName(fileNameWithoutExt);
+
+        // Validate frontmatter name matches filename if explicitly specified
+        if (!string.IsNullOrWhiteSpace(frontmatter.Name))
+        {
+            var expectedName = NormalizeSkillName(fileNameWithoutExt);
+            if (!string.Equals(name, expectedName, StringComparison.OrdinalIgnoreCase))
+            {
+                issues.Add(new SkillScanIssue(
+                    Path: canonicalPath,
+                    Kind: SkillScanIssueKind.FrontmatterNameMismatch,
+                    Message: $"Frontmatter name '{name}' does not match file name '{expectedName}'.",
+                    SkillName: name));
+                return null;
+            }
+        }
+
+        // Extract display name from first # heading in the body
+        var body = ExtractBody(content);
+        var headingMatch = HeadingRegex().Match(body);
+        var displayName = headingMatch.Success
+            ? headingMatch.Groups[1].Value.Trim()
+            : TitleCase(name);
+
+        // Extract version from metadata
+        string? version = null;
+        if (frontmatter.Metadata is not null && frontmatter.Metadata.TryGetValue("version", out var versionValue))
+            version = versionValue;
+
+        return new SkillEntry(
+            Name: name,
+            DisplayName: displayName,
+            Description: Truncate(frontmatter.Description.Trim(), MaxDescriptionLength),
+            FilePath: canonicalPath,
+            SkillDirectory: canonicalRoot, // flat files use the skills root as their directory
+            Category: null) // flat files are always root-level
+        {
+            Version = version,
+            License = frontmatter.License,
+            Compatibility = frontmatter.Compatibility,
+            AllowedTools = frontmatter.AllowedTools,
+            ResourcePaths = null, // flat files cannot have resources
+            DisableModelInvocation = frontmatter.DisableModelInvocation,
+            UserInvocable = frontmatter.UserInvocable,
+            ArgumentHint = frontmatter.ArgumentHint,
+            IsFlatFile = true
+        };
+    }
+
+    /// <summary>
     /// Extracts and deserializes YAML frontmatter from a skill file.
     /// Returns null if the file does not start with <c>---</c> or the YAML is unparseable.
     /// </summary>
-    internal static SkillFrontmatter? ExtractFrontmatter(string content)
+    public static SkillFrontmatter? ExtractFrontmatter(string content)
     {
         if (!content.StartsWith("---", StringComparison.Ordinal))
             return null;
@@ -458,7 +599,7 @@ public static partial class SkillScanner
 /// <summary>
 /// YAML frontmatter schema for AgentSkills.io SKILL.md files.
 /// </summary>
-internal sealed class SkillFrontmatter
+public sealed class SkillFrontmatter
 {
     public string? Name { get; set; }
     public string? Description { get; set; }

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -283,14 +283,22 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (IsExternalSkill(skill))
             return "Cannot delete external skills. External skill directories are read-only.";
 
-        Directory.Delete(skill.SkillDirectory, recursive: true);
-
-        // Clean empty parent category directories
-        var parent = Path.GetDirectoryName(skill.SkillDirectory);
-        if (parent is not null && parent != _paths.SkillsDirectory
-            && Directory.Exists(parent) && !Directory.EnumerateFileSystemEntries(parent).Any())
+        if (skill.IsFlatFile)
         {
-            Directory.Delete(parent);
+            // Flat-file skill: delete the single .md file
+            File.Delete(skill.FilePath);
+        }
+        else
+        {
+            Directory.Delete(skill.SkillDirectory, recursive: true);
+
+            // Clean empty parent category directories
+            var parent = Path.GetDirectoryName(skill.SkillDirectory);
+            if (parent is not null && parent != _paths.SkillsDirectory
+                && Directory.Exists(parent) && !Directory.EnumerateFileSystemEntries(parent).Any())
+            {
+                Directory.Delete(parent);
+            }
         }
 
         return AppendScanWarnings($"Skill '{name}' deleted.", RescanAndUpdateIndex());

--- a/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
@@ -110,7 +110,7 @@ public sealed class CliArgsParserTests
         {
             "chat", "sessions", "init", "doctor", "status", "stats",
             "daemon", "mcp", "provider", "model", "reminder",
-            "secrets", "config", "update", "pair",
+            "secrets", "config", "update", "pair", "skill",
         };
 
         Assert.Equal(expected, CliArgsParser.KnownCommands);

--- a/src/Netclaw.Cli/CliArgsParser.cs
+++ b/src/Netclaw.Cli/CliArgsParser.cs
@@ -30,7 +30,7 @@ public static class CliArgsParser
     {
         "chat", "sessions", "init", "doctor", "status", "stats",
         "daemon", "mcp", "provider", "model", "reminder",
-        "secrets", "config", "update", "pair",
+        "secrets", "config", "update", "pair", "skill",
     };
 
     /// <summary>Returns <c>true</c> if the token is a help flag (<c>help</c>, <c>-h</c>, <c>--help</c>).</summary>

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -17,6 +17,7 @@ using Netclaw.Cli.Secrets;
 using Netclaw.Cli.Model;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
+using Netclaw.Cli.Skills;
 using Netclaw.Cli.Update;
 using Netclaw.Configuration;
 using Netclaw.Providers;
@@ -752,6 +753,16 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    // ── Skill management ──
+    if (mode is "skill")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+        // All skill subcommands are offline — no daemon needed
+        Environment.ExitCode = await SkillCommand.RunAsync(args, paths);
+        return;
+    }
+
     // ── Secrets management ──
     if (mode is "secrets")
     {
@@ -939,6 +950,7 @@ static void WriteGeneralHelp()
     Console.WriteLine("  provider                 Manage LLM providers (TUI) or use subcommands");
     Console.WriteLine("  model                    Manage model assignments (TUI) or use subcommands");
     Console.WriteLine("  reminder                 Manage scheduled reminders (daemon-required)");
+    Console.WriteLine("  skill                    Manage skills and skill sources");
     Console.WriteLine("  secrets                  Manage encrypted secrets (set key/value pairs)");
     Console.WriteLine("  init                     First-run setup wizard");
     Console.WriteLine("  update                   Check for and install updates");

--- a/src/Netclaw.Cli/Skills/SkillCommand.cs
+++ b/src/Netclaw.Cli/Skills/SkillCommand.cs
@@ -1,0 +1,627 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Actors.Skills;
+using Netclaw.Cli.Config;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Skills;
+
+/// <summary>
+/// Handles <c>netclaw skill &lt;subcommand&gt;</c> CLI subcommands.
+/// All commands are offline — no daemon required.
+/// </summary>
+internal static class SkillCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
+    {
+        // default to "list" when no subcommand is provided
+        var subcommand = args.Length > 1 ? args[1] : "list";
+
+        if (subcommand is "help" or "-h" or "--help")
+        {
+            WriteHelp();
+            return 0;
+        }
+
+        // Handle "source" compound subcommands: source list, source add, etc.
+        if (subcommand is "source")
+        {
+            var sourceAction = args.Length > 2 ? args[2] : "list";
+            return sourceAction switch
+            {
+                "list" => RunSourceList(paths),
+                "add" => RunSourceAdd(args, paths),
+                "remove" => RunSourceRemove(args, paths),
+                "enable" => RunSourceToggle(args, paths, enable: true),
+                "disable" => RunSourceToggle(args, paths, enable: false),
+                "help" or "-h" or "--help" => WriteSourceHelp(),
+                _ => WriteSourceHelp()
+            };
+        }
+
+        return subcommand switch
+        {
+            "list" => RunList(paths),
+            "show" => RunShow(args, paths),
+            "validate" => RunValidate(args),
+            "remove" => RunRemove(args, paths),
+            "issues" => RunIssues(paths),
+            "search" => RunSearch(args, paths),
+            _ => WriteHelp()
+        };
+    }
+
+    // ── Subcommand implementations ──
+
+    private static int RunList(NetclawPaths paths)
+    {
+        var result = ScanAll(paths);
+
+        if (result.AcceptedSkills.Count == 0 && result.Issues.Count == 0)
+        {
+            Console.WriteLine("No skills found.");
+            return 0;
+        }
+
+        const int colName = 24;
+        const int colSource = 10;
+        const int colVersion = 10;
+
+        Console.WriteLine(
+            $"{"NAME",-colName}  {"SOURCE",-colSource}  {"VERSION",-colVersion}  STATUS");
+        Console.WriteLine(new string('-', colName + colSource + colVersion + 12));
+
+        foreach (var skill in result.AcceptedSkills)
+        {
+            var source = ClassifySource(skill, paths);
+            var version = skill.Version ?? "-";
+            var status = skill.IsFlatFile ? "flat file (no frontmatter)" : "ok";
+
+            // Flat files with frontmatter that parsed successfully are actually fine
+            if (skill.IsFlatFile && skill.Description.Length > 0)
+                status = "ok";
+
+            Console.WriteLine(
+                $"{skill.Name,-colName}  {source,-colSource}  {version,-colVersion}  {status}");
+        }
+
+        // Also show issues inline
+        foreach (var issue in result.Issues)
+        {
+            var name = issue.SkillName ?? Path.GetFileNameWithoutExtension(issue.Path);
+            Console.WriteLine(
+                $"{name,-colName}  {"?",-colSource}  {"-",-colVersion}  {issue.Kind}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(
+            $"{result.AcceptedSkills.Count} skill(s), {result.Issues.Count} issue(s)");
+
+        return 0;
+    }
+
+    private static int RunShow(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill show <name>");
+            return 1;
+        }
+
+        var name = args[2].ToLowerInvariant();
+        var result = ScanAll(paths);
+        var skill = result.AcceptedSkills.FirstOrDefault(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        if (skill is null)
+        {
+            Console.Error.WriteLine($"[FAIL] skill '{name}' not found.");
+            return 1;
+        }
+
+        Console.WriteLine($"Name:        {skill.Name}");
+        Console.WriteLine($"Display:     {skill.DisplayName}");
+        Console.WriteLine($"Source:      {ClassifySource(skill, paths)}");
+        Console.WriteLine($"Version:     {skill.Version ?? "-"}");
+        Console.WriteLine($"Category:    {skill.Category ?? "-"}");
+        Console.WriteLine($"License:     {skill.License ?? "-"}");
+        Console.WriteLine($"Path:        {skill.FilePath}");
+        Console.WriteLine($"Flat file:   {skill.IsFlatFile}");
+
+        if (skill.AllowedTools is not null)
+            Console.WriteLine($"Tools:       {skill.AllowedTools}");
+        if (skill.ResourcePaths is { Count: > 0 })
+            Console.WriteLine($"Resources:   {string.Join(", ", skill.ResourcePaths)}");
+
+        Console.WriteLine($"Description: {skill.Description}");
+        Console.WriteLine();
+
+        // Print full SKILL.md content
+        if (File.Exists(skill.FilePath))
+        {
+            Console.WriteLine("--- content ---");
+            Console.WriteLine(File.ReadAllText(skill.FilePath));
+        }
+
+        return 0;
+    }
+
+    private static int RunValidate(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill validate <path>");
+            return 1;
+        }
+
+        var filePath = Path.GetFullPath(args[2]);
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"[FAIL] file not found: {filePath}");
+            return 1;
+        }
+
+        string content;
+        try
+        {
+            content = File.ReadAllText(filePath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] cannot read file: {ex.Message}");
+            return 1;
+        }
+
+        // Check frontmatter structure: must start with --- and have a closing ---
+        if (!content.StartsWith("---", StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine("[FAIL] file does not start with YAML frontmatter (---).");
+            return 1;
+        }
+
+        var closingIndex = content.IndexOf("\n---", 3, StringComparison.Ordinal);
+        if (closingIndex < 0)
+        {
+            Console.Error.WriteLine("[FAIL] YAML frontmatter is not properly closed (missing closing ---).");
+            return 1;
+        }
+
+        // Use the scanner to validate — create a temp directory with the file
+        // and scan it to get full validation including frontmatter parsing.
+        var parentDir = Path.GetDirectoryName(filePath)!;
+        var fileName = Path.GetFileName(filePath);
+
+        // If it's a SKILL.md inside a directory, scan the parent's parent
+        // If it's a flat .md file, scan the parent directory
+        string scanDir;
+        if (string.Equals(fileName, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+        {
+            // skill-name/SKILL.md — scan the grandparent
+            scanDir = Path.GetDirectoryName(parentDir) ?? parentDir;
+        }
+        else
+        {
+            // flat file like my-skill.md — scan the parent
+            scanDir = parentDir;
+        }
+
+        var scanResult = SkillScanner.Scan(scanDir);
+
+        // Find the entry or issue matching this file
+        var matchedSkill = scanResult.AcceptedSkills.FirstOrDefault(
+            s => string.Equals(s.FilePath, filePath, StringComparison.OrdinalIgnoreCase));
+
+        if (matchedSkill is not null)
+        {
+            Console.WriteLine("[OK] Valid skill file.");
+            Console.WriteLine($"  Name:        {matchedSkill.Name}");
+            Console.WriteLine($"  Description: {matchedSkill.Description}");
+            Console.WriteLine($"  Version:     {matchedSkill.Version ?? "-"}");
+            Console.WriteLine($"  License:     {matchedSkill.License ?? "-"}");
+            return 0;
+        }
+
+        // Check if there's a specific issue for this file
+        var matchedIssue = scanResult.Issues.FirstOrDefault(
+            i => string.Equals(i.Path, filePath, StringComparison.OrdinalIgnoreCase));
+
+        if (matchedIssue is not null)
+        {
+            Console.Error.WriteLine($"[FAIL] {matchedIssue.Kind}: {matchedIssue.Message}");
+            return 1;
+        }
+
+        // Scanner didn't find it — likely a structural issue
+        Console.Error.WriteLine("[FAIL] scanner did not recognize this file as a valid skill.");
+        return 1;
+    }
+
+    private static int RunRemove(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill remove <name>");
+            return 1;
+        }
+
+        var name = args[2].ToLowerInvariant();
+        var result = ScanAll(paths);
+        var skill = result.AcceptedSkills.FirstOrDefault(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        if (skill is null)
+        {
+            Console.Error.WriteLine($"[FAIL] skill '{name}' not found.");
+            return 1;
+        }
+
+        var source = ClassifySource(skill, paths);
+        if (source is "system")
+        {
+            Console.Error.WriteLine($"[FAIL] cannot remove system skill '{name}'. System skills are managed by the daemon.");
+            return 1;
+        }
+
+        if (source is "external")
+        {
+            Console.Error.WriteLine($"[FAIL] cannot remove external skill '{name}'. Manage it in its source directory.");
+            return 1;
+        }
+
+        // Native skill — delete directory or flat file
+        if (skill.IsFlatFile)
+        {
+            File.Delete(skill.FilePath);
+            Console.WriteLine($"Removed flat skill file: {skill.FilePath}");
+        }
+        else
+        {
+            Directory.Delete(skill.SkillDirectory, recursive: true);
+            Console.WriteLine($"Removed skill directory: {skill.SkillDirectory}");
+        }
+
+        return 0;
+    }
+
+    private static int RunIssues(NetclawPaths paths)
+    {
+        var result = ScanAll(paths);
+
+        if (result.Issues.Count == 0)
+        {
+            Console.WriteLine("No issues found.");
+            return 0;
+        }
+
+        const int colName = 24;
+        const int colKind = 30;
+
+        Console.WriteLine($"{"NAME",-colName}  {"KIND",-colKind}  MESSAGE");
+        Console.WriteLine(new string('-', colName + colKind + 12));
+
+        foreach (var issue in result.Issues)
+        {
+            var name = issue.SkillName ?? Path.GetFileNameWithoutExtension(issue.Path);
+            Console.WriteLine($"{name,-colName}  {issue.Kind,-colKind}  {issue.Message}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{result.Issues.Count} issue(s)");
+
+        return 0;
+    }
+
+    private static int RunSearch(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill search <query>");
+            return 1;
+        }
+
+        var query = string.Join(' ', args.Skip(2)).ToLowerInvariant();
+        var result = ScanAll(paths);
+
+        var matches = result.AcceptedSkills
+            .Where(s =>
+                s.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                s.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                (s.DisplayName?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false))
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            Console.WriteLine($"No skills matching '{query}'.");
+            return 0;
+        }
+
+        const int colName = 24;
+        const int colSource = 10;
+        const int colVersion = 10;
+
+        Console.WriteLine(
+            $"{"NAME",-colName}  {"SOURCE",-colSource}  {"VERSION",-colVersion}  DESCRIPTION");
+        Console.WriteLine(new string('-', colName + colSource + colVersion + 14));
+
+        foreach (var skill in matches)
+        {
+            var source = ClassifySource(skill, paths);
+            var version = skill.Version ?? "-";
+            var desc = skill.Description.Length > 60
+                ? skill.Description[..57] + "..."
+                : skill.Description;
+            Console.WriteLine(
+                $"{skill.Name,-colName}  {source,-colSource}  {version,-colVersion}  {desc}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{matches.Count} match(es)");
+
+        return 0;
+    }
+
+    // ── Source subcommands ──
+
+    private static int RunSourceList(NetclawPaths paths)
+    {
+        var config = LoadExternalSkillsConfig(paths);
+
+        if (config.Sources.Count == 0)
+        {
+            Console.WriteLine("No external skill sources configured.");
+
+            // Probe for well-known sources
+            var probed = ExternalSkillsConfig.ProbeWellKnownSources();
+            if (probed.Count > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Detected well-known skill directories on disk:");
+                foreach (var p in probed)
+                    Console.WriteLine($"  {p.WellKnownAlias,-16} {p.ResolvedPath}");
+                Console.WriteLine();
+                Console.WriteLine("Add one with: netclaw skill source add <name> --well-known <alias>");
+            }
+
+            return 0;
+        }
+
+        const int colName = 20;
+        const int colEnabled = 10;
+        const int colType = 14;
+
+        Console.WriteLine(
+            $"{"NAME",-colName}  {"ENABLED",-colEnabled}  {"TYPE",-colType}  PATH / WELL-KNOWN");
+        Console.WriteLine(new string('-', colName + colEnabled + colType + 24));
+
+        foreach (var source in config.Sources)
+        {
+            var type = source.WellKnown is not null ? "well-known" : "path";
+            var target = source.WellKnown ?? source.Path ?? "-";
+            Console.WriteLine(
+                $"{source.Name,-colName}  {(source.Enabled ? "yes" : "no"),-colEnabled}  {type,-colType}  {target}");
+        }
+
+        return 0;
+    }
+
+    private static int RunSourceAdd(string[] args, NetclawPaths paths)
+    {
+        // netclaw skill source add <name> --path <dir> | --well-known <alias>
+        if (args.Length < 4)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill source add <name> --path <dir>");
+            Console.Error.WriteLine("       netclaw skill source add <name> --well-known <alias>");
+            return 1;
+        }
+
+        var name = args[3];
+        string? sourcePath = null;
+        string? wellKnown = null;
+
+        for (var i = 4; i < args.Length; i++)
+        {
+            if (args[i] is "--path" && i + 1 < args.Length)
+                sourcePath = args[++i];
+            else if (args[i] is "--well-known" && i + 1 < args.Length)
+                wellKnown = args[++i];
+        }
+
+        if (sourcePath is null && wellKnown is null)
+        {
+            Console.Error.WriteLine("[FAIL] must specify --path <dir> or --well-known <alias>.");
+            return 1;
+        }
+
+        if (sourcePath is not null && wellKnown is not null)
+        {
+            Console.Error.WriteLine("[FAIL] --path and --well-known are mutually exclusive.");
+            return 1;
+        }
+
+        // Validate well-known alias resolves
+        if (wellKnown is not null && ExternalSkillsConfig.ResolveWellKnownPath(wellKnown) is null)
+        {
+            Console.Error.WriteLine($"[FAIL] unknown well-known alias '{wellKnown}'. Supported: claude-code, open-code.");
+            return 1;
+        }
+
+        // Validate path exists
+        if (sourcePath is not null && !Directory.Exists(sourcePath))
+        {
+            Console.Error.WriteLine($"[FAIL] directory not found: {sourcePath}");
+            return 1;
+        }
+
+        var config = LoadExternalSkillsConfig(paths);
+
+        // Check for duplicate name
+        if (config.Sources.Any(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase)))
+        {
+            Console.Error.WriteLine($"[FAIL] source '{name}' already exists. Remove it first or use a different name.");
+            return 1;
+        }
+
+        config.Sources.Add(new ExternalSkillSource
+        {
+            Name = name,
+            Path = sourcePath,
+            WellKnown = wellKnown,
+            Enabled = true,
+            AllowSymlinks = wellKnown is not null // well-known sources typically need symlinks
+        });
+
+        SaveExternalSkillsConfig(paths, config);
+        Console.WriteLine($"Added external source '{name}'.");
+        return 0;
+    }
+
+    private static int RunSourceRemove(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 4)
+        {
+            Console.Error.WriteLine("Usage: netclaw skill source remove <name>");
+            return 1;
+        }
+
+        var name = args[3];
+        var config = LoadExternalSkillsConfig(paths);
+
+        var existing = config.Sources.FindIndex(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        if (existing < 0)
+        {
+            Console.Error.WriteLine($"[FAIL] source '{name}' not found.");
+            return 1;
+        }
+
+        config.Sources.RemoveAt(existing);
+        SaveExternalSkillsConfig(paths, config);
+        Console.WriteLine($"Removed external source '{name}'.");
+        return 0;
+    }
+
+    private static int RunSourceToggle(string[] args, NetclawPaths paths, bool enable)
+    {
+        if (args.Length < 4)
+        {
+            Console.Error.WriteLine($"Usage: netclaw skill source {(enable ? "enable" : "disable")} <name>");
+            return 1;
+        }
+
+        var name = args[3];
+        var config = LoadExternalSkillsConfig(paths);
+
+        var source = config.Sources.FirstOrDefault(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        if (source is null)
+        {
+            Console.Error.WriteLine($"[FAIL] source '{name}' not found.");
+            return 1;
+        }
+
+        source.Enabled = enable;
+        SaveExternalSkillsConfig(paths, config);
+        Console.WriteLine($"Source '{name}' {(enable ? "enabled" : "disabled")}.");
+        return 0;
+    }
+
+    // ── Helpers ──
+
+    /// <summary>
+    /// Run the full scan (native + external sources) using config from netclaw.json.
+    /// </summary>
+    private static MergedSkillScanResult ScanAll(NetclawPaths paths)
+    {
+        var config = LoadExternalSkillsConfig(paths);
+        var externalSources = config.ResolveEnabledSources();
+        return SkillScanner.ScanAndMerge(paths.SkillsDirectory, externalSources);
+    }
+
+    /// <summary>
+    /// Load the ExternalSkills section from netclaw.json using Microsoft.Extensions.Configuration.
+    /// </summary>
+    private static ExternalSkillsConfig LoadExternalSkillsConfig(NetclawPaths paths)
+    {
+        var configBuilder = new ConfigurationBuilder();
+        if (File.Exists(paths.NetclawConfigPath))
+            configBuilder.AddJsonFile(paths.NetclawConfigPath, optional: true);
+        var configuration = configBuilder.Build();
+        return configuration.GetSection("ExternalSkills").Get<ExternalSkillsConfig>()
+            ?? new ExternalSkillsConfig();
+    }
+
+    /// <summary>
+    /// Persist the ExternalSkills config back to netclaw.json via ConfigFileHelper.
+    /// </summary>
+    private static void SaveExternalSkillsConfig(NetclawPaths paths, ExternalSkillsConfig config)
+    {
+        var dict = ConfigFileHelper.LoadJsonDict(paths.NetclawConfigPath);
+
+        // Serialize the config to a JsonElement so it round-trips cleanly
+        var serialized = JsonSerializer.SerializeToElement(config, JsonOptions);
+        dict["ExternalSkills"] = serialized;
+
+        ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, dict);
+    }
+
+    /// <summary>
+    /// Classify a skill's source for display purposes.
+    /// </summary>
+    private static string ClassifySource(SkillEntry skill, NetclawPaths paths)
+    {
+        var systemPrefix = paths.SkillsDirectory + Path.DirectorySeparatorChar + ".system" + Path.DirectorySeparatorChar;
+        if (skill.FilePath.StartsWith(systemPrefix, StringComparison.OrdinalIgnoreCase))
+            return "system";
+
+        var nativePrefix = paths.SkillsDirectory + Path.DirectorySeparatorChar;
+        if (skill.FilePath.StartsWith(nativePrefix, StringComparison.OrdinalIgnoreCase))
+            return "native";
+
+        return "external";
+    }
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw skill <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  list                                          List all discovered skills (default)");
+        Console.WriteLine("  show <name>                                   Show skill details and content");
+        Console.WriteLine("  validate <path>                               Validate a SKILL.md file's frontmatter");
+        Console.WriteLine("  remove <name>                                 Remove a native skill");
+        Console.WriteLine("  issues                                        Show only scanner issues");
+        Console.WriteLine("  search <query>                                Search skills by name or description");
+        Console.WriteLine("  source list                                   List configured external sources");
+        Console.WriteLine("  source add <name> --path <dir>                Add a custom external source");
+        Console.WriteLine("  source add <name> --well-known <alias>        Add a well-known source (claude-code, open-code)");
+        Console.WriteLine("  source remove <name>                          Remove an external source");
+        Console.WriteLine("  source enable <name>                          Enable an external source");
+        Console.WriteLine("  source disable <name>                         Disable an external source");
+        Console.WriteLine();
+        Console.WriteLine("All subcommands are offline — no daemon required.");
+        return 0;
+    }
+
+    private static int WriteSourceHelp()
+    {
+        Console.WriteLine("Usage: netclaw skill source <action>");
+        Console.WriteLine();
+        Console.WriteLine("Actions:");
+        Console.WriteLine("  list                                          List configured external sources");
+        Console.WriteLine("  add <name> --path <dir>                       Add a custom external source");
+        Console.WriteLine("  add <name> --well-known <alias>               Add a well-known source (claude-code, open-code)");
+        Console.WriteLine("  remove <name>                                 Remove an external source");
+        Console.WriteLine("  enable <name>                                 Enable an external source");
+        Console.WriteLine("  disable <name>                                Disable an external source");
+        return 0;
+    }
+}

--- a/src/Netclaw.Cli/Skills/SkillCommand.cs
+++ b/src/Netclaw.Cli/Skills/SkillCommand.cs
@@ -19,34 +19,31 @@ internal static class SkillCommand
         Converters = { new JsonStringEnumConverter() }
     };
 
-    public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
+    public static Task<int> RunAsync(string[] args, NetclawPaths paths)
     {
-        // default to "list" when no subcommand is provided
         var subcommand = args.Length > 1 ? args[1] : "list";
 
         if (subcommand is "help" or "-h" or "--help")
         {
             WriteHelp();
-            return 0;
+            return Task.FromResult(0);
         }
 
-        // Handle "source" compound subcommands: source list, source add, etc.
         if (subcommand is "source")
         {
             var sourceAction = args.Length > 2 ? args[2] : "list";
-            return sourceAction switch
+            return Task.FromResult(sourceAction switch
             {
                 "list" => RunSourceList(paths),
                 "add" => RunSourceAdd(args, paths),
                 "remove" => RunSourceRemove(args, paths),
                 "enable" => RunSourceToggle(args, paths, enable: true),
                 "disable" => RunSourceToggle(args, paths, enable: false),
-                "help" or "-h" or "--help" => WriteSourceHelp(),
                 _ => WriteSourceHelp()
-            };
+            });
         }
 
-        return subcommand switch
+        return Task.FromResult(subcommand switch
         {
             "list" => RunList(paths),
             "show" => RunShow(args, paths),
@@ -55,7 +52,7 @@ internal static class SkillCommand
             "issues" => RunIssues(paths),
             "search" => RunSearch(args, paths),
             _ => WriteHelp()
-        };
+        });
     }
 
     // ── Subcommand implementations ──
@@ -82,14 +79,9 @@ internal static class SkillCommand
         {
             var source = ClassifySource(skill, paths);
             var version = skill.Version ?? "-";
-            var status = skill.IsFlatFile ? "flat file (no frontmatter)" : "ok";
-
-            // Flat files with frontmatter that parsed successfully are actually fine
-            if (skill.IsFlatFile && skill.Description.Length > 0)
-                status = "ok";
 
             Console.WriteLine(
-                $"{skill.Name,-colName}  {source,-colSource}  {version,-colVersion}  {status}");
+                $"{skill.Name,-colName}  {source,-colSource}  {version,-colVersion}  ok");
         }
 
         // Also show issues inline
@@ -168,33 +160,7 @@ internal static class SkillCommand
             return 1;
         }
 
-        string content;
-        try
-        {
-            content = File.ReadAllText(filePath);
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"[FAIL] cannot read file: {ex.Message}");
-            return 1;
-        }
-
-        // Check frontmatter structure: must start with --- and have a closing ---
-        if (!content.StartsWith("---", StringComparison.Ordinal))
-        {
-            Console.Error.WriteLine("[FAIL] file does not start with YAML frontmatter (---).");
-            return 1;
-        }
-
-        var closingIndex = content.IndexOf("\n---", 3, StringComparison.Ordinal);
-        if (closingIndex < 0)
-        {
-            Console.Error.WriteLine("[FAIL] YAML frontmatter is not properly closed (missing closing ---).");
-            return 1;
-        }
-
-        // Use the scanner to validate — create a temp directory with the file
-        // and scan it to get full validation including frontmatter parsing.
+        // Delegate to the scanner for full validation (frontmatter, description, name matching).
         var parentDir = Path.GetDirectoryName(filePath)!;
         var fileName = Path.GetFileName(filePath);
 
@@ -275,7 +241,6 @@ internal static class SkillCommand
             return 1;
         }
 
-        // Native skill — delete directory or flat file
         if (skill.IsFlatFile)
         {
             File.Delete(skill.FilePath);
@@ -284,6 +249,15 @@ internal static class SkillCommand
         else
         {
             Directory.Delete(skill.SkillDirectory, recursive: true);
+
+            // Clean empty parent category directories (consistent with SkillManageTool)
+            var parent = Path.GetDirectoryName(skill.SkillDirectory);
+            if (parent is not null && parent != paths.SkillsDirectory
+                && Directory.Exists(parent) && !Directory.EnumerateFileSystemEntries(parent).Any())
+            {
+                Directory.Delete(parent);
+            }
+
             Console.WriteLine($"Removed skill directory: {skill.SkillDirectory}");
         }
 

--- a/src/Netclaw.Configuration/SkillEntry.cs
+++ b/src/Netclaw.Configuration/SkillEntry.cs
@@ -61,4 +61,11 @@ public sealed record SkillEntry(
     /// From frontmatter <c>argument-hint</c>. Example: <c>[subsystem]</c>.
     /// </summary>
     public string? ArgumentHint { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, this skill was loaded from a flat <c>.md</c> file
+    /// rather than the standard <c>skill-name/SKILL.md</c> directory layout.
+    /// Flat-file skills cannot have resources (no subdirectories).
+    /// </summary>
+    public bool IsFlatFile { get; init; }
 }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -730,6 +730,12 @@ static void ConfigureDaemonServices(
         client.Timeout = FeedConstants.FeedHttpTimeout);
     services.AddHostedService<SystemSkillSyncService>();
 
+    // Skill directory watcher — auto-rescan when skill files change on disk.
+    // Covers native skills directory and all external sources.
+    // Registered after SystemSkillSyncService so initial sync completes first.
+    services.AddSingleton<SkillDirectoryWatcherService>();
+    services.AddHostedService(sp => sp.GetRequiredService<SkillDirectoryWatcherService>());
+
     // Binary update check — logs a warning at startup if a newer version is available.
     // Never blocks startup, never downloads anything.
     // Result is cached in UpdateCheckService for 1 hour; DaemonRuntimeStatusService

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -23,6 +23,7 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
     private readonly List<FileSystemWatcher> _watchers = [];
     private Timer? _debounceTimer;
     private int _rescanInProgress;
+    private int _pendingRescan;
 
     public SkillDirectoryWatcherService(
         NetclawPaths paths,
@@ -51,7 +52,6 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
             TryCreateWatcher(source.Path, source.Name);
         }
 
-        // Keep the service alive until cancellation
         return Task.CompletedTask;
     }
 
@@ -114,10 +114,11 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
 
     private void OnDebounceTimerFired()
     {
-        // Prevent overlapping rescans
+        // Prevent overlapping rescans — if one is running, mark pending so it retries after
         if (Interlocked.CompareExchange(ref _rescanInProgress, 1, 0) != 0)
         {
-            _logger.LogDebug("Rescan already in progress, skipping");
+            Interlocked.Exchange(ref _pendingRescan, 1);
+            _logger.LogDebug("Rescan already in progress, marked pending");
             return;
         }
 
@@ -140,6 +141,13 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
         finally
         {
             Interlocked.Exchange(ref _rescanInProgress, 0);
+
+            // If changes arrived while we were scanning, schedule another debounced rescan
+            if (Interlocked.CompareExchange(ref _pendingRescan, 0, 1) == 1)
+            {
+                _logger.LogDebug("Pending rescan detected, scheduling another debounce cycle");
+                ResetDebounceTimer();
+            }
         }
     }
 

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Skills;
+using Netclaw.Configuration;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Watches all skill directories (native + external sources) for file changes
+/// and triggers a debounced rescan to keep the in-memory skill registry
+/// up to date without requiring a daemon restart.
+/// </summary>
+public sealed class SkillDirectoryWatcherService : BackgroundService
+{
+    private static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(500);
+
+    private readonly NetclawPaths _paths;
+    private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
+    private readonly SkillRegistry _registry;
+    private readonly SkillIndexContextLayer _indexLayer;
+    private readonly ILogger<SkillDirectoryWatcherService> _logger;
+
+    private readonly List<FileSystemWatcher> _watchers = [];
+    private Timer? _debounceTimer;
+    private int _rescanInProgress;
+
+    public SkillDirectoryWatcherService(
+        NetclawPaths paths,
+        IReadOnlyList<ResolvedExternalSource> externalSources,
+        SkillRegistry registry,
+        SkillIndexContextLayer indexLayer,
+        ILogger<SkillDirectoryWatcherService> logger)
+    {
+        _paths = paths;
+        _externalSources = externalSources;
+        _registry = registry;
+        _indexLayer = indexLayer;
+        _logger = logger;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _debounceTimer = new Timer(_ => OnDebounceTimerFired(), null, Timeout.Infinite, Timeout.Infinite);
+
+        // Watch the native skills directory
+        TryCreateWatcher(_paths.SkillsDirectory, "native");
+
+        // Watch each external source directory
+        foreach (var source in _externalSources)
+        {
+            TryCreateWatcher(source.Path, source.Name);
+        }
+
+        // Keep the service alive until cancellation
+        return Task.CompletedTask;
+    }
+
+    private void TryCreateWatcher(string directory, string label)
+    {
+        if (!Directory.Exists(directory))
+        {
+            _logger.LogWarning(
+                "Skill directory does not exist, skipping watcher: {Directory} ({Label})",
+                directory, label);
+            return;
+        }
+
+        var watcher = new FileSystemWatcher(directory)
+        {
+            Filter = "*.md",
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.DirectoryName,
+            EnableRaisingEvents = true
+        };
+
+        watcher.Created += OnFileEvent;
+        watcher.Changed += OnFileEvent;
+        watcher.Deleted += OnFileEvent;
+        watcher.Renamed += OnRenameEvent;
+        watcher.Error += OnWatcherError;
+
+        _watchers.Add(watcher);
+        _logger.LogInformation("Watching skill directory: {Directory} ({Label})", directory, label);
+    }
+
+    private void OnFileEvent(object sender, FileSystemEventArgs e)
+    {
+        if (ShouldIgnore(e.FullPath))
+            return;
+
+        _logger.LogDebug("Skill file {ChangeType}: {Path}", e.ChangeType, e.FullPath);
+        ResetDebounceTimer();
+    }
+
+    private void OnRenameEvent(object sender, RenamedEventArgs e)
+    {
+        if (ShouldIgnore(e.FullPath) && ShouldIgnore(e.OldFullPath))
+            return;
+
+        _logger.LogDebug("Skill file renamed: {OldPath} -> {Path}", e.OldFullPath, e.FullPath);
+        ResetDebounceTimer();
+    }
+
+    private void OnWatcherError(object sender, ErrorEventArgs e)
+    {
+        _logger.LogWarning(e.GetException(), "FileSystemWatcher error — triggering recovery rescan");
+        ResetDebounceTimer();
+    }
+
+    private void ResetDebounceTimer()
+    {
+        _debounceTimer?.Change(DebounceInterval, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnDebounceTimerFired()
+    {
+        // Prevent overlapping rescans
+        if (Interlocked.CompareExchange(ref _rescanInProgress, 1, 0) != 0)
+        {
+            _logger.LogDebug("Rescan already in progress, skipping");
+            return;
+        }
+
+        try
+        {
+            _logger.LogDebug("Debounce timer fired, starting skill rescan");
+
+            var result = SkillScanner.ScanAndMerge(_paths.SkillsDirectory, _externalSources);
+            SkillRegistryUpdater.ApplyMergedScanResult(
+                _registry, _indexLayer, result, _paths.SkillsDirectory, _externalSources);
+
+            _logger.LogInformation(
+                "Skill directory rescan complete: {SkillCount} skills loaded, {IssueCount} issues",
+                result.AcceptedSkills.Count, result.Issues.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Skill directory rescan failed");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _rescanInProgress, 0);
+        }
+    }
+
+    private static bool ShouldIgnore(string fullPath)
+    {
+        // Ignore staging directories and temp files used by atomic write operations
+        return fullPath.Contains($"{Path.DirectorySeparatorChar}.staging{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            || fullPath.Contains($"{Path.AltDirectorySeparatorChar}.staging{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal)
+            || fullPath.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override void Dispose()
+    {
+        _debounceTimer?.Dispose();
+
+        foreach (var watcher in _watchers)
+        {
+            watcher.EnableRaisingEvents = false;
+            watcher.Dispose();
+        }
+
+        _watchers.Clear();
+
+        base.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `netclaw skill` CLI command family for offline skill inspection and management (list, show, validate, remove, issues, search, source)
- Add `SkillDirectoryWatcherService` — auto-rescan skill directories on file changes via `FileSystemWatcher`, eliminating need for daemon restart
- Add flat-file `.md` skill support in `SkillScanner` for Claude Code compatibility (6 flat files in `~/.claude/skills/` were previously silently dropped)

## Motivation

A Netqual session (D0AC6CKBK5K/1775140734.665199) revealed that:
1. Skills written by the agent as flat files weren't detected by the scanner
2. No `netclaw skill` CLI commands existed for inspection/management
3. No way to rescan skills without restarting the daemon
4. External skill sources required manual JSON config editing

## Changes

**Scanner (`SkillScanner.cs`):**
- Pass 0: flat-file `.md` skills with valid YAML frontmatter accepted as first-class skills
- Directory skills take precedence over flat files with same name
- Shared `BuildSkillEntry` eliminates duplication between directory and flat-file paths
- New issue kinds: `FlatFileMissingFrontmatter`, `FlatFileNoDescription`

**CLI (`SkillCommand.cs`):**
- `list` — table of all skills with source/version/status (includes rejected items)
- `show <name>` — display skill metadata and content
- `validate <path>` — validate a SKILL.md file's format
- `remove <name>` — delete native skills (refuses system/external)
- `issues` — show only scanner issues
- `search <query>` — substring search across all sources
- `source list/add/remove/enable/disable` — manage external skill sources in config

**Watcher (`SkillDirectoryWatcherService.cs`):**
- `BackgroundService` with `FileSystemWatcher` on native + all external source directories
- 500ms debounced rescan with overlap protection and pending-rescan retry
- Ignores `.staging/` and `.tmp` files from atomic write operations

**Other:**
- `SkillEntry.IsFlatFile` property
- `SkillManageTool` updated for flat-file delete
- `SkillFrontmatter` / `ExtractFrontmatter` made public for CLI use
- `"skill"` added to `CliArgsParser.KnownCommands`

## Related

- Filed #532 for deferred work: public skill directory using Cloudflare `.well-known/agent-skills/` standard

## Test plan

- [ ] `dotnet build` succeeds (verified)
- [ ] All 1,873 tests pass (verified, zero failures)
- [ ] `netclaw skill list` shows skills from native + system + external sources
- [ ] `netclaw skill show <name>` displays skill content
- [ ] `netclaw skill search <query>` finds matching skills
- [ ] `netclaw skill source add/remove/enable/disable` modifies config
- [ ] Flat `.md` files with valid frontmatter are accepted by scanner
- [ ] Watcher triggers rescan when files change on disk