### PR TITLE
cleanup(cli): consolidate scattered JsonSerializerOptions into JsonDefaults

### DIFF
--- a/src/Netclaw.Cli/Config/ClientConfigFile.cs
+++ b/src/Netclaw.Cli/Config/ClientConfigFile.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Config;
@@ -27,6 +28,6 @@ internal sealed class ClientConfigFile
 
         File.WriteAllText(
             paths.ClientConfigPath,
-            JsonSerializer.Serialize(new ClientConfigFile { Endpoint = endpoint.TrimEnd('/') }, ConfigFileHelper.JsonOptions));
+            JsonSerializer.Serialize(new ClientConfigFile { Endpoint = endpoint.TrimEnd('/') }, JsonDefaults.Indented));
     }
 }

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 
@@ -10,8 +11,6 @@ namespace Netclaw.Cli.Config;
 /// </summary>
 internal static class ConfigFileHelper
 {
-    internal static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
-
     /// <summary>
     /// Load both netclaw.json and secrets.json as mutable dictionaries.
     /// Missing files get a default <c>{ "configVersion": 1 }</c> skeleton.
@@ -90,7 +89,7 @@ internal static class ConfigFileHelper
         var dir = Path.GetDirectoryName(path);
         if (dir is not null)
             Directory.CreateDirectory(dir);
-        File.WriteAllText(path, JsonSerializer.Serialize(data, JsonOptions));
+        File.WriteAllText(path, JsonSerializer.Serialize(data, JsonDefaults.Indented));
     }
 
     /// <summary>
@@ -99,7 +98,7 @@ internal static class ConfigFileHelper
     internal static void WriteSecretsFile(Configuration.NetclawPaths paths, Dictionary<string, object> data)
     {
         var protector = SecretsProtection.CreateProtector(paths);
-        SecretsFileWriter.Write(paths.SecretsPath, data, options: JsonOptions, protector: protector);
+        SecretsFileWriter.Write(paths.SecretsPath, data, options: JsonDefaults.Indented, protector: protector);
     }
 
     internal static string DecryptIfEncrypted(Configuration.NetclawPaths paths, string? value)

--- a/src/Netclaw.Cli/Config/ProviderCredentialWriter.cs
+++ b/src/Netclaw.Cli/Config/ProviderCredentialWriter.cs
@@ -1,3 +1,4 @@
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 using Netclaw.Providers;
@@ -88,7 +89,7 @@ internal static class ProviderCredentialWriter
                 ["ApiKey"] = apiKey
             };
             SecretsFileWriter.Write(paths.SecretsPath, secrets,
-                options: ConfigFileHelper.JsonOptions, protector: effectiveProtector);
+                options: JsonDefaults.Indented, protector: effectiveProtector);
         }
     }
 }

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Daemon;
@@ -16,7 +17,6 @@ namespace Netclaw.Cli.Daemon;
 /// </summary>
 public sealed class DaemonApi
 {
-    private static readonly JsonSerializerOptions WebJsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan LongTimeout = TimeSpan.FromSeconds(30);
 
@@ -69,7 +69,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync($"{_endpoint}/api/health/status", cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<DaemonRuntimeStatus.Response>(stream, WebJsonOptions, cts.Token);
+        return await JsonSerializer.DeserializeAsync<DaemonRuntimeStatus.Response>(stream, JsonDefaults.Api, cts.Token);
     }
 
     // ── Sessions ──────────────────────────────────────────────────────
@@ -81,7 +81,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync($"{_endpoint}/api/sessions", cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<List<SessionCatalogEntryDto>>(stream, WebJsonOptions, cts.Token) ?? [];
+        return await JsonSerializer.DeserializeAsync<List<SessionCatalogEntryDto>>(stream, JsonDefaults.Api, cts.Token) ?? [];
     }
 
     // ── Stats ─────────────────────────────────────────────────────────
@@ -96,7 +96,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync(url, cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<DaemonStats.Response>(stream, WebJsonOptions, cts.Token);
+        return await JsonSerializer.DeserializeAsync<DaemonStats.Response>(stream, JsonDefaults.Api, cts.Token);
     }
 
     public async Task<SkillUsageStats.Response?> GetSkillUsageStatsAsync(int? days = null, CancellationToken ct = default)
@@ -109,7 +109,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync(url, cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<SkillUsageStats.Response>(stream, WebJsonOptions, cts.Token);
+        return await JsonSerializer.DeserializeAsync<SkillUsageStats.Response>(stream, JsonDefaults.Api, cts.Token);
     }
 
     // ── Reminders ─────────────────────────────────────────────────────
@@ -219,7 +219,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync($"{_endpoint}/api/mcp/statuses", cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<JsonElement>(stream, WebJsonOptions, cts.Token);
+        return await JsonSerializer.DeserializeAsync<JsonElement>(stream, JsonDefaults.Api, cts.Token);
     }
 
     public async Task<List<string>> GetMcpToolNamesAsync(string serverName, CancellationToken ct = default)
@@ -265,7 +265,7 @@ public sealed class DaemonApi
         using var response = await client.GetAsync($"{_endpoint}/api/pair/devices", cts.Token);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync(cts.Token);
-        return await JsonSerializer.DeserializeAsync<List<PairedDeviceInfoDto>>(stream, WebJsonOptions, cts.Token) ?? [];
+        return await JsonSerializer.DeserializeAsync<List<PairedDeviceInfoDto>>(stream, JsonDefaults.Api, cts.Token) ?? [];
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Json.Schema;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -93,7 +94,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
         if (appliedFixes.Count > 0)
         {
-            var normalized = obj.ToJsonString(ConfigFileHelper.JsonOptions);
+            var normalized = obj.ToJsonString(JsonDefaults.Indented);
 
             var replacement = normalized.EndsWith(Environment.NewLine, StringComparison.Ordinal)
                 ? normalized

--- a/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
@@ -1,18 +1,10 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
 
 internal static class DoctorJsonConfigReader
 {
-    internal static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter() }
-    };
-
     public static (JsonObject? Root, DoctorCheckResult? Error) TryReadConfig(NetclawPaths paths)
     {
         if (!File.Exists(paths.NetclawConfigPath))

--- a/src/Netclaw.Cli/Doctor/InboundWebhookRoutesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/InboundWebhookRoutesDoctorCheck.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -24,7 +25,7 @@ public sealed class InboundWebhookRoutesDoctorCheck(NetclawPaths paths) : IDocto
             var routeName = Path.GetFileNameWithoutExtension(filePath);
             try
             {
-                var route = JsonSerializer.Deserialize<WebhookRouteConfig>(File.ReadAllText(filePath), DoctorJsonConfigReader.JsonOptions)
+                var route = JsonSerializer.Deserialize<WebhookRouteConfig>(File.ReadAllText(filePath), JsonDefaults.ConfigRead)
                     ?? throw new InvalidOperationException($"Webhook route '{routeName}' could not be parsed.");
 
                 ValidateRoute(routeName, route);

--- a/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -29,7 +30,7 @@ public sealed class SecurityPolicyDoctorCheck(NetclawPaths paths) : IDoctorCheck
         SecurityPolicyConfig config;
         try
         {
-            config = JsonSerializer.Deserialize<SecurityPolicyConfig>(securityObject, DoctorJsonConfigReader.JsonOptions)
+            config = JsonSerializer.Deserialize<SecurityPolicyConfig>(securityObject, JsonDefaults.ConfigRead)
                      ?? new SecurityPolicyConfig();
         }
         catch (Exception ex)

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tools;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
@@ -47,7 +48,7 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         ToolConfig toolConfig;
         try
         {
-            toolConfig = JsonSerializer.Deserialize<ToolConfig>(toolsObject, DoctorJsonConfigReader.JsonOptions) ?? new ToolConfig();
+            toolConfig = JsonSerializer.Deserialize<ToolConfig>(toolsObject, JsonDefaults.ConfigRead) ?? new ToolConfig();
         }
         catch (Exception ex)
         {
@@ -58,7 +59,7 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         }
 
         var mcpServers = root["McpServers"] is JsonObject mcpObj
-            ? JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpObj, DoctorJsonConfigReader.JsonOptions) ?? new()
+            ? JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpObj, JsonDefaults.ConfigRead) ?? new()
             : new();
 
         var errors = new List<string>();

--- a/src/Netclaw.Cli/HeadlessChannel.cs
+++ b/src/Netclaw.Cli/HeadlessChannel.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Actors.Protocol;
 using Netclaw.Channels;
@@ -319,12 +320,6 @@ public sealed class HeadlessChannel : IChannel
         }
     }
 
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private void WriteJsonEnvelope()
     {
         // Client-side timing
@@ -346,7 +341,7 @@ public sealed class HeadlessChannel : IChannel
             TotalMs = totalMs.HasValue ? Math.Round(totalMs.Value, 1) : null,
         };
 
-        Console.WriteLine(JsonSerializer.Serialize(envelope, s_jsonOptions));
+        Console.WriteLine(JsonSerializer.Serialize(envelope, JsonDefaults.CliOutput));
     }
 
     private void Log(StreamWriter? log, string message)

--- a/src/Netclaw.Cli/Json/JsonDefaults.cs
+++ b/src/Netclaw.Cli/Json/JsonDefaults.cs
@@ -9,16 +9,18 @@ namespace Netclaw.Cli.Json;
 /// </summary>
 internal static class JsonDefaults
 {
+    private static readonly JsonStringEnumConverter EnumConverter = new();
+
     /// <summary>
     /// Daemon API communication: camelCase names, case-insensitive reads, numeric-string handling.
     /// Equivalent to <see cref="JsonSerializerDefaults.Web"/>.
     /// </summary>
-    public static readonly JsonSerializerOptions Api = new(JsonSerializerDefaults.Web);
+    internal static readonly JsonSerializerOptions Api = new(JsonSerializerDefaults.Web);
 
     /// <summary>
     /// Headless-channel JSON envelope output: camelCase names, nulls omitted.
     /// </summary>
-    public static readonly JsonSerializerOptions CliOutput = new()
+    internal static readonly JsonSerializerOptions CliOutput = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -27,7 +29,7 @@ internal static class JsonDefaults
     /// <summary>
     /// Pretty-printed terminal output.
     /// </summary>
-    public static readonly JsonSerializerOptions Indented = new()
+    internal static readonly JsonSerializerOptions Indented = new()
     {
         WriteIndented = true,
     };
@@ -35,25 +37,25 @@ internal static class JsonDefaults
     /// <summary>
     /// Config and secrets file serialization: pretty-printed with enum values as strings.
     /// </summary>
-    public static readonly JsonSerializerOptions ConfigFile = new()
+    internal static readonly JsonSerializerOptions ConfigFile = new()
     {
         WriteIndented = true,
-        Converters = { new JsonStringEnumConverter() },
+        Converters = { EnumConverter },
     };
 
     /// <summary>
     /// Config file deserialization: Web defaults (camelCase, case-insensitive) plus enum values as strings.
     /// </summary>
-    public static readonly JsonSerializerOptions ConfigRead = new(JsonSerializerDefaults.Web)
+    internal static readonly JsonSerializerOptions ConfigRead = new(JsonSerializerDefaults.Web)
     {
-        Converters = { new JsonStringEnumConverter() },
+        Converters = { EnumConverter },
     };
 
     /// <summary>
     /// Pretty-printed terminal output with camelCase property names.
     /// Used for structured JSON output (stats, sessions) that maps to daemon API response shapes.
     /// </summary>
-    public static readonly JsonSerializerOptions IndentedCamelCase = new()
+    internal static readonly JsonSerializerOptions IndentedCamelCase = new()
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -62,8 +64,8 @@ internal static class JsonDefaults
     /// <summary>
     /// Deserialization of data containing enum values serialized as strings.
     /// </summary>
-    public static readonly JsonSerializerOptions EnumAware = new()
+    internal static readonly JsonSerializerOptions EnumAware = new()
     {
-        Converters = { new JsonStringEnumConverter() },
+        Converters = { EnumConverter },
     };
 }

--- a/src/Netclaw.Cli/Json/JsonDefaults.cs
+++ b/src/Netclaw.Cli/Json/JsonDefaults.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Cli.Json;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> presets for the CLI.
+/// Use these instead of defining per-command static instances.
+/// </summary>
+internal static class JsonDefaults
+{
+    /// <summary>
+    /// Daemon API communication: camelCase names, case-insensitive reads, numeric-string handling.
+    /// Equivalent to <see cref="JsonSerializerDefaults.Web"/>.
+    /// </summary>
+    public static readonly JsonSerializerOptions Api = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Headless-channel JSON envelope output: camelCase names, nulls omitted.
+    /// </summary>
+    public static readonly JsonSerializerOptions CliOutput = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Pretty-printed terminal output.
+    /// </summary>
+    public static readonly JsonSerializerOptions Indented = new()
+    {
+        WriteIndented = true,
+    };
+
+    /// <summary>
+    /// Config and secrets file serialization: pretty-printed with enum values as strings.
+    /// </summary>
+    public static readonly JsonSerializerOptions ConfigFile = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Config file deserialization: Web defaults (camelCase, case-insensitive) plus enum values as strings.
+    /// </summary>
+    public static readonly JsonSerializerOptions ConfigRead = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Pretty-printed terminal output with camelCase property names.
+    /// Used for structured JSON output (stats, sessions) that maps to daemon API response shapes.
+    /// </summary>
+    public static readonly JsonSerializerOptions IndentedCamelCase = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>
+    /// Deserialization of data containing enum values serialized as strings.
+    /// </summary>
+    public static readonly JsonSerializerOptions EnumAware = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+}

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -665,7 +665,7 @@ internal static class McpCommand
 
         // Deserialize, toggle, re-serialize
         var entry = JsonSerializer.Deserialize<McpServerEntry>(
-            JsonSerializer.Serialize(mcpServers[name]), JsonDefaults.Indented) ?? new McpServerEntry();
+            JsonSerializer.Serialize(mcpServers[name])) ?? new McpServerEntry();
         entry.Enabled = enabled;
         mcpServers[name] = SerializeEntry(entry);
 
@@ -832,7 +832,7 @@ internal static class McpCommand
 
     private static JsonElement SerializeEntry(McpServerEntry entry)
     {
-        var json = JsonSerializer.Serialize(entry, JsonDefaults.Indented);
+        var json = JsonSerializer.Serialize(entry);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using ModelContextProtocol.Client;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Providers.OAuth;
 
@@ -32,8 +33,6 @@ internal readonly record struct McpProbeResult(
 /// </summary>
 internal static class McpCommand
 {
-    private static JsonSerializerOptions JsonOptions => ConfigFileHelper.JsonOptions;
-
     public static async Task<int> RunAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi = null, TextWriter? output = null)
     {
         var writer = output ?? Console.Out;
@@ -666,7 +665,7 @@ internal static class McpCommand
 
         // Deserialize, toggle, re-serialize
         var entry = JsonSerializer.Deserialize<McpServerEntry>(
-            JsonSerializer.Serialize(mcpServers[name]), JsonOptions) ?? new McpServerEntry();
+            JsonSerializer.Serialize(mcpServers[name]), JsonDefaults.Indented) ?? new McpServerEntry();
         entry.Enabled = enabled;
         mcpServers[name] = SerializeEntry(entry);
 
@@ -833,7 +832,7 @@ internal static class McpCommand
 
     private static JsonElement SerializeEntry(McpServerEntry entry)
     {
-        var json = JsonSerializer.Serialize(entry, JsonOptions);
+        var json = JsonSerializer.Serialize(entry, JsonDefaults.Indented);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }
@@ -1186,8 +1185,7 @@ internal static class McpCommand
             if (!doc.RootElement.TryGetProperty("Tools", out var toolsSection))
                 return new ToolConfig();
 
-            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(),
-                new JsonSerializerOptions { Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() } })
+            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(), JsonDefaults.EnumAware)
                 ?? new ToolConfig();
         }
         catch

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using R3;
 using Termina.Reactive;
@@ -18,11 +18,6 @@ public enum ToolPermissionsState
 
 public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 {
-    private static readonly JsonSerializerOptions EnumJsonOptions = new()
-    {
-        Converters = { new JsonStringEnumConverter() }
-    };
-
     private readonly NetclawPaths _paths;
     private readonly DaemonApi _daemonApi;
 
@@ -462,7 +457,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             if (!doc.RootElement.TryGetProperty("Tools", out var toolsSection))
                 return new ToolConfig();
 
-            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(), EnumJsonOptions)
+            return JsonSerializer.Deserialize<ToolConfig>(toolsSection.GetRawText(), JsonDefaults.EnumAware)
                 ?? new ToolConfig();
         }
         catch

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Cli.Provider;
 using Netclaw.Configuration;
 using Netclaw.Providers;
@@ -12,10 +12,6 @@ namespace Netclaw.Cli.Model;
 /// </summary>
 internal static class ModelCommand
 {
-    private static readonly JsonSerializerOptions DeserializeOptions = new()
-    {
-        Converters = { new JsonStringEnumConverter() }
-    };
     public static async Task<int> RunAsync(
         string[] args, NetclawPaths paths,
         IProviderProbe? probe = null, TextWriter? output = null)
@@ -277,7 +273,7 @@ internal static class ModelCommand
         if (!doc.RootElement.TryGetProperty("Models", out var modelsElement))
             return null;
 
-        return JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), DeserializeOptions);
+        return JsonSerializer.Deserialize<ModelSelection>(modelsElement.GetRawText(), JsonDefaults.EnumAware);
     }
 
     private static int WriteHelp(TextWriter writer)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -10,6 +10,7 @@ using Netclaw.Channels;
 using Netclaw.Channels.Slack;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Json;
 using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Mcp;
 using Netclaw.Cli.Reminder;
@@ -1167,10 +1168,7 @@ static void WriteDoctorJsonResult(DoctorRunResult result, DoctorFixPlan? fixPlan
         }
     };
 
-    Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions
-    {
-        WriteIndented = true
-    }));
+    Console.WriteLine(JsonSerializer.Serialize(payload, JsonDefaults.Indented));
 }
 
 static void WriteDoctorFixPlan(DoctorFixPlan plan, bool dryRun)
@@ -1250,8 +1248,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
 
         if (jsonOutput)
         {
-            var node = JsonSerializer.SerializeToNode(
-                status, new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+            var node = JsonSerializer.SerializeToNode(status, JsonDefaults.Api)!;
             var updateNode = (node["update"] as JsonObject) ?? new JsonObject();
             var updateAvailable = string.Equals(cliUpdate.State, "update-available", StringComparison.Ordinal);
             updateNode["available"] = updateAvailable;
@@ -1260,7 +1257,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
             updateNode["latestVersion"] = updateAvailable ? cliUpdate.LatestVersion : null;
             updateNode["releaseNotesUrl"] = updateAvailable ? cliUpdate.ReleaseNotesUrl : null;
             node["update"] = updateNode;
-            Console.WriteLine(node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            Console.WriteLine(node.ToJsonString(JsonDefaults.Indented));
         }
         else
         {
@@ -1300,10 +1297,7 @@ static async Task<int> RunSessionsOnceAsync(IServiceProvider services, bool json
 
         if (jsonOutput)
         {
-            Console.WriteLine(JsonSerializer.Serialize(sessions, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            }));
+            Console.WriteLine(JsonSerializer.Serialize(sessions, JsonDefaults.Indented));
         }
         else
         {
@@ -1453,11 +1447,7 @@ static async Task<int> RunStatsAsync(IServiceProvider services, bool jsonOutput,
 
         if (jsonOutput)
         {
-            Console.WriteLine(JsonSerializer.Serialize(stats, new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            }));
+            Console.WriteLine(JsonSerializer.Serialize(stats, JsonDefaults.IndentedCamelCase));
         }
         else
         {
@@ -1496,11 +1486,7 @@ static async Task<int> RunSkillStatsAsync(IServiceProvider services, bool jsonOu
 
         if (jsonOutput)
         {
-            Console.WriteLine(JsonSerializer.Serialize(stats, new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            }));
+            Console.WriteLine(JsonSerializer.Serialize(stats, JsonDefaults.IndentedCamelCase));
         }
         else
         {

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Providers;
 using Netclaw.Providers.OAuth;
@@ -311,14 +312,6 @@ internal static class ProviderCommand
     /// <summary>
     /// Load provider entries from merged config + secrets files.
     /// </summary>
-    private static readonly JsonSerializerOptions DeserializeOptions = new()
-    {
-        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
-    };
-
-    /// <summary>
-    /// Load provider entries from merged config + secrets files.
-    /// </summary>
     internal static Dictionary<string, ProviderEntry> LoadProviders(NetclawPaths paths)
     {
         var configText = File.Exists(paths.NetclawConfigPath)
@@ -335,7 +328,7 @@ internal static class ProviderCommand
         {
             foreach (var prop in configProviders.EnumerateObject())
             {
-                var entry = JsonSerializer.Deserialize<ProviderEntry>(prop.Value.GetRawText(), DeserializeOptions)
+                var entry = JsonSerializer.Deserialize<ProviderEntry>(prop.Value.GetRawText(), JsonDefaults.EnumAware)
                     ?? new ProviderEntry();
                 result[prop.Name] = entry;
             }

--- a/src/Netclaw.Cli/Secrets/SecretsCommand.cs
+++ b/src/Netclaw.Cli/Secrets/SecretsCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
 
@@ -11,8 +12,6 @@ namespace Netclaw.Cli.Secrets;
 /// </summary>
 internal static class SecretsCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
-
     public static int Run(string[] args, NetclawPaths paths, TextWriter? output = null)
     {
         var writer = output ?? Console.Out;
@@ -81,7 +80,7 @@ internal static class SecretsCommand
 
         // Write with encryption — the protector encrypts all plaintext leaves
         var protector = SecretsProtection.CreateProtector(paths);
-        var json = root.ToJsonString(JsonOptions);
+        var json = root.ToJsonString(JsonDefaults.Indented);
         SecretsFileWriter.Write(paths.SecretsPath, json, protector);
 
         writer.WriteLine($"Set {keyPath} (encrypted).");

--- a/src/Netclaw.Cli/Skills/SkillCommand.cs
+++ b/src/Netclaw.Cli/Skills/SkillCommand.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Actors.Skills;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Skills;
@@ -13,12 +13,6 @@ namespace Netclaw.Cli.Skills;
 /// </summary>
 internal static class SkillCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        Converters = { new JsonStringEnumConverter() }
-    };
-
     public static Task<int> RunAsync(string[] args, NetclawPaths paths)
     {
         var subcommand = args.Length > 1 ? args[1] : "list";
@@ -541,7 +535,7 @@ internal static class SkillCommand
         var dict = ConfigFileHelper.LoadJsonDict(paths.NetclawConfigPath);
 
         // Serialize the config to a JsonElement so it round-trips cleanly
-        var serialized = JsonSerializer.SerializeToElement(config, JsonOptions);
+        var serialized = JsonSerializer.SerializeToElement(config, JsonDefaults.ConfigFile);
         dict["ExternalSkills"] = serialized;
 
         ConfigFileHelper.WriteConfigFile(paths.NetclawConfigPath, dict);

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Netclaw.Cli.Config;
+using Netclaw.Cli.Json;
 using Netclaw.Cli.Mcp;
 using Netclaw.Configuration;
 using Netclaw.Configuration.Secrets;
@@ -44,10 +44,8 @@ public sealed class WizardConfigBuilder
         _paths.EnsureDirectoriesExist();
         var config = BuildConfigDictionary();
 
-        var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
-        jsonOptions.Converters.Add(new JsonStringEnumConverter());
         File.WriteAllText(_paths.NetclawConfigPath,
-            JsonSerializer.Serialize(config, jsonOptions));
+            JsonSerializer.Serialize(config, JsonDefaults.ConfigFile));
     }
 
     /// <summary>
@@ -275,10 +273,8 @@ public sealed class WizardSecretsBuilder
         if (_secrets.Count == 0)
             return;
 
-        var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
-        jsonOptions.Converters.Add(new JsonStringEnumConverter());
         SecretsFileWriter.Write(_paths.SecretsPath, _secrets,
-            options: jsonOptions, protector: SensitiveStringTypeConverter.Protector);
+            options: JsonDefaults.ConfigFile, protector: SensitiveStringTypeConverter.Protector);
     }
 }
 


### PR DESCRIPTION
## Summary

- Introduces `Netclaw.Cli.Json.JsonDefaults` with 7 named presets (`Api`, `CliOutput`, `Indented`, `ConfigFile`, `ConfigRead`, `IndentedCamelCase`, `EnumAware`) that replace ~10 scattered `static readonly JsonSerializerOptions` instances across the CLI project
- All presets share a single `JsonStringEnumConverter` instance instead of allocating one per preset
- Removes `JsonDefaults.Indented` from `McpCommand`'s internal JSON round-trips (entry serialization for config storage is not display output — `WriteIndented` was generating whitespace that was immediately discarded)
- Fixes access modifiers: all presets are now `internal` to match the `internal` class visibility

Closes #612.

## Test plan

- [x] `dotnet build src/Netclaw.Cli/Netclaw.Cli.csproj` — 0 warnings, 0 errors
- [x] `dotnet build src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj` — 0 warnings, 0 errors
- [ ] CI passes