### PR TITLE
feat(memory): observability for silent extractor drops

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
@@ -7,11 +7,11 @@ public sealed class MemoryRulesFirstExtractorTests
 {
     private readonly MemoryRulesFirstExtractor _extractor = new(new MemoryPolicyEvaluator());
 
-    private static MemoryCheckpointPayload MakeTurnPayload(string userContent, string? fullContent = null) => new(
+    private static MemoryCheckpointPayload MakeTurnPayload(string userContent) => new(
         SessionId: "D0AC6CKBK5K/1774370274.953879",
         TriggerType: CheckpointTriggerType.TurnComplete.ToWireValue(),
         Source: "session",
-        Content: fullContent ?? userContent,
+        Content: userContent,
         UserContent: userContent,
         AssistantContent: null,
         IsExplicitRequest: false,

--- a/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRulesFirstExtractorTests.cs
@@ -7,11 +7,11 @@ public sealed class MemoryRulesFirstExtractorTests
 {
     private readonly MemoryRulesFirstExtractor _extractor = new(new MemoryPolicyEvaluator());
 
-    private static MemoryCheckpointPayload MakeTurnPayload(string userContent) => new(
+    private static MemoryCheckpointPayload MakeTurnPayload(string userContent, string? fullContent = null) => new(
         SessionId: "D0AC6CKBK5K/1774370274.953879",
         TriggerType: CheckpointTriggerType.TurnComplete.ToWireValue(),
         Source: "session",
-        Content: userContent,
+        Content: fullContent ?? userContent,
         UserContent: userContent,
         AssistantContent: null,
         IsExplicitRequest: false,
@@ -42,5 +42,49 @@ public sealed class MemoryRulesFirstExtractorTests
         var result = _extractor.Extract(MakeTurnPayload(input), new HashSet<string>());
 
         Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void Turn_complete_without_project_fact_reports_no_project_fact()
+    {
+        var payload = MakeTurnPayload("This is just a short chat reply.");
+
+        var result = _extractor.ExtractWithDiagnostics(payload, new HashSet<string>());
+
+        Assert.Empty(result.Candidates);
+        Assert.Equal(MemoryExtractionDropReason.TurnCompleteNoProjectFact, result.DropReason);
+    }
+
+    [Fact]
+    public void Empty_content_reports_empty_content_drop_reason()
+    {
+        var payload = MakeTurnPayload(string.Empty);
+
+        var result = _extractor.ExtractWithDiagnostics(payload, new HashSet<string>());
+
+        Assert.Empty(result.Candidates);
+        Assert.Equal(MemoryExtractionDropReason.EmptyContent, result.DropReason);
+    }
+
+    [Fact]
+    public void Ephemeral_content_reports_ephemeral_drop_reason()
+    {
+        var payload = MakeTurnPayload("thanks");
+
+        var result = _extractor.ExtractWithDiagnostics(payload, new HashSet<string>());
+
+        Assert.Empty(result.Candidates);
+        Assert.Equal(MemoryExtractionDropReason.EphemeralContent, result.DropReason);
+    }
+
+    [Fact]
+    public void Accepted_project_statement_reports_no_drop_reason()
+    {
+        var payload = MakeTurnPayload("Our deployment pipeline uses GitHub Actions for CI/CD");
+
+        var result = _extractor.ExtractWithDiagnostics(payload, new HashSet<string>());
+
+        Assert.NotEmpty(result.Candidates);
+        Assert.Equal(MemoryExtractionDropReason.None, result.DropReason);
     }
 }

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -18,6 +18,7 @@ public enum MemoryExtractionDropReason
     TraceNotExplicit,
     FingerprintDuplicate,
     PayloadDeserializationFailed,
+    ObservedProposalsEmpty,
 }
 
 public sealed record MemoryExtractionResult(
@@ -494,6 +495,13 @@ public sealed class MemoryCurationEngine(
     MemoryRulesFirstExtractor rules,
     ILogger<MemoryCurationEngine>? logger = null)
 {
+    private const string CheckpointDroppedEvent = "memory_checkpoint_dropped_before_curation";
+    private const string CheckpointDroppedTemplate =
+        CheckpointDroppedEvent +
+        " CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType}" +
+        " IsExplicitRequest={IsExplicitRequest} ContentLength={ContentLength}" +
+        " UserContentLength={UserContentLength} DropReason={DropReason} DropDetail={DropDetail}";
+
     private readonly ILogger<MemoryCurationEngine> _logger = logger ?? NullLogger<MemoryCurationEngine>.Instance;
 
     public async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> CurateAsync(
@@ -508,14 +516,7 @@ public sealed class MemoryCurationEngine(
                 var observed = JsonSerializer.Deserialize<ObservedMemoryCheckpointPayload>(checkpoint.PayloadJson);
                 var observedOps = observed?.Operations ?? [];
                 if (observedOps.Count == 0)
-                {
-                    _logger.LogInformation(
-                        "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
-                        checkpoint.CheckpointId,
-                        checkpoint.SessionId,
-                        checkpoint.TriggerType,
-                        "ObservedProposalsEmpty");
-                }
+                    LogCheckpointDropped(checkpoint, MemoryExtractionDropReason.ObservedProposalsEmpty);
                 return observedOps;
             }
 
@@ -523,23 +524,13 @@ public sealed class MemoryCurationEngine(
         }
         catch (JsonException ex)
         {
-            _logger.LogWarning(ex,
-                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
-                checkpoint.CheckpointId,
-                checkpoint.SessionId,
-                checkpoint.TriggerType,
-                MemoryExtractionDropReason.PayloadDeserializationFailed);
+            LogCheckpointDropped(checkpoint, MemoryExtractionDropReason.PayloadDeserializationFailed, exception: ex);
             return [];
         }
 
         if (payload is null)
         {
-            _logger.LogInformation(
-                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
-                checkpoint.CheckpointId,
-                checkpoint.SessionId,
-                checkpoint.TriggerType,
-                MemoryExtractionDropReason.PayloadDeserializationFailed);
+            LogCheckpointDropped(checkpoint, MemoryExtractionDropReason.PayloadDeserializationFailed);
             return [];
         }
 
@@ -558,16 +549,7 @@ public sealed class MemoryCurationEngine(
         var candidates = extraction.Candidates;
         if (candidates.Count == 0)
         {
-            _logger.LogInformation(
-                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} IsExplicitRequest={IsExplicitRequest} ContentLength={ContentLength} UserContentLength={UserContentLength} DropReason={DropReason} DropDetail={DropDetail}",
-                checkpoint.CheckpointId,
-                checkpoint.SessionId,
-                checkpoint.TriggerType,
-                payload.IsExplicitRequest,
-                payload.Content?.Length ?? 0,
-                payload.UserContent?.Length ?? 0,
-                extraction.DropReason,
-                extraction.DropDetail ?? string.Empty);
+            LogCheckpointDropped(checkpoint, extraction.DropReason, payload, extraction.DropDetail);
             return [];
         }
 
@@ -592,5 +574,30 @@ public sealed class MemoryCurationEngine(
             FreshnessAtMs: c.FreshnessAtMs,
             ExpiresAtMs: c.ExpiresAtMs,
             SupersedesRecordId: c.SupersedesRecordId)).ToArray();
+    }
+
+    private void LogCheckpointDropped(
+        SQLiteMemoryCheckpoint checkpoint,
+        MemoryExtractionDropReason reason,
+        MemoryCheckpointPayload? payload = null,
+        string? detail = null,
+        Exception? exception = null)
+    {
+        var level = exception is not null ? LogLevel.Warning : LogLevel.Information;
+        if (!_logger.IsEnabled(level))
+            return;
+
+        _logger.Log(
+            level,
+            exception,
+            CheckpointDroppedTemplate,
+            checkpoint.CheckpointId,
+            checkpoint.SessionId,
+            checkpoint.TriggerType,
+            payload?.IsExplicitRequest,
+            payload?.Content?.Length,
+            payload?.UserContent?.Length,
+            reason,
+            detail ?? string.Empty);
     }
 }

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -1,9 +1,29 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
 using Netclaw.Security;
 
 namespace Netclaw.Actors.Memory;
+
+public enum MemoryExtractionDropReason
+{
+    None = 0,
+    EmptyContent,
+    EphemeralContent,
+    SecretLikeContent,
+    PolicyRejected,
+    TurnCompleteNoProjectFact,
+    TraceNotExplicit,
+    FingerprintDuplicate,
+    PayloadDeserializationFailed,
+}
+
+public sealed record MemoryExtractionResult(
+    IReadOnlyList<MemoryCheckpointCandidate> Candidates,
+    MemoryExtractionDropReason DropReason,
+    string? DropDetail = null);
 
 public sealed record MemoryCheckpointPayload(
     string SessionId,
@@ -67,18 +87,23 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
     public IReadOnlyList<MemoryCheckpointCandidate> Extract(
         MemoryCheckpointPayload payload,
         IReadOnlySet<string> fingerprintSet)
+        => ExtractWithDiagnostics(payload, fingerprintSet).Candidates;
+
+    public MemoryExtractionResult ExtractWithDiagnostics(
+        MemoryCheckpointPayload payload,
+        IReadOnlySet<string> fingerprintSet)
     {
         var results = new List<MemoryCheckpointCandidate>();
 
         var content = payload.Content?.Trim() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(content))
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.EmptyContent);
 
         if (IsEphemeral(content))
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.EphemeralContent);
 
         if (SecretOutputRedactor.ContainsSecretLikeContent(content))
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.SecretLikeContent);
 
         var decision = policy.EvaluateWrite(
             payload.Sensitivity,
@@ -87,7 +112,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
             payload.IsExplicitRequest,
             payload.Audience);
         if (!decision.Allowed)
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.PolicyRejected, decision.Reason);
 
         if (MemoryDomainEnumExtensions.TryFromWireValue(payload.TriggerType, out CheckpointTriggerType trigger)
             && trigger == CheckpointTriggerType.TurnComplete
@@ -97,12 +122,14 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
             if (promoted is not null)
                 results.Add(promoted);
 
-            return results;
+            return results.Count > 0
+                ? new MemoryExtractionResult(results, MemoryExtractionDropReason.None)
+                : new MemoryExtractionResult(results, MemoryExtractionDropReason.TurnCompleteNoProjectFact);
         }
 
         var memoryClass = ResolveMemoryClass(payload);
         if (memoryClass == MemoryClass.Trace && !payload.IsExplicitRequest)
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.TraceNotExplicit);
 
         var resolvedAudienceWire = MemoryPolicyEvaluator.ResolveAudience(payload.Audience, TrustAudience.Public);
         SecurityPolicyDefaults.TryParseAudience(resolvedAudienceWire, out var parsedAudience);
@@ -115,7 +142,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
         var anchorType = kind == MemoryKind.Record ? "event" : "concept";
         var fingerprint = BuildFingerprint(kind.ToWireValue(), title, content);
         if (fingerprintSet.Contains(fingerprint))
-            return results;
+            return new MemoryExtractionResult(results, MemoryExtractionDropReason.FingerprintDuplicate);
 
         results.Add(new MemoryCheckpointCandidate(
             Kind: kind,
@@ -138,7 +165,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
             MemoryId: payload.MemoryId,
             SupersedesRecordId: payload.SupersedesRecordId));
 
-        return results;
+        return new MemoryExtractionResult(results, MemoryExtractionDropReason.None);
     }
 
     private static MemoryClass ResolveMemoryClass(MemoryCheckpointPayload payload)
@@ -462,8 +489,13 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
     }
 }
 
-public sealed class MemoryCurationEngine(SQLiteMemoryStore store, MemoryRulesFirstExtractor rules)
+public sealed class MemoryCurationEngine(
+    SQLiteMemoryStore store,
+    MemoryRulesFirstExtractor rules,
+    ILogger<MemoryCurationEngine>? logger = null)
 {
+    private readonly ILogger<MemoryCurationEngine> _logger = logger ?? NullLogger<MemoryCurationEngine>.Instance;
+
     public async Task<IReadOnlyList<SQLiteMemoryCurationOperation>> CurateAsync(
         SQLiteMemoryCheckpoint checkpoint,
         CancellationToken ct = default)
@@ -474,18 +506,42 @@ public sealed class MemoryCurationEngine(SQLiteMemoryStore store, MemoryRulesFir
             if (checkpoint.TriggerType == CheckpointTriggerType.ObservedMemoryProposals.ToWireValue())
             {
                 var observed = JsonSerializer.Deserialize<ObservedMemoryCheckpointPayload>(checkpoint.PayloadJson);
-                return observed?.Operations ?? [];
+                var observedOps = observed?.Operations ?? [];
+                if (observedOps.Count == 0)
+                {
+                    _logger.LogInformation(
+                        "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
+                        checkpoint.CheckpointId,
+                        checkpoint.SessionId,
+                        checkpoint.TriggerType,
+                        "ObservedProposalsEmpty");
+                }
+                return observedOps;
             }
 
             payload = JsonSerializer.Deserialize<MemoryCheckpointPayload>(checkpoint.PayloadJson);
         }
-        catch
+        catch (JsonException ex)
         {
+            _logger.LogWarning(ex,
+                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
+                checkpoint.CheckpointId,
+                checkpoint.SessionId,
+                checkpoint.TriggerType,
+                MemoryExtractionDropReason.PayloadDeserializationFailed);
             return [];
         }
 
         if (payload is null)
+        {
+            _logger.LogInformation(
+                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} DropReason={DropReason}",
+                checkpoint.CheckpointId,
+                checkpoint.SessionId,
+                checkpoint.TriggerType,
+                MemoryExtractionDropReason.PayloadDeserializationFailed);
             return [];
+        }
 
         var resolvedAudienceWire = MemoryPolicyEvaluator.ResolveAudience(payload.Audience, TrustAudience.Public);
         SecurityPolicyDefaults.TryParseAudience(resolvedAudienceWire, out var parsedAudience);
@@ -498,9 +554,22 @@ public sealed class MemoryCurationEngine(SQLiteMemoryStore store, MemoryRulesFir
             .Select(x => MemoryRulesFirstExtractor.BuildFingerprint(x.Kind, x.Title, x.Snippet))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        var candidates = rules.Extract(payload, fingerprints);
+        var extraction = rules.ExtractWithDiagnostics(payload, fingerprints);
+        var candidates = extraction.Candidates;
         if (candidates.Count == 0)
+        {
+            _logger.LogInformation(
+                "memory_checkpoint_dropped_before_curation CheckpointId={CheckpointId} SessionId={SessionId} TriggerType={TriggerType} IsExplicitRequest={IsExplicitRequest} ContentLength={ContentLength} UserContentLength={UserContentLength} DropReason={DropReason} DropDetail={DropDetail}",
+                checkpoint.CheckpointId,
+                checkpoint.SessionId,
+                checkpoint.TriggerType,
+                payload.IsExplicitRequest,
+                payload.Content?.Length ?? 0,
+                payload.UserContent?.Length ?? 0,
+                extraction.DropReason,
+                extraction.DropDetail ?? string.Empty);
             return [];
+        }
 
         return candidates.Select(c => new SQLiteMemoryCurationOperation(
             Kind: c.Kind.ToWireValue(),


### PR DESCRIPTION
## Summary

- Adds a `MemoryExtractionDropReason` enum covering every drop site in `MemoryRulesFirstExtractor` and a `MemoryExtractionResult` record wrapping the candidate list with the reason.
- New `ExtractWithDiagnostics` method returns the diagnostic result; the existing `Extract` method remains as a thin wrapper, so no existing caller breaks.
- `MemoryCurationEngine` now logs a single structured `memory_checkpoint_dropped_before_curation` event at every drop path via one consolidated helper, so silent drops are no longer invisible at the log level.

## Motivation

Turn-complete checkpoints that do not match the rules-first extractor's project-fact patterns are dropped, and the checkpoint is still marked `completed` in the database. With no categorized drop reason in logs, "why didn't this memory surface?" was only answerable by source inspection. This commit makes those drops observable without changing any memory formation behavior.

## Scope

- Observability only. Zero behavior change.
- Every drop site still drops exactly the content it used to, now tagged with a reason.
- Optional `ILogger<MemoryCurationEngine>` constructor parameter; DI resolves it automatically, and unit tests that construct the engine directly get `NullLogger` via the null-object pattern already used elsewhere in `Netclaw.Actors.Memory`.
- Log helper is gated by `ILogger.IsEnabled(level)` so disabled log levels pay no argument-array allocation on the background-worker hot path.

## Follow-ups

This lays the groundwork for an empirical look at why long conversational content is not becoming durable memory. The right next step is to watch drop reasons in a real session and decide whether any extractor tuning is warranted — that work is deliberately out of scope for this PR.

## Test plan

- [x] \`dotnet build Netclaw.slnx\` — clean, 0 warnings
- [x] \`dotnet test Netclaw.slnx\` — 2,328 tests pass (1000 Actors incl. 4 new drop-reason tests, 435 Daemon, 413 Cli, 256 Security, 187 Config, 32 Search, 5 MemoryRetrievalPoC)
- [x] \`dotnet slopwatch analyze\` — 0 issues
- [x] No changes to public API surface of \`MemoryRulesFirstExtractor.Extract\`
- [x] No changes to DI registration (optional parameter is transparent)