### PR TITLE
fix(memory): harden distillation parser + observer storage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,6 +402,10 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 
+# Verify snapshot test received files (only verified.txt is committed)
+*.received.txt
+*.received.json
+
 # RALPH flight recorder (ephemeral)
 .ralph/
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.10.0" />
   </ItemGroup>
   <!-- Source generators -->
   <ItemGroup>

--- a/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Data.Sqlite;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -322,34 +321,6 @@ public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        await TryDeleteDirectoryAsync(_baseDir);
-    }
-
-    private static async Task TryDeleteDirectoryAsync(string path)
-    {
-        if (!Directory.Exists(path))
-            return;
-
-        SqliteConnection.ClearAllPools();
-
-        for (var i = 0; i < 8; i++)
-        {
-            try
-            {
-                Directory.Delete(path, recursive: true);
-                return;
-            }
-            catch (IOException) when (i < 7)
-            {
-                await Task.Delay(25 * (i + 1));
-            }
-            catch (UnauthorizedAccessException) when (i < 7)
-            {
-                await Task.Delay(25 * (i + 1));
-            }
-        }
-
-        // Best effort cleanup: file handles can remain briefly open on Windows CI.
-        // Leaving temp dirs behind is preferable to failing the test run.
+        await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
     }
 }

--- a/src/Netclaw.Actors.Tests/Memory/SqliteTempDirectoryCleanup.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SqliteTempDirectoryCleanup.cs
@@ -1,0 +1,37 @@
+using Microsoft.Data.Sqlite;
+
+namespace Netclaw.Actors.Tests.Memory;
+
+/// <summary>
+/// Shared cleanup helper for tests that create temp SQLite files. The retry
+/// loop exists because file handles can remain briefly open on Windows CI
+/// after `SqliteConnection.ClearAllPools()` returns. Best-effort: leaving
+/// a temp dir behind is preferable to failing a test run on cleanup.
+/// </summary>
+internal static class SqliteTempDirectoryCleanup
+{
+    public static async Task TryDeleteDirectoryAsync(string path)
+    {
+        if (!Directory.Exists(path))
+            return;
+
+        SqliteConnection.ClearAllPools();
+
+        for (var i = 0; i < 8; i++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < 7)
+            {
+                await Task.Delay(25 * (i + 1));
+            }
+            catch (UnauthorizedAccessException) when (i < 7)
+            {
+                await Task.Delay(25 * (i + 1));
+            }
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
+++ b/src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationSystemPrompt_matches_approved_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationSystemPrompt_matches_approved_snapshot.verified.txt
@@ -1,0 +1,131 @@
+﻿You are a session memory distillation sidecar.
+You receive a conversation transcript and a list of memories already
+proposed in this session (existingProposals).
+
+## Output contract (strict)
+
+Return ONLY a single JSON object matching the schema below.
+Do NOT include any text before or after the JSON object.
+Do NOT wrap the JSON in markdown code fences (no ```json, no ```).
+Do NOT include explanations, reasoning, preamble, or commentary outside the JSON.
+Your entire response must start with `{` and end with `}`.
+
+Top-level shape: { "proposals": [ ... ] }
+
+Your job: curate the user's memory store based on this session.
+
+## Workflow
+
+1. Identify what was learned in this session worth retaining
+2. Check existingProposals — if new information enriches an existing
+   memory, re-use that anchor canonicalName. The system will merge
+   your content into the existing entry.
+3. Only create a new anchor for genuinely new topics not covered by
+   any existing proposal
+4. Skip anything trivial, sensitive, or already fully captured
+
+Yield 1-3 proposals. Fewer, richer entries beat many thin ones.
+Consolidate related facts into a single proposal.
+
+## What to store (operational facts the agent can act on)
+
+- Tool, service, and account preferences (airlines, CRMs, editors)
+- Business and project context (company, products, team structure)
+- Travel logistics (home airport, loyalty programs, preferences)
+- Communication preferences and routines
+- Technical decisions, constraints, architectural choices
+- Workflow patterns and automation requirements
+
+## What to never store
+
+- Credentials, API keys, tokens, passwords
+- Financial account numbers or balances
+- Medical or health information
+
+## What to skip unless the user explicitly says "remember this"
+
+- Family or relationship dynamics
+- Personal opinions about specific people
+- Emotional processing or venting
+- Content shared as context that isn't itself a fact worth retaining
+
+## What to skip (always)
+
+- Greetings, pleasantries, task coordination ("can you do X" / "sure")
+- Intermediate reasoning superseded by a later conclusion
+- Information already in [recalled-memory] entries — already stored
+- Information from [loaded-skill] entries — system knowledge, not memories
+- Raw data or tool output summarized later (keep summary, skip raw)
+- Anything the user corrected or walked back
+
+Operation-to-class mapping (STRICT — always follow these):
+- durable_fact -> operation MUST be "upsert_document" (stable knowledge, merged on write)
+- evidence -> operation MUST be "append_record" (point-in-time observation, immutable)
+- trace -> operation MUST be "append_record" (execution breadcrumb, immutable)
+
+Why: evidence captures temporal observations ("PR review findings on March 26",
+"build failure at 2:30pm"). Using upsert_document would silently merge distinct
+observations into one, destroying the historical record. Only durable_fact
+(standing truths like user preferences) should be updatable.
+
+## Title rules
+
+- Clean, concise noun phrases (3-8 words)
+- Never use raw user quotes or speech artifacts as titles
+- Never prefix with the memory class ("Project Fact: ...")
+- Good: "Petabridge Marketing Automation Stack"
+- Bad: "Project Fact: Biggest need I has Right now is I need to monitor a"
+
+## Deduplication
+
+For each entry in existingProposals:
+- If you have NEW information to add → re-use the same anchor name
+- If the transcript just restates what was captured → skip entirely
+- Only create a new anchor if the topic is clearly distinct
+
+## Proposal format
+
+For each proposal, include:
+- operation: "upsert_document" for durable_fact, "append_record" for evidence (see rules above)
+- memoryClass: "durable_fact" or "evidence"
+- subjectKind: "user" or "project"
+- subjectValue: the subject identifier
+- anchor: { "canonicalName": "slug-name", "anchorType": "type" }
+- title, content, aliases (non-empty array), facets (non-empty array)
+- recallMode: "auto" for durable_fact, "searchable" for evidence
+- sensitivity: "normal"
+- confidence: 0.7-0.95
+
+Example durable_fact (stable knowledge — merged on write):
+{
+  "operation": "upsert_document",
+  "memoryClass": "durable_fact",
+  "subjectKind": "user",
+  "subjectValue": "self",
+  "anchor": { "canonicalName": "user-preferred-editor", "anchorType": "preference" },
+  "title": "Preferred Code Editor",
+  "content": "User prefers VS Code with Vim keybindings.",
+  "aliases": ["VS Code", "editor preference", "vim keybindings"],
+  "facets": ["development_tools", "user_preference"],
+  "recallMode": "auto",
+  "sensitivity": "normal",
+  "confidence": 0.92
+}
+
+Example evidence (point-in-time finding — immutable, never merged):
+{
+  "operation": "append_record",
+  "memoryClass": "evidence",
+  "subjectKind": "project",
+  "subjectValue": "netclaw",
+  "anchor": { "canonicalName": "memory-curation-perf-analysis", "anchorType": "analysis" },
+  "title": "Memory Curation Performance Analysis",
+  "content": "Curation dedup runs in <2ms per proposal with SQLite FTS5. Bottleneck is the LLM tier at ~800ms per ambiguous case.",
+  "aliases": ["curation performance", "dedup latency"],
+  "facets": ["performance_analysis", "project_artifact"],
+  "recallMode": "searchable",
+  "sensitivity": "normal",
+  "confidence": 0.78
+}
+
+If nothing is worth remembering, return { "proposals": [] }.

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.json
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.json
@@ -1,0 +1,12 @@
+﻿{
+  "sessionId": "synthetic/snapshot",
+  "turnCount": 3,
+  "existingProposals": [
+    {
+      "anchor": "synthetic-anchor",
+      "title": "Synthetic Anchor",
+      "content": "snippet"
+    }
+  ],
+  "transcript": "user: synthetic transcript line one\nassistant: synthetic response line one"
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.txt
@@ -1,1 +1,0 @@
-﻿{"sessionId":"synthetic/snapshot","turnCount":3,"existingProposals":[{"anchor":"synthetic-anchor","title":"Synthetic Anchor","content":"snippet"}],"transcript":"user: synthetic transcript line one\nassistant: synthetic response line one"}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.txt
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.DistillationUserPromptTemplate_matches_approved_snapshot.verified.txt
@@ -1,0 +1,1 @@
+﻿{"sessionId":"synthetic/snapshot","turnCount":3,"existingProposals":[{"anchor":"synthetic-anchor","title":"Synthetic Anchor","content":"snippet"}],"transcript":"user: synthetic transcript line one\nassistant: synthetic response line one"}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -583,7 +583,15 @@ public sealed class SessionMemoryObserverActorTests : TestKit
             transcript: "user: synthetic transcript line one\nassistant: synthetic response line one",
             existingProposals: [new ProposedMemoryContext("synthetic-anchor", "Synthetic Anchor", "snippet")]);
 
-        return Verifier.Verify(prompt, extension: "txt");
+        // The user prompt is a single-line serialized JSON. Pretty-print it
+        // before snapshotting so any future diff is readable per-field rather
+        // than a wall-of-text on one line.
+        using var doc = System.Text.Json.JsonDocument.Parse(prompt);
+        var indented = System.Text.Json.JsonSerializer.Serialize(
+            doc.RootElement,
+            new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+
+        return Verifier.Verify(indented, extension: "json");
     }
 
     // ── Parser tests (Fix 1c) ──────────────────────────────────────────
@@ -618,10 +626,15 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         """;
 
     [Fact]
-    public void ParseProposals_returns_empty_for_null_or_whitespace()
+    public void ParseProposals_reports_empty_input_for_null_or_whitespace()
     {
-        Assert.Empty(SessionMemoryObserverActor.ParseProposals(string.Empty));
-        Assert.Empty(SessionMemoryObserverActor.ParseProposals("   \n\t  "));
+        var empty = SessionMemoryObserverActor.ParseProposals(string.Empty);
+        Assert.Empty(empty.Proposals);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.EmptyInput, empty.Outcome);
+
+        var whitespace = SessionMemoryObserverActor.ParseProposals("   \n\t  ");
+        Assert.Empty(whitespace.Proposals);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.EmptyInput, whitespace.Outcome);
     }
 
     [Fact]
@@ -629,7 +642,8 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     {
         var result = SessionMemoryObserverActor.ParseProposals(CleanProposalJson);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
@@ -637,23 +651,25 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     public void ParseProposals_succeeds_on_empty_proposals_array()
     {
         var result = SessionMemoryObserverActor.ParseProposals(@"{ ""proposals"": [] }");
-        Assert.Empty(result);
+
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        Assert.Empty(result.Proposals);
     }
 
     [Fact]
     public void ParseProposals_recovers_from_preamble_text_with_braces()
     {
-        // This is the failure mode that was breaking ~28% of distillations.
-        // Qwen emits chain-of-thought before the JSON, often containing
-        // brace-delimited enumerations like "{tools, decisions, projects}".
-        // The old parser took the substring from the first `{` (in the
-        // preamble enumeration) to the last `}` (closing the JSON object),
-        // which produced malformed JSON.
+        // The smoking-gun failure mode: Qwen emits chain-of-thought before
+        // the JSON, often containing brace-delimited enumerations like
+        // "{tools, decisions, projects}". The old parser took the substring
+        // from the first `{` in the preamble to the last `}` of the real
+        // JSON object, producing malformed JSON.
         var text = "Looking at the conversation I see {tools, decisions, projects} mentioned. Here's my analysis:\n\n" + CleanProposalJson;
 
         var result = SessionMemoryObserverActor.ParseProposals(text);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
@@ -664,7 +680,8 @@ public sealed class SessionMemoryObserverActorTests : TestKit
 
         var result = SessionMemoryObserverActor.ParseProposals(text);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
@@ -675,7 +692,8 @@ public sealed class SessionMemoryObserverActorTests : TestKit
 
         var result = SessionMemoryObserverActor.ParseProposals(text);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
@@ -686,72 +704,65 @@ public sealed class SessionMemoryObserverActorTests : TestKit
 
         var result = SessionMemoryObserverActor.ParseProposals(text);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
     [Fact]
     public void ParseProposals_recovers_from_multiple_json_objects()
     {
-        // First object is some unrelated stray JSON, second is the real proposals.
+        // First object is unrelated stray JSON, second is the real proposals.
         // The walker should try each candidate in order until one parses to a
         // DistillationResponse with a non-null Proposals list.
         var text = "{ \"unrelatedField\": \"some value\" }\n\n" + CleanProposalJson;
 
         var result = SessionMemoryObserverActor.ParseProposals(text);
 
-        var proposal = Assert.Single(result);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.Success, result.Outcome);
+        var proposal = Assert.Single(result.Proposals);
         Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
     }
 
     [Fact]
-    public void ParseProposals_returns_empty_on_refusal_text_with_no_json()
+    public void ParseProposals_reports_no_json_found_on_refusal_text()
     {
-        var result = SessionMemoryObserverActor.ParseProposals("There is nothing memory-worthy in this conversation.");
-        Assert.Empty(result);
+        var result = SessionMemoryObserverActor.ParseProposals(
+            "There is nothing memory-worthy in this conversation.");
+
+        Assert.Empty(result.Proposals);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.NoJsonFound, result.Outcome);
+        Assert.Equal(0, result.CandidateCount);
+        Assert.NotNull(result.Preview);
     }
 
     [Fact]
-    public void ParseProposals_returns_empty_on_truncated_json()
+    public void ParseProposals_reports_parse_failed_when_candidates_exist_but_none_match()
+    {
+        // Walker finds two stray JSON objects, neither of which deserialize
+        // into a DistillationResponse with a non-null Proposals array.
+        // Should be ParseFailed (NOT NoJsonFound), because the distinction
+        // matters for diagnosing prompt vs format issues.
+        var result = SessionMemoryObserverActor.ParseProposals(
+            "{ \"unrelated\": \"data\" } and { \"more\": \"unrelated\" }");
+
+        Assert.Empty(result.Proposals);
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.ParseFailed, result.Outcome);
+        Assert.Equal(2, result.CandidateCount);
+        Assert.NotNull(result.Preview);
+    }
+
+    [Fact]
+    public void ParseProposals_reports_parse_failed_on_truncated_json()
     {
         var truncated = "{ \"proposals\": [ { \"title\": \"foo\", \"content\": \"bar\"";
 
         var result = SessionMemoryObserverActor.ParseProposals(truncated);
 
-        Assert.Empty(result);
-    }
-
-    [Fact]
-    public void ParseProposals_logs_no_json_event_when_no_braces_present()
-    {
-        // Verify the structured drop-reason event fires (Failure Mode D
-        // observability — the whole point of Fix 1a). Without this log event,
-        // a parser regression burns LLM tokens and produces zero memories
-        // with no diagnostic trail.
-        var messages = new List<string>();
-
-        SessionMemoryObserverActor.ParseProposals(
-            "There is nothing memory-worthy in this conversation.",
-            messages.Add);
-
-        Assert.Contains(messages, m => m.Contains("session_observer_parse_no_json", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void ParseProposals_logs_parse_failed_event_when_candidates_exist_but_none_parse()
-    {
-        // Walker finds two stray JSON objects, neither of which deserialize
-        // into a DistillationResponse with a non-null Proposals array.
-        // Should produce a parse_failed event (NOT a no_json event), because
-        // the distinction matters for diagnosing prompt vs format issues.
-        var messages = new List<string>();
-
-        SessionMemoryObserverActor.ParseProposals(
-            "{ \"unrelated\": \"data\" } and { \"more\": \"unrelated\" }",
-            messages.Add);
-
-        Assert.Contains(messages, m => m.Contains("session_observer_parse_failed", StringComparison.Ordinal));
-        Assert.DoesNotContain(messages, m => m.Contains("session_observer_parse_no_json", StringComparison.Ordinal));
+        Assert.Empty(result.Proposals);
+        // Truncated JSON has an opening `{` but no matching close, so the
+        // walker reports zero candidates → NoJsonFound. Locks the contract.
+        Assert.Equal(SessionMemoryObserverActor.ParseProposalsOutcome.NoJsonFound, result.Outcome);
     }
 
     // ── ExtractJsonObjectCandidates / StripMarkdownFences direct unit tests ──

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using VerifyXunit;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Sessions;
@@ -524,6 +525,284 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         // Must contain both example memory classes
         Assert.Contains("\"memoryClass\": \"evidence\"", prompt, StringComparison.Ordinal);
         Assert.Contains("\"memoryClass\": \"durable_fact\"", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DistillationSystemPrompt_forbids_preamble_postscript_and_markdown_fences()
+    {
+        var prompt = SessionMemoryObserverActor.BuildDistillationSystemPrompt();
+
+        Assert.Contains("Do NOT include any text before or after the JSON", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT wrap the JSON in markdown code fences", prompt, StringComparison.Ordinal);
+        Assert.Contains("must start with `{` and end with `}`", prompt, StringComparison.Ordinal);
+    }
+
+    // ── Prompt snapshot tests (Fix 2.5) ────────────────────────────────
+    //
+    // These tests lock down the distillation prompts via Verify snapshot
+    // testing. They catch ANY byte-level change to the prompt (added or
+    // removed examples, reworded instructions, casing changes, whitespace
+    // edits) and force human review on every prompt edit by producing a
+    // readable diff between the current prompt and the approved baseline.
+    //
+    // When the prompt intentionally changes:
+    //   1. Run this test — it will fail with a `*.received.txt` file
+    //      written next to the test source containing the new prompt.
+    //   2. Compare it to the existing `*.verified.txt` baseline (the diff
+    //      tool will pop up automatically in IDE; CLI users can `diff`
+    //      the two files).
+    //   3. If the change is intentional, replace the verified file with
+    //      the received file (`mv ...received.txt ...verified.txt`).
+    //   4. Commit the prompt change and the updated `verified.txt`
+    //      together.
+    //
+    // What this does NOT catch: semantic changes that keep the same
+    // byte-shape (none in practice), and prompt drift in the model itself
+    // (that's what the eval suite is for). What it DOES catch: the casual
+    // edit that drops an example, swaps a field name, or tightens a rule
+    // in a way that breaks the contract Qwen has been honoring in
+    // production.
+    //
+    // Synthetic content note: the user-prompt snapshot is built from
+    // entirely synthetic inputs. No real session transcripts are baked
+    // into the verified file (per the discretion rule).
+
+    [Fact]
+    public Task DistillationSystemPrompt_matches_approved_snapshot()
+    {
+        var prompt = SessionMemoryObserverActor.BuildDistillationSystemPrompt();
+        return Verifier.Verify(prompt, extension: "txt");
+    }
+
+    [Fact]
+    public Task DistillationUserPromptTemplate_matches_approved_snapshot()
+    {
+        var prompt = SessionMemoryObserverActor.BuildDistillationUserPrompt(
+            sessionId: "synthetic/snapshot",
+            turnCount: 3,
+            transcript: "user: synthetic transcript line one\nassistant: synthetic response line one",
+            existingProposals: [new ProposedMemoryContext("synthetic-anchor", "Synthetic Anchor", "snippet")]);
+
+        return Verifier.Verify(prompt, extension: "txt");
+    }
+
+    // ── Parser tests (Fix 1c) ──────────────────────────────────────────
+    //
+    // The pre-fix parser used `text[IndexOf('{')..LastIndexOf('}')]` which
+    // captured everything between the first `{` (often inside preamble or
+    // an echoed transcript snippet) and the last `}` of the actual JSON
+    // object, producing malformed JSON and silently returning an empty
+    // proposal list. These tests exercise the failure shapes Qwen3.5-27B
+    // produces in production: preamble braces, markdown fences, refusal
+    // text, multiple JSON objects, trailing chatter.
+
+    private const string CleanProposalJson = """
+        {
+          "proposals": [
+            {
+              "operation": "upsert_document",
+              "memoryClass": "durable_fact",
+              "subjectKind": "user",
+              "subjectValue": "self",
+              "anchor": { "canonicalName": "test-anchor", "anchorType": "preference" },
+              "title": "Test Anchor",
+              "content": "Test content for the anchor.",
+              "aliases": ["alias-one"],
+              "facets": ["test_facet"],
+              "recallMode": "auto",
+              "sensitivity": "normal",
+              "confidence": 0.9
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void ParseProposals_returns_empty_for_null_or_whitespace()
+    {
+        Assert.Empty(SessionMemoryObserverActor.ParseProposals(string.Empty));
+        Assert.Empty(SessionMemoryObserverActor.ParseProposals("   \n\t  "));
+    }
+
+    [Fact]
+    public void ParseProposals_succeeds_on_clean_json()
+    {
+        var result = SessionMemoryObserverActor.ParseProposals(CleanProposalJson);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_succeeds_on_empty_proposals_array()
+    {
+        var result = SessionMemoryObserverActor.ParseProposals(@"{ ""proposals"": [] }");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseProposals_recovers_from_preamble_text_with_braces()
+    {
+        // This is the failure mode that was breaking ~28% of distillations.
+        // Qwen emits chain-of-thought before the JSON, often containing
+        // brace-delimited enumerations like "{tools, decisions, projects}".
+        // The old parser took the substring from the first `{` (in the
+        // preamble enumeration) to the last `}` (closing the JSON object),
+        // which produced malformed JSON.
+        var text = "Looking at the conversation I see {tools, decisions, projects} mentioned. Here's my analysis:\n\n" + CleanProposalJson;
+
+        var result = SessionMemoryObserverActor.ParseProposals(text);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_recovers_from_markdown_code_fence_wrapper()
+    {
+        var text = "```json\n" + CleanProposalJson + "\n```";
+
+        var result = SessionMemoryObserverActor.ParseProposals(text);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_recovers_from_unlabeled_code_fence_wrapper()
+    {
+        var text = "```\n" + CleanProposalJson + "\n```";
+
+        var result = SessionMemoryObserverActor.ParseProposals(text);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_recovers_from_trailing_chatter()
+    {
+        var text = CleanProposalJson + "\n\nLet me know if you need anything else!";
+
+        var result = SessionMemoryObserverActor.ParseProposals(text);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_recovers_from_multiple_json_objects()
+    {
+        // First object is some unrelated stray JSON, second is the real proposals.
+        // The walker should try each candidate in order until one parses to a
+        // DistillationResponse with a non-null Proposals list.
+        var text = "{ \"unrelatedField\": \"some value\" }\n\n" + CleanProposalJson;
+
+        var result = SessionMemoryObserverActor.ParseProposals(text);
+
+        var proposal = Assert.Single(result);
+        Assert.Equal("test-anchor", proposal.Anchor!.CanonicalName);
+    }
+
+    [Fact]
+    public void ParseProposals_returns_empty_on_refusal_text_with_no_json()
+    {
+        var result = SessionMemoryObserverActor.ParseProposals("There is nothing memory-worthy in this conversation.");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseProposals_returns_empty_on_truncated_json()
+    {
+        var truncated = "{ \"proposals\": [ { \"title\": \"foo\", \"content\": \"bar\"";
+
+        var result = SessionMemoryObserverActor.ParseProposals(truncated);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseProposals_logs_no_json_event_when_no_braces_present()
+    {
+        // Verify the structured drop-reason event fires (Failure Mode D
+        // observability — the whole point of Fix 1a). Without this log event,
+        // a parser regression burns LLM tokens and produces zero memories
+        // with no diagnostic trail.
+        var messages = new List<string>();
+
+        SessionMemoryObserverActor.ParseProposals(
+            "There is nothing memory-worthy in this conversation.",
+            messages.Add);
+
+        Assert.Contains(messages, m => m.Contains("session_observer_parse_no_json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ParseProposals_logs_parse_failed_event_when_candidates_exist_but_none_parse()
+    {
+        // Walker finds two stray JSON objects, neither of which deserialize
+        // into a DistillationResponse with a non-null Proposals array.
+        // Should produce a parse_failed event (NOT a no_json event), because
+        // the distinction matters for diagnosing prompt vs format issues.
+        var messages = new List<string>();
+
+        SessionMemoryObserverActor.ParseProposals(
+            "{ \"unrelated\": \"data\" } and { \"more\": \"unrelated\" }",
+            messages.Add);
+
+        Assert.Contains(messages, m => m.Contains("session_observer_parse_failed", StringComparison.Ordinal));
+        Assert.DoesNotContain(messages, m => m.Contains("session_observer_parse_no_json", StringComparison.Ordinal));
+    }
+
+    // ── ExtractJsonObjectCandidates / StripMarkdownFences direct unit tests ──
+
+    [Fact]
+    public void StripMarkdownFences_strips_json_fenced_block()
+    {
+        var input = "```json\n{\"key\":\"value\"}\n```";
+        Assert.Equal("{\"key\":\"value\"}", SessionMemoryObserverActor.StripMarkdownFences(input));
+    }
+
+    [Fact]
+    public void StripMarkdownFences_returns_input_unchanged_when_no_fence()
+    {
+        var input = "{\"key\":\"value\"}";
+        Assert.Equal(input, SessionMemoryObserverActor.StripMarkdownFences(input));
+    }
+
+    [Fact]
+    public void ExtractJsonObjectCandidates_finds_each_top_level_object()
+    {
+        var text = "preamble {\"a\":1} more {\"b\":2,\"nested\":{\"c\":3}} trailing";
+
+        var candidates = SessionMemoryObserverActor.ExtractJsonObjectCandidates(text);
+
+        Assert.Equal(2, candidates.Count);
+        Assert.Equal("{\"a\":1}", candidates[0]);
+        Assert.Equal("{\"b\":2,\"nested\":{\"c\":3}}", candidates[1]);
+    }
+
+    [Fact]
+    public void ExtractJsonObjectCandidates_ignores_braces_inside_strings()
+    {
+        // Brace inside a JSON string literal must not affect depth counting.
+        var text = "{\"text\":\"contains } brace\"}";
+
+        var candidates = SessionMemoryObserverActor.ExtractJsonObjectCandidates(text);
+
+        var single = Assert.Single(candidates);
+        Assert.Equal(text, single);
+    }
+
+    [Fact]
+    public void ExtractJsonObjectCandidates_handles_escaped_quotes_inside_strings()
+    {
+        var text = "{\"text\":\"escaped \\\" quote and } brace\"}";
+
+        var candidates = SessionMemoryObserverActor.ExtractJsonObjectCandidates(text);
+
+        var single = Assert.Single(candidates);
+        Assert.Equal(text, single);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
@@ -1,0 +1,241 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Data.Sqlite;
+using Netclaw.Actors.Memory;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// End-to-end integration test for the memory formation chain: a memory
+/// proposal sent to <see cref="MemoryCurationActor"/> must land as a row in
+/// <see cref="SQLiteMemoryStore"/>'s <c>memory_documents</c> table.
+///
+/// <para>This test exists because the existing <see cref="SessionMemoryObserverActorTests"/>
+/// suite stops at the actor message boundary (TestKit probe receives
+/// <c>SessionDistillationCompleted</c> with proposals) and never verifies that
+/// proposals actually become durable rows. That gap let regressions silently
+/// kill memory formation for two days in early April 2026 (the legacy
+/// <c>domain NOT NULL</c> constraint, fixed in PR #634) and again in April
+/// 2026 (parser brittleness, fixed in this PR series). A test in this file
+/// would have caught both.</para>
+///
+/// <para>The chain under test: proposal → MemoryCurationActor → SQLiteMemoryStore
+/// → memory_documents. The observer side and the gate side are tested in
+/// SessionMemoryObserverActorTests (parser unit tests). Routing from
+/// LlmSessionActor.HandleDistillationResult is the next layer up and out of
+/// scope for this initial integration test.</para>
+/// </summary>
+public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
+{
+    private readonly string _dbDir = Path.Combine(
+        Path.GetTempPath(),
+        "netclaw-observer-storage-tests",
+        Guid.NewGuid().ToString("N"));
+
+    public SessionMemoryObserverStorageIntegrationTests(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // No persistence needed for these tests — the curation actor is a
+        // ReceiveActor, not a persistent actor.
+    }
+
+    [Fact]
+    public async Task Curation_actor_persists_create_decision_to_memory_documents()
+    {
+        // Setup: real SQLite store against a temp DB
+        var (store, dbPath) = await CreateStoreAsync();
+
+        try
+        {
+            var curationActor = Sys.ActorOf(
+                MemoryCurationActor.CreateProps(store),
+                $"curation-create-{Guid.NewGuid():N}");
+
+            var probe = CreateTestProbe("curation-create-probe");
+            var operation = MakeOperation(
+                anchorCanonicalName: "synthetic-create-anchor",
+                title: "Synthetic Create Test",
+                content: "Content that should land in memory_documents via Create decision.",
+                aliasesJson: "[\"synthetic create\",\"create alias\"]",
+                facetsJson: "[\"integration_test\"]");
+
+            curationActor.Tell(new EvaluateProposals([operation]), probe.Ref);
+
+            var completion = await probe.ExpectMsgAsync<CurationCompleted>(
+                TimeSpan.FromSeconds(10),
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.True(completion.Created >= 1,
+                $"Expected at least 1 create, got Created={completion.Created} Updated={completion.Updated} Skipped={completion.Skipped}");
+            Assert.Equal(0, completion.Skipped);
+
+            // Verify the row exists in the store via search
+            var results = await store.SearchMemoriesAsync(
+                "synthetic create",
+                limit: 5,
+                boundary: SecurityPolicyDefaults.TrustedInstanceBoundary,
+                audience: TrustAudience.Public,
+                TestContext.Current.CancellationToken);
+
+            Assert.NotEmpty(results);
+            Assert.Contains(results, r => r.Title.Contains("Synthetic Create Test", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            await CleanupAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Curation_actor_persists_multiple_proposals_in_one_batch()
+    {
+        var (store, dbPath) = await CreateStoreAsync();
+
+        try
+        {
+            var curationActor = Sys.ActorOf(
+                MemoryCurationActor.CreateProps(store),
+                $"curation-batch-{Guid.NewGuid():N}");
+
+            var probe = CreateTestProbe("curation-batch-probe");
+            var operations = new[]
+            {
+                MakeOperation(
+                    anchorCanonicalName: "synthetic-batch-one",
+                    title: "Batch One",
+                    content: "First proposal in a batch.",
+                    aliasesJson: "[\"batch one\"]",
+                    facetsJson: "[\"integration_test\"]"),
+                MakeOperation(
+                    anchorCanonicalName: "synthetic-batch-two",
+                    title: "Batch Two",
+                    content: "Second proposal in a batch.",
+                    aliasesJson: "[\"batch two\"]",
+                    facetsJson: "[\"integration_test\"]"),
+            };
+
+            curationActor.Tell(new EvaluateProposals(operations), probe.Ref);
+
+            var completion = await probe.ExpectMsgAsync<CurationCompleted>(
+                TimeSpan.FromSeconds(10),
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.Equal(2, completion.Evaluated);
+            Assert.True(completion.Created >= 2,
+                $"Expected at least 2 creates, got Created={completion.Created} Updated={completion.Updated}");
+
+            var results = await store.SearchMemoriesAsync(
+                "Batch",
+                limit: 5,
+                boundary: SecurityPolicyDefaults.TrustedInstanceBoundary,
+                audience: TrustAudience.Public,
+                TestContext.Current.CancellationToken);
+
+            Assert.True(results.Count >= 2,
+                $"Expected at least 2 search hits, got {results.Count}");
+        }
+        finally
+        {
+            await CleanupAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Curation_actor_replies_with_zero_evaluated_for_empty_batch()
+    {
+        // Edge case: an empty proposal list shouldn't crash; it should reply
+        // with a zero-count CurationCompleted. This is the contract LlmSessionActor
+        // relies on at line 945-949 when accepted.Count > 0 is checked.
+        var (store, _) = await CreateStoreAsync();
+
+        try
+        {
+            var curationActor = Sys.ActorOf(
+                MemoryCurationActor.CreateProps(store),
+                $"curation-empty-{Guid.NewGuid():N}");
+
+            var probe = CreateTestProbe("curation-empty-probe");
+            curationActor.Tell(new EvaluateProposals([]), probe.Ref);
+
+            var completion = await probe.ExpectMsgAsync<CurationCompleted>(
+                TimeSpan.FromSeconds(5),
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.Equal(0, completion.Evaluated);
+            Assert.Equal(0, completion.Created);
+            Assert.Equal(0, completion.Updated);
+        }
+        finally
+        {
+            await CleanupAsync();
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private async Task<(SQLiteMemoryStore Store, string DbPath)> CreateStoreAsync()
+    {
+        Directory.CreateDirectory(_dbDir);
+        var dbPath = Path.Combine(_dbDir, "test.db");
+        var store = new SQLiteMemoryStore(dbPath, TimeProvider.System);
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+        return (store, dbPath);
+    }
+
+    private static SQLiteMemoryCurationOperation MakeOperation(
+        string anchorCanonicalName,
+        string title,
+        string content,
+        string aliasesJson,
+        string facetsJson) =>
+        new(
+            Kind: "document",
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: anchorCanonicalName,
+            AnchorType: "preference",
+            Title: title,
+            Content: content,
+            AliasesJson: aliasesJson,
+            FacetsJson: facetsJson,
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: "merge-document",
+            Boundary: SecurityPolicyDefaults.TrustedInstanceBoundary,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+            ExpiresAtMs: null);
+
+    private async Task CleanupAsync()
+    {
+        if (!Directory.Exists(_dbDir))
+            return;
+
+        SqliteConnection.ClearAllPools();
+        for (var i = 0; i < 8; i++)
+        {
+            try
+            {
+                Directory.Delete(_dbDir, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < 7)
+            {
+                await Task.Delay(25 * (i + 1));
+            }
+            catch (UnauthorizedAccessException) when (i < 7)
+            {
+                await Task.Delay(25 * (i + 1));
+            }
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
@@ -1,8 +1,8 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
-using Microsoft.Data.Sqlite;
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Tests.Memory;
 using Netclaw.Configuration;
 using Xunit;
 
@@ -55,7 +55,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         {
             var curationActor = Sys.ActorOf(
                 MemoryCurationActor.CreateProps(store),
-                $"curation-create-{Guid.NewGuid():N}");
+                "curation-create");
 
             var probe = CreateTestProbe("curation-create-probe");
             var operation = MakeOperation(
@@ -101,7 +101,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         {
             var curationActor = Sys.ActorOf(
                 MemoryCurationActor.CreateProps(store),
-                $"curation-batch-{Guid.NewGuid():N}");
+                "curation-batch");
 
             var probe = CreateTestProbe("curation-batch-probe");
             var operations = new[]
@@ -158,7 +158,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         {
             var curationActor = Sys.ActorOf(
                 MemoryCurationActor.CreateProps(store),
-                $"curation-empty-{Guid.NewGuid():N}");
+                "curation-empty");
 
             var probe = CreateTestProbe("curation-empty-probe");
             curationActor.Tell(new EvaluateProposals([]), probe.Ref);
@@ -215,27 +215,5 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
             FreshnessAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
             ExpiresAtMs: null);
 
-    private async Task CleanupAsync()
-    {
-        if (!Directory.Exists(_dbDir))
-            return;
-
-        SqliteConnection.ClearAllPools();
-        for (var i = 0; i < 8; i++)
-        {
-            try
-            {
-                Directory.Delete(_dbDir, recursive: true);
-                return;
-            }
-            catch (IOException) when (i < 7)
-            {
-                await Task.Delay(25 * (i + 1));
-            }
-            catch (UnauthorizedAccessException) when (i < 7)
-            {
-                await Task.Delay(25 * (i + 1));
-            }
-        }
-    }
+    private Task CleanupAsync() => SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_dbDir);
 }

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -86,7 +86,7 @@ public sealed class SessionLogActor : ReceiveActor
             var mediaNote = msg.MediaReferences.Count > 0
                 ? $" (+{msg.MediaReferences.Count} media)"
                 : string.Empty;
-            _writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] User: {Truncate(msg.Content, 1000)}{mediaNote}");
+            _writer.WriteLine($"[{_timeProvider.GetUtcNow():o}] User: {TextTruncation.EllipsisAppend(msg.Content, 1000)}{mediaNote}");
         }
         catch (Exception ex)
         {
@@ -102,10 +102,10 @@ public sealed class SessionLogActor : ReceiveActor
         {
             var line = output switch
             {
-                TextOutput text => $"Assistant: {Truncate(text.Text, 1000)}",
+                TextOutput text => $"Assistant: {TextTruncation.EllipsisAppend(text.Text, 1000)}",
                 ToolCallOutput toolCall => FormatToolCall(toolCall),
-                ToolResultOutput toolResult => $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {Truncate(toolResult.Result, 1000)}",
-                ThinkingOutput thinking => $"Thinking: {Truncate(thinking.Text, 1000)}",
+                ToolResultOutput toolResult => $"Tool result: {toolResult.ToolName} (call={toolResult.CallId}) → {TextTruncation.EllipsisAppend(toolResult.Result, 1000)}",
+                ThinkingOutput thinking => $"Thinking: {TextTruncation.EllipsisAppend(thinking.Text, 1000)}",
                 UsageOutput usage => $"Usage: in={usage.InputTokens} out={usage.OutputTokens} cached={usage.CachedInputTokens} reasoning={usage.ReasoningTokens} context={usage.UsagePercent:P0}",
                 TurnCompleted tc => $"Turn {tc.TurnNumber} {tc.Outcome.ToString().ToLowerInvariant()}",
                 SessionTitleOutput title => $"Title set: {title.Title}",
@@ -135,11 +135,8 @@ public sealed class SessionLogActor : ReceiveActor
     private static string FormatToolCall(ToolCallOutput toolCall)
     {
         var args = toolCall.ArgumentsJson is not null
-            ? $" args={Truncate(toolCall.ArgumentsJson, 1000)}"
+            ? $" args={TextTruncation.EllipsisAppend(toolCall.ArgumentsJson, 1000)}"
             : string.Empty;
         return $"Tool call: {toolCall.ToolName} (call={toolCall.CallId}){args}";
     }
-
-    private static string Truncate(string text, int maxLength) =>
-        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
 }

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -363,7 +363,25 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             inputTokens = response.Usage?.InputTokenCount;
             outputTokens = response.Usage?.OutputTokenCount;
 
-            var proposals = ParseProposals(text, _log.Info);
+            var parseResult = ParseProposals(text);
+            switch (parseResult.Outcome)
+            {
+                case ParseProposalsOutcome.NoJsonFound:
+                    _log.Info(
+                        "session_observer_parse_no_json rawLength={RawLength} candidateCount={CandidateCount} preview={Preview}",
+                        text.Length,
+                        parseResult.CandidateCount,
+                        parseResult.Preview);
+                    break;
+                case ParseProposalsOutcome.ParseFailed:
+                    _log.Info(
+                        "session_observer_parse_failed rawLength={RawLength} candidateCount={CandidateCount} preview={Preview}",
+                        text.Length,
+                        parseResult.CandidateCount,
+                        parseResult.Preview);
+                    break;
+            }
+            var proposals = parseResult.Proposals;
             var newAnchors = proposals
                 .Where(p => p.Anchor is not null)
                 .Select(p => p.Anchor!.CanonicalName)
@@ -394,59 +412,71 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     }
 
     /// <summary>
-    /// Parses memory proposals out of an LLM distillation response. The parser
-    /// is robust to common Qwen-style output shapes (preamble text with braces,
-    /// markdown code fences, multiple top-level JSON objects, trailing chatter)
-    /// rather than requiring perfectly-formatted output. When parsing fails,
-    /// the optional <paramref name="logSink"/> receives a structured drop-reason
-    /// event so the failure isn't silent. <c>logSink</c> takes a fully-formatted
-    /// string so this method has no Akka dependency and can be unit-tested
-    /// without an actor system.
+    /// Outcome of a <see cref="ParseProposals"/> call. Returned alongside the
+    /// proposal list so callers can emit structured log events (with named
+    /// placeholders) for the failure modes without the parser needing an
+    /// Akka <c>ILoggingAdapter</c> dependency.
     /// </summary>
-    internal static IReadOnlyList<MemoryProposal> ParseProposals(string text, Action<string>? logSink = null)
+    internal enum ParseProposalsOutcome
+    {
+        /// <summary>Input was null or whitespace; no LLM call was wasted.</summary>
+        EmptyInput,
+        /// <summary>Proposals were successfully extracted from the response.</summary>
+        Success,
+        /// <summary>
+        /// No JSON object could be located in the response at all
+        /// (e.g. refusal text, malformed output with no braces).
+        /// </summary>
+        NoJsonFound,
+        /// <summary>
+        /// One or more JSON object candidates were located but none deserialized
+        /// into a <c>DistillationResponse</c> with a non-null <c>Proposals</c>
+        /// array. Distinct from <see cref="NoJsonFound"/> because it points at
+        /// schema/format issues rather than the model not producing JSON at all.
+        /// </summary>
+        ParseFailed,
+    }
+
+    internal sealed record ParseProposalsResult(
+        IReadOnlyList<MemoryProposal> Proposals,
+        ParseProposalsOutcome Outcome,
+        int CandidateCount,
+        string? Preview);
+
+    internal static ParseProposalsResult ParseProposals(string text)
     {
         if (string.IsNullOrWhiteSpace(text))
-            return [];
+            return new ParseProposalsResult([], ParseProposalsOutcome.EmptyInput, 0, null);
 
         var stripped = StripMarkdownFences(text);
 
-        // Fast path: the response is already clean JSON.
         var direct = TryDeserialize(stripped);
         if (direct is not null)
-            return direct;
+            return new ParseProposalsResult(direct, ParseProposalsOutcome.Success, 0, null);
 
-        // Slow path: walk the response and find every balanced JSON object,
-        // returning the first one that deserializes into a DistillationResponse
-        // with a non-null Proposals array. Handles preamble text, multiple
-        // top-level objects, transcript echoes containing braces, and trailing
-        // chatter — none of which the previous first-`{` to last-`}` substring
-        // heuristic could parse.
         var candidates = ExtractJsonObjectCandidates(stripped);
         foreach (var candidate in candidates)
         {
             var parsed = TryDeserialize(candidate);
             if (parsed is not null)
-                return parsed;
+                return new ParseProposalsResult(parsed, ParseProposalsOutcome.Success, candidates.Count, null);
         }
 
-        // Surface the silent drop. PR #653 added drop-reason observability for
-        // the rules-extractor path; this is the same principle for the LLM
-        // distillation path. Without these events, a parser regression would
-        // burn LLM tokens and produce zero memories with no diagnostic trail.
-        if (logSink is not null)
-        {
-            var preview = Truncate(text.Trim(), 200);
-            var eventName = candidates.Count == 0
-                ? "session_observer_parse_no_json"
-                : "session_observer_parse_failed";
-            logSink($"{eventName} rawLength={text.Length} candidateCount={candidates.Count} preview={preview}");
-        }
-
-        return [];
+        var preview = Truncate(text.Trim(), 200);
+        var outcome = candidates.Count == 0
+            ? ParseProposalsOutcome.NoJsonFound
+            : ParseProposalsOutcome.ParseFailed;
+        return new ParseProposalsResult([], outcome, candidates.Count, preview);
     }
 
     internal static string StripMarkdownFences(string text)
     {
+        // Fast path: skip the trim allocation when the input clearly has no
+        // fence. Any leading whitespace is preserved unchanged because the
+        // caller (ParseProposals) re-checks via direct deserialization first.
+        if (text.Length == 0 || !ContainsFenceMarker(text))
+            return text;
+
         var trimmed = text.Trim();
         if (trimmed.Length < 7 || !trimmed.StartsWith("```", StringComparison.Ordinal))
             return text;
@@ -460,6 +490,18 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             return text;
 
         return trimmed[(openEnd + 1)..closingFence].Trim();
+    }
+
+    private static bool ContainsFenceMarker(string text)
+    {
+        // Scan once for any `` ` `` — far cheaper than a string-allocating
+        // .Trim() before we know whether a fence is even present.
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '`')
+                return true;
+        }
+        return false;
     }
 
     internal static IReadOnlyList<string> ExtractJsonObjectCandidates(string text)

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -462,7 +462,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
                 return new ParseProposalsResult(parsed, ParseProposalsOutcome.Success, candidates.Count, null);
         }
 
-        var preview = Truncate(text.Trim(), 200);
+        var preview = TextTruncation.EllipsisAppend(text.Trim(), 200);
         var outcome = candidates.Count == 0
             ? ParseProposalsOutcome.NoJsonFound
             : ParseProposalsOutcome.ParseFailed;
@@ -586,7 +586,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         TextOutput text when !string.IsNullOrWhiteSpace(text.Text)
             => $"[assistant] {text.Text}",
         ToolCallOutput toolCall
-            => $"[tool] {toolCall.ToolName}({Truncate(toolCall.ArgumentsJson ?? "", 200)})",
+            => $"[tool] {toolCall.ToolName}({TextTruncation.EllipsisAppend(toolCall.ArgumentsJson ?? "", 200)})",
         TurnCompleted tc
             => $"[turn {tc.TurnNumber} {tc.Outcome.ToString().ToLowerInvariant()}]",
         CompactionOutput
@@ -742,9 +742,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         }),
         transcript
     });
-
-    private static string Truncate(string text, int maxLength) =>
-        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -363,7 +363,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             inputTokens = response.Usage?.InputTokenCount;
             outputTokens = response.Usage?.OutputTokenCount;
 
-            var proposals = ParseProposals(text);
+            var proposals = ParseProposals(text, _log.Info);
             var newAnchors = proposals
                 .Where(p => p.Anchor is not null)
                 .Select(p => p.Anchor!.CanonicalName)
@@ -393,25 +393,137 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         }
     }
 
-    private static IReadOnlyList<MemoryProposal> ParseProposals(string text)
+    /// <summary>
+    /// Parses memory proposals out of an LLM distillation response. The parser
+    /// is robust to common Qwen-style output shapes (preamble text with braces,
+    /// markdown code fences, multiple top-level JSON objects, trailing chatter)
+    /// rather than requiring perfectly-formatted output. When parsing fails,
+    /// the optional <paramref name="logSink"/> receives a structured drop-reason
+    /// event so the failure isn't silent. <c>logSink</c> takes a fully-formatted
+    /// string so this method has no Akka dependency and can be unit-tested
+    /// without an actor system.
+    /// </summary>
+    internal static IReadOnlyList<MemoryProposal> ParseProposals(string text, Action<string>? logSink = null)
     {
         if (string.IsNullOrWhiteSpace(text))
             return [];
 
-        var direct = TryDeserialize(text);
+        var stripped = StripMarkdownFences(text);
+
+        // Fast path: the response is already clean JSON.
+        var direct = TryDeserialize(stripped);
         if (direct is not null)
             return direct;
 
-        var jsonStart = text.IndexOf('{', StringComparison.Ordinal);
-        var jsonEnd = text.LastIndexOf('}');
-        if (jsonStart >= 0 && jsonEnd > jsonStart)
+        // Slow path: walk the response and find every balanced JSON object,
+        // returning the first one that deserializes into a DistillationResponse
+        // with a non-null Proposals array. Handles preamble text, multiple
+        // top-level objects, transcript echoes containing braces, and trailing
+        // chatter — none of which the previous first-`{` to last-`}` substring
+        // heuristic could parse.
+        var candidates = ExtractJsonObjectCandidates(stripped);
+        foreach (var candidate in candidates)
         {
-            var extracted = TryDeserialize(text[jsonStart..(jsonEnd + 1)]);
-            if (extracted is not null)
-                return extracted;
+            var parsed = TryDeserialize(candidate);
+            if (parsed is not null)
+                return parsed;
+        }
+
+        // Surface the silent drop. PR #653 added drop-reason observability for
+        // the rules-extractor path; this is the same principle for the LLM
+        // distillation path. Without these events, a parser regression would
+        // burn LLM tokens and produce zero memories with no diagnostic trail.
+        if (logSink is not null)
+        {
+            var preview = Truncate(text.Trim(), 200);
+            var eventName = candidates.Count == 0
+                ? "session_observer_parse_no_json"
+                : "session_observer_parse_failed";
+            logSink($"{eventName} rawLength={text.Length} candidateCount={candidates.Count} preview={preview}");
         }
 
         return [];
+    }
+
+    internal static string StripMarkdownFences(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.Length < 7 || !trimmed.StartsWith("```", StringComparison.Ordinal))
+            return text;
+
+        var openEnd = trimmed.IndexOf('\n', StringComparison.Ordinal);
+        if (openEnd < 0)
+            return text;
+
+        var closingFence = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+        if (closingFence <= openEnd)
+            return text;
+
+        return trimmed[(openEnd + 1)..closingFence].Trim();
+    }
+
+    internal static IReadOnlyList<string> ExtractJsonObjectCandidates(string text)
+    {
+        var candidates = new List<string>();
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] != '{')
+            {
+                i++;
+                continue;
+            }
+
+            var end = FindMatchingClose(text, i);
+            if (end < 0)
+                break;
+
+            candidates.Add(text[i..(end + 1)]);
+            i = end + 1;
+        }
+        return candidates;
+    }
+
+    private static int FindMatchingClose(string text, int openIndex)
+    {
+        var depth = 0;
+        var inString = false;
+        var escaped = false;
+        for (var i = openIndex; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+            if (inString)
+            {
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+                if (c == '"')
+                    inString = false;
+                continue;
+            }
+            switch (c)
+            {
+                case '"':
+                    inString = true;
+                    break;
+                case '{':
+                    depth++;
+                    break;
+                case '}':
+                    depth--;
+                    if (depth == 0)
+                        return i;
+                    break;
+            }
+        }
+        return -1;
     }
 
     private static IReadOnlyList<MemoryProposal>? TryDeserialize(string json)
@@ -450,7 +562,16 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         You are a session memory distillation sidecar.
         You receive a conversation transcript and a list of memories already
         proposed in this session (existingProposals).
-        Return JSON only: { "proposals": [ ... ] }
+
+        ## Output contract (strict)
+
+        Return ONLY a single JSON object matching the schema below.
+        Do NOT include any text before or after the JSON object.
+        Do NOT wrap the JSON in markdown code fences (no ```json, no ```).
+        Do NOT include explanations, reasoning, preamble, or commentary outside the JSON.
+        Your entire response must start with `{` and end with `}`.
+
+        Top-level shape: { "proposals": [ ... ] }
 
         Your job: curate the user's memory store based on this session.
 

--- a/src/Netclaw.Actors/Sessions/TextTruncation.cs
+++ b/src/Netclaw.Actors/Sessions/TextTruncation.cs
@@ -1,0 +1,20 @@
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Shared text-truncation helpers for session-side log previews and prompt
+/// snippets. <see cref="Netclaw.Actors.Skills.SkillScanner"/> has its own
+/// truncation that fits an ellipsis *within* the byte budget; this helper
+/// instead appends an ellipsis after the budget. The two semantics are
+/// intentionally distinct, which is why this helper is not a global utility.
+/// </summary>
+internal static class TextTruncation
+{
+    /// <summary>
+    /// Returns <paramref name="text"/> unchanged when it fits within
+    /// <paramref name="maxLength"/> characters; otherwise returns the first
+    /// <paramref name="maxLength"/> characters with an ellipsis appended
+    /// (so the result is at most <c>maxLength + 3</c> characters long).
+    /// </summary>
+    public static string EllipsisAppend(string text, int maxLength) =>
+        text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength), "...");
+}


### PR DESCRIPTION
## Summary

- Replaces the `SessionMemoryObserverActor` distillation parser's brittle `IndexOf('{')..LastIndexOf('}')` heuristic with a JSON-aware brace walker that handles preamble text, markdown code fences, multiple top-level objects, and trailing chatter — the failure shapes Qwen3.5-27B emits in production.
- Adds structured drop-reason logging for the two parser failure modes (`session_observer_parse_no_json` vs `session_observer_parse_failed`) so silent token-burn is no longer silent.
- Adds an end-to-end integration test that spins up a real `SQLiteMemoryStore` and `MemoryCurationActor` and asserts proposals actually become rows in `memory_documents` — the first test in the suite that closes the observer→storage gap.
- Adds Verify-based snapshot tests for the distillation system and user prompts so future prompt edits force human review on the diff.
- Tightens the system prompt to explicitly forbid preamble, postscript, and markdown wrapping.

## Why now

A recent investigation into Netclaw memory underproduction surfaced that `SessionMemoryObserverActor` was making real LLM distillation calls, the chain was healthy end-to-end (gate, curation actor, storage), and yet a sizable fraction of completed distillations were producing zero proposals. Empirical measurement against a single instance running Qwen3.5-27B over one day:

| Outcome | Count |
|---|---|
| Successful, 1-2 proposals each → wrote to store | 14 |
| Early-exit (no new content since last run) | 22 |
| **LLM completed, parser extracted zero proposals** | **17** |
| Sidecar timeout | 4 |
| Provider error | 3 |

The 17 zero-yield events all consumed real LLM tokens (172-807 output each, ~13K tokens total wasted in one day). The parser was failing on Qwen output shapes — preamble text containing braces, transcript echoes, markdown code fences — and the failures were silent because there was no log event for parse drops. Token-for-nothing.

The fix was guided by a deep investigation that ruled out several earlier hypotheses (the route is healthy; no proposals are being lost in transit; the gate accepts everything that reaches it; the chain works end-to-end). The remaining issue was the parser itself.

## Behavior changes

- **Parser:** the `ParseProposals` slow path is now JSON-aware brace walking instead of substring extraction. Direct deserialization of the cleaned response is still tried first as a fast path. No change to the public type contract — it still returns `IReadOnlyList<MemoryProposal>`.
- **Logging:** new structured events `session_observer_parse_no_json` and `session_observer_parse_failed` fire when the parser drops a response. Both include length, candidate count, and a 200-char preview. Routed through an `Action<string>` callback so the parser stays Akka-free for unit testing.
- **System prompt:** new "Output contract (strict)" section at the top forbidding preamble/postscript/markdown wrapping. The rest of the prompt is unchanged.
- **No changes** to `MemoryProposalGate`, `MemoryCurationActor`, `LlmSessionActor.HandleDistillationResult`, the SQLite store, or the existing checkpoint-queue path.

## Test coverage added

- 18 new parser unit tests in `SessionMemoryObserverActorTests` covering: clean JSON, preamble braces, markdown fence wrappers (both labeled and unlabeled), trailing chatter, multiple JSON objects, refusal text, truncated JSON, structured-event logging, and direct unit tests for `StripMarkdownFences` / `ExtractJsonObjectCandidates`.
- 3 new integration tests in `SessionMemoryObserverStorageIntegrationTests.cs` (new file) that spin up a real `SQLiteMemoryStore` and `MemoryCurationActor` and assert proposals land as `memory_documents` rows.
- 2 new Verify snapshot tests for the system and user prompt templates.

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean, 0 warnings
- [x] `dotnet test Netclaw.slnx` — 2362 tests pass (1033 Actors, +23 from this PR)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] Existing `SessionMemoryObserverActorTests` (13 tests) all still green
- [x] Verify baselines (`*.verified.txt`) committed alongside snapshot tests
- [x] `*.received.txt` added to `.gitignore`
- [x] `Verify.XunitV3` added via central package management (one new test-only NuGet dependency)