### PR TITLE
feat(subagents): single-file markdown format with contextual prompt

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -274,6 +274,84 @@ public class SubAgentActorTests : TestKit
         Assert.Equal(SubAgentFindingRecallMode.Searchable, result.Findings[0].RecallMode);
     }
 
+    [Fact]
+    public void BuildUserMessage_returns_task_only_when_context_is_null()
+    {
+        var result = SubAgentActor.BuildUserMessage(runtimeContext: null, task: "Find the latest release.");
+
+        Assert.Equal("Find the latest release.", result);
+    }
+
+    [Fact]
+    public void BuildUserMessage_returns_task_only_when_context_is_whitespace()
+    {
+        var result = SubAgentActor.BuildUserMessage(runtimeContext: "   \t  ", task: "Find it.");
+
+        Assert.Equal("Find it.", result);
+    }
+
+    [Fact]
+    public void BuildUserMessage_prefixes_context_block_when_present()
+    {
+        var result = SubAgentActor.BuildUserMessage(
+            runtimeContext: "Workspace is netclaw on branch feature/foo.",
+            task: "Summarize the recent commits.");
+
+        Assert.StartsWith("Context:\nWorkspace is netclaw on branch feature/foo.", result);
+        Assert.Contains("\n\nTask:\nSummarize the recent commits.", result);
+    }
+
+    [Fact]
+    public async Task RuntimeContext_is_prefixed_onto_first_user_message()
+    {
+        var fakeClient = new FakeChatClient();
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Summarize the recent commits.",
+                RuntimeContext = "Workspace is netclaw on branch feature/foo.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+
+        // System prompt is message 0, user message is message 1.
+        Assert.Equal(2, fakeClient.LastReceivedMessages.Count);
+        Assert.Equal(ChatRole.User, fakeClient.LastReceivedMessages[1].Role);
+
+        var userText = fakeClient.LastReceivedMessages[1].Text;
+        Assert.Contains("Context:", userText);
+        Assert.Contains("Workspace is netclaw on branch feature/foo.", userText);
+        Assert.Contains("Task:", userText);
+        Assert.Contains("Summarize the recent commits.", userText);
+    }
+
+    [Fact]
+    public async Task Null_RuntimeContext_leaves_first_user_message_as_raw_task()
+    {
+        var fakeClient = new FakeChatClient();
+        var definition = CreateDefinition();
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Do the thing.",
+                Timeout = TimeSpan.FromSeconds(5)
+            },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.NotNull(fakeClient.LastReceivedMessages);
+        Assert.Equal("Do the thing.", fakeClient.LastReceivedMessages[1].Text);
+        Assert.DoesNotContain("Context:", fakeClient.LastReceivedMessages[1].Text);
+    }
+
     /// <summary>
     /// IChatClient that always throws on GetResponseAsync.
     /// </summary>
@@ -306,6 +384,11 @@ internal sealed class FakeChatClient : IChatClient
 
     public int CallCount => _callCount;
 
+    /// <summary>
+    /// Snapshot of the messages passed to the most recent call. Replaced on every call.
+    /// </summary>
+    public IReadOnlyList<ChatMessage>? LastReceivedMessages { get; private set; }
+
     public TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
     /// <summary>
@@ -329,6 +412,7 @@ internal sealed class FakeChatClient : IChatClient
         CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref _callCount);
+        LastReceivedMessages = messages.ToList();
 
         if (Delay > TimeSpan.Zero)
             await Task.Delay(Delay, cancellationToken);

--- a/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
+++ b/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
@@ -23,7 +23,13 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
         [property: Description("Name of the subagent to invoke (see available-subagents in context)")]
         string Agent,
         [property: Description("Task description for the subagent — be specific about what you need")]
-        string Task);
+        string Task,
+        [property: Description(
+            "Optional background context the subagent should consider while working on the task. "
+            + "Use this to pass along workspace details, the user's broader goal, or facts the "
+            + "subagent would otherwise have to rediscover. Do NOT duplicate the agent's built-in "
+            + "instructions; use this for THIS invocation's situation.")]
+        string? Context = null);
 
     public SpawnAgentTool(SubAgentDefinitionRegistry registry, SubAgentSpawner spawner)
     {
@@ -53,7 +59,7 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
             return $"Error: Unknown agent '{args.Agent}'. Available agents: {names}";
         }
 
-        var result = await _spawner.SpawnAsync(profile, args.Task, context, ct);
+        var result = await _spawner.SpawnAsync(profile, args.Task, args.Context, context, ct);
 
         return result.Success
             ? result.Output

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -106,9 +106,11 @@ public sealed class SubAgentActor : ReceiveActor
             _timeoutSchedule = Context.System.Scheduler.ScheduleTellOnceCancelable(
                 msg.Timeout, Self, SubAgentTimeout.Instance, ActorRefs.NoSender);
 
-            // Build initial conversation: system prompt + task as user message
+            // Build initial conversation: system prompt (from file, verbatim) + task as user message.
+            // If the caller supplied runtime context, prefix it onto the user message so the
+            // system prompt stays reproducible across invocations.
             _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.System, _definition.SystemPrompt));
-            _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, msg.Task));
+            _history.Add(new AiChatMessage(Microsoft.Extensions.AI.ChatRole.User, BuildUserMessage(msg.RuntimeContext, msg.Task)));
 
             _log.Info("SubAgent [{AgentName}] starting (tools={ToolCount}, timeout={Timeout})",
                 _definition.Name, _aiTools.Count, msg.Timeout);
@@ -310,6 +312,21 @@ public sealed class SubAgentActor : ReceiveActor
                 Evidence = []
             }
         ];
+    }
+
+    /// <summary>
+    /// Compose the initial user message for the subagent. When <paramref name="runtimeContext"/>
+    /// is present, prefixes a <c>Context:</c> block ahead of the <c>Task:</c> block so the
+    /// parent-supplied background stays visually separated from the agent's task.
+    /// When runtime context is null or whitespace, returns the raw task string for backward
+    /// compatibility with the pre-Context protocol.
+    /// </summary>
+    internal static string BuildUserMessage(string? runtimeContext, string task)
+    {
+        if (string.IsNullOrWhiteSpace(runtimeContext))
+            return task;
+
+        return $"Context:\n{runtimeContext.Trim()}\n\nTask:\n{task}";
     }
 
     private static string ExtractText(AiChatMessage message)

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -35,8 +35,15 @@ public sealed record SubAgentDefinition
 /// </summary>
 public sealed record RunSubAgent
 {
-    /// <summary>The task for the subagent to perform (becomes the user message).</summary>
+    /// <summary>The task for the subagent to perform (becomes part of the user message).</summary>
     public required string Task { get; init; }
+
+    /// <summary>
+    /// Optional per-invocation background context from the parent session. When present,
+    /// it is prefixed onto the subagent's first user message as a "Context:" block so the
+    /// agent's static system prompt (loaded from disk) remains reproducible.
+    /// </summary>
+    public string? RuntimeContext { get; init; }
 
     /// <summary>Wall-clock timeout set by the caller.</summary>
     public required TimeSpan Timeout { get; init; }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -46,6 +46,7 @@ public sealed class SubAgentSpawner
     public async Task<SubAgentResult> SpawnAsync(
         SubAgentProfile profile,
         string task,
+        string? runtimeContext,
         ToolExecutionContext context,
         CancellationToken ct = default)
     {
@@ -110,6 +111,7 @@ public sealed class SubAgentSpawner
                 new RunSubAgent
                 {
                     Task = task,
+                    RuntimeContext = runtimeContext,
                     Timeout = subAgentTimeout,
                     SessionScopeId = subAgentScopeId,
                     Audience = context.Audience,

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
@@ -305,6 +305,8 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
 
     /// <summary>
     /// Seeds default subagent definition files to the agents directory.
+    /// Each agent is a single <c>.md</c> file with YAML frontmatter, matching
+    /// the <c>SKILL.md</c> pattern and the Claude Code / OpenCode convention.
     /// Does not overwrite existing files so operator customizations are preserved.
     /// </summary>
     public void SeedBuiltInAgents(NetclawPaths paths)
@@ -312,18 +314,16 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
         var agentsDir = paths.AgentsDirectory;
         Directory.CreateDirectory(agentsDir);
 
-        SeedAgentFile(agentsDir, "research-assistant.json", """
-            {
-              "name": "research-assistant",
-              "description": "Deep web research with search and citation",
-              "systemPromptFile": "research-assistant.md",
-              "tools": ["web_search", "web_fetch", "file_read", "attach_file"],
-              "modelRole": "Compaction",
-              "timeoutSeconds": 120
-            }
-            """);
-
         SeedAgentFile(agentsDir, "research-assistant.md", """
+            ---
+            name: research-assistant
+            description: Deep web research with search and citation
+            tools: [web_search, web_fetch, file_read, attach_file]
+            modelRole: Compaction
+            timeoutSeconds: 120
+            visibility: user-facing
+            ---
+
             You are a research assistant. Your job is to help the user by searching the
             web, gathering information from multiple sources, and synthesizing findings
             into clear, well-organized summaries.
@@ -340,18 +340,16 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
             - If a search returns no useful results, say so rather than guessing.
             """);
 
-        SeedAgentFile(agentsDir, "code-analyst.json", """
-            {
-              "name": "code-analyst",
-              "description": "Analyze code, run commands, and review files",
-              "systemPromptFile": "code-analyst.md",
-              "tools": ["file_read"],
-              "modelRole": "Compaction",
-              "timeoutSeconds": 120
-            }
-            """);
-
         SeedAgentFile(agentsDir, "code-analyst.md", """
+            ---
+            name: code-analyst
+            description: Analyze code, run commands, and review files
+            tools: [file_read]
+            modelRole: Compaction
+            timeoutSeconds: 120
+            visibility: user-facing
+            ---
+
             You are a code analyst. Your job is to read source code, run build and test
             commands, and provide clear analysis of code quality, structure, and issues.
 
@@ -364,18 +362,16 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
             - Do not modify code or run commands directly; return analysis for the parent session to act on.
             """);
 
-        SeedAgentFile(agentsDir, "summarizer.json", """
-            {
-              "name": "summarizer",
-              "description": "Summarize documents and content concisely",
-              "systemPromptFile": "summarizer.md",
-              "tools": ["file_read"],
-              "modelRole": "Compaction",
-              "timeoutSeconds": 60
-            }
-            """);
-
         SeedAgentFile(agentsDir, "summarizer.md", """
+            ---
+            name: summarizer
+            description: Summarize documents and content concisely
+            tools: [file_read]
+            modelRole: Compaction
+            timeoutSeconds: 60
+            visibility: user-facing
+            ---
+
             You are a summarizer. Your job is to read content and produce concise,
             structured summaries that capture the essential information.
 

--- a/src/Netclaw.Configuration.Tests/FileSubAgentDefinitionLoaderTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSubAgentDefinitionLoaderTests.cs
@@ -24,6 +24,13 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
             Directory.Delete(_tempDir, recursive: true);
     }
 
+    private string WriteAgent(string fileName, string content)
+    {
+        var path = Path.Combine(_paths.AgentsDirectory, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
     [Fact]
     public void LoadAll_returns_empty_when_no_files()
     {
@@ -32,156 +39,148 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
-    public void LoadAll_loads_inline_system_prompt()
+    public void LoadAll_parses_full_frontmatter_and_body()
     {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPrompt": "You are a test agent.",
-              "tools": ["web_search"],
-              "timeoutSeconds": 30
-            }
+        WriteAgent("research-assistant.md", """
+            ---
+            name: research-assistant
+            description: Deep research
+            tools: [web_search, web_fetch]
+            modelRole: Main
+            timeoutSeconds: 120
+            visibility: user-facing
+            emitStructuredFindings: true
+            ---
+
+            You are a researcher.
+            Follow sources carefully.
             """);
 
         var results = _loader.LoadAll();
+
         Assert.Single(results);
-        Assert.Equal("test-agent", results[0].Name);
-        Assert.Equal("You are a test agent.", results[0].EffectiveSystemPrompt);
+        var profile = results[0];
+        Assert.Equal("research-assistant", profile.Name);
+        Assert.Equal("Deep research", profile.Description);
+        Assert.Contains("You are a researcher.", profile.SystemPrompt);
+        Assert.Contains("Follow sources carefully.", profile.SystemPrompt);
+        Assert.Equal(new[] { "web_search", "web_fetch" }, profile.ToolNames);
+        Assert.Equal(ModelRole.Main, profile.ModelRole);
+        Assert.Equal(120, profile.TimeoutSeconds);
+        Assert.True(profile.EmitStructuredFindings);
+        Assert.Equal(SubAgentVisibility.UserFacing, profile.Visibility);
     }
 
     [Fact]
-    public void LoadAll_loads_system_prompt_from_file()
+    public void LoadAll_defaults_model_role_to_compaction_and_timeout_to_60()
     {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPromptFile": "test.md",
-              "tools": ["web_search"]
-            }
+        WriteAgent("minimal.md", """
+            ---
+            name: minimal
+            description: Minimal agent
+            tools: [web_search]
+            ---
+
+            You are minimal.
             """);
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.md"),
-            "You are a test agent from a file.");
 
         var results = _loader.LoadAll();
+
         Assert.Single(results);
-        Assert.Equal("You are a test agent from a file.", results[0].EffectiveSystemPrompt);
+        Assert.Equal(ModelRole.Compaction, results[0].ModelRole);
+        Assert.Equal(60, results[0].TimeoutSeconds);
+        Assert.False(results[0].EmitStructuredFindings);
+        Assert.Equal(SubAgentVisibility.UserFacing, results[0].Visibility);
     }
 
     [Fact]
-    public void LoadAll_skips_missing_prompt_file()
+    public void LoadAll_skips_file_with_no_frontmatter()
     {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPromptFile": "nonexistent.md",
-              "tools": ["web_search"]
-            }
+        WriteAgent("bare.md", "Just a body. No frontmatter at all.");
+
+        var results = _loader.LoadAll();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void LoadAll_skips_malformed_frontmatter()
+    {
+        WriteAgent("broken.md", """
+            ---
+            name: broken
+            description: [unclosed list
+            ---
+
+            body
             """);
 
         var results = _loader.LoadAll();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void LoadAll_skips_agent_missing_name()
+    {
+        WriteAgent("noname.md", """
+            ---
+            description: Has a description but no name
+            tools: [web_search]
+            ---
+
+            body
+            """);
+
+        var results = _loader.LoadAll();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void LoadAll_skips_agent_missing_description()
+    {
+        WriteAgent("nodesc.md", """
+            ---
+            name: nodesc
+            tools: [web_search]
+            ---
+
+            body
+            """);
+
+        var results = _loader.LoadAll();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void LoadAll_skips_agent_with_empty_body()
+    {
+        WriteAgent("empty-body.md", """
+            ---
+            name: empty-body
+            description: Has frontmatter but nothing after it
+            tools: [web_search]
+            ---
+            """);
+
+        var results = _loader.LoadAll();
+
         Assert.Empty(results);
     }
 
     [Fact]
     public void LoadAll_skips_agent_with_no_tools()
     {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPrompt": "You are a test agent.",
-              "tools": []
-            }
-            """);
+        WriteAgent("no-tools.md", """
+            ---
+            name: no-tools
+            description: A test agent
+            tools: []
+            ---
 
-        var results = _loader.LoadAll();
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_agent_with_no_name()
-    {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "description": "A test agent",
-              "systemPrompt": "You are a test agent.",
-              "tools": ["web_search"]
-            }
-            """);
-
-        var results = _loader.LoadAll();
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_invalid_json()
-    {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "bad.json"), "not json at all");
-
-        var results = _loader.LoadAll();
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void ToProfile_converts_correctly()
-    {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "research-assistant",
-              "description": "Deep research",
-              "systemPrompt": "You are a researcher.",
-              "tools": ["web_search", "web_fetch"],
-              "modelRole": "Main",
-              "timeoutSeconds": 120
-            }
-            """);
-
-        var results = _loader.LoadAll();
-        var profile = results[0].ToProfile();
-
-        Assert.Equal("research-assistant", profile.Name);
-        Assert.Equal("Deep research", profile.Description);
-        Assert.Equal("You are a researcher.", profile.SystemPrompt);
-        Assert.Equal(["web_search", "web_fetch"], profile.ToolNames);
-        Assert.Equal(ModelRole.Main, profile.ModelRole);
-        Assert.Equal(120, profile.TimeoutSeconds);
-        Assert.Equal(SubAgentVisibility.UserFacing, profile.Visibility);
-    }
-
-    [Fact]
-    public void ToProfile_defaults_model_role_to_compaction()
-    {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test",
-              "description": "Test",
-              "systemPrompt": "Test.",
-              "tools": ["web_search"]
-            }
-            """);
-
-        var results = _loader.LoadAll();
-        var profile = results[0].ToProfile();
-
-        Assert.Equal(ModelRole.Compaction, profile.ModelRole);
-        Assert.Equal(60, profile.TimeoutSeconds);
-    }
-
-    [Fact]
-    public void LoadAll_skips_prompt_path_outside_agents_directory()
-    {
-        var escapedPath = Path.Combine("..", "outside.md");
-        File.WriteAllText(Path.Combine(_tempDir, "outside.md"), "secret");
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), $$"""
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPromptFile": "{{escapedPath}}",
-              "tools": ["web_search"]
-            }
+            You are a test agent.
             """);
 
         var results = _loader.LoadAll();
@@ -192,14 +191,85 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
     [Fact]
     public void LoadAll_skips_user_facing_agent_with_disallowed_tools()
     {
-        File.WriteAllText(Path.Combine(_paths.AgentsDirectory, "test.json"), """
-            {
-              "name": "test-agent",
-              "description": "A test agent",
-              "systemPrompt": "You are a test agent.",
-              "tools": ["web_search", "file_write", "shell_execute"]
-            }
+        WriteAgent("bad-tools.md", """
+            ---
+            name: bad-tools
+            description: A test agent
+            tools: [web_search, file_write, shell_execute]
+            ---
+
+            You are a test agent.
             """);
+
+        var results = _loader.LoadAll();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void LoadAll_rejects_duplicate_names_across_files()
+    {
+        WriteAgent("first.md", """
+            ---
+            name: shared
+            description: First agent
+            tools: [web_search]
+            ---
+
+            First body.
+            """);
+        WriteAgent("second.md", """
+            ---
+            name: shared
+            description: Second agent
+            tools: [web_fetch]
+            ---
+
+            Second body.
+            """);
+
+        var results = _loader.LoadAll();
+
+        Assert.Single(results);
+        // Deterministic ordering picks the first file alphabetically.
+        Assert.Equal("First agent", results[0].Description);
+    }
+
+    [Fact]
+    public void LoadAll_accepts_pascal_case_visibility_and_hyphenated_visibility()
+    {
+        WriteAgent("hyphenated.md", """
+            ---
+            name: hyphenated
+            description: Hyphenated visibility value
+            tools: [web_search]
+            visibility: user-facing
+            ---
+
+            body
+            """);
+        WriteAgent("pascal.md", """
+            ---
+            name: pascal
+            description: PascalCase visibility value
+            tools: [web_search]
+            visibility: UserFacing
+            ---
+
+            body
+            """);
+
+        var results = _loader.LoadAll();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal(SubAgentVisibility.UserFacing, r.Visibility));
+    }
+
+    [Fact]
+    public void LoadAll_ignores_non_md_files()
+    {
+        WriteAgent("ignored.json", """{"name":"json","description":"ignored"}""");
+        WriteAgent("ignored.txt", "plain text");
 
         var results = _loader.LoadAll();
 

--- a/src/Netclaw.Configuration/FileSubAgentDefinitionLoader.cs
+++ b/src/Netclaw.Configuration/FileSubAgentDefinitionLoader.cs
@@ -1,39 +1,31 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Netclaw.Configuration;
 
 /// <summary>
-/// Loads subagent definitions from JSON files in the agents directory.
-/// Each agent is a <c>.json</c> file with an optional companion <c>.md</c> prompt file.
+/// Loads subagent definitions from <c>.md</c> files in the agents directory.
+/// Each agent is a single markdown file: YAML frontmatter carries metadata and
+/// the body is the system prompt verbatim. Matches the de facto Claude Code /
+/// OpenCode format and the <c>SKILL.md</c> pattern Netclaw already uses for skills.
 /// Called during startup after MCP discovery so tool names are resolvable.
 /// </summary>
 public sealed class FileSubAgentDefinitionLoader
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
-
     private readonly string _agentsDirectory;
-    private readonly string _agentsDirectoryFullPath;
     private readonly ILogger<FileSubAgentDefinitionLoader> _logger;
 
     public FileSubAgentDefinitionLoader(NetclawPaths paths, ILogger<FileSubAgentDefinitionLoader> logger)
     {
         _agentsDirectory = paths.AgentsDirectory;
-        _agentsDirectoryFullPath = Path.GetFullPath(_agentsDirectory);
         _logger = logger;
     }
 
     /// <summary>
-    /// Scan the agents directory for <c>*.json</c> files and return parsed profiles.
-    /// Invalid or unreadable files are logged and skipped.
+    /// Scan the agents directory for <c>*.md</c> files and return parsed profiles.
+    /// Malformed files are rejected with a loud warning and skipped — no silent fallback.
+    /// Duplicate <c>name</c> values across files are rejected for all but the first occurrence.
     /// </summary>
-    public IReadOnlyList<SubAgentProfileFile> LoadAll()
+    public IReadOnlyList<SubAgentProfile> LoadAll()
     {
         if (!Directory.Exists(_agentsDirectory))
         {
@@ -41,168 +33,147 @@ public sealed class FileSubAgentDefinitionLoader
             return [];
         }
 
-        var files = Directory.GetFiles(_agentsDirectory, "*.json");
+        var files = Directory.GetFiles(_agentsDirectory, "*.md");
         if (files.Length == 0)
         {
             _logger.LogDebug("No agent definition files found in {Path}", _agentsDirectory);
             return [];
         }
 
-        var results = new List<SubAgentProfileFile>();
-        foreach (var filePath in files)
+        var results = new List<SubAgentProfile>();
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Enumerate files in a stable order so duplicate-name diagnostics are deterministic.
+        foreach (var filePath in files.OrderBy(p => p, StringComparer.Ordinal))
         {
-            try
+            var profile = TryParse(filePath);
+            if (profile is null)
+                continue;
+
+            if (!seenNames.Add(profile.Name))
             {
-                var json = File.ReadAllText(filePath);
-                var file = JsonSerializer.Deserialize<SubAgentProfileFile>(json, JsonOptions);
-                if (file is null)
-                {
-                    _logger.LogWarning("Agent definition file is empty or invalid: {Path}", filePath);
-                    continue;
-                }
-
-                if (string.IsNullOrWhiteSpace(file.Name))
-                {
-                    _logger.LogWarning("Agent definition missing 'name': {Path}", filePath);
-                    continue;
-                }
-
-                // Resolve system prompt from companion file or inline
-                if (!string.IsNullOrWhiteSpace(file.SystemPromptFile))
-                {
-                    var promptPath = ResolvePromptPath(file.SystemPromptFile);
-                    if (File.Exists(promptPath))
-                    {
-                        file = file with { ResolvedSystemPrompt = File.ReadAllText(promptPath) };
-                    }
-                    else
-                    {
-                        _logger.LogWarning(
-                            "Agent '{Name}' references prompt file '{PromptFile}' which does not exist — skipping",
-                            file.Name, file.SystemPromptFile);
-                        continue;
-                    }
-                }
-                else if (string.IsNullOrWhiteSpace(file.SystemPrompt))
-                {
-                    _logger.LogWarning(
-                        "Agent '{Name}' has neither 'systemPromptFile' nor 'systemPrompt' — skipping",
-                        file.Name);
-                    continue;
-                }
-
-                if (file.Tools is null || file.Tools.Count == 0)
-                {
-                    _logger.LogWarning("Agent '{Name}' has no tools defined — skipping", file.Name);
-                    continue;
-                }
-
-                var disallowedTools = file.Tools
-                    .Where(t => !SubAgentToolPolicy.IsAllowedForUserFacing(t))
-                    .Distinct(StringComparer.Ordinal)
-                    .OrderBy(t => t, StringComparer.Ordinal)
-                    .ToList();
-                if (disallowedTools.Count > 0)
-                {
-                    _logger.LogWarning(
-                        "Agent '{Name}' references disallowed tools for user-facing agents: {Tools}. Allowed tools: {AllowedTools}. Skipping",
-                        file.Name,
-                        string.Join(", ", disallowedTools),
-                        string.Join(", ", SubAgentToolPolicy.GetAllowedUserFacingTools()));
-                    continue;
-                }
-
-                results.Add(file);
-                _logger.LogInformation("Loaded agent definition: {Name} ({ToolCount} tools, timeout={Timeout}s)",
-                    file.Name, file.Tools.Count, file.TimeoutSeconds);
+                _logger.LogWarning(
+                    "Agent definition at {Path} declares duplicate name '{Name}' — skipping",
+                    filePath,
+                    profile.Name);
+                continue;
             }
-            catch (JsonException ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse agent definition: {Path}", filePath);
-            }
-            catch (IOException ex)
-            {
-                _logger.LogWarning(ex, "Failed to read agent definition: {Path}", filePath);
-            }
+
+            results.Add(profile);
+            _logger.LogInformation(
+                "Loaded agent definition: {Name} ({ToolCount} tools, timeout={Timeout}s)",
+                profile.Name, profile.ToolNames.Count, profile.TimeoutSeconds);
         }
 
         return results;
     }
 
-    private string ResolvePromptPath(string systemPromptFile)
+    private SubAgentProfile? TryParse(string filePath)
     {
-        var combined = Path.Combine(_agentsDirectory, systemPromptFile);
-        var fullPath = Path.GetFullPath(combined);
-        var allowedPrefix = _agentsDirectoryFullPath.EndsWith(Path.DirectorySeparatorChar)
-            ? _agentsDirectoryFullPath
-            : _agentsDirectoryFullPath + Path.DirectorySeparatorChar;
-
-        if (!fullPath.StartsWith(allowedPrefix, StringComparison.Ordinal)
-            && !string.Equals(fullPath, _agentsDirectoryFullPath, StringComparison.Ordinal))
+        string content;
+        try
         {
-            throw new IOException($"Prompt file '{systemPromptFile}' escapes the agents directory.");
+            content = File.ReadAllText(filePath);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Failed to read agent definition: {Path}", filePath);
+            return null;
         }
 
-        return fullPath;
-    }
-}
+        var frontmatter = SubAgentMarkdownParser.ExtractFrontmatter(content);
+        if (frontmatter is null)
+        {
+            _logger.LogWarning(
+                "Agent definition at {Path} has missing or unparseable YAML frontmatter — skipping",
+                filePath);
+            return null;
+        }
 
-/// <summary>
-/// JSON wire type for a subagent definition file.
-/// </summary>
-public sealed record SubAgentProfileFile
-{
-    [JsonPropertyName("name")]
-    public string Name { get; init; } = string.Empty;
+        if (string.IsNullOrWhiteSpace(frontmatter.Name))
+        {
+            _logger.LogWarning("Agent definition at {Path} has no 'name' in frontmatter — skipping", filePath);
+            return null;
+        }
 
-    [JsonPropertyName("description")]
-    public string Description { get; init; } = string.Empty;
+        if (string.IsNullOrWhiteSpace(frontmatter.Description))
+        {
+            _logger.LogWarning(
+                "Agent '{Name}' at {Path} has no 'description' in frontmatter — skipping",
+                frontmatter.Name, filePath);
+            return null;
+        }
 
-    [JsonPropertyName("systemPrompt")]
-    public string? SystemPrompt { get; init; }
+        var systemPrompt = SubAgentMarkdownParser.ExtractBody(content);
+        if (string.IsNullOrWhiteSpace(systemPrompt))
+        {
+            _logger.LogWarning(
+                "Agent '{Name}' at {Path} has an empty system prompt body — skipping",
+                frontmatter.Name, filePath);
+            return null;
+        }
 
-    [JsonPropertyName("systemPromptFile")]
-    public string? SystemPromptFile { get; init; }
+        var tools = frontmatter.Tools ?? [];
+        if (tools.Count == 0)
+        {
+            _logger.LogWarning(
+                "Agent '{Name}' at {Path} has no tools defined — skipping",
+                frontmatter.Name, filePath);
+            return null;
+        }
 
-    [JsonPropertyName("tools")]
-    public List<string> Tools { get; init; } = [];
+        var disallowedTools = tools
+            .Where(t => !SubAgentToolPolicy.IsAllowedForUserFacing(t))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal)
+            .ToList();
+        if (disallowedTools.Count > 0)
+        {
+            _logger.LogWarning(
+                "Agent '{Name}' at {Path} references disallowed tools for user-facing agents: {Tools}. Allowed tools: {AllowedTools}. Skipping",
+                frontmatter.Name,
+                filePath,
+                string.Join(", ", disallowedTools),
+                string.Join(", ", SubAgentToolPolicy.GetAllowedUserFacingTools()));
+            return null;
+        }
 
-    [JsonPropertyName("modelRole")]
-    public string ModelRole { get; init; } = "Compaction";
-
-    [JsonPropertyName("timeoutSeconds")]
-    public int TimeoutSeconds { get; init; } = 60;
-
-    /// <summary>
-    /// Resolved prompt content from the companion .md file. Not serialized.
-    /// </summary>
-    [JsonIgnore]
-    public string? ResolvedSystemPrompt { get; init; }
-
-    /// <summary>
-    /// Returns the effective system prompt (resolved file content or inline).
-    /// </summary>
-    [JsonIgnore]
-    public string EffectiveSystemPrompt => ResolvedSystemPrompt ?? SystemPrompt ?? string.Empty;
-
-    /// <summary>
-    /// Convert to the runtime <see cref="SubAgentProfile"/> type used by the registry and spawner.
-    /// </summary>
-    public SubAgentProfile ToProfile()
-    {
-        var modelRole = Enum.TryParse<Netclaw.Configuration.ModelRole>(ModelRole, ignoreCase: true, out var parsed)
-            ? parsed
-            : Netclaw.Configuration.ModelRole.Compaction;
+        var modelRole = ParseModelRole(frontmatter.ModelRole);
+        var visibility = ParseVisibility(frontmatter.Visibility);
 
         return new SubAgentProfile
         {
-            Name = Name,
-            Description = Description,
-            SystemPrompt = EffectiveSystemPrompt,
-            ToolNames = Tools,
+            Name = frontmatter.Name.Trim(),
+            Description = frontmatter.Description.Trim(),
+            SystemPrompt = systemPrompt,
+            ToolNames = tools,
             ModelRole = modelRole,
-            TimeoutSeconds = TimeoutSeconds,
-            Visibility = SubAgentVisibility.UserFacing
+            TimeoutSeconds = frontmatter.TimeoutSeconds ?? 60,
+            EmitStructuredFindings = frontmatter.EmitStructuredFindings ?? false,
+            Visibility = visibility
         };
+    }
+
+    private static ModelRole ParseModelRole(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return ModelRole.Compaction;
+
+        return Enum.TryParse<ModelRole>(value, ignoreCase: true, out var parsed)
+            ? parsed
+            : ModelRole.Compaction;
+    }
+
+    private static SubAgentVisibility ParseVisibility(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return SubAgentVisibility.UserFacing;
+
+        // Accept both "user-facing" (hyphenated, matches frontmatter convention)
+        // and "UserFacing" (PascalCase, matches the enum value name).
+        var normalized = value.Replace("-", "", StringComparison.Ordinal);
+        return Enum.TryParse<SubAgentVisibility>(normalized, ignoreCase: true, out var parsed)
+            ? parsed
+            : SubAgentVisibility.UserFacing;
     }
 }

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="SauceControl.Blake2Fast" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Configuration/SubAgentMarkdownParser.cs
+++ b/src/Netclaw.Configuration/SubAgentMarkdownParser.cs
@@ -1,0 +1,89 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Parses subagent definition files in the markdown-with-YAML-frontmatter format:
+/// one <c>.md</c> file per agent where the frontmatter carries metadata and
+/// the body is the system prompt verbatim. Matches the <c>SKILL.md</c> convention
+/// from <c>SkillScanner</c> and the de facto format used by Claude Code and OpenCode.
+/// </summary>
+public static class SubAgentMarkdownParser
+{
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Extract the YAML frontmatter block (between the leading and trailing
+    /// <c>---</c> delimiters) and deserialize it into a <see cref="SubAgentFrontmatter"/>.
+    /// Returns <c>null</c> when the file has no frontmatter block or the YAML is unparseable.
+    /// </summary>
+    public static SubAgentFrontmatter? ExtractFrontmatter(string content)
+    {
+        if (content is null)
+            return null;
+
+        if (!content.StartsWith("---", StringComparison.Ordinal))
+            return null;
+
+        var closingIndex = content.IndexOf("\n---", 3, StringComparison.Ordinal);
+        if (closingIndex < 0)
+            return null;
+
+        var firstNewline = content.IndexOf('\n', 0);
+        if (firstNewline < 0 || firstNewline >= closingIndex)
+            return null;
+
+        var yamlBlock = content[(firstNewline + 1)..closingIndex];
+
+        try
+        {
+            return YamlDeserializer.Deserialize<SubAgentFrontmatter>(yamlBlock);
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Extract the markdown body that follows the YAML frontmatter closing delimiter.
+    /// Returns the full content when no frontmatter is present so callers can still
+    /// decide how to fail (typically: reject the file with a loud warning).
+    /// </summary>
+    public static string ExtractBody(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return string.Empty;
+
+        if (!content.StartsWith("---", StringComparison.Ordinal))
+            return content;
+
+        var closingIndex = content.IndexOf("\n---", 3, StringComparison.Ordinal);
+        if (closingIndex < 0)
+            return content;
+
+        var bodyStart = content.IndexOf('\n', closingIndex + 4);
+        return bodyStart < 0 ? string.Empty : content[(bodyStart + 1)..].TrimStart();
+    }
+}
+
+/// <summary>
+/// Shape of a subagent definition's YAML frontmatter. Maps 1:1 onto the
+/// runtime <see cref="SubAgentProfile"/>. Deserialization uses camelCase naming
+/// (so <c>timeoutSeconds</c>, <c>modelRole</c>, <c>emitStructuredFindings</c>,
+/// <c>visibility</c>). Unknown fields are ignored for forward compatibility.
+/// </summary>
+public sealed class SubAgentFrontmatter
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public List<string>? Tools { get; set; }
+    public string? ModelRole { get; set; }
+    public int? TimeoutSeconds { get; set; }
+    public bool? EmitStructuredFindings { get; set; }
+    public string? Visibility { get; set; }
+}

--- a/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
+++ b/src/Netclaw.Daemon/Mcp/ToolIndexUpdater.cs
@@ -71,11 +71,10 @@ internal sealed class ToolIndexUpdater : IHostedService
 
     private void LoadFileBasedAgents()
     {
-        var files = _agentLoader.LoadAll();
+        var profiles = _agentLoader.LoadAll();
         var loaded = 0;
-        foreach (var file in files)
+        foreach (var profile in profiles)
         {
-            var profile = file.ToProfile();
             if (_subAgentRegistry.Register(profile))
             {
                 loaded++;
@@ -103,14 +102,26 @@ internal sealed class ToolIndexUpdater : IHostedService
 
         var sb = new StringBuilder();
         sb.AppendLine("[available-subagents — use spawn_agent to delegate]");
+        sb.AppendLine();
+
         foreach (var agent in agents)
         {
-            sb.AppendLine($"- {agent.Name}: {agent.Description} (timeout: {agent.TimeoutSeconds}s)");
+            sb.AppendLine($"## {agent.Name}");
+            sb.AppendLine($"{agent.Description}");
+            sb.Append("Tools: ");
+            sb.AppendLine(string.Join(", ", agent.ToolNames));
+            sb.AppendLine($"Timeout: {agent.TimeoutSeconds}s");
+            sb.AppendLine();
         }
 
+        sb.AppendLine("## How to delegate");
+        sb.AppendLine("Call `spawn_agent(agent: \"<name>\", task: \"<specific task>\", context: \"<optional background>\")`.");
         sb.AppendLine();
-        sb.AppendLine("Use spawn_agent(agent: \"<name>\", task: \"<description>\") to delegate.");
-        sb.AppendLine("Subagents run autonomously with their own tools and return results.");
+        sb.AppendLine("- `task` is what the subagent should do — be concrete and bounded.");
+        sb.AppendLine("- `context` is optional per-invocation background (workspace details, the user's broader goal,");
+        sb.AppendLine("  facts the subagent would otherwise have to rediscover). Do NOT duplicate the agent's built-in");
+        sb.AppendLine("  instructions — use this for THIS invocation's situation.");
+        sb.AppendLine("- Subagents run autonomously with their own tools and return a synthesized result, not a transcript.");
 
         _subAgentDiscoveryLayer.Update(sb.ToString());
         _logger.LogInformation("Subagent discovery layer updated ({Count} agents)", agents.Count);


### PR DESCRIPTION
## Summary

- Adopt the markdown-with-YAML-frontmatter shape used by Claude Code, OpenCode, and Netclaw's own skill system. Each subagent is now a single `.md` file under `~/.netclaw/agents/` where the frontmatter carries metadata (`name`, `description`, `tools`, `modelRole`, `timeoutSeconds`, `visibility`, `emitStructuredFindings`) and the body is the system prompt verbatim. Replaces the JSON + `.md` sidecar pair that was the only two-file artifact type left in Netclaw.
- Add an optional `Context` parameter to `spawn_agent` so the frontline LLM can pass per-invocation background (workspace details, the user's broader goal, facts the subagent would otherwise have to rediscover) without editing the agent file. Context is prefixed onto the subagent's first user message as a separate `Context:` block, keeping the agent's static system prompt verbatim and reproducible across calls. When `Context` is null the protocol is byte-identical to the pre-change shape.
- Enrich the `[available-subagents]` discovery context layer to emit each agent's full description, tool list, and a usage example that includes the new `Context` field — today's one-line form did not teach the model how or when to delegate.

## Why

Netclaw's sub-agents were the only disk-based artifact in the install that still used a two-file JSON+MD pair. Claude Code, OpenCode, AgentSkills.io `SKILL.md`, and Aaron's own `local-ai-preferences/agents/*.md` library all use single markdown-with-frontmatter files. Adopting the de facto shape means existing libraries become drop-in portable (modulo tool-name translation, tracked separately) and new sub-agents are half the authoring cost.

The `Context` parameter addresses a separate but related problem: Phase 0.2 smoke testing earlier in this session confirmed Qwen won't organically delegate on research-worthy prompts, and even when it does, the sub-agent gets a cold start with no workspace/goal awareness. Runtime context lets the parent session specialize a single profile per invocation rather than authoring N tightly-scoped profiles.

Zero-migration observation: the three stock defaults are the only files that have ever existed in `~/.netclaw/agents/` on a fresh install, so the JSON → markdown migration carries no user-content risk.

## Key changes

- Add `YamlDotNet` PackageReference to `Netclaw.Configuration`
- New `SubAgentMarkdownParser` with `ExtractFrontmatter`/`ExtractBody` matching the `SkillScanner` pattern; `SubAgentFrontmatter` DTO maps 1:1 to `SubAgentProfile`
- Rewrite `FileSubAgentDefinitionLoader` to scan `*.md`, fail loud on malformed frontmatter, missing required fields (name/description/tools/body), unknown tool names for user-facing agents, duplicate names across files
- Regenerate the three init-wizard seeds (`research-assistant`, `code-analyst`, `summarizer`) in the new format
- Thread an optional `runtimeContext` parameter through `SpawnAgentTool.Params` → `SubAgentSpawner.SpawnAsync` → `RunSubAgent` → `SubAgentActor` initial user message
- `BuildUserMessage` helper composes `Context:\n...\n\nTask:\n...` when context is present, raw task otherwise
- Enriched discovery layer produces per-agent description/tools/timeout plus a "how to delegate" block with the context field example

## Test plan

- [x] 13 new/rewritten `FileSubAgentDefinitionLoader` tests covering full frontmatter parsing, required-field failures, duplicate-name rejection, disallowed-tool rejection, hyphenated+PascalCase visibility variants, empty body, missing frontmatter, non-`.md` files ignored
- [x] 5 new `SubAgentActor` tests: `BuildUserMessage` unit cases (null/whitespace/populated) plus end-to-end `RuntimeContext_is_prefixed_onto_first_user_message` and `Null_RuntimeContext_leaves_first_user_message_as_raw_task` via a `FakeChatClient.LastReceivedMessages` capture
- [x] `Netclaw.Configuration.Tests`: **189/189** green
- [x] `Netclaw.Actors.Tests` (SubAgent + Session + ToolIndexUpdater filter): **307/307** green
- [x] `Netclaw.Daemon.Tests`: **436/436** green
- [x] `dotnet slopwatch analyze` — **0 issues**
- [ ] Live smoke test against a fresh daemon (post-merge, not in this PR)

## Related

- Closes #647
- #522 — expand delegation guidance in AGENTS.md (adoption gap, runs in parallel and benefits from the enriched discovery layer in this PR)
- #648 — multi-model provider architecture (follow-on; unblocks #649)
- #649 — per-agent model selection in frontmatter (blocked on #648 and this PR)
- #600 — subagent file paths don't flow into parent WorkingContext (orthogonal)