### PR TITLE
feat(agents): expand subagent delegation guidance in AGENTS.md seed

### DIFF
--- a/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs
@@ -206,17 +206,34 @@ public sealed class IdentityStepViewModel : IWizardStepViewModel
 
             Use spawn_agent to delegate bounded, self-contained tasks to specialist subagents.
             Available subagents are listed in the [available-subagents] context block.
+            Delegation protects this session's context window from token-heavy work — a
+            subagent returns a synthesized summary, not a transcript.
 
-            When to delegate:
-            - Deep web research that requires multiple searches and synthesis
-            - Code analysis tasks on large files or multiple files
+            **When to delegate:**
+            - Research requiring 2+ sources or multiple searches
+            - Parallelizable tasks (multiple independent queries can run concurrently)
+            - Any work that would otherwise pull large files or web pages into this
+              session's context — the subagent reads them, you get the synthesis
+            - Background prep work that doesn't block immediate response
+            - Code analysis on large files or multiple files
             - Summarization of long documents or web pages
+            - Preliminary passes on topics before diving deep
 
-            When NOT to delegate:
-            - Simple searches (use web_search directly)
+            **When NOT to delegate:**
+            - Simple single searches (use web_search directly)
             - Tasks requiring MCP tools (subagents only have web_search, web_fetch,
               file_read, attach_file)
             - Interactive browser tasks (subagents cannot use browser MCP tools)
+            - Tasks where coordination overhead outweighs parallelization benefits
+
+            **Per-call specialization:** spawn_agent accepts an optional `context`
+            argument — pass workspace details, the user's broader goal, or facts the
+            subagent would otherwise have to rediscover. Use it to specialize a
+            general-purpose subagent for the current invocation instead of authoring
+            a whole new agent file. Do not duplicate the agent's built-in instructions.
+
+            **Parallelization tip:** When researching multiple independent topics, spawn
+            separate subagents for each — they run concurrently and reduce total wait time.
 
             spawn_agent is NOT the same as search_tools. Subagents are named specialists
             (e.g., "research-assistant", "code-analyst", "summarizer"). MCP tools are


### PR DESCRIPTION
## Summary

The init wizard seeds an `AGENTS.md` "Subagent Delegation" section that tells the frontline LLM when to delegate to `spawn_agent`. The current guidance sets the bar too high — *"deep web research requiring multiple searches and synthesis"* as the threshold excludes the bulk of research tasks that would benefit from delegation. Live smoke testing earlier in the sub-agent work confirmed this: Qwen performed ~50k tokens of in-process research on a clearly delegable task because the guidance never reached the delegation trigger.

This PR rewrites the section end to end, applying the proposal from #522 verbatim with two adjacent additions I think close a gap in the original proposal:

1. **A context-window-protection bullet in "When to delegate".** Delegation's biggest structural benefit isn't specialization or parallelism — it's keeping raw file/web content out of the main session's context window. The existing guidance never said that out loud, and Phase 0.2 smoke testing showed it's the real problem (Qwen burned ~15k tokens reading GitHub HTML into its own context when `research-assistant` would have returned a 1KB cited summary).
2. **A new "Per-call specialization" paragraph** introducing the optional `context` argument that shipped in #647 / #652. The discovery context layer advertises it, but `AGENTS.md` was still telling the model to call `spawn_agent` with only `agent` + `task`.

## Expanded "When to delegate" list

- Research requiring 2+ sources or multiple searches (was: *"deep research requiring multiple searches and synthesis"*)
- Parallelizable tasks (multiple independent queries can run concurrently)
- Any work that would otherwise pull large files or web pages into this session's context — the subagent reads them, you get the synthesis **(new)**
- Background prep work that doesn't block immediate response
- Code analysis on large files or multiple files
- Summarization of long documents or web pages
- Preliminary passes on topics before diving deep

## Expanded "When NOT to delegate" list

- Simple single searches (use `web_search` directly)
- Tasks requiring MCP tools
- Interactive browser tasks
- Tasks where coordination overhead outweighs parallelization benefits **(new)**

## Per-call specialization paragraph (new)

Teaches the model that `spawn_agent` takes an optional `context` argument for per-invocation background — workspace details, the user's broader goal, facts the subagent would otherwise have to rediscover — and explicitly warns against duplicating the agent's built-in instructions in it. The runtime side of this shipped in #647 / #652 but the AGENTS.md text was stale.

## Scope notes

- **Seed template only.** This updates the init-wizard seed at `src/Netclaw.Cli/Tui/Wizard/Steps/IdentityStepViewModel.cs:205-239`. New installs pick it up via `netclaw init`. Existing users' `~/.netclaw/identity/AGENTS.md` files are **not** mutated automatically — operators who want the new guidance should copy the new block into their identity file manually.
- **Not coupled to #600.** Earlier design discussion considered whether this should land with #600 (sub-agent file paths → parent WorkingContext). After reviewing `WorkingContext.cs` in detail, #600 was closed as `not planned` — the proposed mechanism would misrepresent the parent's actual file awareness (RecentFiles carries an implicit "contents are fresh in my mind" semantic that a subagent-read file doesn't satisfy), and the preservation concern it raised is already handled by the conversation history and the structured findings pipeline (#183 / checkpoint heuristics). This PR ships alone.
- **Related:** `ToolIndexUpdater.UpdateSubAgentDiscovery()` was enriched in #652 to include per-agent description, tool lists, and a `context`-aware example call, so the runtime-side discovery block and the static AGENTS.md guidance are now consistent.

## Test plan

- [x] `dotnet build src/Netclaw.Cli/Netclaw.Cli.csproj` — clean
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] Reviewed the rendered raw-string output by reading the file back at lines 205-239 — indentation matches surrounding block, markdown renders correctly
- [ ] Live delegation retest post-merge — rerun the Phase 0.2 smoke prompt against a fresh install with the new seed and see whether Qwen now reaches for `spawn_agent` organically (this is follow-up validation, not a blocker for merge)

## Related issues

- Closes #522
- Built on #647 (single-file markdown format) and #652 (context parameter) — the AGENTS.md text now references the context argument those PRs shipped
- Adjacent to #655 (runbook rewrite) — both keep the stale JSON+MD references out of user-facing guidance, landing on different files so no conflict