### PR TITLE
fix(evals): mount host system skills into eval container

### DIFF
--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -250,11 +250,27 @@ start_eval_daemon() {
     mkdir -p "$EVAL_HOME/identity" "$EVAL_HOME/logs"
     cp -r "$HOME/.netclaw/identity/." "$EVAL_HOME/identity/"
 
+    # Copy host system skills into the eval home so the Skill Discovery
+    # assertions can actually find netclaw-operations / netclaw-memory /
+    # search-citation on disk. Only `.system/` is copied — operator-
+    # installed user skills stay out of the eval run for reproducibility.
+    # Without this copy the eval container starts with an empty skills
+    # directory and every Skill Discovery case fails on file_read of a
+    # nonexistent path (see daemon logs for ENOENT).
+    mkdir -p "$EVAL_HOME/skills"
+    if [[ -d "$HOME/.netclaw/skills/.system" ]]; then
+        mkdir -p "$EVAL_HOME/skills/.system"
+        cp -r "$HOME/.netclaw/skills/.system/." "$EVAL_HOME/skills/.system/"
+    else
+        echo "WARN: no system skills at $HOME/.netclaw/skills/.system/ — Skill Discovery evals will fail. Run netclaw daemon at least once on the host to trigger the system skill sync." >&2
+    fi
+
     local -a docker_args=(
         run -d --rm
         --name "$EVAL_CONTAINER_NAME"
         --network host
         -v "$EVAL_HOME/identity:/root/.netclaw/identity"
+        -v "$EVAL_HOME/skills:/root/.netclaw/skills"
         -v "$EVAL_HOME/logs:/root/.netclaw/logs"
         -e "NETCLAW_Daemon__Host=127.0.0.1"
         -e "NETCLAW_Daemon__Port=$EVAL_PORT"


### PR DESCRIPTION
## Summary

The eval container's `start_eval_daemon` in `evals/run-evals.sh` only mounted `identity/` and `logs/` from the host, leaving `/root/.netclaw/skills/` empty inside the container. The `SkillScanner` at daemon startup would find zero skills, the skill registry would be empty, and the `[skills]` context layer injected into the system prompt would be empty — making it impossible for the agent to ever `file_read` a skill file by name.

This PR copies the host's `~/.netclaw/skills/.system/` tree into `$EVAL_HOME/skills` (matching the identity copy-to-throwaway pattern) and adds a `-v $EVAL_HOME/skills:/root/.netclaw/skills` bind mount to the docker_args.

## What this fix does

- Mounts the system skill tree so files at `/root/.netclaw/skills/.system/netclaw-operations/SKILL.md` etc. actually exist inside the container
- Only `.system/` is copied — operator-installed user skills (e.g., private research skills, experimental skills) stay out of the eval run for reproducibility
- Adds a `WARN` log when `~/.netclaw/skills/.system/` is missing on the host, directing operators to run the daemon at least once so `SystemSkillSyncService` can populate it
- Zero daemon-side code changes; everything is in the shell script

## Diagnosis summary

The Skill Discovery category has been showing **0/4 passed (RED)** for both the pre-cache-fix eval run (2026-04-12) and the post-cache-fix eval run on the same day. The assertions all check for patterns like:

```bash
stdout_contains '\[tool:call\] file_read' && stdout_contains 'netclaw-operations'
```

Per `CLAUDE.md`'s debugging philosophy ("eval failures are VERY RARELY the model's fault — almost always instrumentation or infrastructure"), I investigated the infrastructure first and found the missing skill mount.

## What this fix does NOT do

**Merging this PR alone will not turn the 4 Skill Discovery assertions green.** There are layered issues still to resolve, being investigated in parallel:

1. **`netclaw-operations` is marked `disable-model-invocation: true`** in its SKILL.md frontmatter. `SkillRegistry.GenerateIndex()` (line 83) explicitly filters these out of the model-visible skill menu: `_skills.Where(static s => !s.DisableModelInvocation)`. The model literally cannot see this skill in its prompt and has no way to know it exists. The skill description says "REQUIRED when the user asks about scheduling" but the flag contradicts that intent. Two cases (`skill_operations_scheduling`, `skill_operations_diagnostics`) fail for this reason regardless of whether files are mounted.

2. **The other 3 skills (`netclaw-memory`, `search-citation`, `netclaw-projects`) ARE visible** in the model's skill menu after this fix (verified by standalone container test). But the model (Qwen3.5-27B-UD-Q4) still chooses direct tools (`find_memories`, `web_search`) over reading the skill file first. That's pragmatic, correct behavior — reading a "how to search memories" skill before calling `find_memories` would be pure ceremony. Two more cases (`skill_memory`, `skill_citation`) fail for this reason.

**Net expected change after this fix lands:** still 0/4 on Skill Discovery until the skill system's auto-load design gets resolved separately. The infra hygiene is the point — the files the skill registry expects to find now exist in the container.

## Why land this anyway

- **It's a prerequisite for any fix.** Whatever the eventual resolution of the skill loading mechanism — whether the assertions get rewritten, the `disable-model-invocation` flags get removed, or a keyword-triggered auto-load mechanism gets added — all of those require the skill files to actually exist in the eval container's filesystem. This PR lands that prerequisite.
- **Fixes a latent correctness issue.** Even if the tests stay RED, any eval case or future regression test that tries to `file_read` a skill file will now actually succeed instead of getting ENOENT.
- **Narrow scope, easily reversible.** 16-line diff in a single shell script. No daemon code changes. No test assertion changes. Safe to merge independently of the broader skill system investigation.

## Verification

- [x] `bash -n evals/run-evals.sh` — syntax valid
- [x] Standalone container test: mounted `.system/` tree visible at `/root/.netclaw/skills/.system/` with all 5 valid skills (`netclaw-memory`, `netclaw-operations`, `netclaw-projects`, `search-citation`, `skill-authoring`)
- [x] Daemon startup log confirms `SkillDirectoryWatcherService: Watching skill directory: /root/.netclaw/skills (native)` and `Skill description menu updated (5 skills)`
- [x] Live prompt test via `netclaw chat -p` against debug container confirms agent can introspect the skill filesystem (though chooses direct tools for current test prompts)
- [x] Assertion regex untouched — existing Skill Discovery test cases will continue to FAIL until the skill loading mechanism work lands

## Test plan

- [ ] CI passes on all configurations
- [ ] Post-merge: rerun `./evals/run-evals.sh` against a live endpoint and confirm Skill Discovery category is still 0/4 (expected) without infrastructure-level errors in the daemon log
- [ ] Any in-progress work on the skill loading mechanism can now assume skill files are present in the eval container