### PR TITLE
feat(providers): parse llama.cpp timings for cache + performance metrics

### DIFF
--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -334,6 +334,18 @@ CREATE TABLE IF NOT EXISTS eval_results (
     details     TEXT,
     PRIMARY KEY (run_id, case_name, run_number)
 );
+CREATE TABLE IF NOT EXISTS eval_metrics (
+    run_id            TEXT NOT NULL REFERENCES eval_runs(run_id),
+    category          TEXT NOT NULL,
+    case_name         TEXT NOT NULL,
+    run_number        INTEGER NOT NULL,
+    input_tokens      INTEGER,
+    output_tokens     INTEGER,
+    cached_tokens     INTEGER,
+    prompt_ms         REAL,
+    predicted_tok_s   REAL,
+    PRIMARY KEY (run_id, case_name, run_number)
+);
 SQL
 }
 
@@ -347,6 +359,73 @@ store_result() {
     sqlite3 "$RESULTS_DB" \
         "INSERT INTO eval_results (run_id, category, case_name, run_number, prompt_used, passed, details)
          VALUES ('$RUN_ID', '$esc_category', '$case_name', $run_number, '$esc_prompt', $passed, '$esc_details');"
+}
+
+## Parses the [usage] line from stdout and stores performance metrics.
+## Called after each run_prompt / store_result pair.
+store_metrics() {
+    [[ -z "$RESULTS_DB" ]] && return
+    [[ ! -f "$STDOUT_FILE" ]] && return
+
+    local case_name="$1" run_number="$2"
+    local usage_line
+    usage_line=$(grep -o '\[usage\].*' "$STDOUT_FILE" 2>/dev/null | tail -1) || return 0
+
+    # Parse fields from: [usage] in=X out=Y total=Z cached=C prompt_ms=P tok_s=T
+    local input_tokens output_tokens cached_tokens prompt_ms tok_s
+    input_tokens=$(echo "$usage_line" | grep -oP 'in=\K[0-9]+' || echo "")
+    output_tokens=$(echo "$usage_line" | grep -oP 'out=\K[0-9]+' || echo "")
+    cached_tokens=$(echo "$usage_line" | grep -oP 'cached=\K[0-9]+' || echo "")
+    prompt_ms=$(echo "$usage_line" | grep -oP 'prompt_ms=\K[0-9.]+' || echo "")
+    tok_s=$(echo "$usage_line" | grep -oP 'tok_s=\K[0-9.]+' || echo "")
+
+    # Skip if no metrics found
+    [[ -z "$input_tokens" && -z "$cached_tokens" && -z "$prompt_ms" ]] && return 0
+
+    local esc_category="${CURRENT_CATEGORY//\'/\'\'}"
+    sqlite3 "$RESULTS_DB" \
+        "INSERT OR REPLACE INTO eval_metrics (run_id, category, case_name, run_number, input_tokens, output_tokens, cached_tokens, prompt_ms, predicted_tok_s)
+         VALUES ('$RUN_ID', '$esc_category', '$case_name', $run_number,
+                 ${input_tokens:-NULL}, ${output_tokens:-NULL}, ${cached_tokens:-NULL},
+                 ${prompt_ms:-NULL}, ${tok_s:-NULL});"
+}
+
+print_metrics_summary() {
+    [[ -z "$RESULTS_DB" ]] && return
+
+    local count
+    count=$(sqlite3 "$RESULTS_DB" "SELECT COUNT(*) FROM eval_metrics WHERE run_id='$RUN_ID' AND prompt_ms IS NOT NULL;" 2>/dev/null || echo "0")
+    [[ "$count" == "0" ]] && return
+
+    echo ""
+    echo "── Performance Metrics ──"
+    sqlite3 -header -column "$RESULTS_DB" <<SQL
+SELECT
+    category,
+    COUNT(*) as prompts,
+    CAST(ROUND(AVG(input_tokens)) AS INTEGER) as avg_input,
+    CAST(ROUND(AVG(output_tokens)) AS INTEGER) as avg_output,
+    CAST(ROUND(AVG(cached_tokens)) AS INTEGER) as avg_cached,
+    ROUND(AVG(prompt_ms), 1) as avg_prompt_ms,
+    ROUND(AVG(predicted_tok_s), 1) as avg_tok_s
+FROM eval_metrics
+WHERE run_id='$RUN_ID' AND input_tokens IS NOT NULL
+GROUP BY category;
+SQL
+
+    echo ""
+    sqlite3 -header -column "$RESULTS_DB" <<SQL
+SELECT
+    'overall' as scope,
+    COUNT(*) as prompts,
+    CAST(ROUND(AVG(prompt_ms)) AS INTEGER) as avg_prompt_ms,
+    CAST(ROUND(MIN(prompt_ms)) AS INTEGER) as min_prompt_ms,
+    CAST(ROUND(MAX(prompt_ms)) AS INTEGER) as max_prompt_ms,
+    ROUND(AVG(predicted_tok_s), 1) as avg_tok_s,
+    CAST(ROUND(AVG(cached_tokens)) AS INTEGER) as avg_cached
+FROM eval_metrics
+WHERE run_id='$RUN_ID' AND prompt_ms IS NOT NULL;
+SQL
 }
 
 finalize_db() {
@@ -615,6 +694,7 @@ run_case() {
         fi
 
         store_result "$case_name" "$run" "$prompt" "$passed" "$details"
+        store_metrics "$case_name" "$run"
     done
 
     local score
@@ -793,6 +873,8 @@ main() {
     echo ""
     echo "─────────────────────────────────────────────────"
     echo "Overall: $PASSED_CASES/$TOTAL_CASES cases passed ($overall_score%)"
+
+    print_metrics_summary
 
     if [[ -n "$RESULTS_DB" ]]; then
         echo "Results: $RESULTS_DB (run_id: $RUN_ID)"

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -384,7 +384,7 @@ store_metrics() {
 
     local esc_category="${CURRENT_CATEGORY//\'/\'\'}"
     sqlite3 "$RESULTS_DB" \
-        "INSERT OR REPLACE INTO eval_metrics (run_id, category, case_name, run_number, input_tokens, output_tokens, cached_tokens, prompt_ms, predicted_tok_s)
+        "INSERT INTO eval_metrics (run_id, category, case_name, run_number, input_tokens, output_tokens, cached_tokens, prompt_ms, predicted_tok_s)
          VALUES ('$RUN_ID', '$esc_category', '$case_name', $run_number,
                  ${input_tokens:-NULL}, ${output_tokens:-NULL}, ${cached_tokens:-NULL},
                  ${prompt_ms:-NULL}, ${tok_s:-NULL});"

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -114,6 +114,21 @@ public sealed record UsageOutput : SessionOutput
     /// are unavailable.
     /// </summary>
     public double? UsagePercent { get; init; }
+
+    // ── Server-side timing (llama.cpp timings object) ──
+
+    /// <summary>
+    /// Server-side prompt processing (prefill) time in milliseconds.
+    /// Sourced from llama.cpp <c>timings.prompt_ms</c>. Null when the
+    /// provider does not report timing data.
+    /// </summary>
+    public double? PromptMs { get; init; }
+
+    /// <summary>
+    /// Server-side output generation throughput in tokens per second.
+    /// Sourced from llama.cpp <c>timings.predicted_per_second</c>.
+    /// </summary>
+    public double? PredictedPerSecond { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -67,8 +67,12 @@ public sealed record SessionOutputDto
     public long? InputTokens { get; init; }
     public long? OutputTokens { get; init; }
     public long? TotalTokens { get; init; }
+    public long? CachedInputTokens { get; init; }
+    public long? ReasoningTokens { get; init; }
     public int? ContextWindowTokens { get; init; }
     public double? UsagePercent { get; init; }
+    public double? PromptMs { get; init; }
+    public double? PredictedPerSecond { get; init; }
 
     // Turn Completed
     public int? TurnNumber { get; init; }

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -68,8 +68,12 @@ public static class SessionOutputDtoMapper
             InputTokens = msg.InputTokens,
             OutputTokens = msg.OutputTokens,
             TotalTokens = msg.TotalTokens,
+            CachedInputTokens = msg.CachedInputTokens,
+            ReasoningTokens = msg.ReasoningTokens,
             ContextWindowTokens = msg.ContextWindowTokens,
-            UsagePercent = msg.UsagePercent
+            UsagePercent = msg.UsagePercent,
+            PromptMs = msg.PromptMs,
+            PredictedPerSecond = msg.PredictedPerSecond,
         },
 
         TurnCompleted msg => new SessionOutputDto
@@ -233,8 +237,12 @@ public static class SessionOutputDtoMapper
                 InputTokens = dto.InputTokens,
                 OutputTokens = dto.OutputTokens,
                 TotalTokens = dto.TotalTokens,
+                CachedInputTokens = dto.CachedInputTokens,
+                ReasoningTokens = dto.ReasoningTokens,
                 ContextWindowTokens = dto.ContextWindowTokens ?? 0,
-                UsagePercent = dto.UsagePercent
+                UsagePercent = dto.UsagePercent,
+                PromptMs = dto.PromptMs,
+                PredictedPerSecond = dto.PredictedPerSecond,
             },
             SessionOutputTypes.TurnCompleted => new TurnCompleted
             {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2503,6 +2503,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ? (double)usage.InputTokenCount.Value / contextWindow
             : null;
 
+        var additional = usage.AdditionalCounts;
+        double? promptMs = additional is not null && additional.TryGetValue("prompt_us", out var pUs)
+            ? pUs / 1000.0 : null;
+        double? predictedPerSec = additional is not null && additional.TryGetValue("predicted_tok_per_sec_x100", out var pps)
+            ? pps / 100.0 : null;
+
         EmitOutput(new UsageOutput
         {
             SessionId = _sessionId,
@@ -2512,7 +2518,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             CachedInputTokens = usage.CachedInputTokenCount,
             ReasoningTokens = usage.ReasoningTokenCount,
             ContextWindowTokens = contextWindow,
-            UsagePercent = usagePercent
+            UsagePercent = usagePercent,
+            PromptMs = promptMs,
+            PredictedPerSecond = predictedPerSec,
         }, OutputFilter.Usage);
     }
 

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2503,6 +2503,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ? (double)usage.InputTokenCount.Value / contextWindow
             : null;
 
+        // Decode llama.cpp server-side timing from UsageDetails.AdditionalCounts.
+        // Canonical encoding lives in Netclaw.Providers.SelfHosted.OpenAiCompatibleChatClient
+        // (PromptUsKey, PredictedTokPerSecX100Key). Keep these strings in sync.
         var additional = usage.AdditionalCounts;
         double? promptMs = additional is not null && additional.TryGetValue("prompt_us", out var pUs)
             ? pUs / 1000.0 : null;

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -257,7 +257,7 @@ public sealed class HeadlessChannel : IChannel
                 }
                 else
                 {
-                    Console.WriteLine($"[usage] in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens}");
+                    Console.WriteLine($"[usage] in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens} cached={msg.CachedInputTokens} prompt_ms={msg.PromptMs} tok_s={msg.PredictedPerSecond}");
                 }
                 Log(log, $"USAGE: in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens} cached={msg.CachedInputTokens} reasoning={msg.ReasoningTokens} context_window={msg.ContextWindowTokens} prompt_ms={msg.PromptMs} predicted_tok_s={msg.PredictedPerSecond}");
                 break;

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
@@ -36,6 +37,10 @@ public sealed class HeadlessChannel : IChannel
     private readonly List<JsonToolCall> _toolCalls = [];
     private JsonUsage? _usage;
     private string? _resolvedSessionId;
+
+    // Client-side timing
+    private long _promptSentTicks;
+    private long _firstDeltaTicks;
 
     public Actors.Channels.ChannelType ChannelType => Actors.Channels.ChannelType.Headless;
     public string DisplayName => "Headless Prompt";
@@ -130,6 +135,8 @@ public sealed class HeadlessChannel : IChannel
             logWriter!.WriteLine($"[{_timeProvider.GetUtcNow():o}] Headless session started: {sessionId}");
             logWriter.WriteLine($"[{_timeProvider.GetUtcNow():o}] PROMPT: {_prompt}");
 
+            _promptSentTicks = Stopwatch.GetTimestamp();
+
             await _daemonClient.SendAsync(new Netclaw.Actors.Channels.ChannelInput
             {
                 SenderId = "local-user",
@@ -185,6 +192,8 @@ public sealed class HeadlessChannel : IChannel
                 break;
 
             case TextDeltaOutput msg:
+                if (!_receivedTextDeltaInCurrentTurn && _promptSentTicks > 0)
+                    Interlocked.CompareExchange(ref _firstDeltaTicks, Stopwatch.GetTimestamp(), 0);
                 _receivedTextDeltaInCurrentTurn = true;
                 if (_jsonOutput)
                     _responseBuffer.Append(msg.Delta);
@@ -241,14 +250,16 @@ public sealed class HeadlessChannel : IChannel
                         OutputTokens = msg.OutputTokens,
                         TotalTokens = msg.TotalTokens,
                         CachedInputTokens = msg.CachedInputTokens,
-                        ReasoningTokens = msg.ReasoningTokens
+                        ReasoningTokens = msg.ReasoningTokens,
+                        PromptMs = msg.PromptMs,
+                        PredictedPerSecond = msg.PredictedPerSecond,
                     };
                 }
                 else
                 {
                     Console.WriteLine($"[usage] in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens}");
                 }
-                Log(log, $"USAGE: in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens} cached={msg.CachedInputTokens} reasoning={msg.ReasoningTokens} context_window={msg.ContextWindowTokens}");
+                Log(log, $"USAGE: in={msg.InputTokens} out={msg.OutputTokens} total={msg.TotalTokens} cached={msg.CachedInputTokens} reasoning={msg.ReasoningTokens} context_window={msg.ContextWindowTokens} prompt_ms={msg.PromptMs} predicted_tok_s={msg.PredictedPerSecond}");
                 break;
 
             case ErrorOutput msg:
@@ -311,12 +322,23 @@ public sealed class HeadlessChannel : IChannel
 
     private void WriteJsonEnvelope()
     {
+        // Client-side timing
+        var now = Stopwatch.GetTimestamp();
+        double? ttftMs = _firstDeltaTicks > 0 && _promptSentTicks > 0
+            ? Stopwatch.GetElapsedTime(_promptSentTicks, _firstDeltaTicks).TotalMilliseconds
+            : null;
+        double? totalMs = _promptSentTicks > 0
+            ? Stopwatch.GetElapsedTime(_promptSentTicks, now).TotalMilliseconds
+            : null;
+
         var envelope = new JsonEnvelope
         {
             SessionId = _resolvedSessionId!,
             Response = _responseBuffer.ToString(),
             ToolCalls = _toolCalls.Count > 0 ? _toolCalls : null,
-            Usage = _usage
+            Usage = _usage,
+            TtftMs = ttftMs.HasValue ? Math.Round(ttftMs.Value, 1) : null,
+            TotalMs = totalMs.HasValue ? Math.Round(totalMs.Value, 1) : null,
         };
 
         Console.WriteLine(JsonSerializer.Serialize(envelope, s_jsonOptions));
@@ -350,6 +372,8 @@ public sealed class HeadlessChannel : IChannel
         public required string Response { get; init; }
         public List<JsonToolCall>? ToolCalls { get; init; }
         public JsonUsage? Usage { get; init; }
+        public double? TtftMs { get; init; }
+        public double? TotalMs { get; init; }
     }
 
     private sealed class JsonToolCall
@@ -366,5 +390,7 @@ public sealed class HeadlessChannel : IChannel
         public long? TotalTokens { get; init; }
         public long? CachedInputTokens { get; init; }
         public long? ReasoningTokens { get; init; }
+        public double? PromptMs { get; init; }
+        public double? PredictedPerSecond { get; init; }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -794,30 +794,6 @@ data: [DONE]
         Assert.Equal(2530, response.Usage.AdditionalCounts["predicted_tok_per_sec_x100"]);
     }
 
-    [Fact(Skip = "Integration test — requires live llama.cpp server")]
-    public async Task LiveServer_StreamingResponse_IncludesTimings()
-    {
-        using var httpClient = new HttpClient { BaseAddress = new Uri("https://llm.testlab.petabridge.net") };
-        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("https://llm.testlab.petabridge.net");
-        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "Qwen3.5-27B-UD-Q4_K_XL.gguf");
-
-        var updates = new List<ChatResponseUpdate>();
-        await foreach (var update in client.GetStreamingResponseAsync(
-            [new ChatMessage(ChatRole.User, "Say hello in one word.")],
-            cancellationToken: TestContext.Current.CancellationToken))
-        {
-            updates.Add(update);
-        }
-
-        var response = updates.ToChatResponse();
-        Assert.NotNull(response.Usage);
-        Assert.True(response.Usage.InputTokenCount > 0);
-        // These should be populated from the timings object
-        Assert.NotNull(response.Usage.CachedInputTokenCount);
-        Assert.NotNull(response.Usage.AdditionalCounts);
-        Assert.True(response.Usage.AdditionalCounts.ContainsKey("prompt_us"));
-    }
-
     [Fact]
     public async Task StreamingRequest_IncludesStreamOptions()
     {

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -634,6 +634,35 @@ data: [DONE]
     }
 
     [Fact]
+    public void ParseUsage_TimingsSurviveUsageDetailsAdd()
+    {
+        // Simulate what ToChatResponse does: creates a new UsageDetails and calls Add()
+        // with the parsed result. Verify CachedInputTokenCount and AdditionalCounts survive.
+        using var doc = JsonDocument.Parse("""
+        {
+            "usage": { "prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120 },
+            "timings": {
+                "cache_n": 85,
+                "prompt_ms": 139.655,
+                "predicted_per_second": 31.241
+            }
+        }
+        """);
+
+        var parsed = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement)!;
+
+        // This is what ToChatResponse does internally: new UsageDetails().Add(parsed)
+        var aggregated = new UsageDetails();
+        aggregated.Add(parsed);
+
+        Assert.Equal(100, aggregated.InputTokenCount);
+        Assert.Equal(85, aggregated.CachedInputTokenCount);
+        Assert.NotNull(aggregated.AdditionalCounts);
+        Assert.Equal(139655, aggregated.AdditionalCounts["prompt_us"]);
+        Assert.Equal(3124, aggregated.AdditionalCounts["predicted_tok_per_sec_x100"]);
+    }
+
+    [Fact]
     public void ParseUsage_ReadsTokenCounts_WithoutTimings()
     {
         using var doc = JsonDocument.Parse("""
@@ -723,6 +752,70 @@ data: [DONE]
         Assert.Equal(30, usage.CachedInputTokenCount);
         // No throughput fields → AdditionalCounts should be empty or null
         Assert.True(usage.AdditionalCounts is null || usage.AdditionalCounts.Count == 0);
+    }
+
+    [Fact]
+    public async Task StreamingResponse_WithTimings_SurfacesCachedTokensAndThroughput()
+    {
+        // Simulate a llama.cpp streaming response where the final chunk includes timings
+        const string sse = """
+            data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":"stop"}]}
+
+            data: {"id":"abc","model":"test","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105},"timings":{"cache_n":80,"prompt_n":20,"prompt_ms":50.5,"predicted_per_second":25.3}}
+
+            data: [DONE]
+
+            """;
+
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sse, Encoding.UTF8, "text/event-stream")
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "hello")],
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            updates.Add(update);
+        }
+
+        var response = updates.ToChatResponse();
+
+        Assert.NotNull(response.Usage);
+        Assert.Equal(100, response.Usage.InputTokenCount);
+        Assert.Equal(5, response.Usage.OutputTokenCount);
+        Assert.Equal(80, response.Usage.CachedInputTokenCount);
+        Assert.NotNull(response.Usage.AdditionalCounts);
+        Assert.Equal(50500, response.Usage.AdditionalCounts["prompt_us"]);
+        Assert.Equal(2530, response.Usage.AdditionalCounts["predicted_tok_per_sec_x100"]);
+    }
+
+    [Fact(Skip = "Integration test — requires live llama.cpp server")]
+    public async Task LiveServer_StreamingResponse_IncludesTimings()
+    {
+        using var httpClient = new HttpClient { BaseAddress = new Uri("https://llm.testlab.petabridge.net") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("https://llm.testlab.petabridge.net");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "Qwen3.5-27B-UD-Q4_K_XL.gguf");
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "Say hello in one word.")],
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            updates.Add(update);
+        }
+
+        var response = updates.ToChatResponse();
+        Assert.NotNull(response.Usage);
+        Assert.True(response.Usage.InputTokenCount > 0);
+        // These should be populated from the timings object
+        Assert.NotNull(response.Usage.CachedInputTokenCount);
+        Assert.NotNull(response.Usage.AdditionalCounts);
+        Assert.True(response.Usage.AdditionalCounts.ContainsKey("prompt_us"));
     }
 
     [Fact]

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -634,6 +634,98 @@ data: [DONE]
     }
 
     [Fact]
+    public void ParseUsage_ReadsTokenCounts_WithoutTimings()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+            "usage": { "prompt_tokens": 50, "completion_tokens": 10, "total_tokens": 60 }
+        }
+        """);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement);
+
+        Assert.NotNull(usage);
+        Assert.Equal(50, usage.InputTokenCount);
+        Assert.Equal(10, usage.OutputTokenCount);
+        Assert.Equal(60, usage.TotalTokenCount);
+        Assert.Null(usage.CachedInputTokenCount);
+        Assert.Null(usage.AdditionalCounts);
+    }
+
+    [Fact]
+    public void ParseUsage_ReadsLlamaCppTimings_WhenPresent()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+            "usage": { "prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120 },
+            "timings": {
+                "cache_n": 85,
+                "prompt_n": 15,
+                "prompt_ms": 139.655,
+                "prompt_per_second": 78.766,
+                "predicted_n": 20,
+                "predicted_ms": 160.048,
+                "predicted_per_token_ms": 8.002,
+                "predicted_per_second": 31.241
+            }
+        }
+        """);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement);
+
+        Assert.NotNull(usage);
+        Assert.Equal(100, usage.InputTokenCount);
+        Assert.Equal(20, usage.OutputTokenCount);
+        Assert.Equal(85, usage.CachedInputTokenCount);
+
+        Assert.NotNull(usage.AdditionalCounts);
+        // prompt_ms stored as microseconds for integer precision
+        Assert.Equal(139655, usage.AdditionalCounts["prompt_us"]);
+        // predicted_per_second stored as x100 for integer precision
+        Assert.Equal(3124, usage.AdditionalCounts["predicted_tok_per_sec_x100"]);
+        // prompt_per_second stored as x100
+        Assert.Equal(7876, usage.AdditionalCounts["prompt_tok_per_sec_x100"]);
+        // predicted_ms stored as microseconds
+        Assert.Equal(160048, usage.AdditionalCounts["predicted_us"]);
+    }
+
+    [Fact]
+    public void ParseUsage_GracefullyIgnoresTimings_WhenTimingsObjectAbsent()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+            "usage": { "prompt_tokens": 50, "completion_tokens": 10, "total_tokens": 60 }
+        }
+        """);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement);
+
+        Assert.NotNull(usage);
+        Assert.Equal(50, usage.InputTokenCount);
+        Assert.Null(usage.CachedInputTokenCount);
+        Assert.Null(usage.AdditionalCounts);
+    }
+
+    [Fact]
+    public void ParseUsage_HandlesPartialTimings()
+    {
+        // Some fields present, others missing — should not throw
+        using var doc = JsonDocument.Parse("""
+        {
+            "usage": { "prompt_tokens": 50, "completion_tokens": 10, "total_tokens": 60 },
+            "timings": { "cache_n": 30 }
+        }
+        """);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement);
+
+        Assert.NotNull(usage);
+        Assert.Equal(30, usage.CachedInputTokenCount);
+        // No throughput fields → AdditionalCounts should be empty or null
+        Assert.True(usage.AdditionalCounts is null || usage.AdditionalCounts.Count == 0);
+    }
+
+    [Fact]
     public async Task StreamingRequest_IncludesStreamOptions()
     {
         const string sse = """

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -625,47 +625,67 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         return details;
     }
 
+    // llama.cpp's OpenAI-compatible endpoint returns a `timings` object alongside
+    // `usage`. Because M.E.AI's UsageDetails.AdditionalCounts is typed
+    // AdditionalPropertiesDictionary<long>, floating-point timing values are encoded
+    // as integer scale factors: microseconds for latency, ×100 for tokens-per-second.
+    // These keys are the only canonical definition; consumers (LlmSessionActor)
+    // duplicate the strings they read and must stay in sync.
+    internal const string PromptUsKey = "prompt_us";
+    internal const string PromptTokPerSecX100Key = "prompt_tok_per_sec_x100";
+    internal const string PredictedUsKey = "predicted_us";
+    internal const string PredictedTokPerSecX100Key = "predicted_tok_per_sec_x100";
+
     /// <summary>
     /// Reads llama.cpp-specific timing fields into <see cref="UsageDetails"/>.
     /// <c>cache_n</c> maps to <see cref="UsageDetails.CachedInputTokenCount"/>;
-    /// throughput and latency fields go into <see cref="UsageDetails.AdditionalCounts"/>.
+    /// throughput and latency fields go into <see cref="UsageDetails.AdditionalCounts"/>
+    /// via integer-encoded keys (see the PromptUsKey/PredictedTokPerSecX100Key
+    /// constants above). Consumers decode by dividing out the scale factor.
     /// </summary>
     internal static void ParseLlamaCppTimings(JsonElement timings, UsageDetails details)
     {
         if (TryGetLong(timings, "cache_n", out var cacheN))
             details.CachedInputTokenCount = cacheN;
 
-        // Prompt (prefill) metrics — stored as microseconds / x100 for integer precision.
-        // Only allocate AdditionalCounts when we have data to put in it.
         if (TryGetDouble(timings, "prompt_ms", out var promptMs))
-            Additional(details)["prompt_us"] = (long)(promptMs * 1000);
+            Additional(details)[PromptUsKey] = (long)(promptMs * 1000);
 
         if (TryGetDouble(timings, "prompt_per_second", out var promptPerSec))
-            Additional(details)["prompt_tok_per_sec_x100"] = (long)(promptPerSec * 100);
+            Additional(details)[PromptTokPerSecX100Key] = (long)(promptPerSec * 100);
 
-        // Generation (decode) metrics
         if (TryGetDouble(timings, "predicted_ms", out var predictedMs))
-            Additional(details)["predicted_us"] = (long)(predictedMs * 1000);
+            Additional(details)[PredictedUsKey] = (long)(predictedMs * 1000);
 
         if (TryGetDouble(timings, "predicted_per_second", out var predictedPerSec))
-            Additional(details)["predicted_tok_per_sec_x100"] = (long)(predictedPerSec * 100);
+            Additional(details)[PredictedTokPerSecX100Key] = (long)(predictedPerSec * 100);
 
         static AdditionalPropertiesDictionary<long> Additional(UsageDetails d)
             => d.AdditionalCounts ??= new AdditionalPropertiesDictionary<long>();
+    }
 
-        static bool TryGetLong(JsonElement obj, string name, out long value)
+    private static bool TryGetLong(JsonElement obj, string name, out long value)
+    {
+        if (obj.TryGetProperty(name, out var prop)
+            && prop.ValueKind == JsonValueKind.Number
+            && prop.TryGetInt64(out value))
         {
-            value = 0;
-            return obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number
-                   && (value = prop.GetInt64()) is var _;
+            return true;
         }
+        value = 0;
+        return false;
+    }
 
-        static bool TryGetDouble(JsonElement obj, string name, out double value)
+    private static bool TryGetDouble(JsonElement obj, string name, out double value)
+    {
+        if (obj.TryGetProperty(name, out var prop)
+            && prop.ValueKind == JsonValueKind.Number
+            && prop.TryGetDouble(out value))
         {
-            value = 0;
-            return obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number
-                   && (value = prop.GetDouble()) is var _;
+            return true;
         }
+        value = 0;
+        return false;
     }
 
     private static ChatFinishReason? ParseFinishReason(JsonElement choice)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -588,7 +588,10 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
 
     /// <summary>
     /// Parses the <c>usage</c> object from an OpenAI-compatible response or streaming chunk.
-    /// Returns null when the field is absent or not an object.
+    /// Also reads the llama.cpp <c>timings</c> object when present, mapping <c>cache_n</c>
+    /// to <see cref="UsageDetails.CachedInputTokenCount"/> and storing throughput/latency
+    /// fields in <see cref="UsageDetails.AdditionalCounts"/>.
+    /// Returns null when the usage field is absent or not an object.
     /// </summary>
     internal static UsageDetails? ParseUsage(JsonElement root)
     {
@@ -605,12 +608,64 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         if (promptTokens is null && completionTokens is null && totalTokens is null)
             return null;
 
-        return new UsageDetails
+        var details = new UsageDetails
         {
             InputTokenCount = promptTokens,
             OutputTokenCount = completionTokens,
             TotalTokenCount = totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0)
         };
+
+        // llama.cpp includes a sibling `timings` object with cache and throughput data.
+        // This is not part of the OpenAI spec — gracefully skip when absent.
+        if (root.TryGetProperty("timings", out var timings) && timings.ValueKind == JsonValueKind.Object)
+        {
+            ParseLlamaCppTimings(timings, details);
+        }
+
+        return details;
+    }
+
+    /// <summary>
+    /// Reads llama.cpp-specific timing fields into <see cref="UsageDetails"/>.
+    /// <c>cache_n</c> maps to <see cref="UsageDetails.CachedInputTokenCount"/>;
+    /// throughput and latency fields go into <see cref="UsageDetails.AdditionalCounts"/>.
+    /// </summary>
+    internal static void ParseLlamaCppTimings(JsonElement timings, UsageDetails details)
+    {
+        if (TryGetLong(timings, "cache_n", out var cacheN))
+            details.CachedInputTokenCount = cacheN;
+
+        // Prompt (prefill) metrics — stored as microseconds / x100 for integer precision.
+        // Only allocate AdditionalCounts when we have data to put in it.
+        if (TryGetDouble(timings, "prompt_ms", out var promptMs))
+            Additional(details)["prompt_us"] = (long)(promptMs * 1000);
+
+        if (TryGetDouble(timings, "prompt_per_second", out var promptPerSec))
+            Additional(details)["prompt_tok_per_sec_x100"] = (long)(promptPerSec * 100);
+
+        // Generation (decode) metrics
+        if (TryGetDouble(timings, "predicted_ms", out var predictedMs))
+            Additional(details)["predicted_us"] = (long)(predictedMs * 1000);
+
+        if (TryGetDouble(timings, "predicted_per_second", out var predictedPerSec))
+            Additional(details)["predicted_tok_per_sec_x100"] = (long)(predictedPerSec * 100);
+
+        static AdditionalPropertiesDictionary<long> Additional(UsageDetails d)
+            => d.AdditionalCounts ??= new AdditionalPropertiesDictionary<long>();
+
+        static bool TryGetLong(JsonElement obj, string name, out long value)
+        {
+            value = 0;
+            return obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number
+                   && (value = prop.GetInt64()) is var _;
+        }
+
+        static bool TryGetDouble(JsonElement obj, string name, out double value)
+        {
+            value = 0;
+            return obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number
+                   && (value = prop.GetDouble()) is var _;
+        }
     }
 
     private static ChatFinishReason? ParseFinishReason(JsonElement choice)


### PR DESCRIPTION
## Summary

Resolves #614. Netclaw's OpenAI-compatible provider now parses llama.cpp's `timings` object from chat completion responses, surfacing KV cache hit counts and server-side throughput/latency data that were previously ignored.

### What's new

**Provider-side parsing (`OpenAiCompatibleChatClient.ParseUsage`)**
- Reads `timings.cache_n` → `UsageDetails.CachedInputTokenCount`
- Stores `prompt_ms`, `prompt_per_second`, `predicted_ms`, `predicted_per_second` in `UsageDetails.AdditionalCounts` using integer-encoded keys (microseconds / ×100 scale factors, since M.E.AI types `AdditionalCounts` as `AdditionalPropertiesDictionary<long>`)
- Graceful degradation: all fields stay null when the provider doesn't emit a `timings` object (OpenAI, Anthropic, vLLM, TGI)

**Protocol surface (`UsageOutput`, `SessionOutputDto`)**
- New typed fields: `PromptMs`, `PredictedPerSecond` (decoded from `AdditionalCounts`), plus `CachedInputTokens`/`ReasoningTokens` which were already in `UsageOutput` but missing from the SignalR wire DTO
- `LlmSessionActor.EmitUsageOutput` decodes the scale factors and populates `UsageOutput`
- `SessionOutputDtoMapper` maps all new fields in both directions

**CLI metrics (`HeadlessChannel`)**
- JSON envelope (`chat -p --json`) now includes `usage.cachedInputTokens`, `usage.promptMs`, `usage.predictedPerSecond`, `ttftMs` (client-side time-to-first-delta), and `totalMs` (client-side prompt→turn-completed wall time)
- Plain-text `[usage]` line extended with `cached=`, `prompt_ms=`, `tok_s=` so the eval runner can parse metrics without requiring `--json` mode

**Eval harness (`evals/run-evals.sh`)**
- New `eval_metrics` SQLite table captures per-prompt performance data
- `store_metrics()` parses the `[usage]` line after every prompt
- `print_metrics_summary()` prints per-category and overall performance stats at the end of the run

### Verified end-to-end

Docker-isolated 2-turn test against live llama.cpp server (Qwen3.5-27B-UD-Q4_K_XL, dual R9700):

| Metric | Turn 1 (cold) | Turn 2 (warm) | Delta |
|--------|--------------|---------------|-------|
| `cachedInputTokens` | 4,855 | 4,855 | Same system prompt cached |
| `promptMs` (server prefill) | 743.6ms | 331.4ms | **55% faster** |
| `ttftMs` (client-side) | 2,821.6ms | 1,247.9ms | **56% faster** |
| `totalMs` | 3,360.5ms | 1,555.1ms | **54% faster** |
| `predictedPerSecond` | 25.3 tok/s | 25.23 tok/s | Stable |

One-iteration eval run on dev branch printed the full performance summary table across 23 prompts with per-category breakdowns.

### Code review fixes (applied after initial pass)

- Extracted magic string keys (`prompt_us`, `predicted_tok_per_sec_x100`, etc.) as `internal const` on `OpenAiCompatibleChatClient` with a cross-reference comment on the consumer side in `LlmSessionActor`
- Rewrote `TryGetLong`/`TryGetDouble` with idiomatic `JsonElement.TryGetInt64`/`TryGetDouble` instead of the `(value = ...) is var _` trick
- `store_metrics` uses plain `INSERT` instead of `INSERT OR REPLACE` so PK collisions fail loudly
- Removed a `Fact(Skip = ...)` live-server integration test — the same coverage exists hermetically via `StreamingResponse_WithTimings_SurfacesCachedTokens`

## Test plan

- [x] `dotnet build` — all projects compile, 0 warnings
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `dotnet test src/Netclaw.Daemon.Tests` (ParseUsage + streaming) — 9/9 pass
- [x] `dotnet test src/Netclaw.Cli.Tests` — 413/413 pass
- [x] End-to-end Docker test: 2-turn headless run shows all timing fields populated in JSON output
- [x] `evals/run-evals.sh` with 1 iteration — performance metrics table prints correctly per-category and overall

## Out of scope (follow-ups)

- **Multi-turn eval cases** — PR #613 added `chat -p --resume` but multi-turn behavioral/performance cases aren't wired into `run_all()` yet. Needed to validate KV cache growth across turns, especially for tool-call flows where sub-turn serialization could silently break cache hits.
- **Caddy session affinity** — round-robin between GPU0/GPU1 currently defeats the prompt cache 50% of the time for same-session follow-ups. The metrics captured here are what's needed to measure the delta when affinity is added.