### PR TITLE
fix(prose): narrow B7 rule to hosted TestKit scope

### DIFF
--- a/.prose/netclaw-quality-audit.prose
+++ b/.prose/netclaw-quality-audit.prose
@@ -187,8 +187,17 @@ parallel (on-fail: "continue"):
         B4. Async state verified via AwaitAssertAsync or TestProbe acks
         B5. No .Result / .Wait() in tests
         B6. Actor tests inherit Akka.Hosting.TestKit, not a custom base
-        B7. External dependencies faked via ConfigureServices, not
-            stub actors
+        B7. Inside hosted Akka.Hosting.TestKit / TestAppBuilderTestKit
+            tests: SERVICE dependencies of actors are faked via
+            ConfigureServices; ACTOR collaborators are faked via
+            TestProbe or a trivial stub actor. Do NOT substitute a
+            stub actor for a production actor under the same typed
+            actor key inside a hosted test — that masks DI/wiring
+            bugs. Bare-ActorSystem fixtures for plain (non-actor)
+            service SUTs are OUT OF SCOPE for this rule: protocol-
+            level stubs there are legitimate (see akka-testing-
+            patterns Best Practice #4: "Use TestProbes for
+            dependencies").
 
       Regression anchors (EXPECT BASELINED — verify via .slopwatch/baseline.json):
         B1 — src/Netclaw.Actors.Tests/Memory/SQLiteMemoryStoreTests.cs:263
@@ -208,7 +217,17 @@ parallel (on-fail: "continue"):
         B5: Grep `\\.Result\\b` and `\\.Wait\\(\\)` in tests.
         B6: Grep `class\\s+\\w+Tests\\s*:` in tests; report any whose
             parent is NOT `TestKit` / `TestAppBuilderTestKit`.
-        B7: `system.ActorOf(.*Stub|Fake|Mock)` patterns (low confidence).
+        B7: `system.ActorOf(.*Stub|Fake|Mock)` patterns — but ONLY
+            flag when the enclosing test class inherits `TestKit` /
+            `TestAppBuilderTestKit` (i.e. a hosted Akka.Hosting test).
+            Bare `ActorSystem.Create(...)` fixtures are OUT OF SCOPE:
+            protocol-level stubs on a bare ActorSystem are the
+            minimum viable fake for a non-actor service SUT whose
+            only actor collaborator is an `IActorRef` or
+            `IRequiredActor<T>`. Also exempt `CreateTestProbe(...)`
+            and `TestProbe` usages entirely (they ARE the upstream
+            skill's Best Practice #4). Low confidence; route to
+            Section 6 "Needs Human Review", not the main backlog.
 
       Waiver check and 10-per-rule cap apply.
     """

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,3 +272,11 @@ Specialist agents:
 - If a workflow repeats twice, extract or refine a skill/workflow doc.
 - Put volatile detail in repo-owned docs, not this constitution.
 - Keep this file stable and high-signal.
+- **Compressing a skill into a rule is a retrieval operation, not a
+  memory operation.** When distilling a dotnet-skills skill (or any
+  upstream authority) into an audit rule, review rubric, or one-line
+  bullet, open the skill first. Preserve the distinctions the skill
+  draws — not just its headline. Rules that collapse two orthogonal
+  axes into one sentence produce false positives that burn
+  trust in the audit. If a rule cannot be written without losing a
+  distinction the source makes, drop it rather than eliding.


### PR DESCRIPTION
## Summary

- Rewrites B7 in `.prose/netclaw-quality-audit.prose` to preserve the two distinctions the upstream `akka-testing-patterns` skill draws: service-vs-actor collaborator and hosted-TestKit-vs-bare-ActorSystem fixture. B7 as originally written collapsed both axes into one sentence and misfired on `DaemonRestartCoordinatorTests.cs:101,166` during the pre-OSS quality audit run (routed to Section 6 "Needs Human Review"; no code change was needed — the rule was wrong, not the test).
- Narrows the B7 search strategy to only flag stub-actor patterns inside classes that inherit `TestKit` / `TestAppBuilderTestKit`, and explicitly exempts `TestProbe` / `CreateTestProbe` usages (which are the skill's Best Practice #4).
- Adds a new bullet under `AGENTS.md`'s Continuous Improvement Rule capturing the meta-lesson: compressing a skill into an audit rule is a retrieval operation, not a memory operation. Open the upstream skill first and preserve the distinctions it draws.

## Test plan

- [ ] Re-run `/open-prose:prose-run .prose/netclaw-quality-audit.prose` after merge and confirm Section 6 "Needs Human Review" no longer contains the two `DaemonRestartCoordinatorTests.cs` B7 hits.
- [ ] Confirm the regression gate still detects all 15 anchors and the overall verdict stays WATCH (or better) — B7 was never on the main backlog, so the unacknowledged/acknowledged counts should be unchanged.
- [ ] Sanity-grep `src/**/*Tests/**/*.cs` for any remaining `system.ActorOf(.*Stub|Fake|Mock)` inside a `TestKit`/`TestAppBuilderTestKit` subclass — if the narrowed rule surfaces a genuine hit elsewhere, it's worth investigating.