### PR TITLE
feat(observability): log turn_tool_call_batch as structured metric

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1475,6 +1475,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
 
         // Execute tools async — results come back as ToolExecutionCompleted
+        TurnLog().Info("turn_tool_call_batch count={Count} tools={Tools}",
+            toolCalls.Count,
+            string.Join(",", toolCalls.Select(tc => tc.Name)));
         foreach (var tc in toolCalls)
         {
             _log.Info("Invoking tool [{ToolName}] (call={CallId}) args={Args}",


### PR DESCRIPTION
## Summary

- Adds `TurnLog().Info("turn_tool_call_batch count={Count} tools={Tools}", ...)` in `HandleToolCallResponse` immediately before the per-tool-call dispatch loop
- Emits count and comma-separated tool names as structured fields on every assistant response that produces tool calls
- Consistent with existing `TurnLog()` patterns in the file (same logging adapter, same structured key style)

Closes #623

## Test plan

- [x] `dotnet build` passes with 0 warnings
- [x] `dotnet slopwatch analyze` passes with 0 new violations
- [ ] After deployment: verify `grep turn_tool_call_batch` in daemon logs emits one line per tool-invocation round-trip with `count` and `tools` fields populated