### PR TITLE
fix(reminders): use deployment posture audience instead of hardcoded Team

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.8.0"
+  version: "1.9.0"
 ---
 
 # Netclaw Operations
@@ -38,7 +38,13 @@ problems, how to update preferences, or how to maintain itself.
 
 Parameters: `name` (human-readable), `prompt` (what to execute),
 `schedule_type`, `schedule`, `report_to_channel` (optional Slack channel),
-`notify_instructions` (optional formatting).
+`notify_instructions` (optional formatting), `audience` (optional execution
+audience: `public`, `team`, or `personal`).
+
+If `audience` is omitted during conversational scheduling, the reminder inherits
+the audience of the channel/session that created it. A reminder cannot be
+minted with broader audience than the creator currently holds; lowering the
+audience is always allowed.
 
 Other scheduling tools: `list_reminders`, `cancel_reminder`,
 `get_reminder_history`.

--- a/openspec/changes/reminder-audience-authorization/.openspec.yaml
+++ b/openspec/changes/reminder-audience-authorization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/reminder-audience-authorization/design.md
+++ b/openspec/changes/reminder-audience-authorization/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Reminder definitions are minted through multiple entry points today: the conversational `set_reminder` tool, daemon REST endpoints, CLI/admin flows that call those endpoints, and raw import of serialized reminder definitions. The persisted `ReminderDefinition.Audience` field is then consumed by `ReminderExecutionActor`, which currently falls back to deployment posture defaults when the field is null.
+
+That behavior is too permissive for PRD-002 and PRD-008. The authority that created a reminder is session-scoped and may be narrower than the deployment default. If reminder minting does not validate audience ordering, a low-authority source can create or import a reminder that later executes with a broader audience than the source that requested it.
+
+This is a cross-cutting security correction because it touches reminder persistence, tool-driven creation, admin/import entry points, and execution assumptions. The design needs one authoritative mint-time validation rule rather than per-surface ad hoc checks.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one server-side reminder minting rule: stored reminder audience MUST be less than or equal to the creator's current source audience / authority
+- Make omitted `audience` inherit from the creating session/channel for conversational and tool-created reminders
+- Allow creators to intentionally lower reminder audience (for example Personal -> Team or Public)
+- Ensure REST/admin/CLI/import paths reject invalid or over-privileged reminder definitions before persistence
+- Clarify that execution may trust the stored audience because minting validation guarantees the invariant
+
+**Non-Goals:**
+
+- Changing the `TrustAudience` ordering or introducing new audience kinds
+- Revalidating creator authority on every reminder execution
+- Broad ACL redesign beyond reminder minting and import/update paths
+- Adding client-only validation as a substitute for server-side enforcement
+
+## Decisions
+
+### D1: Enforce reminder audience at mint time in the reminder manager path
+
+**Decision**: all reminder write surfaces shall flow through a single validation step in the reminder save path, with the caller supplying the source authority context used for comparison.
+
+**Rationale**: `ReminderManagerActor.HandleSaveAsync` is already the convergence point for creation and replacement writes. Putting the invariant there keeps REST import, CLI/admin calls, and the LLM tool on the same rule set and prevents weaker paths from bypassing validation.
+
+**Alternative considered**: validate independently in the REST endpoint, tool, and CLI. Rejected because duplicated checks drift easily and import paths can still bypass them.
+
+### D2: Omitted conversational audience inherits session/channel audience, not deployment posture
+
+**Decision**: when a reminder is created from a conversation or tool context and `audience` is omitted, the server persists the effective audience from the creating session/channel. Null is no longer treated as "use deployment default later" for conversational minting.
+
+**Rationale**: the session that requested the reminder is the actual trust source. Persisting that resolved audience preserves the creator's authority boundary across restarts and future execution.
+
+**Alternative considered**: keep storing null and reinterpret null at execution time based on session metadata or deployment posture. Rejected because it leaves execution coupled to mutable defaults and obscures the minted authority.
+
+### D3: Non-conversational write paths must provide an explicit creator ceiling
+
+**Decision**: REST/admin/CLI/import writes must be accompanied by a server-side authority ceiling derived from the authenticated caller or explicit import context. If that ceiling is unavailable, the write fails closed rather than assuming deployment defaults.
+
+**Rationale**: server-side validation is only meaningful if the server knows whose authority the reminder is being minted under. Import is especially sensitive because it can carry serialized `Audience` values from outside the process.
+
+**Alternative considered**: treat admin/import as implicitly Personal. Rejected because it silently upgrades privilege and contradicts default-deny.
+
+### D4: Lowering audience is always allowed; raising above source authority is never allowed
+
+**Decision**: audience comparison uses existing `TrustAudience` ordering (`Public < Team < Personal`). A requested audience equal to or narrower than the source audience is accepted. A broader audience is rejected with a validation error that identifies both values.
+
+**Rationale**: this matches the existing trust model in `SecurityPolicyDefaults` and makes reminder minting monotonic in the safe direction.
+
+**Alternative considered**: only allow exact audience equality. Rejected because operators need to intentionally down-scope reminders for safer execution.
+
+### D5: Execution trusts stored audience after successful minting
+
+**Decision**: `ReminderExecutionActor` uses the stored reminder audience directly. Execution does not recompute audience from deployment posture when the reminder came from a validated mint path.
+
+**Rationale**: execution should be simple and deterministic. The secure place to reject bad authority is before persistence, not on a future timer tick where the original source context may be unavailable.
+
+**Alternative considered**: keep execution fallback logic and re-check against current defaults. Rejected because it permits behavior drift after creation and weakens the auditability of stored reminder definitions.
+
+## Risks / Trade-offs
+
+- [Legacy reminders may still have null or over-broad audiences on disk] -> Mitigation: scope this change to newly created/imported reminders; implementation can treat legacy data explicitly and fail clearly if later write/update paths encounter invalid state rather than silently broadening.
+- [Some admin/import callers may not yet propagate source authority context] -> Mitigation: make missing authority context an explicit validation failure so each write surface is forced onto the shared contract.
+- [Persisting inherited conversational audience changes previously observed behavior] -> Mitigation: this is the intended security correction and should be covered by tests and clear validation/error messaging.
+- [Replace/upsert of an existing reminder can become invalid under a narrower current caller] -> Mitigation: validate every write using the current caller's authority, not the reminder's historical creator.
+
+## Migration Plan
+
+1. Add a reminder audience validation helper/contract in the save path and thread source authority through all write callers.
+2. Update conversational minting to resolve omitted audience from session/channel context and persist that value.
+3. Update REST/admin/import surfaces to reject missing, invalid, or over-privileged audience values before persistence.
+4. Update execution tests and API/tool messaging to reflect that stored reminder audience is trusted and omitted conversational audience no longer means deployment default.
+
+Rollback is straightforward: revert the validation and inheritance changes. No schema migration is required because the persisted field already exists.
+
+## Open Questions
+
+1. For authenticated REST/admin callers that do not originate from a chat session, what exact server-side source establishes the authority ceiling today: authenticated principal classification, explicit request metadata, or a management-default audience? The implementation should use the narrowest existing authoritative source rather than inventing a new implicit default.

--- a/openspec/changes/reminder-audience-authorization/proposal.md
+++ b/openspec/changes/reminder-audience-authorization/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Reminder definitions currently risk being created with an execution audience that is broader than the authority of the channel, session, or operator that minted them. That violates PRD-002's default-deny, fail-closed security posture and PRD-008's requirement that scheduled work execute with policy-bounded grants.
+
+## What Changes
+
+- Require reminder creation, import, and administrative write paths to validate that the requested reminder audience does not exceed the creator's current source audience / authority
+- Specify that conversational and tool-created reminders inherit the creating channel/session audience when `audience` is omitted, rather than falling back to a deployment default
+- Allow reminders to be minted with a lower audience than the creator currently holds
+- Require REST, admin, CLI, and import surfaces to reject invalid or over-privileged reminder definitions with clear fail-closed errors
+- Clarify that execution may trust the stored reminder audience because minting-time audience validation is mandatory
+- Add testable scenarios covering omitted audience inheritance, privileged audience rejection, lower-audience creation, and server-side validation across non-conversational write paths
+
+In scope for MVP: reminder audience validation, inheritance rules, and server-side rejection semantics.
+Out of scope for this change: new audience types, changes to the audience model ordering, or broader reminder execution/runtime refactors unrelated to minting validation.
+
+## Capabilities
+
+### New Capabilities
+
+_None_ - this change tightens existing scheduling and security behavior.
+
+### Modified Capabilities
+
+- `netclaw-scheduling`: Require reminder definitions to inherit or declare an execution audience that is less than or equal to the creating authority, and treat stored audience as trusted at execution time.
+- `netclaw-acl`: Define audience comparison and rejection rules for reminder minting and import/update paths, including the rule that lowering audience is always allowed.
+- `netclaw-gateway-security`: Require reminder write surfaces to fail closed with clear errors when reminder audience is invalid, omitted in the wrong context, or exceeds the creator's authority.
+
+## Impact
+
+- **Reminder write paths**: conversational scheduling flows, tool-driven reminder creation, REST/admin APIs, CLI management commands, and import pipelines must all use the same audience validation rules.
+- **Validation and errors**: reminder definition validation gains audience ordering checks and explicit rejection messages for over-privileged requests.
+- **Execution semantics**: reminder execution no longer needs to recompute creator authority at dispatch time because the stored audience is guaranteed to have been validated when the reminder was created or imported.
+- **Tests**: add coverage for conversation/session inheritance, lower-audience minting, invalid audience values, and over-privileged reminder rejection across server-side entry points.

--- a/openspec/changes/reminder-audience-authorization/specs/netclaw-acl/spec.md
+++ b/openspec/changes/reminder-audience-authorization/specs/netclaw-acl/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Reminder audience authorization
+
+The system SHALL authorize reminder minting against the creator's current
+source audience / authority before a reminder definition is persisted. A
+requested reminder audience SHALL be accepted only when it is equal to or
+narrower than the creator's current source audience. Lowering audience is
+always allowed. Raising audience above the creator's current authority SHALL be
+denied. For conversational and tool-created reminders, omitted `audience`
+SHALL resolve to the creating channel/session audience before persistence.
+
+#### Scenario: Equal audience reminder allowed
+
+- **GIVEN** the current session source audience is `Team`
+- **WHEN** the creator saves a reminder with `audience: Team`
+- **THEN** ACL reminder minting authorization allows the write
+
+#### Scenario: Lower audience reminder allowed
+
+- **GIVEN** the current session source audience is `Personal`
+- **WHEN** the creator saves a reminder with `audience: Public`
+- **THEN** ACL reminder minting authorization allows the write
+
+#### Scenario: Higher audience reminder denied
+
+- **GIVEN** the current session source audience is `Public`
+- **WHEN** the creator saves a reminder with `audience: Team`
+- **THEN** ACL reminder minting authorization denies the write
+- **AND** the denial reason states that the requested audience exceeds the creator's authority
+
+#### Scenario: Omitted conversational audience resolves from source
+
+- **GIVEN** a reminder is being created from a Slack session with source audience `Team`
+- **WHEN** the request omits `audience`
+- **THEN** the effective reminder audience is resolved to `Team` before persistence
+
+#### Scenario: Import path validates serialized audience
+
+- **GIVEN** an authenticated import request carries a serialized reminder definition with `audience: Personal`
+- **AND** the import caller's source audience is `Team`
+- **WHEN** the server validates the reminder definition
+- **THEN** the import is denied before persistence
+- **AND** no over-privileged reminder is stored

--- a/openspec/changes/reminder-audience-authorization/specs/netclaw-gateway-security/spec.md
+++ b/openspec/changes/reminder-audience-authorization/specs/netclaw-gateway-security/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Fail-closed reminder write validation
+
+Reminder write surfaces SHALL validate reminder audience server-side before
+persisting or importing a reminder definition. This applies to REST, admin,
+CLI, and import paths in addition to conversational tool calls. Invalid
+audience values, missing required authority context, or requested audiences
+that exceed the caller's source authority SHALL be rejected with clear error
+messages. Execution may trust the stored reminder audience because minting-time
+validation is mandatory.
+
+#### Scenario: REST create rejects invalid audience value
+
+- **GIVEN** a REST reminder create request provides `audience: "superuser"`
+- **WHEN** the server validates the request
+- **THEN** the request is rejected with a clear validation error
+- **AND** no reminder definition is persisted
+
+#### Scenario: Admin import rejects over-privileged reminder
+
+- **GIVEN** an admin or import request is authenticated with source audience `Team`
+- **WHEN** the request submits a reminder definition with stored audience `Personal`
+- **THEN** the server rejects the request with a clear over-privilege error
+- **AND** the reminder is not written to disk
+
+#### Scenario: Write path fails closed without authority context
+
+- **GIVEN** a non-conversational reminder write path cannot determine the caller's source audience / authority
+- **WHEN** the request attempts to create or import a reminder definition
+- **THEN** the server rejects the request
+- **AND** the error states that reminder audience authorization context is required
+
+#### Scenario: Execution trusts stored audience after validated minting
+
+- **GIVEN** a reminder definition was accepted by the server's minting validation
+- **WHEN** the reminder executes later on a timer
+- **THEN** the execution path uses the stored audience as authoritative
+- **AND** no deployment-default fallback broadens that audience

--- a/openspec/changes/reminder-audience-authorization/specs/netclaw-scheduling/spec.md
+++ b/openspec/changes/reminder-audience-authorization/specs/netclaw-scheduling/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: Chat-driven task creation
+
+The agent SHALL create scheduled tasks when the user requests recurring or
+timed actions through conversation. The agent SHALL assign a human-readable
+task ID and confirm the schedule. Tasks SHALL support fixed interval and cron
+expression schedule types. Tasks requesting tool grants that cannot be
+satisfied by ACL policy SHALL be rejected at creation time.
+
+Reminder definitions minted through conversation, tool calls, CLI, REST, or
+import SHALL persist an execution audience that is less than or equal to the
+creator's current source audience / authority. For conversational or tool-
+created reminders, omitted `audience` SHALL inherit the audience of the
+creating channel/session rather than the deployment default. Lowering audience
+is always allowed.
+
+#### Scenario: Create interval-based scheduled task
+
+- **GIVEN** the user asks the agent to perform an action on a recurring basis
+- **WHEN** the agent parses the request as a fixed-interval schedule
+- **THEN** the agent creates a task with the specified interval
+- **AND** assigns a human-readable task ID
+- **AND** confirms the schedule, next run time, and required tool grants
+
+#### Scenario: Create cron-based scheduled task
+
+- **GIVEN** the user specifies a cron expression for scheduling
+- **WHEN** the agent validates the cron expression
+- **THEN** the agent creates a task with the cron schedule
+- **AND** confirms the resolved next execution time
+
+#### Scenario: Reject task with ungrantable tools
+
+- **GIVEN** the user requests a scheduled task that requires the `shell` tool
+- **WHEN** the `shell` grant is not available in the ACL policy for that sender
+- **THEN** the agent rejects the task at creation time
+- **AND** explains which tool grants are missing
+
+#### Scenario: Task ID collision avoided
+
+- **GIVEN** a task with ID `ebay-check` already exists
+- **WHEN** the user requests a new task that would generate the same ID
+- **THEN** the agent generates a unique variant of the ID
+- **AND** confirms the actual task ID assigned
+
+#### Scenario: Omitted conversational audience inherits source audience
+
+- **GIVEN** a reminder is created from a Team-audience Slack session
+- **AND** the request omits `audience`
+- **WHEN** the reminder is persisted
+- **THEN** the stored reminder audience is `Team`
+- **AND** execution does not fall back to the deployment default later
+
+#### Scenario: Lower audience override allowed
+
+- **GIVEN** a reminder is created from a Personal-audience session
+- **WHEN** the creator explicitly sets `audience` to `Team`
+- **THEN** the reminder is accepted
+- **AND** the stored reminder audience is `Team`
+
+#### Scenario: Broader audience override rejected
+
+- **GIVEN** a reminder is created from a Team-audience session
+- **WHEN** the creator explicitly sets `audience` to `Personal`
+- **THEN** the reminder is rejected before persistence
+- **AND** the error explains that the requested audience exceeds the creator's current authority
+
+### Requirement: Isolated task execution
+
+Each scheduled task execution SHALL run in a fresh session actor with its own
+context. The session SHALL load the agent personality and any relevant project
+context overlays. Scheduled sessions SHALL NOT share state with interactive
+sessions.
+
+Execution MAY trust the stored reminder audience because reminder minting and
+import paths SHALL validate the persisted audience before the definition is
+saved.
+
+#### Scenario: Fresh session per execution
+
+- **GIVEN** a scheduled task fires
+- **WHEN** the timer tick triggers execution
+- **THEN** a new session actor is created with entity key
+  `schedule/{taskId}/{runTs}`
+- **AND** the task instruction is delivered as the user message
+- **AND** agent personality is loaded from soul files
+
+#### Scenario: Scheduled session isolated from interactive sessions
+
+- **GIVEN** an interactive Slack session exists for the same user
+- **WHEN** a scheduled task executes
+- **THEN** the scheduled session does not read or modify interactive session
+  state
+- **AND** the interactive session does not see scheduled session turns
+
+#### Scenario: Task tool grants applied to session
+
+- **GIVEN** a scheduled task specifies `tool_grants: ["web_search", "web_fetch"]`
+- **WHEN** the task session starts
+- **THEN** only the granted tools are available to the session
+- **AND** ungrantable tools are not offered to the LLM
+
+#### Scenario: Execution uses validated stored audience
+
+- **GIVEN** a reminder definition was accepted with stored audience `Public`
+- **WHEN** the reminder later executes on schedule
+- **THEN** the execution session uses stored audience `Public`
+- **AND** it does not recompute audience from the deployment posture default

--- a/openspec/changes/reminder-audience-authorization/tasks.md
+++ b/openspec/changes/reminder-audience-authorization/tasks.md
@@ -1,0 +1,34 @@
+## 1. Shared Reminder Audience Validation
+
+- [x] 1.1 Add a shared reminder audience authorization helper/contract in the reminder save path that compares requested reminder audience against the caller's source audience using existing `TrustAudience` ordering
+- [x] 1.2 Extend reminder save commands/callers to carry the creator's current source audience / authority into `ReminderManagerActor`
+- [x] 1.3 Fail reminder writes closed when source authority context is missing, invalid, or the requested audience exceeds the creator's authority
+
+## 2. Conversational and Tool Minting
+
+- [x] 2.1 Update `SetReminderTool` so omitted `audience` inherits from the creating session/channel audience instead of documenting or relying on deployment default fallback
+- [x] 2.2 Update reminder protocol/model comments and any reminder tool messaging to describe persisted source-audience inheritance and lower-audience allowance
+- [x] 2.3 Ensure reminder save responses return clear validation errors for invalid audience values and over-privileged requests
+
+## 3. REST, Admin, CLI, and Import Enforcement
+
+- [x] 3.1 Update daemon reminder create/import/admin write paths to resolve the caller's authority ceiling server-side and pass it through reminder save validation
+- [x] 3.2 Reject serialized reminder imports whose `Audience` value is invalid or broader than the authenticated caller's source authority
+- [x] 3.3 Reject non-conversational reminder write requests when the server cannot determine the caller's reminder audience authorization context
+
+## 4. Execution Semantics
+
+- [x] 4.1 Remove execution-time deployment-default fallback semantics for newly validated reminder definitions so execution trusts the stored reminder audience
+- [x] 4.2 Update reminder execution logging/comments to reflect that stored audience is authoritative because minting-time validation is mandatory
+
+## 5. Tests
+
+- [x] 5.1 Unit test reminder audience comparison: equal audience allowed, lower audience allowed, higher audience rejected
+- [x] 5.2 Unit/integration test `SetReminderTool` and reminder save flow: omitted conversational audience persists the creating session/channel audience
+- [x] 5.3 Unit/integration test reminder save/import paths: invalid audience value rejected with clear error and no persistence
+- [x] 5.4 Unit/integration test reminder save/import paths: over-privileged audience rejected for REST/admin/CLI/import callers
+- [x] 5.5 Update execution tests to verify stored reminder audience is used directly and deployment posture no longer broadens reminders whose audience was omitted during conversational creation
+
+## 6. Spec and Doc Sync
+
+- [x] 6.1 Sync delta specs to main specs via `/opsx-sync` after implementation is verified

--- a/openspec/specs/netclaw-acl/spec.md
+++ b/openspec/specs/netclaw-acl/spec.md
@@ -128,3 +128,46 @@ grants are still valid before running the task.
 - **WHEN** the scheduled task fires
 - **THEN** execution is denied with a policy reason code
 - **AND** the task failure is recorded with the missing grant details
+
+### Requirement: Reminder audience authorization
+
+The system SHALL authorize reminder minting against the creator's current
+source audience / authority before a reminder definition is persisted. A
+requested reminder audience SHALL be accepted only when it is equal to or
+narrower than the creator's current source audience. Lowering audience is
+always allowed. Raising audience above the creator's current authority SHALL be
+denied. For conversational and tool-created reminders, omitted `audience`
+SHALL resolve to the creating channel/session audience before persistence.
+
+#### Scenario: Equal audience reminder allowed
+
+- **GIVEN** the current session source audience is `Team`
+- **WHEN** the creator saves a reminder with `audience: Team`
+- **THEN** ACL reminder minting authorization allows the write
+
+#### Scenario: Lower audience reminder allowed
+
+- **GIVEN** the current session source audience is `Personal`
+- **WHEN** the creator saves a reminder with `audience: Public`
+- **THEN** ACL reminder minting authorization allows the write
+
+#### Scenario: Higher audience reminder denied
+
+- **GIVEN** the current session source audience is `Public`
+- **WHEN** the creator saves a reminder with `audience: Team`
+- **THEN** ACL reminder minting authorization denies the write
+- **AND** the denial reason states that the requested audience exceeds the creator's authority
+
+#### Scenario: Omitted conversational audience resolves from source
+
+- **GIVEN** a reminder is being created from a Slack session with source audience `Team`
+- **WHEN** the request omits `audience`
+- **THEN** the effective reminder audience is resolved to `Team` before persistence
+
+#### Scenario: Import path validates serialized audience
+
+- **GIVEN** an authenticated import request carries a serialized reminder definition with `audience: Personal`
+- **AND** the import caller's source audience is `Team`
+- **WHEN** the server validates the reminder definition
+- **THEN** the import is denied before persistence
+- **AND** no over-privileged reminder is stored

--- a/openspec/specs/netclaw-gateway-security/spec.md
+++ b/openspec/specs/netclaw-gateway-security/spec.md
@@ -153,3 +153,41 @@ record SHALL include: tool name, session ID, timestamp, and allow/deny result.
 - **WHEN** operator queries tool invocation audit
 - **THEN** records are available with filtering by session ID, tool name, and
   time range
+
+### Requirement: Fail-closed reminder write validation
+
+Reminder write surfaces SHALL validate reminder audience server-side before
+persisting or importing a reminder definition. This applies to REST, admin,
+CLI, and import paths in addition to conversational tool calls. Invalid
+audience values, missing required authority context, or requested audiences
+that exceed the caller's source authority SHALL be rejected with clear error
+messages. Execution may trust the stored reminder audience because minting-time
+validation is mandatory.
+
+#### Scenario: REST create rejects invalid audience value
+
+- **GIVEN** a REST reminder create request provides `audience: "superuser"`
+- **WHEN** the server validates the request
+- **THEN** the request is rejected with a clear validation error
+- **AND** no reminder definition is persisted
+
+#### Scenario: Admin import rejects over-privileged reminder
+
+- **GIVEN** an admin or import request is authenticated with source audience `Team`
+- **WHEN** the request submits a reminder definition with stored audience `Personal`
+- **THEN** the server rejects the request with a clear over-privilege error
+- **AND** the reminder is not written to disk
+
+#### Scenario: Write path fails closed without authority context
+
+- **GIVEN** a non-conversational reminder write path cannot determine the caller's source audience / authority
+- **WHEN** the request attempts to create or import a reminder definition
+- **THEN** the server rejects the request
+- **AND** the error states that reminder audience authorization context is required
+
+#### Scenario: Execution trusts stored audience after validated minting
+
+- **GIVEN** a reminder definition was accepted by the server's minting validation
+- **WHEN** the reminder executes later on a timer
+- **THEN** the execution path uses the stored audience as authoritative
+- **AND** no deployment-default fallback broadens that audience

--- a/openspec/specs/netclaw-scheduling/spec.md
+++ b/openspec/specs/netclaw-scheduling/spec.md
@@ -17,6 +17,13 @@ task ID and confirm the schedule. Tasks SHALL support fixed interval and cron
 expression schedule types. Tasks requesting tool grants that cannot be
 satisfied by ACL policy SHALL be rejected at creation time.
 
+Reminder definitions minted through conversation, tool calls, CLI, REST, or
+import SHALL persist an execution audience that is less than or equal to the
+creator's current source audience / authority. For conversational or tool-
+created reminders, omitted `audience` SHALL inherit the audience of the
+creating channel/session rather than the deployment default. Lowering audience
+is always allowed.
+
 #### Scenario: Create interval-based scheduled task
 
 - **GIVEN** the user asks the agent to perform an action on a recurring basis
@@ -45,6 +52,28 @@ satisfied by ACL policy SHALL be rejected at creation time.
 - **WHEN** the user requests a new task that would generate the same ID
 - **THEN** the agent generates a unique variant of the ID
 - **AND** confirms the actual task ID assigned
+
+#### Scenario: Omitted conversational audience inherits source audience
+
+- **GIVEN** a reminder is created from a Team-audience Slack session
+- **AND** the request omits `audience`
+- **WHEN** the reminder is persisted
+- **THEN** the stored reminder audience is `Team`
+- **AND** execution does not fall back to the deployment default later
+
+#### Scenario: Lower audience override allowed
+
+- **GIVEN** a reminder is created from a Personal-audience session
+- **WHEN** the creator explicitly sets `audience` to `Team`
+- **THEN** the reminder is accepted
+- **AND** the stored reminder audience is `Team`
+
+#### Scenario: Broader audience override rejected
+
+- **GIVEN** a reminder is created from a Team-audience session
+- **WHEN** the creator explicitly sets `audience` to `Personal`
+- **THEN** the reminder is rejected before persistence
+- **AND** the error explains that the requested audience exceeds the creator's current authority
 
 ### Requirement: Schedule persistence
 
@@ -82,6 +111,10 @@ context. The session SHALL load the agent personality and any relevant project
 context overlays. Scheduled sessions SHALL NOT share state with interactive
 sessions.
 
+Execution MAY trust the stored reminder audience because reminder minting and
+import paths SHALL validate the persisted audience before the definition is
+saved.
+
 #### Scenario: Fresh session per execution
 
 - **GIVEN** a scheduled task fires
@@ -105,6 +138,13 @@ sessions.
 - **WHEN** the task session starts
 - **THEN** only the granted tools are available to the session
 - **AND** ungrantable tools are not offered to the LLM
+
+#### Scenario: Execution uses validated stored audience
+
+- **GIVEN** a reminder definition was accepted with stored audience `Public`
+- **WHEN** the reminder later executes on schedule
+- **THEN** the execution session uses stored audience `Public`
+- **AND** it does not recompute audience from the deployment posture default
 
 ### Requirement: Result reporting
 

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -261,7 +261,12 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     /// </summary>
     private sealed class ParentProxy : ReceiveActor
     {
-        public ParentProxy(IActorRef probe, ReminderDefinition definition, ISessionPipeline pipeline, ReminderHistoryStore historyStore)
+        public ParentProxy(
+            IActorRef probe,
+            ReminderDefinition definition,
+            ISessionPipeline pipeline,
+            ReminderHistoryStore historyStore,
+            EffectivePolicyDefaults? defaults = null)
         {
             var executionId = Guid.NewGuid();
             Context.ActorOf(
@@ -270,6 +275,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                     definition,
                     pipeline,
                     new ReminderConfig(),
+                    defaults ?? DefaultPolicyDefaults,
                     TimeProvider.System,
                     historyStore),
                 "exec");
@@ -277,6 +283,12 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             ReceiveAny(msg => probe.Tell(msg));
         }
     }
+
+    private static readonly EffectivePolicyDefaults DefaultPolicyDefaults = new(
+        DeploymentPosture.Team,
+        TrustAudience.Team,
+        ShellExecutionMode.Off,
+        UsedStrictFallback: false);
 
     /// <summary>Fake pipeline that throws a pre-configured exception on CreateAsync.</summary>
     private sealed class FailingSessionPipeline(Exception exception) : ISessionPipeline
@@ -318,6 +330,76 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
 
         public Task SendFeedbackAsync(IWithSessionId feedback, CancellationToken ct = default) =>
             Task.CompletedTask;
+    }
+
+    // ── Audience resolution tests ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execution_uses_definition_audience_when_set()
+    {
+        var pipeline = new ScriptedSessionPipeline(sessionId =>
+        [
+            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+        ]);
+
+        var definition = CreateDefinition("audience-override") with
+        {
+            Audience = TrustAudience.Personal,
+            NotifyInstructions = string.Empty
+        };
+        var teamDefaults = new EffectivePolicyDefaults(
+            DeploymentPosture.Team, TrustAudience.Team, ShellExecutionMode.Off, false);
+        var probe = CreateTestProbe();
+        Sys.ActorOf(
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, teamDefaults)),
+            "exec-audience-override");
+
+        await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(pipeline.CapturedOptions);
+        Assert.Equal(TrustAudience.Personal, pipeline.CapturedOptions!.DefaultAudience);
+    }
+
+    [Fact]
+    public async Task Execution_falls_back_to_deployment_posture_when_definition_audience_null()
+    {
+        var pipeline = new ScriptedSessionPipeline(sessionId =>
+        [
+            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+        ]);
+
+        var definition = CreateDefinition("audience-fallback") with { NotifyInstructions = string.Empty };
+        var personalDefaults = new EffectivePolicyDefaults(
+            DeploymentPosture.Personal, TrustAudience.Personal, ShellExecutionMode.HostAllowed, false);
+        var probe = CreateTestProbe();
+        Sys.ActorOf(
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, personalDefaults)),
+            "exec-audience-fallback");
+
+        await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(pipeline.CapturedOptions);
+        Assert.Equal(TrustAudience.Personal, pipeline.CapturedOptions!.DefaultAudience);
+    }
+
+    [Fact]
+    public async Task Execution_uses_team_audience_when_no_override_and_team_posture()
+    {
+        var pipeline = new ScriptedSessionPipeline(sessionId =>
+        [
+            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+        ]);
+
+        var definition = CreateDefinition("audience-team-default") with { NotifyInstructions = string.Empty };
+        var probe = CreateTestProbe();
+        Sys.ActorOf(
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore)),
+            "exec-audience-team-default");
+
+        await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(pipeline.CapturedOptions);
+        Assert.Equal(TrustAudience.Team, pipeline.CapturedOptions!.DefaultAudience);
     }
 
     // ── History integration tests ─────────────────────────────────────────────

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -248,6 +248,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                 Type = ReminderScheduleType.OneShot,
                 FireAt = now.AddHours(1)
             },
+            Audience = TrustAudience.Team,
             Enabled = true,
             CreatedBy = "test",
             CreatedAt = now,
@@ -265,8 +266,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             IActorRef probe,
             ReminderDefinition definition,
             ISessionPipeline pipeline,
-            ReminderHistoryStore historyStore,
-            TrustAudience defaultAudience = TrustAudience.Team)
+            ReminderHistoryStore historyStore)
         {
             var executionId = Guid.NewGuid();
             Context.ActorOf(
@@ -275,7 +275,6 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                     definition,
                     pipeline,
                     new ReminderConfig(),
-                    defaultAudience,
                     TimeProvider.System,
                     historyStore),
                 "exec");
@@ -343,7 +342,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
         };
         var probe = CreateTestProbe();
         Sys.ActorOf(
-            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, TrustAudience.Team)),
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore)),
             "exec-audience-override");
 
         await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
@@ -353,34 +352,43 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     }
 
     [Fact]
-    public async Task Execution_falls_back_to_deployment_posture_when_definition_audience_null()
+    public async Task Execution_fails_when_definition_audience_missing()
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
             new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
         ]);
 
-        var definition = CreateDefinition("audience-fallback") with { NotifyInstructions = string.Empty };
+        var definition = CreateDefinition("audience-fallback") with
+        {
+            NotifyInstructions = string.Empty,
+            Audience = null
+        };
         var probe = CreateTestProbe();
         Sys.ActorOf(
-            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, TrustAudience.Personal)),
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore)),
             "exec-audience-fallback");
 
-        await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var completed = await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.NotNull(pipeline.CapturedOptions);
-        Assert.Equal(TrustAudience.Personal, pipeline.CapturedOptions!.DefaultAudience);
+        Assert.False(completed.Success);
+        Assert.Contains("missing a persisted execution audience", completed.ErrorMessage);
+        Assert.Null(pipeline.CapturedOptions);
     }
 
     [Fact]
-    public async Task Execution_uses_team_audience_when_no_override_and_team_posture()
+    public async Task Execution_uses_stored_audience_directly()
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
             new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
         ]);
 
-        var definition = CreateDefinition("audience-team-default") with { NotifyInstructions = string.Empty };
+        var definition = CreateDefinition("audience-team-default") with
+        {
+            NotifyInstructions = string.Empty,
+            Audience = TrustAudience.Team
+        };
         var probe = CreateTestProbe();
         Sys.ActorOf(
             Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore)),

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -266,7 +266,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             ReminderDefinition definition,
             ISessionPipeline pipeline,
             ReminderHistoryStore historyStore,
-            EffectivePolicyDefaults? defaults = null)
+            TrustAudience defaultAudience = TrustAudience.Team)
         {
             var executionId = Guid.NewGuid();
             Context.ActorOf(
@@ -275,7 +275,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                     definition,
                     pipeline,
                     new ReminderConfig(),
-                    defaults ?? DefaultPolicyDefaults,
+                    defaultAudience,
                     TimeProvider.System,
                     historyStore),
                 "exec");
@@ -283,12 +283,6 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             ReceiveAny(msg => probe.Tell(msg));
         }
     }
-
-    private static readonly EffectivePolicyDefaults DefaultPolicyDefaults = new(
-        DeploymentPosture.Team,
-        TrustAudience.Team,
-        ShellExecutionMode.Off,
-        UsedStrictFallback: false);
 
     /// <summary>Fake pipeline that throws a pre-configured exception on CreateAsync.</summary>
     private sealed class FailingSessionPipeline(Exception exception) : ISessionPipeline
@@ -347,11 +341,9 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
             Audience = TrustAudience.Personal,
             NotifyInstructions = string.Empty
         };
-        var teamDefaults = new EffectivePolicyDefaults(
-            DeploymentPosture.Team, TrustAudience.Team, ShellExecutionMode.Off, false);
         var probe = CreateTestProbe();
         Sys.ActorOf(
-            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, teamDefaults)),
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, TrustAudience.Team)),
             "exec-audience-override");
 
         await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
@@ -369,11 +361,9 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
         ]);
 
         var definition = CreateDefinition("audience-fallback") with { NotifyInstructions = string.Empty };
-        var personalDefaults = new EffectivePolicyDefaults(
-            DeploymentPosture.Personal, TrustAudience.Personal, ShellExecutionMode.HostAllowed, false);
         var probe = CreateTestProbe();
         Sys.ActorOf(
-            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, personalDefaults)),
+            Props.Create(() => new ParentProxy(probe.Ref, definition, pipeline, _historyStore, TrustAudience.Personal)),
             "exec-audience-fallback");
 
         await probe.ExpectMsgAsync<ReminderExecutionCompleted>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -80,9 +80,10 @@ public class ReminderManagerActorTests : TestKit
         var manager = await GetManagerAsync();
 
         var definition = CreateDefinition("test-list", "Check status");
+        var authorization = new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test");
 
         var scheduled = await manager.Ask<ReminderSavedResponse>(
-            new SaveReminderCommand(definition), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new SaveReminderCommand(definition, Authorization: authorization), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal("test-list", scheduled.Title);
         Assert.NotNull(scheduled.NextFire);
@@ -101,9 +102,10 @@ public class ReminderManagerActorTests : TestKit
         var manager = await GetManagerAsync();
 
         var definition = CreateDefinition("test-cancel", "Check it");
+        var authorization = new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test");
 
         await manager.Ask<ReminderSavedResponse>(
-            new SaveReminderCommand(definition), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new SaveReminderCommand(definition, Authorization: authorization), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var cancelled = await manager.Ask<ReminderCancelledResponse>(
             new CancelReminderCommand(new ReminderId(definition.Id)), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
@@ -129,9 +131,10 @@ public class ReminderManagerActorTests : TestKit
         var manager = await GetManagerAsync();
 
         var definition = CreateDefinition("test-health", "Check health");
+        var authorization = new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test");
 
         await manager.Ask<ReminderSavedResponse>(
-            new SaveReminderCommand(definition), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new SaveReminderCommand(definition, Authorization: authorization), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var health = await manager.Ask<ReminderHealthResponse>(
             GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
@@ -203,6 +206,72 @@ public class ReminderManagerActorTests : TestKit
         // Verify definition has been deleted from the store
         var afterReconcile = _definitionStore.Get(new ReminderId("zombie-oneshot"));
         Assert.Null(afterReconcile);
+    }
+
+    [Theory]
+    [InlineData(TrustAudience.Team, TrustAudience.Team, true)]
+    [InlineData(TrustAudience.Public, TrustAudience.Personal, true)]
+    [InlineData(TrustAudience.Personal, TrustAudience.Team, false)]
+    public async Task Save_authorizes_requested_audience_against_source_authority(
+        TrustAudience requestedAudience,
+        TrustAudience sourceAudience,
+        bool shouldSucceed)
+    {
+        var manager = await GetManagerAsync();
+        var definition = CreateDefinition($"audience-{requestedAudience}-{sourceAudience}", "Check audience") with
+        {
+            Audience = requestedAudience
+        };
+
+        var response = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(
+                definition,
+                Authorization: new ReminderAudienceAuthorizationContext(sourceAudience, "test")),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(shouldSucceed, response.Success);
+        if (!shouldSucceed)
+            Assert.Contains("exceeds creator authority", response.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Save_rejects_missing_authorization_context()
+    {
+        var manager = await GetManagerAsync();
+        var definition = CreateDefinition("missing-auth", "Check auth");
+
+        var response = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(definition),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(response.Success);
+        Assert.Equal(ReminderSaveError.Validation, response.Error);
+        Assert.Contains("authorization context is required", response.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Save_omitted_audience_persists_source_audience()
+    {
+        var manager = await GetManagerAsync();
+        var definition = CreateDefinition("inherit-source", "Check inheritance") with
+        {
+            Audience = null
+        };
+
+        var response = await manager.Ask<ReminderSavedResponse>(
+            new SaveReminderCommand(
+                definition,
+                Authorization: new ReminderAudienceAuthorizationContext(TrustAudience.Team, "test")),
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(response.Success);
+
+        var saved = _definitionStore.Get(response.Id);
+        Assert.NotNull(saved);
+        Assert.Equal(TrustAudience.Team, saved!.Audience);
     }
 
     private static ReminderDefinition CreateDefinition(string name, string instructions)

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -50,10 +50,13 @@ public class ReminderManagerActorTests : TestKit
                 system,
                 new RequiredActor<SessionManagerActorKey>(ActorRegistry.For(system)));
 
+            var defaults = new EffectivePolicyDefaults(
+                DeploymentPosture.Team, TrustAudience.Team, ShellExecutionMode.Off, false);
             var reminderManager = system.ActorOf(
                 Props.Create(() => new ReminderManagerActor(
                     reminderConfig,
                     pipeline,
+                    defaults,
                     TimeProvider.System,
                     definitionStore,
                     historyStore,

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -193,7 +193,10 @@ public class SetReminderToolTests : TestKit
     {
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
-        var context = new ToolExecutionContext("C0123ABC/1234567890.123456", null);
+        var context = new ToolExecutionContext("C0123ABC/1234567890.123456", null)
+        {
+            Audience = "team"
+        };
 
         var execution = Task.Run(async () =>
         {
@@ -213,6 +216,7 @@ public class SetReminderToolTests : TestKit
         Assert.Equal("C0123ABC", cmd.Definition.ReportToChannel);
         Assert.Equal("1234567890.123456", cmd.Definition.ReportToThreadTs);
         Assert.Equal("C0123ABC/1234567890.123456", cmd.Definition.SessionId);
+        Assert.Equal(TrustAudience.Team, cmd.Authorization?.SourceAudience);
         Assert.Equal(ReminderWriteMode.Upsert, cmd.WriteMode);
 
         probe.Reply(new ReminderSavedResponse(
@@ -262,6 +266,10 @@ public class SetReminderToolTests : TestKit
     {
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+        var context = new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = "personal"
+        };
 
         var execution = Task.Run(async () =>
         {
@@ -273,12 +281,13 @@ public class SetReminderToolTests : TestKit
                 ["ScheduleType"] = "once",
                 ["Schedule"] = "30m",
                 ["Audience"] = "personal"
-            });
+            }, context);
             return result;
         });
 
         var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(TrustAudience.Personal, cmd.Definition.Audience);
+        Assert.Equal(TrustAudience.Personal, cmd.Authorization?.SourceAudience);
 
         probe.Reply(new ReminderSavedResponse(
             new ReminderId(cmd.Definition.Id),
@@ -311,10 +320,14 @@ public class SetReminderToolTests : TestKit
     }
 
     [Fact]
-    public async Task Audience_is_null_when_omitted()
+    public async Task Omitted_audience_inherits_source_audience()
     {
         var probe = CreateTestProbe();
         var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+        var context = new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = "team"
+        };
 
         var execution = Task.Run(async () =>
         {
@@ -325,12 +338,13 @@ public class SetReminderToolTests : TestKit
                 ["Prompt"] = "Check something",
                 ["ScheduleType"] = "once",
                 ["Schedule"] = "1h"
-            });
+            }, context);
             return result;
         });
 
         var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Null(cmd.Definition.Audience);
+        Assert.Equal(TrustAudience.Team, cmd.Authorization?.SourceAudience);
 
         probe.Reply(new ReminderSavedResponse(
             new ReminderId(cmd.Definition.Id),
@@ -339,6 +353,69 @@ public class SetReminderToolTests : TestKit
             NextFire: _timeProvider.GetUtcNow().AddHours(1)));
 
         await execution;
+    }
+
+    [Fact]
+    public async Task Rejects_invalid_source_audience_context()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+        var context = new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = "superadmin"
+        };
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Id"] = "bad-source-audience",
+            ["Name"] = "bad-source-audience",
+            ["Prompt"] = "Test",
+            ["ScheduleType"] = "once",
+            ["Schedule"] = "1h"
+        }, context, TestContext.Current.CancellationToken);
+
+        Assert.Contains("Invalid source audience", result);
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Manager_validation_failure_returns_error_prefix()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+        var context = new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = "team"
+        };
+
+        var execution = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Id"] = "manager-validation-failure",
+                ["Name"] = "manager-validation-failure",
+                ["Prompt"] = "Check something",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "1h",
+                ["Audience"] = "personal"
+            }, context);
+            return result;
+        });
+
+        var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(TrustAudience.Team, cmd.Authorization?.SourceAudience);
+
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: false,
+            NextFire: null,
+            Error: ReminderSaveError.Validation,
+            ErrorMessage: "Requested audience 'personal' exceeds creator authority 'team' (team)."));
+
+        var result = await execution;
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("exceeds creator authority", result);
     }
 
     private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -257,6 +257,90 @@ public class SetReminderToolTests : TestKit
         await execution;
     }
 
+    [Fact]
+    public async Task Sets_audience_when_provided()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+
+        var execution = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Id"] = "audience-test",
+                ["Name"] = "audience-test",
+                ["Prompt"] = "Search the web",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "30m",
+                ["Audience"] = "personal"
+            });
+            return result;
+        });
+
+        var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(TrustAudience.Personal, cmd.Definition.Audience);
+
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: _timeProvider.GetUtcNow().AddMinutes(30)));
+
+        await execution;
+    }
+
+    [Fact]
+    public async Task Rejects_invalid_audience()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["Id"] = "bad-audience",
+            ["Name"] = "bad-audience",
+            ["Prompt"] = "Test",
+            ["ScheduleType"] = "once",
+            ["Schedule"] = "30m",
+            ["Audience"] = "superadmin"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Invalid audience", result);
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Audience_is_null_when_omitted()
+    {
+        var probe = CreateTestProbe();
+        var tool = new SetReminderTool(probe, _timeProvider, new ReminderConfig());
+
+        var execution = Task.Run(async () =>
+        {
+            var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+            {
+                ["Id"] = "no-audience",
+                ["Name"] = "no-audience",
+                ["Prompt"] = "Check something",
+                ["ScheduleType"] = "once",
+                ["Schedule"] = "1h"
+            });
+            return result;
+        });
+
+        var cmd = await probe.ExpectMsgAsync<SaveReminderCommand>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Null(cmd.Definition.Audience);
+
+        probe.Reply(new ReminderSavedResponse(
+            new ReminderId(cmd.Definition.Id),
+            cmd.Definition.Title,
+            Success: true,
+            NextFire: _timeProvider.GetUtcNow().AddHours(1)));
+
+        await execution;
+    }
+
     private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => utcNow;

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -21,7 +21,6 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private readonly ReminderDefinition _definition;
     private readonly ISessionPipeline _pipeline;
     private readonly ReminderHistoryStore _historyStore;
-    private readonly TrustAudience _defaultAudience;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
     private readonly DateTimeOffset _dispatchedAt;
@@ -43,17 +42,15 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
-        TrustAudience defaultAudience,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore) =>
-        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, defaultAudience, timeProvider, historyStore));
+        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, timeProvider, historyStore));
 
     public ReminderExecutionActor(
         Guid executionId,
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
-        TrustAudience defaultAudience,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore)
     {
@@ -61,7 +58,6 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         _definition = definition;
         _pipeline = pipeline;
         _historyStore = historyStore;
-        _defaultAudience = defaultAudience;
         _timeProvider = timeProvider;
         _dispatchedAt = timeProvider.GetUtcNow();
         _log = Context.GetLogger();
@@ -97,9 +93,11 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 : new SessionId($"reminder/{_definition.Id}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
 
             _sessionIdValue = sessionId.Value;
-            var audience = _definition.Audience ?? _defaultAudience;
+            if (_definition.Audience is not { } audience)
+                throw new InvalidOperationException($"Reminder '{_definition.Id}' is missing a persisted execution audience.");
+
             _log.Info(
-                $"ReminderExecution Initialized: execution_id={_executionId} reminder_id={_definition.Id} session_id={sessionId.Value} audience={audience}");
+                $"ReminderExecution Initialized: execution_id={_executionId} reminder_id={_definition.Id} session_id={sessionId.Value} audience={audience} source=stored-definition");
 
             _materializer = Context.Materializer(namePrefix: "reminder-exec");
 

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -21,6 +21,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private readonly ReminderDefinition _definition;
     private readonly ISessionPipeline _pipeline;
     private readonly ReminderHistoryStore _historyStore;
+    private readonly EffectivePolicyDefaults _defaults;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
     private readonly DateTimeOffset _dispatchedAt;
@@ -42,15 +43,17 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
+        EffectivePolicyDefaults defaults,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore) =>
-        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, timeProvider, historyStore));
+        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, defaults, timeProvider, historyStore));
 
     public ReminderExecutionActor(
         Guid executionId,
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
+        EffectivePolicyDefaults defaults,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore)
     {
@@ -58,6 +61,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         _definition = definition;
         _pipeline = pipeline;
         _historyStore = historyStore;
+        _defaults = defaults;
         _timeProvider = timeProvider;
         _dispatchedAt = timeProvider.GetUtcNow();
         _log = Context.GetLogger();
@@ -93,15 +97,16 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 : new SessionId($"reminder/{_definition.Id}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
 
             _sessionIdValue = sessionId.Value;
+            var audience = _definition.Audience ?? _defaults.Audience;
             _log.Info(
-                $"ReminderExecution Initialized: execution_id={_executionId} reminder_id={_definition.Id} session_id={sessionId.Value}");
+                $"ReminderExecution Initialized: execution_id={_executionId} reminder_id={_definition.Id} session_id={sessionId.Value} audience={audience}");
 
             _materializer = Context.Materializer(namePrefix: "reminder-exec");
 
             var materialized = await _pipeline.CreateAsync(sessionId, new SessionPipelineOptions
             {
                 ChannelType = Channels.ChannelType.Reminder,
-                DefaultAudience = TrustAudience.Team,
+                DefaultAudience = audience,
                 DefaultBoundary = SecurityPolicyDefaults.LocalDaemonBoundary,
                 DefaultPrincipal = PrincipalClassification.VerifiedAutomation,
                 DefaultProvenance = new SourceProvenance

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -21,7 +21,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
     private readonly ReminderDefinition _definition;
     private readonly ISessionPipeline _pipeline;
     private readonly ReminderHistoryStore _historyStore;
-    private readonly EffectivePolicyDefaults _defaults;
+    private readonly TrustAudience _defaultAudience;
     private readonly TimeProvider _timeProvider;
     private readonly ILoggingAdapter _log;
     private readonly DateTimeOffset _dispatchedAt;
@@ -43,17 +43,17 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
-        EffectivePolicyDefaults defaults,
+        TrustAudience defaultAudience,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore) =>
-        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, defaults, timeProvider, historyStore));
+        Props.Create(() => new ReminderExecutionActor(executionId, definition, pipeline, config, defaultAudience, timeProvider, historyStore));
 
     public ReminderExecutionActor(
         Guid executionId,
         ReminderDefinition definition,
         ISessionPipeline pipeline,
         ReminderConfig config,
-        EffectivePolicyDefaults defaults,
+        TrustAudience defaultAudience,
         TimeProvider timeProvider,
         ReminderHistoryStore historyStore)
     {
@@ -61,7 +61,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         _definition = definition;
         _pipeline = pipeline;
         _historyStore = historyStore;
-        _defaults = defaults;
+        _defaultAudience = defaultAudience;
         _timeProvider = timeProvider;
         _dispatchedAt = timeProvider.GetUtcNow();
         _log = Context.GetLogger();
@@ -97,7 +97,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 : new SessionId($"reminder/{_definition.Id}/{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}");
 
             _sessionIdValue = sessionId.Value;
-            var audience = _definition.Audience ?? _defaults.Audience;
+            var audience = _definition.Audience ?? _defaultAudience;
             _log.Info(
                 $"ReminderExecution Initialized: execution_id={_executionId} reminder_id={_definition.Id} session_id={sessionId.Value} audience={audience}");
 

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -19,6 +19,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
     private readonly ReminderConfig _config;
     private readonly ISessionPipeline _pipeline;
+    private readonly EffectivePolicyDefaults _defaults;
     private readonly TimeProvider _timeProvider;
     private readonly ReminderDefinitionStore _definitionStore;
     private readonly ReminderHistoryStore _historyStore;
@@ -34,6 +35,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     public ReminderManagerActor(
         ReminderConfig config,
         ISessionPipeline pipeline,
+        EffectivePolicyDefaults defaults,
         TimeProvider timeProvider,
         ReminderDefinitionStore definitionStore,
         ReminderHistoryStore historyStore,
@@ -41,6 +43,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     {
         _config = config;
         _pipeline = pipeline;
+        _defaults = defaults;
         _timeProvider = timeProvider;
         _definitionStore = definitionStore;
         _historyStore = historyStore;
@@ -575,6 +578,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 definition,
                 _pipeline,
                 _config,
+                _defaults,
                 _timeProvider,
                 _historyStore),
             actorName);
@@ -740,7 +744,8 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         SessionId: d.SessionId,
         ReportToChannel: d.ReportToChannel,
         ReportToThreadTs: d.ReportToThreadTs,
-        AgentDefinitionId: d.AgentDefinitionId);
+        AgentDefinitionId: d.AgentDefinitionId,
+        Audience: d.Audience);
 
     private static string SanitizeActorName(string raw)
     {

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -77,6 +77,15 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     {
         var replyTo = Sender;
 
+        static ReminderSavedResponse ValidationFailure(ReminderId id, string title, string message)
+            => new(
+                id,
+                title,
+                Success: false,
+                NextFire: null,
+                Error: ReminderSaveError.Validation,
+                ErrorMessage: message);
+
         if (cmd.Definition is null)
         {
             replyTo.Tell(new ReminderSavedResponse(
@@ -132,10 +141,18 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         }
 
         var now = _timeProvider.GetUtcNow();
+        var authorization = ValidateRequestedAudience(cmd.Definition.Audience, cmd.Authorization);
+        if (!authorization.IsSuccess)
+        {
+            replyTo.Tell(ValidationFailure(id, title, authorization.ErrorMessage!));
+            return;
+        }
+
         var normalized = cmd.Definition with
         {
             Id = id.Value,
             Title = title,
+            Audience = authorization.EffectiveAudience,
             CreatedBy = string.IsNullOrWhiteSpace(cmd.Definition.CreatedBy)
                 ? "system"
                 : cmd.Definition.CreatedBy
@@ -195,6 +212,30 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             normalized.Title,
             Success: true,
             NextFire: nextFire));
+    }
+
+    private static ReminderAudienceAuthorizationResult ValidateRequestedAudience(
+        TrustAudience? requestedAudience,
+        ReminderAudienceAuthorizationContext? authorization)
+    {
+        if (authorization?.SourceAudience is not { } sourceAudience)
+        {
+            return ReminderAudienceAuthorizationResult.Fail(
+                "Reminder audience authorization context is required.");
+        }
+
+        var effectiveAudience = requestedAudience ?? sourceAudience;
+        if (effectiveAudience > sourceAudience)
+        {
+            var sourceDescription = string.IsNullOrWhiteSpace(authorization.SourceDescription)
+                ? sourceAudience.ToWireValue()
+                : authorization.SourceDescription;
+
+            return ReminderAudienceAuthorizationResult.Fail(
+                $"Requested audience '{effectiveAudience.ToWireValue()}' exceeds creator authority '{sourceDescription}' ({sourceAudience.ToWireValue()}).");
+        }
+
+        return ReminderAudienceAuthorizationResult.Success(effectiveAudience);
     }
 
     private async Task HandleCancelAsync(CancelReminderCommand cmd)
@@ -578,7 +619,6 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 definition,
                 _pipeline,
                 _config,
-                _defaults.Audience,
                 _timeProvider,
                 _historyStore),
             actorName);
@@ -770,6 +810,15 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     {
         public static ScheduleAttempt Ok(DateTimeOffset? nextFire) => new(true, nextFire, null);
         public static ScheduleAttempt Fail(string message) => new(false, null, message);
+    }
+
+    private sealed record ReminderAudienceAuthorizationResult(bool IsSuccess, TrustAudience? EffectiveAudience, string? ErrorMessage)
+    {
+        public static ReminderAudienceAuthorizationResult Success(TrustAudience effectiveAudience)
+            => new(true, effectiveAudience, null);
+
+        public static ReminderAudienceAuthorizationResult Fail(string errorMessage)
+            => new(false, null, errorMessage);
     }
 
     internal sealed record ReconcileReminders

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -578,7 +578,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                 definition,
                 _pipeline,
                 _config,
-                _defaults,
+                _defaults.Audience,
                 _timeProvider,
                 _historyStore),
             actorName);

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -104,10 +104,10 @@ public sealed record ReminderDefinition
     public string? AgentDefinitionId { get; init; }
 
     /// <summary>
-    /// Optional per-reminder audience override.
-    /// When null, falls back to the deployment posture's default audience
-    /// (<see cref="Configuration.EffectivePolicyDefaults.Audience"/>).
-    /// Controls which tools are available during this reminder's execution.
+    /// Persisted execution audience for this reminder.
+    /// Conversational and tool-created reminders inherit the creating
+    /// session/channel audience when omitted at mint time. Reminder save paths
+    /// fail closed if they cannot resolve or authorize this audience.
     /// </summary>
     public TrustAudience? Audience { get; init; }
 
@@ -160,7 +160,12 @@ public enum ReminderSaveError
 
 public sealed record SaveReminderCommand(
     ReminderDefinition Definition,
-    ReminderWriteMode WriteMode = ReminderWriteMode.CreateOnly);
+    ReminderWriteMode WriteMode = ReminderWriteMode.CreateOnly,
+    ReminderAudienceAuthorizationContext? Authorization = null);
+
+public sealed record ReminderAudienceAuthorizationContext(
+    TrustAudience? SourceAudience,
+    string? SourceDescription = null);
 
 /// <summary>
 /// Permanently deletes a reminder definition and cancels any active schedule.

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -103,6 +103,14 @@ public sealed record ReminderDefinition
     /// </summary>
     public string? AgentDefinitionId { get; init; }
 
+    /// <summary>
+    /// Optional per-reminder audience override.
+    /// When null, falls back to the deployment posture's default audience
+    /// (<see cref="Configuration.EffectivePolicyDefaults.Audience"/>).
+    /// Controls which tools are available during this reminder's execution.
+    /// </summary>
+    public TrustAudience? Audience { get; init; }
+
     public string CreatedBy { get; init; } = "system";
     public long CreatedAtMs { get; set; }
     public long UpdatedAtMs { get; set; }
@@ -197,7 +205,8 @@ public sealed record ReminderInfo(
     string? SessionId,
     string? ReportToChannel,
     string? ReportToThreadTs,
-    string? AgentDefinitionId);
+    string? AgentDefinitionId,
+    TrustAudience? Audience);
 
 // ── Internal messages ──
 

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -35,7 +35,9 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
         [property: Description("Optional notify instructions describing how Netclaw should report results.")]
         string? NotifyInstructions = null,
         [property: Description("Notification policy: 'required' (default, fail if no notification sent) or 'conditional' (OK to skip notification if nothing actionable).")]
-        string? NotifyPolicy = null);
+        string? NotifyPolicy = null,
+        [property: Description("Trust audience for this reminder's execution: 'personal' (all tools including web_search, shell), 'team' (restricted tools), or 'public' (minimal tools). Omit to use the deployment default.")]
+        string? Audience = null);
 
     public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider, ReminderConfig config)
     {
@@ -101,6 +103,14 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
             ? parsed
             : NotificationPolicy.Required;
 
+        TrustAudience? audience = null;
+        if (!string.IsNullOrWhiteSpace(args.Audience))
+        {
+            if (!SecurityPolicyDefaults.TryParseAudience(args.Audience, out var parsedAudience))
+                return $"Error: Invalid audience '{args.Audience}'. Use 'personal', 'team', or 'public'.";
+            audience = parsedAudience;
+        }
+
         var definition = new ReminderDefinition
         {
             Id = id.Value,
@@ -109,6 +119,7 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
             Instructions = args.Prompt,
             NotifyInstructions = notifyInstructions,
             NotifyPolicy = notifyPolicy,
+            Audience = audience,
             Enabled = true,
             SessionId = sessionId,
             ReportToChannel = reportToChannel,

--- a/src/Netclaw.Actors/Reminders/SetReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/SetReminderTool.cs
@@ -36,7 +36,7 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
         string? NotifyInstructions = null,
         [property: Description("Notification policy: 'required' (default, fail if no notification sent) or 'conditional' (OK to skip notification if nothing actionable).")]
         string? NotifyPolicy = null,
-        [property: Description("Trust audience for this reminder's execution: 'personal' (all tools including web_search, shell), 'team' (restricted tools), or 'public' (minimal tools). Omit to use the deployment default.")]
+        [property: Description("Trust audience for this reminder's execution: 'personal' (all tools including web_search, shell), 'team' (restricted tools), or 'public' (minimal tools). Omit to inherit the creating session/channel audience.")]
         string? Audience = null);
 
     public SetReminderTool(IActorRef reminderManager, TimeProvider timeProvider, ReminderConfig config)
@@ -111,6 +111,15 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
             audience = parsedAudience;
         }
 
+        TrustAudience? sourceAudience = null;
+        if (!string.IsNullOrWhiteSpace(context.Audience))
+        {
+            if (!SecurityPolicyDefaults.TryParseAudience(context.Audience, out var parsedSourceAudience))
+                return $"Error: Invalid source audience '{context.Audience}' in tool execution context.";
+
+            sourceAudience = parsedSourceAudience;
+        }
+
         var definition = new ReminderDefinition
         {
             Id = id.Value,
@@ -130,10 +139,20 @@ public sealed partial class SetReminderTool : NetclawTool<SetReminderTool.Params
         };
 
         var response = await _reminderManager.Ask<ReminderSavedResponse>(
-            new SaveReminderCommand(definition, ReminderWriteMode.Upsert), TimeSpan.FromSeconds(10), ct);
+            new SaveReminderCommand(
+                definition,
+                ReminderWriteMode.Upsert,
+                new ReminderAudienceAuthorizationContext(sourceAudience, context.SessionId ?? context.ChannelType)),
+            TimeSpan.FromSeconds(10),
+            ct);
 
         if (!response.Success)
-            return $"Failed to schedule reminder '{args.Name}': {response.ErrorMessage ?? "unknown error"}";
+        {
+            var message = response.ErrorMessage ?? "unknown error";
+            return response.Error == ReminderSaveError.Validation
+                ? $"Error: {message}"
+                : $"Failed to schedule reminder '{args.Name}': {message}";
+        }
 
         var nextFireStr = FormatNextFire(response.NextFire);
 

--- a/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
@@ -1,0 +1,273 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Reminders;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Security;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Reminder;
+
+public sealed class ReminderEndpointAuthorizationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly ReminderDefinitionStore _definitionStore;
+    private readonly ReminderHistoryStore _historyStore;
+
+    public ReminderEndpointAuthorizationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-reminder-endpoint-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 9, 12, 0, 0, TimeSpan.Zero));
+
+        var paths = new NetclawPaths(_tempDir);
+        paths.EnsureDirectoriesExist();
+        _definitionStore = new ReminderDefinitionStore(paths);
+        _historyStore = new ReminderHistoryStore(paths, new ReminderConfig());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private async Task<WebApplication> CreateAppAsync(bool spoofLoopback)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddSingleton(_definitionStore);
+        builder.Services.AddSingleton(_historyStore);
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton(new ReminderConfig());
+        builder.Services.AddSingleton(new EffectivePolicyDefaults(
+            DeploymentPosture.Team,
+            TrustAudience.Team,
+            ShellExecutionMode.Off,
+            UsedStrictFallback: false));
+        builder.Services.AddSingleton<ClaimsPrincipalMapper>();
+        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddAuthorization();
+
+        var app = builder.Build();
+
+        if (spoofLoopback)
+        {
+            app.Use(async (ctx, next) =>
+            {
+                ctx.Connection.RemoteIpAddress = IPAddress.Loopback;
+                await next(ctx);
+            });
+        }
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        var reminders = app.MapGroup("/api/reminders").RequireAuthorization();
+
+        reminders.MapPost("", async (
+            ReminderCreateRequest request,
+            ReminderDefinitionStore definitionStore,
+            ClaimsPrincipalMapper mapper,
+            HttpContext httpContext,
+            CancellationToken ct) =>
+        {
+            var identity = mapper.Map(httpContext.User);
+            if (identity.Principal is not PrincipalClassification.Operator)
+                return Results.BadRequest(new { error = "Reminder audience authorization context is required." });
+
+            var parsedAudience = default(TrustAudience);
+            if (!string.IsNullOrWhiteSpace(request.Audience)
+                && !SecurityPolicyDefaults.TryParseAudience(request.Audience, out parsedAudience))
+            {
+                return Results.BadRequest(new { error = $"Error: Invalid audience '{request.Audience}'. Use 'personal', 'team', or 'public'." });
+            }
+
+            var effectiveAudience = string.IsNullOrWhiteSpace(request.Audience)
+                ? TrustAudience.Personal
+                : parsedAudience;
+
+            var now = _timeProvider.GetUtcNow();
+            var definition = new ReminderDefinition
+            {
+                Id = request.Id,
+                Title = request.Name,
+                Instructions = request.Prompt,
+                NotifyInstructions = request.NotifyInstructions ?? "Reply in thread.",
+                Schedule = new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.OneShot,
+                    FireAt = now.AddMinutes(30)
+                },
+                Audience = effectiveAudience,
+                Enabled = true,
+                CreatedBy = "test",
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            definitionStore.Save(definition);
+            return Results.Ok(new { message = $"Reminder '{request.Name}' scheduled." });
+        });
+
+        reminders.MapPost("/import", async (
+            ReminderImportRequest request,
+            ReminderDefinitionStore definitionStore,
+            ClaimsPrincipalMapper mapper,
+            HttpContext httpContext,
+            CancellationToken ct) =>
+        {
+            if (request.Definition is null)
+                return Results.BadRequest(new { error = "Reminder definition is required." });
+
+            var identity = mapper.Map(httpContext.User);
+            if (identity.Principal is not PrincipalClassification.Operator)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "Reminder audience authorization context is required.",
+                    code = ReminderSaveError.Validation.ToString(),
+                    id = request.Definition.Id
+                });
+            }
+
+            if (request.Definition.Audience is not { } audience)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "Reminder definition must include a valid audience for import.",
+                    code = ReminderSaveError.Validation.ToString(),
+                    id = request.Definition.Id
+                });
+            }
+
+            if (audience > TrustAudience.Personal)
+            {
+                return Results.BadRequest(new
+                {
+                    error = $"Requested audience '{audience.ToWireValue()}' exceeds creator authority 'Operator/LocalProcess' (personal).",
+                    code = ReminderSaveError.Validation.ToString(),
+                    id = request.Definition.Id
+                });
+            }
+
+            definitionStore.Save(request.Definition);
+            return Results.Ok(new { id = request.Definition.Id, message = $"Imported reminder '{request.Definition.Id}'." });
+        });
+
+        await app.StartAsync();
+        return app;
+    }
+
+    [Fact]
+    public async Task Create_persists_personal_audience_when_omitted_for_loopback_operator()
+    {
+        await using var app = await CreateAppAsync(spoofLoopback: true);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/reminders", new
+        {
+            id = "rest-create-inherit",
+            name = "rest-create-inherit",
+            prompt = "check status",
+            scheduleType = "once",
+            schedule = "30m"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(TrustAudience.Personal, _definitionStore.Get(new ReminderId("rest-create-inherit"))!.Audience);
+    }
+
+    [Fact]
+    public async Task Create_rejects_invalid_audience_without_persisting()
+    {
+        await using var app = await CreateAppAsync(spoofLoopback: true);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/reminders", new
+        {
+            id = "rest-create-invalid",
+            name = "rest-create-invalid",
+            prompt = "check status",
+            scheduleType = "once",
+            schedule = "30m",
+            audience = "superuser"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        Assert.Contains("Invalid audience", body.GetProperty("error").GetString());
+        Assert.Null(_definitionStore.Get(new ReminderId("rest-create-invalid")));
+    }
+
+    [Fact]
+    public async Task Import_rejects_missing_audience_without_persisting()
+    {
+        await using var app = await CreateAppAsync(spoofLoopback: true);
+        var client = app.GetTestClient();
+        var now = _timeProvider.GetUtcNow();
+
+        var response = await client.PostAsJsonAsync("/api/reminders/import", new ReminderImportRequest(
+            new ReminderDefinition
+            {
+                Id = "rest-import-missing-audience",
+                Title = "rest-import-missing-audience",
+                Instructions = "check status",
+                NotifyInstructions = "reply",
+                Schedule = new ReminderSchedule
+                {
+                    Type = ReminderScheduleType.OneShot,
+                    FireAt = now.AddMinutes(30)
+                },
+                Enabled = true,
+                CreatedBy = "test",
+                CreatedAt = now,
+                UpdatedAt = now
+            }), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        Assert.Contains("must include a valid audience", body.GetProperty("error").GetString());
+        Assert.Null(_definitionStore.Get(new ReminderId("rest-import-missing-audience")));
+    }
+
+    [Fact]
+    public async Task Create_requires_authenticated_authority_context()
+    {
+        await using var app = await CreateAppAsync(spoofLoopback: false);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/reminders", new
+        {
+            id = "rest-create-unauthorized",
+            name = "rest-create-unauthorized",
+            prompt = "check status",
+            scheduleType = "once",
+            schedule = "30m"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Null(_definitionStore.Get(new ReminderId("rest-create-unauthorized")));
+    }
+
+    private sealed record ReminderCreateRequest(
+        string Id,
+        string Name,
+        string Prompt,
+        string ScheduleType,
+        string Schedule,
+        string? Audience = null,
+        string? NotifyInstructions = null);
+
+    private sealed record ReminderImportRequest(ReminderDefinition Definition);
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1122,7 +1122,7 @@ static void MapReminderEndpoints(WebApplication app)
             enabled = r.Enabled,
             schedule = Netclaw.Actors.Reminders.ListRemindersTool.DescribeSchedule(r.Schedule),
             nextFire = Netclaw.Actors.Reminders.SetReminderTool.FormatNextFire(r.NextFire),
-            audience = r.Audience?.ToString().ToLowerInvariant(),
+            audience = r.Audience?.ToWireValue(),
         });
         return Results.Ok(projected);
     });
@@ -1332,7 +1332,7 @@ static void MapReminderEndpoints(WebApplication app)
             notifyPolicy = r.NotifyPolicy.ToString().ToLowerInvariant(),
             sessionId = r.SessionId,
             reportToChannel = r.ReportToChannel,
-            audience = r.Audience?.ToString().ToLowerInvariant(),
+            audience = r.Audience?.ToWireValue(),
         });
     });
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1122,6 +1122,7 @@ static void MapReminderEndpoints(WebApplication app)
             enabled = r.Enabled,
             schedule = Netclaw.Actors.Reminders.ListRemindersTool.DescribeSchedule(r.Schedule),
             nextFire = Netclaw.Actors.Reminders.SetReminderTool.FormatNextFire(r.NextFire),
+            audience = r.Audience?.ToString().ToLowerInvariant(),
         });
         return Results.Ok(projected);
     });
@@ -1179,7 +1180,8 @@ static void MapReminderEndpoints(WebApplication app)
                 ["Schedule"] = request.Schedule,
                 ["ReportToChannel"] = reportToChannel,
                 ["NotifyInstructions"] = notifyInstructions,
-                ["NotifyPolicy"] = request.NotifyPolicy
+                ["NotifyPolicy"] = request.NotifyPolicy,
+                ["Audience"] = request.Audience
             }, ct);
 
         return result.StartsWith("Error", StringComparison.Ordinal)
@@ -1330,6 +1332,7 @@ static void MapReminderEndpoints(WebApplication app)
             notifyPolicy = r.NotifyPolicy.ToString().ToLowerInvariant(),
             sessionId = r.SessionId,
             reportToChannel = r.ReportToChannel,
+            audience = r.Audience?.ToString().ToLowerInvariant(),
         });
     });
 
@@ -1376,6 +1379,7 @@ sealed record CreateReminderRequest
     public string? ReportTarget { get; init; }
     public string? NotifyInstructions { get; init; }
     public string? NotifyPolicy { get; init; }
+    public string? Audience { get; init; }
 }
 
 sealed record ImportReminderRequest

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1108,6 +1108,17 @@ static void MapReminderEndpoints(WebApplication app)
     var reminders = app.MapGroup("/api/reminders")
         .RequireAuthorization();
 
+    static ReminderAudienceAuthorizationContext? ResolveReminderAuthorizationContext(ClaimsPrincipalMapper mapper, HttpContext httpContext)
+    {
+        var identity = mapper.Map(httpContext.User);
+        if (identity.Principal is not PrincipalClassification.Operator)
+            return null;
+
+        return new ReminderAudienceAuthorizationContext(
+            TrustAudience.Personal,
+            $"{identity.Principal}/{identity.Transport}");
+    }
+
     reminders.MapGet("", async (
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
         CancellationToken ct) =>
@@ -1131,11 +1142,14 @@ static void MapReminderEndpoints(WebApplication app)
         CreateReminderRequest request,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
         IServiceProvider serviceProvider,
+        ClaimsPrincipalMapper mapper,
+        HttpContext httpContext,
         TimeProvider timeProvider,
         ReminderConfig reminderConfig,
         CancellationToken ct) =>
     {
         var manager = await actor.GetAsync(ct);
+        var authorization = ResolveReminderAuthorizationContext(mapper, httpContext);
 
         string? reportToChannel = request.ReportToChannel;
         string? notifyInstructions = request.NotifyInstructions;
@@ -1170,6 +1184,9 @@ static void MapReminderEndpoints(WebApplication app)
             : Netclaw.Actors.Reminders.ReminderIdGenerator.Generate(request.Name).Value;
 
         var tool = new Netclaw.Actors.Reminders.SetReminderTool(manager, timeProvider, reminderConfig);
+        var toolContext = new Netclaw.Tools.ToolExecutionContext(sessionId: null, sessionDirectory: null);
+        toolContext.Audience = authorization?.SourceAudience?.ToWireValue();
+        toolContext.ChannelType = "manual";
         var result = await tool.ExecuteAsync(
             new Dictionary<string, object?>
             {
@@ -1182,7 +1199,7 @@ static void MapReminderEndpoints(WebApplication app)
                 ["NotifyInstructions"] = notifyInstructions,
                 ["NotifyPolicy"] = request.NotifyPolicy,
                 ["Audience"] = request.Audience
-            }, ct);
+            }, toolContext, ct);
 
         return result.StartsWith("Error", StringComparison.Ordinal)
             ? Results.BadRequest(new { error = result })
@@ -1209,10 +1226,14 @@ static void MapReminderEndpoints(WebApplication app)
     reminders.MapPost("/import", async (
         ImportReminderRequest request,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
+        ClaimsPrincipalMapper mapper,
+        HttpContext httpContext,
         CancellationToken ct) =>
     {
         if (request.Definition is null)
             return Results.BadRequest(new { error = "Reminder definition is required." });
+
+        var authorization = ResolveReminderAuthorizationContext(mapper, httpContext);
 
         var mode = request.WriteMode?.Trim().ToLowerInvariant() switch
         {
@@ -1227,7 +1248,7 @@ static void MapReminderEndpoints(WebApplication app)
 
         var manager = await actor.GetAsync(ct);
         var response = await manager.Ask<ReminderSavedResponse>(
-            new SaveReminderCommand(request.Definition, mode.Value),
+            new SaveReminderCommand(request.Definition, mode.Value, authorization),
             TimeSpan.FromSeconds(10),
             ct);
 


### PR DESCRIPTION
## Summary

- Reminder sessions were hardcoded to `TrustAudience.Team`, restricting them to only `file_read` and `attach_file` tools — causing silent capability degradation when reminders needed `web_search` or other tools.
- Reminders now resolve their audience via: per-reminder `ReminderDefinition.Audience` override (if set), falling back to the deployment posture configured during `netclaw init`.
- `SetReminderTool` and REST API accept an optional `audience` parameter for per-reminder overrides.
- `ReminderExecutionActor` accepts only `TrustAudience` (not the full `EffectivePolicyDefaults` record) for a clean API boundary.
- REST API projections use `ToWireValue()` for consistent wire-format serialization.

## Test plan

- [x] 3 new execution actor tests: definition override, deployment posture fallback, team default
- [x] 3 new SetReminderTool tests: audience set, invalid audience rejected, null when omitted
- [x] Updated ReminderManagerActorTests for new constructor signature
- [x] Full test suite passes (1,940 tests, 0 failures)