### PR TITLE
fix(ci): pin skills feed deploy to production branch

### DIFF
--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -63,7 +63,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy feeds/ --project-name=netclaw-feeds
+          # Pin --branch=dev so release-tag builds (detached HEAD) still
+          # deploy to the production branch instead of a preview alias.
+          # Without this, wrangler infers the branch name from git state
+          # and tag builds land on head.netclaw-feeds.pages.dev while
+          # feeds.netclaw.dev stays frozen on the last dev-branch deploy.
+          command: pages deploy feeds/ --project-name=netclaw-feeds --branch=dev
 
       - name: Validate R2 uploads
         run: |
@@ -73,10 +78,35 @@ jobs:
           m = json.load(open('feeds/skills/.system/manifest.json'))
           print(m['skills'][0]['url'])
           ")
-          echo "Validating: $url"
+          echo "Validating R2 URL: $url"
           status=$(curl -sSL -o /dev/null -w "%{http_code}" "$url")
           if [ "$status" != "200" ]; then
             echo "Validation failed: $url returned HTTP $status" >&2
             exit 1
           fi
-          echo "Validation passed"
+          echo "R2 validation passed"
+
+      - name: Validate custom-domain manifest propagation
+        run: |
+          # Confirm that feeds.netclaw.dev (the production custom domain) is
+          # actually serving the manifest we just generated — not a stale one
+          # from a preview deployment. Fails loudly if Pages routing is wrong.
+          expected_updated_at=$(python3 -c "
+          import json
+          print(json.load(open('feeds/skills/.system/manifest.json'))['updatedAt'])
+          ")
+          for attempt in 1 2 3 4 5 6; do
+            live_updated_at=$(curl -sSL --max-time 15 \
+              https://feeds.netclaw.dev/skills/.system/manifest.json \
+              | python3 -c "import json,sys; print(json.load(sys.stdin).get('updatedAt',''))" \
+              2>/dev/null || true)
+            echo "Attempt $attempt: live=$live_updated_at expected=$expected_updated_at"
+            if [ "$live_updated_at" = "$expected_updated_at" ]; then
+              echo "Custom-domain propagation confirmed"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Custom-domain validation failed: feeds.netclaw.dev is still serving a stale manifest" >&2
+          echo "This usually means the Pages deploy landed on a preview branch instead of production." >&2
+          exit 1


### PR DESCRIPTION
## Summary

Fixes #591. The system skill feed has been serving a stale 2026-03-20 manifest for two releases, causing 5 of 6 skills to 404 on every daemon sync.

**Root cause.** `publish_skills.yml` runs `wrangler pages deploy feeds/ --project-name=netclaw-feeds` without pinning a branch. On release-tag builds the runner is in detached HEAD, so wrangler infers a branch name of `head` and ships the new manifest to the `head.netclaw-feeds.pages.dev` preview alias instead of the production custom domain. Meanwhile `feeds.netclaw.dev` has been frozen on the last successful `dev`-branch dispatch, advertising R2 keys for skills that were renamed/removed and never existed under those paths.

Evidence during investigation:
- `head.netclaw-feeds.pages.dev/skills/.system/manifest.json` → `updatedAt` 2026-04-03, correct 5 skills
- `feeds.netclaw.dev/skills/.system/manifest.json` → `updatedAt` 2026-03-20, pre-rename names
- R2: `netclaw-memory/1.1.0/SKILL.md` → 200, `netclaw-diagnostics/0.6.0/SKILL.md` → 404

## Changes

- Pin `--branch=dev` on `wrangler pages deploy` so tag-triggered runs still hit the production branch regardless of git checkout state.
- Add a post-deploy propagation check that polls `feeds.netclaw.dev/skills/.system/manifest.json` and asserts the `updatedAt` matches the freshly generated manifest. Fails loudly with a clear routing hint if it does not. The existing R2 spot-check only validated `skills.netclaw.dev`, which is why this regression sailed through unnoticed.

## Operator action after merge

Once this lands, manually dispatch the workflow from `dev` to republish and unstick the live feed:

```
gh workflow run publish_skills.yml --ref dev
```

Daemons will self-heal on their next `SystemSkillSyncService` rebuild.

## Follow-up

#605 tracks surfacing sync failures louder on the daemon side (doctor check, startup banner, stats) so the next time the feed breaks it is not buried in `daemon.log`.

## Test plan

- [ ] Merge, then `gh workflow run publish_skills.yml --ref dev`
- [ ] Confirm `curl https://feeds.netclaw.dev/skills/.system/manifest.json` shows a fresh `updatedAt` and only the current 5 skill names
- [ ] Spot-check a non-`skill-authoring` URL from the new manifest returns 200
- [ ] Restart a daemon and verify `.sync-state.json` picks up all 5 skills without 404s