### PR TITLE
fix(slack): restore gap image DataContent in thread hydration

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -164,11 +164,9 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
         Assert.Contains("can you help with this?", mergedText);
         Assert.Equal(1, CountOccurrences(mergedText, "can you help with this?"));
 
-        // Gap image bytes are deliberately NOT forwarded to the session —
-        // the summary line records them instead. Live mention carries no
-        // image, so no DataContent should reach the session at all.
         Assert.Contains("[image attachments:", mergedText);
-        Assert.Empty(mergedUserTurn.Contents.OfType<DataContent>());
+        Assert.True(mergedUserTurn.Contents.OfType<DataContent>().Any(),
+            "Expected merged user turn to include image DataContent from backfill");
     }
 
     [Fact]

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -607,9 +607,19 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         var merged = new List<AIContent> { new TextContent(mergedText) };
 
-        // Gap image bytes are intentionally NOT copied into the merged input:
-        // the summary line above already records the count. Copying the raw
-        // bytes duplicates multi-MB payloads on every hydrated first turn.
+        // Gap image DataContent is carried through to the session so vision-
+        // capable models see the prior-thread images. The session actor's
+        // modality gate strips them when the resolved model doesn't support
+        // image input, so non-vision models are unaffected.
+        foreach (var item in gap)
+        {
+            foreach (var content in item.Contents)
+            {
+                if (content is not TextContent)
+                    merged.Add(content);
+            }
+        }
+
         foreach (var content in liveContents)
         {
             if (content is not TextContent)


### PR DESCRIPTION
## Summary

- The prior \"drop gap image bytes\" optimization (merged in #576) stripped images from hydrated thread history unconditionally. This broke vision on prior-thread context for image-capable models — exactly the feature the spec documents with *\"Backfilled messages SHALL include inline multimodal content (images as DataContent) so the LLM receives them as vision content.\"*
- The modality decision belongs to the session actor, not the channel binding actor. \`LlmSessionActor\` already has a capability gate (\`src/Netclaw.Actors/Sessions/LlmSessionActor.cs:1620\`) that strips image media refs and notifies the user when the resolved model can't handle vision.
- This restores the original merge behavior: gap \`DataContent\` items flow through to the session, the session's gate decides based on \`IModelCapabilityResolver\`.

## Test plan

- [x] \`dotnet build\`
- [x] \`dotnet slopwatch analyze\` — 0 issues
- [x] \`dotnet test\` — all 122 Slack tests pass, including the restored \`Backfill_messages_are_merged_into_single_user_turn\` assertion that gap \`DataContent\` reaches the session.