### PR TITLE
feat(prose): add pre-OSS quality audit and fix programs

### DIFF
--- a/.prose/netclaw-quality-audit.prose
+++ b/.prose/netclaw-quality-audit.prose
@@ -1,0 +1,622 @@
+# NetClaw Pre-OSS Code Quality Audit
+#
+# Fans out one specialist agent per standards group (A..G) in parallel,
+# each producing structured findings. Aggregator merges into a single
+# ranked markdown report + paste-ready tasks.md checklist.
+#
+# The report is the contract: the sibling fix program
+# (netclaw-quality-fix.prose) reads Section 9 of the output and
+# dispatches fix agents against it.
+#
+# Invocation:
+#   /open-prose:prose-compile .prose/netclaw-quality-audit.prose
+#   /open-prose:prose-run .prose/netclaw-quality-audit.prose \
+#     repo_path=/home/petabridge/repositories/stannardlabs/netclaw \
+#     strictness=normal
+#
+# Full rule definitions and design rationale live in
+# /home/petabridge/.claude/plans/reactive-beaming-sprout.md
+
+input repo_path: "Absolute path to the NetClaw repo"
+input strictness: "loose | normal | strict (default: normal)"
+
+# ---------------------------------------------------------------------
+# Shared agent: quality auditor
+# ---------------------------------------------------------------------
+# One template. Per-group prompts supply the rule list and search
+# strategy. Sonnet is fine for the mechanical Grep-confirm-classify
+# loop; opus is reserved for the aggregator.
+
+agent aggregator:
+  model: opus
+  prompt: """
+    You are the aggregator for the NetClaw pre-OSS code quality audit.
+    You receive per-group findings and produce a single ranked markdown
+    report that a sibling fix program can parse. Format discipline is
+    non-negotiable — downstream tools depend on exact section layout.
+  """
+
+agent quality_auditor:
+  model: sonnet
+  prompt: """
+    You are a C# code quality specialist auditing the NetClaw repository
+    at {repo_path}. You will be assigned exactly one standards group
+    with a rule list. For every rule:
+
+      1. Use Glob/Grep to find candidate violations.
+      2. Read each candidate to CONFIRM the hit — do not trust regex alone.
+      3. BEFORE reporting, check for a waiver. A candidate is NOT an
+         unacknowledged finding if any of these holds:
+           a) An inline `// WHY: <reason>` comment appears on the same
+              line as the violation OR on the 1..3 lines immediately
+              preceding it.
+           b) `.slopwatch/baseline.json` contains an entry whose
+              filePath matches the file and whose lineNumber is within
+              3 lines of the violation (slopwatch line numbers drift).
+           c) The rule text itself allows the pattern in this context
+              (e.g., D4 permits broad catches at top-level entry points).
+      4. Classify every confirmed hit into exactly one of:
+           - "unacknowledged" — reported as a hard finding
+           - "acknowledged"   — has // WHY:, counted only
+           - "baselined"      — in baseline.json, counted only
+
+    D5 and D6 are NO-WAIVER. Report them regardless of `// WHY:` state
+    (they are security-critical); still mark classification based on
+    waiver state but include the note "no-waiver rule — escalate".
+
+    Search discipline:
+      - ALWAYS skip: bin/, obj/, .prose/, .slopwatch/, feeds/skills/,
+        artifacts/, publish/, *.g.cs, **/GlobalUsings.g.cs,
+        node_modules/, evals/ fixtures.
+      - Restrict to src/**/*.cs (production + tests). Read
+        Directory.Build.props / Directory.Packages.props / *.csproj
+        only when a rule explicitly targets them.
+      - Use Grep file-type hints and glob filters to cut noise.
+      - Precision over recall. Mark confidence=low for borderline hits;
+        the aggregator routes them to a "Needs Human Review" appendix
+        rather than dropping them.
+
+    Per-rule cap: 10 reported unacknowledged hits. If a rule saturates,
+    append a single summary record noting saturation and approximate
+    total so the backlog generator can treat it as one refactor
+    campaign task rather than 50 individual items.
+
+    Emit a structured report with two sections:
+
+      ## Findings
+      For each confirmed hit, one row of the form:
+        - [<severity>] <rule_id> <file>:<line> (<classification>) —
+          <one-line fix hint>
+            ```csharp
+            <the offending 1-3 lines, trimmed>
+            ```
+          Confidence: <high|medium|low>
+          Waiver reason: <text if acknowledged/baselined, else "none">
+
+      ## Acknowledged Counts
+      Table of rule_id → count for every rule in this group, so the
+      aggregator can flag rules with an unusually high waiver rate
+      (signal that the rule is wrong, not the code).
+
+    Severity rubric:
+      - blocker: D5/D6 security violations, secrets, any "no-waiver" rule
+      - major:   D1 silent fallbacks, B1/B5 test discipline that masks
+                 bugs, F4/F5 wire-format breaks, C1/C4 determinism
+      - minor:   style, F7 XML docs, acknowledged-but-noisy rules
+
+    If strictness == "strict", promote every minor to major before
+    emitting. If "loose", demote every minor to informational and
+    drop from the main findings list.
+  """
+
+# ---------------------------------------------------------------------
+# Parallel fan-out: one session per group
+# ---------------------------------------------------------------------
+# on-fail: "continue" keeps the run alive if one group crashes — the
+# aggregator notes which groups did not run.
+
+parallel (on-fail: "continue"):
+
+  group_a = session: quality_auditor
+    prompt: """
+      AUDIT GROUP A — Value & Type Safety
+      (csharp-coding-standards, type-design-performance, CLAUDE.md)
+
+      Rules:
+        A1. Domain identifiers are value objects, not raw string/int
+            (SessionId, ChannelId, UserId, ToolName, GrantId, TenantId)
+        A2. Value objects never expose `implicit operator` to primitives
+        A3. Classes are `sealed` by default unless inheritance is a
+            design goal (abstract base classes excused)
+        A4. Immutable structs are `readonly struct`
+        A5. DTOs, messages, and events are `record` or
+            `readonly record struct`
+        A6. `<Nullable>enable</Nullable>` project-wide; no blanket
+            `#nullable disable`
+        A7. No null-forgiving `!` on a value object's `.Value` without
+            a guard
+        A8. No primitive obsession in method signatures (3+ consecutive
+            `string` params on a public method)
+
+      Regression anchors (MUST be detected — if missed, rules are broken):
+        A1 — src/Netclaw.Actors/Restart/RestartManifestStore.cs:12-14
+        A1 — src/Netclaw.Channels.Slack/SlackChannelOptions.cs:15,30,32
+        A1 — src/Netclaw.Channels/HeadlessChannel.cs:371
+        A7 — src/Netclaw.Configuration.Tests/Providers/OAuth/OAuthDeviceFlowServiceTests.cs:79
+        A7 — src/Netclaw.Daemon/Services/SchemaMigrator.cs:231
+        A7 — src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs:54
+
+      Search strategy:
+        A1: Grep `public\\s+string\\s+(SessionId|ChannelId|UserId|ToolName|GrantId|TenantId)\\b`
+            in src/**/*.cs. Also fields named `_sessionId`, `_channelId`,
+            etc. typed string.
+        A2: Grep `implicit\\s+operator` — inspect hits inside records or
+            structs whose name ends in "Id", "Name", "Token", "Key", "Uri".
+        A3: Grep `^public\\s+class\\s+\\w+` in src/**/*.cs. Exclude
+            abstract classes, classes inheriting from `ActorBase` /
+            `ReceiveActor` / `UntypedActor` (Akka actors are routinely
+            non-sealed), and static `*Extensions` classes.
+        A4: Grep `public\\s+struct\\s+` — check declaration for `readonly`.
+            Also baseline grep `readonly struct` for context.
+        A5: For `Protocol/` and `Messages/` directories, any `class`
+            (not `record`) is a candidate. Read file to confirm it's
+            used as an Akka message.
+        A6: Grep `#nullable disable` in src/**/*.cs — report every
+            file-scoped hit. Also read Directory.Build.props to confirm
+            `<Nullable>enable</Nullable>` is set project-wide.
+        A7: Grep `\\.Value!` and `\\.\\w+!` where the preceding
+            identifier is a known value-object type.
+        A8: Multiline grep for `public\\s+(async\\s+)?\\w+\\s+\\w+\\(\\s*string\\s+\\w+,\\s*string\\s+\\w+,\\s*string\\s+\\w+`
+            (3 consecutive string params).
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+  group_b = session: quality_auditor
+    prompt: """
+      AUDIT GROUP B — Test Discipline
+      (akka-testing-patterns, testing-strategy, CLAUDE.md)
+
+      Rules:
+        B1. No Thread.Sleep / Task.Delay in test orchestration
+            (design smell — use AwaitAssertAsync or TestProbe acks)
+        B2. No trivial tests (constructor-assignment asserts,
+            string interpolation tests of the form "a/b", property
+            getters with no logic)
+        B3. No [Fact(Skip=...)] / [Ignore] / disabled tests
+        B4. Async state verified via AwaitAssertAsync or TestProbe acks
+        B5. No .Result / .Wait() in tests
+        B6. Actor tests inherit Akka.Hosting.TestKit, not a custom base
+        B7. External dependencies faked via ConfigureServices, not
+            stub actors
+
+      Regression anchors (EXPECT BASELINED — verify via .slopwatch/baseline.json):
+        B1 — src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs:263
+        B1 — src/Netclaw.Actors.Tests/Sessions/MemoryRecallScenarioTests.cs:318-322
+        B1 — src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs:62
+
+      Search strategy:
+        B1: Grep `(Thread\\.Sleep|Task\\.Delay)` in src/**/*Tests/**/*.cs.
+            Expect heavy waiver activity.
+        B2: Grep `Assert\\.Equal\\(.*,\\s*new\\s+\\w+` — constructor-
+            assignment smell. Also find test methods <5 lines with a
+            single Assert line.
+        B3: Grep `\\[Fact\\(Skip\\s*=` and `\\[Ignore`.
+        B4: Count test classes with >3 [Fact] methods and ZERO uses of
+            AwaitAssertAsync or TestProbe — medium-confidence "probably
+            sync-tested" candidates.
+        B5: Grep `\\.Result\\b` and `\\.Wait\\(\\)` in tests.
+        B6: Grep `class\\s+\\w+Tests\\s*:` in tests; report any whose
+            parent is NOT `TestKit` / `TestAppBuilderTestKit`.
+        B7: `system.ActorOf(.*Stub|Fake|Mock)` patterns (low confidence).
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+  group_c = session: quality_auditor
+    prompt: """
+      AUDIT GROUP C — Time & Determinism
+      (CLAUDE.md, csharp-coding-standards)
+
+      Rules:
+        C1. Production never calls DateTime.UtcNow / DateTimeOffset.UtcNow
+            directly — use injected TimeProvider.GetUtcNow()
+        C2. DateTimeOffset preferred over DateTime
+        C3. Tests use FakeTimeProvider where time matters (not wall clock)
+        C4. No un-injected Random / Guid.NewGuid() on determinism-
+            sensitive paths (session ids, retry jitter, test setups)
+
+      Regression anchors (all are C3 — test files should use FakeTimeProvider):
+        C3 — src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs:37
+        C3 — src/Netclaw.Actors.Tests/Memory/MemoryPolicyGatesTests.cs:14
+        C3 — src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs:17
+
+      Search strategy:
+        C1: Grep `(DateTime|DateTimeOffset)\\.UtcNow` in src/**/*.cs.
+            - In src/*.Tests/**: candidates for C3, not C1
+            - In src/** (production): ALL hits are C1 unless the
+              enclosing class already has a TimeProvider field
+              (read to confirm)
+        C2: Grep `\\bDateTime\\b` in production src/**; exclude
+            `DateTimeOffset`. Minor severity; mostly informational.
+        C3: Count test files that import
+            Microsoft.Extensions.Time.Testing vs those that use
+            DateTimeOffset.UtcNow. Report mismatches.
+        C4: Grep `\\bnew\\s+Random\\(\\)` and `Guid\\.NewGuid\\(\\)`
+            in src/** (not tests). Match file/method names against
+            retry, backoff, jitter, session, id, token.
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+  group_d = session: quality_auditor
+    prompt: """
+      AUDIT GROUP D — Error Handling, Fallbacks & Security
+      (CLAUDE.md, akka-best-practices)
+
+      Rules:
+        D1. No silent fallbacks on misconfiguration or security-
+            relevant paths
+        D2. (waiverable) Bare catch (Exception) that swallows and
+            continues (OK with // WHY:)
+        D3. (waiverable) Empty catch blocks (OK with // WHY:)
+        D4. (waiverable) Narrow exception types in INTERIOR code.
+            Top-level CLI command handlers and daemon entry-point
+            handlers may catch Exception broadly if they log with
+            context and exit non-zero or rethrow.
+        D5. Default-deny on gateway/ACL/tool boundaries — no implicit
+            allow (NO WAIVER — security-critical)
+        D6. No `?? defaultValue` patterns on auth/grant/permission
+            paths (NO WAIVER — security-critical)
+
+      Regression anchors (MUST be detected):
+        D2 — src/Netclaw.Cli/Mcp/McpCommand.cs:365
+        D2 — src/Netclaw.Cli/Mcp/McpCommand.cs:432
+        D2 — src/Netclaw.Cli/Mcp/McpCommand.cs:504
+
+      Search strategy:
+        D1: Grep `\\?\\?|fallback|default` in files under
+            src/Netclaw.Configuration/, src/Netclaw.Security/,
+            src/Netclaw.Providers/. Read each hit — "silent fallback
+            on misconfig" means the code swallows a config error and
+            proceeds with a weaker posture. Confidence=medium at best.
+        D2/D3/D4: Grep `catch\\s*\\(\\s*Exception` in src/**/*.cs.
+            Read next 10 lines:
+              - empty body → D3
+              - body with no rethrow, no log, continues → D2
+              - immediate rethrow / logger.LogError then rethrow → OK
+            Cite the enclosing method name. Known hot spots
+            (McpCommand.cs:365/432/504) MUST surface.
+        D4: Same grep as D2/D3. Classify top-level CLI/daemon handlers
+            as acceptable; interior catches are findings.
+        D5: Grep `Allow\\s*=\\s*true`, `Default.*Allow`,
+            `return\\s+AccessDecision\\.Allow` in src/Netclaw.Security/,
+            Acl/, gateway files. BLOCKER severity. Report even if
+            `// WHY:` is present — D5 is no-waiver.
+        D6: Grep `\\?\\?` in src/Netclaw.Security/, Acl/, Grants/,
+            Auth/ paths. Same no-waiver rule as D5.
+
+      Waiver check applies to D1-D4. D5 and D6 are reported regardless
+      of waiver state (flag them clearly in the fix hint).
+    """
+
+  group_e = session: quality_auditor
+    prompt: """
+      AUDIT GROUP E — Concurrency
+      (csharp-concurrency-patterns, akka-best-practices)
+
+      Rules:
+        E1. (waiverable) `lock` on business logic (OK with // WHY:)
+        E2. No manual `new Thread()`; use Task or actor supervision
+        E3. Producer/consumer uses Akka.Streams (Source/Flow/Sink) OR
+            System.Threading.Channels.Channel<T>. No hand-rolled task
+            queues or unbounded work lists.
+        E4. No `.Select(async o => ...)` + Task.WhenAll chains without
+            bounded parallelism
+        E5. Supervision strategies defined on parents apply to children
+            (not self)
+        E6. Actors use Context.GetLogger(), not DI-injected ILogger<T>
+
+      CRITICAL — E3 is an ANTI-detection:
+        Akka.Streams is NetClaw's default producer/consumer pattern
+        (30+ files use Source/Flow/Sink). DO NOT report Akka.Streams
+        hits. DO NOT report Channel<T> hits — pre-approved sites are
+        SlackThreadBindingActor, SignalRSessionActor,
+        WebhookNotificationService.
+        E3 target: HAND-ROLLED alternatives only:
+          - ConcurrentQueue<T> used as a work queue with a dedicated
+            polling Task
+          - BlockingCollection<T> queues
+          - A long-running Task.Run that drains a work queue in a
+            `while(true)` loop
+          - Unbounded List<Task> + Task.WhenAll on a hot path
+        Mark all E3 candidates confidence=medium and always read context.
+
+      Search strategy:
+        E1: Grep `\\block\\s*\\(` in src/** (excluding tests). For each
+            hit, check 3 lines above for // WHY:. Report unwaived hits.
+        E2: Grep `new\\s+Thread\\s*\\(` in src/**.
+        E3: See above. Target hand-rolled alternatives only.
+        E4: Grep `\\.Select\\s*\\(\\s*(async\\s*)?\\w+\\s*=>\\s*` in
+            src/**. For each, check the next 3 lines for `Task\\.WhenAll`.
+        E5: Grep `OneForOneStrategy|AllForOneStrategy|SupervisorStrategy`
+            — check whether applied on parent or self. Low confidence.
+        E6: Grep `ILogger<` in files whose base classes include
+            ReceiveActor / UntypedActor / ActorBase — those should
+            use Context.GetLogger() instead.
+
+      If E3 + E4 unacknowledged count >20 after first run, paginate:
+      split this group rule-by-rule in a follow-up.
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+  group_f = session: quality_auditor
+    prompt: """
+      AUDIT GROUP F — Public Contract & Wire Compatibility
+      (csharp-api-design, serialization, CLAUDE.md)
+
+      SCOPE (CRITICAL): NetClaw ships as a hosted executable
+      (CLI + Daemon), NOT as a published NuGet library. "Public
+      contract" is ONLY:
+        1. Config file schema — netclaw-config.v1.schema.json,
+           src/Netclaw.Configuration types
+        2. Persistence / journal types — anything serialized long-term
+        3. Wire protocol messages — cross-process / persisted actor
+           messages (src/Netclaw.Actors/Protocol/**)
+        4. CLI command surface — src/Netclaw.Cli/**Command.cs, argument
+           parsing, exit codes
+        5. MCP tool schemas — src/Netclaw.Tools.*, MCP-related files
+        6. HTTP/SignalR daemon gateway — src/Netclaw.Daemon/Gateway/**
+      Ignore every other `public class`. F is NOT a "public API sprawl"
+      audit.
+
+      Rules:
+        F1. Async methods accept CancellationToken = default (contract
+            surface only)
+        F2. Public returns IReadOnlyList<T>, not List<T> (contract
+            surface only)
+        F3. DROPPED — ConfigureAwait(false) is not meaningful for a
+            hosted executable. DO NOT report.
+        F4. Schema-based serialization (Protobuf / MessagePack / STJ
+            source-gen) for persistence and wire — Newtonsoft only
+            where explicitly justified
+        F5. No polymorphic `$type` discriminators in wire format
+        F6. `additionalProperties: false` honored on all JSON schemas
+        F7. XML doc comments on CONTRACT types only (config records,
+            CLI commands, MCP tool schemas, protocol messages). NOT
+            required on every internal class.
+
+      Search strategy:
+        F1: Grep `public\\s+(async\\s+)?Task` in the six scope paths.
+            Check parameter list for CancellationToken.
+        F2: Grep `public\\s+\\w*List<\\w+>` in the six scope paths —
+            only report when it's a return type, not a field.
+        F4: Grep `Newtonsoft\\.Json` in src/**/*.cs. Any hit in
+            Protocol/, Persistence/, Journal/, persisted actor state
+            is a candidate.
+        F5: Grep `"\\$type"` and `TypeNameHandling` in JSON serializer
+            configurations.
+        F6: Find all *.schema.json under the repo. Confirm each
+            contains `additionalProperties`. Absent or `true` = finding.
+        F7: For each file in the six scope paths, grep `^\\s*public\\s+`
+            and check the preceding line for `///`. Missing XML doc on
+            a public contract type = finding. Severity=minor. Expect
+            many — mark saturated if >10.
+
+      F is the most subjective group. When in doubt, confidence=low.
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+  group_g = session: quality_auditor
+    prompt: """
+      AUDIT GROUP G — Project Structure & Slopwatch
+      (project-structure, slopwatch, CLAUDE.md)
+
+      Rules:
+        G1. Vertical slice organization under src/ (feature projects,
+            not layers)
+        G2. Central package management via Directory.Packages.props
+        G3. Nullable + TreatWarningsAsErrors via Directory.Build.props
+        G4. (waiverable) #pragma warning disable usage (OK with
+            adjacent // WHY:)
+        G5. No TODO-as-done comments or commented-out code
+        G6. (waiverable) Hardcoded magic values that should be config
+            (OK with // WHY:)
+        G7. dotnet slopwatch analyze passes against baseline (existing
+            baseline entries = acknowledged waivers)
+
+      Search strategy:
+        G1: List directories under src/. Expected vertical slices:
+            Netclaw.Actors, Netclaw.Channels, Netclaw.Channels.Slack,
+            Netclaw.Configuration, Netclaw.Providers, Netclaw.Security,
+            Netclaw.Search, Netclaw.Tools.Abstractions,
+            Netclaw.Tools.Generators, Netclaw.Cli, Netclaw.Daemon,
+            plus matching *.Tests. Any project named "Domain",
+            "Application", "Infrastructure", "Common", or "Core" is a
+            layered-architecture smell.
+        G2: Read Directory.Packages.props. If missing, report. If any
+            *.csproj has a `Version=` attribute on a PackageReference,
+            report.
+        G3: Read Directory.Build.props. Confirm `<Nullable>enable`
+            AND `<TreatWarningsAsErrors>true`. Missing = blocker.
+        G4: Grep `#pragma\\s+warning\\s+disable` in src/**/*.cs. Check
+            preceding 3 lines for // WHY:.
+        G5: Grep `// TODO` in src/**/*.cs. Also heuristic: 5+
+            consecutive comment-only lines inside a method body suggest
+            commented-out code.
+        G6: Subjective — flag magic numbers (>3-digit integers) and
+            suspicious string literals (URLs, paths) in configuration-
+            adjacent files. Low confidence.
+        G7: DO NOT run `dotnet slopwatch analyze` (this is a read-only
+            audit). Instead, read .slopwatch/baseline.json and list
+            existing entries as acknowledged. Informational only.
+
+      G1-G3 are project-level one-shots — report each at most once.
+
+      Waiver check and 10-per-rule cap apply.
+    """
+
+# ---------------------------------------------------------------------
+# Aggregate and rank
+# ---------------------------------------------------------------------
+# Opus for the aggregator: cross-references 7 group outputs, de-dupes
+# false positives, builds the ranked backlog, runs the regression gate.
+
+output audit_report = session: aggregator
+  prompt: """
+    You receive seven per-group reports (group_a..group_g); some may be
+    missing or errored (parallel ran with on-fail: continue).
+
+    Produce ONE markdown report with this EXACT structure. The fix
+    program parses Section 9 — format discipline is non-negotiable.
+
+    ---
+
+    # NetClaw Pre-OSS Code Quality Audit — <YYYY-MM-DD>
+
+    **Verdict:** PASS | WATCH | FAIL
+    **Strictness:** <loose | normal | strict>
+    **Groups run:** <comma-separated list, with "(FAILED)" for any that did not run>
+
+    ## 1. Regression Gate
+
+    The audit is only valid if these known 2026-04-14 hot spots are
+    detected. Any MISSED entry forces verdict=FAIL.
+
+    | Hot Spot | Group | Rule | Expected Status | Actual |
+    |----------|-------|------|-----------------|--------|
+    | SQLiteMemoryStoreTests.cs:37 | C | C3 | DETECTED | ? |
+    | MemoryPolicyGatesTests.cs:14 | C | C3 | DETECTED | ? |
+    | MessageSourceFactoryTests.cs:17 | C | C3 | DETECTED | ? |
+    | SQLiteMemoryStoreTests.cs:263 | B | B1 | DETECTED (baselined OK) | ? |
+    | MemoryRecallScenarioTests.cs:318-322 | B | B1 | DETECTED (baselined OK) | ? |
+    | DaemonRuntimeStatusServiceTests.cs:62 | B | B1 | DETECTED (baselined OK) | ? |
+    | RestartManifestStore.cs:12-14 | A | A1 | DETECTED | ? |
+    | SlackChannelOptions.cs:15,30,32 | A | A1 | DETECTED | ? |
+    | HeadlessChannel.cs:371 | A | A1 | DETECTED | ? |
+    | OAuthDeviceFlowServiceTests.cs:79 | A | A7 | DETECTED | ? |
+    | SchemaMigrator.cs:231 | A | A7 | DETECTED | ? |
+    | SlackChannelRegistrationExtensions.cs:54 | A | A7 | DETECTED | ? |
+    | McpCommand.cs:365 | D | D2 | DETECTED | ? |
+    | McpCommand.cs:432 | D | D2 | DETECTED | ? |
+    | McpCommand.cs:504 | D | D2 | DETECTED | ? |
+
+    ## 2. Executive Summary
+
+    | Group | Unacknowledged | Acknowledged | Baselined | Top Severity |
+    |-------|---------------:|-------------:|----------:|--------------|
+    | A     |                |              |           |              |
+    | B     |                |              |           |              |
+    | C     |                |              |           |              |
+    | D     |                |              |           |              |
+    | E     |                |              |           |              |
+    | F     |                |              |           |              |
+    | G     |                |              |           |              |
+    | **TOTAL** |            |              |           |              |
+
+    ## 3. Top-20 Ranked Fix Backlog
+
+    Ranking key:
+      1. severity (blocker → major → minor)
+      2. blast radius (multi-group hits first)
+      3. high-value path (src/Netclaw.Security/, src/Netclaw.Actors/Protocol/,
+         src/Netclaw.Configuration/)
+      4. alphabetical by file path
+
+    1. **[severity] rule_id** file:line — fix hint
+    2. ...
+
+    ## 4. Per-Group Findings
+
+    ### Group A — Value & Type Safety
+    (up to 10 findings per rule, sorted by severity then file path)
+
+    ### Group B — Test Discipline
+    ...
+
+    ### Group C — Time & Determinism
+    ...
+
+    ### Group D — Error Handling, Fallbacks & Security
+    ...
+
+    ### Group E — Concurrency
+    ...
+
+    ### Group F — Public Contract & Wire Compatibility
+    ...
+
+    ### Group G — Project Structure & Slopwatch
+    ...
+
+    ## 5. Waiver Rate Observations
+
+    Rules with acknowledged_count > 5 indicate the rule may be wrong:
+
+    - <rule_id>: <count> acknowledged hits — <suggestion>
+
+    ## 6. Needs Human Review (low confidence)
+
+    Low-confidence findings without corroboration from a second group.
+    These are NOT in the main backlog; the human decides whether to
+    action them.
+
+    - <rule_id> file:line — <reason>
+
+    ## 7. Groups That Did Not Run
+
+    (empty if all seven completed)
+
+    - <group_id>: <error summary>
+
+    ## 8. tasks.md Checklist
+
+    **This section is the contract read by netclaw-quality-fix.prose.**
+    Format every row EXACTLY as:
+
+      - [ ] <rule_id> <repo-relative-path>:<line> — <fix hint>
+
+    For saturated rules (>10 hits), emit a single campaign row:
+
+      - [ ] Campaign <rule_id> — <description> (~<N> hits)
+
+    No other row formats. No blank lines inside the list. The fix
+    program's drift check depends on this format.
+
+    Example rows:
+      - [ ] A1 src/Netclaw.Actors/Restart/RestartManifestStore.cs:12 — introduce SessionId value object
+      - [ ] D2 src/Netclaw.Cli/Mcp/McpCommand.cs:365 — narrow to FormatException or add // WHY:
+      - [ ] Campaign F7 — XML docs on contract types (~42 hits)
+
+    ---
+
+    Steps:
+
+      1. Parse each group output. Record missing or errored groups.
+      2. Build the Regression Gate table. For each expected hot spot,
+         mark DETECTED (with the actual classification) or MISSED. Any
+         MISSED immediately pins verdict=FAIL.
+      3. Build the Executive Summary.
+      4. Cross-reference: if two groups flag the same file/line,
+         merge and elevate severity by one step.
+      5. Demote confidence=low findings without corroboration to
+         Section 6 (Needs Human Review), NOT the main backlog.
+      6. Build the top-20 ranked backlog using the key above.
+      7. Emit per-group sections with up to 10 findings per rule,
+         plus any saturation summary rows.
+      8. Flag rules with acknowledged_count > 5 in Section 5.
+      9. Emit Section 8 tasks.md checklist in the strict format above.
+          Saturated rules become campaign rows.
+     10. Pick the final verdict:
+          - PASS:  zero blockers, zero MISSED
+          - WATCH: zero blockers, zero MISSED, but >20 major findings
+          - FAIL:  any blocker OR any MISSED hot spot
+         Put the verdict at the very top of the report.
+
+    Return the full markdown as your binding content. Do NOT write
+    files from inside the aggregator — the VM handles the binding
+    write to .prose/runs/<run-id>/bindings/audit_report.md.
+  """
+  context: { group_a, group_b, group_c, group_d, group_e, group_f, group_g }

--- a/.prose/netclaw-quality-fix.prose
+++ b/.prose/netclaw-quality-fix.prose
@@ -1,0 +1,489 @@
+# NetClaw Pre-OSS Code Quality Fix
+#
+# Reads a markdown audit report produced by netclaw-quality-audit.prose,
+# dispatches a fix orchestrator, and produces a summary + an OpsX
+# handoff for the findings it couldn't handle itself.
+#
+# Safety model:
+#   - dry_run defaults to "true" — first invocation emits diffs only
+#   - always runs on a dedicated branch (netclaw/quality-fix-<date>),
+#     never directly on main / dev / master
+#   - commits per batch, runs `dotnet build` after each batch, auto-
+#     reverts any batch that breaks the build
+#   - runs `dotnet test` after all batches; test failures are escalated,
+#     not reverted (tests tell us semantics broke — needs human review)
+#   - D5 / D6 findings are NEVER auto-fixed (security-critical)
+#   - confidence=low findings are skipped unless explicitly escalated
+#   - every finding is drift-checked before the agent edits anything
+#
+# Scope: AGGRESSIVE — the orchestrator attempts mechanical AND
+# structural fixes. Truly cross-cutting refactors (>5 files, require
+# new tests, or touch public contract) are escalated to a single
+# /opsx-new pre-oss-quality-audit-remainder change.
+#
+# Invocation:
+#   /open-prose:prose-compile .prose/netclaw-quality-fix.prose
+#
+#   # Dry run (default) — prints diffs, no edits, no commits
+#   /open-prose:prose-run .prose/netclaw-quality-fix.prose \
+#     repo_path=/home/petabridge/repositories/stannardlabs/netclaw \
+#     report_path=audit-reports/pre-oss-quality-audit-20260414.md
+#
+#   # Live run — creates branch, applies fixes with build/test gates
+#   /open-prose:prose-run .prose/netclaw-quality-fix.prose \
+#     repo_path=/home/petabridge/repositories/stannardlabs/netclaw \
+#     report_path=audit-reports/pre-oss-quality-audit-20260414.md \
+#     dry_run=false
+
+input repo_path: "Absolute path to the NetClaw repo"
+input report_path: "Repo-relative path to the audit report markdown"
+input dry_run: "true | false (default: true — no edits without explicit false)"
+input max_items: "Max findings to attempt (default: 40)"
+input batch_size: "Findings per batch (default: 4)"
+
+# ---------------------------------------------------------------------
+# Shared agent templates
+# ---------------------------------------------------------------------
+# fix_helper — sonnet — mechanical pipeline steps (parse, verify, report)
+# fix_orchestrator — opus — the batched fix executor (edits + commits)
+
+agent fix_helper:
+  model: sonnet
+  prompt: """
+    You are a pipeline step in the NetClaw quality fix program. Do
+    exactly what the session prompt tells you. Be precise, be
+    conservative, and fail loud on anything unexpected. Do not take
+    initiative beyond the step's instructions.
+  """
+
+agent fix_orchestrator:
+  model: opus
+  prompt: """
+    You are the fix orchestrator for the NetClaw pre-OSS quality
+    audit. You process quality findings in batches on a dedicated
+    git branch, with build gates and explicit escalation for any
+    finding you cannot cleanly fix. You never touch main/dev/master.
+    You never fix D5/D6 findings. You always prefer partial progress
+    over a broken batch. See the session prompt for the full runbook.
+  """
+
+# ---------------------------------------------------------------------
+# Step 1: Preflight — parse the report and categorize findings
+# ---------------------------------------------------------------------
+
+let preflight = session: fix_helper
+  prompt: """
+    You are the preflight step for the NetClaw quality fix program.
+    Your job is to read the audit report and produce a categorized
+    list of findings for the orchestrator.
+
+    Steps:
+
+      1. Read {repo_path}/{report_path}. Locate Section 8 titled
+         "tasks.md Checklist" (or Section 9 in older reports).
+
+      2. For each row, extract:
+           - rule_id    (e.g., "A1", "D2", "F7", or "Campaign <id>")
+           - file_path  (repo-relative)
+           - line       (integer; null for Campaign rows)
+           - fix_hint   (free text after the em-dash)
+         Row format:
+           - [ ] <rule_id> <file>:<line> — <fix_hint>
+         Campaign row format:
+           - [ ] Campaign <rule_id> — <description> (~<N> hits)
+
+      3. For each non-campaign row, drift-check against the live repo:
+           - Does the file still exist?
+           - Is the line number within the file length?
+           - Does the rule's pattern still appear at or near that line?
+             (Use Grep with the rule's expected regex from the audit
+             program's group prompts. If you can't confirm, mark
+             confidence=low.)
+         Drifted findings → move to the "drifted" bucket. The
+         orchestrator will skip them.
+
+      4. Cross-reference the audit report's Section 4 (Per-Group
+         Findings) to attach the severity and confidence fields to
+         each row.
+
+      5. Categorize every finding into exactly one bucket:
+
+         a) NO_TOUCH — the orchestrator refuses to auto-fix:
+            - D5 (default-deny) or D6 (?? on auth paths) — security
+            - confidence=low without corroboration
+            - Severity=blocker that isn't clearly mechanical
+            - Rows the audit explicitly marked "needs human review"
+
+         b) MECHANICAL — safe, one-line or narrow edits the
+            orchestrator can apply with high confidence:
+            - A3 (add `sealed`), A4 (add `readonly` to struct)
+            - A6 (remove `#nullable disable`)
+            - B3 (remove [Fact(Skip=...)] — re-enable test)
+            - C1 (swap DateTime.UtcNow → _timeProvider.GetUtcNow()
+                  IF the class already has a TimeProvider field)
+            - C3 (test-side: swap DateTimeOffset.UtcNow for
+                  FakeTimeProvider usage)
+            - F1 (add CancellationToken = default to async signature)
+            - F2 (change return type List<T> → IReadOnlyList<T>)
+            - F6 (add `"additionalProperties": false` to a JSON schema)
+            - G4 (add // WHY: waiver to a #pragma warning disable)
+
+         c) STRUCTURAL — attempted in aggressive mode, but the
+            orchestrator creates a focused branch commit and the
+            human reviews the diff before merging:
+            - A1 (introduce value object — affects many call sites)
+            - A2 (remove implicit operator)
+            - A5 (class → record)
+            - A7 (add .HasValue guard before `!`)
+            - A8 (refactor primitive-obsession signature)
+            - B1 (replace Task.Delay with AwaitAssertAsync)
+            - B2 (delete trivial test)
+            - B5 (replace .Result / .Wait() with await)
+            - D1 (rewrite silent fallback — fail loud)
+            - D2, D3, D4 (narrow exception types or add // WHY:)
+            - E1 (add // WHY: to lock; or refactor to actor)
+            - E4 (bound parallelism with Parallel.ForEachAsync)
+            - F4 (Newtonsoft → System.Text.Json source-gen)
+            - F7 (add XML doc to a contract type)
+            - G5 (remove commented-out code / resolved TODO)
+
+         d) CAMPAIGN — saturated rules the orchestrator won't touch
+            file-by-file. Escalated to the OpsX change as a single
+            roll-up task.
+
+         e) DRIFTED — the finding no longer applies; skip.
+
+      6. Respect {max_items}: take the first N non-campaign,
+         non-drifted findings ranked by severity then rule_id order.
+         Campaigns always escalate regardless of the cap.
+
+    Output a markdown summary organized by bucket, each row keeping
+    the original format plus a parenthetical `(severity, confidence)`.
+    The orchestrator reads this verbatim.
+
+    Also include a "Preflight Verdict" line at the top:
+      - "CLEAR TO PROCEED" if there is at least one finding in
+        MECHANICAL or STRUCTURAL and no fatal errors (report
+        missing, wrong format, repo path wrong, etc.)
+      - "BLOCKED: <reason>" otherwise
+
+    If BLOCKED, the orchestrator will abort without touching the repo.
+  """
+
+# ---------------------------------------------------------------------
+# Step 2: Branch setup + safety checks
+# ---------------------------------------------------------------------
+
+let branch_setup = session: fix_helper
+  prompt: """
+    You are the branch-setup step. Do NOT run any commands that
+    modify the repo if dry_run=={dry_run} is not exactly the string
+    "false".
+
+    Safety checks (fail loud on any violation):
+
+      1. Confirm {repo_path} is a git repo.
+      2. Confirm the working tree is clean:
+           git -C {repo_path} status --porcelain
+         If the output is non-empty, abort with message:
+         "working tree dirty — commit or stash before running fix".
+      3. Confirm the current branch is NOT main, dev, or master.
+         If it is, and dry_run=="false", abort with message:
+         "fix program refuses to run directly on <current branch>".
+         Substitute the actual branch name into the <current branch>
+         placeholder before reporting.
+      4. If the preflight verdict is BLOCKED, abort immediately and
+         forward the preflight reason.
+
+    If dry_run=="false" AND all checks pass:
+      5. Create a new branch named
+           netclaw/quality-fix-<YYYYMMDD>
+         using `git -C {repo_path} checkout -b netclaw/quality-fix-<date>`.
+         If a branch with that name already exists, append `-<N>`
+         starting at 2.
+      6. Return: branch_name, "READY"
+
+    If dry_run!="false":
+      5. Report the current branch but do NOT create anything.
+      6. Return: branch_name="<current> (dry-run)", "READY (DRY RUN)"
+
+    You have access to Bash. Use it only for the `git status`,
+    `git branch --show-current`, and (if live) `git checkout -b`
+    commands above. Do not run anything else.
+
+    Preflight context for abort forwarding:
+  """
+  context: { preflight }
+
+# ---------------------------------------------------------------------
+# Step 3: Fix orchestrator — the main event
+# ---------------------------------------------------------------------
+# One opus session handles all fix batches sequentially. Parallelism
+# is deliberately NOT used here — shared git state and shared build
+# state make parallel edits unsafe. The orchestrator uses Bash + Edit
+# + Read tools directly.
+
+let apply_fixes = session: fix_orchestrator
+  prompt: """
+    The preflight has categorized findings into buckets; you will
+    work through MECHANICAL and STRUCTURAL findings in batches of
+    {batch_size}, with a `dotnet build` gate between every batch.
+
+    Inputs:
+      - repo_path:   {repo_path}
+      - dry_run:     {dry_run} (treat any value other than exactly
+                     the string "false" as dry-run)
+      - max_items:   {max_items}
+      - batch_size:  {batch_size}
+      - preflight:   see context
+      - branch:      see context (already created if live)
+
+    Hard rules — non-negotiable:
+
+      1. NEVER touch a finding in the NO_TOUCH bucket. D5/D6 are
+         security-critical; the orchestrator forwards them to
+         escalation unconditionally.
+      2. NEVER modify files outside {repo_path}/src/. If a fix
+         requires touching Directory.Build.props or similar, STOP
+         and escalate.
+      3. NEVER delete a test unless the B2 finding explicitly calls
+         the test trivial and the test has zero unique assertions.
+      4. If dry_run is not "false", apply NO edits. For each finding,
+         generate a unified diff (show old lines → new lines), write
+         it to the batch's dry-run log, and move on. No git commits.
+      5. If you can't figure out a safe fix for a specific finding,
+         add it to the escalation list and move on. Partial progress
+         beats a broken batch.
+
+    Per-batch workflow (repeat until all MECHANICAL + STRUCTURAL
+    findings are handled or {max_items} is reached):
+
+      a) Select the next {batch_size} findings (drift-checked,
+         ordered MECHANICAL first, then STRUCTURAL).
+
+      b) For each finding in the batch:
+           i.   Read the file (Read tool) with enough context
+                around the line.
+           ii.  Confirm the pattern the audit flagged is still
+                present (drift re-check). If not, skip and log.
+           iii. Plan the fix. For structural fixes, write down your
+                reasoning BEFORE editing so the review diff includes
+                the rationale as a commit message.
+           iv.  Apply the fix (Edit tool) — OR, if dry_run, append
+                the diff to the batch's dry-run log.
+           v.   Re-read the modified region to verify the edit
+                landed cleanly.
+
+      c) dry_run branch:
+           - Do not git-add, do not commit. Move to the next batch.
+      c') live branch:
+           - `git -C {repo_path} add -A` then
+             `git -C {repo_path} commit -m "quality-fix batch <N>: <rule summary>"`
+             (one commit per batch; include the fix hints in the
+             body as a bulleted list).
+           - Run `dotnet build {repo_path}` and capture output.
+           - On build failure:
+               - `git -C {repo_path} reset --hard HEAD~1`
+               - Mark every finding in this batch as
+                 status=build_revert and add to escalation.
+               - Continue to the NEXT batch.
+           - On build success: continue.
+
+      d) After {max_items} findings processed OR all findings done:
+           stop batching and produce the summary.
+
+    Summary output (markdown):
+
+      ## Fix Orchestrator Summary
+
+      - Mode: DRY RUN or LIVE (pick based on the dry_run input:
+        "false" means LIVE, anything else means DRY RUN)
+      - Branch: <branch-name>
+      - Batches attempted: <N>
+      - Batches committed: <N>         (live only)
+      - Batches reverted: <N>          (live only)
+      - Findings fixed: <N>
+      - Findings escalated: <N>
+      - Findings skipped (drifted): <N>
+
+      ## Per-Batch Log
+      Batch 1: <rule-summary> — committed / reverted / dry-run
+        - <rule_id> <file>:<line> — <status> — <note>
+      ...
+
+      ## Escalated Findings
+      (findings the orchestrator refused or failed to fix)
+        - <rule_id> <file>:<line> — <reason>
+      ...
+
+    Do NOT try to be clever about rollbacks beyond `git reset --hard
+    HEAD~1` on the batch commit. If anything more complicated is
+    needed, stop and escalate the remaining batches.
+  """
+  context: { preflight, branch_setup }
+
+# ---------------------------------------------------------------------
+# Step 4: Test gate
+# ---------------------------------------------------------------------
+# Build passing doesn't mean tests pass. Run the full suite; on
+# failure, escalate the batches that changed the affected files.
+
+let test_gate = session: fix_helper
+  prompt: """
+    You are the test-gate step. If dry_run=={dry_run} is not exactly
+    "false", skip this step entirely — output:
+      "SKIPPED (dry run)"
+    and return.
+
+    Otherwise:
+
+      1. Run `dotnet test {repo_path}` and capture the output.
+         (If NetClaw has a faster test target — e.g., skipping
+         slow integration tests — the fix orchestrator or human
+         should set it up; use `dotnet test` by default.)
+
+      2. If exit code 0: output "PASS — <N> tests passed".
+         All batches stand as committed.
+
+      3. If exit code non-zero:
+           - DO NOT revert commits. Test failures may signal
+             legitimate semantic regressions that need human review.
+           - Parse the output to identify which test projects failed.
+           - Cross-reference with the apply_fixes batch log (in
+             context) to guess which batch introduced the failure.
+           - Output:
+               "FAIL — <N> failures"
+               "Suspected batches: <list>"
+               "Human review required — branch is on <branch-name>"
+             (substitute the actual branch name into the placeholder)
+           - Emit the failing test names in a bulleted list so the
+             escalation step can include them in the OpsX change.
+
+    You have access to Bash. Use it only for `dotnet test`.
+  """
+  context: { preflight, branch_setup, apply_fixes }
+
+# ---------------------------------------------------------------------
+# Step 5: Escalation — build the OpsX handoff
+# ---------------------------------------------------------------------
+
+let escalation = session: fix_helper
+  prompt: """
+    You are the escalation step. Produce a single markdown block
+    that a human can paste into `/opsx-new pre-oss-quality-audit-remainder`
+    to create an OpenSpec change covering everything the fix
+    orchestrator could not (or would not) auto-fix.
+
+    Collect from context:
+      - preflight.NO_TOUCH bucket (always escalated)
+      - preflight.CAMPAIGN bucket (always escalated)
+      - preflight.DRIFTED bucket (note as "likely already fixed")
+      - apply_fixes escalated findings (build reverts, skipped,
+        failed, refused)
+      - test_gate failures with suspected batches
+
+    Produce this structure:
+
+      # pre-oss-quality-audit-remainder
+
+      ## Context
+      Remainder from the first quality-fix run against audit
+      {report_path}. The orchestrator handled N findings; the items
+      below were escalated for reasons listed per item. See
+      audit-reports/ for the original audit report.
+
+      ## Security-sensitive (D5/D6 — human only)
+      - [ ] <rule_id> <file>:<line> — <fix hint> (reason: security,
+            no-auto-fix)
+      ...
+
+      ## Refactor campaigns (saturated rules)
+      - [ ] Campaign <rule_id> — <description> (~<N> hits) —
+            <strategy suggestion>
+      ...
+
+      ## Build or test failures
+      - [ ] <rule_id> <file>:<line> — <batch reverted because
+            `dotnet build` failed> — <suggested root cause>
+      - [ ] Test regression: <test name> — <suspected batch>
+      ...
+
+      ## Drifted (likely already fixed)
+      - [ ] <rule_id> <file>:<line> — <file changed since audit;
+            re-run audit to confirm>
+      ...
+
+      ## Notes
+      - Fix orchestrator mode: LIVE or DRY RUN (pick based on the
+        dry_run input: "false" means LIVE, anything else DRY RUN)
+      - Branch: <branch>
+      - Batches committed: <N>
+      - Batches reverted: <N>
+
+    This is literal markdown the human will paste. No code fences
+    around it, no extra commentary.
+  """
+  context: { preflight, apply_fixes, test_gate }
+
+# ---------------------------------------------------------------------
+# Final output: fix report
+# ---------------------------------------------------------------------
+
+output fix_report = session: fix_orchestrator
+  prompt: """
+    You are the final reporter. Produce one markdown document
+    summarizing the full fix run. Human-readable.
+
+    Structure:
+
+      # NetClaw Quality Fix Run — <YYYY-MM-DD>
+
+      **Mode:** DRY RUN | LIVE
+      **Branch:** <branch-name>
+      **Audit report:** {report_path}
+      **Verdict:** SUCCESS | PARTIAL | FAILED
+
+      ## Quick Numbers
+      - Preflight parsed: <N> findings
+      - Mechanical fixed: <N>
+      - Structural fixed: <N>
+      - Escalated to OpsX: <N>
+      - Drifted (skipped): <N>
+      - Build reverts: <N>
+      - Test regressions: <N>
+
+      ## Preflight
+      (a short extract — bucket counts only)
+
+      ## Fix Orchestrator Log
+      (from apply_fixes — batch-by-batch summary)
+
+      ## Test Gate
+      (from test_gate — pass/fail with suspected batches)
+
+      ## OpsX Handoff (paste into /opsx-new)
+      (from escalation — verbatim)
+
+      ## Next Actions
+      - If DRY RUN: review diffs in the per-batch log, re-run with
+        `dry_run=false` to apply.
+      - If LIVE + SUCCESS: the branch is ready for PR review.
+        Recommended title: "pre-oss quality fixes (audit YYYY-MM-DD)".
+      - If LIVE + PARTIAL: some batches reverted or tests failed.
+        Create the OpsX change (pasted above) for the remainder.
+      - If LIVE + FAILED: the entire run failed. Branch should be
+        inspected or deleted; audit rules may need tightening.
+
+    Verdict rule:
+      SUCCESS — live mode, zero build reverts, zero test regressions,
+                all MECHANICAL + STRUCTURAL findings handled
+      PARTIAL — live mode, some batches reverted or tests failed,
+                but at least one batch committed cleanly
+      FAILED  — live mode and zero batches committed cleanly, OR
+                the preflight blocked before any fix was attempted
+      (Dry runs always report as SUCCESS or FAILED based on whether
+       the preflight cleared — dry runs don't have a "partial".)
+
+    Return the full markdown as your binding content.
+  """
+  context: { preflight, branch_setup, apply_fixes, test_gate, escalation }


### PR DESCRIPTION
## Summary

Two OpenProse programs establish a read-only audit → staged fix workflow ahead of the open-source release.

- **`.prose/netclaw-quality-audit.prose`** — 7 parallel sonnet scanners (one per standards group A–G: value/type safety, test discipline, time/determinism, error handling, concurrency, public contract, project structure) feeding an opus aggregator. Produces a ranked markdown report with a regression gate against known 2026-04-14 hot spots, three-way finding classification (unacknowledged / acknowledged via `// WHY:` / baselined via `.slopwatch/baseline.json`), and a strict Section 8 task list format.
- **`.prose/netclaw-quality-fix.prose`** — reads the audit report's Section 8, categorizes findings into mechanical / structural / no-touch buckets, runs a sequential batched orchestrator on a dedicated `netclaw/quality-fix-<date>` branch with a `dotnet build` gate and per-batch auto-revert, runs `dotnet test` as a post-run gate, and escalates security-critical (D5/D6) and saturated-rule findings to an OpsX handoff checklist. Dry-run is the default; live mode requires explicit `dry_run=false`.

## Design notes

- Markdown (not JSON) is the contract between audit and fix — single source of truth, LLM-friendly, human-editable between runs.
- Group F scope is narrowed to NetClaw's actual public contract surfaces (config schema, persistence, wire protocol, CLI, MCP, HTTP gateway) rather than every `public class`.
- E3 (producer/consumer) is an **anti-detection**: Akka.Streams and `Channel<T>` are sanctioned; only hand-rolled queues get flagged.
- D5/D6 are detection-only — the fix program never auto-edits security-critical code even in aggressive mode.
- The fix program never runs on `main`/`dev`/`master` — always creates a dedicated feature branch first.

## Test plan

- [ ] `/open-prose:prose-compile .prose/netclaw-quality-audit.prose` — confirm grammar passes the real compiler (static analysis already passed)
- [ ] `/open-prose:prose-compile .prose/netclaw-quality-fix.prose` — same
- [ ] Dry-run the audit against the current `dev` branch; confirm the regression gate detects all 2026-04-14 hot spots listed in the aggregator prompt
- [ ] Review the dry-run audit report for false positive rate on E3 (Akka.Streams false-positive risk) and F7 (XML doc saturation)
- [ ] Dry-run the fix program against the first audit report; confirm preflight categorization is sensible before any live run
- [ ] Only after both dry runs look clean, attempt a live fix run on a throwaway branch