### PR TITLE
fix(slack): stop inlining PDFs as DataContent on vision-capable models

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -139,10 +139,21 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
     }
 
     [Fact]
-    public async Task Pdf_in_dm_on_vision_capable_model_is_saved_to_inbox_and_inlined()
+    public async Task Pdf_in_dm_is_saved_to_inbox_path_only_and_never_inlined()
     {
+        // Regression for the "Invalid url format: data:application/pdf;base64"
+        // failure surfaced in session D0AC6CKBK5K/1776091017.523089 on 2026-04-13.
+        // Root cause: the live-ingress path was wrapping PDF bytes as DataContent
+        // (application/pdf), which OpenAiCompatibleChatClient.ToMessage then
+        // serialized as an `image_url` content part with a data:application/pdf
+        // URL — rejected by every OpenAI-compatible upstream (llama.cpp, vLLM,
+        // Ollama). The fix is to stop inlining PDFs at all: the file already
+        // lives in inbox/ and the agent reads it via shell_execute + pdftotext
+        // (see AttachmentNotes.ModelMissingPdf). Vision-capable models are
+        // still exercised here to make sure we don't accidentally re-introduce
+        // the "Image flag implies PDF inline" conflation.
         _httpHandler.RespondWith("application/pdf", FakePdfBytes);
-        var gateway = BuildGateway("slack-gw-pdf-inline");
+        var gateway = BuildGateway("slack-gw-pdf-path-only");
 
         var files = new List<SlackFileReference>
         {
@@ -167,17 +178,28 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         await AwaitAssertAsync(() =>
         {
             Assert.Contains(_chatClient.ReceivedMessages,
-                contents => contents.Any(c => c is TextContent t && t.Text.Contains("[attachment]", StringComparison.Ordinal))
-                            && contents.Any(c => c is DataContent d && d.MediaType == "application/pdf"));
+                contents => contents.Any(c => c is TextContent t
+                    && t.Text.Contains("[attachment]", StringComparison.Ordinal)
+                    && t.Text.Contains("report.pdf", StringComparison.Ordinal)));
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         var announcement = _chatClient.ReceivedMessages
             .SelectMany(m => m)
             .OfType<TextContent>()
-            .First(t => t.Text.Contains("[attachment]", StringComparison.Ordinal));
+            .First(t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
+                     && t.Text.Contains("report.pdf", StringComparison.Ordinal));
         Assert.Contains("report.pdf", announcement.Text, StringComparison.Ordinal);
-        Assert.Contains("inlined=\"true\"", announcement.Text, StringComparison.Ordinal);
+        Assert.Contains("inlined=\"false\"", announcement.Text, StringComparison.Ordinal);
         Assert.Contains("path=\"inbox/report.pdf\"", announcement.Text, StringComparison.Ordinal);
+        Assert.Contains("current model has no native PDF support", announcement.Text, StringComparison.Ordinal);
+
+        // PDFs are never handed to the LLM as DataContent — otherwise they'd
+        // reach OpenAiCompatibleChatClient and be wrapped as a broken image_url.
+        var pdfDataContents = _chatClient.ReceivedMessages
+            .SelectMany(m => m)
+            .OfType<DataContent>()
+            .Where(d => d.MediaType == "application/pdf");
+        Assert.Empty(pdfDataContents);
 
         var sessionId = new SessionId("D1/2000.1");
         var inboxPath = Path.Combine(

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -333,15 +333,13 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
 
         // Resolve the capability view once per message — the active model's
-        // InputModalities determine which accepted categories get inlined
-        // as DataContent versus path-only announcements.
+        // InputModalities determine whether images get inlined as DataContent
+        // versus path-only announcements. PDFs are always path-only: no
+        // provider plugin currently serializes application/pdf inline, and
+        // the agent can always read them from inbox/ via shell_execute +
+        // pdftotext or other file tools.
         var modelCapabilities = _dependencies.ModelCapabilities;
         var inlineImages = modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
-        // Microsoft.Extensions.AI doesn't define a dedicated Pdf modality flag;
-        // provider plugins that natively accept application/pdf use the Image
-        // flag on the document pipeline. This matches how LlmSessionActor's
-        // existing mediaRefs gate surfaces modality support today.
-        var inlinePdfs = modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
 
         var acceptedLines = new List<string>(files.Count);
         var dataContents = new List<DataContent>();
@@ -356,7 +354,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 audience,
                 policy,
                 inlineImages,
-                inlinePdfs,
                 inboxDir,
                 cancellationToken);
 
@@ -394,7 +391,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         TrustAudience audience,
         ChannelAttachmentPolicy policy,
         bool inlineImages,
-        bool inlinePdfs,
         string inboxDir,
         CancellationToken cancellationToken)
     {
@@ -515,7 +511,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
 
         // Decide inlining based on model modalities and category.
-        var (inlined, note) = ResolveInlineDecision(category, inlineImages, inlinePdfs);
+        var (inlined, note) = ResolveInlineDecision(category, inlineImages);
 
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
         var line = BuildAttachmentLine(file.Name, file.MimeType, bytes.Length, relativePath, inlined, note);
@@ -533,14 +529,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private static (bool Inlined, string? Note) ResolveInlineDecision(
         AttachmentCategory category,
-        bool inlineImages,
-        bool inlinePdfs)
+        bool inlineImages)
     {
         return category switch
         {
             AttachmentCategory.Image when inlineImages => (true, null),
             AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
-            AttachmentCategory.Pdf when inlinePdfs => (true, null),
             AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
             _ => (false, AttachmentNotes.FormatNotInlineable)
         };
@@ -886,7 +880,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var profile = ToolAudienceProfileDefaults.GetResolvedProfile(audienceProfiles, audience);
         var attachmentPolicy = profile.ChannelAttachments ?? ChannelAttachmentPolicy.Empty;
         var inlineImages = modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
-        var inlinePdfs = modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
 
         var sb = new StringBuilder();
         sb.AppendLine("[thread history — messages exchanged before this inbound event]");
@@ -920,7 +913,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                             break;
                         }
 
-                        var (inlined, note) = ResolveInlineDecision(category, inlineImages, inlinePdfs);
+                        var (inlined, note) = ResolveInlineDecision(category, inlineImages);
                         if (!inlined)
                         {
                             var effectiveNote = note ?? AttachmentNotes.FormatNotInlineable;


### PR DESCRIPTION
## Summary

Fixes the urgent production incident where Slack PDF uploads to ArdyBot fail with `LLM provider error (500): Invalid url format: data:application/pdf;base64`.

**Root cause:** `SlackThreadBindingActor` was computing `inlinePdfs = InputModalities.HasFlag(ModelModality.Image)` — conflating "vision-capable" with "accepts inline PDFs". A PDF dropped into a Slack DM against a llama.cpp / vLLM / Ollama endpoint via `OpenAiCompatibleChatClient` got wrapped as `DataContent(application/pdf)`, which `ToMessage` unconditionally serialized as an `image_url` content part with a `data:application/pdf;base64,...` URL. No OpenAI-compatible upstream accepts that.

**Fix:** PDFs are now unconditionally path-only on all providers. The file still lands in `{sessionDir}/inbox/` and the announcement line already points the agent at `AttachmentNotes.ModelMissingPdf` — _"current model has no native PDF support; use shell_execute (e.g., pdftotext) to extract text"_. The agent reads the file via tool calls instead of the runtime shoving bytes through a wire format the endpoint doesn't support.

Images are unchanged: vision-capable models still inline as `image_url`, because that's the only way they can be "seen" on OpenAI-compatible wire formats.

Reproduces on session `D0AC6CKBK5K/1776091017.523089` (2026-04-13).

## Changes

- `src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs` — delete `inlinePdfs` from live ingress and historical backfill paths; simplify `ResolveInlineDecision` to two parameters.
- `src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs` — flip `Pdf_in_dm_on_vision_capable_model_*` into a regression lock asserting no `DataContent(application/pdf)` ever reaches the chat client.

Three prior PRs (#601, #607, #626) plumbed PDFs through ingress → scanner → inbox → LLM input assembly, which is what unmasked this far-end gating bug. None of them touched the modality gate or the provider client.

## Out of scope (deliberate)

- Enabling native inline PDFs on providers that actually support them (Anthropic document blocks via `DataContent` through the Anthropic SDK, OpenAI `file` content parts) — those go through different client paths and need their own plumbing. Separate PR if/when someone wants that feature.
- Revisiting whether `Qwen3.5-27B-UD-Q4_K_XL.gguf`'s detected modalities are accurate. Orthogonal.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — full suite, 2500+ tests pass including the flipped `Pdf_in_dm_is_saved_to_inbox_path_only_and_never_inlined` regression
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Manual end-to-end: rebuild netclawd, re-send the same PDF to ArdyBot in Slack. Expected: announcement line arrives with `inlined="false"` and the `"current model has no native PDF support"` note; agent runs `shell_execute pdftotext ...` against `inbox/Logo Design Services.pdf` and answers the user. No 500.