### PR TITLE
fix(wizard): init wizard fixes for 0.10.1 (#537, #538, #540)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Actors.Channels;
 using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard.Steps;
@@ -98,6 +99,82 @@ public sealed class InitWizardPageTests : IDisposable
         await app.RunAsync(cts.Token);
 
         Assert.Equal(_registry.KnownTypeKeys[1], vm.ProviderStep.SelectedProviderType);
+    }
+
+    // ── Channels step key routing (#539) ───────────────────────────────────
+
+    /// <summary>
+    /// Verifies that DownArrow reaches the Channels step view through
+    /// HandlePageInput, even when a stale SelectionListNode is on the
+    /// focus stack from a previous step.
+    /// </summary>
+    [Fact]
+    public async Task ChannelsStep_DownArrow_RendersChannelList()
+    {
+        var (terminal, app, vm) = CreateHeadlessApp(out var input);
+
+        // Make Channels step applicable
+        vm.Context.AnyChatServicesEnabled = true;
+
+        // Skip: provider → security-posture → slack → channels
+        vm.Orchestrator.GoNext(); // provider → security-posture
+        vm.Orchestrator.GoNext(); // security-posture → slack
+        vm.Orchestrator.GoNext(); // slack → channels (Slack.OnLeave clears entries)
+
+        Assert.Equal("channels", vm.Orchestrator.CurrentStep?.StepId);
+
+        // Populate entries AFTER Slack.OnLeave has run (it removes Slack entries when disabled)
+        vm.Context.ChannelEntries[ChannelType.Slack] =
+        [
+            new ChannelEntry("#general", "C123", TrustAudience.Team),
+            new ChannelEntry("#random", "C456", TrustAudience.Team),
+        ];
+
+        // Send DownArrow (the key that was broken) then Ctrl+Q to exit
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        // Terminal should contain both channel names
+        Assert.True(terminal.Contains("#general"),
+            $"Expected #general in terminal. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("#random"),
+            $"Expected #random in terminal. Screen:\n{terminal}");
+    }
+
+    /// <summary>
+    /// Verifies that the 'A' key enters add-channel mode on the Channels step.
+    /// </summary>
+    [Fact]
+    public async Task ChannelsStep_AKey_EntersAddMode()
+    {
+        var (terminal, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.Context.AnyChatServicesEnabled = true;
+
+        // Skip to channels
+        vm.Orchestrator.GoNext();
+        vm.Orchestrator.GoNext();
+        vm.Orchestrator.GoNext();
+
+        Assert.Equal("channels", vm.Orchestrator.CurrentStep?.StepId);
+
+        // No entries needed — testing add mode ('A' key should work regardless)
+
+        // Send 'A' key then Ctrl+Q to exit
+        input.EnqueueKey(ConsoleKey.A);
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        // Verify the Channels view entered add mode
+        var channelsView = (ChannelsStepView)vm.StepViews["channels"];
+        Assert.True(channelsView.IsAddMode,
+            $"Expected Channels view to be in add mode after pressing 'A'. " +
+            $"CurrentStep={vm.Orchestrator.CurrentStep?.StepId}, Screen:\n{terminal}");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -1,3 +1,6 @@
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text.Json;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Cli.Tui.Wizard.Steps;
@@ -427,5 +430,89 @@ public sealed class ExposureModeStepViewModelTests : IDisposable
         step.SelectedMode = ExposureMode.TailscaleFunnel;
 
         Assert.Equal(2, step.WebhookSubStep);
+    }
+
+    // ── Bootstrap device pairing (#540) ──────────────────────────────────────
+
+    [Fact]
+    public void ContributeSecrets_NonLocal_AddsDeviceToken()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.TailscaleFunnel;
+
+        var builder = new WizardSecretsBuilder(_context.Paths);
+        step.ContributeSecrets(builder);
+
+        Assert.NotNull(step.BootstrapRawToken);
+        Assert.NotNull(step.BootstrapDevice);
+        Assert.Equal(Environment.MachineName, step.BootstrapDevice.Name);
+    }
+
+    [Fact]
+    public void ContributeSecrets_Local_DoesNotAddDeviceToken()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.Local;
+
+        var builder = new WizardSecretsBuilder(_context.Paths);
+        step.ContributeSecrets(builder);
+
+        Assert.Null(step.BootstrapRawToken);
+        Assert.Null(step.BootstrapDevice);
+    }
+
+    [Fact]
+    public void WriteBootstrapDevice_NonLocal_WritesDevicesJson()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.TailscaleServe;
+
+        var builder = new WizardSecretsBuilder(_context.Paths);
+        step.ContributeSecrets(builder);
+        step.WriteBootstrapDevice(_context.Paths);
+
+        Assert.True(File.Exists(_context.Paths.DevicesPath));
+
+        var json = File.ReadAllText(_context.Paths.DevicesPath);
+        var devices = JsonSerializer.Deserialize<List<PairedDevice>>(json);
+        Assert.NotNull(devices);
+        Assert.Single(devices);
+        Assert.Equal(Environment.MachineName, devices[0].Name);
+    }
+
+    [Fact]
+    public void WriteBootstrapDevice_Local_DoesNotWriteFile()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.Local;
+
+        var builder = new WizardSecretsBuilder(_context.Paths);
+        step.ContributeSecrets(builder);
+        step.WriteBootstrapDevice(_context.Paths);
+
+        Assert.False(File.Exists(_context.Paths.DevicesPath));
+    }
+
+    [Fact]
+    public void WriteBootstrapDevice_TokenVerifiesAgainstDevice()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.CloudflareTunnel;
+
+        var builder = new WizardSecretsBuilder(_context.Paths);
+        step.ContributeSecrets(builder);
+
+        // Re-compute the hash from the raw token and device salt to verify consistency
+        var rawToken = step.BootstrapRawToken!;
+        var device = step.BootstrapDevice!;
+
+        var tokenBytes = Base64Url.DecodeFromChars(rawToken);
+        var saltBytes = Convert.FromHexString(device.Salt);
+        Span<byte> combined = stackalloc byte[tokenBytes.Length + saltBytes.Length];
+        tokenBytes.CopyTo(combined);
+        saltBytes.CopyTo(combined[tokenBytes.Length..]);
+        var expectedHash = Convert.ToHexString(SHA256.HashData(combined)).ToLowerInvariant();
+
+        Assert.Equal(expectedHash, device.TokenHash);
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -200,6 +200,14 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
                 return providerView.BuildContent(step, CreateCallbacks());
             }
 
+            // Channels step manages its own state (cursor position, add mode)
+            // across invalidations — don't clear it on content refresh.
+            if (step is ChannelsStepViewModel)
+            {
+                var channelsView = ViewModel.StepViews["channels"];
+                return channelsView.BuildContent(step, CreateCallbacks());
+            }
+
             // Normal: clear state, build fresh
             _stepSubs.Clear();
             var currentView = ViewModel.StepViews[step.StepId];
@@ -253,6 +261,43 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     // Input handling
     // ═══════════════════════════════════════════════════════════════════
 
+    /// <summary>
+    /// Capture-phase input handler — runs BEFORE the focus manager routes keys
+    /// to focused components. This prevents stale IFocusable nodes (SelectionListNode,
+    /// TextInputNode) from consuming keys meant for steps with custom key handling.
+    /// </summary>
+    public override bool HandlePageInput(ConsoleKeyInfo keyInfo)
+    {
+        // Let base key bindings run first
+        if (base.HandlePageInput(keyInfo))
+            return true;
+
+        // Global: Ctrl+Q always shuts down — must be captured here so stale
+        // focused components (TextInputNode in add mode) can't consume it.
+        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.RequestQuit();
+            return true;
+        }
+
+        // Channels step: intercept keys before the focus manager can consume them.
+        // Stale IFocusable components (SelectionListNode, TextInputNode) from prior
+        // steps remain on the focus stack and consume ↑/↓ arrows and letter keys.
+        // Escape is NOT intercepted — it flows through ViewModel.Input for back-navigation.
+        if (ViewModel.Orchestrator.CurrentStep is ChannelsStepViewModel
+            && keyInfo.Key != ConsoleKey.Escape)
+        {
+            var channelsView = ViewModel.StepViews["channels"];
+            if (channelsView.HandleKeyPress(new KeyPressed(keyInfo)))
+            {
+                ViewModel.RequestRedraw();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void HandleKeyPress(KeyPressed key)
     {
         var keyInfo = key.KeyInfo;
@@ -266,17 +311,6 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
         }
 
         var currentStep = ViewModel.Orchestrator.CurrentStep;
-
-        // Channels step: custom keyboard handling (delegated to view)
-        if (currentStep is ChannelsStepViewModel)
-        {
-            var channelsView = ViewModel.StepViews["channels"];
-            if (channelsView.HandleKeyPress(key))
-            {
-                ViewModel.RequestRedraw();
-                return;
-            }
-        }
 
         // Provider step special keys
         if (currentStep is ProviderStepViewModel providerVm)

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -80,7 +80,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         };
 
         // Create step VMs in the canonical order:
-        // provider → security-posture → exposure-mode → slack → channels → search → browser-automation → identity → health-check
+        // provider → security-posture → slack → channels → search → browser-automation → identity → external-skills → exposure-mode → health-check
         ProviderStep = new ProviderStepViewModel(registry, probe, oauthFactory);
         var securityPostureStep = new SecurityPostureStepViewModel();
         var exposureModeStep = new ExposureModeStepViewModel();
@@ -96,13 +96,13 @@ public partial class InitWizardViewModel : ReactiveViewModel
         {
             ProviderStep,
             securityPostureStep,
-            exposureModeStep,
             slackStep,
             channelsStep,
             searchStep,
             browserStep,
             identityStep,
             externalSkillsStep,
+            exposureModeStep,
             _healthCheckStep
         };
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
@@ -27,6 +27,9 @@ public sealed class ChannelsStepView : IWizardStepView
 
     public string StepId => "channels";
 
+    /// <summary>Whether the view is in add-channel mode. Exposed for headless testing.</summary>
+    internal bool IsAddMode => _addMode;
+
     public ILayoutNode BuildContent(IWizardStepViewModel stepVm, StepViewCallbacks callbacks)
     {
         _callbacks = callbacks;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
@@ -173,10 +173,6 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
             return;
 
         var json = JsonSerializer.Serialize(new[] { _bootstrapDevice }, DevicesJsonOptions);
-        var dir = Path.GetDirectoryName(paths.DevicesPath);
-        if (dir is not null)
-            Directory.CreateDirectory(dir);
-
         File.WriteAllText(paths.DevicesPath, json);
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(paths.DevicesPath))
             File.SetUnixFileMode(paths.DevicesPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
@@ -1,3 +1,8 @@
+using System.Buffers.Text;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Tui.Wizard.Steps;
@@ -8,8 +13,18 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class ExposureModeStepViewModel : IWizardStepViewModel
 {
+    private static readonly JsonSerializerOptions DevicesJsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     private int _currentSubStep;
     private int _highWaterSubStep;
+
+    // Bootstrap device state — populated during ContributeSecrets for non-Local modes.
+    private string? _bootstrapRawToken;
+    private PairedDevice? _bootstrapDevice;
 
     public string StepId => "exposure-mode";
     public string DisplayTitle => "Network Exposure";
@@ -111,10 +126,67 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
         }
     }
 
-    public void ContributeSecrets(WizardSecretsBuilder builder) { }
+    public void ContributeSecrets(WizardSecretsBuilder builder)
+    {
+        if (SelectedMode == ExposureMode.Local)
+            return;
+
+        // Generate a bootstrap device token so the daemon can start with at least
+        // one paired device — satisfies ExposureModeValidationService's requirement.
+        var tokenBytes = RandomNumberGenerator.GetBytes(32);
+        var rawToken = Base64Url.EncodeToString(tokenBytes);
+
+        var saltBytes = RandomNumberGenerator.GetBytes(16);
+        var saltHex = Convert.ToHexString(saltBytes).ToLowerInvariant();
+
+        // SHA256(token_bytes || salt_bytes) — matches DeviceRegistry.ComputeTokenHash
+        Span<byte> combined = stackalloc byte[tokenBytes.Length + saltBytes.Length];
+        tokenBytes.CopyTo(combined);
+        saltBytes.CopyTo(combined[tokenBytes.Length..]);
+        var tokenHash = Convert.ToHexString(SHA256.HashData(combined)).ToLowerInvariant();
+
+        var now = DateTimeOffset.UtcNow;
+        _bootstrapDevice = new PairedDevice
+        {
+            Name = Environment.MachineName,
+            TokenHash = tokenHash,
+            Salt = saltHex,
+            CreatedAt = now,
+            LastUsedAt = now,
+        };
+        _bootstrapRawToken = rawToken;
+
+        builder.AddValue("DeviceToken", rawToken);
+    }
 
     public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
         => Task.CompletedTask;
+
+    /// <summary>
+    /// Write the bootstrap paired device to <c>devices.json</c> so the daemon can start
+    /// with at least one paired device. No-op for Local mode.
+    /// Called from <see cref="WizardOrchestrator.WriteConfig"/> after secrets are written.
+    /// </summary>
+    public void WriteBootstrapDevice(NetclawPaths paths)
+    {
+        if (_bootstrapDevice is null)
+            return;
+
+        var json = JsonSerializer.Serialize(new[] { _bootstrapDevice }, DevicesJsonOptions);
+        var dir = Path.GetDirectoryName(paths.DevicesPath);
+        if (dir is not null)
+            Directory.CreateDirectory(dir);
+
+        File.WriteAllText(paths.DevicesPath, json);
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(paths.DevicesPath))
+            File.SetUnixFileMode(paths.DevicesPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    /// <summary>The raw bootstrap token, exposed for testing.</summary>
+    internal string? BootstrapRawToken => _bootstrapRawToken;
+
+    /// <summary>The bootstrap device, exposed for testing.</summary>
+    internal PairedDevice? BootstrapDevice => _bootstrapDevice;
 
     public void Dispose() { }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SecurityPostureStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SecurityPostureStepView.cs
@@ -25,8 +25,8 @@ public sealed class SecurityPostureStepView : IWizardStepView
 
         _postureList = Layouts.SelectionList(
                 "Personal \u2014 Only you on this machine",
-                "Team \u2014 Shared with trusted teammates (Slack/VPN)",
-                "Public \u2014 Open to untrusted users (webhooks/public)")
+                "Team \u2014 Shared with trusted teammates",
+                "Public \u2014 Open to untrusted users")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
@@ -51,7 +51,7 @@ public sealed class SecurityPostureStepView : IWizardStepView
             .DisposeWith(callbacks.Subscriptions);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode("  How will this Netclaw instance be accessed?").WithForeground(Color.White))
+            .WithChild(new TextNode("  Who will interact with this Netclaw instance?").WithForeground(Color.White))
             .WithSpacing(1)
             .WithChild(_postureList)
             .WithSpacing(1)

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -266,6 +266,9 @@ public sealed class WizardSecretsBuilder
         _secrets[key] = section;
     }
 
+    /// <summary>Add a top-level value to the secrets file (e.g., DeviceToken).</summary>
+    public void AddValue(string key, object value) => _secrets[key] = value;
+
     /// <summary>Write secrets.json if any secrets were contributed.</summary>
     public void WriteSecretsFile()
     {

--- a/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
@@ -165,6 +165,11 @@ public sealed class WizardOrchestrator : IDisposable
             identityStep.WriteIdentityFiles(_context.Paths);
             identityStep.SeedBuiltInAgents(_context.Paths);
         }
+
+        // Write bootstrap paired device for non-Local exposure modes so the daemon
+        // can start with at least one paired device (satisfies ExposureModeValidationService).
+        var exposureStep = _allSteps.OfType<ExposureModeStepViewModel>().FirstOrDefault();
+        exposureStep?.WriteBootstrapDevice(_context.Paths);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Three init wizard fixes for the 0.10.1 milestone:

- **#537** — Security posture step copy reframed from "How will this instance be accessed?" to "Who will interact with this instance?" and stripped transport-specific parentheticals from option labels
- **#538** — Moved exposure mode step from position 3 to second-to-last (before health check) for natural inside-out ordering
- **#540** — Auto-register local machine as paired device during init when non-Local exposure mode is selected, fixing the bootstrap problem where the daemon crashed on first boot

Closes #537, closes #538, closes #540

## Test plan

- [x] `dotnet build` passes
- [x] All 37 `ExposureModeStepViewModelTests` pass (5 new)
- [x] All 38 `WizardOrchestratorTests` + `SecurityPostureStepViewModelTests` + `WizardConfigBuilderTests` pass
- [ ] E2E: `netclaw init` with Tailscale Funnel → daemon starts successfully (devices.json + DeviceToken written)
- [ ] E2E: `netclaw init` with Local mode → no devices.json, no DeviceToken in secrets