### PR TITLE
fix(slack): attachment contract parity + hardening (#604 follow-ups)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.9.0"
+  version: "1.10.0"
 ---
 
 # Netclaw Operations
@@ -142,6 +142,43 @@ Webhook rejected route={Route} reason={Reason} remote_ip={RemoteIp}
 Rejection paths only log + increment counters — they do NOT fire outbound
 operational notifications, so bad or adversarial traffic does not spam the
 configured notification target.
+
+## Inbound Attachments
+
+When a user sends a file in Slack, Netclaw runs the attachment through an
+ingress pipeline before it reaches the LLM:
+
+1. **Policy gate** — checks audience, file category, and per-message file count
+   against `ChannelAttachmentPolicy`
+2. **Size gate** — rejects files above the per-audience byte limit
+3. **Download** — fetches from Slack's private file API with bot-token auth
+4. **Content scan** — runs the configured `IContentScanner` (e.g. antivirus)
+5. **Inbox write** — saves to `~/.netclaw/sessions/{session-id}/inbox/`
+6. **Announcement line** — appends `[attachment]` text to the user turn
+
+The `[attachment]` line format is:
+```
+[attachment] name="..." mime="..." size=N path="inbox/..." inlined="true|false"
+```
+
+`inlined="true"` means the file bytes were forwarded to the model as
+`DataContent` (images and PDFs on vision-capable models). `inlined="false"`
+means the model only sees the path reference.
+
+**Historical thread backfill** follows the same download/scan flow for all
+file types (not just images) — PDFs and other documents from prior thread
+messages are included.
+
+**When attachment ingress fails**, Netclaw posts a stable user-facing message
+(e.g. "Couldn't download `file.pdf` — please try again later.") and logs the
+full exception internally. Exception details are **never** forwarded to Slack.
+
+| Symptom | Check |
+|---------|-------|
+| File rejected before download | audience/category policy gate; check `ChannelAttachmentPolicy` config |
+| Download timeout | bot token valid? Slack network reachable? check `daemon-{date}.log` |
+| Content scan rejection | `netclaw status` scanner section; check scan config |
+| Inbox write failure | disk space? permissions on `~/.netclaw/sessions/`? |
 
 ## Diagnostics
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -477,6 +477,49 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         Assert.Empty(Directory.GetFiles(inboxDir));
     }
 
+    [Fact]
+    public async Task Download_failure_posts_stable_message_without_raw_exception_detail()
+    {
+        // Arrange: HTTP handler throws an exception whose message contains an
+        // internal detail (IP address) that must not reach the Slack user.
+        const string internalDetail = "192.168.99.1:443";
+        _httpHandler.RespondWithException(
+            new HttpRequestException($"Network unreachable: {internalDetail}"));
+        var gateway = BuildGateway("slack-gw-dl-error");
+
+        var files = new List<SlackFileReference>
+        {
+            new("F_DL_ERR", "report.pdf", "application/pdf", 1024,
+                "https://files.slack.com/files-pri/T1234-F_DL_ERR/report.pdf")
+        };
+
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("D_DL_ERR:9000"),
+            ChannelId: new SlackChannelId("D_DL_ERR"),
+            ThreadTs: null,
+            EventTs: new SlackEventTs("9000.1"),
+            UserId: new SlackUserId("U_HUMAN"),
+            BotId: null,
+            Text: "here",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: true,
+            Files: files));
+
+        // A user-facing rejection reply for report.pdf should be posted.
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Contains(_replyClient.PostedMessages,
+                m => m.Text.Contains("report.pdf", StringComparison.Ordinal));
+        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+
+        // The raw exception message (internal network detail) must not be
+        // surfaced to the user.
+        Assert.DoesNotContain(_replyClient.PostedMessages,
+            m => m.Text.Contains(internalDetail, StringComparison.Ordinal));
+    }
+
     // ── Test doubles ──────────────────────────────────────────────────────
 
     private sealed class ConfigurableFakeSlackFileHandler : DelegatingHandler
@@ -484,6 +527,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         private int _requestCount;
         private string _contentType = "image/png";
         private byte[] _bytes = FakePngBytes;
+        private Exception? _exceptionToThrow;
 
         public int RequestCount => _requestCount;
 
@@ -491,12 +535,22 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         {
             _contentType = contentType;
             _bytes = bytes;
+            _exceptionToThrow = null;
+        }
+
+        public void RespondWithException(Exception exception)
+        {
+            _exceptionToThrow = exception;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _requestCount);
+
+            if (_exceptionToThrow is not null)
+                return Task.FromException<HttpResponseMessage>(_exceptionToThrow);
+
             var response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent(_bytes)

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -480,8 +480,8 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
     [Fact]
     public async Task Download_failure_posts_stable_message_without_raw_exception_detail()
     {
-        // Arrange: HTTP handler throws an exception whose message contains an
-        // internal detail (IP address) that must not reach the Slack user.
+        // Internal network details (IPs, hostnames) in exception messages must
+        // not reach Slack users — only a stable generic message is safe to show.
         const string internalDetail = "192.168.99.1:443";
         _httpHandler.RespondWithException(
             new HttpRequestException($"Network unreachable: {internalDetail}"));
@@ -507,15 +507,12 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
             IsDirectMessage: true,
             Files: files));
 
-        // A user-facing rejection reply for report.pdf should be posted.
         await AwaitAssertAsync(() =>
         {
             Assert.Contains(_replyClient.PostedMessages,
                 m => m.Text.Contains("report.pdf", StringComparison.Ordinal));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        // The raw exception message (internal network detail) must not be
-        // surfaced to the user.
         Assert.DoesNotContain(_replyClient.PostedMessages,
             m => m.Text.Contains(internalDetail, StringComparison.Ordinal));
     }

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
@@ -1,0 +1,69 @@
+using Netclaw.Channels.Slack;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+/// <summary>
+/// Unit tests for <see cref="SlackThreadBindingActor.EscapeQuoted"/> and
+/// <see cref="SlackThreadBindingActor.BuildAttachmentLine"/> covering
+/// control-character sanitization and quote/backslash escaping.
+/// </summary>
+public sealed class SlackAttachmentLineTests
+{
+    [Theory]
+    [InlineData("normal.pdf", "normal.pdf")]
+    [InlineData("file\nname.pdf", "file name.pdf")]
+    [InlineData("file\r\nname.pdf", "file  name.pdf")]
+    [InlineData("file\tname.pdf", "file name.pdf")]
+    [InlineData("inject\u0001\u0002control.pdf", "inject  control.pdf")]
+    public void EscapeQuoted_normalizes_control_chars_to_spaces(string input, string expected)
+    {
+        var result = SlackThreadBindingActor.EscapeQuoted(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void EscapeQuoted_escapes_backslash_and_double_quote()
+    {
+        Assert.Equal("has \\\"quotes\\\"", SlackThreadBindingActor.EscapeQuoted("has \"quotes\""));
+        Assert.Equal("has \\\\backslash", SlackThreadBindingActor.EscapeQuoted("has \\backslash"));
+    }
+
+    [Fact]
+    public void EscapeQuoted_passes_through_normal_text_unchanged()
+    {
+        const string plain = "report-Q4_2025 final.pdf";
+        Assert.Equal(plain, SlackThreadBindingActor.EscapeQuoted(plain));
+    }
+
+    [Fact]
+    public void BuildAttachmentLine_with_hostile_name_produces_single_parseable_line()
+    {
+        var line = SlackThreadBindingActor.BuildAttachmentLine(
+            name: "evil\nfile\r\nname.pdf",
+            mimeType: "application/pdf",
+            size: 1234,
+            relativePath: "inbox/evil.pdf",
+            inlined: false,
+            note: null);
+
+        Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", line, StringComparison.Ordinal);
+        Assert.StartsWith("[attachment]", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildAttachmentLine_with_hostile_note_produces_single_parseable_line()
+    {
+        var line = SlackThreadBindingActor.BuildAttachmentLine(
+            name: "ok.pdf",
+            mimeType: "application/pdf",
+            size: 100,
+            relativePath: "inbox/ok.pdf",
+            inlined: false,
+            note: "some\nnote with\r\nnewlines");
+
+        Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", line, StringComparison.Ordinal);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
@@ -36,34 +36,22 @@ public sealed class SlackAttachmentLineTests
         Assert.Equal(plain, SlackThreadBindingActor.EscapeQuoted(plain));
     }
 
-    [Fact]
-    public void BuildAttachmentLine_with_hostile_name_produces_single_parseable_line()
+    [Theory]
+    [InlineData("evil\nfile\r\nname.pdf", "application/pdf", null)]
+    [InlineData("ok.pdf", "application/pdf", "some\nnote with\r\nnewlines")]
+    public void BuildAttachmentLine_with_hostile_metadata_produces_single_parseable_line(
+        string name, string mimeType, string? note)
     {
         var line = SlackThreadBindingActor.BuildAttachmentLine(
-            name: "evil\nfile\r\nname.pdf",
-            mimeType: "application/pdf",
+            name: name,
+            mimeType: mimeType,
             size: 1234,
-            relativePath: "inbox/evil.pdf",
+            relativePath: "inbox/test.pdf",
             inlined: false,
-            note: null);
+            note: note);
 
         Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
         Assert.DoesNotContain("\r", line, StringComparison.Ordinal);
         Assert.StartsWith("[attachment]", line, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void BuildAttachmentLine_with_hostile_note_produces_single_parseable_line()
-    {
-        var line = SlackThreadBindingActor.BuildAttachmentLine(
-            name: "ok.pdf",
-            mimeType: "application/pdf",
-            size: 100,
-            relativePath: "inbox/ok.pdf",
-            inlined: false,
-            note: "some\nnote with\r\nnewlines");
-
-        Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
-        Assert.DoesNotContain("\r", line, StringComparison.Ordinal);
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -90,6 +90,47 @@ public sealed class SlackThreadHistoryFetcherTests
     }
 
     [Fact]
+    public async Task Historical_non_image_files_are_downloaded_and_included()
+    {
+        // Verify that PDFs and other non-image attachments in thread history are
+        // no longer hard-filtered to image/* — they should be downloaded and
+        // returned as DataContent just like images.
+        _replies.Set("C1", "2000.0", null, new ConversationMessagesResponse
+        {
+            Messages =
+            [
+                new MessageEvent { Ts = "2000.0", User = "U1", Text = "root" },
+                new MessageEvent
+                {
+                    Ts = "2000.1",
+                    User = "U2",
+                    Text = "check this report",
+                    Files =
+                    [
+                        new SlackNet.File
+                        {
+                            Id = "F_PDF",
+                            Name = "report.pdf",
+                            Mimetype = "application/pdf",
+                            Size = 3,
+                            UrlPrivateDownload = "https://files.slack.com/fake/report.pdf"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var result = await CreateFetcher().FetchThreadHistoryAsync(
+            new SessionId("C1/2000.0"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.Count);
+        var messageWithPdf = result.First(r =>
+            r.Contents.OfType<DataContent>().Any());
+        Assert.Contains(messageWithPdf.Contents,
+            c => c is DataContent d && d.MediaType == "application/pdf");
+    }
+
+    [Fact]
     public async Task Paginates_through_all_pages()
     {
         _replies.Set("C1", "1000.0", null, new ConversationMessagesResponse

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -582,6 +582,21 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     /// </summary>
     internal static string EscapeQuoted(string value)
     {
+        // Fast path: skip allocation when no special characters are present.
+        // This covers the common case of ordinary filenames.
+        var needsProcessing = false;
+        foreach (var c in value)
+        {
+            if (c < ' ' || c == '\\' || c == '"')
+            {
+                needsProcessing = true;
+                break;
+            }
+        }
+
+        if (!needsProcessing)
+            return value;
+
         var sb = new StringBuilder(value.Length + 8);
         foreach (var c in value)
         {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -442,7 +442,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 "slack_attachment_rejected name={Name} mime={Mime} reason=download-failed",
                 file.Name, file.MimeType);
             return new AttachmentIngestResult.Rejected(
-                $"Couldn't download `{file.Name}`: {ex.Message}.");
+                $"Couldn't download `{file.Name}` — please try again later.");
         }
 
         if (bytes.Length == 0)
@@ -468,7 +468,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 "slack_attachment_rejected name={Name} mime={Mime} reason=scan-exception",
                 file.Name, file.MimeType);
             return new AttachmentIngestResult.Rejected(
-                $"Couldn't scan `{file.Name}`: {ex.Message}.");
+                $"Couldn't scan `{file.Name}` — please try again later.");
         }
 
         if (!scanResult.IsAllowed)
@@ -515,7 +515,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 "slack_attachment_rejected name={Name} reason=inbox-write-failed",
                 file.Name);
             return new AttachmentIngestResult.Rejected(
-                $"Couldn't save `{file.Name}` to disk: {ex.Message}.");
+                $"Couldn't save `{file.Name}` — please try again later.");
         }
 
         // Decide inlining based on model modalities and category.
@@ -554,7 +554,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     /// Formats a single <c>[attachment]</c> announcement line in the
     /// canonical cross-channel shape defined in netclaw-input-adapters.
     /// </summary>
-    private static string BuildAttachmentLine(
+    internal static string BuildAttachmentLine(
         string name,
         string mimeType,
         long size,
@@ -574,9 +574,28 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         return sb.ToString();
     }
 
-    private static string EscapeQuoted(string value) =>
-        value.Replace("\\", "\\\\", StringComparison.Ordinal)
-             .Replace("\"", "\\\"", StringComparison.Ordinal);
+    /// <summary>
+    /// Escapes a metadata value for safe embedding inside a double-quoted
+    /// attribute on an attachment announcement line. Control characters
+    /// (including CR/LF) are replaced with spaces so hostile filenames
+    /// cannot embed newlines in the single-line format.
+    /// </summary>
+    internal static string EscapeQuoted(string value)
+    {
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var c in value)
+        {
+            if (c < ' ')
+                sb.Append(' ');
+            else if (c == '\\')
+                sb.Append("\\\\");
+            else if (c == '"')
+                sb.Append("\\\"");
+            else
+                sb.Append(c);
+        }
+        return sb.ToString();
+    }
 
     private static string FormatBytes(long size)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -145,8 +145,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         {
             var downloadableFiles = message.Files
                 .Where(f => f.Mimetype is not null
-                    && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate))
-                .ToList();
+                    && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate));
 
             var downloadTasks = downloadableFiles.Select(file => DownloadAndScanFileAsync(file, cancellationToken));
             var results = await Task.WhenAll(downloadTasks);

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -143,13 +143,12 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 
         if (message.Files is { Count: > 0 })
         {
-            var imageFiles = message.Files
+            var downloadableFiles = message.Files
                 .Where(f => f.Mimetype is not null
-                    && f.Mimetype.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
                     && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate))
                 .ToList();
 
-            var downloadTasks = imageFiles.Select(file => DownloadAndScanFileAsync(file, cancellationToken));
+            var downloadTasks = downloadableFiles.Select(file => DownloadAndScanFileAsync(file, cancellationToken));
             var results = await Task.WhenAll(downloadTasks);
 
             foreach (var result in results)


### PR DESCRIPTION
## Summary

Closes Aaronontheweb/netclaw#604. Lands all five follow-up items deferred after PR #601.

- **Backfill parity** — `SlackThreadHistoryFetcher` no longer hard-filters to `image/*`. Historical PDFs, DOCX files, and other non-image attachments are now downloaded and scanned during thread history hydration, consistent with live ingress.
- **Error hygiene** — `SlackThreadBindingActor` replaces raw `ex.Message` in all three user-facing `Rejected` paths (download timeout/failure, scan exception, inbox-write failure) with stable messages. Exception details stay in structured logs only.
- **Attachment-line safety** — `EscapeQuoted` now strips control characters (CR, LF, tabs, and all chars < 0x20) in addition to escaping `\` and `"`. Hostile filenames can no longer embed newlines in the `[attachment]` announcement line. `BuildAttachmentLine` and `EscapeQuoted` are promoted to `internal` for unit testability.
- **Regression tests** — four new test cases: historical non-image backfill, `EscapeQuoted` control-char suite (5 inline inputs), `BuildAttachmentLine` hostile-name/note assertions, download-failure stable-message guard.
- **Ops skill sync** — `netclaw-operations` v1.10.0 adds an "Inbound Attachments" section covering the attachment line format, backfill behavior, failure hygiene, and a diagnostic table.

## Test plan

- [ ] `dotnet test src/Netclaw.Actors.Tests` — all 23 Slack tests pass
- [ ] `dotnet slopwatch analyze` — 0 new violations
- [ ] `Historical_non_image_files_are_downloaded_and_included` — PDF backfill works
- [ ] `Download_failure_posts_stable_message_without_raw_exception_detail` — no IP/stack in Slack reply
- [ ] `EscapeQuoted_normalizes_control_chars_to_spaces` — newlines in filenames become spaces
- [ ] `BuildAttachmentLine_with_hostile_name_produces_single_parseable_line` — announcement stays single-line