### PR TITLE
fix(daemon): harden crash handling and diagnostics

### DIFF
--- a/docs/runbooks/behavior-debugging.md
+++ b/docs/runbooks/behavior-debugging.md
@@ -21,6 +21,17 @@ message loops, dropped sessions, or unexpected policy decisions).
 3. If session rows are created but Slack has no reply, focus on outbound adapter
    path (Slack thread binding actor and Slack post client).
 
+4. Check crash evidence immediately when behavior looks like a sudden process
+   disappearance:
+
+   ```bash
+   ls -lt "$HOME/.netclaw/logs"/crash-*.log
+   netclaw doctor
+   ```
+
+   `netclaw doctor` includes a daemon crash-log check that flags recent
+   `Netclaw daemon*` crash files and points to remediation.
+
 ## Enable Debug Logging
 
 Set these in `~/.netclaw/config/netclaw.json`:

--- a/docs/spec/SPEC-011-daemon-architecture.md
+++ b/docs/spec/SPEC-011-daemon-architecture.md
@@ -199,6 +199,19 @@ the actor system cleanly.
 `netclaw daemon status` checks the PID file and verifies the process is alive.
 Reports: running/stopped, PID, uptime, port, number of active sessions.
 
+### Crash interception and evidence
+
+The daemon installs process-level exception handlers at startup for:
+
+- `AppDomain.CurrentDomain.UnhandledException`
+- `TaskScheduler.UnobservedTaskException`
+
+On either path, Netclaw writes a crash log under `~/.netclaw/logs/crash-*.log`
+with process diagnostics and the latest known session/turn context. When DI is
+available, the daemon also emits an operational alert with type
+`daemon.crashing` (category `DaemonCrashed`) so configured webhook targets can
+capture crash signals even when the process is unstable.
+
 ### Service Registration (Linux)
 
 `netclaw daemon install` creates a systemd user service at

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.12.0"
+  version: "1.13.0"
 ---
 
 # Netclaw Operations
@@ -213,7 +213,7 @@ full exception internally. Exception details are **never** forwarded to Slack.
 When something seems wrong with Netclaw itself:
 
 1. Run `netclaw doctor` via `shell_execute` — validates config, providers,
-   MCP connections, memory health
+   MCP connections, memory health, and recent daemon crash logs
 2. If doctor reports fixable issues, run `netclaw doctor --fix --dry-run` to
    preview auto-repairs (schema-driven: stale properties, enum coercion, missing defaults)
 3. Run `netclaw status` via `shell_execute` — live runtime state from daemon
@@ -226,6 +226,10 @@ When something seems wrong with Netclaw itself:
 | Missing tools | `netclaw mcp list`; check MCP connection state |
 | Memory recall degraded | `netclaw status` memory section |
 | Daemon won't start | crash logs at `~/.netclaw/logs/crash-*.log` |
+
+If webhook notifications are configured, daemon crash paths emit
+`daemon.crashing` operational alerts with context (PID, reason, and latest known
+session/turn snapshot when available).
 
 Doctor checks include `exposure-mode`, which validates that the `Daemon`
 config section (if present) specifies a supported exposure mode and that

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2550,6 +2550,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             ?? sourceMessageId
             ?? Guid.NewGuid().ToString("N")[..8];
         _activeChannelType = source?.ChannelType;
+
+        CrashContextSnapshot.Update(
+            _sessionId.Value,
+            _activeTurnId,
+            _activeMessageId,
+            _activeChannelType?.ToWireValue(),
+            _timeProvider.GetUtcNow());
     }
 
     private ILoggingAdapter TurnLog()

--- a/src/Netclaw.Cli.Tests/Doctor/DaemonCrashDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DaemonCrashDoctorCheckTests.cs
@@ -1,0 +1,80 @@
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class DaemonCrashDoctorCheckTests
+{
+    [Fact]
+    public async Task ReturnsWarning_WhenRecentDaemonCrashLogExists()
+    {
+        var paths = CreateTempPaths();
+        var now = new DateTimeOffset(2026, 4, 14, 18, 30, 0, TimeSpan.Zero);
+
+        var crashPath = Path.Combine(paths.LogsDirectory, "crash-20260414-182900.log");
+        await File.WriteAllTextAsync(
+            crashPath,
+            "Netclaw daemon-unhandled crash at 2026-04-14T18:29:00.0000000+00:00\n\nSystem.InvalidOperationException: boom",
+            TestContext.Current.CancellationToken);
+
+        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("crash-20260414-182900.log", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenOnlyCliCrashLogsExist()
+    {
+        var paths = CreateTempPaths();
+        var now = new DateTimeOffset(2026, 4, 14, 18, 30, 0, TimeSpan.Zero);
+
+        var crashPath = Path.Combine(paths.LogsDirectory, "crash-20260414-182900.log");
+        await File.WriteAllTextAsync(
+            crashPath,
+            "Netclaw CLI crash at 2026-04-14T18:29:00.0000000+00:00\n\nSystem.InvalidOperationException: cli failure",
+            TestContext.Current.CancellationToken);
+
+        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenDaemonCrashLogIsOutsideRecentWindow()
+    {
+        var paths = CreateTempPaths();
+        var now = new DateTimeOffset(2026, 4, 14, 18, 30, 0, TimeSpan.Zero);
+
+        var crashPath = Path.Combine(paths.LogsDirectory, "crash-20260401-080000.log");
+        await File.WriteAllTextAsync(
+            crashPath,
+            "Netclaw daemon crash at 2026-04-01T08:00:00.0000000+00:00\n\nSystem.InvalidOperationException: old",
+            TestContext.Current.CancellationToken);
+
+        File.SetLastWriteTimeUtc(crashPath, new DateTime(2026, 4, 1, 8, 0, 0, DateTimeKind.Utc));
+
+        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    private static NetclawPaths CreateTempPaths()
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+        return paths;
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        private DateTimeOffset _now = now;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DaemonCrashDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/DaemonCrashDoctorCheck.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+public sealed class DaemonCrashDoctorCheck(
+    NetclawPaths paths,
+    TimeProvider? timeProvider = null) : IDoctorCheck
+{
+    private const string CheckName = "Daemon Crash Logs";
+    private static readonly TimeSpan RecentWindow = TimeSpan.FromDays(7);
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var recentCrashes = FindRecentDaemonCrashes(paths.LogsDirectory, now).ToList();
+        if (recentCrashes.Count == 0)
+        {
+            return Task.FromResult(DoctorCheckResult.Pass(
+                CheckName,
+                "No recent daemon crash logs found."));
+        }
+
+        var latest = recentCrashes[0];
+        var occurredAt = TryParseCrashTimestamp(latest.Name)
+            ?.ToString("u", CultureInfo.InvariantCulture)
+            ?? latest.LastWriteTimeUtc.ToString("u", CultureInfo.InvariantCulture);
+
+        var restartedSinceLatestCrash = IsCrashLogStale(latest, paths.PidFilePath);
+        var restartNote = restartedSinceLatestCrash
+            ? "daemon appears to have restarted since this crash"
+            : "daemon has not recorded a newer PID timestamp since this crash";
+
+        return Task.FromResult(DoctorCheckResult.Warning(
+            CheckName,
+            $"Detected {recentCrashes.Count} daemon crash log(s) in the last {(int)RecentWindow.TotalDays} days (latest: {latest.Name}, {occurredAt}; {restartNote}).",
+            "Inspect ~/.netclaw/logs/crash-*.log for stack traces, run `netclaw daemon status`, and verify notification targets received `daemon.crashing` alerts."));
+    }
+
+    private static IEnumerable<FileInfo> FindRecentDaemonCrashes(string logsDirectory, DateTimeOffset now)
+    {
+        if (!Directory.Exists(logsDirectory))
+            return [];
+
+        var cutoff = now.UtcDateTime - RecentWindow;
+        return new DirectoryInfo(logsDirectory)
+            .GetFiles("crash-*.log", SearchOption.TopDirectoryOnly)
+            .Where(f => f.LastWriteTimeUtc >= cutoff)
+            .OrderByDescending(f => f.LastWriteTimeUtc)
+            .Where(IsDaemonCrashLog);
+    }
+
+    private static bool IsDaemonCrashLog(FileInfo crashLog)
+    {
+        try
+        {
+            using var stream = crashLog.OpenRead();
+            using var reader = new StreamReader(stream);
+            var firstLine = reader.ReadLine();
+            return !string.IsNullOrWhiteSpace(firstLine)
+                   && firstLine.Contains("Netclaw daemon", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsCrashLogStale(FileInfo crashLog, string pidFilePath)
+    {
+        var pidFile = new FileInfo(pidFilePath);
+        return pidFile.Exists && pidFile.LastWriteTimeUtc > crashLog.LastWriteTimeUtc;
+    }
+
+    private static DateTimeOffset? TryParseCrashTimestamp(string fileName)
+    {
+        // crash-YYYYMMDD-HHMMSS.log (+ optional suffixes)
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        const string prefix = "crash-";
+        if (!stem.StartsWith(prefix, StringComparison.Ordinal))
+            return null;
+
+        var payload = stem[prefix.Length..];
+        if (payload.Length < 15)
+            return null;
+
+        var timestampPart = payload[..15];
+        if (!DateTimeOffset.TryParseExact(
+                timestampPart,
+                "yyyyMMdd-HHmmss",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal,
+                out var parsed))
+            return null;
+
+        return parsed.ToUniversalTime();
+    }
+}

--- a/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorRegistrationExtensions.cs
@@ -16,6 +16,7 @@ public static class DoctorRegistrationExtensions
         services.AddSingleton<IDoctorCheck, SecretsJsonDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SlackAuthDoctorCheck>();
         services.AddSingleton<IDoctorCheck, SqliteProvisioningDoctorCheck>();
+        services.AddSingleton<IDoctorCheck, DaemonCrashDoctorCheck>();
         services.AddSingleton<IDoctorCheck, MemoryCheckpointHealthDoctorCheck>();
         services.AddSingleton<IDoctorCheck, McpServersDoctorCheck>();
         services.AddSingleton<IDoctorCheck, ContextWindowDoctorCheck>();

--- a/src/Netclaw.Configuration/CrashContextSnapshot.cs
+++ b/src/Netclaw.Configuration/CrashContextSnapshot.cs
@@ -1,0 +1,48 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Process-wide best-effort snapshot of the most recent session/turn context.
+/// Updated by session actors so process-level crash handlers can include
+/// actionable context in crash logs and alerts.
+/// </summary>
+public static class CrashContextSnapshot
+{
+    private static readonly object Gate = new();
+    private static CrashTurnContext? _latest;
+
+    public static void Update(
+        string sessionId,
+        string? turnId,
+        string? messageId,
+        string? channelType,
+        DateTimeOffset observedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return;
+
+        lock (Gate)
+        {
+            _latest = new CrashTurnContext(
+                sessionId,
+                turnId,
+                messageId,
+                channelType,
+                observedAtUtc);
+        }
+    }
+
+    public static CrashTurnContext? GetLatest()
+    {
+        lock (Gate)
+        {
+            return _latest;
+        }
+    }
+}
+
+public sealed record CrashTurnContext(
+    string SessionId,
+    string? TurnId,
+    string? MessageId,
+    string? ChannelType,
+    DateTimeOffset ObservedAtUtc);

--- a/src/Netclaw.Configuration/CrashLogWriter.cs
+++ b/src/Netclaw.Configuration/CrashLogWriter.cs
@@ -2,12 +2,13 @@ namespace Netclaw.Configuration;
 
 public static class CrashLogWriter
 {
-    public static void Write(
+    public static string? TryWrite(
         Exception ex,
         string processName,
         TimeProvider? timeProvider = null,
         TextWriter? errorWriter = null,
-        string? logsDirectory = null)
+        string? logsDirectory = null,
+        IReadOnlyDictionary<string, string>? context = null)
     {
         ArgumentNullException.ThrowIfNull(ex);
         if (string.IsNullOrWhiteSpace(processName))
@@ -25,21 +26,75 @@ public static class CrashLogWriter
 
             Directory.CreateDirectory(effectiveLogsDirectory);
 
-            var crashPath = Path.Combine(effectiveLogsDirectory,
+            var basePath = Path.Combine(effectiveLogsDirectory,
                 $"crash-{now:yyyyMMdd-HHmmss}.log");
+            var crashPath = EnsureUniquePath(basePath, now);
 
-            File.WriteAllText(crashPath,
-                $"""
-                Netclaw {processName} crash at {now:O}
-
-                {ex}
-                """);
+            File.WriteAllText(crashPath, BuildCrashLogContent(processName, now, ex, context));
 
             errorWriter.WriteLine($"Fatal error — crash log written to {crashPath}");
+            return crashPath;
         }
         catch
         {
             errorWriter.WriteLine($"Fatal error (could not write crash log): {ex}");
+            return null;
         }
+    }
+
+    public static void Write(
+        Exception ex,
+        string processName,
+        TimeProvider? timeProvider = null,
+        TextWriter? errorWriter = null,
+        string? logsDirectory = null,
+        IReadOnlyDictionary<string, string>? context = null)
+    {
+        _ = TryWrite(ex, processName, timeProvider, errorWriter, logsDirectory, context);
+    }
+
+    private static string BuildCrashLogContent(
+        string processName,
+        DateTimeOffset timestamp,
+        Exception ex,
+        IReadOnlyDictionary<string, string>? context)
+    {
+        var writer = new StringWriter();
+        writer.WriteLine($"Netclaw {processName} crash at {timestamp:O}");
+        writer.WriteLine();
+
+        if (context is { Count: > 0 })
+        {
+            writer.WriteLine("Context:");
+            foreach (var kv in context.OrderBy(static x => x.Key, StringComparer.Ordinal))
+                writer.WriteLine($"{kv.Key}: {kv.Value}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine(ex.ToString());
+        return writer.ToString();
+    }
+
+    private static string EnsureUniquePath(string basePath, DateTimeOffset now)
+    {
+        if (!File.Exists(basePath))
+            return basePath;
+
+        var directory = Path.GetDirectoryName(basePath) ?? string.Empty;
+        var baseName = Path.GetFileNameWithoutExtension(basePath);
+        var extension = Path.GetExtension(basePath);
+
+        for (var i = 1; i <= 1000; i++)
+        {
+            var candidate = Path.Combine(
+                directory,
+                $"{baseName}-{Environment.ProcessId}-{now:fff}-{i}{extension}");
+            if (!File.Exists(candidate))
+                return candidate;
+        }
+
+        return Path.Combine(
+            directory,
+            $"{baseName}-{Environment.ProcessId}-{Guid.NewGuid():N}{extension}");
     }
 }

--- a/src/Netclaw.Configuration/OperationalAlert.cs
+++ b/src/Netclaw.Configuration/OperationalAlert.cs
@@ -17,6 +17,7 @@ public enum AlertType
     WebhookRouteInvalid,
     DaemonStarted,
     DaemonStopping,
+    DaemonCrashed,
     UpdateAvailable,
 }
 

--- a/src/Netclaw.Daemon.Tests/Services/DaemonLifecycleNotifierTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/DaemonLifecycleNotifierTests.cs
@@ -56,6 +56,27 @@ public sealed class DaemonLifecycleNotifierTests
         Assert.Equal("Netclaw daemon stopping: update", alert.Summary);
     }
 
+    [Fact]
+    public void NotifyCrashing_EmitsCriticalAlert()
+    {
+        var ex = new InvalidOperationException("kaboom");
+
+        _sut.NotifyCrashing(
+            "daemon-unhandled",
+            ex,
+            "/tmp/crash-20260414-182900.log",
+            new Dictionary<string, string> { ["latest_session_id"] = "C123/171313.123" });
+
+        var alert = Assert.Single(_sink.Alerts);
+        Assert.Equal("daemon.crashing", alert.Type);
+        Assert.Equal(AlertType.DaemonCrashed, alert.Category);
+        Assert.Equal("critical", alert.Severity);
+        Assert.NotNull(alert.Context);
+        Assert.Equal("daemon-unhandled", alert.Context["reason"]);
+        Assert.Equal("/tmp/crash-20260414-182900.log", alert.Context["crashLogPath"]);
+        Assert.Equal("C123/171313.123", alert.Context["latest_session_id"]);
+    }
+
     private sealed class RecordingSink : IOperationalNotificationSink
     {
         public List<OperationalAlert> Alerts { get; } = [];

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -40,20 +40,22 @@ using Netclaw.Search;
 using Netclaw.Security;
 using static Microsoft.Extensions.Logging.LogLevel;
 
+var bootstrapPaths = new NetclawPaths();
+bootstrapPaths.EnsureDirectoriesExist();
+using var crashMonitor = DaemonCrashMonitor.Register(bootstrapPaths);
+
 try
 {
     // Acquire an exclusive lock file before anything else. This is the OS-level
     // singleton guard — a second netclawd instance will fail to open the file
     // and exit immediately. The lock survives soft restarts (same process) and
     // is released by the OS on crash (fd closed → flock released).
-    var paths = new NetclawPaths();
-    paths.EnsureDirectoriesExist();
 
     FileStream lockFile;
     try
     {
         lockFile = new FileStream(
-            paths.LockFilePath,
+            bootstrapPaths.LockFilePath,
             FileMode.OpenOrCreate,
             FileAccess.ReadWrite,
             FileShare.None);
@@ -72,17 +74,17 @@ try
         do
         {
             restartSignal.Reset();
-            await RunDaemonAsync(args, restartSignal);
+            await RunDaemonAsync(args, restartSignal, crashMonitor);
         } while (restartSignal.RestartRequested);
     }
 }
 catch (Exception ex)
 {
-    WriteCrashLog(ex);
+    crashMonitor.RecordTopLevelException(ex);
     throw;
 }
 
-static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSignal)
+static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSignal, DaemonCrashMonitor crashMonitor)
 {
     // Anchor process CWD to a user-owned temp directory.
     // Without this, the daemon runs from its install location (e.g. /usr/local/bin),
@@ -154,6 +156,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     builder.Services.AddSingleton<IDaemonRestartCoordinator>(sp => sp.GetRequiredService<DaemonRestartCoordinator>());
 
     var app = builder.Build();
+    crashMonitor.AttachServices(app.Services);
 
     // Eagerly resolve so StartedAt reflects daemon startup, not first request.
     app.Services.GetRequiredService<DaemonStartClock>();
@@ -380,14 +383,25 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     // Fire startup notification after all hosted services are ready
     app.Lifetime.ApplicationStarted.Register(() =>
-        app.Services.GetRequiredService<DaemonLifecycleNotifier>().NotifyStarted());
+    {
+        try
+        {
+            app.Services.GetRequiredService<DaemonLifecycleNotifier>().NotifyStarted();
+        }
+        catch (Exception ex)
+        {
+            CrashLogWriter.Write(ex, "daemon-started-hook");
+        }
+    });
 
-    await app.RunAsync();
-}
-
-static void WriteCrashLog(Exception ex)
-{
-    CrashLogWriter.Write(ex, "daemon");
+    try
+    {
+        await app.RunAsync();
+    }
+    finally
+    {
+        crashMonitor.DetachServices();
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/Netclaw.Daemon/Providers/IProviderOAuthCallbackListener.cs
+++ b/src/Netclaw.Daemon/Providers/IProviderOAuthCallbackListener.cs
@@ -1,4 +1,5 @@
 using Netclaw.Providers.OAuth;
+using Microsoft.Extensions.Logging;
 
 namespace Netclaw.Daemon.Providers;
 
@@ -10,14 +11,29 @@ internal interface IProviderOAuthCallbackListener
 internal sealed class ProviderOAuthCallbackListener : IProviderOAuthCallbackListener
 {
     private readonly OAuthPkceService _pkceService;
+    private readonly ILogger<ProviderOAuthCallbackListener> _logger;
 
-    public ProviderOAuthCallbackListener(OAuthPkceService pkceService)
+    public ProviderOAuthCallbackListener(
+        OAuthPkceService pkceService,
+        ILogger<ProviderOAuthCallbackListener> logger)
     {
         _pkceService = pkceService;
+        _logger = logger;
     }
 
     public void StartListening(string redirectUri, string state)
     {
-        _ = _pkceService.ListenForCallbackAsync(redirectUri, state);
+        var task = _pkceService.ListenForCallbackAsync(redirectUri, state);
+        _ = task.ContinueWith(t =>
+            {
+                var exception = t.Exception?.GetBaseException();
+                _logger.LogWarning(
+                    exception,
+                    "Provider OAuth callback listener failed for state {State}",
+                    state);
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -81,19 +81,33 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
 
     private void OnFileChanged(object sender, FileSystemEventArgs e)
     {
-        if (!IsWatchedFile(e.Name))
-            return;
+        try
+        {
+            if (!IsWatchedFile(e.Name))
+                return;
 
-        _logger.LogDebug("Config file changed: {FileName}", e.Name);
-        ScheduleReload();
+            _logger.LogDebug("Config file changed: {FileName}", e.Name);
+            ScheduleReload();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in config watcher Changed callback for {FileName}", e.Name);
+        }
     }
 
     private void OnFileDeleted(object sender, FileSystemEventArgs e)
     {
-        if (!IsWatchedFile(e.Name))
-            return;
+        try
+        {
+            if (!IsWatchedFile(e.Name))
+                return;
 
-        _logger.LogWarning("Config file deleted: {FileName}. Keeping current config.", e.Name);
+            _logger.LogWarning("Config file deleted: {FileName}. Keeping current config.", e.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in config watcher Deleted callback for {FileName}", e.Name);
+        }
     }
 
     private void ScheduleReload()

--- a/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
+++ b/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
@@ -110,9 +110,9 @@ internal sealed class DaemonCrashMonitor : IDisposable
             context["private_memory_mb"] = (process.PrivateMemorySize64 / (1024 * 1024)).ToString();
             context["gc_total_memory_mb"] = (GC.GetTotalMemory(forceFullCollection: false) / (1024 * 1024)).ToString();
         }
-        catch
+        catch (Exception ex)
         {
-            // Best effort only.
+            TryLogMonitorFailure("Failed to capture process metrics for crash diagnostics.", ex);
         }
 
         var latestTurn = CrashContextSnapshot.GetLatest();
@@ -203,9 +203,9 @@ internal sealed class DaemonCrashMonitor : IDisposable
                 return;
             }
         }
-        catch
+        catch (Exception loggingFailure)
         {
-            // Fall through to stderr.
+            Console.Error.WriteLine($"[Netclaw.Daemon.CrashMonitor] Failed to write monitor warning via logger factory: {loggingFailure}");
         }
 
         Console.Error.WriteLine($"[Netclaw.Daemon.CrashMonitor] {message} {exception}");

--- a/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
+++ b/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
@@ -1,0 +1,213 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Gateway;
+
+namespace Netclaw.Daemon.Services;
+
+internal sealed class DaemonCrashMonitor : IDisposable
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly string _logsDirectory;
+    private readonly UnhandledExceptionEventHandler _unhandledHandler;
+    private readonly EventHandler<UnobservedTaskExceptionEventArgs> _unobservedTaskHandler;
+    private IServiceProvider? _services;
+
+    private DaemonCrashMonitor(string logsDirectory, TimeProvider? timeProvider = null)
+    {
+        _logsDirectory = logsDirectory;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+
+        _unhandledHandler = HandleUnhandledException;
+        _unobservedTaskHandler = HandleUnobservedTaskException;
+
+        AppDomain.CurrentDomain.UnhandledException += _unhandledHandler;
+        TaskScheduler.UnobservedTaskException += _unobservedTaskHandler;
+    }
+
+    public static DaemonCrashMonitor Register(NetclawPaths paths, TimeProvider? timeProvider = null)
+        => new(paths.LogsDirectory, timeProvider);
+
+    public void AttachServices(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public void DetachServices()
+    {
+        _services = null;
+    }
+
+    public void RecordTopLevelException(Exception exception)
+    {
+        HandleCrash("daemon-main", exception, isTerminating: true, isUnobservedTask: false);
+    }
+
+    public void Dispose()
+    {
+        AppDomain.CurrentDomain.UnhandledException -= _unhandledHandler;
+        TaskScheduler.UnobservedTaskException -= _unobservedTaskHandler;
+    }
+
+    private void HandleUnhandledException(object sender, UnhandledExceptionEventArgs args)
+    {
+        var exception = args.ExceptionObject as Exception
+            ?? new InvalidOperationException($"Unhandled non-exception object: {args.ExceptionObject?.GetType().FullName ?? "null"}");
+
+        HandleCrash("daemon-unhandled", exception, args.IsTerminating, isUnobservedTask: false);
+    }
+
+    private void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs args)
+    {
+        HandleCrash("daemon-unobserved", args.Exception, isTerminating: false, isUnobservedTask: true);
+        args.SetObserved();
+    }
+
+    private void HandleCrash(string reason, Exception exception, bool isTerminating, bool isUnobservedTask)
+    {
+        try
+        {
+            var context = BuildContext(reason, isTerminating, isUnobservedTask);
+            var crashLogPath = CrashLogWriter.TryWrite(
+                exception,
+                reason,
+                timeProvider: _timeProvider,
+                logsDirectory: _logsDirectory,
+                context: context);
+
+            if (!string.IsNullOrWhiteSpace(crashLogPath))
+                context["crash_log_path"] = crashLogPath;
+
+            TryNotifyCrashing(reason, exception, crashLogPath, context);
+        }
+        catch (Exception ex)
+        {
+            TryLogMonitorFailure("Crash monitor failed while handling process exception.", ex);
+        }
+    }
+
+    private Dictionary<string, string> BuildContext(string reason, bool isTerminating, bool isUnobservedTask)
+    {
+        var context = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["reason"] = reason,
+            ["is_terminating"] = isTerminating.ToString(),
+            ["is_unobserved_task"] = isUnobservedTask.ToString(),
+            ["pid"] = Environment.ProcessId.ToString(),
+            ["managed_thread_id"] = Environment.CurrentManagedThreadId.ToString(),
+            ["working_directory"] = Environment.CurrentDirectory,
+        };
+
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            var startTimeUtc = process.StartTime.ToUniversalTime();
+            var uptime = _timeProvider.GetUtcNow() - startTimeUtc;
+
+            context["process_uptime_seconds"] = Math.Max(0, (long)uptime.TotalSeconds).ToString();
+            context["working_set_mb"] = (process.WorkingSet64 / (1024 * 1024)).ToString();
+            context["private_memory_mb"] = (process.PrivateMemorySize64 / (1024 * 1024)).ToString();
+            context["gc_total_memory_mb"] = (GC.GetTotalMemory(forceFullCollection: false) / (1024 * 1024)).ToString();
+        }
+        catch
+        {
+            // Best effort only.
+        }
+
+        var latestTurn = CrashContextSnapshot.GetLatest();
+        if (latestTurn is not null)
+        {
+            context["latest_session_id"] = latestTurn.SessionId;
+            if (!string.IsNullOrWhiteSpace(latestTurn.TurnId))
+                context["latest_turn_id"] = latestTurn.TurnId!;
+            if (!string.IsNullOrWhiteSpace(latestTurn.MessageId))
+                context["latest_message_id"] = latestTurn.MessageId!;
+            if (!string.IsNullOrWhiteSpace(latestTurn.ChannelType))
+                context["latest_channel_type"] = latestTurn.ChannelType!;
+            context["latest_turn_observed_at_utc"] = latestTurn.ObservedAtUtc.ToString("O");
+        }
+
+        TryPopulateCatalogContext(context);
+        return context;
+    }
+
+    private void TryPopulateCatalogContext(IDictionary<string, string> context)
+    {
+        var services = _services;
+        if (services is null)
+            return;
+
+        try
+        {
+            var startClock = services.GetService<DaemonStartClock>();
+            if (startClock is not null)
+                context["daemon_started_at_utc"] = startClock.StartedAt.ToString("O");
+
+            var sessionCatalog = services.GetService<SessionCatalogService>();
+            if (sessionCatalog is null)
+                return;
+
+            var stats = sessionCatalog.GetStats();
+            context["session_total"] = stats.TotalSessions.ToString();
+            context["session_active"] = stats.ActiveSessions.ToString();
+            context["session_turn_total"] = stats.TotalTurns.ToString();
+
+            var latest = sessionCatalog.ListRecent(1).FirstOrDefault();
+            if (latest is null)
+                return;
+
+            context["catalog_latest_session"] = latest.PersistenceId;
+            context["catalog_latest_status"] = latest.Status;
+            context["catalog_latest_turn_count"] = latest.TurnCount.ToString();
+            context["catalog_latest_last_activity_ms"] = latest.LastActivity.ToString();
+        }
+        catch (Exception ex)
+        {
+            TryLogMonitorFailure("Failed to capture session catalog context for crash diagnostics.", ex);
+        }
+    }
+
+    private void TryNotifyCrashing(
+        string reason,
+        Exception exception,
+        string? crashLogPath,
+        IReadOnlyDictionary<string, string> context)
+    {
+        var services = _services;
+        if (services is null)
+            return;
+
+        try
+        {
+            var notifier = services.GetService<DaemonLifecycleNotifier>();
+            notifier?.NotifyCrashing(reason, exception, crashLogPath, context);
+        }
+        catch (Exception ex)
+        {
+            TryLogMonitorFailure("Failed to emit daemon crashing notification.", ex);
+        }
+    }
+
+    private void TryLogMonitorFailure(string message, Exception exception)
+    {
+        var services = _services;
+
+        try
+        {
+            var loggerFactory = services?.GetService<ILoggerFactory>();
+            var logger = loggerFactory?.CreateLogger("Netclaw.Daemon.CrashMonitor");
+            if (logger is not null)
+            {
+                logger.LogWarning(exception, "{Message}", message);
+                return;
+            }
+        }
+        catch
+        {
+            // Fall through to stderr.
+        }
+
+        Console.Error.WriteLine($"[Netclaw.Daemon.CrashMonitor] {message} {exception}");
+    }
+}

--- a/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
+++ b/src/Netclaw.Daemon/Services/DaemonLifecycleNotifier.cs
@@ -84,4 +84,72 @@ public sealed class DaemonLifecycleNotifier
             Context = context,
         });
     }
+
+    /// <summary>
+    /// Announces that the daemon encountered a process-level crash path.
+    /// Emission is best-effort and must not throw.
+    /// </summary>
+    public void NotifyCrashing(
+        string reason,
+        Exception exception,
+        string? crashLogPath = null,
+        IReadOnlyDictionary<string, string>? additionalContext = null)
+    {
+        var pid = Environment.ProcessId;
+        var exceptionType = exception.GetType().FullName ?? exception.GetType().Name;
+        var exceptionMessage = string.IsNullOrWhiteSpace(exception.Message)
+            ? "(no exception message)"
+            : exception.Message;
+
+        _logger.LogCritical(
+            exception,
+            "Netclaw daemon crashing (PID {Pid}, reason: {Reason}, exceptionType: {ExceptionType})",
+            pid,
+            reason,
+            exceptionType);
+
+        var context = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["pid"] = pid.ToString(CultureInfo.InvariantCulture),
+            ["reason"] = reason,
+            ["exceptionType"] = exceptionType,
+            ["exceptionMessage"] = Trim(exceptionMessage, 400),
+        };
+
+        if (!string.IsNullOrWhiteSpace(crashLogPath))
+            context["crashLogPath"] = crashLogPath!;
+
+        if (additionalContext is not null)
+        {
+            foreach (var pair in additionalContext)
+                context[pair.Key] = pair.Value;
+        }
+
+        try
+        {
+            _sink.Emit(new OperationalAlert
+            {
+                AlertId = Guid.NewGuid().ToString("N")[..12],
+                Type = "daemon.crashing",
+                Category = AlertType.DaemonCrashed,
+                Severity = "critical",
+                Summary = $"Netclaw daemon crashing: {reason} ({exceptionType})",
+                Timestamp = _timeProvider.GetUtcNow(),
+                Source = pid.ToString(CultureInfo.InvariantCulture),
+                Context = context,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to emit daemon crashing alert");
+        }
+    }
+
+    private static string Trim(string value, int maxChars)
+    {
+        if (value.Length <= maxChars)
+            return value;
+
+        return value[..maxChars];
+    }
 }

--- a/src/Netclaw.Daemon/Services/MemoryCurationWorkerService.cs
+++ b/src/Netclaw.Daemon/Services/MemoryCurationWorkerService.cs
@@ -92,6 +92,10 @@ internal sealed class MemoryCurationWorkerService(
         {
             logger.LogDebug("Memory curation worker stopped.");
         }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Memory curation worker terminated due to an unexpected exception.");
+        }
     }
 
     public void Dispose()

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -91,26 +91,47 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
 
     private void OnFileEvent(object sender, FileSystemEventArgs e)
     {
-        if (ShouldIgnore(e.FullPath))
-            return;
+        try
+        {
+            if (ShouldIgnore(e.FullPath))
+                return;
 
-        _logger.LogDebug("Skill file {ChangeType}: {Path}", e.ChangeType, e.FullPath);
-        ResetDebounceTimer();
+            _logger.LogDebug("Skill file {ChangeType}: {Path}", e.ChangeType, e.FullPath);
+            ResetDebounceTimer();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in skill watcher file callback for {Path}", e.FullPath);
+        }
     }
 
     private void OnRenameEvent(object sender, RenamedEventArgs e)
     {
-        if (ShouldIgnore(e.FullPath) && ShouldIgnore(e.OldFullPath))
-            return;
+        try
+        {
+            if (ShouldIgnore(e.FullPath) && ShouldIgnore(e.OldFullPath))
+                return;
 
-        _logger.LogDebug("Skill file renamed: {OldPath} -> {Path}", e.OldFullPath, e.FullPath);
-        ResetDebounceTimer();
+            _logger.LogDebug("Skill file renamed: {OldPath} -> {Path}", e.OldFullPath, e.FullPath);
+            ResetDebounceTimer();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in skill watcher rename callback for {Path}", e.FullPath);
+        }
     }
 
     private void OnWatcherError(object sender, ErrorEventArgs e)
     {
-        _logger.LogWarning(e.GetException(), "FileSystemWatcher error — triggering recovery rescan");
-        ResetDebounceTimer();
+        try
+        {
+            _logger.LogWarning(e.GetException(), "FileSystemWatcher error — triggering recovery rescan");
+            ResetDebounceTimer();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in skill watcher error callback");
+        }
     }
 
     private void ResetDebounceTimer()


### PR DESCRIPTION
## Summary
- Add a daemon crash monitor that captures unhandled and unobserved process-level exceptions, writes enriched crash logs, and emits critical operational alerts.
- Harden high-risk daemon callback surfaces (startup callbacks, watcher handlers, fire-and-forget OAuth listener task, and memory curation worker loop) so failures are logged and observable instead of silently terminating.
- Add crash context and diagnostics improvements via latest session/turn snapshot wiring, a new doctor check for recent daemon crash logs, and updated spec/runbook/system-skill documentation.

## Validation
- dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj
- dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
- dotnet slopwatch analyze