### PR TITLE
test(slack): fix RecordingReplyClient thread-safety flake (#635)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -613,17 +613,25 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
 
     private sealed class RecordingReplyClient : ISlackReplyClient
     {
-        public List<SlackPostMessage> PostedMessages { get; } = [];
+        private readonly object _lock = new();
+        private readonly List<SlackPostMessage> _postedMessages = [];
+
+        public IReadOnlyList<SlackPostMessage> PostedMessages
+        {
+            get { lock (_lock) return _postedMessages.ToList(); }
+        }
 
         public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
-            PostedMessages.Add(message);
+            lock (_lock)
+                _postedMessages.Add(message);
             return Task.CompletedTask;
         }
 
         public Task<string> PostThreadReplyWithTsAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
-            PostedMessages.Add(message);
+            lock (_lock)
+                _postedMessages.Add(message);
             return Task.FromResult("fake.ts");
         }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -1283,9 +1283,26 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
     /// </summary>
     private sealed class RecordingReplyClient : ISlackReplyClient
     {
-        public List<SlackPostMessage> PostedMessages { get; } = [];
-        public List<(SlackChannelId ChannelId, string MessageTs, string Text, IReadOnlyList<Block>? Blocks)> UpdatedMessages { get; } = [];
-        public List<(SlackChannelId ChannelId, SlackThreadTs ThreadTs, string FilePath, string? FileName)> UploadedFiles { get; } = [];
+        private readonly object _lock = new();
+        private readonly List<SlackPostMessage> _postedMessages = [];
+        private readonly List<(SlackChannelId ChannelId, string MessageTs, string Text, IReadOnlyList<Block>? Blocks)> _updatedMessages = [];
+        private readonly List<(SlackChannelId ChannelId, SlackThreadTs ThreadTs, string FilePath, string? FileName)> _uploadedFiles = [];
+
+        public IReadOnlyList<SlackPostMessage> PostedMessages
+        {
+            get { lock (_lock) return _postedMessages.ToList(); }
+        }
+
+        public IReadOnlyList<(SlackChannelId ChannelId, string MessageTs, string Text, IReadOnlyList<Block>? Blocks)> UpdatedMessages
+        {
+            get { lock (_lock) return _updatedMessages.ToList(); }
+        }
+
+        public IReadOnlyList<(SlackChannelId ChannelId, SlackThreadTs ThreadTs, string FilePath, string? FileName)> UploadedFiles
+        {
+            get { lock (_lock) return _uploadedFiles.ToList(); }
+        }
+
         public Queue<Exception> PostFailures { get; } = new();
         public Queue<Exception> UploadFailures { get; } = new();
         public volatile bool BlockPostsUntilCanceled;
@@ -1320,7 +1337,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 }
             }
 
-            PostedMessages.Add(message);
+            lock (_lock)
+                _postedMessages.Add(message);
             var next = Interlocked.Increment(ref _postSequence);
             return $"{next}.0";
         }
@@ -1332,7 +1350,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             IReadOnlyList<Block>? blocks = null,
             CancellationToken cancellationToken = default)
         {
-            UpdatedMessages.Add((channelId, messageTs, text, blocks));
+            lock (_lock)
+                _updatedMessages.Add((channelId, messageTs, text, blocks));
             return Task.CompletedTask;
         }
 
@@ -1343,7 +1362,8 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             if (UploadFailures.Count > 0)
                 throw UploadFailures.Dequeue();
 
-            UploadedFiles.Add((channelId, threadTs, filePath, filename));
+            lock (_lock)
+                _uploadedFiles.Add((channelId, threadTs, filePath, filename));
             return Task.CompletedTask;
         }
     }

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -633,17 +633,25 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
 
     private sealed class RecordingReplyClient : ISlackReplyClient
     {
-        public List<SlackPostMessage> PostedMessages { get; } = [];
+        private readonly object _lock = new();
+        private readonly List<SlackPostMessage> _postedMessages = [];
+
+        public IReadOnlyList<SlackPostMessage> PostedMessages
+        {
+            get { lock (_lock) return _postedMessages.ToList(); }
+        }
 
         public Task PostThreadReplyAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
-            PostedMessages.Add(message);
+            lock (_lock)
+                _postedMessages.Add(message);
             return Task.CompletedTask;
         }
 
         public Task<string> PostThreadReplyWithTsAsync(SlackPostMessage message, CancellationToken cancellationToken = default)
         {
-            PostedMessages.Add(message);
+            lock (_lock)
+                _postedMessages.Add(message);
             return Task.FromResult("1.0");
         }
 


### PR DESCRIPTION
## Summary

Fixes #635 — `RecordingReplyClient` test doubles expose raw `List<T>` buffers that are written from the actor thread (inside `PostThreadReplyAsync` / `UpdateThreadMessageAsync` / `UploadFileToThreadAsync`) while the test thread enumerates them inside `AwaitAssertAsync` polling predicates. `List<T>.Enumerator.MoveNext()` throws `InvalidOperationException: Collection was modified; enumeration operation may not execute.` when the two races collide — first observed as a CI flake in [PR #633 run 24340315102](https://github.com/Aaronontheweb/netclaw/actions/runs/24340315102).

- Wrap `PostedMessages`, `UpdatedMessages`, `UploadedFiles` behind a private `_lock` with snapshot-on-read (`IReadOnlyList<T>` property returning `.ToList()` under lock); wrap every `.Add(...)` site in the same lock. Zero test call-site changes — `Assert.Contains` / `Assert.Single` / `.Count` all keep working against the returned snapshot.
- Applied symmetrically to **three** sibling `RecordingReplyClient` classes — the issue body only named one, but the CI failure actually hit a second (`SlackAttachmentIngressTests.cs:614`), and a third (`SlackThreadBackfillIntegrationTests.cs:634`) shares the identical latent bug. Keeping all three consistent prevents a future racy assertion from resurrecting the flake.

### Why lock+snapshot instead of actors or `ConcurrentBag`

- `ISlackReplyClient` is already a `Task`-returning interface, so wrapping the test double in an actor adds ceremony without changing the read path (assertions still need a materialized list).
- `ConcurrentBag<T>` is disqualified — multiple assertions depend on insertion order (`Assert.Single`, `Assert.Single(UpdatedMessages)` at `SlackFileFlowIntegrationTests.cs:763`/`918`).
- The pattern matches the existing `RecordingChatClient` in the same test file (`SlackAttachmentIngressTests.cs:645-657`), which already uses this idiom.

`PostFailures`/`UploadFailures` (`Queue<Exception>`) are deliberately left unsynchronized — verified all enqueue sites run in test Arrange before the actor system starts; only the actor thread dequeues.

## Test plan

- [x] `dotnet build src/Netclaw.Actors.Tests` — clean
- [x] 20× loop rerun of the originally-failing test `SlackAttachmentIngressVisionTests.Download_failure_posts_stable_message_without_raw_exception_detail` — 20/20 pass
- [x] `SlackFileFlowIntegrationTests` + `SlackAttachmentIngressTests` + `SlackThreadBackfillIntegrationTests` — all pass
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] CI passes on all OS runners