### PR TITLE
fix(skills): resolve claude-code marketplaces and commands compatibility

### DIFF
--- a/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
@@ -274,13 +274,19 @@ public class SkillRegistryTests
         {
             new ResolvedExternalSource(
                 "claude-code",
-                new[] { "/home/user/.claude/skills", "/home/user/.claude/commands" },
+                new[]
+                {
+                    "/home/user/.claude/skills",
+                    "/home/user/.claude/plugins/marketplaces/dotnet-skills/skills"
+                },
                 true)
         };
 
         var index = registry.GenerateIndex("/home/user/.netclaw/skills", externalSources);
 
-        Assert.Contains("claude-code=/home/user/.claude/skills;/home/user/.claude/commands", index);
+        Assert.Contains(
+            "claude-code=/home/user/.claude/skills;/home/user/.claude/plugins/marketplaces/dotnet-skills/skills",
+            index);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillRegistryTests.cs
@@ -277,6 +277,7 @@ public class SkillRegistryTests
                 new[]
                 {
                     "/home/user/.claude/skills",
+                    "/home/user/.claude/commands",
                     "/home/user/.claude/plugins/marketplaces/dotnet-skills/skills"
                 },
                 true)
@@ -285,7 +286,7 @@ public class SkillRegistryTests
         var index = registry.GenerateIndex("/home/user/.netclaw/skills", externalSources);
 
         Assert.Contains(
-            "claude-code=/home/user/.claude/skills;/home/user/.claude/plugins/marketplaces/dotnet-skills/skills",
+            "claude-code=/home/user/.claude/skills;/home/user/.claude/commands;/home/user/.claude/plugins/marketplaces/dotnet-skills/skills",
             index);
     }
 

--- a/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
+++ b/src/Netclaw.Actors.Tests/Skills/SkillScannerTests.cs
@@ -495,6 +495,102 @@ public class SkillScannerTests : IDisposable
     }
 
     [Fact]
+    public void Frontmatterless_flat_file_is_accepted_in_compatibility_mode()
+    {
+        File.WriteAllText(Path.Combine(_skillsDir, "review-pr.md"),
+            "Use the pr-review-specialist subagent to review pull requests.");
+
+        var result = SkillScanner.Scan(_skillsDir, strictNameMatch: false, allowFrontmatterlessFlatFiles: true);
+
+        var skill = Assert.Single(result.AcceptedSkills);
+        Assert.Equal("review-pr", skill.Name);
+        Assert.Equal("Review Pr", skill.DisplayName);
+        Assert.Equal("Use the pr-review-specialist subagent to review pull requests.", skill.Description);
+        Assert.True(skill.IsFlatFile);
+    }
+
+    [Fact]
+    public void Frontmatterless_flat_file_is_rejected_without_compatibility_mode()
+    {
+        File.WriteAllText(Path.Combine(_skillsDir, "review-pr.md"),
+            "Use the pr-review-specialist subagent to review pull requests.");
+
+        var result = SkillScanner.Scan(_skillsDir, strictNameMatch: false, allowFrontmatterlessFlatFiles: false);
+
+        Assert.Empty(result.AcceptedSkills);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal(SkillScanIssueKind.FlatFileMissingFrontmatter, issue.Kind);
+    }
+
+    [Fact]
+    public void Frontmatterless_flat_file_uses_heading_for_display_name()
+    {
+        File.WriteAllText(Path.Combine(_skillsDir, "release.md"), """
+            # Create Release
+
+            Use the release-manager subagent to run release steps.
+            """);
+
+        var result = SkillScanner.Scan(_skillsDir, strictNameMatch: false, allowFrontmatterlessFlatFiles: true);
+
+        var skill = Assert.Single(result.AcceptedSkills);
+        Assert.Equal("release", skill.Name);
+        Assert.Equal("Create Release", skill.DisplayName);
+        Assert.Equal("Create Release", skill.Description);
+    }
+
+    [Fact]
+    public void Frontmatterless_empty_flat_file_is_rejected_with_no_description_issue()
+    {
+        File.WriteAllText(Path.Combine(_skillsDir, "empty.md"), "   \n\n");
+
+        var result = SkillScanner.Scan(_skillsDir, strictNameMatch: false, allowFrontmatterlessFlatFiles: true);
+
+        Assert.Empty(result.AcceptedSkills);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal(SkillScanIssueKind.FlatFileNoDescription, issue.Kind);
+    }
+
+    [Fact]
+    public void ScanAndMerge_accepts_frontmatterless_files_for_claude_commands_path()
+    {
+        var commandsDir = Path.Combine(_skillsDir, ".claude", "commands");
+        Directory.CreateDirectory(commandsDir);
+        File.WriteAllText(Path.Combine(commandsDir, "review-pr.md"),
+            "Use the pr-review-specialist subagent to review pull requests.");
+
+        var merged = SkillScanner.ScanAndMerge(
+            nativeSkillsDirectory: _skillsDir,
+            externalSources:
+            [
+                new ResolvedExternalSource("claude-code", [commandsDir], true)
+            ]);
+
+        var skill = Assert.Single(merged.AcceptedSkills);
+        Assert.Equal("review-pr", skill.Name);
+        Assert.DoesNotContain(merged.Issues, i => i.Kind == SkillScanIssueKind.FlatFileMissingFrontmatter);
+    }
+
+    [Fact]
+    public void ScanAndMerge_rejects_frontmatterless_files_for_non_commands_external_paths()
+    {
+        var externalDir = Path.Combine(_skillsDir, "team-skills");
+        Directory.CreateDirectory(externalDir);
+        File.WriteAllText(Path.Combine(externalDir, "review-pr.md"),
+            "Use the pr-review-specialist subagent to review pull requests.");
+
+        var merged = SkillScanner.ScanAndMerge(
+            nativeSkillsDirectory: _skillsDir,
+            externalSources:
+            [
+                new ResolvedExternalSource("team", [externalDir], true)
+            ]);
+
+        Assert.Empty(merged.AcceptedSkills);
+        Assert.Contains(merged.Issues, i => i.Kind == SkillScanIssueKind.FlatFileMissingFrontmatter);
+    }
+
+    [Fact]
     public void Symlinked_resource_tree_is_rejected_with_issue()
     {
         WriteSkill("linked-skill", """

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -52,7 +52,17 @@ public static partial class SkillScanner
     /// canonical — used for external sources like Claude Code where skill directory
     /// names don't have to align with the declared name.
     /// </param>
-    public static SkillScanResult Scan(string skillsDirectory, bool allowSymlinks = false, bool strictNameMatch = true)
+    /// <param name="allowFrontmatterlessFlatFiles">
+    /// When <c>true</c>, flat <c>.md</c> files without YAML frontmatter are treated
+    /// as valid skills with name derived from filename and description inferred from
+    /// first non-empty line. This compatibility mode is used for Claude Code
+    /// <c>~/.claude/commands</c> files.
+    /// </param>
+    public static SkillScanResult Scan(
+        string skillsDirectory,
+        bool allowSymlinks = false,
+        bool strictNameMatch = true,
+        bool allowFrontmatterlessFlatFiles = false)
     {
         if (!Directory.Exists(skillsDirectory))
             return SkillScanResult.Empty;
@@ -72,7 +82,7 @@ public static partial class SkillScanner
                 || fileName.StartsWith('.'))
                 continue;
 
-            var entry = ParseFlatSkillFile(mdFile, rootFull, issues, allowSymlinks, strictNameMatch);
+            var entry = ParseFlatSkillFile(mdFile, rootFull, issues, allowSymlinks, strictNameMatch, allowFrontmatterlessFlatFiles);
             if (entry is not null)
                 acceptedCandidates.Add(entry);
         }
@@ -197,7 +207,11 @@ public static partial class SkillScanner
         {
             foreach (var path in source.Paths)
             {
-                var externalScan = Scan(path, allowSymlinks: source.AllowSymlinks, strictNameMatch: false);
+                var externalScan = Scan(
+                    path,
+                    allowSymlinks: source.AllowSymlinks,
+                    strictNameMatch: false,
+                    allowFrontmatterlessFlatFiles: IsClaudeCommandsDirectory(path));
                 allIssues.AddRange(externalScan.Issues);
 
                 foreach (var skill in externalScan.AcceptedSkills)
@@ -268,7 +282,13 @@ public static partial class SkillScanner
     /// files with valid YAML frontmatter — supported for compatibility with Claude Code
     /// and other platforms that allow skills without the directory wrapper.
     /// </summary>
-    private static SkillEntry? ParseFlatSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false, bool strictNameMatch = true)
+    private static SkillEntry? ParseFlatSkillFile(
+        string filePath,
+        string rootDirectory,
+        List<SkillScanIssue> issues,
+        bool allowSymlinks = false,
+        bool strictNameMatch = true,
+        bool allowFrontmatterlessFlatFiles = false)
     {
         var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
         var canonicalPath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "flat skill file", allowSymlinks);
@@ -292,6 +312,9 @@ public static partial class SkillScanner
         var frontmatter = ExtractFrontmatter(content);
         if (frontmatter is null)
         {
+            if (allowFrontmatterlessFlatFiles && !content.StartsWith("---", StringComparison.Ordinal))
+                return BuildFlatSkillEntryWithoutFrontmatter(canonicalPath, canonicalRoot, content, issues);
+
             issues.Add(new SkillScanIssue(
                 Path: canonicalPath,
                 Kind: SkillScanIssueKind.FlatFileMissingFrontmatter,
@@ -526,12 +549,82 @@ public static partial class SkillScanner
         return value[..(maxLength - 3)] + "...";
     }
 
+    private static SkillEntry? BuildFlatSkillEntryWithoutFrontmatter(
+        string canonicalPath,
+        string canonicalRoot,
+        string content,
+        List<SkillScanIssue> issues)
+    {
+        var description = ExtractFirstNonEmptyMarkdownLine(content);
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            issues.Add(new SkillScanIssue(
+                Path: canonicalPath,
+                Kind: SkillScanIssueKind.FlatFileNoDescription,
+                Message: "Flat .md file without frontmatter must contain at least one non-empty line to infer a description."));
+            return null;
+        }
+
+        var fileNameWithoutExt = Path.GetFileNameWithoutExtension(canonicalPath);
+        var name = NormalizeSkillName(fileNameWithoutExt);
+
+        var headingMatch = HeadingRegex().Match(content);
+        var displayName = headingMatch.Success
+            ? headingMatch.Groups[1].Value.Trim()
+            : TitleCase(name);
+
+        return new SkillEntry(
+            Name: name,
+            DisplayName: displayName,
+            Description: Truncate(description, MaxDescriptionLength),
+            FilePath: canonicalPath,
+            SkillDirectory: canonicalRoot,
+            Category: null)
+        {
+            ResourcePaths = null,
+            IsFlatFile = true
+        };
+    }
+
+    private static string? ExtractFirstNonEmptyMarkdownLine(string content)
+    {
+        var lines = content.Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+
+            if (line.StartsWith("#", StringComparison.Ordinal))
+                line = line.TrimStart('#').Trim();
+
+            if (line.Length > 0)
+                return line;
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Only <c>.system</c> is scanned as a hidden directory (system skills from CDN).
     /// All other hidden directories are ignored.
     /// </summary>
     private static bool IsAllowedHiddenDirectory(string dirName)
         => string.Equals(dirName, SystemCategory, StringComparison.Ordinal);
+
+    private static bool IsClaudeCommandsDirectory(string path)
+    {
+        var normalized = NormalizeDirectoryPath(path);
+        var directoryName = Path.GetFileName(normalized);
+        if (!string.Equals(directoryName, "commands", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var parent = Path.GetDirectoryName(normalized);
+        if (string.IsNullOrEmpty(parent))
+            return false;
+
+        return string.Equals(Path.GetFileName(parent), ".claude", StringComparison.OrdinalIgnoreCase);
+    }
 
     internal static string NormalizeSkillName(string value)
         => value.Trim().ToLowerInvariant();

--- a/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
@@ -72,6 +72,30 @@ public class ExternalSkillsConfigTests : IDisposable
     }
 
     [Fact]
+    public void ClaudeCode_marketplace_paths_are_sorted_for_stable_precedence()
+    {
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "zeta"));
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "alpha"));
+
+        var config = new ExternalSkillsConfig
+        {
+            Sources =
+            {
+                new ExternalSkillSource { Name = "claude-code", WellKnown = "claude-code", Enabled = true }
+            }
+        };
+
+        var resolved = config.ResolveEnabledSources(_homeDir);
+
+        var source = Assert.Single(resolved);
+        Assert.Equal(3, source.Paths.Count);
+        Assert.EndsWith(Path.Combine(".claude", "skills"), source.Paths[0]);
+        Assert.EndsWith(Path.Combine("marketplaces", "alpha", "skills"), source.Paths[1]);
+        Assert.EndsWith(Path.Combine("marketplaces", "zeta", "skills"), source.Paths[2]);
+    }
+
+    [Fact]
     public void ClaudeCode_skips_marketplaces_that_have_no_skills_subdir()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
@@ -232,6 +256,18 @@ public class ExternalSkillsConfigTests : IDisposable
         var probed = ExternalSkillsConfig.ProbeWellKnownSources(_homeDir);
 
         Assert.Empty(probed);
+    }
+
+    [Fact]
+    public void Probe_detects_claude_code_when_only_marketplace_skills_exist()
+    {
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
+
+        var probed = ExternalSkillsConfig.ProbeWellKnownSources(_homeDir);
+
+        var result = Assert.Single(probed);
+        Assert.Equal("claude-code", result.WellKnownAlias);
+        Assert.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), result.ResolvedPath);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
@@ -27,9 +27,10 @@ public class ExternalSkillsConfigTests : IDisposable
         Path.Combine(home, ".claude", "plugins", "marketplaces", marketplace, "skills");
 
     [Fact]
-    public void ClaudeCode_resolves_only_the_skills_path_when_no_marketplaces_installed()
+    public void ClaudeCode_resolves_skills_and_commands_paths_when_no_marketplaces_installed()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
 
         var config = new ExternalSkillsConfig
         {
@@ -43,14 +44,16 @@ public class ExternalSkillsConfigTests : IDisposable
 
         var source = Assert.Single(resolved);
         Assert.Equal("claude-code", source.Name);
-        Assert.Single(source.Paths);
+        Assert.Equal(2, source.Paths.Count);
         Assert.EndsWith(Path.Combine(".claude", "skills"), source.Paths[0]);
+        Assert.EndsWith(Path.Combine(".claude", "commands"), source.Paths[1]);
     }
 
     [Fact]
     public void ClaudeCode_expands_every_installed_marketplace_with_a_skills_subdir()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "prose"));
 
@@ -65,8 +68,9 @@ public class ExternalSkillsConfigTests : IDisposable
         var resolved = config.ResolveEnabledSources(_homeDir);
 
         var source = Assert.Single(resolved);
-        Assert.Equal(3, source.Paths.Count);
+        Assert.Equal(4, source.Paths.Count);
         Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "skills"), StringComparison.Ordinal));
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "commands"), StringComparison.Ordinal));
         Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), StringComparison.Ordinal));
         Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "prose", "skills"), StringComparison.Ordinal));
     }
@@ -75,6 +79,7 @@ public class ExternalSkillsConfigTests : IDisposable
     public void ClaudeCode_marketplace_paths_are_sorted_for_stable_precedence()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "zeta"));
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "alpha"));
 
@@ -89,16 +94,18 @@ public class ExternalSkillsConfigTests : IDisposable
         var resolved = config.ResolveEnabledSources(_homeDir);
 
         var source = Assert.Single(resolved);
-        Assert.Equal(3, source.Paths.Count);
+        Assert.Equal(4, source.Paths.Count);
         Assert.EndsWith(Path.Combine(".claude", "skills"), source.Paths[0]);
-        Assert.EndsWith(Path.Combine("marketplaces", "alpha", "skills"), source.Paths[1]);
-        Assert.EndsWith(Path.Combine("marketplaces", "zeta", "skills"), source.Paths[2]);
+        Assert.EndsWith(Path.Combine(".claude", "commands"), source.Paths[1]);
+        Assert.EndsWith(Path.Combine("marketplaces", "alpha", "skills"), source.Paths[2]);
+        Assert.EndsWith(Path.Combine("marketplaces", "zeta", "skills"), source.Paths[3]);
     }
 
     [Fact]
     public void ClaudeCode_skips_marketplaces_that_have_no_skills_subdir()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
         Directory.CreateDirectory(Path.Combine(MarketplacesRoot(_homeDir), "empty-marketplace"));
 
@@ -113,8 +120,9 @@ public class ExternalSkillsConfigTests : IDisposable
         var resolved = config.ResolveEnabledSources(_homeDir);
 
         var source = Assert.Single(resolved);
-        Assert.Equal(2, source.Paths.Count);
+        Assert.Equal(3, source.Paths.Count);
         Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "skills"), StringComparison.Ordinal));
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "commands"), StringComparison.Ordinal));
         Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), StringComparison.Ordinal));
         Assert.DoesNotContain(source.Paths, p => p.Contains("empty-marketplace", StringComparison.Ordinal));
     }
@@ -246,16 +254,16 @@ public class ExternalSkillsConfigTests : IDisposable
     }
 
     [Fact]
-    public void Probe_does_not_surface_commands_directory_as_a_skill_source()
+    public void Probe_surfaces_commands_directory_for_claude_code()
     {
-        // Claude Code's flat slash-command files live at ~/.claude/commands. They
-        // use a different frontmatter schema and must not be reported as a
-        // valid claude-code source even when the skills/ dir is absent.
+        // Claude Code now treats ~/.claude/commands markdown files as skills.
         Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
 
         var probed = ExternalSkillsConfig.ProbeWellKnownSources(_homeDir);
 
-        Assert.Empty(probed);
+        var result = Assert.Single(probed);
+        Assert.Equal("claude-code", result.WellKnownAlias);
+        Assert.EndsWith(Path.Combine(".claude", "commands"), result.ResolvedPath);
     }
 
     [Fact]
@@ -271,12 +279,13 @@ public class ExternalSkillsConfigTests : IDisposable
     }
 
     [Fact]
-    public void ResolveWellKnownPaths_returns_only_the_skills_path_for_claude_code()
+    public void ResolveWellKnownPaths_returns_skills_and_commands_paths_for_claude_code()
     {
         var paths = ExternalSkillsConfig.ResolveWellKnownPaths("claude-code", _homeDir);
 
-        Assert.Single(paths);
+        Assert.Equal(2, paths.Count);
         Assert.EndsWith(Path.Combine(".claude", "skills"), paths[0]);
+        Assert.EndsWith(Path.Combine(".claude", "commands"), paths[1]);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
@@ -19,13 +19,17 @@ public class ExternalSkillsConfigTests : IDisposable
             Directory.Delete(_homeDir, recursive: true);
     }
 
+    private static string ClaudeSkillsPath(string home) => Path.Combine(home, ".claude", "skills");
+
+    private static string MarketplacesRoot(string home) => Path.Combine(home, ".claude", "plugins", "marketplaces");
+
+    private static string MarketplaceSkillsPath(string home, string marketplace) =>
+        Path.Combine(home, ".claude", "plugins", "marketplaces", marketplace, "skills");
+
     [Fact]
-    public void ClaudeCode_resolves_to_one_source_with_both_paths_when_skills_and_commands_exist()
+    public void ClaudeCode_resolves_only_the_skills_path_when_no_marketplaces_installed()
     {
-        var skillsDir = Path.Combine(_homeDir, ".claude", "skills");
-        var commandsDir = Path.Combine(_homeDir, ".claude", "commands");
-        Directory.CreateDirectory(skillsDir);
-        Directory.CreateDirectory(commandsDir);
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
 
         var config = new ExternalSkillsConfig
         {
@@ -39,15 +43,87 @@ public class ExternalSkillsConfigTests : IDisposable
 
         var source = Assert.Single(resolved);
         Assert.Equal("claude-code", source.Name);
-        Assert.Equal(2, source.Paths.Count);
-        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "skills"), StringComparison.Ordinal));
-        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "commands"), StringComparison.Ordinal));
+        Assert.Single(source.Paths);
+        Assert.EndsWith(Path.Combine(".claude", "skills"), source.Paths[0]);
     }
 
     [Fact]
-    public void ClaudeCode_drops_missing_commands_path_silently()
+    public void ClaudeCode_expands_every_installed_marketplace_with_a_skills_subdir()
     {
-        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "skills"));
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "prose"));
+
+        var config = new ExternalSkillsConfig
+        {
+            Sources =
+            {
+                new ExternalSkillSource { Name = "claude-code", WellKnown = "claude-code", Enabled = true }
+            }
+        };
+
+        var resolved = config.ResolveEnabledSources(_homeDir);
+
+        var source = Assert.Single(resolved);
+        Assert.Equal(3, source.Paths.Count);
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "skills"), StringComparison.Ordinal));
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), StringComparison.Ordinal));
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "prose", "skills"), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ClaudeCode_skips_marketplaces_that_have_no_skills_subdir()
+    {
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        // Populated marketplace with a skills/ subdir
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
+        // Marketplace dir exists but has no skills/ subdir — should be silently skipped
+        Directory.CreateDirectory(Path.Combine(MarketplacesRoot(_homeDir), "empty-marketplace"));
+
+        var config = new ExternalSkillsConfig
+        {
+            Sources =
+            {
+                new ExternalSkillSource { Name = "claude-code", WellKnown = "claude-code", Enabled = true }
+            }
+        };
+
+        var resolved = config.ResolveEnabledSources(_homeDir);
+
+        var source = Assert.Single(resolved);
+        Assert.Equal(2, source.Paths.Count);
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine(".claude", "skills"), StringComparison.Ordinal));
+        Assert.Contains(source.Paths, p => p.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), StringComparison.Ordinal));
+        Assert.DoesNotContain(source.Paths, p => p.Contains("empty-marketplace", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ClaudeCode_resolves_marketplace_only_when_primary_skills_dir_is_missing()
+    {
+        // No ~/.claude/skills directory — user has Claude Code plugins but never created a
+        // bare skills/ dir. The claude-code source should still resolve from the marketplace alone.
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
+
+        var config = new ExternalSkillsConfig
+        {
+            Sources =
+            {
+                new ExternalSkillSource { Name = "claude-code", WellKnown = "claude-code", Enabled = true }
+            }
+        };
+
+        var resolved = config.ResolveEnabledSources(_homeDir);
+
+        var source = Assert.Single(resolved);
+        Assert.Single(source.Paths);
+        Assert.EndsWith(Path.Combine("marketplaces", "dotnet-skills", "skills"), source.Paths[0]);
+    }
+
+    [Fact]
+    public void ClaudeCode_does_not_crash_when_marketplaces_root_is_missing()
+    {
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        // Intentionally no .claude/plugins/marketplaces at all
 
         var config = new ExternalSkillsConfig
         {
@@ -65,15 +141,17 @@ public class ExternalSkillsConfigTests : IDisposable
     }
 
     [Fact]
-    public void ClaudeCode_resolves_when_only_commands_dir_exists()
+    public void Marketplace_expansion_does_not_apply_to_open_code()
     {
-        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
+        Directory.CreateDirectory(Path.Combine(_homeDir, ".open-code", "skills"));
+        // Marketplaces exist under ~/.claude but this source is open-code, not claude-code.
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
 
         var config = new ExternalSkillsConfig
         {
             Sources =
             {
-                new ExternalSkillSource { Name = "claude-code", WellKnown = "claude-code", Enabled = true }
+                new ExternalSkillSource { Name = "open-code", WellKnown = "open-code", Enabled = true }
             }
         };
 
@@ -81,13 +159,37 @@ public class ExternalSkillsConfigTests : IDisposable
 
         var source = Assert.Single(resolved);
         Assert.Single(source.Paths);
-        Assert.EndsWith(Path.Combine(".claude", "commands"), source.Paths[0]);
+        Assert.EndsWith(Path.Combine(".open-code", "skills"), source.Paths[0]);
+    }
+
+    [Fact]
+    public void Marketplace_expansion_does_not_apply_to_custom_path_sources()
+    {
+        var customDir = Path.Combine(_homeDir, "team-skills");
+        Directory.CreateDirectory(customDir);
+        // Marketplaces exist but this source uses a custom Path, not WellKnown=claude-code.
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
+
+        var config = new ExternalSkillsConfig
+        {
+            Sources =
+            {
+                new ExternalSkillSource { Name = "team", Path = customDir, Enabled = true }
+            }
+        };
+
+        var resolved = config.ResolveEnabledSources(_homeDir);
+
+        var source = Assert.Single(resolved);
+        Assert.Single(source.Paths);
+        Assert.Equal(customDir, source.Paths[0]);
     }
 
     [Fact]
     public void Disabled_source_is_skipped_even_if_paths_exist()
     {
-        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "skills"));
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
+        Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
 
         var config = new ExternalSkillsConfig
         {
@@ -105,13 +207,12 @@ public class ExternalSkillsConfigTests : IDisposable
     [Fact]
     public void Probe_returns_one_result_per_alias_when_any_path_exists()
     {
-        Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "skills"));
+        Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
 
         var probed = ExternalSkillsConfig.ProbeWellKnownSources(_homeDir);
 
         var result = Assert.Single(probed);
         Assert.Equal("claude-code", result.WellKnownAlias);
-        // Primary (skills) preferred when it exists
         Assert.EndsWith(Path.Combine(".claude", "skills"), result.ResolvedPath);
     }
 
@@ -124,24 +225,25 @@ public class ExternalSkillsConfigTests : IDisposable
     }
 
     [Fact]
-    public void Probe_uses_commands_dir_as_fallback_when_primary_skills_missing()
+    public void Probe_does_not_surface_commands_directory_as_a_skill_source()
     {
+        // Claude Code's flat slash-command files live at ~/.claude/commands. They
+        // use a different frontmatter schema and must not be reported as a
+        // valid claude-code source even when the skills/ dir is absent.
         Directory.CreateDirectory(Path.Combine(_homeDir, ".claude", "commands"));
 
         var probed = ExternalSkillsConfig.ProbeWellKnownSources(_homeDir);
 
-        var result = Assert.Single(probed);
-        Assert.EndsWith(Path.Combine(".claude", "commands"), result.ResolvedPath);
+        Assert.Empty(probed);
     }
 
     [Fact]
-    public void ResolveWellKnownPaths_returns_all_paths_for_claude_code()
+    public void ResolveWellKnownPaths_returns_only_the_skills_path_for_claude_code()
     {
         var paths = ExternalSkillsConfig.ResolveWellKnownPaths("claude-code", _homeDir);
 
-        Assert.Equal(2, paths.Count);
+        Assert.Single(paths);
         Assert.EndsWith(Path.Combine(".claude", "skills"), paths[0]);
-        Assert.EndsWith(Path.Combine(".claude", "commands"), paths[1]);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ExternalSkillsConfigTests.cs
@@ -75,9 +75,7 @@ public class ExternalSkillsConfigTests : IDisposable
     public void ClaudeCode_skips_marketplaces_that_have_no_skills_subdir()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
-        // Populated marketplace with a skills/ subdir
         Directory.CreateDirectory(MarketplaceSkillsPath(_homeDir, "dotnet-skills"));
-        // Marketplace dir exists but has no skills/ subdir — should be silently skipped
         Directory.CreateDirectory(Path.Combine(MarketplacesRoot(_homeDir), "empty-marketplace"));
 
         var config = new ExternalSkillsConfig
@@ -123,7 +121,6 @@ public class ExternalSkillsConfigTests : IDisposable
     public void ClaudeCode_does_not_crash_when_marketplaces_root_is_missing()
     {
         Directory.CreateDirectory(ClaudeSkillsPath(_homeDir));
-        // Intentionally no .claude/plugins/marketplaces at all
 
         var config = new ExternalSkillsConfig
         {

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -10,21 +10,41 @@ public sealed class ExternalSkillsConfig
     /// Single catalog of well-known external skill sources. Both
     /// <see cref="ResolveWellKnownPath"/> and <see cref="ProbeWellKnownSources"/>
     /// consume this so alias/display/symlink metadata stays in one place.
-    /// Each alias can own multiple relative paths — e.g. <c>claude-code</c>
-    /// scans both <c>~/.claude/skills/</c> and <c>~/.claude/commands/</c>
-    /// because Claude Code user slash commands live alongside skills and
-    /// share the same YAML-frontmatter format. The first path is the primary
-    /// (used for display/validation); all existing paths are scanned.
+    /// Each alias can own multiple relative paths — the first path is the
+    /// primary (used for display/validation); all existing paths are scanned.
     /// </summary>
+    /// <remarks>
+    /// The <c>claude-code</c> alias is also expanded at resolution time by
+    /// <see cref="ResolveEnabledSources(string)"/> to include every installed
+    /// plugin marketplace under <c>~/.claude/plugins/marketplaces/*/skills/</c>,
+    /// so marketplace skills (e.g. the dotnet-skills plugin) show up without
+    /// needing a separate configured source. That expansion is dynamic and
+    /// lives outside the static catalog.
+    /// </remarks>
     private static readonly (string Alias, string DisplayName, string[] RelativePaths, bool DefaultAllowSymlinks)[] WellKnownCatalog =
     [
         ("claude-code", "Claude Code",
-            new[] { Path.Combine(".claude", "skills"), Path.Combine(".claude", "commands") },
+            new[] { Path.Combine(".claude", "skills") },
             true),
         ("open-code", "Open Code",
             new[] { Path.Combine(".open-code", "skills") },
             false)
     ];
+
+    /// <summary>
+    /// Well-known alias whose resolution also enumerates Claude Code plugin
+    /// marketplaces. Kept as a constant so the dynamic-expansion branch in
+    /// <see cref="ResolveEnabledSources(string)"/> stays discoverable.
+    /// </summary>
+    internal const string ClaudeCodeAlias = "claude-code";
+
+    /// <summary>
+    /// Relative path from the home directory to the Claude Code plugins root
+    /// whose subdirectories each contain a <c>skills/</c> folder for an
+    /// installed marketplace.
+    /// </summary>
+    private static readonly string ClaudeCodeMarketplacesRelativePath =
+        Path.Combine(".claude", "plugins", "marketplaces");
 
     /// <summary>
     /// Ordered list of external skill sources. Precedence follows list order —
@@ -59,6 +79,13 @@ public sealed class ExternalSkillsConfig
                 ? ResolveWellKnownPaths(source.WellKnown, homeDirectory)
                 : source.Path is not null ? new[] { source.Path } : Array.Empty<string>();
 
+            if (string.Equals(source.WellKnown, ClaudeCodeAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                var marketplacePaths = EnumerateClaudeCodeMarketplaceSkillPaths(homeDirectory);
+                if (marketplacePaths.Count > 0)
+                    candidatePaths = candidatePaths.Concat(marketplacePaths).ToList();
+            }
+
             var existingPaths = new List<string>();
             foreach (var candidate in candidatePaths)
             {
@@ -79,6 +106,39 @@ public sealed class ExternalSkillsConfig
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Enumerates the live <c>skills/</c> directories of every Claude Code plugin
+    /// marketplace installed under <c>~/.claude/plugins/marketplaces/</c>. Returns
+    /// an empty list if the marketplaces root doesn't exist or if no installed
+    /// marketplace has a <c>skills/</c> subdirectory. The filesystem is the source
+    /// of truth — we intentionally don't parse <c>known_marketplaces.json</c> or
+    /// <c>installed_plugins.json</c> so Netclaw stays decoupled from Claude Code's
+    /// plugin metadata format. The version cache at <c>plugins/cache/</c> is
+    /// skipped because Claude Code itself reads the live marketplace path at
+    /// runtime; scanning the cache would duplicate entries.
+    /// </summary>
+    private static IReadOnlyList<string> EnumerateClaudeCodeMarketplaceSkillPaths(string homeDirectory)
+    {
+        var marketplacesRoot = Path.Combine(homeDirectory, ClaudeCodeMarketplacesRelativePath);
+        if (!Directory.Exists(marketplacesRoot))
+            return Array.Empty<string>();
+
+        try
+        {
+            return Directory.EnumerateDirectories(marketplacesRoot)
+                .Select(d => Path.Combine(d, "skills"))
+                .ToList();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Array.Empty<string>();
+        }
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -87,6 +87,7 @@ public sealed class ExternalSkillsConfig
             }
 
             var existingPaths = new List<string>();
+            var seenPaths = new HashSet<string>(GetPathComparer());
             foreach (var candidate in candidatePaths)
             {
                 if (string.IsNullOrWhiteSpace(candidate))
@@ -96,7 +97,8 @@ public sealed class ExternalSkillsConfig
                 if (!Directory.Exists(fullPath))
                     continue;
 
-                existingPaths.Add(fullPath);
+                if (seenPaths.Add(fullPath))
+                    existingPaths.Add(fullPath);
             }
 
             if (existingPaths.Count == 0)
@@ -124,16 +126,14 @@ public sealed class ExternalSkillsConfig
         if (!Directory.Exists(marketplacesRoot))
             return Array.Empty<string>();
 
-        try
-        {
-            return Directory.EnumerateDirectories(marketplacesRoot)
-                .Select(d => Path.Combine(d, "skills"))
-                .ToList();
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return Array.Empty<string>();
-        }
+        var pathComparer = GetPathComparer();
+
+        return Directory.EnumerateDirectories(marketplacesRoot)
+            .Select(d => Path.GetFullPath(Path.Combine(d, "skills")))
+            .Where(Directory.Exists)
+            .Distinct(pathComparer)
+            .OrderBy(p => p, pathComparer)
+            .ToList();
     }
 
     /// <summary>
@@ -162,6 +162,13 @@ public sealed class ExternalSkillsConfig
                     firstExisting = path;
                     break;
                 }
+            }
+
+            if (firstExisting is null
+                && string.Equals(alias, ClaudeCodeAlias, StringComparison.Ordinal)
+                && EnumerateClaudeCodeMarketplaceSkillPaths(homeDirectory) is { Count: > 0 } marketplacePaths)
+            {
+                firstExisting = marketplacePaths[0];
             }
 
             if (firstExisting is not null)
@@ -201,6 +208,9 @@ public sealed class ExternalSkillsConfig
 
         return Array.Empty<string>();
     }
+
+    private static StringComparer GetPathComparer()
+        => OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -23,7 +23,7 @@ public sealed class ExternalSkillsConfig
     /// </remarks>
     private static readonly (string Alias, string DisplayName, string[] RelativePaths, bool DefaultAllowSymlinks)[] WellKnownCatalog =
     [
-        ("claude-code", "Claude Code",
+        (ClaudeCodeAlias, "Claude Code",
             new[] { Path.Combine(".claude", "skills") },
             true),
         ("open-code", "Open Code",
@@ -109,15 +109,14 @@ public sealed class ExternalSkillsConfig
     }
 
     /// <summary>
-    /// Enumerates the live <c>skills/</c> directories of every Claude Code plugin
-    /// marketplace installed under <c>~/.claude/plugins/marketplaces/</c>. Returns
-    /// an empty list if the marketplaces root doesn't exist or if no installed
-    /// marketplace has a <c>skills/</c> subdirectory. The filesystem is the source
-    /// of truth — we intentionally don't parse <c>known_marketplaces.json</c> or
-    /// <c>installed_plugins.json</c> so Netclaw stays decoupled from Claude Code's
-    /// plugin metadata format. The version cache at <c>plugins/cache/</c> is
-    /// skipped because Claude Code itself reads the live marketplace path at
-    /// runtime; scanning the cache would duplicate entries.
+    /// Enumerates the live <c>skills/</c> directories of every Claude Code
+    /// plugin marketplace installed under <c>~/.claude/plugins/marketplaces/</c>.
+    /// The filesystem is the source of truth — we intentionally don't parse
+    /// <c>known_marketplaces.json</c> or <c>installed_plugins.json</c> so
+    /// Netclaw stays decoupled from Claude Code's plugin metadata format. The
+    /// version cache at <c>plugins/cache/</c> is skipped because Claude Code
+    /// itself reads the live marketplace path at runtime; scanning the cache
+    /// would duplicate entries.
     /// </summary>
     private static IReadOnlyList<string> EnumerateClaudeCodeMarketplaceSkillPaths(string homeDirectory)
     {
@@ -132,10 +131,6 @@ public sealed class ExternalSkillsConfig
                 .ToList();
         }
         catch (UnauthorizedAccessException)
-        {
-            return Array.Empty<string>();
-        }
-        catch (DirectoryNotFoundException)
         {
             return Array.Empty<string>();
         }

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -14,17 +14,20 @@ public sealed class ExternalSkillsConfig
     /// primary (used for display/validation); all existing paths are scanned.
     /// </summary>
     /// <remarks>
-    /// The <c>claude-code</c> alias is also expanded at resolution time by
-    /// <see cref="ResolveEnabledSources(string)"/> to include every installed
-    /// plugin marketplace under <c>~/.claude/plugins/marketplaces/*/skills/</c>,
-    /// so marketplace skills (e.g. the dotnet-skills plugin) show up without
-    /// needing a separate configured source. That expansion is dynamic and
-    /// lives outside the static catalog.
+    /// The <c>claude-code</c> alias includes both <c>~/.claude/skills/</c> and
+    /// <c>~/.claude/commands/</c>. Claude Code treats command markdown files as
+    /// skills, so Netclaw must scan both locations. The alias is also expanded
+    /// at resolution time by <see cref="ResolveEnabledSources(string)"/> to
+    /// include every installed plugin marketplace under
+    /// <c>~/.claude/plugins/marketplaces/*/skills/</c>, so marketplace skills
+    /// (e.g. the dotnet-skills plugin) show up without needing a separate
+    /// configured source. That marketplace expansion is dynamic and lives
+    /// outside the static catalog.
     /// </remarks>
     private static readonly (string Alias, string DisplayName, string[] RelativePaths, bool DefaultAllowSymlinks)[] WellKnownCatalog =
     [
         (ClaudeCodeAlias, "Claude Code",
-            new[] { Path.Combine(".claude", "skills") },
+            new[] { Path.Combine(".claude", "skills"), Path.Combine(".claude", "commands") },
             true),
         ("open-code", "Open Code",
             new[] { Path.Combine(".open-code", "skills") },

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -47,7 +47,8 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
         TryCreateWatcher(_paths.SkillsDirectory, "native");
 
         // Watch each external source directory. A single source may cover multiple
-        // paths (e.g. claude-code = ~/.claude/skills + ~/.claude/commands).
+        // paths (e.g. claude-code = ~/.claude/skills plus one path per installed
+        // plugin marketplace under ~/.claude/plugins/marketplaces/*/skills/).
         foreach (var source in _externalSources)
         {
             foreach (var path in source.Paths)

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -47,8 +47,9 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
         TryCreateWatcher(_paths.SkillsDirectory, "native");
 
         // Watch each external source directory. A single source may cover multiple
-        // paths (e.g. claude-code = ~/.claude/skills plus one path per installed
-        // plugin marketplace under ~/.claude/plugins/marketplaces/*/skills/).
+        // paths (e.g. claude-code = ~/.claude/skills + ~/.claude/commands + one
+        // path per installed plugin marketplace under
+        // ~/.claude/plugins/marketplaces/*/skills/).
         foreach (var source in _externalSources)
         {
             foreach (var path in source.Paths)


### PR DESCRIPTION
## Summary

- `ExternalSkillsConfig.ResolveEnabledSources` now resolves the `claude-code` alias to all of the following:
  - `~/.claude/skills`
  - `~/.claude/commands`
  - every installed marketplace under `~/.claude/plugins/marketplaces/*/skills/`
- Restores `~/.claude/commands` support and handles it correctly: command markdown files without YAML frontmatter are accepted **only** for the Claude commands path, matching current Claude Code behavior where commands are treated as skills.
- Keeps deterministic source resolution and probe behavior: marketplace paths are normalized, deduped, and sorted for stable precedence; `ProbeWellKnownSources` now detects marketplace-only Claude installs.

## Why

Two grounding issues needed to be solved together:

1. Marketplace skills (e.g. dotnet-skills) were missing from Netclaw's resolved external sources, so agents could not see highly relevant C#/.NET skills.
2. Dropping `~/.claude/commands` was incorrect now that Claude Code treats command files as skills. Netclaw should mirror that behavior, but without globally relaxing flat-file validation.

## Implementation notes

- `claude-code` well-known catalog includes both `~/.claude/skills` and `~/.claude/commands`.
- Marketplace enumeration remains dynamic and scoped to `claude-code` only.
- Compatibility parsing for frontmatterless flat `.md` files is enabled only when scanning a resolved path that is exactly `~/.claude/commands`.
  - Non-commands paths still require valid YAML frontmatter for flat files.
- `ProbeWellKnownSources` now aligns with resolution behavior and can detect marketplace-only setups.

## Test plan

- [x] `dotnet test src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj --filter FullyQualifiedName~ExternalSkillsConfigTests` — 17 passing
- [x] `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter 'FullyQualifiedName~SkillScannerTests|FullyQualifiedName~SkillRegistryTests'` — 59 passing
- [x] `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --filter 'FullyQualifiedName~SystemSkillSyncServiceTests|FullyQualifiedName~SessionCatalogServiceTests'` — 32 passing
- [x] `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter 'FullyQualifiedName~ExternalSkillsStepViewModelTests|FullyQualifiedName~WizardConfigBuilderTests'` — 28 passing
- [x] `dotnet build` — clean, 0 warnings, 0 errors
- [x] `dotnet slopwatch analyze` — clean
- [ ] Live daemon restart verification: ensure commands load as skills and marketplace inventory appears as expected

## New / updated tests

`ExternalSkillsConfigTests` now covers:

- Claude resolves `skills + commands` when no marketplaces are present
- Commands + marketplaces resolve together
- Stable deterministic ordering across skills/commands/marketplaces
- Commands surfaced by probe when skills dir is missing
- Marketplace-only probe detection

`SkillScannerTests` now covers:

- frontmatterless flat-file acceptance in compatibility mode
- rejection of frontmatterless flat files outside compatibility mode
- heading-based display/description inference
- empty-file rejection in compatibility mode
- `ScanAndMerge` behavior: compatibility applies to `~/.claude/commands` but not arbitrary external paths

## Related follow-ups (milestone 0.12)

Filed separately — these aren't in this PR:

- #591 — System skill feed returns 404 for 5 of 6 manifest entries
- #592 — `SkillIndexEnrichmentService` fails silently, trigger phrase cache empty
- #593 — `netclaw stats` `skills_loaded` resets on daemon restart — read from `daily_stats` instead
- #594 — `skills_loaded` counter ignores agent-initiated `skill_load` tool calls
