### PR TITLE
Improve memory dedup: prefix matching, relaxed content fallback, ambiguous auto-resolve

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/AnchorNameMatcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/AnchorNameMatcherTests.cs
@@ -138,11 +138,12 @@ public sealed class AnchorNameMatcherTests
 
         // "akka-net-release-1.5.62" tokens = {akka, net, release, 1.5.62}
         // "akka-net-release" tokens = {akka, net, release} -> subset of proposal -> match
-        // "akka-net-latest-release" tokens = {akka, net, latest, release} -> NOT subset (has "latest"), and
-        //   Jaccard = 3/5 = 0.6 but symmetric diff = 2 -> no match
+        // "akka-net-latest-release" tokens = {akka, net, latest, release} -> Jaccard = 3/5 = 0.6,
+        //   unmatched = 2 which is <= MaxTokenDifference(2) -> also matches
         var matches = AnchorNameMatcher.FindFuzzyMatches("akka-net-release-1.5.62", existing);
 
         Assert.Contains("akka-net-release", matches);
+        Assert.Contains("akka-net-latest-release", matches);
         Assert.DoesNotContain("user-preferred-color", matches);
         Assert.DoesNotContain("database-config", matches);
     }
@@ -215,5 +216,77 @@ public sealed class AnchorNameMatcherTests
         Assert.Equal(0.0, AnchorNameMatcher.ComputeContentOverlap("", "something"));
         Assert.Equal(0.0, AnchorNameMatcher.ComputeContentOverlap("something", ""));
         Assert.Equal(0.0, AnchorNameMatcher.ComputeContentOverlap("", ""));
+    }
+
+    // ── IsFuzzyMatch: two-token difference (MaxTokenDifference = 2) ──
+
+    [Fact]
+    public void IsFuzzyMatch_returns_true_for_two_token_difference()
+    {
+        // {email, draft, editing, preference} vs {email, draft, editing, workflow}
+        // Jaccard = 3/5 = 0.60, unmatched = 2 <= MaxTokenDifference(2)
+        var tokensA = AnchorNameMatcher.Tokenize("email-draft-editing-preference");
+        var tokensB = AnchorNameMatcher.Tokenize("email-draft-editing-workflow");
+        Assert.True(AnchorNameMatcher.IsFuzzyMatch(tokensA, tokensB));
+    }
+
+    // ── IsFuzzyMatch: prefix matching ───────────────────────────────
+
+    [Fact]
+    public void IsFuzzyMatch_returns_true_for_prefix_match_repo_vs_repository()
+    {
+        // "repo" prefix-matches "repository" -> treated as same token for Jaccard
+        var tokensA = AnchorNameMatcher.Tokenize("netclaw-github-repo");
+        var tokensB = AnchorNameMatcher.Tokenize("netclaw-github-repository");
+        Assert.True(AnchorNameMatcher.IsFuzzyMatch(tokensA, tokensB));
+    }
+
+    [Fact]
+    public void IsFuzzyMatch_returns_true_for_prefix_match_snake_vs_snakey()
+    {
+        // "snake" prefix-matches "snakey"; combined with MaxTokenDifference=2
+        // this catches different descriptors (game vs trail) as long as enough tokens overlap
+        var tokensA = AnchorNameMatcher.Tokenize("snake-game-project-location");
+        var tokensB = AnchorNameMatcher.Tokenize("snakey-trail-project-location");
+        Assert.True(AnchorNameMatcher.IsFuzzyMatch(tokensA, tokensB));
+    }
+
+    [Fact]
+    public void IsFuzzyMatch_prefix_requires_minimum_length()
+    {
+        // "in" is only 2 chars — too short to prefix-match "integration"
+        var tokensA = new[] { "in", "memory", "store" };
+        var tokensB = new[] { "integration", "memory", "store" };
+        // Without prefix: Jaccard = 2/4 = 0.5 < 0.6 -> no match
+        // "in" is too short (< 3 chars) for prefix matching, so it stays at 0.5
+        Assert.False(AnchorNameMatcher.IsFuzzyMatch(tokensA, tokensB));
+    }
+
+    // ── ComputeAnchorJaccard ────────────────────────────────────────
+
+    [Fact]
+    public void ComputeAnchorJaccard_returns_1_for_identical_tokens()
+    {
+        var tokens = new[] { "akka", "net", "release" };
+        Assert.Equal(1.0, AnchorNameMatcher.ComputeAnchorJaccard(tokens, tokens), 2);
+    }
+
+    [Fact]
+    public void ComputeAnchorJaccard_accounts_for_prefix_matching()
+    {
+        // "repo" prefix-matches "repository", so soft intersection = 3
+        // union = {netclaw, github, repo, repository} = 4
+        // Jaccard = 3/4 = 0.75
+        var tokensA = AnchorNameMatcher.Tokenize("netclaw-github-repo");
+        var tokensB = AnchorNameMatcher.Tokenize("netclaw-github-repository");
+        var jaccard = AnchorNameMatcher.ComputeAnchorJaccard(tokensA, tokensB);
+        Assert.True(jaccard > 0.7);
+    }
+
+    [Fact]
+    public void ComputeAnchorJaccard_returns_0_for_empty_tokens()
+    {
+        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard([], new[] { "a" }));
+        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard(new[] { "a" }, []));
     }
 }

--- a/src/Netclaw.Actors.Tests/Memory/CurationRulesEvaluatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/CurationRulesEvaluatorTests.cs
@@ -236,4 +236,77 @@ public sealed class CurationRulesEvaluatorTests
         Assert.Equal(CurationDecisionKind.Update, decision.Kind);
         Assert.Equal("doc-recent", decision.TargetDocumentId);
     }
+
+    // ── TryAutoResolveAmbiguous ─────────────────────────────────────
+
+    [Fact]
+    public void TryAutoResolveAmbiguous_returns_Skip_when_high_overlap_and_anchor_similarity()
+    {
+        // Content overlap > 60% and anchor Jaccard > 50%
+        var proposal = MakeProposal(
+            anchor: "netclaw-github-repo",
+            content: "Netclaw GitHub repository at https://github.com/Aaronontheweb/netclaw, private repo");
+        var candidates = new[]
+        {
+            MakeCandidate(
+                anchorName: "netclaw-github-repository",
+                content: "Netclaw GitHub repository: https://github.com/Aaronontheweb/netclaw. The repository is private.",
+                isExact: false)
+        };
+
+        var decision = CurationRulesEvaluator.TryAutoResolveAmbiguous(proposal, candidates);
+
+        Assert.NotNull(decision);
+        Assert.Equal(CurationDecisionKind.Skip, decision.Kind);
+        Assert.Contains("auto-resolved", decision.Reason);
+    }
+
+    [Fact]
+    public void TryAutoResolveAmbiguous_returns_null_when_content_overlap_below_threshold()
+    {
+        // High anchor similarity but low content overlap
+        var proposal = MakeProposal(
+            anchor: "akka-net-release",
+            content: "The CI pipeline deploys to staging on every merge");
+        var candidates = new[]
+        {
+            MakeCandidate(
+                anchorName: "akka-net-latest-release",
+                content: "PostgreSQL 15 is the primary datastore for user profiles",
+                isExact: false)
+        };
+
+        var decision = CurationRulesEvaluator.TryAutoResolveAmbiguous(proposal, candidates);
+
+        Assert.Null(decision);
+    }
+
+    [Fact]
+    public void TryAutoResolveAmbiguous_returns_null_when_anchor_jaccard_below_threshold()
+    {
+        // High content overlap but very different anchor names
+        var proposal = MakeProposal(
+            anchor: "snake-game-location",
+            content: "The project is at /home/user/projects/snakey-trail with HTML and CSS");
+        var candidates = new[]
+        {
+            MakeCandidate(
+                anchorName: "deployment-url-config",
+                content: "The project is at /home/user/projects/snakey-trail with HTML and JavaScript",
+                isExact: false)
+        };
+
+        var decision = CurationRulesEvaluator.TryAutoResolveAmbiguous(proposal, candidates);
+
+        Assert.Null(decision);
+    }
+
+    [Fact]
+    public void TryAutoResolveAmbiguous_returns_null_for_empty_candidates()
+    {
+        var proposal = MakeProposal();
+        var decision = CurationRulesEvaluator.TryAutoResolveAmbiguous(proposal, []);
+
+        Assert.Null(decision);
+    }
 }

--- a/src/Netclaw.Actors/Memory/AnchorNameMatcher.cs
+++ b/src/Netclaw.Actors/Memory/AnchorNameMatcher.cs
@@ -7,7 +7,8 @@ namespace Netclaw.Actors.Memory;
 public static class AnchorNameMatcher
 {
     private const double JaccardThreshold = 0.6;
-    private const int MaxTokenDifference = 1;
+    private const int MaxTokenDifference = 2;
+    private const int MinPrefixLength = 3;
 
     /// <summary>
     /// Tokenize an anchor name by splitting on '-' and lowering.
@@ -24,10 +25,30 @@ public static class AnchorNameMatcher
     }
 
     /// <summary>
+    /// Compute Jaccard similarity between two sets of anchor tokens,
+    /// using prefix-aware matching (one token is a prefix of the other, min 3 chars).
+    /// </summary>
+    public static double ComputeAnchorJaccard(string[] tokensA, string[] tokensB)
+    {
+        if (tokensA.Length == 0 || tokensB.Length == 0)
+            return 0.0;
+
+        var setA = new HashSet<string>(tokensA, StringComparer.OrdinalIgnoreCase);
+        var setB = new HashSet<string>(tokensB, StringComparer.OrdinalIgnoreCase);
+
+        var softIntersection = SoftIntersectionCount(setA, setB);
+
+        // Use inclusion-exclusion with soft intersection so that prefix-matched
+        // pairs (e.g., "repo" / "repository") count as one item, not two.
+        var softUnion = setA.Count + setB.Count - softIntersection;
+        return softUnion == 0 ? 0.0 : (double)softIntersection / softUnion;
+    }
+
+    /// <summary>
     /// Check if two token arrays are a fuzzy match.
     /// Two anchors are fuzzy matches if:
-    /// - Jaccard similarity >= 0.6
-    /// - AND (the shorter is a subset of the longer, OR they differ by at most 1 token)
+    /// - Jaccard similarity >= 0.6 (using prefix-aware token matching)
+    /// - AND (the shorter is a soft-subset of the longer, OR they differ by at most 2 tokens)
     /// </summary>
     public static bool IsFuzzyMatch(string[] tokensA, string[] tokensB)
     {
@@ -37,30 +58,61 @@ public static class AnchorNameMatcher
         var setA = new HashSet<string>(tokensA, StringComparer.OrdinalIgnoreCase);
         var setB = new HashSet<string>(tokensB, StringComparer.OrdinalIgnoreCase);
 
-        var intersection = new HashSet<string>(setA, StringComparer.OrdinalIgnoreCase);
-        intersection.IntersectWith(setB);
+        var softIntersection = SoftIntersectionCount(setA, setB);
 
-        var union = new HashSet<string>(setA, StringComparer.OrdinalIgnoreCase);
-        union.UnionWith(setB);
-
-        if (union.Count == 0)
+        // Use inclusion-exclusion with soft intersection so that prefix-matched
+        // pairs (e.g., "repo" / "repository") count as one item, not two.
+        var softUnion = setA.Count + setB.Count - softIntersection;
+        if (softUnion == 0)
             return false;
 
-        var jaccard = (double)intersection.Count / union.Count;
+        var jaccard = (double)softIntersection / softUnion;
         if (jaccard < JaccardThreshold)
             return false;
 
-        // Check subset: all tokens of the shorter set are in the longer set
+        // Check soft-subset: all tokens of the shorter set prefix-match something in the longer set
         var shorter = setA.Count <= setB.Count ? setA : setB;
         var longer = setA.Count <= setB.Count ? setB : setA;
-        var isSubset = shorter.All(t => longer.Contains(t));
+        var isSoftSubset = shorter.All(t => longer.Any(l => IsPrefixMatch(t, l)));
 
-        if (isSubset)
+        if (isSoftSubset)
             return true;
 
-        // Check token difference: symmetric difference <= 1
-        var symmetricDifference = union.Count - intersection.Count;
-        return symmetricDifference <= MaxTokenDifference;
+        // Check token difference: unmatched tokens <= MaxTokenDifference
+        var unmatchedCount = softUnion - softIntersection;
+        return unmatchedCount <= MaxTokenDifference;
+    }
+
+    /// <summary>
+    /// Count tokens from setA that prefix-match at least one token in setB (or vice versa).
+    /// Two tokens match if they are equal or one is a prefix of the other (min 3 chars).
+    /// </summary>
+    private static int SoftIntersectionCount(HashSet<string> setA, HashSet<string> setB)
+    {
+        var count = 0;
+        foreach (var a in setA)
+        {
+            if (setB.Any(b => IsPrefixMatch(a, b)))
+                count++;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Two tokens match if they are equal (case-insensitive) or one is a prefix
+    /// of the other with minimum prefix length of 3 characters.
+    /// </summary>
+    private static bool IsPrefixMatch(string a, string b)
+    {
+        if (string.Equals(a, b, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // The shorter string must be at least MinPrefixLength chars to count as a prefix
+        var shorter = a.Length <= b.Length ? a : b;
+        var longer = a.Length <= b.Length ? b : a;
+
+        return shorter.Length >= MinPrefixLength
+            && longer.StartsWith(shorter, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Memory/AnchorNameMatcher.cs
+++ b/src/Netclaw.Actors/Memory/AnchorNameMatcher.cs
@@ -36,12 +36,7 @@ public static class AnchorNameMatcher
         var setA = new HashSet<string>(tokensA, StringComparer.OrdinalIgnoreCase);
         var setB = new HashSet<string>(tokensB, StringComparer.OrdinalIgnoreCase);
 
-        var softIntersection = SoftIntersectionCount(setA, setB);
-
-        // Use inclusion-exclusion with soft intersection so that prefix-matched
-        // pairs (e.g., "repo" / "repository") count as one item, not two.
-        var softUnion = setA.Count + setB.Count - softIntersection;
-        return softUnion == 0 ? 0.0 : (double)softIntersection / softUnion;
+        return ComputeSoftJaccard(setA, setB);
     }
 
     /// <summary>
@@ -58,15 +53,7 @@ public static class AnchorNameMatcher
         var setA = new HashSet<string>(tokensA, StringComparer.OrdinalIgnoreCase);
         var setB = new HashSet<string>(tokensB, StringComparer.OrdinalIgnoreCase);
 
-        var softIntersection = SoftIntersectionCount(setA, setB);
-
-        // Use inclusion-exclusion with soft intersection so that prefix-matched
-        // pairs (e.g., "repo" / "repository") count as one item, not two.
-        var softUnion = setA.Count + setB.Count - softIntersection;
-        if (softUnion == 0)
-            return false;
-
-        var jaccard = (double)softIntersection / softUnion;
+        var (jaccard, softIntersection, softUnion) = ComputeSoftJaccardDetail(setA, setB);
         if (jaccard < JaccardThreshold)
             return false;
 
@@ -83,19 +70,34 @@ public static class AnchorNameMatcher
         return unmatchedCount <= MaxTokenDifference;
     }
 
-    /// <summary>
-    /// Count tokens from setA that prefix-match at least one token in setB (or vice versa).
-    /// Two tokens match if they are equal or one is a prefix of the other (min 3 chars).
-    /// </summary>
-    private static int SoftIntersectionCount(HashSet<string> setA, HashSet<string> setB)
+    private static double ComputeSoftJaccard(HashSet<string> setA, HashSet<string> setB)
     {
-        var count = 0;
+        var (jaccard, _, _) = ComputeSoftJaccardDetail(setA, setB);
+        return jaccard;
+    }
+
+    /// <summary>
+    /// Compute prefix-aware Jaccard similarity, returning the score plus the raw
+    /// soft-intersection and soft-union counts for callers that need them.
+    /// </summary>
+    private static (double Jaccard, int SoftIntersection, int SoftUnion) ComputeSoftJaccardDetail(
+        HashSet<string> setA, HashSet<string> setB)
+    {
+        var rawCount = 0;
         foreach (var a in setA)
         {
             if (setB.Any(b => IsPrefixMatch(a, b)))
-                count++;
+                rawCount++;
         }
-        return count;
+
+        // Cap at min(|A|, |B|) to prevent many-to-one prefix matches
+        // (e.g., {"repo", "repos"} both matching "repository") from inflating
+        // the intersection beyond what inclusion-exclusion allows.
+        var softIntersection = Math.Min(rawCount, Math.Min(setA.Count, setB.Count));
+        var softUnion = setA.Count + setB.Count - softIntersection;
+        var jaccard = softUnion == 0 ? 0.0 : (double)softIntersection / softUnion;
+
+        return (jaccard, softIntersection, softUnion);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
@@ -53,6 +53,11 @@ public static class CurationRulesEvaluator
     private const double HighOverlapThreshold = 0.80;
     private const double AmbiguousLowerThreshold = 0.40;
 
+    // Auto-resolution thresholds for Ambiguous decisions when LLM is unavailable.
+    // Both thresholds must be exceeded to auto-resolve to Skip.
+    private const double AmbiguousAutoResolveContentThreshold = 0.60;
+    private const double AmbiguousAutoResolveAnchorJaccard = 0.50;
+
     /// <summary>
     /// Evaluate a single proposal against existing candidates and return a decision.
     /// </summary>
@@ -173,5 +178,41 @@ public static class CurationRulesEvaluator
             null,
             null,
             $"fuzzy anchor match but low content overlap ({overlap:P0})");
+    }
+
+    /// <summary>
+    /// Attempt to resolve an Ambiguous decision without LLM involvement.
+    /// Returns a Skip decision when both content overlap and anchor Jaccard exceed
+    /// auto-resolution thresholds. Returns null if the case is too uncertain —
+    /// caller should fall back to Create.
+    /// </summary>
+    public static CurationDecision? TryAutoResolveAmbiguous(
+        SQLiteMemoryCurationOperation proposal,
+        IReadOnlyList<ExistingMemoryCandidate> candidates)
+    {
+        if (candidates.Count == 0)
+            return null;
+
+        var best = candidates
+            .OrderByDescending(c => c.Confidence)
+            .ThenByDescending(c => c.FreshnessAtMs ?? 0)
+            .First();
+
+        var contentOverlap = AnchorNameMatcher.ComputeContentOverlap(proposal.Content, best.Content);
+        if (contentOverlap < AmbiguousAutoResolveContentThreshold)
+            return null;
+
+        var proposalTokens = AnchorNameMatcher.Tokenize(proposal.AnchorCanonicalName);
+        var bestTokens = AnchorNameMatcher.Tokenize(best.AnchorCanonicalName);
+        var anchorJaccard = AnchorNameMatcher.ComputeAnchorJaccard(proposalTokens, bestTokens);
+        if (anchorJaccard < AmbiguousAutoResolveAnchorJaccard)
+            return null;
+
+        return new CurationDecision(
+            CurationDecisionKind.Skip,
+            best.DocumentId,
+            null,
+            null,
+            $"auto-resolved ambiguous: content overlap ({contentOverlap:P0}) + anchor similarity ({anchorJaccard:F2})");
     }
 }

--- a/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
+++ b/src/Netclaw.Actors/Memory/CurationRulesEvaluator.cs
@@ -198,14 +198,15 @@ public static class CurationRulesEvaluator
             .ThenByDescending(c => c.FreshnessAtMs ?? 0)
             .First();
 
-        var contentOverlap = AnchorNameMatcher.ComputeContentOverlap(proposal.Content, best.Content);
-        if (contentOverlap < AmbiguousAutoResolveContentThreshold)
-            return null;
-
+        // Check anchor similarity first (cheap: 2-6 tokens) before content overlap (expensive: full text)
         var proposalTokens = AnchorNameMatcher.Tokenize(proposal.AnchorCanonicalName);
         var bestTokens = AnchorNameMatcher.Tokenize(best.AnchorCanonicalName);
         var anchorJaccard = AnchorNameMatcher.ComputeAnchorJaccard(proposalTokens, bestTokens);
         if (anchorJaccard < AmbiguousAutoResolveAnchorJaccard)
+            return null;
+
+        var contentOverlap = AnchorNameMatcher.ComputeContentOverlap(proposal.Content, best.Content);
+        if (contentOverlap < AmbiguousAutoResolveContentThreshold)
             return null;
 
         return new CurationDecision(

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -256,8 +256,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 return llmDecision;
             }
 
-            // LLM failed — try deterministic auto-resolution before defaulting to Create
-            _log.Warning("curation_llm_fallback anchor={0}", operation.AnchorCanonicalName);
+            // LLM failed — fall through to deterministic auto-resolution below
         }
 
         // Ambiguous (LLM unavailable or failed) — try deterministic auto-resolution
@@ -274,7 +273,8 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 return autoResolved;
             }
 
-            _log.Warning("curation_ambiguous_create_fallback anchor={0}", operation.AnchorCanonicalName);
+            _log.Warning("curation_ambiguous_create_fallback anchor={0} llm_available={1}",
+                operation.AnchorCanonicalName, _llmClient is not null);
             return new CurationDecision(CurationDecisionKind.Create, null, null, null,
                 "ambiguous: auto-resolve insufficient, defaulting to create");
         }

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -190,15 +190,18 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         }
 
         // Query existing anchors for matches (by name)
-        var candidates = await _store.FindFuzzyAnchorMatchesAsync(
+        var anchorCandidates = await _store.FindFuzzyAnchorMatchesAsync(
             operation.AnchorCanonicalName,
             domain);
 
-        // If anchor-based search found nothing, fall back to content-based search
-        // using the same per-term scoring strategy the recall system uses.
-        // This catches "favorite color is blue" under anchor "favorite" when the
-        // existing copy is under "user-preferred-color" — different names, same content.
-        if (candidates.Count == 0 && !string.IsNullOrWhiteSpace(operation.Content))
+        // Build a mutable candidate list — content search may add more candidates below.
+        var candidates = new List<ExistingMemoryCandidate>(anchorCandidates);
+
+        // Run content-based search when there is no exact anchor match.
+        // This catches semantically identical content under very different anchor names
+        // (e.g., "netclaw-github-repo" vs "netclaw-source-location" — different names, same info).
+        var hasExactAnchorMatch = anchorCandidates.Any(c => c.IsExactAnchorMatch);
+        if (!hasExactAnchorMatch && !string.IsNullOrWhiteSpace(operation.Content))
         {
             var contentTerms = operation.Content
                 .Split([' ', '\t', '\n', '\r', '.', ',', ':', ';', '!', '?', '"', '\''],
@@ -215,8 +218,24 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                     contentTerms,
                     domain);
 
+                // Merge content candidates with anchor candidates, deduplicating by DocumentId.
                 if (contentCandidates.Count > 0)
-                    candidates = contentCandidates;
+                {
+                    var existingDocIds = new HashSet<string>(
+                        candidates.Select(c => c.DocumentId), StringComparer.OrdinalIgnoreCase);
+                    foreach (var cc in contentCandidates)
+                    {
+                        if (!existingDocIds.Contains(cc.DocumentId))
+                            candidates.Add(cc);
+                    }
+
+                    _log.Debug(
+                        "curation_dual_search anchor={0} anchor_hits={1} content_hits={2} merged={3}",
+                        operation.AnchorCanonicalName,
+                        anchorCandidates.Count,
+                        contentCandidates.Count,
+                        candidates.Count);
+                }
             }
         }
 
@@ -237,15 +256,27 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 return llmDecision;
             }
 
-            // LLM failed — fall back to Create (safe default for ambiguous cases)
-            _log.Warning("curation_llm_fallback anchor={0} falling_back_to=Create", operation.AnchorCanonicalName);
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "LLM timeout/failure fallback");
+            // LLM failed — try deterministic auto-resolution before defaulting to Create
+            _log.Warning("curation_llm_fallback anchor={0}", operation.AnchorCanonicalName);
         }
 
-        // Ambiguous with no LLM available -> default to Create
+        // Ambiguous (LLM unavailable or failed) — try deterministic auto-resolution
         if (rulesDecision.Kind == CurationDecisionKind.Ambiguous)
         {
-            return new CurationDecision(CurationDecisionKind.Create, null, null, null, "ambiguous without LLM, defaulting to create");
+            var autoResolved = CurationRulesEvaluator.TryAutoResolveAmbiguous(operation, candidates);
+            if (autoResolved is not null)
+            {
+                _log.Info(
+                    "curation_ambiguous_auto_resolved anchor={0} decision={1} reason={2}",
+                    operation.AnchorCanonicalName,
+                    autoResolved.Kind,
+                    autoResolved.Reason);
+                return autoResolved;
+            }
+
+            _log.Warning("curation_ambiguous_create_fallback anchor={0}", operation.AnchorCanonicalName);
+            return new CurationDecision(CurationDecisionKind.Create, null, null, null,
+                "ambiguous: auto-resolve insufficient, defaulting to create");
         }
 
         return rulesDecision;


### PR DESCRIPTION
## Why

An audit of the production SQLite memory database found ~21 redundant items out of 366 total (~5.7% redundancy rate). The existing multi-layer curation pipeline catches most duplicates, but several near-miss cases slip through due to three root causes:

1. **Content search too conservative** — only ran when anchor search returned zero results. Semantically identical content under very different anchor names (e.g., 4 copies of "Netclaw repo location" under `netclaw-github-repo`, `netclaw-github-repository`, `netclaw-source-location`, `netclaw-local-source-path`) was never content-compared because each had at least one fuzzy anchor match.

2. **Anchor matching too strict lexically** — "repo" ≠ "repository" and "snake" ≠ "snakey" because the matcher used exact token equality. Porter stemming was investigated but doesn't help here (abbreviations and synonyms, not inflections). Prefix matching is the right tool.

3. **Ambiguous cases always created new entries** — when the LLM tier was unavailable or timed out, the system defaulted to Create for all ambiguous decisions (40-80% content overlap), even when both anchor and content similarity were high enough to confidently skip.

## Summary

- **Content fallback gate relaxed**: content-based search now runs whenever there is no exact anchor match (not just zero matches), merging anchor and content candidates by DocumentId. Catches semantically identical content under very different anchor names.
- **Prefix-aware anchor matching**: "repo" now matches "repository", "snake" matches "snakey" (min 3-char prefix). Uses soft-union Jaccard formula with intersection capped at min(|A|, |B|) to prevent many-to-one inflation.
- **MaxTokenDifference 1→2**: anchors sharing most tokens but differing by two now match (e.g., `email-draft-editing-preference` vs `email-draft-editing-workflow`).
- **Ambiguous auto-resolution**: when the LLM tier is unavailable, ambiguous decisions (40-80% overlap) are auto-resolved to Skip when content overlap ≥60% AND anchor Jaccard ≥50%, instead of always defaulting to Create.

## Test plan

- [x] 40/40 unit tests pass (AnchorNameMatcherTests + CurationRulesEvaluatorTests)
- [x] \`dotnet slopwatch analyze\` — 0 violations
- [x] New tests for: prefix matching, two-token difference, ComputeAnchorJaccard, TryAutoResolveAmbiguous (4 tests)
- [ ] CI build passes