### PR TITLE
fix(tools): strip llama.cpp-incompatible JSON Schema keywords in McpSchemaSanitizer

### DIFF
--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -26,7 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Tools/Fixtures/*.html" />
+    <None Include="Tools/Fixtures/*.html" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Tools/Fixtures/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Actors.Tests/Tools/Fixtures/notion-search-input.raw.json
+++ b/src/Netclaw.Actors.Tests/Tools/Fixtures/notion-search-input.raw.json
@@ -1,0 +1,86 @@
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Semantic search query over your entire Notion workspace and connected sources (Slack, Google Drive, Github, Jira, Microsoft Teams, Sharepoint, OneDrive, or Linear). For best results, don't provide more than one question per tool call. Use a separate \"search\" tool call for each search you want to perform.\nAlternatively, the query can be a substring or keyword to find users by matching against their name or email address. For example: \"john\" or \"john@example.com\""
+    },
+    "query_type": {
+      "type": "string",
+      "enum": [
+        "internal",
+        "user"
+      ]
+    },
+    "content_search_mode": {
+      "type": "string",
+      "enum": [
+        "workspace_search",
+        "ai_search"
+      ]
+    },
+    "data_source_url": {
+      "description": "Optionally, provide the URL of a Data source to search. This will perform a semantic search over the pages in the Data Source. Note: must be a Data Source, not a Database. <data-source> tags are part of the Notion flavored Markdown format returned by tools like fetch. The full spec is available in the create-pages tool description.",
+      "type": "string"
+    },
+    "page_url": {
+      "description": "Optionally, provide the URL or ID of a page to search within. This will perform a semantic search over the content within and under the specified page. Accepts either a full page URL (e.g. https://notion.so/workspace/Page-Title-1234567890) or just the page ID (UUIDv4) with or without dashes.",
+      "type": "string"
+    },
+    "teamspace_id": {
+      "description": "Optionally, provide the ID of a teamspace to restrict search results to. This will perform a search over content within the specified teamspace only. Accepts the teamspace ID (UUIDv4) with or without dashes.",
+      "type": "string"
+    },
+    "filters": {
+      "description": "Optionally provide filters to apply to the search results. Only valid when query_type is 'internal'.",
+      "type": "object",
+      "properties": {
+        "created_date_range": {
+          "description": "Optional filter to only produce search results created within the specified date range.",
+          "type": "object",
+          "properties": {
+            "start_date": {
+              "description": "The start date of the date range as an ISO 8601 date string, if any.",
+              "type": "string",
+              "format": "date",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+            },
+            "end_date": {
+              "description": "The end date of the date range as an ISO 8601 date string, if any.",
+              "type": "string",
+              "format": "date",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+            }
+          },
+          "additionalProperties": true
+        },
+        "created_by_user_ids": {
+          "description": "Optional filter to only produce search results created by the Notion users that have the specified user IDs.",
+          "maxItems": 100,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "page_size": {
+      "description": "Maximum number of results to return (default 10). Lower values reduce response size.",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 25
+    },
+    "max_highlight_length": {
+      "description": "Maximum character length for result highlights (default 200). Set to 0 to omit highlights entirely.",
+      "type": "integer",
+      "minimum": -9007199254740991,
+      "maximum": 500
+    }
+  },
+  "required": [
+    "query",
+    "filters"
+  ]
+}

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -535,13 +535,9 @@ public class McpSchemaSanitizerTests
     [Fact]
     public void SanitizeSchema_RealNotionSearchFixture_StripsLeapYearPattern()
     {
-        // This is the exact schema that SIGSEGV'd llama-server@gpu0 on
-        // 2026-04-14. The two `pattern` fields on created_date_range contain
-        // a ~240-char leap-year ISO-8601 regex with nested alternations that
-        // llama.cpp's _visit_pattern() grinds on until the process core-dumps.
-        // After sanitization, both patterns must be gone and format/description
-        // must survive so the LLM still understands "this is a date".
-        var raw = LoadJsonFixture("notion-search-input.raw.json");
+        // Regression: notion-search's leap-year ISO date `pattern` must be
+        // stripped so llama.cpp's grammar compiler can't SEGV on it.
+        var raw = TestFixtures.Load("notion-search-input.raw.json");
         var schema = JsonDocument.Parse(raw).RootElement;
 
         var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
@@ -572,13 +568,6 @@ public class McpSchemaSanitizerTests
         Assert.True(sanitized.GetProperty("properties").TryGetProperty("query", out _));
     }
 
-    private static string LoadJsonFixture(string filename)
-    {
-        var path = Path.Combine(AppContext.BaseDirectory, "Tools", "Fixtures", filename);
-        if (!File.Exists(path))
-            throw new FileNotFoundException($"Fixture not found: {path}");
-        return File.ReadAllText(path);
-    }
 
     [Fact]
     public void SanitizeSchema_HandlesNotionSearchSchema()

--- a/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/McpToolAdapterTests.cs
@@ -410,6 +410,176 @@ public class McpSchemaSanitizerTests
         Assert.Equal(JsonValueKind.Null, defaultProp.ValueKind);
     }
 
+    [Theory]
+    [InlineData("pattern", "\"^\\\\d{4}-\\\\d{2}-\\\\d{2}$\"")]
+    [InlineData("patternProperties", "{ \"^x-\": { \"type\": \"string\" } }")]
+    [InlineData("propertyNames", "{ \"pattern\": \"^[a-z]+$\" }")]
+    [InlineData("not", "{ \"type\": \"null\" }")]
+    [InlineData("if", "{ \"properties\": { \"kind\": { \"const\": \"a\" } } }")]
+    [InlineData("then", "{ \"required\": [\"x\"] }")]
+    [InlineData("else", "{ \"required\": [\"y\"] }")]
+    [InlineData("multipleOf", "10")]
+    [InlineData("contentEncoding", "\"base64\"")]
+    [InlineData("contentMediaType", "\"image/png\"")]
+    [InlineData("contentSchema", "{ \"type\": \"string\" }")]
+    public void SanitizeSchema_Strips_LlamaCppIncompatibleKeyword(string keyword, string valueJson)
+    {
+        // These keywords either crash llama.cpp's json_schema_to_grammar
+        // converter (pattern/patternProperties/propertyNames regex family),
+        // are unsupported and fatal (not, if/then/else, multipleOf), or are
+        // silently dropped (contentEncoding/MediaType/Schema). We strip them
+        // uniformly so a pathological MCP tool schema can't take down the
+        // backend.
+        var schema = JsonDocument.Parse($$"""
+            {
+                "type": "object",
+                "properties": {
+                    "field": {
+                        "type": "string",
+                        "description": "Kept verbatim",
+                        "{{keyword}}": {{valueJson}}
+                    }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var field = sanitized.GetProperty("properties").GetProperty("field");
+
+        Assert.False(field.TryGetProperty(keyword, out _), $"{keyword} should be stripped");
+        // Adjacent metadata is preserved so the LLM still understands the field
+        Assert.Equal("string", field.GetProperty("type").GetString());
+        Assert.Equal("Kept verbatim", field.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public void SanitizeSchema_StripsPattern_FromNestedArrayItems()
+    {
+        // Regression coverage: recursion through SanitizeSchemaArray and the
+        // items handler must still reach strip rules so a pathological pattern
+        // inside a nested array item can't slip through.
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "dates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                        }
+                    }
+                }
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var items = sanitized.GetProperty("properties")
+            .GetProperty("dates")
+            .GetProperty("items");
+
+        Assert.False(items.TryGetProperty("pattern", out _));
+        Assert.Equal("string", items.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void SanitizeSchema_Preserves_LlamaCppSupportedKeywords()
+    {
+        // Guard against future over-stripping. These keywords are handled by
+        // llama.cpp's converter and must survive sanitization — real MCP tool
+        // schemas (including Notion's) rely on them.
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "minLength": 10,
+                        "maxLength": 10
+                    },
+                    "count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000
+                    },
+                    "mode": { "enum": ["a", "b", "c"] },
+                    "ids": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "maxItems": 100
+                    },
+                    "union": {
+                        "oneOf": [
+                            { "type": "string" },
+                            { "type": "integer" }
+                        ]
+                    }
+                },
+                "required": ["date"]
+            }
+            """).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+        var props = sanitized.GetProperty("properties");
+
+        Assert.Equal("date", props.GetProperty("date").GetProperty("format").GetString());
+        Assert.Equal(10, props.GetProperty("date").GetProperty("minLength").GetInt32());
+        Assert.Equal(1000, props.GetProperty("count").GetProperty("maximum").GetInt32());
+        Assert.Equal(3, props.GetProperty("mode").GetProperty("enum").GetArrayLength());
+        Assert.Equal(100, props.GetProperty("ids").GetProperty("maxItems").GetInt32());
+        Assert.Equal(2, props.GetProperty("union").GetProperty("oneOf").GetArrayLength());
+    }
+
+    [Fact]
+    public void SanitizeSchema_RealNotionSearchFixture_StripsLeapYearPattern()
+    {
+        // This is the exact schema that SIGSEGV'd llama-server@gpu0 on
+        // 2026-04-14. The two `pattern` fields on created_date_range contain
+        // a ~240-char leap-year ISO-8601 regex with nested alternations that
+        // llama.cpp's _visit_pattern() grinds on until the process core-dumps.
+        // After sanitization, both patterns must be gone and format/description
+        // must survive so the LLM still understands "this is a date".
+        var raw = LoadJsonFixture("notion-search-input.raw.json");
+        var schema = JsonDocument.Parse(raw).RootElement;
+
+        var sanitized = McpSchemaSanitizer.SanitizeSchema(schema);
+
+        var dateRange = sanitized
+            .GetProperty("properties")
+            .GetProperty("filters")
+            .GetProperty("properties")
+            .GetProperty("created_date_range")
+            .GetProperty("properties");
+
+        var startDate = dateRange.GetProperty("start_date");
+        var endDate = dateRange.GetProperty("end_date");
+
+        Assert.False(startDate.TryGetProperty("pattern", out _),
+            "leap-year regex pattern on start_date must be stripped");
+        Assert.False(endDate.TryGetProperty("pattern", out _),
+            "leap-year regex pattern on end_date must be stripped");
+
+        // `format: date` survives — llama.cpp has a built-in date format rule
+        // that constrains the LLM output without needing the regex.
+        Assert.Equal("date", startDate.GetProperty("format").GetString());
+        Assert.Equal("date", endDate.GetProperty("format").GetString());
+
+        // Core schema structure is intact
+        Assert.Equal("object", sanitized.GetProperty("type").GetString());
+        Assert.Equal(2, sanitized.GetProperty("required").GetArrayLength());
+        Assert.True(sanitized.GetProperty("properties").TryGetProperty("query", out _));
+    }
+
+    private static string LoadJsonFixture(string filename)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Tools", "Fixtures", filename);
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Fixture not found: {path}");
+        return File.ReadAllText(path);
+    }
+
     [Fact]
     public void SanitizeSchema_HandlesNotionSearchSchema()
     {

--- a/src/Netclaw.Actors.Tests/Tools/TestFixtures.cs
+++ b/src/Netclaw.Actors.Tests/Tools/TestFixtures.cs
@@ -1,0 +1,12 @@
+namespace Netclaw.Actors.Tests.Tools;
+
+internal static class TestFixtures
+{
+    public static string Load(string filename)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Tools", "Fixtures", filename);
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Fixture not found: {path}");
+        return File.ReadAllText(path);
+    }
+}

--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -683,12 +683,10 @@ public class WebFetchToolTests : IDisposable
 
     private static string LoadFixture(string filename)
     {
-        var assembly = typeof(WebFetchToolTests).Assembly;
-        var resourceName = $"Netclaw.Actors.Tests.Tools.Fixtures.{filename}";
-        using var stream = assembly.GetManifestResourceStream(resourceName)
-            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        var path = Path.Combine(AppContext.BaseDirectory, "Tools", "Fixtures", filename);
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Fixture not found: {path}");
+        return File.ReadAllText(path);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/WebFetchToolTests.cs
@@ -128,7 +128,7 @@ public class WebFetchToolTests : IDisposable
     [Fact]
     public void ExtractTextFromHtml_works_on_ddg_fixture()
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var html = TestFixtures.Load("ddg-lite-akka-dotnet.html");
 
         var text = WebFetchTool.ExtractTextFromHtml(html);
 
@@ -169,7 +169,7 @@ public class WebFetchToolTests : IDisposable
     [Fact]
     public void ExtractTitle_from_ddg_fixture()
     {
-        var html = LoadFixture("ddg-lite-akka-dotnet.html");
+        var html = TestFixtures.Load("ddg-lite-akka-dotnet.html");
         var title = WebFetchTool.ExtractTitle(html);
 
         Assert.NotNull(title);
@@ -681,13 +681,6 @@ public class WebFetchToolTests : IDisposable
         Assert.Equal(expected, WebFetchTool.GetFallbackExtension(contentType, isBinary));
     }
 
-    private static string LoadFixture(string filename)
-    {
-        var path = Path.Combine(AppContext.BaseDirectory, "Tools", "Fixtures", filename);
-        if (!File.Exists(path))
-            throw new FileNotFoundException($"Fixture not found: {path}");
-        return File.ReadAllText(path);
-    }
 
     /// <summary>
     /// Fake HTTP handler that returns a canned response (text or binary).

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -111,6 +111,47 @@ public static class McpSchemaSanitizer
                 // breaks llama.cpp's JSON-schema-to-GBNF grammar conversion.
                 "$schema" => (object?)null,
 
+                // Strip keywords that llama.cpp's json_schema_to_grammar.cpp
+                // either cannot express in GBNF or crashes while expanding.
+                //
+                // `pattern` is the primary killer: regex→GBNF rule expansion
+                // in `_visit_pattern()` has no bounds on rule-string length,
+                // so a pathological pattern (e.g. Notion's leap-year ISO date
+                // regex with nested alternations) can grind for minutes and
+                // then SIGSEGV the server. Confirmed root cause of the
+                // 2026-04-14 Lemonade/gpu0 core dump on notion/notion-search.
+                //
+                // `patternProperties` and `propertyNames` are the same regex
+                // family and share the same crash path.
+                //
+                // `not`, `if`/`then`/`else` are unsupported — the converter
+                // returns "Unrecognized schema" which maps to a fatal error
+                // depending on call-site.
+                //
+                // `multipleOf` is unsupported (no integer arithmetic in GBNF).
+                //
+                // `contentEncoding`/`contentMediaType`/`contentSchema` are
+                // silently ignored by the converter and also disallowed by
+                // OpenAI's strict-mode schema subset — safe to remove and
+                // keeps our output on the converging "safe subset" across
+                // providers.
+                //
+                // Everything else ($ref/$defs, oneOf/anyOf/allOf, enum,
+                // format, minItems/maxItems, minLength/maxLength,
+                // minimum/maximum) is handled by the converter and must be
+                // preserved — real MCP tool schemas rely on these.
+                "pattern"
+                    or "patternProperties"
+                    or "propertyNames"
+                    or "not"
+                    or "if"
+                    or "then"
+                    or "else"
+                    or "multipleOf"
+                    or "contentEncoding"
+                    or "contentMediaType"
+                    or "contentSchema" => (object?)null,
+
                 // Handle type arrays like ["string", "null"] -> "string"
                 "type" when property.Value.ValueKind == JsonValueKind.Array =>
                     SimplifyTypeArray(property.Value),

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -111,35 +111,14 @@ public static class McpSchemaSanitizer
                 // breaks llama.cpp's JSON-schema-to-GBNF grammar conversion.
                 "$schema" => (object?)null,
 
-                // Strip keywords that llama.cpp's json_schema_to_grammar.cpp
-                // either cannot express in GBNF or crashes while expanding.
-                //
-                // `pattern` is the primary killer: regex→GBNF rule expansion
-                // in `_visit_pattern()` has no bounds on rule-string length,
-                // so a pathological pattern (e.g. Notion's leap-year ISO date
-                // regex with nested alternations) can grind for minutes and
-                // then SIGSEGV the server. Confirmed root cause of the
-                // 2026-04-14 Lemonade/gpu0 core dump on notion/notion-search.
-                //
-                // `patternProperties` and `propertyNames` are the same regex
-                // family and share the same crash path.
-                //
-                // `not`, `if`/`then`/`else` are unsupported — the converter
-                // returns "Unrecognized schema" which maps to a fatal error
-                // depending on call-site.
-                //
-                // `multipleOf` is unsupported (no integer arithmetic in GBNF).
-                //
-                // `contentEncoding`/`contentMediaType`/`contentSchema` are
-                // silently ignored by the converter and also disallowed by
-                // OpenAI's strict-mode schema subset — safe to remove and
-                // keeps our output on the converging "safe subset" across
-                // providers.
-                //
-                // Everything else ($ref/$defs, oneOf/anyOf/allOf, enum,
-                // format, minItems/maxItems, minLength/maxLength,
-                // minimum/maximum) is handled by the converter and must be
-                // preserved — real MCP tool schemas rely on these.
+                // Strip keywords llama.cpp's json_schema_to_grammar cannot
+                // express in GBNF. `pattern`/`patternProperties`/`propertyNames`
+                // crash `_visit_pattern()` on pathological regex (unbounded rule
+                // expansion); `not`/`if`/`then`/`else`/`multipleOf` are fatal
+                // "Unrecognized schema"; content* are silently dropped. Keep
+                // $ref/$defs, oneOf/anyOf/allOf, format, enum, and length/
+                // range bounds — converter handles those and real MCP tools
+                // rely on them.
                 "pattern"
                     or "patternProperties"
                     or "propertyNames"


### PR DESCRIPTION
## Summary

- Root cause of the 2026-04-14 Lemonade SIGSEGV: Notion's `notion/notion-search` MCP tool schema carries a pair of pathological leap-year ISO-8601 date `pattern` regexes that crash llama.cpp's `json_schema_to_grammar` converter (core dump confirmed via `journalctl -u llama-server@gpu0` on big-gpu).
- Extend `McpSchemaSanitizer` to strip JSON Schema keywords that cross-checked evidence (llama.cpp converter source, OpenAI strict mode, middleware survey) confirms are either crash paths or silently unsupported: `pattern`, `patternProperties`, `propertyNames`, `not`, `if`/`then`/`else`, `multipleOf`, `contentEncoding`, `contentMediaType`, `contentSchema`.
- Explicitly **keep** `\$ref`/`\$defs`, `oneOf`/`anyOf`/`allOf`, `format`, `enum`, `minItems`/`maxItems`, `minLength`/`maxLength`, `minimum`/`maximum` — the converter handles these and real MCP tool schemas depend on them.
- Switch `Tools/Fixtures/*.html` and `Tools/Fixtures/*.json` from `EmbeddedResource` to `None CopyToOutputDirectory="PreserveNewest"` so fixtures live at a predictable path on disk. Update `WebFetchToolTests.LoadFixture` accordingly.

## Evidence

**Crash confirmation** (from big-gpu journal, Memorizer record `7a112968-ea21-47b5-a9c0-2dbbf05594dc`):

- ` 16:44:43` — \`srv update_slots: all slots are idle\` (last healthy heartbeat, immediately before \`load_tool notion/notion-search\`)
- ` 16:50:23` — \`llama-server@gpu0.service: Main process exited, code=dumped, status=11/SEGV\`
- ` 16:50:23` — \`Failed with result 'core-dump'\`
- No grammar-error text preceded the SEGV — the crash happened inside \`_visit_pattern()\` before any structured error could be logged.

**The killing pattern** (extracted verbatim from \`daemon-2026-04-14.log\`, `filters.created_date_range.start_date` and `end_date`):

\`\`\`
^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))\$
\`\`\`

~240 chars, nested alternations, digit-range character classes, leap-year arithmetic, duplicated on both date fields so llama.cpp compiles it twice. `_visit_pattern()` in \`common/json-schema-to-grammar.cpp\` expands each branch into GBNF rules with no bound on the output rule-string length.

## Why this strip list, and not a bigger one

The first speculative plan stripped `\$ref`/`\$defs`/`oneOf`/`anyOf`/`allOf`/large-enum as a defensive over-correction. Three parallel Explore agents (llama.cpp converter source, middleware survey across M.E.AI / Ollama / llama-cpp-python / LangChain / OpenAI strict / Anthropic / vLLM, and live schema extraction) converged on a tighter list:

| Keyword | llama.cpp | OpenAI strict | Verdict |
|---|---|---|---|
| \`pattern\` | crash on complex regex | disallowed | **STRIP** |
| \`patternProperties\` | unsupported | disallowed | STRIP |
| \`propertyNames\` | unsupported | disallowed | STRIP |
| \`not\` | "Unrecognized schema" fatal | disallowed | STRIP |
| \`if\`/\`then\`/\`else\` | unsupported | disallowed | STRIP |
| \`multipleOf\` | unsupported | allowed | STRIP |
| \`contentEncoding\`/\`contentMediaType\`/\`contentSchema\` | silently dropped | disallowed | STRIP |
| \`\$ref\`/\`\$defs\` | handled (cycle-tracked) | disallowed | **KEEP** |
| \`oneOf\`/\`anyOf\`/\`allOf\` | handled via union rules | disallowed in mixed | **KEEP** |
| \`format\`, \`enum\`, \`minItems\`/\`maxItems\`, etc. | handled | allowed | KEEP |

Stripping something the converter actually supports would break real MCP tool schemas that rely on it.

## Test plan

- [x] `dotnet test src/Netclaw.Actors.Tests/` — 1024 passed, 0 failed
- [x] `McpSchemaSanitizerTests` — 13 existing + 14 new (theory spanning 11 keywords, recursion coverage, preserve-supported keywords guard, real notion-search fixture regression)
- [x] `WebFetchToolTests` — 61 passed after loader switch to `File.ReadAllText`
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] End-to-end repro: replay "Can you find our NATO pages in the consulting area of Notion?" in a fresh Slack session against Lemonade and confirm \`load_tool notion/notion-search\` → streaming turn completes without a 5xx. This is the "does it actually stop killing llama-server" check and needs a deploy to verify.

## Out of scope (separate PR)

PR 1 from the plan — payload + mid-stream-failure observability in `OpenAiCompatibleChatClient` — will ship separately. Not required to fix this bug; useful for the next time llama.cpp dies mid-stream.