### PR TITLE
test(oss): add contributor hardening baseline

### DIFF
--- a/openspec/changes/oss-contributor-hardening/.openspec.yaml
+++ b/openspec/changes/oss-contributor-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/oss-contributor-hardening/design.md
+++ b/openspec/changes/oss-contributor-hardening/design.md
@@ -1,0 +1,492 @@
+## Context
+
+Netclaw already documents provider-agnostic model access, transport-agnostic
+session commands, and fail-closed validation, but the current runtime still has
+first-provider and first-channel assumptions leaking across shared seams.
+`netclaw-model-providers` requires provider interactions to route through
+`IChatClient`, `netclaw-input-adapters` requires adapters to emit generic
+`SendUserMessage` commands, `netclaw-config-hot-reload` requires validate-before-
+apply behavior, and `netclaw-testing` already expects provider-independent CI.
+
+This change is a cross-cutting contributor-hardening program that makes those
+seams explicit before broader OSS contribution expands the number of touched
+paths. The design protects three compatibility-critical paths first:
+
+- OpenAI API-key inference path
+- OpenAI OAuth/subscription path
+- Slack runtime behavior, especially Socket Mode connection, thread routing, and
+  reply delivery
+
+Those paths are protected early because they are the highest-risk combinations
+of user-visible behavior and seam complexity. If refactors regress them, the
+project becomes harder to validate, harder to review, and harder to trust.
+
+This design is constrained by current MVP boundaries:
+
+- single-process host
+- actor-driven session runtime with transport-agnostic session contracts
+- default-deny security posture
+- loud validation failures with no silent fallbacks
+- no dynamic plugin loading in MVP
+
+Stakeholders are maintainers extending provider/channel support, OSS
+contributors validating changes from a fresh clone, and operators who need
+existing Slack and OpenAI behavior preserved while the seams are hardened.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce one compiled-in provider module seam for all inference providers.
+- Introduce one compiled-in channel module seam for all human-facing and
+  machine-facing channel adapters.
+- Introduce one provider-auth seam that separates token acquisition, token
+  refresh, persistence, and token-to-runtime-client mapping while preserving
+  OpenAI as the first implementation.
+- Replace free-form seam strings at provider/channel/notification boundaries
+  with shared value objects and explicit conversions.
+- Remove Slack-specific target kinds and tool names from generic notification,
+  reminder, and inbound webhook flows.
+- Make schema validation, doctor, startup validation, and hot reload enforce
+  the same invariants and fail loudly on the same invalid states.
+- Shift test coverage toward compatibility contract tests and broader scenario
+  tests, with Phase 0 safety nets added before refactors.
+- Keep actor boundaries transport-agnostic and avoid persistence churn outside
+  explicit boundary-value changes.
+- Make the change merge-safe through phased milestones that can land
+  independently without breaking protected paths.
+
+**Non-Goals:**
+
+- Dynamic plugin loading, provider marketplaces, or runtime-discovered
+  extensions.
+- Shipping new non-Slack channels in this change.
+- Replacing OpenAI or Slack as the primary compatibility baseline.
+- Introducing silent compatibility shims, permissive auth downgrades, or hidden
+  fallback providers/channels.
+- Rewriting actor architecture, persistence strategy, or session identity.
+- Solving every future extension point in one pass; this change establishes the
+  seam model for MVP.
+
+## Decisions
+
+### 1. Use compiled-in module registries for provider and channel extensibility
+
+Netclaw will converge on two explicit registries:
+
+- `ProviderModule` seam for inference providers
+- `ChannelModule` seam for input/output channels and delivery adapters
+
+Each module is compiled into the product and registered centrally during host
+startup. Generic runtime code consumes these registries through typed module
+descriptors rather than ad hoc `if provider == "openai"` or Slack-specific
+branching.
+
+Rationale:
+
+- Gives contributors one obvious place to add a provider and one obvious place
+  to add a channel.
+- Preserves MVP simplicity and static reviewability.
+- Supports fail-closed startup: unknown module kinds cannot appear at runtime if
+  they are not compiled in and schema-approved.
+
+Alternatives considered:
+
+- Dynamic plugin loading: rejected because it complicates startup validation,
+  dependency management, security review, and reproducible contributor setups.
+- Leaving current scattered seams in place: rejected because it preserves the
+  exact ambiguity and accidental coupling this change is meant to remove.
+
+### 2. Separate provider authentication into four explicit responsibilities
+
+Provider authentication will be modeled as four independent responsibilities:
+
+- token acquisition
+- token refresh
+- token persistence
+- token-to-runtime-client mapping
+
+OpenAI remains the first implementation and the compatibility baseline for both
+API-key and OAuth/subscription paths.
+
+The seam boundary exists above provider-specific SDK details and below session
+runtime code. Session actors and their persisted state continue to depend on the
+provider-agnostic runtime client contract rather than storing provider-auth
+internals.
+
+Rationale:
+
+- Prevents OAuth logic from spreading across onboarding, doctor, runtime
+  startup, and provider client factories.
+- Makes provider auth reviewable by responsibility.
+- Allows API-key and OAuth-backed providers to share lifecycle stages without
+  sharing provider-specific assumptions.
+
+Alternatives considered:
+
+- Keep auth logic embedded per provider factory: rejected because OpenAI already
+  exercises more than one auth mode and has shown the need for sharper seams.
+- Model auth as one monolithic provider-specific service: rejected because it
+  hides refresh/persistence invariants and makes diagnostics less precise.
+
+### 3. Introduce shared seam value objects at provider, channel, and notification boundaries
+
+Free-form strings crossing generic seam boundaries will be replaced by shared
+value objects such as provider identifiers, channel kinds, notification target
+kinds, and module keys. These objects expose explicit primitive access only.
+
+Rationale:
+
+- Prevents generic code from accidentally depending on provider/channel naming
+  conventions.
+- Improves schema, doctor, and runtime invariant alignment.
+- Matches the repository rule that value objects should not implicitly convert
+  back to primitives.
+
+Alternatives considered:
+
+- Keep strings with helper constants: rejected because constants do not stop
+  boundary drift or typo-driven runtime errors.
+
+### 4. Generic notification flows must target abstract delivery contracts, not Slack specifics
+
+Reminder, notification, and inbound webhook flows will depend on a generic
+notification contract that identifies who should receive a message and through
+which channel kind, without hardcoding Slack target kinds or Slack tool names.
+
+The notification flow becomes:
+
+1. producer emits a generic notification request
+2. notification router resolves the target via value-object identifiers
+3. channel module delivers through its compiled-in adapter
+
+Slack remains the first delivery implementation, but generic producers do not
+embed Slack assumptions.
+
+Rationale:
+
+- Keeps reminders and webhook-triggered flows aligned with transport-agnostic
+  runtime boundaries.
+- Avoids spreading Slack-only vocabulary into generic feature code.
+
+Alternatives considered:
+
+- Keep Slack as the notification shape and adapt later: rejected because this is
+  the exact hardening window needed before more contributors build on the wrong
+  seam.
+
+### 5. Validation layers must share one invariant model and fail loudly
+
+Schema validation, `netclaw doctor`, startup validation, and hot reload must all
+agree on the same seam invariants:
+
+- configured provider kinds must map to compiled-in provider modules
+- configured channel kinds must map to compiled-in channel modules
+- provider-auth configuration must satisfy the selected auth strategy
+- notification targets must reference valid channel/target kinds
+- partial or unknown seam definitions are invalid
+
+The enforcement model is intentionally loud:
+
+- schema rejects invalid structure
+- doctor reports actionable seam-specific remediation
+- startup blocks invalid runtime activation
+- hot reload rejects invalid updates and preserves last valid state
+
+No layer silently creates defaults, ignores unknown values, or swaps to another
+provider/channel.
+
+Rationale:
+
+- Contributors need the same answer regardless of whether they validate via
+  schema, doctor, startup, or hot reload.
+- Loud failure protects security posture and prevents confusing partial runtime
+  states.
+
+Alternatives considered:
+
+- Layer-specific validation behavior: rejected because inconsistent validators
+  create contributor confusion and hide bugs.
+- Silent fallback to previous or alternate modules: rejected because it hides
+  invalid configuration and can change security-sensitive behavior.
+
+### 6. Protect compatibility first with Phase 0 safety nets
+
+Before any seam extraction, Phase 0 adds regression safety nets around the three
+protected paths:
+
+- OpenAI API-key inference path
+- OpenAI OAuth/subscription path
+- Slack runtime behavior
+
+Phase 0 coverage emphasizes contract and scenario tests over many narrow local
+tests. These tests become the merge gate for later phases.
+
+Rationale:
+
+- Reduces risk before refactors touch the most fragile cross-cutting paths.
+- Produces contributor-visible confidence that the seam extraction is not
+  changing external behavior accidentally.
+
+Alternatives considered:
+
+- Refactor first and backfill tests later: rejected because compatibility risk is
+  highest at the start, not the end.
+
+### 7. Preserve actor boundaries and minimize persistence impact
+
+Session actors, schedule actors, and pub/sub broadcasts remain transport-
+agnostic. Provider/channel/auth modules are startup and service-layer seams, not
+new actor responsibilities.
+
+Persistence implications are intentionally narrow:
+
+- persisted session identity remains unchanged
+- persisted actor events should not store provider/channel-specific primitive
+  identifiers beyond existing stable contracts
+- if notification/provider/channel identifiers cross persistence boundaries, use
+  shared value objects with explicit serialization rules
+
+Rationale:
+
+- Keeps seam extraction from turning into an actor rewrite.
+- Limits migration risk and review surface.
+
+Alternatives considered:
+
+- Push module resolution into actors: rejected because it leaks host-composition
+  concerns into runtime state machines.
+
+## Architecture Overview
+
+The hardened seam model is:
+
+```text
+Config Files / Schema
+        |
+        v
+Shared Validation Invariants
+        |
+        +--> Doctor
+        +--> Startup Validation
+        +--> Hot Reload Validation
+        |
+        v
+Compiled-In Module Registries
+        |
+        +--> Provider Modules -----------------------------+
+        |        |                                        |
+        |        +--> Auth Strategy -------------------+  |
+        |               |                              |  |
+        |               +--> Token Acquisition         |  |
+        |               +--> Token Refresh             |  |
+        |               +--> Token Persistence         |  |
+        |               +--> Runtime Client Mapping ---+  |
+        |                                               \/
+        |                                         IChatClient /
+        |                                         runtime model client
+        |
+        +--> Channel Modules ------------------------------+
+        |        |                                         |
+        |        +--> Inbound adapter -> SendUserMessage   |
+        |        +--> Broadcast subscriber -> delivery     |
+        |                                                  |
+        +--> Notification Router --------------------------+
+                 |
+                 +--> reminder flows
+                 +--> webhook flows
+                 +--> operational alerts
+```
+
+Relationship details:
+
+- Provider modules own provider registration, model metadata access, and runtime
+  client construction.
+- Auth strategies are subordinate to provider modules and are selected by typed
+  auth configuration, not by scattered provider-specific conditionals.
+- Channel modules own inbound translation to generic runtime commands and
+  outbound delivery from generic broadcasts or notifications.
+- Notification routing depends on shared target value objects and channel-module
+  dispatch, not Slack-specific target types.
+- Generic runtime and actor code depend only on typed seam contracts and value
+  objects.
+
+## Merge-Safe Phased Milestones
+
+### Phase 0: Compatibility safety nets
+
+- Add contract and scenario coverage for the protected OpenAI and Slack paths.
+- Capture current validation invariants and expected diagnostics for schema,
+  doctor, startup, and hot reload.
+- Reduce or delete low-value narrow tests that do not protect seam behavior.
+
+Exit criteria:
+
+- protected compatibility suites are green
+- seam invariants are documented in specs and test names
+- no production seam refactor required yet
+
+### Phase 1: Shared seam types and invariant normalization
+
+- Introduce shared value objects for provider/channel/notification boundaries.
+- Normalize validation terminology and error categories across schema, doctor,
+  startup, and hot reload.
+- Keep OpenAI and Slack wired through existing behavior while typed seams appear
+  underneath.
+
+Exit criteria:
+
+- seam boundary strings are reduced to config parsing and explicit conversion
+- validators agree on unknown kind, missing config, and invalid auth states
+
+### Phase 2: Provider module seam and OpenAI auth separation
+
+- Introduce the single compiled-in provider module registry.
+- Extract OpenAI into the first provider module.
+- Split auth lifecycle into acquisition, refresh, persistence, and runtime
+  client mapping.
+- Preserve OpenAI API-key and OAuth/subscription behavior with Phase 0 tests.
+
+Exit criteria:
+
+- provider registration lives in one compiled-in seam
+- session/runtime code consumes provider-agnostic module contracts
+- protected OpenAI paths remain behaviorally identical
+
+### Phase 3: Channel module seam and Slack compatibility preservation
+
+- Introduce the single compiled-in channel module registry.
+- Move Slack behind the channel seam without changing its Socket Mode and
+  thread-bound behavior.
+- Remove Slack-specific assumptions from generic runtime composition points.
+
+Exit criteria:
+
+- channel registration lives in one compiled-in seam
+- Slack runtime scenario coverage remains green
+- actor contracts remain transport-agnostic
+
+### Phase 4: Generic notification routing
+
+- Replace Slack-specific notification target kinds and tool names in generic
+  reminder, webhook, and operational-notification flows.
+- Route notifications through abstract targets resolved by channel modules.
+
+Exit criteria:
+
+- generic producers do not reference Slack-only target types
+- Slack remains the first delivery implementation through the generic router
+
+### Phase 5: Cleanup and contributor-facing simplification
+
+- Remove dead compatibility branches that existed only during seam migration.
+- Consolidate contract/scenario suites and contributor guidance around the new
+  seam model.
+
+Exit criteria:
+
+- provider/channel/auth/notification seams are singular and reviewable
+- contributor extension path is obvious and spec-backed
+
+## Key Tradeoffs
+
+- Static modules vs plugins: static modules reduce flexibility, but they keep MVP
+  reviewable, deterministic, and secure-by-default.
+- Early compatibility protection vs faster refactor velocity: Phase 0 adds work
+  up front, but it lowers the cost of every later phase and reduces regression
+  risk on the most visible paths.
+- Broader scenario tests vs many local tests: broader tests can be slower and
+  more setup-heavy, but they better protect cross-cutting seam behavior and make
+  regressions easier to reason about.
+- Shared value objects vs raw string convenience: typed seams add some ceremony,
+  but they prevent boundary ambiguity and align with the repo's type-safety
+  rules.
+
+OpenAI and Slack compatibility are protected early because they are both the
+highest-value existing paths and the most likely to break during seam
+extraction. Preserving them first gives maintainers confidence that the new seam
+architecture is an internal cleanup, not a behavioral rewrite.
+
+## Validation And Rollout Strategy
+
+- Land changes phase-by-phase behind merge-safe milestones rather than as one
+  large refactor.
+- Make Phase 0 compatibility suites required before later seam extraction merges.
+- Update specs and design artifacts before implementation changes when invariants
+  move.
+- Keep startup and hot-reload behavior aligned by sharing validation vocabulary
+  and failure categories.
+- Use contributor-safe required CI that avoids live secrets, while keeping
+  explicit live smoke and runtime checks opt-in.
+- Treat any protected-path regression as a stop-ship issue for subsequent phases.
+
+Recovery behavior:
+
+- startup rejects invalid provider/channel/auth/notification seam state and does
+  not boot partially
+- hot reload rejects invalid changes and retains the last valid runtime state
+- doctor explains the same invalid state without claiming success or applying
+  hidden defaults
+- optional live checks may report degraded/unreachable states, but must not
+  rewrite config or silently switch modules
+
+Rollback strategy:
+
+- phases are designed to be revertable independently because compatibility tests
+  remain stable across phases
+- if a seam extraction phase regresses a protected path, revert that phase and
+  keep the prior validated seam baseline
+
+## Risks / Trade-offs
+
+- [Provider seam extraction regresses OpenAI API-key path] -> Mitigation: Phase 0
+  contract/scenario coverage lands first; do not merge Phase 2 without those
+  suites green.
+- [OAuth separation changes subscription behavior] -> Mitigation: make OpenAI
+  the first provider-auth implementation and lock API-key and OAuth/subscription
+  compatibility paths with shared scenarios and diagnostics assertions.
+- [Slack abstraction leaks into actor contracts] -> Mitigation: keep channel
+  seams at adapter/composition boundaries and preserve `SendUserMessage` plus
+  broadcast contracts as the actor-facing interface.
+- [Notification generalization reintroduces free-form string coupling] ->
+  Mitigation: require shared value objects and explicit conversion at router
+  boundaries.
+- [Validation layers drift apart again] -> Mitigation: define one invariant model
+  in spec/design and test it through schema, doctor, startup, and hot reload
+  scenarios.
+- [Phased migration leaves dead branches or double registration] -> Mitigation:
+  each phase has explicit exit criteria and a cleanup phase removes temporary
+  bridges.
+- [Contributor CI becomes slower due to broader scenarios] -> Mitigation: prefer
+  a smaller number of high-value scenario suites, keep live checks opt-in, and
+  delete narrow tests that no longer buy confidence.
+- [Future contributors ask for plugin loading prematurely] -> Mitigation:
+  explicitly codify compiled-in seams as the MVP boundary in specs and design.
+
+## Migration Plan
+
+1. Approve the design and create the spec deltas for provider auth,
+   notifications, and the modified provider/channel/testing/config capabilities.
+2. Implement Phase 0 safety nets and confirm they protect OpenAI API-key,
+   OpenAI OAuth/subscription, and Slack runtime behavior.
+3. Introduce shared seam value objects and validation invariant alignment.
+4. Extract provider module and provider-auth seams with OpenAI as the first
+   module.
+5. Extract channel module seam with Slack as the first channel implementation.
+6. Generalize notification routing away from Slack-specific target semantics.
+7. Remove transitional branches and keep only the singular seam model.
+
+If rollout pauses mid-program, the last completed phase remains a valid merge
+point because it preserves protected compatibility behavior and keeps all
+validation layers fail-closed.
+
+## Open Questions
+
+- Should reminders and inbound webhooks share one notification-target model, or
+  should they share only a lower-level delivery contract with separate producer
+  metadata?
+- Which existing identifiers already cross persistence boundaries and therefore
+  need explicit serialization guidance when converted to value objects?
+- Should provider-auth diagnostics surface lifecycle stage names directly
+  (`acquisition`, `refresh`, `persistence`, `mapping`) or translate them into
+  more operator-facing wording while retaining the same invariant categories?

--- a/openspec/changes/oss-contributor-hardening/proposal.md
+++ b/openspec/changes/oss-contributor-hardening/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Netclaw's existing product and engineering docs already require contributor-facing seams that are provider-agnostic (`PRD-005`, `SPEC-008`) and transport-agnostic (`PRD-001`, `PRD-009`, `SPEC-001`), but the current runtime still carries Slack- and OpenAI-shaped assumptions across shared seams. Before open source expansion makes those assumptions harder to unwind, Netclaw needs a phased hardening pass that adds compatibility safety nets first, then extracts compiled-in provider and channel module seams without behaviorally regressing the protected OpenAI and Slack paths.
+
+Source traceability: `PRD-001`, `PRD-004`, `PRD-005`, `PRD-009`; `SPEC-001`, `SPEC-004`, `SPEC-008`, `SPEC-010`, `SPEC-011`; `docs/spec/configuration.md`; `openspec/specs/netclaw-model-providers/spec.md`; `openspec/specs/netclaw-input-adapters/spec.md`; `openspec/specs/netclaw-testing/spec.md`; `openspec/specs/netclaw-slack-socket/spec.md`; `openspec/specs/netclaw-config-hot-reload/spec.md`.
+
+## What Changes
+
+- Phase 0 adds compatibility safety nets before refactors: contract and scenario coverage, protected regression paths, and validation baselines for the OpenAI API-key path, the OpenAI subscription/OAuth path, and current Slack runtime behavior.
+- Tighten inference-provider extensibility around a single compiled-in provider module seam so new providers are added in one place, with no actor-contract churn and no broad plugin loader or dynamic runtime plugin system in MVP.
+- Add an explicit provider-auth seam for API-key and OAuth-backed providers, with special hardening for subscription-backed provider flows and doctor/runtime/schema validation that preserves current OpenAI behavior exactly during early phases.
+- Tighten channel extensibility around a single compiled-in channel module seam so new communication channels are added in one place while preserving current Slack runtime behavior during early refactors.
+- Remove Slack- and OpenAI-specific assumptions from generic notification, webhook, and runtime wiring so shared flows depend on generic contracts and module seams rather than first-provider/first-channel shortcuts.
+- Make value-object usage consistent at shared seams, especially where provider/channel registration, routing, notification targets, and config binding currently cross generic boundaries.
+- Tighten config schema, doctor checks, startup validation, and hot-reload validation around provider, channel, and auth extension points; invalid or partial seam configuration must fail loudly with no silent fallbacks.
+- Consolidate scattered low-value tests into smaller, higher-value contract and scenario suites focused on seam behavior, fail-closed validation, and the protected compatibility paths.
+
+In scope now:
+- phased seam extraction with Phase 0 safety nets first
+- compiled-in provider/channel module registration and shared contract cleanup
+- OAuth/auth extensibility hardening for provider onboarding and runtime validation
+- generic notification/webhook/runtime decoupling needed for contributor readiness
+- value-object consistency and test-suite consolidation around these seams
+
+Out of scope later:
+- dynamic plugin loading, provider marketplaces, or runtime-discovered extensions
+- broad behavior changes to the protected OpenAI API-key, OpenAI OAuth/subscription, or Slack runtime paths during early phases
+- new non-Slack channel implementations as part of this change
+- silent compatibility shims or implicit fallback behavior for misconfigured seams
+
+## Capabilities
+
+### New Capabilities
+
+- `netclaw-provider-auth`: provider authentication contracts for API-key and OAuth/subscription-backed providers, including compatibility-preserving OpenAI scenarios, token/config validation expectations, and fail-closed diagnostics guidance.
+- `netclaw-runtime-notifications`: generic notification target and runtime notification contracts shared by reminders, inbound webhooks, and operational alerts so human-facing delivery does not assume Slack even when Slack remains the first implementation.
+
+### Modified Capabilities
+
+- `netclaw-model-providers`: tighten provider registration to a single compiled-in module seam, require contributor-safe provider extension boundaries, preserve existing OpenAI API-key and OAuth/subscription behavior during staged extraction, and require explicit validation at provider seams.
+- `netclaw-input-adapters`: tighten channel registration to a single compiled-in module seam and remove Slack-specific assumptions from generic adapter/runtime contracts while preserving current Slack behavior during early phases.
+- `netclaw-testing`: replace low-value seam-adjacent tests with higher-value contract and scenario suites that protect compatibility paths, fail-closed behavior, and contributor-facing extension contracts.
+- `netclaw-slack-socket`: preserve current Slack Socket Mode connection, thread identity, and reply-delivery behavior while Slack moves behind the generic channel seam.
+- `netclaw-config-hot-reload`: require provider, channel, auth, and notification seam configuration to validate before apply and remain fail-closed under invalid reloads, with explicit diagnostics and no silent fallback.
+
+## Impact
+
+- **Runtime architecture**: provider and channel extension points become explicit compiled-in modules instead of ad hoc seams spread across generic runtime code.
+- **Protected compatibility paths**: OpenAI API-key, OpenAI OAuth/subscription, and Slack runtime behavior gain dedicated regression coverage before refactors begin.
+- **Configuration and diagnostics**: schema, `netclaw doctor`, startup validation, and hot-reload checks must agree on provider/channel/auth invariants and reject invalid seam definitions loudly.
+- **Webhook and notification alignment**: shared notification contracts must align with the existing `inbound-webhooks` change and reminder-style notification behavior without hard-coding Slack into generic flows.
+- **Type safety**: shared provider/channel/auth/notification seams use consistent value objects and explicit conversions only.
+- **Testing strategy**: CI shifts further toward focused contract/scenario suites instead of many narrow seam-local tests, consistent with `SPEC-010`.
+- **Security impact**: extension seams remain default-deny and fail-closed; there is no plugin loader, no implicit auth downgrade, and no silent fallback from invalid or partially configured provider/channel/auth state.
+- **Operational impact**: contributors get one clear seam for adding providers and one clear seam for adding channels, while operators keep existing Slack and OpenAI behavior stable throughout early phases.

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-config-hot-reload/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-config-hot-reload/spec.md
@@ -1,0 +1,24 @@
+# netclaw-config-hot-reload Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Seam invariant agreement across reload validation
+Hot reload validation SHALL enforce the same provider, channel, auth, and notification seam invariants as schema validation, doctor, and startup validation.
+
+#### Scenario: Reload rejects provider seam invariant violation
+- **WHEN** a hot reload update introduces an unknown provider kind or invalid provider-auth configuration
+- **THEN** the update is rejected with explicit remediation
+- **AND** the last valid runtime configuration remains in effect
+
+#### Scenario: Reload rejects channel or notification seam invariant violation
+- **WHEN** a hot reload update introduces an unknown channel kind or invalid notification target kind
+- **THEN** the update is rejected with explicit remediation
+- **AND** no partial runtime activation occurs for the invalid seam state
+
+### Requirement: Hot reload does not silently fallback across seam kinds
+When seam-related hot reload validation fails, the system SHALL NOT silently substitute another provider module, another channel module, or another auth mode.
+
+#### Scenario: Invalid seam reload does not switch modules
+- **WHEN** a hot reload update invalidates the currently requested provider, channel, or auth mode
+- **THEN** the runtime retains the last valid configuration
+- **AND** the system does not silently switch to a fallback provider, fallback channel, or fallback auth path

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,47 @@
+# netclaw-input-adapters Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Compiled-in channel module registry
+The system SHALL register inbound and outbound channel adapters through a single compiled-in channel module registry. Generic runtime code SHALL resolve channel behavior through that registry instead of hardcoding channel-specific branches.
+
+#### Scenario: Configured channel resolves through compiled-in module
+- **WHEN** startup loads a configured channel kind that is compiled into the product
+- **THEN** the channel is resolved from the single channel module registry
+- **AND** inbound and outbound channel behavior is activated through the registry contract
+
+#### Scenario: Unknown channel kind fails closed
+- **WHEN** startup, doctor, or hot reload encounters a configured channel kind that is not registered in the compiled-in channel module registry
+- **THEN** validation fails with channel-specific remediation
+- **AND** the invalid channel configuration is not applied
+
+#### Scenario: Dynamic channel plugin loading is rejected
+- **WHEN** configuration references a runtime-discovered channel plugin or external channel assembly
+- **THEN** validation fails explicitly
+- **AND** the error states that MVP supports compiled-in channel modules only
+
+### Requirement: Generic adapter runtime remains transport-agnostic
+Channel modules SHALL translate inbound events into generic session commands and outbound deliveries from generic runtime broadcasts or notification requests. Session actors SHALL remain transport-agnostic during and after channel seam extraction.
+
+#### Scenario: Extracted channel still emits generic session command
+- **WHEN** an inbound message is received through a compiled-in channel module
+- **THEN** the channel module emits the generic session command contract required by the runtime
+- **AND** session actors do not import channel-specific transport types
+
+### Requirement: Protected Slack compatibility during early extraction phases
+During compatibility-first phases of the contributor-hardening program, the system SHALL preserve current Slack Socket Mode behavior while Slack is moved behind the channel module seam.
+
+#### Scenario: Slack thread routing remains stable during seam extraction
+- **WHEN** the channel module seam is introduced and a Slack mention arrives in a thread
+- **THEN** the inbound Slack message still resolves to the `{channelId}/{threadTs}` session identity
+- **AND** the message is routed through the same generic session command contract as before
+
+#### Scenario: Slack reply delivery remains stable during seam extraction
+- **WHEN** a session emits a reply originating from a Slack thread during an early extraction phase
+- **THEN** the reply is delivered to the same Slack thread
+- **AND** no generic notification or channel seam change alters the protected Slack reply behavior
+
+#### Scenario: Early extraction does not silently reroute Slack traffic
+- **WHEN** Slack channel configuration is invalid or incomplete during an extraction phase
+- **THEN** validation fails explicitly
+- **AND** the system does not silently reroute traffic to another channel or target kind

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-model-providers/spec.md
@@ -1,0 +1,47 @@
+# netclaw-model-providers Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Compiled-in provider module registry
+The system SHALL register inference providers through a single compiled-in provider module registry. Provider selection, validation, model discovery, and runtime client construction SHALL resolve through this registry rather than through scattered provider-specific branching in generic runtime code.
+
+#### Scenario: Configured provider resolves through compiled-in module
+- **WHEN** startup loads a configured provider kind that is compiled into the product
+- **THEN** the provider is resolved from the single provider module registry
+- **AND** generic runtime code consumes the provider through the registry contract rather than provider-specific conditionals
+
+#### Scenario: Unknown provider kind fails closed
+- **WHEN** startup or doctor encounters a configured provider kind that is not registered in the compiled-in provider module registry
+- **THEN** validation fails with provider-specific remediation
+- **AND** runtime startup is blocked for that configuration
+
+#### Scenario: Dynamic provider plugin loading is rejected
+- **WHEN** configuration references a runtime-discovered provider plugin or external provider assembly
+- **THEN** validation fails explicitly
+- **AND** the error states that MVP supports compiled-in provider modules only
+
+### Requirement: Provider module seam preserves provider-agnostic runtime contracts
+Provider modules SHALL terminate at the provider/runtime boundary. Session actors and shared runtime flows SHALL continue to depend on provider-agnostic runtime client contracts and SHALL NOT import provider-specific SDK types.
+
+#### Scenario: Session runtime remains provider-agnostic after seam extraction
+- **WHEN** a session turn is executed using any configured provider module
+- **THEN** the session runtime invokes the provider through the shared runtime client contract
+- **AND** no provider-specific type crosses into actor-facing contracts
+
+### Requirement: Protected OpenAI compatibility during early extraction phases
+During compatibility-first phases of the contributor-hardening program, the system SHALL preserve the current OpenAI API-key inference path and the current OpenAI OAuth/subscription path while provider seam extraction is in progress.
+
+#### Scenario: OpenAI API-key inference path remains behaviorally stable
+- **WHEN** the provider module seam is introduced and OpenAI is configured for API-key authentication
+- **THEN** model validation, runtime client construction, and inference requests continue to succeed through the OpenAI path
+- **AND** no new contributor-facing migration step is required for that protected path
+
+#### Scenario: OpenAI OAuth or subscription path remains behaviorally stable
+- **WHEN** the provider module seam is introduced and OpenAI is configured for OAuth or subscription-backed authentication
+- **THEN** the OpenAI runtime path continues to acquire usable runtime credentials through the protected compatibility flow
+- **AND** the runtime behavior remains equivalent to the pre-extraction path for successful configurations
+
+#### Scenario: Early extraction does not silently downgrade OpenAI auth mode
+- **WHEN** a protected OpenAI path is partially configured or invalid during an early extraction phase
+- **THEN** validation fails with an explicit auth-specific error
+- **AND** the system does not silently switch between API-key and OAuth/subscription modes

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-provider-auth/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-provider-auth/spec.md
@@ -1,0 +1,42 @@
+# netclaw-provider-auth Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Explicit provider auth lifecycle stages
+The system SHALL model provider authentication as four explicit lifecycle responsibilities: token acquisition, token refresh, token persistence, and token-to-runtime-client mapping. Provider auth implementations SHALL compose these responsibilities without collapsing them into a single opaque runtime path.
+
+#### Scenario: API-key provider uses explicit mapping stage
+- **WHEN** a provider is configured for API-key authentication
+- **THEN** runtime client construction resolves through the token-to-runtime-client mapping stage
+- **AND** the auth flow does not require token refresh behavior for a valid API-key configuration
+
+#### Scenario: OAuth-backed provider uses explicit lifecycle stages
+- **WHEN** a provider is configured for OAuth or subscription-backed authentication
+- **THEN** runtime activation resolves acquisition, refresh, persistence, and runtime-client mapping through explicit auth stages
+- **AND** each stage can report stage-specific validation or runtime failures
+
+### Requirement: OpenAI is the first protected provider-auth implementation
+OpenAI SHALL be the first implementation of the provider-auth seam and SHALL preserve compatibility for both API-key and OAuth/subscription-backed paths during early extraction phases.
+
+#### Scenario: OpenAI API-key auth remains valid through extracted auth seam
+- **WHEN** provider-auth extraction is introduced and OpenAI is configured with a valid API key
+- **THEN** the OpenAI runtime client is created successfully through the extracted auth seam
+- **AND** successful inference behavior remains equivalent to the pre-extraction path
+
+#### Scenario: OpenAI OAuth or subscription auth remains valid through extracted auth seam
+- **WHEN** provider-auth extraction is introduced and OpenAI is configured with valid OAuth or subscription-backed credentials
+- **THEN** the OpenAI runtime client is created successfully through the extracted auth seam
+- **AND** successful runtime behavior remains equivalent to the pre-extraction path
+
+### Requirement: Provider auth validation fails closed
+Provider auth validation SHALL fail closed across schema, doctor, startup, and hot reload. Invalid or partial auth state SHALL NOT silently downgrade to another auth mode or to anonymous runtime behavior.
+
+#### Scenario: Partial OAuth configuration is rejected
+- **WHEN** provider auth configuration declares an OAuth-backed mode but omits a required auth stage input
+- **THEN** validation fails with explicit stage-specific remediation
+- **AND** runtime activation is blocked for that provider configuration
+
+#### Scenario: Invalid refresh state does not fall back to stale runtime client
+- **WHEN** runtime auth refresh fails for a provider requiring refreshable credentials
+- **THEN** the failure is surfaced as an auth-specific runtime error
+- **AND** the system does not silently substitute another auth mode or stale fallback client

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-runtime-notifications/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-runtime-notifications/spec.md
@@ -1,0 +1,37 @@
+# netclaw-runtime-notifications Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Generic runtime notification targets
+The system SHALL model reminder notifications, webhook-driven notifications, and operational alerts through generic runtime notification targets rather than through Slack-only target kinds or Slack-only tool names.
+
+#### Scenario: Reminder failure notification uses generic target contract
+- **WHEN** a reminder execution reaches a notification-worthy failure state
+- **THEN** the runtime emits a generic notification request referencing a typed target and channel kind
+- **AND** the reminder flow does not hardcode a Slack-only target kind or Slack-only delivery tool name
+
+#### Scenario: Operational alert uses generic target contract
+- **WHEN** the daemon emits an operational alert
+- **THEN** the alert is expressed through the generic runtime notification contract
+- **AND** delivery selection is resolved by channel kind rather than by Slack-specific branching in the alert producer
+
+### Requirement: Notification delivery resolves through channel modules
+Runtime notification delivery SHALL resolve through the compiled-in channel module seam. Notification producers SHALL NOT bypass the channel registry with direct Slack-specific delivery logic.
+
+#### Scenario: Slack remains first notification delivery implementation
+- **WHEN** a generic runtime notification targets a Slack-backed channel during early hardening phases
+- **THEN** delivery resolves through the compiled-in channel module registry
+- **AND** the resulting Slack delivery preserves current runtime behavior for successful delivery
+
+#### Scenario: Unknown notification channel kind fails closed
+- **WHEN** a notification target references an unknown or unregistered channel kind
+- **THEN** validation fails explicitly or the runtime rejects delivery with a loud error
+- **AND** the system does not silently reroute the notification to Slack or any other channel
+
+### Requirement: Typed notification seam values
+Notification targets, channel kinds, and runtime routing identifiers SHALL use shared seam value objects at generic notification boundaries.
+
+#### Scenario: Notification routing uses typed seam values
+- **WHEN** a runtime notification is created and routed for delivery
+- **THEN** the producer and router exchange typed notification target and channel identifiers
+- **AND** raw free-form strings are limited to explicit parsing and serialization boundaries

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-slack-socket/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-slack-socket/spec.md
@@ -1,0 +1,24 @@
+# netclaw-slack-socket Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Slack transport compatibility during channel seam extraction
+During compatibility-first phases of the contributor-hardening program, the Slack Socket Mode transport SHALL preserve its current observable behavior while Slack is moved behind the compiled-in channel module seam.
+
+#### Scenario: Socket Mode transport remains protected during extraction
+- **WHEN** the channel module seam is introduced and valid Slack credentials are configured
+- **THEN** Netclaw still opens a Slack Socket Mode connection for the protected Slack path
+- **AND** the transport is not replaced by another channel mechanism during early extraction phases
+
+#### Scenario: Protected Slack thread reply behavior remains unchanged
+- **WHEN** a Slack-originated session produces a reply during an early extraction phase
+- **THEN** Netclaw posts the reply into the same Slack thread that produced the session command
+- **AND** the extracted channel seam does not change that protected reply behavior
+
+### Requirement: Slack extraction fails closed on invalid seam state
+If Slack's extracted channel module configuration is invalid, the system SHALL fail loudly rather than silently degrading Slack transport behavior.
+
+#### Scenario: Invalid Slack seam state is rejected
+- **WHEN** startup or hot reload encounters invalid or partial Slack channel module configuration
+- **THEN** the invalid configuration is rejected with explicit diagnostics
+- **AND** the system does not silently reroute Slack traffic or mask the Slack transport failure

--- a/openspec/changes/oss-contributor-hardening/specs/netclaw-testing/spec.md
+++ b/openspec/changes/oss-contributor-hardening/specs/netclaw-testing/spec.md
@@ -1,0 +1,37 @@
+# netclaw-testing Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Phase 0 compatibility safety nets
+Before provider, channel, auth, or notification seam extraction changes are merged, the system SHALL maintain Phase 0 compatibility safety nets for the protected OpenAI and Slack paths.
+
+#### Scenario: Protected compatibility suite gates seam refactor
+- **WHEN** a change modifies provider, channel, auth, or notification seam code during the hardening program
+- **THEN** required validation includes compatibility coverage for the OpenAI API-key path, the OpenAI OAuth/subscription path, and Slack runtime behavior
+- **AND** the seam refactor does not merge unless those protected-path checks pass
+
+#### Scenario: Compatibility suite remains contributor-safe
+- **WHEN** a contributor runs the required hardening validation suite from a fresh clone without live secrets
+- **THEN** the required suite uses fakes, stubs, or contract fixtures rather than private credentials
+- **AND** protected-path regressions remain detectable without requiring private operator infrastructure
+
+### Requirement: Contract and scenario oriented seam coverage
+The hardening program SHALL prefer a smaller number of contract tests and broader scenario tests over many seam-local narrow tests when validating provider, channel, auth, and notification seams.
+
+#### Scenario: New seam behavior is covered by contract tests
+- **WHEN** a new provider, channel, auth, or notification seam contract is introduced or changed
+- **THEN** the required test suite includes contract tests that verify the seam invariants and fail-closed behavior
+- **AND** the suite does not rely only on narrow implementation-local tests
+
+#### Scenario: End-to-end seam scenario covers compatibility-critical flow
+- **WHEN** a protected OpenAI or Slack path is changed by a seam extraction phase
+- **THEN** the required test suite includes at least one broader scenario that exercises the compatibility-critical path through the relevant seam boundary
+- **AND** the scenario asserts the expected user-visible behavior rather than only internal method calls
+
+### Requirement: No silent fallback in seam validation tests
+Required seam validation tests SHALL assert fail-closed behavior for invalid provider, channel, auth, and notification configurations.
+
+#### Scenario: Invalid seam configuration fails loudly in tests
+- **WHEN** a required test exercises an unknown provider kind, unknown channel kind, invalid auth configuration, or invalid notification target
+- **THEN** the test asserts an explicit validation failure
+- **AND** the test asserts that no silent fallback runtime activation occurs

--- a/openspec/changes/oss-contributor-hardening/tasks.md
+++ b/openspec/changes/oss-contributor-hardening/tasks.md
@@ -1,0 +1,69 @@
+## 1. Phase 0 Compatibility Safety Nets
+
+- [ ] 1.1 Identify and document the current protected regression paths for OpenAI API-key inference, OpenAI OAuth/subscription runtime, and Slack Socket Mode thread routing/reply delivery.
+- [ ] 1.2 Add contract tests that protect OpenAI API-key runtime client construction and inference behavior without requiring live provider credentials.
+- [ ] 1.3 Add contract tests that protect OpenAI OAuth/subscription token-to-runtime-client behavior and auth failure reporting without requiring live provider credentials.
+- [ ] 1.4 Add scenario tests that protect Slack Socket Mode connection, `{channelId}/{threadTs}` session routing, and in-thread reply delivery behavior.
+- [ ] 1.5 Add validation scenario coverage for unknown provider kinds, unknown channel kinds, invalid auth state, and invalid notification targets asserting fail-closed behavior with no silent fallback.
+
+## 2. Shared Seam Types And Invariants
+
+- [ ] 2.1 Introduce shared value objects for provider identifiers, channel kinds, notification target kinds, and related seam keys at generic boundaries.
+- [ ] 2.2 Replace free-form seam strings in shared runtime contracts and config-binding boundaries with the new value objects using explicit conversions only.
+- [ ] 2.3 Inventory persistence and serialization boundaries touched by provider/channel/notification identifiers and update serialization behavior to preserve compatibility.
+- [ ] 2.4 Normalize validation vocabulary and invariant categories so schema, doctor, startup, and hot reload report the same seam failures.
+
+## 3. Provider Module Seam Extraction
+
+- [ ] 3.1 Introduce a single compiled-in provider module registry for provider selection, validation, model discovery, and runtime client construction.
+- [ ] 3.2 Move existing provider registration into the compiled-in provider module seam without changing actor-facing runtime contracts.
+- [ ] 3.3 Update provider configuration binding and startup composition to resolve providers exclusively through the compiled-in registry.
+- [ ] 3.4 Add contributor-facing validation errors for unknown provider kinds and explicitly reject dynamic provider plugin loading.
+- [ ] 3.5 Run the protected OpenAI API-key and OAuth/subscription regression coverage after provider seam extraction and fix any compatibility drift before continuing.
+
+## 4. Provider Auth And OAuth Seam Extraction
+
+- [ ] 4.1 Introduce explicit provider-auth lifecycle seams for token acquisition, token refresh, token persistence, and token-to-runtime-client mapping.
+- [ ] 4.2 Extract OpenAI API-key authentication onto the provider-auth seam while preserving current successful runtime behavior.
+- [ ] 4.3 Extract OpenAI OAuth/subscription authentication onto the provider-auth seam while preserving current successful runtime behavior.
+- [ ] 4.4 Update doctor and startup validation to report provider-auth stage-specific failures for incomplete or invalid auth configurations.
+- [ ] 4.5 Ensure auth refresh/runtime failures fail loudly and do not silently downgrade to another auth mode or stale fallback client.
+
+## 5. Channel Module Seam Extraction
+
+- [ ] 5.1 Introduce a single compiled-in channel module registry for inbound adapters, outbound delivery, and channel registration.
+- [ ] 5.2 Move Slack registration behind the compiled-in channel module seam without changing `SendUserMessage` or broadcast-based actor contracts.
+- [ ] 5.3 Update channel composition and validation to resolve configured channels exclusively through the compiled-in registry.
+- [ ] 5.4 Add contributor-facing validation errors for unknown channel kinds and explicitly reject dynamic channel plugin loading.
+- [ ] 5.5 Run the protected Slack runtime regression coverage after channel seam extraction and fix any Socket Mode, thread routing, or reply-delivery drift before continuing.
+
+## 6. Runtime Notification, Webhook, And Reminder Decoupling
+
+- [ ] 6.1 Inventory Slack-only assumptions in reminder notifications, inbound webhook flows, operational alerts, and other runtime notification producers.
+- [ ] 6.2 Introduce a generic runtime notification contract using typed notification targets and channel kinds.
+- [ ] 6.3 Refactor reminder, webhook, and operational alert producers to emit generic runtime notifications instead of Slack-specific target kinds or Slack-only tool names.
+- [ ] 6.4 Route runtime notification delivery through the compiled-in channel module seam while preserving Slack as the first successful delivery implementation.
+- [ ] 6.5 Add fail-closed behavior for unknown notification target kinds or channel kinds with no silent reroute to Slack or any other channel.
+
+## 7. Schema And Validation Alignment
+
+- [ ] 7.1 Update the configuration schema for provider, channel, auth, and notification seam changes so unknown or partial seam definitions are rejected structurally.
+- [ ] 7.2 Update `netclaw doctor` seam diagnostics to distinguish provider, channel, auth, and notification invariant failures with actionable remediation.
+- [ ] 7.3 Update startup validation to enforce the same seam invariants as schema and doctor before runtime activation.
+- [ ] 7.4 Update hot-reload validation to reject invalid provider, channel, auth, and notification changes and retain the last valid runtime state.
+- [ ] 7.5 Add regression coverage proving schema, doctor, startup, and hot reload agree on the same invalid seam cases and never apply silent fallbacks.
+
+## 8. Test Consolidation And Cleanup
+
+- [ ] 8.1 Identify seam-local narrow tests that no longer provide meaningful protection once contract and scenario coverage exists.
+- [ ] 8.2 Remove or consolidate low-value seam-local tests in favor of smaller high-value contract suites around provider, channel, auth, and notification seams.
+- [ ] 8.3 Add broader scenario coverage that exercises compatibility-critical user-visible flows across the extracted seams.
+- [ ] 8.4 Verify required CI remains contributor-safe and secret-free while optional live smoke checks remain explicit opt-in workflows.
+
+## 9. Verification And Exit Checks
+
+- [ ] 9.1 Re-run the protected OpenAI API-key, OpenAI OAuth/subscription, and Slack runtime regression suites after all seam changes are integrated.
+- [ ] 9.2 Run targeted validation coverage for unknown provider kinds, unknown channel kinds, invalid auth configurations, and invalid notification targets to confirm fail-closed behavior.
+- [ ] 9.3 Run `dotnet slopwatch analyze` and fix any new violations introduced by the hardening work.
+- [ ] 9.4 Confirm no dynamic plugin loading paths, no silent fallbacks, and no actor-contract regressions remain in the final implementation.
+- [ ] 9.5 Verify the OpenSpec task list, delta specs, and implementation outcomes stay aligned before marking the change ready for archive or apply completion.

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -39,6 +39,40 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
     }
 
     [Fact]
+    public async Task Gateway_routes_thread_followups_to_original_session_id()
+    {
+        var sink = CreateTestProbe("gateway-thread-sink");
+
+        SlackGatewayDependencies? deps = null;
+        deps = CreateDependencies(
+            conversationPropsFactory: (channelId, _) => SlackConversationActor.CreateProps(channelId, deps!),
+            threadPropsFactory: (_, _, _, _) => Props.Create(() => new ForwardActor(sink.Ref)));
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gateway-test-2");
+
+        gateway.Tell(CreateAppMention(
+            eventId: "C1:700",
+            channelId: "C1",
+            eventTs: "700.1",
+            text: "<@UBOT> start"));
+
+        var first = await sink.ExpectMsgAsync<SlackThreadInbound>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("C1/700.1", first.SessionId.Value);
+        Assert.Equal("start", first.Text);
+
+        gateway.Tell(CreateMessage(
+            eventId: "C1:701",
+            channelId: "C1",
+            eventTs: "701.1",
+            text: "follow up",
+            threadTs: "700.1"));
+
+        var second = await sink.ExpectMsgAsync<SlackThreadInbound>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("C1/700.1", second.SessionId.Value);
+        Assert.Equal("follow up", second.Text);
+    }
+
+    [Fact]
     public async Task Conversation_requires_mention_to_start_and_allows_thread_followups()
     {
         var sink = CreateTestProbe("conversation-sink");

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexRequestPolicyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexRequestPolicyTests.cs
@@ -1,0 +1,133 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Netclaw.Providers.OpenAi;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class OpenAiCodexRequestPolicyTests
+{
+    [Fact]
+    public void InjectsAccountHeader_AndCodexRequiredBodyFields()
+    {
+        var policy = new OpenAiCodexRequestPolicy("org-123");
+        var body = new JsonObject
+        {
+            ["input"] = new JsonArray(
+                new JsonObject
+                {
+                    ["role"] = "user",
+                    ["content"] = new JsonArray(
+                        new JsonObject { ["type"] = "input_text", ["text"] = "hello" })
+                })
+        };
+
+        var (message, result) = ProcessSync(policy, body);
+
+        Assert.True(message.Request.Headers.TryGetValue("ChatGPT-Account-Id", out var accountId));
+        Assert.Equal("org-123", accountId);
+        Assert.NotNull(result);
+        Assert.False(result!["store"]!.GetValue<bool>());
+        Assert.Equal(string.Empty, result["instructions"]!.GetValue<string>());
+        Assert.Single(result["input"]!.AsArray());
+    }
+
+    [Fact]
+    public void MovesSystemMessages_IntoInstructions_AndStripsNullStrict()
+    {
+        var policy = new OpenAiCodexRequestPolicy(accountId: null);
+        var body = new JsonObject
+        {
+            ["instructions"] = "existing",
+            ["input"] = new JsonArray(
+                new JsonObject
+                {
+                    ["role"] = "system",
+                    ["content"] = new JsonArray(
+                        new JsonObject { ["type"] = "input_text", ["text"] = "first system" })
+                },
+                new JsonObject
+                {
+                    ["role"] = "user",
+                    ["content"] = new JsonArray(
+                        new JsonObject { ["type"] = "input_text", ["text"] = "hello" })
+                },
+                new JsonObject
+                {
+                    ["role"] = "system",
+                    ["content"] = new JsonArray(
+                        new JsonObject { ["type"] = "input_text", ["text"] = "second system" })
+                }),
+            ["tools"] = new JsonArray(
+                new JsonObject
+                {
+                    ["type"] = "function",
+                    ["strict"] = null,
+                    ["name"] = "tool-a"
+                },
+                new JsonObject
+                {
+                    ["type"] = "function",
+                    ["strict"] = true,
+                    ["name"] = "tool-b"
+                })
+        };
+
+        var (_, result) = ProcessSync(policy, body);
+
+        Assert.NotNull(result);
+        Assert.Equal("existing\nfirst system\nsecond system", result!["instructions"]!.GetValue<string>());
+
+        var input = result["input"]!.AsArray();
+        Assert.Single(input);
+        Assert.Equal("user", input[0]!["role"]!.GetValue<string>());
+
+        var tools = result["tools"]!.AsArray();
+        Assert.False(tools[0]!.AsObject().ContainsKey("strict"));
+        Assert.True(tools[1]!["strict"]!.GetValue<bool>());
+    }
+
+    private static (PipelineMessage Message, JsonObject? Body) ProcessSync(OpenAiCodexRequestPolicy policy, JsonObject body)
+    {
+        var pipeline = new CapturePolicy();
+        var message = CreateMessage(body);
+
+        policy.Process(message, [policy, pipeline], 0);
+
+        Assert.True(pipeline.WasCalled, "Policy must call ProcessNext");
+
+        if (message.Request.Content is null)
+            return (message, null);
+
+        using var stream = new MemoryStream();
+        message.Request.Content.WriteTo(stream, default);
+        return (message, JsonSerializer.Deserialize<JsonObject>(stream.ToArray()));
+    }
+
+    private static PipelineMessage CreateMessage(JsonObject body)
+    {
+        var pipeline = ClientPipeline.Create();
+        var message = pipeline.CreateMessage();
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(body);
+        message.Request.Content = BinaryContent.Create(BinaryData.FromBytes(bytes));
+        return message;
+    }
+
+    private sealed class CapturePolicy : PipelinePolicy
+    {
+        public bool WasCalled { get; private set; }
+
+        public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            WasCalled = true;
+        }
+
+        public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            WasCalled = true;
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an OpenSpec change for OSS contributor hardening covering provider, channel, auth, notification, validation, and test strategy cleanup
- add Phase 0 compatibility safety nets for the protected OpenAI Codex/OAuth request contract and Slack thread session routing behavior
- establish a phased, compatibility-first refactoring plan that preserves current OpenAI and Slack behavior during seam extraction

## Validation
- dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --filter \"FullyQualifiedName~OpenAiCodexRequestPolicyTests\"
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter \"FullyQualifiedName~SlackActorHierarchyTests.Gateway_routes_thread_followups_to_original_session_id\"
- dotnet slopwatch analyze

## Notes
- slopwatch reports two existing SW005 warnings for OPENAI001 NoWarn entries in project files; this change does not modify those suppressions
- this PR is intentionally limited to planning artifacts plus the first compatibility-focused test slice before larger seam refactors begin