### PR TITLE
fix(subagents): use streaming LLM path so reasoning content isn't dropped

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -358,7 +358,20 @@ internal sealed class FakeChatClient : IChatClient
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
-        => throw new NotSupportedException("SubAgentActor does not use streaming");
+        => CreateStreamingUpdatesAsync(messages, options, cancellationToken);
+
+    private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingUpdatesAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var response = await GetResponseAsync(messages, options, cancellationToken);
+        foreach (var update in response.ToChatResponseUpdates())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return update;
+        }
+    }
 
     public object? GetService(Type serviceType, object? serviceKey = null) => null;
     public void Dispose() { }

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -25,6 +25,7 @@ namespace Netclaw.Actors.SubAgents;
 public sealed class SubAgentActor : ReceiveActor
 {
     private const int MaxToolIterations = 10;
+    private const string EmptyResponseMarker = "(no response)";
 
     private readonly SubAgentDefinition _definition;
     private readonly IChatClient _chatClient;
@@ -133,6 +134,18 @@ public sealed class SubAgentActor : ReceiveActor
 
             // Final text response — we're done
             var text = ExtractText(lastMessage);
+            if (string.IsNullOrWhiteSpace(text) || text == EmptyResponseMarker)
+            {
+                // LLM returned neither tool calls nor usable text. Surface as failure
+                // so the parent session sees a real error instead of fabricating
+                // "subagent still working" from an empty tool result.
+                _log.Warning(
+                    "SubAgent [{AgentName}] LLM returned empty response (no text content, no tool calls) — reporting as failure",
+                    _definition.Name);
+                Complete(false, "Subagent returned an empty response (no text content and no tool calls). "
+                    + "The provider may have dropped reasoning content or the model produced no output.");
+                return;
+            }
             Complete(true, text);
         });
 
@@ -311,7 +324,7 @@ public sealed class SubAgentActor : ReceiveActor
             }
         }
 
-        return sb.Length > 0 ? sb.ToString() : "(no response)";
+        return sb.Length > 0 ? sb.ToString() : EmptyResponseMarker;
     }
 
     // ── Static async helpers (same pattern as LlmSessionActor) ──
@@ -321,8 +334,23 @@ public sealed class SubAgentActor : ReceiveActor
     {
         try
         {
-            // No streaming for subagents — just get the complete response
-            var response = await client.GetResponseAsync(messages, options, ct);
+            // Use streaming to match the main session path. The non-streaming
+            // GetResponseAsync path drops reasoning content for some providers
+            // (e.g., Qwen emits <think> blocks that surface as TextReasoningContent
+            // only in streaming mode), leaving the assistant message with no
+            // TextContent and causing the subagent to report empty "(no response)".
+            var updates = new List<ChatResponseUpdate>();
+            await foreach (var update in client.GetStreamingResponseAsync(messages, options, ct))
+            {
+                updates.Add(update);
+            }
+
+            var response = updates.ToChatResponse();
+            if (response.Messages.Count == 0)
+            {
+                response = new ChatResponse(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.Assistant, []));
+            }
+
             self.Tell(new LlmResponseReceived { Response = response });
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

- Switch `SubAgentActor.InvokeLlmAsync` from `GetResponseAsync` to `GetStreamingResponseAsync` + `updates.ToChatResponse()`, matching the streaming path `LlmSessionActor` already uses via `SessionLlmInvoker.StreamAsync`. Non-streaming was dropping `TextReasoningContent` for providers that emit thinking blocks (e.g., Qwen), leaving the subagent's final assistant message with no `TextContent` and causing `ExtractText` to return the literal string `"(no response)"` while `Complete` reported `success=True` with 13 chars of output.
- Guard against future empty-response regressions: if `ExtractText` returns the empty-response marker, surface as `Complete(false, ...)` with a loud warning instead of fake success. Parent sessions used to receive `(no response)` as a tool result and hallucinate "subagent still processing" from it.
- Update `SubAgents` `FakeChatClient` to delegate `GetStreamingResponseAsync` through `GetResponseAsync + ToChatResponseUpdates()` so existing test cases exercise the new streaming path.

## Why

Pre-fix daemon logs and live smoke testing both reproduced the symptom: `research-assistant` and `code-analyst` subagent spawns frequently returned 13-character outputs (exact length of `"(no response)"`) while the actor reported success and `iterations=0`. From the parent LLM's perspective, `spawn_agent` appeared to return nothing, leading the frontline model to fabricate "the subagent is still processing" responses and to eventually stop reaching for the tool. This is the root cause of the "launch pad crash" and "0% success rate" symptoms reported in #264.

## Test plan

- [x] `dotnet test src/Netclaw.Actors.Tests --filter "FullyQualifiedName~SubAgent"` — 25/25 green
- [x] Live smoke test (Phase 0.1): explicit-delegation prompt against Qwen3.5-27B-UD produced `success=True, output=1065 chars, iterations=5, duration=49958ms` with real cited findings, vs. the broken path's `success=True, output=13 chars, iterations=0`
- [x] Live daemon deployment via local binary swap; sub-agent performed 10+ tool iterations of real `web_search` / `web_fetch` / `file_read` work before terminating naturally on a second successful run
- [x] Phase 0.2 organic-delegation test already run: confirmed the streaming fix is orthogonal to the adoption gap — Qwen still does the research in-process instead of delegating. Adoption work tracked in #522 and the new sub-agent format work filed in #647.

## Related follow-ups (not closed by this PR)

- #522 — expand sub-agent delegation guidance in `AGENTS.md` (adoption gap, orthogonal to this streaming fix)
- #643 — daemon silently dies on background-thread exceptions (observability gap uncovered while smoke-testing this fix)
- #647 — single-file markdown format + contextual prompt + project scoping (format redesign)
- #648, #649 — multi-model provider architecture and per-agent model selection (follow-ons)

Closes #264