### PR TITLE
test(subagents): consolidate anemic loader and actor tests

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -275,33 +275,6 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
-    public void BuildUserMessage_returns_task_only_when_context_is_null()
-    {
-        var result = SubAgentActor.BuildUserMessage(runtimeContext: null, task: "Find the latest release.");
-
-        Assert.Equal("Find the latest release.", result);
-    }
-
-    [Fact]
-    public void BuildUserMessage_returns_task_only_when_context_is_whitespace()
-    {
-        var result = SubAgentActor.BuildUserMessage(runtimeContext: "   \t  ", task: "Find it.");
-
-        Assert.Equal("Find it.", result);
-    }
-
-    [Fact]
-    public void BuildUserMessage_prefixes_context_block_when_present()
-    {
-        var result = SubAgentActor.BuildUserMessage(
-            runtimeContext: "Workspace is netclaw on branch feature/foo.",
-            task: "Summarize the recent commits.");
-
-        Assert.StartsWith("Context:\nWorkspace is netclaw on branch feature/foo.", result);
-        Assert.Contains("\n\nTask:\nSummarize the recent commits.", result);
-    }
-
-    [Fact]
     public async Task RuntimeContext_is_prefixed_onto_first_user_message()
     {
         var fakeClient = new FakeChatClient();

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -321,7 +321,7 @@ public sealed class SubAgentActor : ReceiveActor
     /// When runtime context is null or whitespace, returns the raw task string for backward
     /// compatibility with the pre-Context protocol.
     /// </summary>
-    internal static string BuildUserMessage(string? runtimeContext, string task)
+    private static string BuildUserMessage(string? runtimeContext, string task)
     {
         if (string.IsNullOrWhiteSpace(runtimeContext))
             return task;

--- a/src/Netclaw.Configuration.Tests/FileSubAgentDefinitionLoaderTests.cs
+++ b/src/Netclaw.Configuration.Tests/FileSubAgentDefinitionLoaderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -7,6 +8,7 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly NetclawPaths _paths;
+    private readonly ListLogger<FileSubAgentDefinitionLoader> _logger;
     private readonly FileSubAgentDefinitionLoader _loader;
 
     public FileSubAgentDefinitionLoaderTests()
@@ -15,7 +17,8 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
         Directory.CreateDirectory(_tempDir);
         _paths = new NetclawPaths(_tempDir);
         _paths.EnsureDirectoriesExist();
-        _loader = new FileSubAgentDefinitionLoader(_paths, NullLogger<FileSubAgentDefinitionLoader>.Instance);
+        _logger = new ListLogger<FileSubAgentDefinitionLoader>();
+        _loader = new FileSubAgentDefinitionLoader(_paths, _logger);
     }
 
     public void Dispose()
@@ -29,13 +32,6 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
         var path = Path.Combine(_paths.AgentsDirectory, fileName);
         File.WriteAllText(path, content);
         return path;
-    }
-
-    [Fact]
-    public void LoadAll_returns_empty_when_no_files()
-    {
-        var results = _loader.LoadAll();
-        Assert.Empty(results);
     }
 
     [Fact]
@@ -58,8 +54,7 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
 
         var results = _loader.LoadAll();
 
-        Assert.Single(results);
-        var profile = results[0];
+        var profile = Assert.Single(results);
         Assert.Equal("research-assistant", profile.Name);
         Assert.Equal("Deep research", profile.Description);
         Assert.Contains("You are a researcher.", profile.SystemPrompt);
@@ -86,157 +81,15 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
 
         var results = _loader.LoadAll();
 
-        Assert.Single(results);
-        Assert.Equal(ModelRole.Compaction, results[0].ModelRole);
-        Assert.Equal(60, results[0].TimeoutSeconds);
-        Assert.False(results[0].EmitStructuredFindings);
-        Assert.Equal(SubAgentVisibility.UserFacing, results[0].Visibility);
+        var profile = Assert.Single(results);
+        Assert.Equal(ModelRole.Compaction, profile.ModelRole);
+        Assert.Equal(60, profile.TimeoutSeconds);
+        Assert.False(profile.EmitStructuredFindings);
+        Assert.Equal(SubAgentVisibility.UserFacing, profile.Visibility);
     }
 
     [Fact]
-    public void LoadAll_skips_file_with_no_frontmatter()
-    {
-        WriteAgent("bare.md", "Just a body. No frontmatter at all.");
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_malformed_frontmatter()
-    {
-        WriteAgent("broken.md", """
-            ---
-            name: broken
-            description: [unclosed list
-            ---
-
-            body
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_agent_missing_name()
-    {
-        WriteAgent("noname.md", """
-            ---
-            description: Has a description but no name
-            tools: [web_search]
-            ---
-
-            body
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_agent_missing_description()
-    {
-        WriteAgent("nodesc.md", """
-            ---
-            name: nodesc
-            tools: [web_search]
-            ---
-
-            body
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_agent_with_empty_body()
-    {
-        WriteAgent("empty-body.md", """
-            ---
-            name: empty-body
-            description: Has frontmatter but nothing after it
-            tools: [web_search]
-            ---
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_agent_with_no_tools()
-    {
-        WriteAgent("no-tools.md", """
-            ---
-            name: no-tools
-            description: A test agent
-            tools: []
-            ---
-
-            You are a test agent.
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_skips_user_facing_agent_with_disallowed_tools()
-    {
-        WriteAgent("bad-tools.md", """
-            ---
-            name: bad-tools
-            description: A test agent
-            tools: [web_search, file_write, shell_execute]
-            ---
-
-            You are a test agent.
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
-    public void LoadAll_rejects_duplicate_names_across_files()
-    {
-        WriteAgent("first.md", """
-            ---
-            name: shared
-            description: First agent
-            tools: [web_search]
-            ---
-
-            First body.
-            """);
-        WriteAgent("second.md", """
-            ---
-            name: shared
-            description: Second agent
-            tools: [web_fetch]
-            ---
-
-            Second body.
-            """);
-
-        var results = _loader.LoadAll();
-
-        Assert.Single(results);
-        // Deterministic ordering picks the first file alphabetically.
-        Assert.Equal("First agent", results[0].Description);
-    }
-
-    [Fact]
-    public void LoadAll_accepts_pascal_case_visibility_and_hyphenated_visibility()
+    public void LoadAll_accepts_hyphenated_and_pascal_case_visibility()
     {
         WriteAgent("hyphenated.md", """
             ---
@@ -266,13 +119,190 @@ public class FileSubAgentDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
-    public void LoadAll_ignores_non_md_files()
+    public void LoadAll_duplicate_name_keeps_first_alphabetically_and_logs_the_rejection()
     {
-        WriteAgent("ignored.json", """{"name":"json","description":"ignored"}""");
-        WriteAgent("ignored.txt", "plain text");
+        WriteAgent("a-wins.md", """
+            ---
+            name: shared
+            description: First agent
+            tools: [web_search]
+            ---
+
+            First body.
+            """);
+        WriteAgent("b-loses.md", """
+            ---
+            name: shared
+            description: Second agent
+            tools: [web_fetch]
+            ---
+
+            Second body.
+            """);
 
         var results = _loader.LoadAll();
 
-        Assert.Empty(results);
+        var profile = Assert.Single(results);
+        Assert.Equal("First agent", profile.Description);
+        Assert.Contains("First body.", profile.SystemPrompt);
+
+        // The second file should have produced a loud warning pointing at the duplicate.
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("b-loses.md", StringComparison.Ordinal)
+            && w.Contains("duplicate name", StringComparison.OrdinalIgnoreCase)
+            && w.Contains("shared", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LoadAll_loads_valid_agent_and_rejects_invalid_siblings_with_warnings()
+    {
+        // One valid agent — must survive loading alongside every invalid sibling below.
+        WriteAgent("valid.md", """
+            ---
+            name: valid
+            description: A real agent
+            tools: [web_search]
+            ---
+
+            You are the only valid agent in this directory.
+            """);
+
+        // No frontmatter at all.
+        WriteAgent("no-frontmatter.md", "Just a body. No YAML frontmatter delimiter.");
+
+        // Frontmatter present but unparseable YAML.
+        WriteAgent("malformed-yaml.md", """
+            ---
+            name: broken
+            description: [unclosed list
+            ---
+
+            body
+            """);
+
+        // Frontmatter missing required name field.
+        WriteAgent("missing-name.md", """
+            ---
+            description: Has description but no name
+            tools: [web_search]
+            ---
+
+            body
+            """);
+
+        // Frontmatter missing required description field.
+        WriteAgent("missing-description.md", """
+            ---
+            name: nodesc
+            tools: [web_search]
+            ---
+
+            body
+            """);
+
+        // Valid frontmatter but empty body.
+        WriteAgent("empty-body.md", """
+            ---
+            name: empty-body
+            description: Frontmatter only
+            tools: [web_search]
+            ---
+            """);
+
+        // Empty tools list.
+        WriteAgent("no-tools.md", """
+            ---
+            name: no-tools
+            description: Has no tools
+            tools: []
+            ---
+
+            body
+            """);
+
+        // Tool not allowed for user-facing agents (file_write, shell_execute).
+        WriteAgent("bad-tools.md", """
+            ---
+            name: bad-tools
+            description: Uses disallowed tools
+            tools: [web_search, file_write, shell_execute]
+            ---
+
+            body
+            """);
+
+        // Non-markdown file dropped in the directory — should be silently ignored (not scanned at all).
+        WriteAgent("stray.json", """{"name":"json","description":"legacy"}""");
+        WriteAgent("readme.txt", "notes");
+
+        var results = _loader.LoadAll();
+
+        // Positive: the valid agent survived despite every sibling being broken.
+        var profile = Assert.Single(results);
+        Assert.Equal("valid", profile.Name);
+        Assert.Contains("You are the only valid agent", profile.SystemPrompt);
+
+        // Negative: every invalid sibling produced a specific warning that names the file
+        // AND points at the reason. This is the "fail loud" contract — without log checks,
+        // a silent-skip regression would sail through the suite.
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("no-frontmatter.md", StringComparison.Ordinal)
+            && w.Contains("frontmatter", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("malformed-yaml.md", StringComparison.Ordinal)
+            && w.Contains("frontmatter", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("missing-name.md", StringComparison.Ordinal)
+            && w.Contains("name", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("missing-description.md", StringComparison.Ordinal)
+            && w.Contains("description", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("empty-body.md", StringComparison.Ordinal)
+            && w.Contains("system prompt body", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("no-tools.md", StringComparison.Ordinal)
+            && w.Contains("no tools", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(_logger.Warnings, w =>
+            w.Contains("bad-tools.md", StringComparison.Ordinal)
+            && w.Contains("disallowed tools", StringComparison.OrdinalIgnoreCase)
+            && w.Contains("file_write", StringComparison.Ordinal)
+            && w.Contains("shell_execute", StringComparison.Ordinal));
+
+        // The .json and .txt files must not have produced any warning at all — they should be
+        // ignored at the Directory.GetFiles("*.md") pattern layer, never reaching the parser.
+        Assert.DoesNotContain(_logger.Warnings, w => w.Contains("stray.json", StringComparison.Ordinal));
+        Assert.DoesNotContain(_logger.Warnings, w => w.Contains("readme.txt", StringComparison.Ordinal));
+    }
+}
+
+/// <summary>
+/// Capturing <see cref="ILogger{T}"/> that records formatted warning messages into a list.
+/// Used to verify the "fail loud" contract — a loader that silently skips invalid files
+/// would produce zero warnings and break these assertions instead of sailing through.
+/// </summary>
+internal sealed class ListLogger<T> : ILogger<T>
+{
+    public List<string> Warnings { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel >= LogLevel.Warning)
+            Warnings.Add(formatter(state, exception));
     }
 }


### PR DESCRIPTION
## Summary

- Replace nine near-identical `LoadAll_skips_X` tests — each of which wrote one bad file and just asserted `Assert.Empty(results)` — with one consolidated `LoadAll_loads_valid_agent_and_rejects_invalid_siblings_with_warnings` that drops a valid agent alongside eight kinds of invalid siblings in the same directory and verifies (a) the valid agent still loads, (b) each invalid sibling produced a specific warning naming both the file and the reason, and (c) stray `.json` / `.txt` files produce no warning at all because the scanner never touches them.
- Introduce a minimal `ListLogger<T>` (≈20 lines, inline in the test file) that captures warning-level formatted messages so tests can assert on log contents.
- Delete three `BuildUserMessage_*` unit tests on `SubAgentActor`. They pinned a 4-line string interpolation helper whose behavior is already fully covered by the two end-to-end `RuntimeContext_is_prefixed_onto_first_user_message` and `Null_RuntimeContext_leaves_first_user_message_as_raw_task` tests. With the unit tests gone, `BuildUserMessage` has no external caller, so tighten its visibility from `internal` to `private`.

## Why

The `LoadAll_skips_X` tests from #652 were a pattern the Netclaw constitution explicitly warns against: *"If the test is just asserting that `$"{a}/{b}"` equals `"a/b"`, delete it. Prefer fewer tests that cover real behavior over many tests that pad coverage."* They looked like they pinned nine distinct validation paths but if the loader were rewritten to unconditionally return an empty list for every file, all nine would still pass. That's negative signal dressed up as coverage.

More importantly, the whole point of the format redesign was "fail loud on malformed files" (per CLAUDE.md's no-silent-fallbacks rule), and the old tests didn't actually verify any warning was logged. A silent-skip regression would have sailed through the suite.

The `BuildUserMessage_*` unit tests were the same smell applied to a string helper. The E2E tests exercise the same helper through the actor pipeline and catch any regression the unit tests would.

## Test plan

- [x] `dotnet test src/Netclaw.Configuration.Tests` — 181/181 green (was 189 before; removed 8 redundant tests)
- [x] `dotnet test src/Netclaw.Actors.Tests --filter FullyQualifiedName~SubAgent` — 27/27 green (was 30; removed 3 redundant unit tests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] GPG signed commit

## Notes

The one consolidated test intentionally asserts on **substring matches in captured warning messages** rather than exact strings, so minor copy edits to the loader's warning text won't break the suite — but a silent skip (no warning at all) or a warning that omits the filename / reason absolutely will.