### PR TITLE
feat(stats): track skill loads by method and skill name

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.10.0"
+  version: "1.11.0"
 ---
 
 # Netclaw Operations
@@ -233,6 +233,7 @@ file. If it should be recalled when relevant → SQLite memory.
 | Self-diagnose | `netclaw doctor` |
 | Runtime health | `netclaw status` |
 | Memory/token stats | `netclaw stats` |
+| Historical skill usage by method/name | `netclaw stats skills` |
 | List/manage skills | `netclaw skill list` |
 | List past sessions | `netclaw sessions --once` |
 | Inspect reminder history | `netclaw reminder history <id> --last 5` |

--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -335,16 +335,16 @@ fi
 echo "Testing netclaw stats skills..."
 skill_stats_output="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw stats skills)"
 echo "$skill_stats_output"
-if [[ "$skill_stats_output" != *"by method:"* ]]; then
-  echo "Expected stats skills output to include method breakdown."
+if [[ "$skill_stats_output" != *"by method:"* && "$skill_stats_output" != *"No skill loads recorded."* ]]; then
+  echo "Expected stats skills output to include either a method breakdown or the empty-state message."
   exit 1
 fi
 
 echo "Testing netclaw stats skills --json..."
 skill_stats_json="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw stats skills --json)"
 echo "$skill_stats_json"
-if [[ "$skill_stats_json" != *"totalLoads"* ]]; then
-  echo "Expected stats skills --json to include totalLoads field."
+if [[ "$skill_stats_json" != *"\"daily\""* ]]; then
+  echo "Expected stats skills --json to include the daily field."
   exit 1
 fi
 

--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -332,6 +332,22 @@ if [[ "$stats_days" != *"date"* ]]; then
   exit 1
 fi
 
+echo "Testing netclaw stats skills..."
+skill_stats_output="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw stats skills)"
+echo "$skill_stats_output"
+if [[ "$skill_stats_output" != *"by method:"* ]]; then
+  echo "Expected stats skills output to include method breakdown."
+  exit 1
+fi
+
+echo "Testing netclaw stats skills --json..."
+skill_stats_json="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw stats skills --json)"
+echo "$skill_stats_json"
+if [[ "$skill_stats_json" != *"totalLoads"* ]]; then
+  echo "Expected stats skills --json to include totalLoads field."
+  exit 1
+fi
+
 # ── Reminder lifecycle smoke tests ──
 # Schedule a one-shot reminder, wait for it to execute and record history,
 # then cancel it and verify it is fully removed.

--- a/scripts/smoke/cli-smoke.sh
+++ b/scripts/smoke/cli-smoke.sh
@@ -192,6 +192,12 @@ else
   fail "stats skills: unexpected exit code $skill_stats_exit (expected 0 or 1)"
 fi
 
+if [[ $skill_stats_exit -eq 0 && "$skill_stats_output" != *"by method:"* && "$skill_stats_output" != *"No skill loads recorded."* ]]; then
+  fail "stats skills: expected method breakdown or empty-state message when command succeeds"
+else
+  pass "stats skills: output shape is valid when command succeeds"
+fi
+
 echo ""
 echo "=== netclaw stats skills --json (daemon-optional) ==="
 set +e
@@ -204,6 +210,12 @@ if [[ $skill_stats_json_exit -le 1 ]]; then
   pass "stats skills --json: exits with valid code $skill_stats_json_exit"
 else
   fail "stats skills --json: unexpected exit code $skill_stats_json_exit (expected 0 or 1)"
+fi
+
+if [[ $skill_stats_json_exit -eq 0 && "$skill_stats_json_output" != *"\"daily\""* ]]; then
+  fail "stats skills --json: expected daily field when command succeeds"
+else
+  pass "stats skills --json: output shape is valid when command succeeds"
 fi
 
 # ── No-args and unknown command behavior ─────────────────────────────────────

--- a/scripts/smoke/cli-smoke.sh
+++ b/scripts/smoke/cli-smoke.sh
@@ -142,10 +142,10 @@ echo "=== netclaw stats --help ==="
 stats_help_exit=0
 stats_help_output="$(run_netclaw stats --help)" || stats_help_exit=$?
 echo "$stats_help_output"
-if [[ $stats_help_exit -eq 0 && "$stats_help_output" == *"--days"* ]]; then
-  pass "stats --help: exits 0 and mentions --days"
+if [[ $stats_help_exit -eq 0 && "$stats_help_output" == *"--days"* && "$stats_help_output" == *"stats skills"* ]]; then
+  pass "stats --help: exits 0 and mentions --days and stats skills"
 else
-  fail "stats --help: exit=$stats_help_exit, missing --days in output"
+  fail "stats --help: exit=$stats_help_exit, missing --days or stats skills in output"
 fi
 
 echo ""
@@ -176,6 +176,34 @@ if [[ $stats_json_exit -le 1 ]]; then
   pass "stats --json: exits with valid code $stats_json_exit"
 else
   fail "stats --json: unexpected exit code $stats_json_exit (expected 0 or 1)"
+fi
+
+echo ""
+echo "=== netclaw stats skills (daemon-optional) ==="
+set +e
+skill_stats_exit=0
+skill_stats_output="$(run_netclaw stats skills 2>&1)"
+skill_stats_exit=$?
+set -e
+echo "$skill_stats_output"
+if [[ $skill_stats_exit -le 1 ]]; then
+  pass "stats skills: exits with valid code $skill_stats_exit"
+else
+  fail "stats skills: unexpected exit code $skill_stats_exit (expected 0 or 1)"
+fi
+
+echo ""
+echo "=== netclaw stats skills --json (daemon-optional) ==="
+set +e
+skill_stats_json_exit=0
+skill_stats_json_output="$(run_netclaw stats skills --json 2>&1)"
+skill_stats_json_exit=$?
+set -e
+echo "$skill_stats_json_output"
+if [[ $skill_stats_json_exit -le 1 ]]; then
+  pass "stats skills --json: exits with valid code $skill_stats_json_exit"
+else
+  fail "stats skills --json: unexpected exit code $skill_stats_json_exit (expected 0 or 1)"
 fi
 
 # ── No-args and unknown command behavior ─────────────────────────────────────

--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -1,4 +1,6 @@
 using Netclaw.Actors.Tools;
+using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -162,6 +164,44 @@ public class FileReadToolTests : IDisposable
     }
 
     [Fact]
+    public async Task Reading_registered_skill_file_records_skill_file_read_telemetry()
+    {
+        var paths = new NetclawPaths(_tempDir);
+        var registry = new SkillRegistry();
+        var metrics = new FakeMetrics();
+        var skillFile = Path.Combine(paths.SkillsDirectory, "tracked-skill", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(skillFile)!);
+        await File.WriteAllTextAsync(skillFile, "---\nname: tracked-skill\ndescription: tracked\n---\n\n# Tracked", TestContext.Current.CancellationToken);
+
+        var scan = SkillScanner.Scan(paths.SkillsDirectory);
+        registry.ReplaceAll(scan.AcceptedSkills, scan.Issues);
+
+        var tool = new FileReadTool(new ToolConfig(), paths: paths, skillRegistry: registry, sessionMetrics: metrics);
+
+        await tool.ExecuteAsync(new Dictionary<string, object?> { ["Path"] = skillFile }, CreateTeamContext(), CancellationToken.None);
+
+        var call = Assert.Single(metrics.SkillLoadedCalls);
+        Assert.Equal("tracked-skill", call.SkillName);
+        Assert.Equal(SkillLoadMethod.FileRead, call.Method);
+    }
+
+    [Fact]
+    public async Task Reading_non_skill_file_does_not_record_skill_telemetry()
+    {
+        var paths = new NetclawPaths(_tempDir);
+        var registry = new SkillRegistry();
+        var metrics = new FakeMetrics();
+        var filePath = Path.Combine(_sessionDir, "notes.txt");
+        await File.WriteAllTextAsync(filePath, "notes", TestContext.Current.CancellationToken);
+
+        var tool = new FileReadTool(new ToolConfig(), paths: paths, skillRegistry: registry, sessionMetrics: metrics);
+
+        await tool.ExecuteAsync(new Dictionary<string, object?> { ["Path"] = filePath }, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Empty(metrics.SkillLoadedCalls);
+    }
+
+    [Fact]
     public async Task Team_context_can_read_file_inside_identity_directory_via_global_read_roots()
     {
         var identityDir = Path.Combine(_tempDir, "identity");
@@ -284,4 +324,19 @@ public class FileReadToolTests : IDisposable
             Boundary = SecurityPolicyDefaults.PublicBoundary,
             ChannelType = "slack"
         };
+
+    private sealed class FakeMetrics : ISessionMetrics
+    {
+        public List<(string SkillName, SkillLoadMethod Method)> SkillLoadedCalls { get; } = [];
+
+        public void RecordTokenUsage(long inputTokens, long outputTokens) { }
+        public void RecordTurnCompleted() { }
+        public void RecordSessionCreated() { }
+        public void RecordMemoriesFormed(int count) { }
+        public void RecordMemoriesRecalled(int count) { }
+        public void RecordSkillsLoaded(int count) { }
+
+        public void RecordSkillLoaded(string skillName, SkillLoadMethod method)
+            => SkillLoadedCalls.Add((skillName, method));
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SkillToolTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -54,6 +55,32 @@ public class SkillToolTests : IDisposable
         Assert.Contains("Test Skill", result);
         Assert.Contains("Do the thing.", result);
         Assert.Contains("1.0.0", result);
+    }
+
+    [Fact]
+    public async Task SkillLoad_RecordsDetailedTelemetryForKnownSkill()
+    {
+        WriteSkill("test-skill", """
+            ---
+            name: test-skill
+            description: A test skill.
+            ---
+
+            # Test Skill
+
+            Do the thing.
+            """);
+        ScanSkills();
+
+        var metrics = new FakeMetrics();
+        var tool = new SkillLoadTool(_registry, new NoOpSkillContentScanner(), metrics);
+
+        await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["Name"] = "test-skill" }, TestContext.Current.CancellationToken);
+
+        var call = Assert.Single(metrics.SkillLoadedCalls);
+        Assert.Equal("test-skill", call.SkillName);
+        Assert.Equal(SkillLoadMethod.SkillLoadTool, call.Method);
     }
 
     [Fact]
@@ -676,5 +703,20 @@ public class SkillToolTests : IDisposable
             if (Directory.Exists(externalDir))
                 Directory.Delete(externalDir, recursive: true);
         }
+    }
+
+    private sealed class FakeMetrics : ISessionMetrics
+    {
+        public List<(string SkillName, SkillLoadMethod Method)> SkillLoadedCalls { get; } = [];
+
+        public void RecordTokenUsage(long inputTokens, long outputTokens) { }
+        public void RecordTurnCompleted() { }
+        public void RecordSessionCreated() { }
+        public void RecordMemoriesFormed(int count) { }
+        public void RecordMemoriesRecalled(int count) { }
+        public void RecordSkillsLoaded(int count) { }
+
+        public void RecordSkillLoaded(string skillName, SkillLoadMethod method)
+            => SkillLoadedCalls.Add((skillName, method));
     }
 }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2248,7 +2248,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return true; // Handled — do NOT fall through to LLM
             }
 
-            _sessionMetrics?.RecordSkillsLoaded(1);
+            _sessionMetrics?.RecordSkillLoaded(skill.Name, SkillLoadMethod.SlashCommand);
 
             // Inject skill as system context, use remainder as user message
             var effectiveUserContent = string.IsNullOrWhiteSpace(remainder)

--- a/src/Netclaw.Actors/Skills/SkillRegistry.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistry.cs
@@ -17,10 +17,14 @@ public sealed class SkillRegistry
     /// <see cref="SkillEntry.UserInvocable"/> is true.
     /// </summary>
     private readonly Dictionary<string, SkillEntry> _slashCommands = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, SkillEntry> _skillFiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, SkillEntry> _skillsByName = new(StringComparer.OrdinalIgnoreCase);
 
     public void Register(SkillEntry skill)
     {
         _skills.Add(skill);
+        _skillsByName[skill.Name] = skill;
+        _skillFiles[Path.GetFullPath(skill.FilePath)] = skill;
         if (skill.UserInvocable)
             _slashCommands[skill.Name] = skill;
     }
@@ -33,6 +37,8 @@ public sealed class SkillRegistry
     {
         _skills.Clear();
         _slashCommands.Clear();
+        _skillFiles.Clear();
+        _skillsByName.Clear();
         _scanIssues = [];
     }
 
@@ -46,6 +52,26 @@ public sealed class SkillRegistry
     }
 
     public IReadOnlyList<SkillEntry> GetAll() => _skills;
+
+    public SkillEntry? GetByName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        return _skillsByName.TryGetValue(name.Trim(), out var skill)
+            ? skill
+            : null;
+    }
+
+    public SkillEntry? GetByFilePath(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            return null;
+
+        return _skillFiles.TryGetValue(Path.GetFullPath(filePath), out var skill)
+            ? skill
+            : null;
+    }
 
     public IReadOnlyList<SkillScanIssue> GetScanIssues() => _scanIssues;
 

--- a/src/Netclaw.Actors/Telemetry/ISessionMetrics.cs
+++ b/src/Netclaw.Actors/Telemetry/ISessionMetrics.cs
@@ -13,4 +13,5 @@ public interface ISessionMetrics
     void RecordMemoriesFormed(int count);
     void RecordMemoriesRecalled(int count);
     void RecordSkillsLoaded(int count);
+    void RecordSkillLoaded(string skillName, Netclaw.Configuration.SkillLoadMethod method);
 }

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
 using System.Text;
+using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -19,17 +21,26 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     private readonly ToolConfig _config;
     private readonly ToolPathPolicy? _pathPolicy;
     private readonly ScopedFileAccessPolicy _fileAccessPolicy;
+    private readonly SkillRegistry? _skillRegistry;
+    private readonly ISessionMetrics? _sessionMetrics;
 
     public record Params(
         [property: Description("Absolute path to the file to read")] string Path,
         [property: Description("Line number to start reading from (1-based, optional)")] int? Offset = null,
         [property: Description("Maximum number of lines to read (optional)")] int? Limit = null);
 
-    public FileReadTool(ToolConfig config, ToolPathPolicy? pathPolicy = null, NetclawPaths? paths = null)
+    public FileReadTool(
+        ToolConfig config,
+        ToolPathPolicy? pathPolicy = null,
+        NetclawPaths? paths = null,
+        SkillRegistry? skillRegistry = null,
+        ISessionMetrics? sessionMetrics = null)
     {
         _config = config;
         _pathPolicy = pathPolicy;
         _fileAccessPolicy = new ScopedFileAccessPolicy(config, paths);
+        _skillRegistry = skillRegistry;
+        _sessionMetrics = sessionMetrics;
     }
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
@@ -57,10 +68,13 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         {
             if (offset.HasValue || limit.HasValue)
             {
-                return await ReadLinesAsync(authorizedPath, offset ?? 1, limit, _config.MaxOutputChars, ct);
+                var lines = await ReadLinesAsync(authorizedPath, offset ?? 1, limit, _config.MaxOutputChars, ct);
+                RecordSkillReadIfApplicable(authorizedPath);
+                return lines;
             }
 
             var content = await File.ReadAllTextAsync(authorizedPath, Encoding.UTF8, ct);
+            RecordSkillReadIfApplicable(authorizedPath);
             return ShellTool.TruncateOutput(content, _config.MaxOutputChars);
         }
         catch (UnauthorizedAccessException)
@@ -102,5 +116,14 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         }
 
         return sb.ToString();
+    }
+
+    private void RecordSkillReadIfApplicable(string authorizedPath)
+    {
+        var skill = _skillRegistry?.GetByFilePath(authorizedPath);
+        if (skill is null)
+            return;
+
+        _sessionMetrics?.RecordSkillLoaded(skill.Name, SkillLoadMethod.FileRead);
     }
 }

--- a/src/Netclaw.Actors/Tools/SkillLoadTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillLoadTool.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security.Skills;
 using Netclaw.Tools;
@@ -18,22 +19,23 @@ public sealed partial class SkillLoadTool : NetclawTool<SkillLoadTool.Params>
 {
     private readonly SkillRegistry _skillRegistry;
     private readonly ISkillContentScanner _scanner;
+    private readonly ISessionMetrics? _sessionMetrics;
 
     public record Params(
         [property: Description("Name of the skill to load (e.g., 'search-citation', 'netclaw-memory')")]
         string Name);
 
-    public SkillLoadTool(SkillRegistry skillRegistry, ISkillContentScanner scanner)
+    public SkillLoadTool(SkillRegistry skillRegistry, ISkillContentScanner scanner, ISessionMetrics? sessionMetrics = null)
     {
         _skillRegistry = skillRegistry;
         _scanner = scanner;
+        _sessionMetrics = sessionMetrics;
     }
 
     protected override async Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
         var name = args.Name.Trim().ToLowerInvariant();
-        var skill = _skillRegistry.GetAll()
-            .FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        var skill = _skillRegistry.GetByName(name);
 
         if (skill is null)
         {
@@ -58,6 +60,8 @@ public sealed partial class SkillLoadTool : NetclawTool<SkillLoadTool.Params>
         var scanResult = await _scanner.ScanAsync(name, content, ct);
         if (!scanResult.IsAllowed)
             return $"Skill '{name}' blocked by content scan: {scanResult.Reason}";
+
+        _sessionMetrics?.RecordSkillLoaded(skill.Name, SkillLoadMethod.SkillLoadTool);
 
         var sb = new StringBuilder();
         if (scanResult.Verdict == ScanVerdict.Warning)

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Search;
 using Netclaw.Security;
@@ -59,9 +60,10 @@ public static class ToolRegistrationExtensions
         SkillIndexContextLayer skillIndexLayer,
         NetclawPaths paths,
         ISkillContentScanner scanner,
-        IReadOnlyList<ResolvedExternalSource> externalSources)
+        IReadOnlyList<ResolvedExternalSource> externalSources,
+        ISessionMetrics? sessionMetrics = null)
     {
-        registry.Register(new SkillLoadTool(skillRegistry, scanner));
+        registry.Register(new SkillLoadTool(skillRegistry, scanner, sessionMetrics));
         registry.Register(new SkillReadResourceTool(skillRegistry, scanner));
         registry.Register(new SkillManageTool(skillRegistry, skillIndexLayer, paths, scanner, externalSources));
         return registry;

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -28,6 +28,12 @@ public sealed class ToolRegistry
         _tools.Add(new ToolRegistration(tool, tool.GrantCategory));
     }
 
+    public void Replace(INetclawTool tool)
+    {
+        _tools.RemoveAll(t => string.Equals(t.Tool.Name, tool.Name, StringComparison.Ordinal));
+        Register(tool);
+    }
+
     /// <summary>
     /// Register an <see cref="AITool"/> directly (for test fakes that don't implement INetclawTool).
     /// </summary>

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -99,6 +99,19 @@ public sealed class DaemonApi
         return await JsonSerializer.DeserializeAsync<DaemonStats.Response>(stream, WebJsonOptions, cts.Token);
     }
 
+    public async Task<SkillUsageStats.Response?> GetSkillUsageStatsAsync(int? days = null, CancellationToken ct = default)
+    {
+        using var cts = CreateTimeoutCts(DefaultTimeout, ct);
+        var url = $"{_endpoint}/api/stats/skills";
+        if (days.HasValue)
+            url += $"?days={days.Value}";
+        var client = CreateHttpClient();
+        using var response = await client.GetAsync(url, cts.Token);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+        return await JsonSerializer.DeserializeAsync<SkillUsageStats.Response>(stream, WebJsonOptions, cts.Token);
+    }
+
     // ── Reminders ─────────────────────────────────────────────────────
 
     public async Task<HttpResponseMessage> ListRemindersAsync(CancellationToken ct = default)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -302,7 +302,10 @@ static async Task RunAsync(string[] args)
 
     if (mode is "stats")
     {
-        if (args.Length > 1 && IsHelpToken(args[1]))
+        var skillStatsMode = args.Length > 1 && string.Equals(args[1], "skills", StringComparison.OrdinalIgnoreCase);
+        var optionStart = skillStatsMode ? 2 : 1;
+
+        if (args.Length > optionStart && IsHelpToken(args[optionStart]))
         {
             WriteStatsHelp();
             return;
@@ -311,7 +314,7 @@ static async Task RunAsync(string[] args)
         var statsAsJson = false;
         var statsTui = false;
         int? statsDays = null;
-        for (var i = 1; i < args.Length; i++)
+        for (var i = optionStart; i < args.Length; i++)
         {
             var arg = args[i];
             if (arg is "--json")
@@ -413,7 +416,9 @@ static async Task RunAsync(string[] args)
 
         using var host = builder.Build();
         using var scope = host.Services.CreateScope();
-        var exitCode = await RunStatsAsync(scope.ServiceProvider, statsAsJson, statsDays);
+        var exitCode = skillStatsMode
+            ? await RunSkillStatsAsync(scope.ServiceProvider, statsAsJson, statsDays)
+            : await RunStatsAsync(scope.ServiceProvider, statsAsJson, statsDays);
         Environment.ExitCode = exitCode;
         return;
     }
@@ -1096,12 +1101,13 @@ static void WriteStatusHelp()
 static void WriteStatsHelp()
 {
     Console.WriteLine("Usage: netclaw stats [options]");
+    Console.WriteLine("       netclaw stats skills [options]");
     Console.WriteLine();
     Console.WriteLine("Shows usage activity statistics from the running daemon:");
     Console.WriteLine("  - token consumption (input, output)");
     Console.WriteLine("  - session and turn counts");
     Console.WriteLine("  - memory formation and recall counts");
-    Console.WriteLine("  - skill auto-load counts");
+    Console.WriteLine("  - skill load counts");
     Console.WriteLine("  - memory store statistics");
     Console.WriteLine("  - Slack activity counters");
     Console.WriteLine("  - webhook route counts and delivery counters");
@@ -1474,6 +1480,49 @@ static async Task<int> RunStatsAsync(IServiceProvider services, bool jsonOutput,
     }
 }
 
+static async Task<int> RunSkillStatsAsync(IServiceProvider services, bool jsonOutput, int? days = null)
+{
+    var api = services.GetRequiredService<DaemonApi>();
+
+    try
+    {
+        var stats = await api.GetSkillUsageStatsAsync(days);
+
+        if (stats is null)
+        {
+            Console.WriteLine("[FAIL] stats skills: daemon returned an empty stats payload.");
+            return 1;
+        }
+
+        if (jsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(stats, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            }));
+        }
+        else
+        {
+            WriteSkillStatsResult(stats, days);
+        }
+
+        return 0;
+    }
+    catch (HttpRequestException ex) when (ex.StatusCode is not null)
+    {
+        Console.WriteLine($"[FAIL] stats skills: daemon returned {(int)ex.StatusCode} from {api.Endpoint}");
+        Console.WriteLine("       fix: run `netclaw daemon start` and retry.");
+        return 1;
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"[FAIL] stats skills: unable to reach daemon at {api.Endpoint}: {ex.Message}");
+        Console.WriteLine("       fix: run `netclaw daemon start` and retry.");
+        return 1;
+    }
+}
+
 static void WriteStatsResult(DaemonStats.Response stats, int? days)
 {
     // Header
@@ -1530,6 +1579,40 @@ static void WriteStatsResult(DaemonStats.Response stats, int? days)
         Console.WriteLine();
         Console.WriteLine("reminders:");
         Console.WriteLine($"  scheduled: {reminders.ScheduledCount}    active: {reminders.ActiveExecutions}    failed: {reminders.FailedCount}");
+    }
+}
+
+static void WriteSkillStatsResult(SkillUsageStats.Response stats, int? days)
+{
+    if (days is > 0)
+        Console.WriteLine($"netclaw stats skills — last {days} days");
+    else if (days == 0)
+        Console.WriteLine("netclaw stats skills — all time");
+    else
+        Console.WriteLine("netclaw stats skills — last 7 days");
+
+    Console.WriteLine();
+
+    if (stats.Daily.Count == 0)
+    {
+        Console.WriteLine("No skill loads recorded.");
+        return;
+    }
+
+    foreach (var day in stats.Daily)
+    {
+        Console.WriteLine($"{day.Date}  total={day.TotalLoads:N0}");
+        Console.WriteLine($"  by method: {string.Join(", ", day.Methods.Select(m => $"{m.Method}={m.Count:N0}"))}");
+
+        foreach (var skill in day.Skills.Take(15))
+        {
+            Console.WriteLine($"  {skill.SkillName}: {skill.TotalLoads:N0} ({string.Join(", ", skill.Methods.Select(m => $"{m.Method}={m.Count:N0}"))})");
+        }
+
+        if (day.Skills.Count > 15)
+            Console.WriteLine($"  ... {day.Skills.Count - 15} more skill(s)");
+
+        Console.WriteLine();
     }
 }
 

--- a/src/Netclaw.Configuration/SkillTelemetry.cs
+++ b/src/Netclaw.Configuration/SkillTelemetry.cs
@@ -1,0 +1,42 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Stable load methods for skill-usage telemetry.
+/// Stored as lowercase wire values in SQLite and JSON.
+/// </summary>
+public enum SkillLoadMethod
+{
+    SlashCommand,
+    SkillLoadTool,
+    FileRead,
+}
+
+public static class SkillLoadMethodExtensions
+{
+    public static string ToWireValue(this SkillLoadMethod value) => value switch
+    {
+        SkillLoadMethod.SlashCommand => "slash-command",
+        SkillLoadMethod.SkillLoadTool => "skill-load",
+        SkillLoadMethod.FileRead => "file-read",
+        _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+    };
+
+    public static bool TryFromWireValue(string? wireValue, out SkillLoadMethod value)
+    {
+        switch (wireValue?.Trim())
+        {
+            case "slash-command":
+                value = SkillLoadMethod.SlashCommand;
+                return true;
+            case "skill-load":
+                value = SkillLoadMethod.SkillLoadTool;
+                return true;
+            case "file-read":
+                value = SkillLoadMethod.FileRead;
+                return true;
+            default:
+                value = default;
+                return false;
+        }
+    }
+}

--- a/src/Netclaw.Configuration/SkillUsageStats.cs
+++ b/src/Netclaw.Configuration/SkillUsageStats.cs
@@ -1,0 +1,39 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Wire types for the detailed skill-usage statistics endpoint.
+/// </summary>
+public static class SkillUsageStats
+{
+    public sealed class Response : IWireType
+    {
+        public required List<DailySkillRow> Daily { get; init; }
+    }
+
+    public sealed class DailySkillRow : IWireType
+    {
+        public required string Date { get; init; }
+
+        public long TotalLoads { get; init; }
+
+        public required List<MethodCount> Methods { get; init; }
+
+        public required List<SkillCount> Skills { get; init; }
+    }
+
+    public sealed class MethodCount : IWireType
+    {
+        public required string Method { get; init; }
+
+        public long Count { get; init; }
+    }
+
+    public sealed class SkillCount : IWireType
+    {
+        public required string SkillName { get; init; }
+
+        public long TotalLoads { get; init; }
+
+        public required List<MethodCount> Methods { get; init; }
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -1,0 +1,73 @@
+using Akka.Actor;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Gateway;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Gateway;
+
+public sealed class DailyStatsActorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly ActorSystem _system;
+
+    public DailyStatsActorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-dailystats-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+        _system = ActorSystem.Create($"daily-stats-tests-{Guid.NewGuid():N}");
+    }
+
+    [Fact]
+    public async Task QuerySkillUsageStats_returns_groupable_rows_for_each_method()
+    {
+        var time = new AdjustableTimeProvider(new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero));
+        var actor = _system.ActorOf(Props.Create(() => new DailyStatsActor(
+            _paths,
+            time,
+            NullLogger<DailyStatsActor>.Instance)));
+
+        actor.Tell(new DailyStatsActor.RecordSkillLoaded("netclaw-operations", SkillLoadMethod.FileRead));
+        actor.Tell(new DailyStatsActor.RecordSkillLoaded("netclaw-operations", SkillLoadMethod.FileRead));
+        actor.Tell(new DailyStatsActor.RecordSkillLoaded("create-release", SkillLoadMethod.SkillLoadTool));
+        actor.Tell(new DailyStatsActor.RecordSkillLoaded("create-release", SkillLoadMethod.SlashCommand));
+
+        var rows = await actor.Ask<DailyStatsActor.QuerySkillUsageStatsResult>(
+            new DailyStatsActor.QuerySkillUsageStats(7),
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, rows.Rows.Count);
+
+        var opsFileRead = Assert.Single(rows.Rows, r => r.SkillName == "netclaw-operations" && r.Method == SkillLoadMethod.FileRead);
+        Assert.Equal(2, opsFileRead.Count);
+
+        var releaseRows = rows.Rows.Where(r => r.SkillName == "create-release").OrderBy(r => r.Method.ToWireValue()).ToList();
+        Assert.Equal(2, releaseRows.Count);
+        Assert.Contains(releaseRows, r => r.Method == SkillLoadMethod.SkillLoadTool && r.Count == 1);
+        Assert.Contains(releaseRows, r => r.Method == SkillLoadMethod.SlashCommand && r.Count == 1);
+
+        var totals = await actor.Ask<DailyStatsActor.ProcessStatsResult>(
+            new DailyStatsActor.QueryProcessStats(),
+            TimeSpan.FromSeconds(3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(4, totals.SkillsLoadedTotal);
+    }
+
+    public void Dispose()
+    {
+        _system.Terminate().GetAwaiter().GetResult();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private sealed class AdjustableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
@@ -439,6 +439,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
         public void RecordMemoriesFormed(int count) { }
         public void RecordMemoriesRecalled(int count) { }
         public void RecordSkillsLoaded(int count) { }
+        public void RecordSkillLoaded(string skillName, SkillLoadMethod method) { }
     }
 
     private sealed class AdjustableTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
+++ b/src/Netclaw.Daemon/Configuration/SkillToolRegistration.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Netclaw.Actors.Skills;
+using Netclaw.Actors.Telemetry;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Security.Skills;
 
 namespace Netclaw.Daemon.Configuration;
@@ -20,9 +22,14 @@ internal static class SkillToolRegistration
         var skillRegistry = services.GetRequiredService<SkillRegistry>();
         var skillIndexLayer = services.GetRequiredService<SkillIndexContextLayer>();
         var paths = services.GetRequiredService<NetclawPaths>();
+        var toolConfig = services.GetRequiredService<ToolConfig>();
+        var pathPolicy = services.GetService<ToolPathPolicy>();
         var scanner = services.GetRequiredService<ISkillContentScanner>();
         var externalSources = services.GetRequiredService<IReadOnlyList<ResolvedExternalSource>>();
+        var metrics = services.GetService<ISessionMetrics>();
 
-        registry.WithSkillTools(skillRegistry, skillIndexLayer, paths, scanner, externalSources);
+        registry.Replace(new FileReadTool(toolConfig, pathPolicy, paths, skillRegistry, metrics));
+
+        registry.WithSkillTools(skillRegistry, skillIndexLayer, paths, scanner, externalSources, metrics);
     }
 }

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -84,6 +84,57 @@ internal sealed class DaemonStatsService(
         };
     }
 
+    public async Task<SkillUsageStats.Response> GetSkillUsageStatsAsync(int? days = null, CancellationToken ct = default)
+    {
+        var actorRef = await dailyStatsActor.GetAsync(ct);
+        var rows = await QuerySkillUsageAsync(actorRef, days ?? 7, ct);
+
+        var daily = rows
+            .GroupBy(r => r.DateKey, StringComparer.Ordinal)
+            .OrderByDescending(g => g.Key, StringComparer.Ordinal)
+            .Select(group => new SkillUsageStats.DailySkillRow
+            {
+                Date = group.Key,
+                TotalLoads = group.Sum(x => x.Count),
+                Methods = group
+                    .GroupBy(x => x.Method)
+                    .Select(methodGroup => new SkillUsageStats.MethodCount
+                    {
+                        Method = methodGroup.Key.ToWireValue(),
+                        Count = methodGroup.Sum(x => x.Count)
+                    })
+                    .OrderByDescending(x => x.Count)
+                    .ThenBy(x => x.Method, StringComparer.Ordinal)
+                    .ToList(),
+                Skills = group
+                    .GroupBy(x => x.SkillName, StringComparer.OrdinalIgnoreCase)
+                    .Select(skillGroup => new SkillUsageStats.SkillCount
+                    {
+                        SkillName = skillGroup.Key,
+                        TotalLoads = skillGroup.Sum(x => x.Count),
+                        Methods = skillGroup
+                            .GroupBy(x => x.Method)
+                            .Select(methodGroup => new SkillUsageStats.MethodCount
+                            {
+                                Method = methodGroup.Key.ToWireValue(),
+                                Count = methodGroup.Sum(x => x.Count)
+                            })
+                            .OrderByDescending(x => x.Count)
+                            .ThenBy(x => x.Method, StringComparer.Ordinal)
+                            .ToList()
+                    })
+                    .OrderByDescending(x => x.TotalLoads)
+                    .ThenBy(x => x.SkillName, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+            })
+            .ToList();
+
+        return new SkillUsageStats.Response
+        {
+            Daily = daily
+        };
+    }
+
     private static async Task<List<DaemonStats.DailyRow>> QueryDailyStatsAsync(IActorRef actorRef, int days, CancellationToken ct)
     {
         try
@@ -103,6 +154,20 @@ internal sealed class DaemonStatsService(
                     SkillsLoaded = r.SkillsLoaded
                 })
                 .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static async Task<List<DailyStatsActor.DailySkillUsageRow>> QuerySkillUsageAsync(IActorRef actorRef, int days, CancellationToken ct)
+    {
+        try
+        {
+            var result = await actorRef.Ask<DailyStatsActor.QuerySkillUsageStatsResult>(
+                new DailyStatsActor.QuerySkillUsageStats(days), TimeSpan.FromSeconds(5), ct);
+            return result.Rows;
         }
         catch
         {

--- a/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
+++ b/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
@@ -18,6 +18,7 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<DailyStatsActor> _logger;
     private readonly Dictionary<string, Accumulator> _pending = new();
+    private readonly Dictionary<(string DateKey, string SkillName, SkillLoadMethod Method), long> _pendingSkillUsage = new();
 
     // Process-lifetime totals (never reset, never persisted — lost on restart)
     private long _totalInputTokens;
@@ -61,6 +62,20 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
         {
             if (msg.Count > 0) { GetOrCreate().SkillsLoaded += msg.Count; _totalSkillsLoaded += msg.Count; }
         });
+        Receive<RecordSkillLoaded>(msg =>
+        {
+            var normalizedSkill = msg.SkillName.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedSkill))
+                return;
+
+            GetOrCreate().SkillsLoaded++;
+            _totalSkillsLoaded++;
+
+            var key = (_timeProvider.GetUtcNow().ToString("yyyy-MM-dd"), normalizedSkill, msg.Method);
+            _pendingSkillUsage[key] = _pendingSkillUsage.TryGetValue(key, out var existing)
+                ? existing + 1
+                : 1;
+        });
 
         Receive<Flush>(_ => FlushToSqlite());
 
@@ -74,6 +89,12 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
         Receive<QueryProcessStats>(_ => Sender.Tell(new ProcessStatsResult(
             _totalInputTokens, _totalOutputTokens, _totalTurns,
             _totalMemoriesFormed, _totalMemoriesRecalled, _totalSkillsLoaded)));
+        Receive<QuerySkillUsageStats>(msg =>
+        {
+            var rows = ReadSkillUsageFromSqlite(msg.Days);
+            MergeUnflushedSkillUsage(rows);
+            Sender.Tell(new QuerySkillUsageStatsResult(rows));
+        });
     }
 
     protected override void PreStart()
@@ -102,7 +123,7 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
 
     private void FlushToSqlite()
     {
-        if (_pending.Count == 0)
+        if (_pending.Count == 0 && _pendingSkillUsage.Count == 0)
             return;
 
         try
@@ -110,12 +131,15 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();
 
+            using var tx = conn.BeginTransaction();
+
             foreach (var (dateKey, acc) in _pending)
             {
                 if (acc.IsEmpty)
                     continue;
 
                 using var cmd = conn.CreateCommand();
+                cmd.Transaction = tx;
                 cmd.CommandText =
                     """
                     INSERT INTO daily_stats (date_key, input_tokens, output_tokens, turns, sessions,
@@ -141,7 +165,31 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
                 cmd.ExecuteNonQuery();
             }
 
+            foreach (var ((dateKey, skillName, method), count) in _pendingSkillUsage)
+            {
+                if (count <= 0)
+                    continue;
+
+                using var cmd = conn.CreateCommand();
+                cmd.Transaction = tx;
+                cmd.CommandText =
+                    """
+                    INSERT INTO daily_skill_usage (date_key, skill_name, load_method, count)
+                    VALUES ($date, $skill, $method, $count)
+                    ON CONFLICT(date_key, skill_name, load_method) DO UPDATE SET
+                        count = count + $count
+                    """;
+                cmd.Parameters.AddWithValue("$date", dateKey);
+                cmd.Parameters.AddWithValue("$skill", skillName);
+                cmd.Parameters.AddWithValue("$method", method.ToWireValue());
+                cmd.Parameters.AddWithValue("$count", count);
+                cmd.ExecuteNonQuery();
+            }
+
+            tx.Commit();
+
             _pending.Clear();
+            _pendingSkillUsage.Clear();
         }
         catch (Exception ex)
         {
@@ -205,6 +253,59 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
         return rows;
     }
 
+    private List<DailySkillUsageRow> ReadSkillUsageFromSqlite(int days)
+    {
+        var rows = new List<DailySkillUsageRow>();
+
+        try
+        {
+            using var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+
+            using var cmd = conn.CreateCommand();
+            if (days > 0)
+            {
+                var startDate = _timeProvider.GetUtcNow().AddDays(-(days - 1)).ToString("yyyy-MM-dd");
+                cmd.CommandText =
+                    """
+                    SELECT date_key, skill_name, load_method, count
+                    FROM daily_skill_usage
+                    WHERE date_key >= $start
+                    ORDER BY date_key DESC, count DESC, skill_name ASC, load_method ASC
+                    """;
+                cmd.Parameters.AddWithValue("$start", startDate);
+            }
+            else
+            {
+                cmd.CommandText =
+                    """
+                    SELECT date_key, skill_name, load_method, count
+                    FROM daily_skill_usage
+                    ORDER BY date_key DESC, count DESC, skill_name ASC, load_method ASC
+                    """;
+            }
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                if (!SkillLoadMethodExtensions.TryFromWireValue(reader.GetString(2), out var method))
+                    continue;
+
+                rows.Add(new DailySkillUsageRow(
+                    DateKey: reader.GetString(0),
+                    SkillName: reader.GetString(1),
+                    Method: method,
+                    Count: reader.GetInt64(3)));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to query daily skill usage stats");
+        }
+
+        return rows;
+    }
+
     /// <summary>
     /// Merge any unflushed in-memory accumulators into the SQLite-read rows
     /// so the query response is always up-to-date.
@@ -242,13 +343,55 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
         rows.Sort((a, b) => string.Compare(b.DateKey, a.DateKey, StringComparison.Ordinal));
     }
 
+    private void MergeUnflushedSkillUsage(List<DailySkillUsageRow> rows)
+    {
+        foreach (var ((dateKey, skillName, method), count) in _pendingSkillUsage)
+        {
+            if (count <= 0)
+                continue;
+
+            var existing = rows.FindIndex(r => r.DateKey == dateKey
+                && string.Equals(r.SkillName, skillName, StringComparison.Ordinal)
+                && r.Method == method);
+
+            if (existing >= 0)
+            {
+                var row = rows[existing];
+                rows[existing] = row with { Count = row.Count + count };
+            }
+            else
+            {
+                rows.Add(new DailySkillUsageRow(dateKey, skillName, method, count));
+            }
+        }
+
+        rows.Sort((a, b) =>
+        {
+            var dateCompare = string.Compare(b.DateKey, a.DateKey, StringComparison.Ordinal);
+            if (dateCompare != 0)
+                return dateCompare;
+
+            var countCompare = b.Count.CompareTo(a.Count);
+            if (countCompare != 0)
+                return countCompare;
+
+            var skillCompare = string.Compare(a.SkillName, b.SkillName, StringComparison.Ordinal);
+            if (skillCompare != 0)
+                return skillCompare;
+
+            return string.Compare(a.Method.ToWireValue(), b.Method.ToWireValue(), StringComparison.Ordinal);
+        });
+    }
+
     private void EnsureTable()
     {
         try
         {
             using var conn = new SqliteConnection(_connectionString);
             conn.Open();
+            using var tx = conn.BeginTransaction();
             using var cmd = conn.CreateCommand();
+            cmd.Transaction = tx;
             cmd.CommandText =
                 """
                 CREATE TABLE IF NOT EXISTS daily_stats (
@@ -263,6 +406,22 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
                 )
                 """;
             cmd.ExecuteNonQuery();
+
+            using var usageCmd = conn.CreateCommand();
+            usageCmd.Transaction = tx;
+            usageCmd.CommandText =
+                """
+                CREATE TABLE IF NOT EXISTS daily_skill_usage (
+                    date_key    TEXT NOT NULL,
+                    skill_name  TEXT NOT NULL,
+                    load_method TEXT NOT NULL,
+                    count       INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (date_key, skill_name, load_method)
+                )
+                """;
+            usageCmd.ExecuteNonQuery();
+
+            tx.Commit();
         }
         catch (Exception ex)
         {
@@ -278,8 +437,11 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
     public sealed record RecordMemoriesFormed(int Count);
     public sealed record RecordMemoriesRecalled(int Count);
     public sealed record RecordSkillsLoaded(int Count);
+    public sealed record RecordSkillLoaded(string SkillName, SkillLoadMethod Method);
     public sealed record QueryDailyStats(int Days);
     public sealed record QueryDailyStatsResult(List<DailyStatsRow> Rows);
+    public sealed record QuerySkillUsageStats(int Days);
+    public sealed record QuerySkillUsageStatsResult(List<DailySkillUsageRow> Rows);
     public sealed record QueryProcessStats;
     public sealed record ProcessStatsResult(
         long InputTokensTotal, long OutputTokensTotal, long TurnsCompletedTotal,
@@ -297,6 +459,12 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
         long MemoriesFormed,
         long MemoriesRecalled,
         long SkillsLoaded);
+
+    public sealed record DailySkillUsageRow(
+        string DateKey,
+        string SkillName,
+        SkillLoadMethod Method,
+        long Count);
 
     private sealed class Accumulator
     {

--- a/src/Netclaw.Daemon/Gateway/DailyStatsPublisher.cs
+++ b/src/Netclaw.Daemon/Gateway/DailyStatsPublisher.cs
@@ -3,6 +3,7 @@ using Akka.Hosting;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Telemetry;
 using Netclaw.Channels.Telemetry;
+using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Gateway;
 
@@ -52,6 +53,14 @@ public sealed class DailyStatsPublisher : ISessionMetrics
     public void RecordSkillsLoaded(int count)
     {
         GetActor()?.Tell(new DailyStatsActor.RecordSkillsLoaded(count));
+    }
+
+    public void RecordSkillLoaded(string skillName, SkillLoadMethod method)
+    {
+        if (string.IsNullOrWhiteSpace(skillName))
+            return;
+
+        GetActor()?.Tell(new DailyStatsActor.RecordSkillLoaded(skillName.Trim(), method));
     }
 
     /// <summary>

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -171,6 +171,8 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
         Results.Ok(catalog.ListRecent(limit: 50))).RequireAuthorization();
     app.MapGet("/api/stats", async (DaemonStatsService statsService, int? days, CancellationToken ct) =>
         Results.Ok(await statsService.GetStatsAsync(days, ct))).RequireAuthorization();
+    app.MapGet("/api/stats/skills", async (DaemonStatsService statsService, int? days, CancellationToken ct) =>
+        Results.Ok(await statsService.GetSkillUsageStatsAsync(days, ct))).RequireAuthorization();
     app.MapWebhookEndpoints();
 
     // Device pairing exchange — unauthenticated, rate-limited, with per-IP lockout guard.


### PR DESCRIPTION
## Summary
- count skill loads across slash commands, `skill_load`, and direct `SKILL.md` file reads while preserving the existing top-level `netclaw stats` view
- persist daily skill usage history in SQLite by skill and load method, and expose it through `/api/stats/skills` plus `netclaw stats skills`
- add focused tests and smoke coverage for the new skill usage telemetry surfaces