### PR TITLE
fix(sessions): drain LLM sessions during SIGTERM to prevent stale active counts

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -139,6 +139,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly Telemetry.ISessionMetrics? _sessionMetrics;
 
     private bool _restartDrainRequested;
+    private bool _passivationCompleted;
     private IActorRef? _restartDrainReplyTo;
     private string? _pendingRestartNotice;
     private string? _turnRestartNotice;
@@ -1184,6 +1185,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void CompletePassivation()
     {
+        _passivationCompleted = true;
         _lifecycleObserver?.OnSessionDeactivated(_sessionId);
         SaveSnapshot(BuildSnapshot());
         _restartDrainReplyTo?.Tell(CommandAck.For(_sessionId));
@@ -1822,11 +1824,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         CancelAndDisposeLlmCts();
 
-        // Safety net: if the actor was killed without going through CompletePassivation()
-        // (e.g., Akka shutdown timeout, OOM, or any non-graceful stop path), ensure the
-        // session catalog is updated. OnSessionDeactivated is idempotent — calling it
-        // after CompletePassivation() already ran is a harmless no-op UPDATE.
-        _lifecycleObserver?.OnSessionDeactivated(_sessionId);
+        // Safety net for non-graceful stop paths (shutdown timeout, OOM, etc.).
+        if (!_passivationCompleted)
+            _lifecycleObserver?.OnSessionDeactivated(_sessionId);
 
         base.PostStop();
     }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1821,6 +1821,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     protected override void PostStop()
     {
         CancelAndDisposeLlmCts();
+
+        // Safety net: if the actor was killed without going through CompletePassivation()
+        // (e.g., Akka shutdown timeout, OOM, or any non-graceful stop path), ensure the
+        // session catalog is updated. OnSessionDeactivated is idempotent — calling it
+        // after CompletePassivation() already ran is a harmless no-op UPDATE.
+        _lifecycleObserver?.OnSessionDeactivated(_sessionId);
+
         base.PostStop();
     }
 

--- a/src/Netclaw.Daemon.Tests/Services/DaemonRestartCoordinatorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/DaemonRestartCoordinatorTests.cs
@@ -157,6 +157,40 @@ public sealed class DaemonRestartCoordinatorTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task SessionDrainHelper_queries_manager_drains_sessions_and_reports_timeouts()
+    {
+        // One session acks normally, the other times out
+        var activeIds = new[] { "slack/drain-ok", "slack/drain-timeout" };
+        var timedOut = new[] { "slack/drain-timeout" };
+        var sessionManager = _system.ActorOf(Props.Create(() => new StubSessionManagerActor(
+            activeIds, timedOut, false)));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+
+        var result = await SessionDrainHelper.DrainAsync(
+            sessionManager,
+            "integration-test",
+            NullLogger<DaemonRestartCoordinator>.Instance,
+            cts.Token);
+
+        // All sessions were discovered
+        Assert.Equal(2, result.AllSessionIds.Count);
+
+        // One drained, one timed out
+        Assert.Single(result.DrainedSessionIds);
+        Assert.Equal("slack/drain-ok", result.DrainedSessionIds[0].Value);
+        Assert.Single(result.TimedOutSessionIds);
+        Assert.Equal("slack/drain-timeout", result.TimedOutSessionIds[0].Value);
+
+        // Notification context reflects the outcome
+        var ctx = result.ToNotificationContext();
+        Assert.Equal("timeout", ctx["drainOutcome"]);
+        Assert.Equal("2", ctx["activeSessions"]);
+        Assert.Equal("1", ctx["drainedSessions"]);
+        Assert.Equal("1", ctx["timedOutSessions"]);
+    }
+
     private sealed class FakeApplicationLifetime : IHostApplicationLifetime
     {
         public bool StopRequested { get; private set; }

--- a/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionCatalogService.cs
@@ -280,6 +280,37 @@ public sealed class SessionCatalogService : ISessionLifecycleObserver
         return entries;
     }
 
+    /// <summary>
+    /// Marks all 'active' sessions as 'inactive'. Called during daemon startup
+    /// before any sessions are materialized, to clean up stale state from
+    /// unclean shutdowns (crash, kill -9, power loss).
+    /// </summary>
+    public int ReconcileStaleActiveSessions()
+    {
+        try
+        {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            EnsureSchemaUpToDate(conn, _logger);
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "UPDATE sessions SET status = 'inactive' WHERE status = 'active'";
+            var affected = cmd.ExecuteNonQuery();
+
+            if (affected > 0)
+                _logger.LogInformation(
+                    "Reconciled {Count} stale active session(s) from previous run.", affected);
+
+            return affected;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to reconcile stale active sessions during startup.");
+            return 0;
+        }
+    }
+
     public void MarkSessionActive(SessionId sessionId)
     {
         var persistenceId = $"session-{sessionId.Value}";

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -882,6 +882,66 @@ static void ConfigureDaemonServices(
             var rc = sp.GetRequiredService<ReminderConfig>();
             var historyStore = sp.GetRequiredService<ReminderHistoryStore>();
             toolRegistry.WithReminderTools(reminderManager, tp, rc, historyStore);
+
+            // Drain all active LLM sessions during any actor system termination (SIGTERM, daemon stop).
+            // Runs in an early CoordinatedShutdown phase while actors are still alive.
+            // If DaemonRestartCoordinator already drained sessions (config reload), the ingress
+            // gate will be closed and this task skips its drain to avoid double-draining.
+            var cs = CoordinatedShutdown.Get(system);
+            var sessionManager = registry.Get<SessionManagerActorKey>();
+            var ingressGate = sp.GetRequiredService<SessionIngressGate>();
+            var lifecycleNotifier = sp.GetRequiredService<DaemonLifecycleNotifier>();
+            var drainLogger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("Netclaw.Daemon.SessionDrain");
+
+            cs.AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "drain-llm-sessions", async () =>
+            {
+                if (!ingressGate.TryClose("Daemon shutting down."))
+                {
+                    drainLogger.LogDebug("Ingress gate already closed; skipping CoordinatedShutdown session drain.");
+                    return Akka.Done.Instance;
+                }
+
+                try
+                {
+                    var activeIdsResponse = await sessionManager.Ask<ActiveEntityIds>(
+                        GetActiveEntityIds.Instance,
+                        timeout: TimeSpan.FromSeconds(5));
+
+                    var sessionIds = activeIdsResponse.EntityIds
+                        .Select(id => new Netclaw.Actors.Protocol.SessionId(id))
+                        .ToArray();
+
+                    if (sessionIds.Length == 0)
+                    {
+                        drainLogger.LogDebug("No active sessions to drain during shutdown.");
+                        return Akka.Done.Instance;
+                    }
+
+                    drainLogger.LogInformation(
+                        "Draining {SessionCount} active session(s) during daemon shutdown.",
+                        sessionIds.Length);
+
+                    var drainResult = await SessionDrainHelper.DrainAsync(
+                        sessionManager, sessionIds, "daemon-stop",
+                        timeout: TimeSpan.FromSeconds(15), drainLogger, CancellationToken.None);
+
+                    var notificationContext = new Dictionary<string, string>
+                    {
+                        ["drainOutcome"] = drainResult.TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
+                        ["activeSessions"] = sessionIds.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        ["drainedSessions"] = drainResult.DrainedSessionIds.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        ["timedOutSessions"] = drainResult.TimedOutSessionIds.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    };
+
+                    lifecycleNotifier.NotifyShutdown("daemon-stop", notificationContext);
+                }
+                catch (Exception ex)
+                {
+                    drainLogger.LogWarning(ex, "Session drain during shutdown failed; sessions will recover from last durable checkpoint.");
+                }
+
+                return Akka.Done.Instance;
+            });
         });
     });
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -925,15 +925,7 @@ static void ConfigureDaemonServices(
                         sessionManager, sessionIds, "daemon-stop",
                         timeout: TimeSpan.FromSeconds(15), drainLogger, CancellationToken.None);
 
-                    var notificationContext = new Dictionary<string, string>
-                    {
-                        ["drainOutcome"] = drainResult.TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
-                        ["activeSessions"] = sessionIds.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        ["drainedSessions"] = drainResult.DrainedSessionIds.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        ["timedOutSessions"] = drainResult.TimedOutSessionIds.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)
-                    };
-
-                    lifecycleNotifier.NotifyShutdown("daemon-stop", notificationContext);
+                    lifecycleNotifier.NotifyShutdown("daemon-stop", drainResult.ToNotificationContext(sessionIds.Length));
                 }
                 catch (Exception ex)
                 {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -836,8 +836,16 @@ static void ConfigureDaemonServices(
     {
         // Prevent coordinated shutdown from calling Environment.Exit(),
         // which would kill the process before the restart loop can iterate.
+        // The before-service-unbind phase needs a generous timeout because sessions
+        // mid-LLM-call (TurnLlmTimeout defaults to 3 minutes) must finish before
+        // passivation can begin.
         akkaBuilder.AddHocon(
-            "akka.coordinated-shutdown.exit-clr = off",
+            """
+            akka.coordinated-shutdown {
+                exit-clr = off
+                phases.before-service-unbind.timeout = 200s
+            }
+            """,
             HoconAddMode.Prepend);
 
         akkaBuilder = akkaBuilder.ConfigureLoggers(setup =>
@@ -887,6 +895,8 @@ static void ConfigureDaemonServices(
             // Runs in an early CoordinatedShutdown phase while actors are still alive.
             // If DaemonRestartCoordinator already drained sessions (config reload), the ingress
             // gate will be closed and this task skips its drain to avoid double-draining.
+            // The phase timeout (200s) is generous because sessions mid-LLM-call must finish
+            // before passivation can begin.
             var cs = CoordinatedShutdown.Get(system);
             var sessionManager = registry.Get<SessionManagerActorKey>();
             var ingressGate = sp.GetRequiredService<SessionIngressGate>();
@@ -903,29 +913,10 @@ static void ConfigureDaemonServices(
 
                 try
                 {
-                    var activeIdsResponse = await sessionManager.Ask<ActiveEntityIds>(
-                        GetActiveEntityIds.Instance,
-                        timeout: TimeSpan.FromSeconds(5));
-
-                    var sessionIds = activeIdsResponse.EntityIds
-                        .Select(id => new Netclaw.Actors.Protocol.SessionId(id))
-                        .ToArray();
-
-                    if (sessionIds.Length == 0)
-                    {
-                        drainLogger.LogDebug("No active sessions to drain during shutdown.");
-                        return Akka.Done.Instance;
-                    }
-
-                    drainLogger.LogInformation(
-                        "Draining {SessionCount} active session(s) during daemon shutdown.",
-                        sessionIds.Length);
-
                     var drainResult = await SessionDrainHelper.DrainAsync(
-                        sessionManager, sessionIds, "daemon-stop",
-                        timeout: TimeSpan.FromSeconds(15), drainLogger, CancellationToken.None);
+                        sessionManager, "daemon-stop", drainLogger, CancellationToken.None);
 
-                    lifecycleNotifier.NotifyShutdown("daemon-stop", drainResult.ToNotificationContext(sessionIds.Length));
+                    lifecycleNotifier.NotifyShutdown("daemon-stop", drainResult.ToNotificationContext());
                 }
                 catch (Exception ex)
                 {

--- a/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
@@ -79,7 +79,8 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
                 "Starting coordinated config restart for {SessionCount} active session(s).",
                 sessionIds.Length);
 
-            var drainResult = await DrainSessionsAsync(sessionManager, sessionIds, cancellationToken);
+            var drainResult = await SessionDrainHelper.DrainAsync(
+                sessionManager, sessionIds, "config-reload", _restartDrainTimeout, _logger, cancellationToken);
 
             var manifest = new RestartManifest
             {
@@ -111,65 +112,5 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
             _ingressGate.Reopen();
             throw;
         }
-    }
-
-    private async Task<DrainResult> DrainSessionsAsync(IActorRef sessionManager, IReadOnlyList<SessionId> sessionIds, CancellationToken cancellationToken)
-    {
-        if (sessionIds.Count == 0)
-            return DrainResult.Empty;
-
-        using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        drainCts.CancelAfter(_restartDrainTimeout);
-
-        var drainTasks = sessionIds.Select(async sessionId =>
-        {
-            try
-            {
-                var ack = await sessionManager.Ask<CommandAck>(
-                    new PrepareForDaemonRestart
-                    {
-                        SessionId = sessionId,
-                        Reason = "config-reload"
-                    },
-                    timeout: _restartDrainTimeout,
-                    cancellationToken: drainCts.Token);
-
-                return new DrainOutcome(sessionId, ack.SessionId == sessionId);
-            }
-            catch (OperationCanceledException)
-            {
-                return new DrainOutcome(sessionId, false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to drain session {SessionId} before restart.", sessionId.Value);
-                return new DrainOutcome(sessionId, false);
-            }
-        }).ToArray();
-
-        var outcomes = await Task.WhenAll(drainTasks);
-        var drained = outcomes.Where(static x => x.Drained).Select(static x => x.SessionId).ToArray();
-        var timedOut = outcomes.Where(static x => !x.Drained).Select(static x => x.SessionId).ToArray();
-
-        if (timedOut.Length == 0)
-        {
-            _logger.LogInformation("All {SessionCount} active session(s) drained before restart.", drained.Length);
-        }
-        else
-        {
-            _logger.LogWarning(
-                "Proceeding with restart after drain timeout; {DrainedCount} session(s) drained and {TimedOutCount} will recover from the last durable checkpoint.",
-                drained.Length,
-                timedOut.Length);
-        }
-
-        return new DrainResult(drained, timedOut);
-    }
-
-    private sealed record DrainOutcome(SessionId SessionId, bool Drained);
-
-    private sealed record DrainResult(IReadOnlyList<SessionId> DrainedSessionIds, IReadOnlyList<SessionId> TimedOutSessionIds)
-    {
-        public static readonly DrainResult Empty = new([], []);
     }
 }

--- a/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Linq;
 using Akka.Actor;
 using Akka.Hosting;
@@ -95,15 +94,7 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
             else
                 await _manifestStore.WriteAsync(manifest, cancellationToken);
 
-            var notificationContext = new Dictionary<string, string>
-            {
-                ["drainOutcome"] = drainResult.TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
-                ["activeSessions"] = sessionIds.Length.ToString(CultureInfo.InvariantCulture),
-                ["drainedSessions"] = drainResult.DrainedSessionIds.Count.ToString(CultureInfo.InvariantCulture),
-                ["timedOutSessions"] = drainResult.TimedOutSessionIds.Count.ToString(CultureInfo.InvariantCulture)
-            };
-
-            _lifecycleNotifier.NotifyShutdown("config-reload", notificationContext);
+            _lifecycleNotifier.NotifyShutdown("config-reload", drainResult.ToNotificationContext(sessionIds.Length));
             _restartSignal.RequestRestart();
             _appLifetime.StopApplication();
         }

--- a/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -65,27 +64,18 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
         try
         {
             var sessionManager = await _sessionManagerProvider.GetAsync(cancellationToken);
-            var activeIdsResponse = await sessionManager.Ask<ActiveEntityIds>(
-                GetActiveEntityIds.Instance,
-                timeout: _restartDrainTimeout,
-                cancellationToken: cancellationToken);
 
-            var sessionIds = activeIdsResponse.EntityIds
-                .Select(id => new SessionId(id))
-                .ToArray();
-
-            _logger.LogInformation(
-                "Starting coordinated config restart for {SessionCount} active session(s).",
-                sessionIds.Length);
+            using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            drainCts.CancelAfter(_restartDrainTimeout);
 
             var drainResult = await SessionDrainHelper.DrainAsync(
-                sessionManager, sessionIds, "config-reload", _restartDrainTimeout, _logger, cancellationToken);
+                sessionManager, "config-reload", _logger, drainCts.Token);
 
             var manifest = new RestartManifest
             {
                 Reason = "config-reload",
                 RequestedAt = _timeProvider.GetUtcNow(),
-                SessionIds = sessionIds.Select(static id => id.Value).ToList(),
+                SessionIds = drainResult.AllSessionIds.Select(static id => id.Value).ToList(),
                 TimedOutSessionIds = drainResult.TimedOutSessionIds.Select(static id => id.Value).ToList()
             };
 
@@ -94,7 +84,7 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
             else
                 await _manifestStore.WriteAsync(manifest, cancellationToken);
 
-            _lifecycleNotifier.NotifyShutdown("config-reload", drainResult.ToNotificationContext(sessionIds.Length));
+            _lifecycleNotifier.NotifyShutdown("config-reload", drainResult.ToNotificationContext());
             _restartSignal.RequestRestart();
             _appLifetime.StopApplication();
         }

--- a/src/Netclaw.Daemon/Services/RestartRecoveryService.cs
+++ b/src/Netclaw.Daemon/Services/RestartRecoveryService.cs
@@ -35,6 +35,11 @@ public sealed class RestartRecoveryService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Reconcile stale 'active' sessions from the previous daemon lifetime.
+        // Must run before reading the manifest so that re-warmed sessions get
+        // a clean 'inactive' → 'active' transition via MarkSessionActive().
+        _sessionCatalog.ReconcileStaleActiveSessions();
+
         var manifest = await _manifestStore.ReadAsync(cancellationToken);
         if (manifest is null)
             return;

--- a/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
+++ b/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Akka.Actor;
 using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 
 namespace Netclaw.Daemon.Services;
@@ -12,25 +13,35 @@ namespace Netclaw.Daemon.Services;
 internal static class SessionDrainHelper
 {
     /// <summary>
-    /// Sends <see cref="PrepareForDaemonRestart"/> to each session in parallel and waits
-    /// for acknowledgement or timeout.
+    /// Queries the session manager for active sessions, sends <see cref="PrepareForDaemonRestart"/>
+    /// to each in parallel, and waits for acknowledgement or cancellation.
     /// </summary>
+    /// <remarks>
+    /// Callers control the timeout by providing a <see cref="CancellationToken"/> from a
+    /// <see cref="CancellationTokenSource"/> with the desired deadline.
+    /// </remarks>
     public static async Task<DrainResult> DrainAsync(
         IActorRef sessionManager,
-        IReadOnlyList<SessionId> sessionIds,
         string reason,
-        TimeSpan timeout,
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        if (sessionIds.Count == 0)
+        var activeIdsResponse = await sessionManager.Ask<ActiveEntityIds>(
+            GetActiveEntityIds.Instance,
+            timeout: Timeout.InfiniteTimeSpan,
+            cancellationToken: cancellationToken);
+
+        var sessionIds = activeIdsResponse.EntityIds
+            .Select(id => new SessionId(id))
+            .ToArray();
+
+        if (sessionIds.Length == 0)
             return DrainResult.Empty;
 
-        using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        drainCts.CancelAfter(timeout);
+        logger.LogInformation(
+            "Draining {SessionCount} active session(s) for {Reason}.",
+            sessionIds.Length, reason);
 
-        // Per-session Ask uses Timeout.InfiniteTimeSpan so the CTS is the sole
-        // timeout authority — avoids a race between Ask timeout and CTS cancellation.
         var drainTasks = sessionIds.Select(async sessionId =>
         {
             try
@@ -42,7 +53,7 @@ internal static class SessionDrainHelper
                         Reason = reason
                     },
                     timeout: Timeout.InfiniteTimeSpan,
-                    cancellationToken: drainCts.Token);
+                    cancellationToken: cancellationToken);
 
                 return new DrainOutcome(sessionId, ack.SessionId == sessionId);
             }
@@ -73,19 +84,22 @@ internal static class SessionDrainHelper
                 timedOut.Length);
         }
 
-        return new DrainResult(drained, timedOut);
+        return new DrainResult(sessionIds, drained, timedOut);
     }
 
     internal sealed record DrainOutcome(SessionId SessionId, bool Drained);
 
-    internal sealed record DrainResult(IReadOnlyList<SessionId> DrainedSessionIds, IReadOnlyList<SessionId> TimedOutSessionIds)
+    internal sealed record DrainResult(
+        IReadOnlyList<SessionId> AllSessionIds,
+        IReadOnlyList<SessionId> DrainedSessionIds,
+        IReadOnlyList<SessionId> TimedOutSessionIds)
     {
-        public static readonly DrainResult Empty = new([], []);
+        public static readonly DrainResult Empty = new([], [], []);
 
-        public Dictionary<string, string> ToNotificationContext(int totalActiveSessions) => new()
+        public Dictionary<string, string> ToNotificationContext() => new()
         {
             ["drainOutcome"] = TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
-            ["activeSessions"] = totalActiveSessions.ToString(CultureInfo.InvariantCulture),
+            ["activeSessions"] = AllSessionIds.Count.ToString(CultureInfo.InvariantCulture),
             ["drainedSessions"] = DrainedSessionIds.Count.ToString(CultureInfo.InvariantCulture),
             ["timedOutSessions"] = TimedOutSessionIds.Count.ToString(CultureInfo.InvariantCulture)
         };

--- a/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
+++ b/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
@@ -1,0 +1,82 @@
+using Akka.Actor;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Protocol;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Shared drain logic used by both <see cref="DaemonRestartCoordinator"/> (config restart)
+/// and the CoordinatedShutdown drain task (SIGTERM / daemon stop).
+/// </summary>
+internal static class SessionDrainHelper
+{
+    /// <summary>
+    /// Sends <see cref="PrepareForDaemonRestart"/> to each session in parallel and waits
+    /// for acknowledgement or timeout.
+    /// </summary>
+    public static async Task<DrainResult> DrainAsync(
+        IActorRef sessionManager,
+        IReadOnlyList<SessionId> sessionIds,
+        string reason,
+        TimeSpan timeout,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (sessionIds.Count == 0)
+            return DrainResult.Empty;
+
+        using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        drainCts.CancelAfter(timeout);
+
+        var drainTasks = sessionIds.Select(async sessionId =>
+        {
+            try
+            {
+                var ack = await sessionManager.Ask<CommandAck>(
+                    new PrepareForDaemonRestart
+                    {
+                        SessionId = sessionId,
+                        Reason = reason
+                    },
+                    timeout: timeout,
+                    cancellationToken: drainCts.Token);
+
+                return new DrainOutcome(sessionId, ack.SessionId == sessionId);
+            }
+            catch (OperationCanceledException)
+            {
+                return new DrainOutcome(sessionId, false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to drain session {SessionId} before shutdown.", sessionId.Value);
+                return new DrainOutcome(sessionId, false);
+            }
+        }).ToArray();
+
+        var outcomes = await Task.WhenAll(drainTasks);
+        var drained = outcomes.Where(static x => x.Drained).Select(static x => x.SessionId).ToArray();
+        var timedOut = outcomes.Where(static x => !x.Drained).Select(static x => x.SessionId).ToArray();
+
+        if (timedOut.Length == 0)
+        {
+            logger.LogInformation("All {SessionCount} active session(s) drained successfully.", drained.Length);
+        }
+        else
+        {
+            logger.LogWarning(
+                "Drain completed with {DrainedCount} session(s) drained and {TimedOutCount} timed out; timed-out sessions will recover from the last durable checkpoint.",
+                drained.Length,
+                timedOut.Length);
+        }
+
+        return new DrainResult(drained, timedOut);
+    }
+
+    internal sealed record DrainOutcome(SessionId SessionId, bool Drained);
+
+    internal sealed record DrainResult(IReadOnlyList<SessionId> DrainedSessionIds, IReadOnlyList<SessionId> TimedOutSessionIds)
+    {
+        public static readonly DrainResult Empty = new([], []);
+    }
+}

--- a/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
+++ b/src/Netclaw.Daemon/Services/SessionDrainHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Akka.Actor;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Protocol;
@@ -28,6 +29,8 @@ internal static class SessionDrainHelper
         using var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         drainCts.CancelAfter(timeout);
 
+        // Per-session Ask uses Timeout.InfiniteTimeSpan so the CTS is the sole
+        // timeout authority — avoids a race between Ask timeout and CTS cancellation.
         var drainTasks = sessionIds.Select(async sessionId =>
         {
             try
@@ -38,7 +41,7 @@ internal static class SessionDrainHelper
                         SessionId = sessionId,
                         Reason = reason
                     },
-                    timeout: timeout,
+                    timeout: Timeout.InfiniteTimeSpan,
                     cancellationToken: drainCts.Token);
 
                 return new DrainOutcome(sessionId, ack.SessionId == sessionId);
@@ -78,5 +81,13 @@ internal static class SessionDrainHelper
     internal sealed record DrainResult(IReadOnlyList<SessionId> DrainedSessionIds, IReadOnlyList<SessionId> TimedOutSessionIds)
     {
         public static readonly DrainResult Empty = new([], []);
+
+        public Dictionary<string, string> ToNotificationContext(int totalActiveSessions) => new()
+        {
+            ["drainOutcome"] = TimedOutSessionIds.Count == 0 ? "drained" : "timeout",
+            ["activeSessions"] = totalActiveSessions.ToString(CultureInfo.InvariantCulture),
+            ["drainedSessions"] = DrainedSessionIds.Count.ToString(CultureInfo.InvariantCulture),
+            ["timedOutSessions"] = TimedOutSessionIds.Count.ToString(CultureInfo.InvariantCulture)
+        };
     }
 }


### PR DESCRIPTION
## Summary

- **CoordinatedShutdown drain task** — registers a `PhaseBeforeServiceUnbind` task that sends `PrepareForDaemonRestart` to all active LLM sessions during any actor system termination (SIGTERM, `daemon stop`). Uses `SessionIngressGate.TryClose()` to skip drain if `DaemonRestartCoordinator` already handled a config restart.
- **PostStop safety net** — adds `OnSessionDeactivated` call in `LlmSessionActor.PostStop()` for actors killed without completing passivation (Akka timeout, OOM). Guarded by `_passivationCompleted` flag to avoid redundant writes on the happy path.
- **Startup reconciliation** — marks all stale `active` sessions as `inactive` at the top of `RestartRecoveryService.StartAsync()` to catch hard crashes, `kill -9`, and power loss.
- **Extracted `SessionDrainHelper`** — shared drain logic between config-restart and SIGTERM paths, with `DrainResult.ToNotificationContext()` to eliminate duplicated notification dictionary construction.

Closes #563

## Test plan

- [x] `dotnet build` succeeds
- [x] All 1919 tests pass
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual: start daemon, create session, `netclaw daemon stop`, verify `netclaw stats` shows 0 active on next start