### PR TITLE
feat(webhooks): add ingress observability and stats surface

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.5.0"
+  version: "1.6.0"
 ---
 
 # Netclaw Operations
@@ -114,6 +114,28 @@ Verification kinds are generic:
 
 Route files hot-reload without restarting the daemon. If a route file becomes
 invalid, Netclaw removes that route immediately and emits an operational alert.
+
+### Webhook observability
+
+`netclaw stats` includes a `webhooks:` section with:
+
+- **Route counts** — `total`, `enabled`, `disabled`, `invalid` (files on disk,
+  classified by parse/validation status plus the per-route `Enabled` flag).
+- **Delivery counters** — `accepted`, `filtered` (event not in allowlist),
+  `duplicate` (delivery id already seen), plus per-rejection counts:
+  `404` (route_not_found), `401` (verification_failed), `413` (body_too_large),
+  `400` (invalid_json), `429` (rate_limited).
+
+Every ingress outcome writes a structured line to `daemon-{date}.log`:
+
+```
+Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp}
+  delivery_id={DeliveryId} event_type={EventType}
+```
+
+Rejection paths only log + increment counters — they do NOT fire outbound
+operational notifications, so bad or adversarial traffic does not spam the
+configured notification target.
 
 ## Diagnostics
 

--- a/openspec/changes/inbound-webhooks/specs/inbound-webhooks/spec.md
+++ b/openspec/changes/inbound-webhooks/specs/inbound-webhooks/spec.md
@@ -206,3 +206,98 @@ the existing operational notification sink so route failures are never silent.
 - **THEN** an operational alert is emitted identifying the route and reload
   failure
 - **AND** the route remains unavailable until the file is valid again
+
+### Requirement: Webhook rejections emit structured logs and counters
+
+Every webhook ingress outcome — accepted, rejected, filtered, or rate-limited —
+SHALL increment a durable in-process counter and emit a structured daemon log
+line with at minimum the route name, outcome reason, client remote IP, and
+delivery identifier (when available). Rejection paths SHALL NOT emit outbound
+operational notification alerts, to avoid spamming operator channels on
+adversarial or misconfigured traffic.
+
+Counters SHALL cover: `accepted`, `route_not_found`, `verification_failed`,
+`body_too_large`, `invalid_json`, `rate_limited`, `event_filtered`, and
+`duplicate_delivery`.
+
+#### Scenario: Route-not-found emits log and counter
+
+- **GIVEN** no route file exists for `unknown-route`
+- **WHEN** an HTTP POST arrives at the webhook ingress path for `unknown-route`
+- **THEN** the daemon returns `404 Not Found`
+- **AND** the `route_not_found` counter is incremented
+- **AND** a structured warning log line is emitted with `route=unknown-route`,
+  `reason=route_not_found`, and the client remote IP
+- **AND** no outbound operational notification alert is emitted for the rejection
+
+#### Scenario: Verification failure emits log and counter
+
+- **GIVEN** a route with HMAC verification is configured
+- **WHEN** a request arrives with an invalid signature
+- **THEN** the daemon returns `401 Unauthorized`
+- **AND** the `verification_failed` counter is incremented
+- **AND** a structured warning log line is emitted including the route name,
+  the delivery identifier (when the provider supplied one), and
+  `reason=verification_failed`
+
+#### Scenario: Duplicate delivery increments counter
+
+- **GIVEN** a webhook delivery has already been processed within the
+  deduplication window
+- **WHEN** the same delivery identifier arrives again for the same route
+- **THEN** the daemon returns `202 Accepted` with `reason=duplicate_delivery`
+- **AND** the `duplicate_delivery` counter is incremented
+
+### Requirement: Stats surface exposes webhook route counts and delivery counters
+
+The `netclaw stats` CLI surface and `/api/stats` daemon endpoint SHALL include
+webhook metrics covering both route registry counts and delivery counters, so
+operators can see at a glance how many routes are configured and how ingress
+traffic is being handled.
+
+Route counts SHALL cover `total`, `enabled`, `disabled`, and `invalid` routes.
+Delivery counters SHALL cover the same set defined by the rejection
+observability requirement above.
+
+#### Scenario: Stats response includes webhook section
+
+- **GIVEN** webhook routes are configured under `config/webhooks`
+- **WHEN** an operator requests `netclaw stats`
+- **THEN** the response includes a dedicated webhooks section
+- **AND** the section reports route counts (total, enabled, disabled, invalid)
+- **AND** the section reports delivery counters (accepted, filtered, duplicate,
+  and each rejection reason)
+
+#### Scenario: Invalid route files counted as invalid
+
+- **GIVEN** three route files exist under `config/webhooks` and one fails to
+  parse or validate
+- **WHEN** an operator requests `netclaw stats`
+- **THEN** the invalid route counter reflects the single unparseable file
+- **AND** the enabled counter reflects only the successfully loaded routes
+
+### Requirement: Notification tool invocation surfaces as session output
+
+The session actor SHALL emit a tool-result session output for every tool
+invocation whose results are fed back into the conversation. Subscribers that
+track notification-tool completion (such as webhook and reminder execution
+actors) SHALL rely on those session outputs to determine whether the agent
+fulfilled a required notification, rather than waiting on information that is
+never emitted in production.
+
+#### Scenario: Required notification succeeds when agent invokes notification tool
+
+- **GIVEN** a webhook route configures `NotifyPolicy = Required` with a Slack
+  notification target
+- **WHEN** the agent successfully invokes the Slack notification tool during
+  the webhook session
+- **THEN** the webhook execution completes successfully
+- **AND** the daemon does not log a false-positive warning that no notification
+  tool was invoked
+
+#### Scenario: Required notification still fails when no notification tool invoked
+
+- **GIVEN** a webhook route configures `NotifyPolicy = Required`
+- **WHEN** the agent completes its turn without invoking any notification tool
+- **THEN** the webhook execution is marked failed with the "no notification
+  tool was invoked" reason

--- a/openspec/changes/inbound-webhooks/tasks.md
+++ b/openspec/changes/inbound-webhooks/tasks.md
@@ -25,3 +25,13 @@
 - [x] 4.2 Add tests that route load/reload/unload failures emit operational alerts and that accepted-delivery receipt alerts remain separate from reminder-style human notifications.
 - [x] 4.3 Update config and operator docs for webhook feature enablement in `netclaw.json`, per-route file registration under `config/webhooks`, ingress security expectations, secret-bearing config handling, and Slack notification-target setup.
 - [ ] 4.4 Update any required system skill/docs for config-format changes and run the relevant test/quality gates (`dotnet test`, `dotnet slopwatch analyze`, and evals if skill content changes).
+
+## 5. Observability polish (0.10.1)
+
+- [ ] 5.1 Emit `ToolResultOutput` for every tool result in `LlmSessionActor.ToolExecutionCompleted` so webhook/reminder execution actors can correctly track notification-tool completion (fixes false-positive "no notification tool was invoked" warning — Aaronontheweb/netclaw#546). Update existing session integration tests to drain the new output between `ToolCallOutput` and following assertions.
+- [ ] 5.2 Add a `WebhookTelemetry` static class mirroring `ChannelTelemetry` with per-outcome `Interlocked` counters (`accepted`, `route_not_found`, `verification_failed`, `body_too_large`, `invalid_json`, `rate_limited`, `event_filtered`, `duplicate_delivery`), OpenTelemetry `Meter` instruments, `GetSnapshot()`, and `ResetForTests()`.
+- [ ] 5.3 Instrument `/api/webhooks/{route}` ingress in `WebhookEndpointRouteBuilderExtensions` with structured daemon logs per outcome (fields: `route`, `reason`, `remote_ip`, `delivery_id`, `event_type`) and matching `WebhookTelemetry.Record*()` calls. Rejection paths MUST NOT emit outbound operational notification alerts (Aaronontheweb/netclaw#545).
+- [ ] 5.4 Add `WebhookRouteCatalog.GetRouteCounts()` returning total / enabled / disabled / invalid route tallies; gate on the webhook feature flag.
+- [ ] 5.5 Add `DaemonStats.Webhooks` to the stats contract, wire it through `DaemonStatsService`, and render a `webhooks:` section in `netclaw stats` text output, TUI, and help text (Aaronontheweb/netclaw#543).
+- [ ] 5.6 Add tests covering rejection counter increments per reason, route-count tallies across enabled/disabled/invalid states, and the webhook stats contract surface.
+- [ ] 5.7 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md` to describe the new stats section and structured rejection log fields; bump `metadata.version`.

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -299,6 +299,7 @@ public class LlmSessionIntegrationTests : TestKit
         }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(sessionId, error.SessionId);
         Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
@@ -839,6 +840,7 @@ public class LlmSessionIntegrationTests : TestKit
         }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(6), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -903,6 +905,9 @@ public class LlmSessionIntegrationTests : TestKit
         var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("browser_chrome_devtools/navigate_page", toolCall.ToolName);
 
+        // Drain tool result output emitted after tool execution
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
         // After tool execution and follow-up LLM call, final text response
         var finalText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("fake", finalText.Text, StringComparison.OrdinalIgnoreCase);
@@ -955,6 +960,9 @@ public class LlmSessionIntegrationTests : TestKit
         // Tool call output
         var toolCall = await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("browser_chrome_devtools/navigate_page", toolCall.ToolName);
+
+        // Drain tool result output emitted after tool execution
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         // Final text response after tool execution
         var finalText = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -119,10 +119,11 @@ public class MaxToolIterationTests : TestKit
             Content = "Keep calling tools forever"
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
-        // Expect 3 rounds of tool calls (the configured limit)
+        // Expect 3 rounds of tool calls (the configured limit); each call is followed by a tool result
         for (var i = 0; i < 3; i++)
         {
             await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+            await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         // After circuit breaker fires, LLM is called without tools → text response
@@ -169,7 +170,10 @@ public class MaxToolIterationTests : TestKit
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
         for (var i = 0; i < 3; i++)
+        {
             await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+            await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        }
 
         var error = await subscriber.ExpectMsgAsync<ErrorOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ErrorCategory.ProviderFailure, error.Category);
@@ -213,7 +217,10 @@ public class MaxToolIterationTests : TestKit
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
         for (var i = 0; i < 3; i++)
+        {
             await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+            await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        }
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -225,7 +232,10 @@ public class MaxToolIterationTests : TestKit
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
         for (var i = 0; i < 3; i++)
+        {
             await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+            await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        }
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -267,6 +277,7 @@ public class MaxToolIterationTests : TestKit
 
         // One tool call, then normal text response (well within limit of 3)
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -152,6 +152,9 @@ public class SubAgentSpawnIntegrationTests : TestKit
         Assert.Equal(0, completed.FindingsCount);
         Assert.Null(completed.MemoryDecision);
 
+        // Drain the tool result output for spawn_agent emitted after tool execution
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
         var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("fake", text.Text, StringComparison.OrdinalIgnoreCase);
 

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -125,6 +125,9 @@ public class ToolExecutionIntegrationTests : TestKit
         Assert.Equal("web_search", toolCall.ToolName);
         Assert.Equal("call-1", toolCall.CallId);
 
+        // Drain the tool result output emitted after tool execution
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
         // Then: subscriber receives final text response (after tool result fed back)
         var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Contains("fake", text.Text, StringComparison.OrdinalIgnoreCase);
@@ -179,6 +182,10 @@ public class ToolExecutionIntegrationTests : TestKit
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
+        // Drain two tool result outputs emitted after tool execution
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
         // Final text response
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
@@ -217,6 +224,9 @@ public class ToolExecutionIntegrationTests : TestKit
 
         // Tool call output emitted
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+
+        // Drain the tool result output (error text is fed back as a tool result)
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         // LLM gets called again with the error message as tool result,
         // then returns normal text
@@ -258,6 +268,7 @@ public class ToolExecutionIntegrationTests : TestKit
         }, TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
         await subscriber.ExpectMsgAsync<ToolCallOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
@@ -142,6 +142,7 @@ public class ToolLoopCompactionTests : TestKit
         // of firing another LLM call.
         await subscriber.ExpectMsgAsync<ToolCallOutput>(cancellationToken: TestContext.Current.CancellationToken);
         await subscriber.ExpectMsgAsync<UsageOutput>(cancellationToken: TestContext.Current.CancellationToken);
+        await subscriber.ExpectMsgAsync<ToolResultOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         var compaction = await subscriber.ExpectMsgAsync<CompactionOutput>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.True(compaction.MessagesAfter < compaction.MessagesBefore,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -551,7 +551,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 }, OutputFilter.ToolCalls);
             }
 
-            // Add tool results to history, log each result, and emit as session output
             foreach (var result in msg.ToolResults)
             {
                 _state = _state with { History = _state.History.Add(result) };

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -551,7 +551,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 }, OutputFilter.ToolCalls);
             }
 
-            // Add tool results to history and log each result
+            // Add tool results to history, log each result, and emit as session output
             foreach (var result in msg.ToolResults)
             {
                 _state = _state with { History = _state.History.Add(result) };
@@ -561,6 +561,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     : result.Content ?? "(null)";
                 _log.Info("Tool [{ToolName}] (call={CallId}) result: {Result}",
                     result.Name ?? "unknown", result.ToolCallId ?? "?", preview);
+
+                EmitOutput(new ToolResultOutput
+                {
+                    SessionId = _sessionId,
+                    CallId = result.ToolCallId ?? string.Empty,
+                    ToolName = result.Name ?? "unknown",
+                    Result = result.Content ?? string.Empty
+                }, OutputFilter.ToolCalls);
             }
 
             // Dynamic tool loading: if load_tool was called, activate the requested tool.

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1059,6 +1059,7 @@ static void WriteStatsHelp()
     Console.WriteLine("  - skill auto-load counts");
     Console.WriteLine("  - memory store statistics");
     Console.WriteLine("  - Slack activity counters");
+    Console.WriteLine("  - webhook route counts and delivery counters");
     Console.WriteLine("  - reminder statistics");
     Console.WriteLine();
     Console.WriteLine("Options:");
@@ -1472,6 +1473,12 @@ static void WriteStatsResult(DaemonStats.Response stats, int? days)
     Console.WriteLine("slack:");
     Console.WriteLine($"  events: recv={stats.SlackActivity.EventsReceived} routed={stats.SlackActivity.EventsRouted} dropped={stats.SlackActivity.EventsDropped}");
     Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} rejected={stats.SlackActivity.RepliesRejected} failed={stats.SlackActivity.RepliesFailed}");
+
+    Console.WriteLine();
+    Console.WriteLine("webhooks:");
+    Console.WriteLine($"  routes: total={stats.Webhooks.TotalRoutes} enabled={stats.Webhooks.EnabledRoutes} disabled={stats.Webhooks.DisabledRoutes} invalid={stats.Webhooks.InvalidRoutes}");
+    Console.WriteLine($"  deliveries: accepted={stats.Webhooks.Accepted} filtered={stats.Webhooks.EventFiltered} duplicate={stats.Webhooks.DuplicateDelivery}");
+    Console.WriteLine($"  rejected: 404={stats.Webhooks.RouteNotFound} 401={stats.Webhooks.VerificationFailed} 413={stats.Webhooks.BodyTooLarge} 400={stats.Webhooks.InvalidJson} 429={stats.Webhooks.RateLimited}");
 
     if (stats.Reminders is { } reminders)
     {

--- a/src/Netclaw.Cli/Tui/StatsPage.cs
+++ b/src/Netclaw.Cli/Tui/StatsPage.cs
@@ -93,10 +93,10 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         }
         else
         {
-            // Bottom row: Memory + Slack side by side
-            var bottomRow = Layouts.Horizontal();
+            // Middle row: Memory + Slack side by side
+            var middleRow = Layouts.Horizontal();
 
-            bottomRow.WithChild(
+            middleRow.WithChild(
                 new PanelNode()
                     .WithTitle("Memory")
                     .WithBorder(BorderStyle.Rounded)
@@ -104,7 +104,7 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
                     .WithContent(BuildMemoryPanel(stats))
                     .Fill());
 
-            bottomRow.WithChild(
+            middleRow.WithChild(
                 new PanelNode()
                     .WithTitle("Slack")
                     .WithBorder(BorderStyle.Rounded)
@@ -112,7 +112,16 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
                     .WithContent(BuildSlackPanel(stats))
                     .Fill());
 
-            root.WithChild(bottomRow.Height(6));
+            root.WithChild(middleRow.Height(6));
+
+            // Bottom row: Webhooks (full width)
+            root.WithChild(
+                new PanelNode()
+                    .WithTitle("Webhooks")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Red)
+                    .WithContent(BuildWebhooksPanel(stats))
+                    .Height(6));
         }
 
         // Status bar
@@ -173,6 +182,19 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         var content = Layouts.Vertical();
         content.WithChild(new TextNode($"  Events: recv={sl.EventsReceived} routed={sl.EventsRouted} dropped={sl.EventsDropped}").WithForeground(Color.White).Height(1));
         content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} rejected={sl.RepliesRejected} failed={sl.RepliesFailed}").WithForeground(sl.RepliesFailed > 0 || sl.RepliesRejected > 0 ? Color.Yellow : Color.White).Height(1));
+        return content;
+    }
+
+    private static ILayoutNode BuildWebhooksPanel(DaemonStats.Response stats)
+    {
+        var w = stats.Webhooks;
+        var content = Layouts.Vertical();
+        content.WithChild(new TextNode($"  Routes: total={w.TotalRoutes} enabled={w.EnabledRoutes} disabled={w.DisabledRoutes} invalid={w.InvalidRoutes}")
+            .WithForeground(w.InvalidRoutes > 0 ? Color.Yellow : Color.White).Height(1));
+        content.WithChild(new TextNode($"  Deliveries: accepted={w.Accepted} filtered={w.EventFiltered} duplicate={w.DuplicateDelivery}").WithForeground(Color.White).Height(1));
+        var rejectedAny = w.RouteNotFound + w.VerificationFailed + w.BodyTooLarge + w.InvalidJson + w.RateLimited;
+        content.WithChild(new TextNode($"  Rejected: 404={w.RouteNotFound} 401={w.VerificationFailed} 413={w.BodyTooLarge} 400={w.InvalidJson} 429={w.RateLimited}")
+            .WithForeground(rejectedAny > 0 ? Color.Yellow : Color.White).Height(1));
         return content;
     }
 

--- a/src/Netclaw.Configuration/DaemonStats.cs
+++ b/src/Netclaw.Configuration/DaemonStats.cs
@@ -20,6 +20,8 @@ public static class DaemonStats
 
         public required SlackActivity SlackActivity { get; init; }
 
+        public required Webhooks Webhooks { get; init; }
+
         public Reminders? Reminders { get; init; }
 
         /// <summary>
@@ -99,6 +101,45 @@ public static class DaemonStats
         public long RepliesRejected { get; init; }
 
         public long RepliesFailed { get; init; }
+    }
+
+    public sealed class Webhooks : IWireType
+    {
+        /// <summary>Total webhook route definition files present on disk.</summary>
+        public int TotalRoutes { get; init; }
+
+        /// <summary>Routes currently loaded and serving traffic.</summary>
+        public int EnabledRoutes { get; init; }
+
+        /// <summary>Routes whose file has <c>Enabled=false</c> (parsed but disabled).</summary>
+        public int DisabledRoutes { get; init; }
+
+        /// <summary>Routes whose file failed to parse or validate.</summary>
+        public int InvalidRoutes { get; init; }
+
+        /// <summary>Deliveries accepted and dispatched to a webhook session.</summary>
+        public long Accepted { get; init; }
+
+        /// <summary>Requests for unknown routes (HTTP 404).</summary>
+        public long RouteNotFound { get; init; }
+
+        /// <summary>Requests with invalid HMAC signature or header secret (HTTP 401).</summary>
+        public long VerificationFailed { get; init; }
+
+        /// <summary>Requests exceeding the route's <c>MaxBodyBytes</c> (HTTP 413).</summary>
+        public long BodyTooLarge { get; init; }
+
+        /// <summary>Requests with an unparseable JSON body (HTTP 400).</summary>
+        public long InvalidJson { get; init; }
+
+        /// <summary>Requests rejected by the per-route rate limiter (HTTP 429).</summary>
+        public long RateLimited { get; init; }
+
+        /// <summary>Deliveries filtered out because their event type is not allowed by the route.</summary>
+        public long EventFiltered { get; init; }
+
+        /// <summary>Deliveries ignored because their delivery identifier was seen recently.</summary>
+        public long DuplicateDelivery { get; init; }
     }
 
     public sealed class Reminders : IWireType

--- a/src/Netclaw.Daemon.Tests/Webhooks/WebhookEndpointRouteBuilderExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Webhooks/WebhookEndpointRouteBuilderExtensionsTests.cs
@@ -28,6 +28,7 @@ public sealed class WebhookEndpointRouteBuilderExtensionsTests : IDisposable
         _paths = new NetclawPaths(_tempDir);
         _paths.EnsureDirectoriesExist();
         _store = new Netclaw.Configuration.WebhookRouteStore(_paths);
+        WebhookTelemetry.ResetForTests();
     }
 
     [Fact]
@@ -172,6 +173,108 @@ public sealed class WebhookEndpointRouteBuilderExtensionsTests : IDisposable
             Directory.Delete(_tempDir, recursive: true);
     }
 
+    [Fact]
+    public async Task Telemetry_counts_accepted_deliveries_and_each_rejection_reason()
+    {
+        _store.Save("github-issues", CreateRoute(maxBodyBytes: 16));
+        BumpWriteTime("github-issues");
+        await using var app = await CreateHostAsync();
+        var client = app.GetTestClient();
+        var body = "{\"repository\":{\"full_name\":\"petabridge/netclaw\"}}";
+
+        // route_not_found
+        var unknown = await client.PostAsync("/api/webhooks/missing", JsonContent.Create(new { hello = "world" }), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, unknown.StatusCode);
+
+        // verification_failed
+        using var badSig = new HttpRequestMessage(HttpMethod.Post, "/api/webhooks/github-issues")
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        badSig.Headers.Add("X-Hub-Signature-256", "sha256=deadbeef");
+        badSig.Headers.Add("X-GitHub-Event", "issues");
+        badSig.Headers.Add("X-GitHub-Delivery", "d-verification");
+        var badSigResponse = await client.SendAsync(badSig, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, badSigResponse.StatusCode);
+
+        // body_too_large — MaxBodyBytes=64, so this body overflows
+        using var tooLarge = BuildGitHubRequest("/api/webhooks/github-issues", body, "issues", "d-toolarge", "secret");
+        var tooLargeResponse = await client.SendAsync(tooLarge, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, tooLargeResponse.StatusCode);
+
+        // event_filtered — small body but event type not in allowlist
+        var smallBody = "{\"x\":1}";
+        using var filtered = BuildGitHubRequest("/api/webhooks/github-issues", smallBody, "pull_request", "d-filtered", "secret");
+        var filteredResponse = await client.SendAsync(filtered, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Accepted, filteredResponse.StatusCode);
+
+        // accepted — small body, allowed event
+        using var accepted = BuildGitHubRequest("/api/webhooks/github-issues", smallBody, "issues", "d-accepted", "secret");
+        var acceptedResponse = await client.SendAsync(accepted, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Accepted, acceptedResponse.StatusCode);
+
+        // duplicate_delivery — same delivery id as accepted
+        using var dup = BuildGitHubRequest("/api/webhooks/github-issues", smallBody, "issues", "d-accepted", "secret");
+        var dupResponse = await client.SendAsync(dup, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Accepted, dupResponse.StatusCode);
+
+        var snapshot = WebhookTelemetry.GetSnapshot();
+        Assert.Equal(1, snapshot.RouteNotFound);
+        Assert.Equal(1, snapshot.VerificationFailed);
+        Assert.Equal(1, snapshot.BodyTooLarge);
+        Assert.Equal(1, snapshot.EventFiltered);
+        Assert.Equal(1, snapshot.Accepted);
+        Assert.Equal(1, snapshot.DuplicateDelivery);
+        Assert.Equal(0, snapshot.InvalidJson);
+        Assert.Equal(0, snapshot.RateLimited);
+
+        // rejection paths MUST NOT emit outbound operational alerts — only the
+        // accepted delivery emits a receipt alert
+        var notifications = app.Services.GetRequiredService<RecordingNotificationSink>();
+        Assert.Single(notifications.Alerts, x => x.Category == AlertType.WebhookReceived);
+    }
+
+    [Fact]
+    public async Task Telemetry_counts_rate_limited_requests()
+    {
+        _store.Save("github-issues", CreateRoute(rateLimitPerMinute: 1));
+        BumpWriteTime("github-issues");
+        await using var app = await CreateHostAsync();
+        var client = app.GetTestClient();
+        var body = "{\"x\":1}";
+
+        using var first = BuildGitHubRequest("/api/webhooks/github-issues", body, "issues", "rate-1", "secret");
+        var firstResponse = await client.SendAsync(first, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Accepted, firstResponse.StatusCode);
+
+        using var second = BuildGitHubRequest("/api/webhooks/github-issues", body, "issues", "rate-2", "secret");
+        var secondResponse = await client.SendAsync(second, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.TooManyRequests, secondResponse.StatusCode);
+
+        var snapshot = WebhookTelemetry.GetSnapshot();
+        Assert.Equal(1, snapshot.RateLimited);
+        Assert.Equal(1, snapshot.Accepted);
+    }
+
+    [Fact]
+    public async Task Telemetry_counts_invalid_json()
+    {
+        _store.Save("github-issues", CreateRoute());
+        BumpWriteTime("github-issues");
+        await using var app = await CreateHostAsync();
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/webhooks/github-issues")
+        {
+            Content = new StringContent("{ not valid json", Encoding.UTF8, "application/json")
+        };
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var snapshot = WebhookTelemetry.GetSnapshot();
+        Assert.Equal(1, snapshot.InvalidJson);
+    }
+
     private void BumpWriteTime(string routeName)
     {
         var filePath = Path.Combine(_paths.WebhooksDirectory, $"{routeName}.json");
@@ -219,7 +322,7 @@ public sealed class WebhookEndpointRouteBuilderExtensionsTests : IDisposable
         return request;
     }
 
-    private static WebhookRouteConfig CreateRoute(int maxBodyBytes = 1024 * 1024) => new()
+    private static WebhookRouteConfig CreateRoute(int maxBodyBytes = 1024 * 1024, int rateLimitPerMinute = 30) => new()
     {
         Prompt = "triage this event",
         Events = ["issues"],
@@ -238,7 +341,7 @@ public sealed class WebhookEndpointRouteBuilderExtensionsTests : IDisposable
             DeliveryIdHeaderName = "X-GitHub-Delivery"
         },
         MaxBodyBytes = maxBodyBytes,
-        RateLimitPerMinute = 30
+        RateLimitPerMinute = rateLimitPerMinute
     };
 
     private sealed class FakeWebhookExecutionService : IWebhookExecutionService

--- a/src/Netclaw.Daemon.Tests/Webhooks/WebhookEndpointRouteBuilderExtensionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Webhooks/WebhookEndpointRouteBuilderExtensionsTests.cs
@@ -15,6 +15,10 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Webhooks;
 
+[CollectionDefinition("WebhookTelemetry", DisableParallelization = true)]
+public sealed class WebhookTelemetryCollection;
+
+[Collection("WebhookTelemetry")]
 public sealed class WebhookEndpointRouteBuilderExtensionsTests : IDisposable
 {
     private int _writeVersion;

--- a/src/Netclaw.Daemon.Tests/Webhooks/WebhookRouteCatalogTests.cs
+++ b/src/Netclaw.Daemon.Tests/Webhooks/WebhookRouteCatalogTests.cs
@@ -72,6 +72,52 @@ public sealed class WebhookRouteCatalogTests : IDisposable
         Assert.Equal(AlertType.WebhookRouteInvalid, Assert.Single(_sink.Alerts).Category);
     }
 
+    [Fact]
+    public void GetRouteCounts_returns_zero_when_feature_disabled()
+    {
+        WriteRouteFile("alpha", CreateRoute());
+        var sut = new WebhookRouteCatalog(
+            _paths,
+            new WebhooksConfig { Enabled = false },
+            _sink,
+            _timeProvider,
+            NullLogger<WebhookRouteCatalog>.Instance);
+
+        var counts = sut.GetRouteCounts();
+
+        Assert.Equal(new WebhookRouteCounts(0, 0, 0, 0), counts);
+    }
+
+    [Fact]
+    public void GetRouteCounts_classifies_enabled_disabled_and_invalid()
+    {
+        WriteRouteFile("alpha", CreateRoute());
+        WriteRouteFile("beta", CreateRoute());
+        var disabled = CreateRoute();
+        disabled.Enabled = false;
+        WriteRouteFile("gamma", disabled);
+        WriteRouteText("delta", "{ not valid json");
+
+        var sut = CreateCatalog();
+
+        var counts = sut.GetRouteCounts();
+
+        Assert.Equal(4, counts.Total);
+        Assert.Equal(2, counts.Enabled);
+        Assert.Equal(1, counts.Disabled);
+        Assert.Equal(1, counts.Invalid);
+    }
+
+    [Fact]
+    public void GetRouteCounts_returns_zero_when_directory_is_empty()
+    {
+        var sut = CreateCatalog();
+
+        var counts = sut.GetRouteCounts();
+
+        Assert.Equal(new WebhookRouteCounts(0, 0, 0, 0), counts);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -7,6 +7,7 @@ using Netclaw.Actors.Skills;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Services;
+using Netclaw.Daemon.Webhooks;
 
 namespace Netclaw.Daemon.Gateway;
 
@@ -16,6 +17,7 @@ internal sealed class DaemonStatsService(
     SessionCatalogService sessionCatalog,
     SkillRegistry skillRegistry,
     IRequiredActor<DailyStatsActorKey> dailyStatsActor,
+    WebhookRouteCatalog webhookRouteCatalog,
     SQLiteMemoryStore? sqliteMemoryStore = null,
     IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
 {
@@ -76,6 +78,7 @@ internal sealed class DaemonStatsService(
                 RepliesRejected = slackSnapshot.SlackRepliesRejected,
                 RepliesFailed = slackSnapshot.SlackRepliesFailed
             },
+            Webhooks = BuildWebhookStats(),
             Reminders = await BuildReminderStatsAsync(ct),
             DailyBreakdown = dailyBreakdown
         };
@@ -131,6 +134,36 @@ internal sealed class DaemonStatsService(
         {
             return new DaemonStats.Memory { Status = "degraded" };
         }
+    }
+
+    private DaemonStats.Webhooks BuildWebhookStats()
+    {
+        WebhookRouteCounts counts;
+        try
+        {
+            counts = webhookRouteCatalog.GetRouteCounts();
+        }
+        catch
+        {
+            counts = new WebhookRouteCounts(0, 0, 0, 0);
+        }
+
+        var snapshot = WebhookTelemetry.GetSnapshot();
+        return new DaemonStats.Webhooks
+        {
+            TotalRoutes = counts.Total,
+            EnabledRoutes = counts.Enabled,
+            DisabledRoutes = counts.Disabled,
+            InvalidRoutes = counts.Invalid,
+            Accepted = snapshot.Accepted,
+            RouteNotFound = snapshot.RouteNotFound,
+            VerificationFailed = snapshot.VerificationFailed,
+            BodyTooLarge = snapshot.BodyTooLarge,
+            InvalidJson = snapshot.InvalidJson,
+            RateLimited = snapshot.RateLimited,
+            EventFiltered = snapshot.EventFiltered,
+            DuplicateDelivery = snapshot.DuplicateDelivery,
+        };
     }
 
     private async Task<DaemonStats.Reminders?> BuildReminderStatsAsync(CancellationToken ct)

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -138,16 +138,7 @@ internal sealed class DaemonStatsService(
 
     private DaemonStats.Webhooks BuildWebhookStats()
     {
-        WebhookRouteCounts counts;
-        try
-        {
-            counts = webhookRouteCatalog.GetRouteCounts();
-        }
-        catch
-        {
-            counts = new WebhookRouteCounts(0, 0, 0, 0);
-        }
-
+        var counts = webhookRouteCatalog.GetRouteCounts();
         var snapshot = WebhookTelemetry.GetSnapshot();
         return new DaemonStats.Webhooks
         {

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -2,6 +2,9 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 
@@ -11,6 +14,10 @@ public static class WebhookEndpointRouteBuilderExtensions
 {
     public static IEndpointRouteBuilder MapWebhookEndpoints(this IEndpointRouteBuilder app)
     {
+        var logger = app.ServiceProvider
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Netclaw.Daemon.Webhooks.Endpoint");
+
         app.MapPost("/api/webhooks/{route}", async (
             string route,
             HttpContext httpContext,
@@ -22,25 +29,52 @@ public static class WebhookEndpointRouteBuilderExtensions
             TimeProvider timeProvider,
             CancellationToken ct) =>
         {
+            var remoteIp = httpContext.Connection.RemoteIpAddress?.ToString();
+
             if (!routeCatalog.TryGetRoute(route, out var registeredRoute))
+            {
+                WebhookTelemetry.RecordRouteNotFound(route);
+                logger.LogWarning(
+                    "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    route, "route_not_found", remoteIp, (string?)null, (string?)null);
                 return Results.NotFound();
+            }
 
             var bodyRead = await ReadRequestBodyAsync(httpContext.Request, registeredRoute.Config.MaxBodyBytes, ct);
             if (!bodyRead.Success)
             {
-                return bodyRead.Reason switch
+                if (bodyRead.Reason == "body_too_large")
                 {
-                    "body_too_large" => Results.StatusCode(StatusCodes.Status413PayloadTooLarge),
-                    _ => Results.BadRequest(new { error = "Invalid JSON request body." })
-                };
+                    WebhookTelemetry.RecordBodyTooLarge(registeredRoute.Name);
+                    logger.LogWarning(
+                        "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                        registeredRoute.Name, "body_too_large", remoteIp, (string?)null, (string?)null);
+                    return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+                }
+
+                WebhookTelemetry.RecordInvalidJson(registeredRoute.Name);
+                logger.LogWarning(
+                    "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    registeredRoute.Name, "invalid_json", remoteIp, (string?)null, (string?)null);
+                return Results.BadRequest(new { error = "Invalid JSON request body." });
             }
 
             var verification = verifier.Verify(registeredRoute, httpContext.Request.Headers, bodyRead.BodyBytes!);
             if (!verification.IsAccepted)
+            {
+                WebhookTelemetry.RecordVerificationFailed(registeredRoute.Name);
+                logger.LogWarning(
+                    "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    registeredRoute.Name, "verification_failed", remoteIp, verification.DeliveryId, verification.EventType);
                 return Results.Unauthorized();
+            }
 
             if (!registeredRoute.IsEventAllowed(verification.EventType))
             {
+                WebhookTelemetry.RecordEventFiltered(registeredRoute.Name);
+                logger.LogDebug(
+                    "Webhook filtered route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    registeredRoute.Name, "event_filtered", remoteIp, verification.DeliveryId, verification.EventType);
                 return Results.Json(
                     new { status = "ignored", reason = "event_filtered" },
                     statusCode: StatusCodes.Status202Accepted);
@@ -53,6 +87,10 @@ public static class WebhookEndpointRouteBuilderExtensions
 
             if (guardDecision.Kind == WebhookIngressDecisionKind.Duplicate)
             {
+                WebhookTelemetry.RecordDuplicateDelivery(registeredRoute.Name);
+                logger.LogDebug(
+                    "Webhook filtered route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    registeredRoute.Name, "duplicate_delivery", remoteIp, verification.DeliveryId, verification.EventType);
                 return Results.Json(
                     new { status = "ignored", reason = "duplicate_delivery" },
                     statusCode: StatusCodes.Status202Accepted);
@@ -60,6 +98,11 @@ public static class WebhookEndpointRouteBuilderExtensions
 
             if (guardDecision.Kind == WebhookIngressDecisionKind.RateLimited)
             {
+                WebhookTelemetry.RecordRateLimited(registeredRoute.Name);
+                logger.LogWarning(
+                    "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                    registeredRoute.Name, "rate_limited", remoteIp, verification.DeliveryId, verification.EventType);
+
                 if (guardDecision.RetryAfterSeconds is { } retryAfter)
                     httpContext.Response.Headers.RetryAfter = retryAfter.ToString();
 
@@ -79,6 +122,11 @@ public static class WebhookEndpointRouteBuilderExtensions
                 bodyRead.BodyJson!,
                 sessionId,
                 now);
+
+            WebhookTelemetry.RecordAccepted(registeredRoute.Name);
+            logger.LogInformation(
+                "Webhook accepted route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                registeredRoute.Name, "accepted", remoteIp, verification.DeliveryId, verification.EventType);
 
             notificationSink.Emit(new OperationalAlert
             {

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -41,22 +41,21 @@ public static class WebhookEndpointRouteBuilderExtensions
             }
 
             var bodyRead = await ReadRequestBodyAsync(httpContext.Request, registeredRoute.Config.MaxBodyBytes, ct);
-            if (!bodyRead.Success)
+            switch (bodyRead.Status)
             {
-                if (bodyRead.Reason == "body_too_large")
-                {
+                case WebhookBodyReadStatus.TooLarge:
                     WebhookTelemetry.RecordBodyTooLarge(registeredRoute.Name);
                     logger.LogWarning(
                         "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
                         registeredRoute.Name, "body_too_large", remoteIp, (string?)null, (string?)null);
                     return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
-                }
 
-                WebhookTelemetry.RecordInvalidJson(registeredRoute.Name);
-                logger.LogWarning(
-                    "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
-                    registeredRoute.Name, "invalid_json", remoteIp, (string?)null, (string?)null);
-                return Results.BadRequest(new { error = "Invalid JSON request body." });
+                case WebhookBodyReadStatus.InvalidJson:
+                    WebhookTelemetry.RecordInvalidJson(registeredRoute.Name);
+                    logger.LogWarning(
+                        "Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp} delivery_id={DeliveryId} event_type={EventType}",
+                        registeredRoute.Name, "invalid_json", remoteIp, (string?)null, (string?)null);
+                    return Results.BadRequest(new { error = "Invalid JSON request body." });
             }
 
             var verification = verifier.Verify(registeredRoute, httpContext.Request.Headers, bodyRead.BodyBytes!);
@@ -205,9 +204,17 @@ public static class WebhookEndpointRouteBuilderExtensions
     }
 }
 
-internal sealed record WebhookBodyReadResult(bool Success, string? Reason, byte[]? BodyBytes, string? BodyJson)
+internal enum WebhookBodyReadStatus
 {
-    public static WebhookBodyReadResult Ok(byte[] bodyBytes, string bodyJson) => new(true, null, bodyBytes, bodyJson);
-    public static WebhookBodyReadResult TooLarge() => new(false, "body_too_large", null, null);
-    public static WebhookBodyReadResult InvalidJson() => new(false, "invalid_json", null, null);
+    Ok,
+    TooLarge,
+    InvalidJson
+}
+
+internal sealed record WebhookBodyReadResult(WebhookBodyReadStatus Status, byte[]? BodyBytes, string? BodyJson)
+{
+    public static WebhookBodyReadResult Ok(byte[] bodyBytes, string bodyJson)
+        => new(WebhookBodyReadStatus.Ok, bodyBytes, bodyJson);
+    public static WebhookBodyReadResult TooLarge() => new(WebhookBodyReadStatus.TooLarge, null, null);
+    public static WebhookBodyReadResult InvalidJson() => new(WebhookBodyReadStatus.InvalidJson, null, null);
 }

--- a/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
@@ -59,6 +59,32 @@ public sealed class WebhookRouteCatalog
         }
     }
 
+    /// <summary>
+    /// Returns per-state route tallies for stats reporting.
+    /// Disabled routes sit on disk but are removed from the live catalog,
+    /// so they are computed as <c>total - enabled - invalid</c>.
+    /// </summary>
+    public WebhookRouteCounts GetRouteCounts()
+    {
+        if (!_config.Enabled)
+            return new WebhookRouteCounts(0, 0, 0, 0);
+
+        lock (_sync)
+        {
+            Directory.CreateDirectory(_paths.WebhooksDirectory);
+            RefreshAllRoutes();
+
+            var total = Directory
+                .EnumerateFiles(_paths.WebhooksDirectory, "*.json", SearchOption.TopDirectoryOnly)
+                .Count();
+            var enabled = _routes.Count;
+            var invalid = _failedRouteVersions.Count;
+            var disabled = Math.Max(0, total - enabled - invalid);
+
+            return new WebhookRouteCounts(total, enabled, disabled, invalid);
+        }
+    }
+
     private void RefreshRoutes(string? routeNameHint)
     {
         lock (_sync)
@@ -225,3 +251,5 @@ public sealed class WebhookRouteCatalog
     private static string GetRouteName(string filePath)
         => Path.GetFileNameWithoutExtension(filePath);
 }
+
+public sealed record WebhookRouteCounts(int Total, int Enabled, int Disabled, int Invalid);

--- a/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
@@ -60,9 +60,9 @@ public sealed class WebhookRouteCatalog
     }
 
     /// <summary>
-    /// Returns per-state route tallies for stats reporting.
-    /// Disabled routes sit on disk but are removed from the live catalog,
-    /// so they are computed as <c>total - enabled - invalid</c>.
+    /// Returns per-state route tallies for stats reporting. Disabled routes sit on
+    /// disk but are removed from the live catalog during refresh, so we enumerate
+    /// once and classify each file by looking it up in the catalog's maps.
     /// </summary>
     public WebhookRouteCounts GetRouteCounts()
     {
@@ -74,12 +74,21 @@ public sealed class WebhookRouteCatalog
             Directory.CreateDirectory(_paths.WebhooksDirectory);
             RefreshAllRoutes();
 
-            var total = Directory
-                .EnumerateFiles(_paths.WebhooksDirectory, "*.json", SearchOption.TopDirectoryOnly)
-                .Count();
-            var enabled = _routes.Count;
-            var invalid = _failedRouteVersions.Count;
-            var disabled = Math.Max(0, total - enabled - invalid);
+            int total = 0, enabled = 0, disabled = 0, invalid = 0;
+            foreach (var file in Directory.EnumerateFiles(_paths.WebhooksDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                var name = GetRouteName(file);
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                total++;
+                if (_failedRouteVersions.ContainsKey(name))
+                    invalid++;
+                else if (_routes.ContainsKey(name))
+                    enabled++;
+                else
+                    disabled++;
+            }
 
             return new WebhookRouteCounts(total, enabled, disabled, invalid);
         }

--- a/src/Netclaw.Daemon/Webhooks/WebhookTelemetry.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookTelemetry.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics.Metrics;
+
+namespace Netclaw.Daemon.Webhooks;
+
+/// <summary>
+/// Process-wide counters for inbound webhook ingress outcomes. Every accepted
+/// delivery, rejection, filter, or duplicate suppression increments a durable
+/// counter here so <c>netclaw stats</c> (and any OpenTelemetry exporter) can
+/// surface webhook traffic without reading the daemon's HTTP logs.
+///
+/// Rejections MUST NOT cross over to <c>IOperationalNotificationSink</c>;
+/// those trigger outbound operator notifications. This telemetry surface is
+/// strictly in-process.
+/// </summary>
+public static class WebhookTelemetry
+{
+    public const string MeterName = "Netclaw.Webhooks";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> Accepted =
+        Meter.CreateCounter<long>("netclaw.webhooks.accepted");
+
+    private static readonly Counter<long> RouteNotFound =
+        Meter.CreateCounter<long>("netclaw.webhooks.rejected.route_not_found");
+
+    private static readonly Counter<long> VerificationFailed =
+        Meter.CreateCounter<long>("netclaw.webhooks.rejected.verification_failed");
+
+    private static readonly Counter<long> BodyTooLarge =
+        Meter.CreateCounter<long>("netclaw.webhooks.rejected.body_too_large");
+
+    private static readonly Counter<long> InvalidJson =
+        Meter.CreateCounter<long>("netclaw.webhooks.rejected.invalid_json");
+
+    private static readonly Counter<long> RateLimited =
+        Meter.CreateCounter<long>("netclaw.webhooks.rejected.rate_limited");
+
+    private static readonly Counter<long> EventFiltered =
+        Meter.CreateCounter<long>("netclaw.webhooks.filtered.event");
+
+    private static readonly Counter<long> DuplicateDelivery =
+        Meter.CreateCounter<long>("netclaw.webhooks.filtered.duplicate");
+
+    private static long _acceptedTotal;
+    private static long _routeNotFoundTotal;
+    private static long _verificationFailedTotal;
+    private static long _bodyTooLargeTotal;
+    private static long _invalidJsonTotal;
+    private static long _rateLimitedTotal;
+    private static long _eventFilteredTotal;
+    private static long _duplicateDeliveryTotal;
+
+    public sealed record Snapshot(
+        long Accepted,
+        long RouteNotFound,
+        long VerificationFailed,
+        long BodyTooLarge,
+        long InvalidJson,
+        long RateLimited,
+        long EventFiltered,
+        long DuplicateDelivery);
+
+    public static void RecordAccepted(string route)
+    {
+        Interlocked.Increment(ref _acceptedTotal);
+        Accepted.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordRouteNotFound(string route)
+    {
+        Interlocked.Increment(ref _routeNotFoundTotal);
+        RouteNotFound.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordVerificationFailed(string route)
+    {
+        Interlocked.Increment(ref _verificationFailedTotal);
+        VerificationFailed.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordBodyTooLarge(string route)
+    {
+        Interlocked.Increment(ref _bodyTooLargeTotal);
+        BodyTooLarge.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordInvalidJson(string route)
+    {
+        Interlocked.Increment(ref _invalidJsonTotal);
+        InvalidJson.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordRateLimited(string route)
+    {
+        Interlocked.Increment(ref _rateLimitedTotal);
+        RateLimited.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordEventFiltered(string route)
+    {
+        Interlocked.Increment(ref _eventFilteredTotal);
+        EventFiltered.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static void RecordDuplicateDelivery(string route)
+    {
+        Interlocked.Increment(ref _duplicateDeliveryTotal);
+        DuplicateDelivery.Add(1, new KeyValuePair<string, object?>("route", route));
+    }
+
+    public static Snapshot GetSnapshot()
+        => new(
+            Accepted: Interlocked.Read(ref _acceptedTotal),
+            RouteNotFound: Interlocked.Read(ref _routeNotFoundTotal),
+            VerificationFailed: Interlocked.Read(ref _verificationFailedTotal),
+            BodyTooLarge: Interlocked.Read(ref _bodyTooLargeTotal),
+            InvalidJson: Interlocked.Read(ref _invalidJsonTotal),
+            RateLimited: Interlocked.Read(ref _rateLimitedTotal),
+            EventFiltered: Interlocked.Read(ref _eventFilteredTotal),
+            DuplicateDelivery: Interlocked.Read(ref _duplicateDeliveryTotal));
+
+    internal static void ResetForTests()
+    {
+        Interlocked.Exchange(ref _acceptedTotal, 0);
+        Interlocked.Exchange(ref _routeNotFoundTotal, 0);
+        Interlocked.Exchange(ref _verificationFailedTotal, 0);
+        Interlocked.Exchange(ref _bodyTooLargeTotal, 0);
+        Interlocked.Exchange(ref _invalidJsonTotal, 0);
+        Interlocked.Exchange(ref _rateLimitedTotal, 0);
+        Interlocked.Exchange(ref _eventFilteredTotal, 0);
+        Interlocked.Exchange(ref _duplicateDeliveryTotal, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses three related 0.10.1 webhook polish issues that ship together as one PR:

- **Aaronontheweb/netclaw#543** — `netclaw stats` now includes a `webhooks:` section with route counts (total/enabled/disabled/invalid) and delivery counters (accepted, filtered, duplicate, and per-rejection reason)
- **Aaronontheweb/netclaw#545** — every `/api/webhooks/{route}` outcome now emits a structured daemon log line (`route`, `reason`, `remote_ip`, `delivery_id`, `event_type`) and increments a `WebhookTelemetry` counter. Rejection paths do **not** emit outbound operational alerts (no ops-channel spam on adversarial traffic)
- **Aaronontheweb/netclaw#546** — fixes false-positive "Notification instructions were provided but no notification tool was invoked" warning by having `LlmSessionActor.ToolExecutionCompleted` emit `ToolResultOutput` for each tool result. `WebhookExecutionActor`/`ReminderExecutionActor` (and all other `SessionOutput` subscribers that already handled `ToolResultOutput`) now see the tool completions they were silently missing.

## What changed

- New `WebhookTelemetry` static class with `Interlocked` counters + OpenTelemetry `Meter` instruments per outcome, mirroring the existing `ChannelTelemetry` pattern.
- New `DaemonStats.Webhooks` wire type, wired through `DaemonStatsService`, rendered in the CLI text output, TUI (new Webhooks panel), and help text.
- `WebhookRouteCatalog.GetRouteCounts()` enumerates the webhook directory once and classifies each file by cross-referencing `_routes` and `_failedRouteVersions`.
- `WebhookBodyReadResult` is now keyed by a `WebhookBodyReadStatus` enum instead of stringly-typed status.
- Updated ~16 session integration test assertions to drain the new `ToolResultOutput` between `ToolCallOutput` and following expectations. Reminder tests are unchanged — the scripted pipeline already emitted `ToolResultOutput` manually.
- Extended the inbound-webhooks OpenSpec change with four new requirements and seven observability tasks. Bumped `netclaw-operations` skill to 1.6.0 with the new stats section and structured log format documented.

## Test plan

- [x] Full solution build is clean (0 warnings, 0 errors)
- [x] Full test suite passes (2000 tests, Actors/Daemon/Cli/Config/Search/Security/Memory)
- [x] `dotnet slopwatch analyze` reports no new violations
- [x] New tests cover each rejection counter path, rate-limited path, invalid-json path, route-count classification (enabled/disabled/invalid), and webhook-feature-disabled zeros
- [x] WebhookTelemetry tests serialized behind a dedicated xUnit collection to avoid process-wide-state races

## Notes

- No schema migration required (neither JSON config schema nor SQLite).
- `DaemonStats.Webhooks` is `required` on `DaemonStats.Response`, which matches the pattern used by `SlackActivity` and means CLI + daemon need to stay in-sync on major upgrades (same as every prior stats addition).