### PR TITLE
feat(providers): session-sticky LLM routing via X-Session-Id header

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2186,7 +2186,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             forceNoTools,
             _activeCallId);
 
-        _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _activeLlmCts!.Token);
+        _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _sessionId.Value, _activeLlmCts!.Token);
     }
 
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Akka.Actor;
 using Microsoft.Extensions.AI;
+using Netclaw.Configuration;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace Netclaw.Actors.Sessions.Pipelines;
@@ -17,8 +18,15 @@ internal static class SessionLlmInvoker
         ChatOptions? options,
         IActorRef self,
         long callId,
+        string sessionId,
         CancellationToken cancellationToken)
     {
+        // Set session affinity so the HTTP-layer DelegatingHandler adds an
+        // X-Session-Id header, keeping self-hosted LLM requests pinned to
+        // the same backend for KV cache reuse. Set here (not in the actor)
+        // so sidecar calls (compaction, title gen) that bypass this invoker
+        // naturally omit the header and round-robin across backends.
+        SessionAffinityContext.SessionId = sessionId;
         try
         {
             var response = await StreamAsync(client, messages, options, self, callId, cancellationToken);
@@ -34,6 +42,10 @@ internal static class SessionLlmInvoker
         catch (Exception ex)
         {
             self.Tell(new LlmCallFailed { Cause = ex, CallId = callId });
+        }
+        finally
+        {
+            SessionAffinityContext.SessionId = null;
         }
     }
 

--- a/src/Netclaw.Configuration.Tests/SessionAffinityTests.cs
+++ b/src/Netclaw.Configuration.Tests/SessionAffinityTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Configuration;
+using Netclaw.Providers;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class SessionAffinityTests
+{
+    [Fact]
+    public async Task Handler_adds_header_when_context_is_set()
+    {
+        var captured = new CaptureHandler();
+        using var handler = new SessionAffinityHandler(captured);
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        SessionAffinityContext.SessionId = "C99999/1708531200.000100";
+        try
+        {
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions"),
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            SessionAffinityContext.SessionId = null;
+        }
+
+        Assert.NotNull(captured.LastRequest);
+        Assert.True(captured.LastRequest!.Headers.Contains(SessionAffinityHandler.HeaderName));
+        Assert.Equal("C99999/1708531200.000100",
+            captured.LastRequest.Headers.GetValues(SessionAffinityHandler.HeaderName).Single());
+    }
+
+    [Fact]
+    public async Task Handler_omits_header_when_context_is_null()
+    {
+        var captured = new CaptureHandler();
+        using var handler = new SessionAffinityHandler(captured);
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        SessionAffinityContext.SessionId = null;
+        await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions"),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured.LastRequest);
+        Assert.False(captured.LastRequest!.Headers.Contains(SessionAffinityHandler.HeaderName));
+    }
+
+    [Fact]
+    public async Task Context_flows_through_async_boundary()
+    {
+        var captured = new CaptureHandler();
+        using var handler = new SessionAffinityHandler(captured);
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        SessionAffinityContext.SessionId = "test/async-flow";
+        try
+        {
+            await Task.Yield();
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions"),
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            SessionAffinityContext.SessionId = null;
+        }
+
+        Assert.Equal("test/async-flow",
+            captured.LastRequest!.Headers.GetValues(SessionAffinityHandler.HeaderName).Single());
+    }
+
+    [Fact]
+    public async Task Header_flows_through_OpenAiCompatibleChatClient()
+    {
+        // Integration test: proves the AsyncLocal survives through the real
+        // OpenAiCompatibleChatClient → HttpClient → SessionAffinityHandler
+        // chain, which is the production code path.
+        var captured = new CaptureHandler(FakeOpenAiResponse);
+        using var handler = new SessionAffinityHandler(captured);
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        SessionAffinityContext.SessionId = "C12345/1708531200.000100";
+        try
+        {
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.User, "hello")
+            };
+            await client.GetResponseAsync(messages, cancellationToken: TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            SessionAffinityContext.SessionId = null;
+        }
+
+        Assert.NotNull(captured.LastRequest);
+        Assert.True(captured.LastRequest!.Headers.Contains(SessionAffinityHandler.HeaderName),
+            "X-Session-Id header should be present on the HTTP request sent by OpenAiCompatibleChatClient");
+        Assert.Equal("C12345/1708531200.000100",
+            captured.LastRequest.Headers.GetValues(SessionAffinityHandler.HeaderName).Single());
+    }
+
+    private static readonly string FakeOpenAiResponse = """
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "hello back" },
+                "finish_reason": "stop"
+            }],
+            "usage": { "prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15 }
+        }
+        """;
+
+    private sealed class CaptureHandler : HttpMessageHandler
+    {
+        private readonly string? _responseBody;
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public CaptureHandler(string? responseBody = null)
+        {
+            _responseBody = responseBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            if (_responseBody is not null)
+                response.Content = new StringContent(_responseBody, System.Text.Encoding.UTF8, "application/json");
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Netclaw.Configuration/SessionAffinityContext.cs
+++ b/src/Netclaw.Configuration/SessionAffinityContext.cs
@@ -1,0 +1,24 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Ambient context that carries a session identifier through async call chains
+/// so that an <see cref="SessionAffinityHandler"/> on the <see cref="HttpClient"/>
+/// pipeline can promote it to an HTTP header. This enables load-balancer session
+/// affinity for self-hosted inference servers — keeping the KV cache warm across
+/// turns within the same session.
+///
+/// Only main-model calls should set this. Sidecar calls (title generation, memory
+/// extraction, compaction observer) run from separate Akka message handlers with
+/// fresh execution contexts, so they naturally see <c>null</c> and round-robin
+/// across backends without competing for the main session's KV cache slot.
+/// </summary>
+public static class SessionAffinityContext
+{
+    private static readonly AsyncLocal<string?> Current = new();
+
+    public static string? SessionId
+    {
+        get => Current.Value;
+        set => Current.Value = value;
+    }
+}

--- a/src/Netclaw.Providers/ProviderPluginBase.cs
+++ b/src/Netclaw.Providers/ProviderPluginBase.cs
@@ -42,7 +42,7 @@ public abstract class ProviderPluginBase<TDescriptor> : ILlmProviderPlugin
     /// </summary>
     protected static HttpClient CreateLlmHttpClient(Uri? baseAddress = null)
     {
-        return new HttpClient
+        return new HttpClient(new SessionAffinityHandler())
         {
             BaseAddress = baseAddress,
             Timeout = TimeSpan.FromHours(1)

--- a/src/Netclaw.Providers/SessionAffinityHandler.cs
+++ b/src/Netclaw.Providers/SessionAffinityHandler.cs
@@ -1,0 +1,30 @@
+using Netclaw.Configuration;
+
+namespace Netclaw.Providers;
+
+/// <summary>
+/// <see cref="DelegatingHandler"/> that reads the ambient session ID from
+/// <see cref="SessionAffinityContext"/> and promotes it to an
+/// <c>X-Session-Id</c> HTTP header. When the ambient value is <c>null</c>
+/// (sidecar calls, startup probes), no header is added and the load
+/// balancer falls back to its default policy (typically round-robin).
+/// </summary>
+public sealed class SessionAffinityHandler : DelegatingHandler
+{
+    public const string HeaderName = "X-Session-Id";
+
+    public SessionAffinityHandler() : base(new HttpClientHandler()) { }
+
+    public SessionAffinityHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var sessionId = SessionAffinityContext.SessionId;
+        if (!string.IsNullOrEmpty(sessionId))
+            request.Headers.TryAddWithoutValidation(HeaderName, sessionId);
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Self-hosted inference servers behind a load balancer (e.g., Caddy round-robin across multiple GPUs) defeat KV cache reuse when consecutive requests from the same session land on different backends. Every turn and every tool-call follow-up pays full prompt processing cost as a cold start.

- Adds a `DelegatingHandler` on the `HttpClient` pipeline that promotes an ambient session ID to an `X-Session-Id` HTTP header
- The load balancer can hash on this header (`lb_policy header X-Session-Id` in Caddy) to pin same-session requests to the same backend GPU
- Works for **all providers** automatically — wired into `ProviderPluginBase.CreateLlmHttpClient()`
- Only main-model calls get the header; sidecar calls (compaction, title gen, memory extraction) bypass `SessionLlmInvoker` and naturally omit the header, round-robining across backends without competing for the main session's KV cache slot

### Architecture

```
SessionAffinityContext (AsyncLocal<string?>) — ambient context in Netclaw.Configuration
        ↓ set by SessionLlmInvoker.InvokeAsync()
SessionAffinityHandler (DelegatingHandler) — reads context, adds X-Session-Id header
        ↓ wired into every HttpClient via ProviderPluginBase
Load Balancer (Caddy) — hashes on X-Session-Id → same GPU
```

### Impact on managed providers

None. Anthropic, OpenAI, and OpenRouter handle routing server-side. The header is harmless — these APIs ignore unknown request headers. The feature only matters for self-hosted deployments (llama-server, vLLM, etc.) behind a load balancer.

Closes #609

## Test plan

- [x] `Handler_adds_header_when_context_is_set` — header present with correct value
- [x] `Handler_omits_header_when_context_is_null` — no header for sidecar calls
- [x] `Context_flows_through_async_boundary` — AsyncLocal survives Task.Yield
- [x] Full actor test suite passes (971 tests)
- [x] Slopwatch clean
- [ ] CI passes