### PR TITLE
feat(mcp): fail-closed mcp add + server-default approvals + permissions TUI

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -4,7 +4,7 @@ description: "REQUIRED when the user asks about Netclaw capabilities, scheduling
 disable-model-invocation: true
 metadata:
   author: netclaw
-  version: "1.13.0"
+  version: "1.14.0"
 ---
 
 # Netclaw Operations
@@ -72,6 +72,67 @@ After discovery, matched tools become callable for the session.
 Sessions receive granted tool categories. `builtin` is always granted.
 Other categories (`web`, `file`, `shell`, `scheduling`) depend on ACL
 config. If a tool is missing, it may not be granted for this session.
+
+### Adding MCP servers (fail-closed by default)
+
+`netclaw mcp add` writes new MCP servers with **zero granted tools** and
+per-audience approval defaults so freshly added servers are never silently
+exposed:
+
+| Audience | Grants | Approval default |
+|----------|--------|------------------|
+| Personal | `[]` (empty list — all tools denied until the operator opts in) | `Approval` |
+| Team     | `[]` | `Approval` |
+| Public   | `[]` | `Deny` |
+
+After `mcp add`, the operator uses `netclaw mcp permissions` — an
+interactive TUI — to grant specific tools and adjust the per-tool or
+per-server approval mode. Bare `netclaw mcp tools` is a read-only CLI view
+of the same state; both commands surface a discoverability hint toward the
+TUI.
+
+Escape hatch: `netclaw mcp add --grant-all` keeps the legacy "null grants
+= all tools pass" behavior for CI. Even with `--grant-all`, the per-audience
+approval defaults (Personal/Team=Approval, Public=Deny) are still written —
+you cannot turn off the approval prompts at `mcp add` time.
+
+Inside the TUI (`netclaw mcp permissions`):
+
+- `Enter` toggles the highlighted tool's grant
+- `A` toggles all tools on/off for the current audience
+- `E` enables/disables the whole server for the current audience
+- `M` cycles the **server default** approval mode (`Auto → Approval → Deny → Auto`)
+- `P` cycles the **highlighted tool's explicit override** (`inherit → Auto → Approval → Deny → inherit`) — `inherit` removes any explicit override so the tool inherits the server default
+- `S` saves pending changes to `netclaw.json`
+- `←/→` cycles the selected audience
+
+Approval-mode resolution precedence (for MCP tools):
+
+1. Exact `ToolOverrides["{server}/{tool}"]` override
+2. `McpServerDefaults[{server}]` default
+3. Fail-closed fallback (Personal audience, shell/file-edit matcher family)
+4. Audience `DefaultMode`
+
+Newly discovered tools on an existing server automatically inherit the
+server default; you do not need to re-run `permissions` after the server
+learns a new tool.
+
+### Migrating existing MCP servers
+
+Servers added to `netclaw.json` before this behavior shipped stay untouched —
+their tool grants, `ApprovalPolicy.McpServerDefaults`, and `ToolOverrides`
+entries are not rewritten during an upgrade.
+
+`netclaw doctor` will emit a warning for each enabled MCP server that
+Personal can reach (`McpServersMode = All`) but has no
+`ApprovalPolicy.McpServerDefaults[server]` entry and no `notion/*`-style
+`ToolOverrides` entry. The warning points at `netclaw mcp permissions`.
+
+To resolve: run `netclaw mcp permissions`, pick the server, switch to the
+Personal audience, press `M` to set a server default (`Approval` is the
+safe choice), `S` to save, then restart the daemon. Repeat for each
+audience you want to tighten. `doctor` stops warning once the default is
+set.
 
 ## Approval Prompts
 

--- a/openspec/changes/mcp-server-approval-defaults/.openspec.yaml
+++ b/openspec/changes/mcp-server-approval-defaults/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/mcp-server-approval-defaults/design.md
+++ b/openspec/changes/mcp-server-approval-defaults/design.md
@@ -1,0 +1,305 @@
+## Context
+
+Three interlocking gaps caused a real regression when Aaron added Notion via
+`netclaw mcp add`: all tools were immediately available to Personal, no
+approval prompts fired, and the `McpToolPermissionsPage` TUI had no way to
+touch approval modes. The prior `mcp-audience-tool-grants` change
+deliberately adopted the "null grants = pass" invariant as
+backward-compatible opt-in tightening, but for brand-new servers there is
+nothing to be backward-compatible with — the default is silent exposure.
+
+Current enforcement lives in two places that must agree:
+
+- **Config accessor**: `ToolApprovalConfig.GetEffectiveMode` in
+  `src/Netclaw.Configuration/ToolApprovalConfig.cs` returns the mode for a
+  tool name via a two-step lookup (`ToolOverrides` exact → `DefaultMode`).
+- **Runtime gate**: `ToolAccessPolicy.ResolveApprovalMode` in
+  `src/Netclaw.Actors/Tools/ToolAccessPolicy.cs` (lines 189-213) reproduces
+  the same lookup but also consults `IToolApprovalMatcher.GetApprovalModeKey`
+  for argument-aware overrides and `IToolApprovalMatcher.IsFailClosedOnPersonal`
+  for the Personal-audience fail-closed escape.
+
+MCP tool names are `{serverName}/{toolName}` — slash-separated — per
+`src/Netclaw.Actors/Tools/McpToolAdapter.cs:32`. The stale comment at
+`ToolApprovalConfig.cs:30-31` says `mcp:server:tool`; it is wrong and must
+be fixed.
+
+The editable TUI at `netclaw mcp tools` (bare) routes through
+`src/Netclaw.Cli/Program.cs:617` to `/mcp-tools`, rendering
+`McpToolPermissionsPage` with `McpToolPermissionsViewModel`. `Save()` at
+lines 290-358 already uses `ConfigFileHelper.GetOrCreateSection` /
+`WriteConfigFile`; the same helper fits the approval-default writes
+cleanly.
+
+Stakeholders: operators who add MCP servers; the daemon at
+`McpClientManager.ConnectAsync`; the Slack approval UI in
+`SlackApprovalBlockBuilder` / `SessionToolExecutionPipeline`; doctor users
+running `netclaw doctor` as a posture check.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give MCP servers a first-class per-audience approval default so newly
+  discovered tools inherit a sensible mode without per-tool enumeration.
+- Make `netclaw mcp add` fail-closed by default: empty grants plus
+  per-audience `McpServerDefaults` entries (Personal=Approval,
+  Team=Approval, Public=Deny) with a `--grant-all` CI escape hatch.
+- Give the TUI a single place to set the server default and per-tool
+  overrides, with an obvious discoverability path via `netclaw mcp
+  permissions` and a post-add hint.
+- Keep the two approval-resolution code paths (`GetEffectiveMode` and
+  `ResolveApprovalMode`) bit-for-bit consistent.
+- Preserve backward compatibility: existing configs with null grants and
+  no `McpServerDefaults` entries SHALL continue to resolve exactly as they
+  do today.
+
+**Non-Goals:**
+
+- Flipping global `DefaultMode` to `Approval` for MCP tools. That would
+  break every user who restarts the daemon after upgrading.
+- Auto-migrating existing `netclaw.json` entries. Pre-existing null-grants
+  configurations stay null; the doctor warning surfaces posture, operators
+  opt in manually via the TUI.
+- Changing the `McpServersMode = All` default for Personal or the "null
+  grants = pass" invariant encoded at
+  `ToolAudienceProfileResolver.cs:161-167`.
+- Wildcard keys in `ToolOverrides` (`notion/*`). We chose explicit
+  `McpServerDefaults` dict over wildcard overloading.
+- Per-MCP-server approval default on `McpServerEntry`. Approval is
+  per-audience; splitting it between `McpServers` and
+  `Tools.AudienceProfiles` creates two sources of truth.
+- Hot-reload of approval config. `ConfigWatcherService` already excludes
+  `tool-approvals.json`; the new fields live in `netclaw.json` and inherit
+  its existing reload semantics (daemon restart).
+
+## Decisions
+
+### 1. Explicit `McpServerDefaults` dict, not wildcard keys in `ToolOverrides`
+
+**Decision:** Add a new `Dictionary<string, ToolApprovalMode>
+McpServerDefaults` field to `ToolApprovalConfig`. Keys are MCP server
+names (`notion`, not `notion/*`).
+
+**Rationale:** The dict form is explicit in the schema and in `netclaw.json`
+— operators can see "what is the server default" as a distinct concept from
+"what is a per-tool override". Wildcard keys in `ToolOverrides` would
+require every reader of the dictionary to be aware of the convention, and
+we would have to special-case wildcard matching in both the config
+accessor and the runtime gate. Having a separate field localizes the
+concept and keeps `ToolOverrides` purely tool-keyed.
+
+**Alternatives considered:**
+
+- **Wildcard keys** (`notion/*` in `ToolOverrides`): rejected. Implicit
+  convention encoded in key shape is harder to reason about and would
+  require parsing logic in both `GetEffectiveMode` and
+  `ResolveApprovalMode`.
+- **Server default on `McpServerEntry`**: rejected. Approval is per-audience;
+  splitting the field between two config sections creates two sources of
+  truth. It also prevents giving Public a different default than Personal.
+
+### 2. Three-step lookup precedence (exact → server default → global default)
+
+**Decision:** Both `ToolApprovalConfig.GetEffectiveMode` and
+`ToolAccessPolicy.ResolveApprovalMode` SHALL consult overrides in a fixed
+order: exact `ToolOverrides[toolName]` → `McpServerDefaults[serverName]` (if
+`toolName` contains `/`) → matcher fail-closed-on-Personal → audience
+`DefaultMode`. The MCP server-default step slots in between the exact key
+check and the fail-closed matcher branch so that:
+
+- A deliberate per-tool override always wins.
+- Unconfigured MCP tools on a server with a default inherit the default
+  before the matcher even sees them.
+- Tools on a server without a default still fall through to the existing
+  fail-closed-on-Personal safety net.
+
+**Rationale:** The ordering preserves every existing precedence guarantee
+in `tool-approval-gates` and only adds one new step. `GetEffectiveMode`
+becomes the single source of truth: `ResolveApprovalMode` delegates the
+no-matcher case to it, and only diverges when an `IToolApprovalMatcher`
+provides an argument-aware key (e.g. `file_write:control-plane`) which is
+unrelated to MCP tools.
+
+**Alternatives considered:**
+
+- **Server default above exact override**: rejected. Breaks the existing
+  guarantee that operators can override specific tools to escape a broad
+  policy.
+- **Server default below fail-closed-on-Personal**: rejected. For an MCP
+  server with an explicit default on Personal, the fail-closed fallback
+  would never fire — which is fine — but the precedence becomes harder to
+  reason about if the two interact. Server default first keeps the
+  hierarchy flat.
+
+### 3. Fail-closed `mcp add` writes empty grants AND server defaults
+
+**Decision:** `netclaw mcp add` writes both `McpServerToolGrants[name] = []`
+(across all three audiences) and `McpServerDefaults[name]` per audience
+(Personal=Approval, Team=Approval, Public=Deny). The `--grant-all` escape
+hatch skips the grant writes but still writes the approval defaults.
+
+**Rationale:** The two writes cover two orthogonal concerns. Empty grants
+close the tool-exposure gap at the `ToolAudienceProfileResolver` layer
+(which runs before approval). Server defaults close the approval gap
+(which runs after grants succeed). Writing both means that even if an
+operator runs `--grant-all` for a CI scenario, the approval plumbing is
+still primed for interactive sessions. Writing only one of them leaves a
+half-secure posture that depends on which audience the session runs in.
+
+The per-audience approval-default choice reflects approver authority:
+Personal operators can approve themselves; Team members have authority
+within the team context; Public users do not have authority to grant
+trust and therefore get `Deny` as belt-and-suspenders even if the operator
+later adds the server to Public's `AllowedMcpServers`.
+
+**Alternatives considered:**
+
+- **Interactive prompt at add time**: rejected. Breaks CI/automation and
+  relies on tool names being known before the daemon has connected to the
+  server.
+- **Default to `Approval` globally with flag to disable**: rejected. A
+  global flip breaks existing non-MCP users on daemon restart; per-server
+  entries localize the blast radius.
+
+### 4. TUI surface: server-default row + per-tool override column
+
+**Decision:** Extend `McpToolPermissionsPage.BuildToolGrid` to render a new
+`[M] Server default: [Approval]` row under the existing "Server enabled"
+line and a new per-tool `[mode] (def|override)` column on each tool row.
+Add two keybindings — `M` cycles the server default, `P` cycles the
+highlighted tool's explicit override (with an `inherit` sentinel that
+removes the entry on save).
+
+**Rationale:** The user explicitly chose per-tool column over server-level
+only. The server-default row provides the "most common" lever (one
+keystroke changes all inherited tools), while the per-tool column provides
+escape-hatch visibility (which tools are overriding, which inherit). The
+two keybindings are orthogonal: `M` affects state shared across every
+inherited row, `P` affects only the highlighted row.
+
+`inherit` as a fourth cycle state for `P` is the only clean way to remove
+an existing override without introducing a modal "delete override?" prompt.
+It renders as `(def)` and forces the view to re-resolve the effective mode
+via `GetEffectiveMode`, keeping render logic declarative.
+
+**Alternatives considered:**
+
+- **Server default only, no per-tool column**: rejected. The user
+  explicitly wanted per-tool visibility.
+- **Separate sub-screen for approval modes**: rejected. Two surfaces for
+  related state doubles the cognitive load and splits the save path.
+
+### 5. `ResolveApprovalMode` delegates to `GetEffectiveMode` when there is
+no argument-aware matcher
+
+**Decision:** `ToolAccessPolicy.ResolveApprovalMode` calls
+`ToolApprovalConfig.GetEffectiveMode(toolName)` directly for the common
+case (non-matcher, non-argument), keeping the two code paths identical by
+construction. The matcher branch (control-plane file paths, shell verb
+chains) remains untouched and continues to use its own key form.
+
+**Rationale:** Keeping the two resolvers in sync is a maintenance burden
+and a latent bug. Delegating is free — `GetEffectiveMode` already has the
+three-step lookup, and the runtime path was mirroring it anyway. The only
+reason the runtime path was separate in the first place is that it needs
+to consult the matcher's custom key before falling back to the base tool
+key. We preserve that behavior: exact matcher key → exact tool key →
+`GetEffectiveMode(toolName)` → fail-closed-on-Personal → `DefaultMode`.
+
+**Alternatives considered:**
+
+- **Duplicate the three-step lookup inline in `ResolveApprovalMode`**:
+  rejected. Future changes to precedence would require editing two files
+  in sync and introduce drift risk.
+
+### 6. Doctor check is warning-only, no `--fix`
+
+**Decision:** `ToolAudienceProfilesDoctorCheck` gains a new warning-severity
+check for Personal audience servers lacking a `McpServerDefaults` entry.
+No `--fix` auto-remediation. Existing null-grants advisory stays at
+advisory severity.
+
+**Rationale:** Writing approval defaults on behalf of the operator could
+silently flip their workflow from auto-run to approval-prompts on next
+daemon restart. That is exactly the kind of invisible posture change the
+"no silent fallbacks" rule in `CLAUDE.md` prohibits. The warning surfaces
+the posture without touching config; the operator opts in via the TUI.
+
+**Alternatives considered:**
+
+- **Error severity**: rejected. Would break `netclaw doctor` CI pipelines
+  on first upgrade.
+- **`--fix` auto-writes defaults**: rejected per the above.
+- **Stay at advisory**: rejected. Advisory didn't catch the Notion
+  regression; the severity elevation is the whole point.
+
+## Risks / Trade-offs
+
+- **Three consumers of the same precedence**. `GetEffectiveMode`,
+  `ResolveApprovalMode`, and the TUI's `GetEffectiveMode` helper all encode
+  the same order. Mitigation: the TUI helper delegates to the config
+  accessor; `ResolveApprovalMode` delegates to it for the no-matcher case;
+  unit tests assert both callers agree for the same input. If we ever
+  fork the precedence, we do it in one place.
+- **Null-grant invariant is load-bearing**. Existing users rely on `null =
+  all pass`. The new `mcp add` flow writes empty lists for new servers
+  only; pre-existing null entries remain null. The
+  `EmptyGrantList_NoToolsExposed` test at
+  `src/Netclaw.Actors.Tests/Tools/McpToolAudienceGrantsTests.cs:32`
+  pins the empty-list semantic.
+- **Aaron's existing Notion server** is already in `netclaw.json` with
+  null grants and no server defaults. The new `mcp add` path does not
+  retroactively mutate it — the doctor warning is the migration signal,
+  and the fix is `netclaw mcp permissions` → cycle server default → save
+  → restart.
+- **TUI keybinding collision**. `P` is unused today at
+  `McpToolPermissionsPage.cs:211-272`, but we must double-check that no
+  shared Termina key handler (e.g. for quitting) intercepts it. Fallback
+  is `Shift+M` or `Ctrl+P`.
+- **Schema additive-only**. The new `McpServerDefaults` property must be
+  added to `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json`
+  in the same PR (CLAUDE.md Configuration Schema Sync Rule). Include
+  `"default": {}` so existing configs continue to validate.
+- **Doctor warning false negatives**. If an operator uses `McpServersMode
+  = Allowlist` for Personal with an explicit `AllowedMcpServers` entry but
+  no approval default, the warning still fires. That is intentional: the
+  server is reachable for Personal and therefore needs a default.
+- **Public `Deny` as belt-and-suspenders** is potentially surprising if
+  an operator later tries to add the server to Public's allowlist — they
+  will see denials until they change the default. Document in the
+  `netclaw-operations` skill update and surface the situation in doctor
+  output.
+
+## Migration Plan
+
+1. Ship the schema, config model, policy, CLI, TUI, and doctor changes
+   together.
+2. On first daemon start after upgrade, existing `netclaw.json` files
+   continue to validate (new field is optional with `"default": {}`).
+3. Pre-existing MCP servers with null grants continue to work unchanged.
+4. `netclaw doctor` emits the new warning for Personal-audience servers
+   without an approval default — this is the operator's signal to run
+   `netclaw mcp permissions`.
+5. New `netclaw mcp add` invocations are fail-closed by default; operators
+   who need the legacy behavior for CI pass `--grant-all`.
+6. No data migration, no config rewrite, no daemon-level one-time upgrade
+   step.
+7. **Rollback**: reverting the package restores the old `mcp add` behavior
+   and the two-step approval resolution. New `McpServerDefaults` entries
+   persisted to `netclaw.json` become unknown fields; `additionalProperties:
+   false` in the schema would reject them, but the old binary no longer
+   runs schema validation against this path, so rollback remains safe for
+   the runtime even if the schema check complains. Operators who rolled
+   forward and want to roll back should remove `McpServerDefaults` keys
+   manually from `netclaw.json` before launching the older binary.
+
+## Open Questions
+
+- **None.** All design decisions in this document were validated with the
+  primary stakeholder before writing. The approved plan at
+  `/home/petabridge/.claude/plans/virtual-brewing-quasar.md` locked in the
+  four decisions above (config shape, fail-closed mcp add, TUI layout,
+  doctor severity). Remaining open items are implementation details
+  captured in `tasks.md` (e.g. final column alignment for the `(def)` /
+  `(override)` suffix).

--- a/openspec/changes/mcp-server-approval-defaults/proposal.md
+++ b/openspec/changes/mcp-server-approval-defaults/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+Three interlocking MCP permissioning gaps break Netclaw's default-deny posture in
+practice: `netclaw mcp add` silently exposes every tool on a new MCP server to
+Personal audience (because `McpServersMode = All` combined with null
+`McpServerToolGrants` means "all pass" at
+`src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs:159-168`); MCP tools
+never fire approval prompts because the approval system has no concept of a
+per-server default — only exact-key `ToolOverrides[notion/create-pages]` entries,
+and any tool discovered later falls through to `DefaultMode = Auto`; and the
+editable `McpToolPermissionsPage` TUI cannot touch approval modes at all, while
+`netclaw mcp tools <server>` is a read-only CLI table that operators mistake for
+"the TUI". Relates to PRD-002 (security posture), the prior
+`mcp-audience-tool-grants` change, and the `tool-approval-gates` spec.
+
+## What Changes
+
+- Add `McpServerDefaults: Dictionary<string, ToolApprovalMode>` field to
+  `ToolApprovalConfig` in `src/Netclaw.Configuration/ToolApprovalConfig.cs`.
+  Applies to all tools exposed by an MCP server unless overridden by an exact
+  entry in `ToolOverrides`.
+- Extend `ToolApprovalConfig.GetEffectiveMode` and
+  `ToolAccessPolicy.ResolveApprovalMode` with a three-step lookup precedence:
+  exact `ToolOverrides[{server}/{tool}]` → `McpServerDefaults[{server}]` →
+  global `DefaultMode`. Newly discovered MCP tools inherit the server default
+  automatically.
+- Add `McpServerDefaults` to the `ToolApprovalConfig` definition in
+  `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` with
+  `"default": {}` so existing configs keep validating.
+- Fix the stale `"mcp:server:tool"` comment in `ToolApprovalConfig.cs:30-31` —
+  the actual exact-key format is `{server}/{tool}` (see `McpToolAdapter.cs:32`).
+- Make `netclaw mcp add` fail-closed: after writing the `McpServers` entry,
+  write `McpServerToolGrants[name] = []` for all three audience profiles and
+  write `McpServerDefaults[name]` as `Approval` for Personal, `Approval` for
+  Team, and `Deny` for Public. Add a `--grant-all` flag as a CI escape hatch
+  that keeps the server-default writes but skips the grant writes (leaving
+  grants null so legacy "all pass" applies). Emit a loud post-add hint
+  pointing to `netclaw mcp permissions`.
+- Extend `McpToolPermissionsPage` with a per-tool approval column and a
+  server-default row. New keybindings: `M` cycles the server default
+  (`Auto → Approval → Deny → Auto`), `P` cycles the highlighted tool's
+  explicit override (`inherit → Auto → Approval → Deny → inherit`). Rendering
+  shows `[Approval]` / `[Auto]` / `[Deny]` with `(def)` or `(override)` suffix.
+- Extend `McpToolPermissionsViewModel` to track
+  `_pendingServerDefaults` and `_pendingToolOverrides` (with a null sentinel
+  for `inherit`); add `GetEffectiveMode`, `CycleServerDefault`,
+  `CycleToolOverride`; extend `Save()` to write
+  `ApprovalPolicy.McpServerDefaults` and `ApprovalPolicy.ToolOverrides`
+  alongside existing `McpServerToolGrants` writes.
+- Add `netclaw mcp permissions` subcommand alias that routes to the same
+  Termina host as bare `netclaw mcp tools`. Append an `"Edit interactively:
+  netclaw mcp permissions"` hint to `RunToolsList` output. Update help text.
+- Extend `ToolAudienceProfilesDoctorCheck` with a new warning-level check: for
+  each enabled MCP server, if Personal audience has `McpServersMode = All`
+  AND no `ApprovalPolicy.McpServerDefaults[server]` entry AND no matching
+  per-tool override, warn `"MCP server '{server}' has no approval default on
+  Personal. Tools invoke without prompting."` No `--fix` auto-remediation.
+- Bump `metadata.version` and update
+  `feeds/skills/.system/files/netclaw-operations/SKILL.md` with `netclaw mcp
+  permissions`, fail-closed `mcp add`, and the server-default model.
+
+None of these changes are breaking for existing configs: null `McpServerToolGrants`
+still means "all pass", absent `McpServerDefaults` still falls through to
+`DefaultMode`, and existing servers in `netclaw.json` are untouched.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ This change extends four existing capabilities.
+
+### Modified Capabilities
+
+- `tool-approval-gates`: add `McpServerDefaults` to `ToolApprovalConfig`;
+  extend approval-mode resolution with a three-step precedence (exact override
+  → server default → global default) in both `GetEffectiveMode` and the
+  runtime `ResolveApprovalMode` path.
+- `netclaw-mcp`: change `netclaw mcp add` to be fail-closed by writing empty
+  `McpServerToolGrants[name]` and per-audience `McpServerDefaults[name]` entries
+  (Personal=Approval, Team=Approval, Public=Deny). Add `--grant-all` escape
+  hatch. Add `netclaw mcp permissions` subcommand alias.
+- `netclaw-acl`: extend `ToolAudienceProfilesDoctorCheck` with a
+  warning-severity check for Personal audience servers lacking an approval
+  default. Existing null-grants advisory remains unchanged.
+- `netclaw-cli`: extend `McpToolPermissionsPage` TUI with a per-tool approval
+  column, a server-default row, and `M`/`P` keybindings. Append discoverability
+  hint to `RunToolsList` output. Update help text.
+
+## Impact
+
+- **Config schema:** additive — new `McpServerDefaults` property on
+  `ToolApprovalConfig`. `"default": {}` keeps existing configs validating.
+- **Enforcement path:** `ToolAccessPolicy.ResolveApprovalMode` gains one
+  dictionary lookup per MCP tool invocation. Negligible hot-path cost.
+- **Default behavior for new servers:** changes from "all tools auto-execute on
+  Personal" to "zero tools until explicitly granted; approval required on
+  Personal/Team, Deny on Public". Opt-out via `--grant-all` flag for CI.
+- **Default behavior for existing servers:** unchanged. Pre-existing
+  `netclaw.json` entries with null grants still "pass" at the tool gate; the
+  new doctor warning surfaces the posture but does not auto-remediate.
+- **Operator workflow:** `netclaw mcp permissions` becomes the one obvious
+  place to manage MCP tool grants and approval modes. TUI gains two new
+  keybindings; existing keys preserved.
+- **Security:** closes the silent-exposure regression observed when adding
+  Notion via `netclaw mcp add`. Satisfies PRD-002's default-deny requirement
+  for new MCP servers. Supply-chain detection via the existing tool-drift
+  warnings is unchanged.
+- **System skills:** `netclaw-operations` must update its `metadata.version`
+  and document the new command, per the `CLAUDE.md` system-skills sync rule.
+- **Tests:** new unit tests for `GetEffectiveMode` precedence,
+  `ResolveApprovalMode` precedence, `McpCommand.RunAdd` fail-closed writes,
+  TUI `CycleServerDefault` / `CycleToolOverride` / `Save` round-trip, and
+  doctor warning. Regression: existing `EmptyGrantList_NoToolsExposed` and
+  approval exact-key tests must still pass unchanged.
+- **No new runtime dependencies.** Slack approval plumbing, `DaemonApi`,
+  `ConfigFileHelper`, and Termina helpers are reused without modification.

--- a/openspec/changes/mcp-server-approval-defaults/specs/netclaw-acl/spec.md
+++ b/openspec/changes/mcp-server-approval-defaults/specs/netclaw-acl/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Tool and data grants
+
+The system SHALL enforce explicit grants for tool and data access. Grants SHALL
+be organized into specific tool grant categories: `shell`, `web_search`,
+`web_fetch`, `github`, `mcp:{server_name}`, `config_write`, and
+`schedule_write`. Each grant SHALL specify the allowed senders and channels to
+which it applies.
+
+For MCP tools, the system SHALL support an additional per-tool grant layer via
+`McpServerToolGrants` on each audience profile. When configured for a server,
+only explicitly listed tools SHALL pass the audience check. This per-tool
+check SHALL execute after the server-level `AllowedMcpServers` check.
+
+Each `ToolAudienceProfile` SHALL support an optional `ApprovalPolicy` of type
+`ToolApprovalConfig`. The `ApprovalPolicy` SHALL define a `DefaultMode` (Auto,
+Approval, Deny), per-tool overrides via `ToolOverrides`, and per-MCP-server
+defaults via `McpServerDefaults`. The approval check SHALL execute after the
+tool access grant check passes and SHALL resolve the effective mode via the
+precedence defined in `tool-approval-gates` (exact override → MCP server
+default → matcher fail-closed on Personal → `DefaultMode`). Tools in Approval
+mode SHALL consult the approval cache (session-scoped and persistent) before
+execution. Tools in Deny mode SHALL be blocked without an approval prompt.
+
+#### Scenario: Missing grant blocks tool call
+
+- **WHEN** a tool call is attempted without a matching grant
+- **THEN** execution is denied with a policy reason code
+
+#### Scenario: Category-specific grant allows tool
+
+- **GIVEN** ACL grants `web_search` for sender `U12345` on channel `C99999`
+- **WHEN** sender `U12345` requests a web search in channel `C99999`
+- **THEN** ACL evaluation returns allow for the `web_search` tool category
+
+#### Scenario: MCP server-scoped grant
+
+- **GIVEN** ACL grants `mcp:memorizer` for sender `U12345`
+- **WHEN** sender `U12345` requests an MCP tool from the `memorizer` server
+- **THEN** ACL evaluation returns allow
+- **AND** MCP tools from other servers without explicit grants are denied
+
+#### Scenario: MCP tool blocked by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/store`
+- **THEN** the invocation is denied with reason `mcp_tool_not_allowed_for_audience_profile`
+
+#### Scenario: MCP tool allowed by per-tool grant
+
+- **GIVEN** the session's audience allows `memorizer` server via `AllowedMcpServers`
+- **AND** `McpServerToolGrants` for this audience lists `["search_memories", "get"]`
+- **WHEN** the agent invokes `memorizer/search_memories`
+- **THEN** the invocation is allowed
+
+#### Scenario: Tool granted but requires approval
+
+- **GIVEN** the session has a grant for `shell_execute`
+- **AND** the Personal `ApprovalPolicy` sets `shell_execute` to Approval mode
+- **AND** the command pattern `git push` is not in the approval cache
+- **WHEN** the agent invokes `shell_execute` with `git push origin main`
+- **THEN** the grant check passes
+- **AND** the approval check returns `RequiresApproval`
+
+#### Scenario: Tool granted with approval already cached
+
+- **GIVEN** the session has a grant for `shell_execute`
+- **AND** `git push` is in the session or persistent approval cache
+- **WHEN** the agent invokes `shell_execute` with `git push origin main`
+- **THEN** both the grant check and approval check pass
+- **AND** the tool executes immediately
+
+#### Scenario: MCP tool approval mode inherited from server default
+
+- **GIVEN** Personal profile allows `notion` via `AllowedMcpServers` (or `McpServersMode = All`)
+- **AND** `Tools.AudienceProfiles.Personal.McpServerToolGrants.notion = ["create-pages"]`
+- **AND** `Tools.AudienceProfiles.Personal.ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **AND** no entry for `notion/create-pages` exists in `ToolOverrides`
+- **WHEN** the agent invokes `notion/create-pages`
+- **THEN** the grant check passes
+- **AND** the approval check resolves the effective mode to `Approval`
+- **AND** the call is approval-gated
+
+#### Scenario: MCP tool exact override beats server default at the grant gate
+
+- **GIVEN** `Tools.AudienceProfiles.Personal.ApprovalPolicy.McpServerDefaults.notion = Deny`
+- **AND** `Tools.AudienceProfiles.Personal.ApprovalPolicy.ToolOverrides["notion/search"] = Auto`
+- **AND** `Tools.AudienceProfiles.Personal.McpServerToolGrants.notion = ["search"]`
+- **WHEN** the agent invokes `notion/search`
+- **THEN** the grant check passes
+- **AND** the approval check resolves the effective mode to `Auto`
+- **AND** the call executes immediately
+
+#### Scenario: Config write grant required for self-configuration
+
+- **GIVEN** ACL does not grant `config_write` for the current sender
+- **WHEN** the agent attempts to write configuration files through conversation
+- **THEN** the write is denied with a policy reason code

--- a/openspec/changes/mcp-server-approval-defaults/specs/netclaw-cli/spec.md
+++ b/openspec/changes/mcp-server-approval-defaults/specs/netclaw-cli/spec.md
@@ -1,0 +1,230 @@
+## MODIFIED Requirements
+
+### Requirement: MCP tool permissions CLI
+
+The system SHALL provide a `netclaw mcp tools` subcommand for viewing and
+managing per-server tool grants across audience profiles. The system SHALL
+additionally provide a `netclaw mcp permissions` subcommand as the canonical
+alias that routes to the same interactive TUI host as bare `netclaw mcp
+tools`. The CLI read-only listing (`netclaw mcp tools <server>`) SHALL append
+a discoverability hint pointing operators to `netclaw mcp permissions` for
+interactive editing.
+
+The `netclaw mcp add` command SHALL be fail-closed by default: after
+successfully writing the `McpServers[name]` entry, it SHALL write empty
+`McpServerToolGrants[name] = []` entries and per-audience
+`ApprovalPolicy.McpServerDefaults[name]` entries (per `netclaw-mcp` →
+`Secure defaults for new MCP servers`) and print a post-add hint directing
+the operator to run `netclaw mcp permissions`. `netclaw mcp add` SHALL
+accept a `--grant-all` flag as a CI escape hatch that skips the grant
+writes but still writes the approval defaults.
+
+#### Scenario: List tools for a server
+
+- **GIVEN** the daemon is running and `memorizer` is connected
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI displays all discovered tools from `memorizer`
+- **AND** each tool shows its grant status per audience (Public, Team, Personal)
+- **AND** tools not granted to any audience are visually distinguished
+- **AND** the output ends with a hint: `Edit interactively: netclaw mcp permissions`
+
+#### Scenario: List tools when daemon is unavailable
+
+- **GIVEN** the daemon is not running
+- **WHEN** operator runs `netclaw mcp tools memorizer`
+- **THEN** the CLI reports that tool discovery requires the daemon
+- **AND** exits with a non-zero exit code
+
+#### Scenario: Snapshot current tools as grants
+
+- **GIVEN** the daemon is running and `memorizer` exposes 5 tools
+- **WHEN** operator runs `netclaw mcp tools memorizer --snapshot`
+- **THEN** the CLI populates `McpServerToolGrants` for all audience profiles that allow `memorizer`
+- **AND** each profile's grant list contains all 5 currently discovered tool names
+- **AND** the updated config is written to `netclaw.json`
+
+#### Scenario: Help for tools subcommand
+
+- **WHEN** operator runs `netclaw mcp tools --help`
+- **THEN** the CLI displays usage, subcommand description, and available flags
+- **AND** the help text references `netclaw mcp permissions` as the interactive editor
+
+#### Scenario: `permissions` subcommand launches the TUI
+
+- **GIVEN** the daemon is running with MCP servers connected
+- **WHEN** operator runs `netclaw mcp permissions`
+- **THEN** the TUI launches identically to `netclaw mcp tools` with no
+  server argument
+- **AND** the CLI reports no unrecognized-subcommand error
+
+#### Scenario: Fail-closed `mcp add` emits post-add hint
+
+- **WHEN** operator runs `netclaw mcp add --transport http notion https://mcp.notion.com/mcp`
+- **THEN** the CLI prints the confirmation line naming the server
+- **AND** the CLI prints a security note stating that 0 tools are granted
+- **AND** the CLI prints an instruction to run `netclaw mcp permissions`
+
+#### Scenario: `--grant-all` flag bypasses empty-grant writes
+
+- **WHEN** operator runs `netclaw mcp add --grant-all --transport stdio trusted -- /usr/local/bin/trusted`
+- **THEN** no `McpServerToolGrants.trusted` entry is written to `netclaw.json`
+- **AND** `ApprovalPolicy.McpServerDefaults.trusted` entries are still
+  written per audience (Personal=Approval, Team=Approval, Public=Deny)
+- **AND** the post-add hint omits the "0 tools granted" note and mentions
+  the legacy grant behavior
+
+### Requirement: MCP tool permissions TUI
+
+The system SHALL provide an interactive TUI mode for `netclaw mcp tools`
+(invoked without a server name argument) that allows operators to browse
+servers, view discovered tools, toggle per-tool grants per audience, edit
+the per-audience MCP server approval default, and set per-tool approval
+mode overrides. The `netclaw mcp permissions` subcommand SHALL route to
+the same TUI host as an alias.
+
+For each server/audience view, the TUI SHALL render a server-default row
+showing the current
+`ApprovalPolicy.McpServerDefaults[serverName]` value and a per-tool list
+where each tool row shows the effective approval mode and a suffix
+identifying whether the effective mode comes from inheritance (`(def)`)
+or from an explicit `ToolOverrides` entry (`(override)`).
+
+The TUI SHALL provide these keybindings for the per-audience server view:
+
+- `Enter` — toggle the grant for the highlighted tool (existing)
+- `A` — toggle all grants for the server (existing)
+- `E` — toggle server access for the audience (existing)
+- `←/→` — cycle the selected audience (existing)
+- `S` — save pending changes (existing)
+- `M` — cycle the server approval default through `Auto → Approval → Deny → Auto`
+- `P` — cycle the highlighted tool's explicit override through
+  `inherit → Auto → Approval → Deny → inherit` where `inherit` removes any
+  existing `ToolOverrides[{server}/{tool}]` entry on save
+
+`Save` SHALL persist `McpServerToolGrants`, `McpServerDefaults`, and
+`ToolOverrides` changes atomically via `ConfigFileHelper.WriteConfigFile`.
+Entries cycled back to `inherit` SHALL be removed from `ToolOverrides`
+rather than written as `"Auto"`.
+
+#### Scenario: Launch TUI without arguments
+
+- **GIVEN** the daemon is running with MCP servers connected
+- **WHEN** operator runs `netclaw mcp tools` (no server name)
+- **THEN** the TUI launches showing a list of configured MCP servers
+
+#### Scenario: Launch TUI via `permissions` alias
+
+- **GIVEN** the daemon is running with MCP servers connected
+- **WHEN** operator runs `netclaw mcp permissions`
+- **THEN** the TUI launches showing the same server list as bare
+  `netclaw mcp tools`
+
+#### Scenario: Browse tools for a server
+
+- **GIVEN** the TUI is showing the server list
+- **WHEN** operator selects a server
+- **THEN** the TUI shows all discovered tools for that server
+- **AND** each tool shows its current grant status for the selected audience
+- **AND** the top of the view shows a `Server default:` row
+
+#### Scenario: Cycle audience in TUI
+
+- **GIVEN** the TUI is showing tools for a server
+- **WHEN** operator presses left/right arrow to cycle audience
+- **THEN** the tool grant checkboxes update to reflect the selected audience's grants
+- **AND** the server-default row updates to reflect that audience's
+  `McpServerDefaults` entry (or `Auto` if absent)
+- **AND** per-tool rows re-resolve their effective mode against the new audience
+
+#### Scenario: Toggle tool grant in TUI
+
+- **GIVEN** the TUI is showing tools for a server under the Team audience
+- **WHEN** operator toggles a tool's checkbox
+- **THEN** the tool is added to or removed from the Team profile's `McpServerToolGrants` for this server
+
+#### Scenario: Toggle server access in TUI
+
+- **GIVEN** the TUI is showing tools for a server not allowed for the Team audience
+- **WHEN** operator presses the enable/disable key
+- **THEN** the server is added to the Team profile's `AllowedMcpServers`
+- **AND** all tools start unchecked (secure by default)
+
+#### Scenario: Cycle server approval default
+
+- **GIVEN** the TUI shows Notion tools under the Personal audience with
+  `Server default: [Auto]`
+- **WHEN** operator presses `M`
+- **THEN** the server-default display advances to `[Approval]`
+- **AND** per-tool rows whose effective mode is inherited update to show
+  `[Approval] (def)`
+
+#### Scenario: Cycle per-tool override
+
+- **GIVEN** the TUI shows a Notion tool `notion/delete-page` with an
+  inherited effective mode of `[Approval] (def)`
+- **WHEN** operator highlights the tool and presses `P`
+- **THEN** the effective mode advances to `[Auto] (override)` on the first
+  press, then `[Approval] (override)`, then `[Deny] (override)`, then back
+  to the inherited `[Approval] (def)` on the fourth press
+
+#### Scenario: Save changes from TUI
+
+- **GIVEN** the operator has toggled tool grants, cycled a server default, and
+  cycled tool overrides in the TUI
+- **WHEN** operator presses the save key
+- **THEN** `McpServerToolGrants`, `ApprovalPolicy.McpServerDefaults`, and
+  `ApprovalPolicy.ToolOverrides` are written to `netclaw.json`
+- **AND** tool overrides cycled back to `inherit` are removed from
+  `ToolOverrides` rather than written as `"Auto"`
+- **AND** the TUI confirms the save and prompts the operator to restart
+  the daemon
+
+## ADDED Requirements
+
+### Requirement: MCP doctor warning for missing approval defaults
+
+The `netclaw doctor` command SHALL emit a warning-severity diagnostic for
+each enabled MCP server whose Personal audience profile has
+`McpServersMode = All` AND no entry in
+`Tools.AudienceProfiles.Personal.ApprovalPolicy.McpServerDefaults[serverName]`
+AND no `ToolOverrides` entries whose key starts with `{serverName}/`. The
+warning SHALL direct the operator to run `netclaw mcp permissions` to
+configure an approval default. The warning SHALL NOT auto-remediate the
+missing entry. The existing info-level null-grants advisory (`MCP doctor
+advisory for ungated servers`) SHALL remain unchanged and continue to fire
+independently.
+
+#### Scenario: Server missing Personal approval default triggers warning
+
+- **GIVEN** `notion` is enabled in `McpServers`
+- **AND** Personal profile has `McpServersMode = All`
+- **AND** Personal profile has no `ApprovalPolicy.McpServerDefaults.notion`
+- **AND** Personal profile has no `notion/*` entries in `ToolOverrides`
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** a warning-severity diagnostic is reported for `notion`
+- **AND** the message directs the operator to run `netclaw mcp permissions`
+
+#### Scenario: Server with server default passes warning
+
+- **GIVEN** `notion` is enabled in `McpServers`
+- **AND** Personal profile has
+  `ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** the missing-approval-default warning does NOT fire for `notion`
+
+#### Scenario: Server with per-tool overrides passes warning
+
+- **GIVEN** `notion` is enabled in `McpServers`
+- **AND** Personal profile has `McpServersMode = All`
+- **AND** Personal profile has no `McpServerDefaults` entry for `notion`
+- **AND** Personal profile has an explicit override
+  `ApprovalPolicy.ToolOverrides["notion/create-pages"] = Approval`
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** the missing-approval-default warning does NOT fire for `notion`
+
+#### Scenario: Warning does not change exit code alone
+
+- **GIVEN** the missing-approval-default warning is the only diagnostic
+- **WHEN** operator runs `netclaw doctor`
+- **THEN** the command exits with code `2` (warnings only)
+- **AND** does NOT exit with code `1` (errors)

--- a/openspec/changes/mcp-server-approval-defaults/specs/netclaw-mcp/spec.md
+++ b/openspec/changes/mcp-server-approval-defaults/specs/netclaw-mcp/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Secure defaults for new MCP servers
+
+The `netclaw mcp add` command SHALL configure new MCP servers with
+fail-closed defaults across all audience profiles. After writing the
+`McpServers[name]` entry, the command SHALL write an explicit empty
+`McpServerToolGrants[name] = []` entry to every audience profile under
+`Tools.AudienceProfiles` (Public, Team, Personal). This empty list SHALL
+cause the existing per-tool grant check at `ToolAudienceProfileResolver`
+to deny every tool from the server until the operator explicitly grants
+specific tools.
+
+The command SHALL also write `ApprovalPolicy.McpServerDefaults[name]`
+entries per audience with the following defaults:
+
+- Personal: `Approval` (operator prompts themselves)
+- Team: `Approval` (trusted members can approve in team context)
+- Public: `Deny` (public users cannot grant trust)
+
+The `ApprovalPolicy` section SHALL be created if missing, reusing the
+existing `ConfigFileHelper.GetOrCreateSection` pattern. The command SHALL
+print a post-add hint identifying that zero tools are currently granted
+and directing the operator to `netclaw mcp permissions` to review.
+
+The command SHALL accept a `--grant-all` flag as a CI/automation escape
+hatch. When passed, the command SHALL skip writing `McpServerToolGrants`
+entries (leaving `McpServerToolGrants[name]` absent, which preserves the
+legacy "null grants = all pass" behavior for the new server). The
+`McpServerDefaults` writes SHALL still occur even with `--grant-all` so
+that new servers always have an explicit approval default, regardless of
+grant configuration.
+
+The command SHALL NOT retroactively modify existing `McpServers` entries
+or their corresponding audience-profile state. Only the newly added
+server's name SHALL be touched.
+
+#### Scenario: Fail-closed writes for new server
+
+- **GIVEN** a fresh `netclaw.json` with default audience profiles
+- **WHEN** operator runs `netclaw mcp add --transport http notion https://mcp.notion.com/mcp`
+- **THEN** `Tools.AudienceProfiles.Public.McpServerToolGrants.notion` is `[]`
+- **AND** `Tools.AudienceProfiles.Team.McpServerToolGrants.notion` is `[]`
+- **AND** `Tools.AudienceProfiles.Personal.McpServerToolGrants.notion` is `[]`
+- **AND** `Tools.AudienceProfiles.Personal.ApprovalPolicy.McpServerDefaults.notion` is `Approval`
+- **AND** `Tools.AudienceProfiles.Team.ApprovalPolicy.McpServerDefaults.notion` is `Approval`
+- **AND** `Tools.AudienceProfiles.Public.ApprovalPolicy.McpServerDefaults.notion` is `Deny`
+- **AND** the CLI output includes a hint pointing to `netclaw mcp permissions`
+
+#### Scenario: `--grant-all` preserves approval defaults but skips grants
+
+- **GIVEN** a fresh `netclaw.json` with default audience profiles
+- **WHEN** operator runs `netclaw mcp add --grant-all --transport stdio trusted-server -- /usr/local/bin/trusted`
+- **THEN** no `McpServerToolGrants.trusted-server` entry is written
+- **AND** `Tools.AudienceProfiles.Personal.ApprovalPolicy.McpServerDefaults.trusted-server` is `Approval`
+- **AND** `Tools.AudienceProfiles.Public.ApprovalPolicy.McpServerDefaults.trusted-server` is `Deny`
+
+#### Scenario: Pre-existing servers are not mutated
+
+- **GIVEN** a `netclaw.json` that already contains an MCP server `old-server`
+  with `McpServerToolGrants = null` and no `McpServerDefaults` entry
+- **WHEN** operator runs `netclaw mcp add --transport http new-server https://new.example/mcp`
+- **THEN** no `McpServerToolGrants` or `McpServerDefaults` entries are
+  written for `old-server`
+- **AND** only `new-server` receives the fail-closed defaults
+
+#### Scenario: Missing `ApprovalPolicy` section is created
+
+- **GIVEN** a `netclaw.json` whose audience profiles do not yet include
+  `ApprovalPolicy` sections
+- **WHEN** operator runs `netclaw mcp add new-server …`
+- **THEN** each affected audience profile receives an `ApprovalPolicy`
+  section with the appropriate `McpServerDefaults[new-server]` entry
+- **AND** no existing keys in `ApprovalPolicy` (if present) are removed
+
+#### Scenario: Personal `McpServersMode = All` does not bypass empty grants
+
+- **GIVEN** Personal profile has `McpServersMode = All`
+- **WHEN** operator runs `netclaw mcp add notion …` (without `--grant-all`)
+- **AND** the daemon connects to the new Notion server after restart
+- **THEN** Personal-audience tool resolution blocks every Notion tool with
+  `mcp_tool_not_allowed_for_audience_profile` until explicit grants are added
+- **AND** the server-level check still passes, but the empty grant list
+  short-circuits the per-tool check

--- a/openspec/changes/mcp-server-approval-defaults/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/mcp-server-approval-defaults/specs/tool-approval-gates/spec.md
@@ -1,0 +1,144 @@
+## MODIFIED Requirements
+
+### Requirement: Tool approval configuration per audience
+
+The system SHALL support per-audience tool approval configuration via
+`ToolApprovalConfig` on `ToolAudienceProfile`. Each audience profile SHALL
+independently specify a `DefaultMode` (Auto, Approval, Deny), per-tool
+overrides in `ToolOverrides`, and per-MCP-server defaults in
+`McpServerDefaults`.
+
+Approval mode resolution SHALL use deterministic precedence:
+
+1. Matcher-derived approval-mode key override (for example
+   `file_write:control-plane`)
+2. Base tool key override (for example `file_write` or `notion/create-pages`)
+3. MCP server default from `McpServerDefaults[serverName]` when the tool
+   name is `{serverName}/{toolName}` (MCP-namespaced tool)
+4. Matcher fail-closed behavior for Personal audience
+5. Audience `DefaultMode`
+
+Both `ToolApprovalConfig.GetEffectiveMode` and
+`ToolAccessPolicy.ResolveApprovalMode` SHALL implement this precedence
+consistently. Runtime audience defaults SHALL NOT implicitly place
+`shell_execute` in `Approval` mode. Instead, the init-generated Personal
+config SHALL explicitly write
+`ApprovalPolicy.ToolOverrides.shell_execute = Approval` as the recommended
+shell-safe default.
+
+#### Scenario: Shell requires approval in init-generated Personal config
+
+- **GIVEN** a Personal audience session whose generated config explicitly sets
+  `ApprovalPolicy.ToolOverrides.shell_execute` to `Approval`
+- **WHEN** the agent invokes `shell_execute`
+- **THEN** the system checks the approval cache before execution
+- **AND** if the command pattern is not approved, an approval prompt is emitted
+
+#### Scenario: Tool in Auto mode executes without approval
+
+- **GIVEN** a tool whose approval mode is `Auto` for the session's audience
+- **WHEN** the agent invokes the tool
+- **THEN** the tool executes immediately without an approval prompt
+
+#### Scenario: Tool in Deny mode is always blocked
+
+- **GIVEN** a tool whose approval mode is `Deny` for the session's audience
+- **WHEN** the agent invokes the tool
+- **THEN** the tool is denied with reason `tool_denied_by_approval_policy`
+- **AND** no approval prompt is offered
+
+#### Scenario: Per-audience independence
+
+- **GIVEN** Personal sets `shell_execute` to `Approval` and Team sets it to `Deny`
+- **WHEN** a Personal session invokes `shell_execute`
+- **THEN** the system checks approval cache and may prompt
+- **AND** when a Team session invokes `shell_execute`
+- **THEN** the system denies immediately without prompting
+
+#### Scenario: Matcher-specific override key takes precedence over base tool key
+
+- **GIVEN** `ApprovalPolicy.ToolOverrides.file_write = Auto`
+- **AND** `ApprovalPolicy.ToolOverrides.file_write:control-plane = Approval`
+- **WHEN** the agent invokes `file_write` targeting a control-plane path
+- **THEN** the resolved mode is `Approval`
+- **AND** the call is approval-gated unless already approved for that path pattern
+
+#### Scenario: Base tool key applies when matcher-specific key is absent
+
+- **GIVEN** `ApprovalPolicy.ToolOverrides.file_write = Approval`
+- **AND** no override exists for `file_write:control-plane`
+- **WHEN** the agent invokes `file_write` targeting a control-plane path
+- **THEN** the resolved mode is `Approval`
+- **AND** mode resolution does NOT fall directly to `DefaultMode`
+
+#### Scenario: Exact MCP tool override beats server default
+
+- **GIVEN** `ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **AND** `ApprovalPolicy.ToolOverrides["notion/search"] = Auto`
+- **WHEN** the agent invokes `notion/search`
+- **THEN** the resolved mode is `Auto`
+- **AND** the call executes immediately without an approval prompt
+
+#### Scenario: MCP server default applies when no exact override exists
+
+- **GIVEN** `ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **AND** no entry for `notion/create-pages` exists in `ToolOverrides`
+- **WHEN** the agent invokes `notion/create-pages`
+- **THEN** the resolved mode is `Approval`
+- **AND** the call is approval-gated
+
+#### Scenario: MCP server default does not leak to non-MCP tools
+
+- **GIVEN** `ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **AND** `ApprovalPolicy.DefaultMode = Auto`
+- **WHEN** the agent invokes `shell_execute`
+- **THEN** the resolved mode is `Auto`
+- **AND** the MCP server default is not consulted for names without a `/` segment
+
+#### Scenario: `GetEffectiveMode` and `ResolveApprovalMode` agree on precedence
+
+- **GIVEN** a `ToolApprovalConfig` with both `McpServerDefaults` and
+  `ToolOverrides` entries
+- **WHEN** the same tool name is resolved through
+  `ToolApprovalConfig.GetEffectiveMode` and through
+  `ToolAccessPolicy.ResolveApprovalMode` with a default matcher
+- **THEN** both paths return the same `ToolApprovalMode`
+
+## ADDED Requirements
+
+### Requirement: MCP server approval default inheritance
+
+The system SHALL apply a per-audience `McpServerDefaults[serverName]` entry
+to all tools exposed by that MCP server unless an exact entry in
+`ToolOverrides` takes precedence. New tools discovered on the server at
+later daemon startups SHALL automatically inherit the server default
+without requiring per-tool enumeration in the config. Absence of
+`McpServerDefaults[serverName]` SHALL NOT fail-close the tool — the
+approval-mode resolution SHALL fall through to the fail-closed-on-Personal
+matcher decision and the audience `DefaultMode` (preserving
+backward-compatible behavior for configs written before this change).
+
+#### Scenario: New tool inherits server default without config change
+
+- **GIVEN** `ApprovalPolicy.McpServerDefaults.notion = Approval`
+- **AND** the Notion server is extended with a new tool `notion/archive`
+  between two daemon starts
+- **WHEN** the agent invokes `notion/archive` after the restart
+- **THEN** the resolved mode is `Approval`
+- **AND** no config edit was required to cover the new tool
+
+#### Scenario: Absent server default falls through to legacy resolution
+
+- **GIVEN** a config has no `McpServerDefaults` entry for `notion`
+- **AND** no exact override exists for any `notion/*` tool
+- **WHEN** the agent invokes `notion/create-pages`
+- **THEN** resolution proceeds to matcher fail-closed-on-Personal and then
+  to audience `DefaultMode`
+- **AND** no silent denial is introduced for pre-existing configs
+
+#### Scenario: Removing the server default reverts tools to legacy resolution
+
+- **GIVEN** `ApprovalPolicy.McpServerDefaults.notion = Deny`
+- **WHEN** the operator removes the entry and restarts the daemon
+- **THEN** subsequent invocations of `notion/*` tools without exact overrides
+  fall through to matcher fail-closed-on-Personal and audience `DefaultMode`

--- a/openspec/changes/mcp-server-approval-defaults/tasks.md
+++ b/openspec/changes/mcp-server-approval-defaults/tasks.md
@@ -1,0 +1,95 @@
+## 1. Config Model & Schema
+
+- [ ] 1.1 Add `McpServerDefaults: Dictionary<string, ToolApprovalMode>` property to `ToolApprovalConfig` in `src/Netclaw.Configuration/ToolApprovalConfig.cs` with XML doc explaining the inheritance semantics.
+- [ ] 1.2 Fix stale `mcp:server-name:tool-name` comment on `ToolOverrides` at `ToolApprovalConfig.cs:30-31` — the actual exact-key format is `{serverName}/{toolName}`.
+- [ ] 1.3 Extend `ToolApprovalConfig.GetEffectiveMode(string toolName)` with a three-step lookup: exact `ToolOverrides[toolName]` → `McpServerDefaults[serverName]` (when `toolName` contains `/`) → `DefaultMode`.
+- [ ] 1.4 Add `McpServerDefaults` to the `ToolApprovalConfig` definition in `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` with `"default": {}` and value type referencing the existing `ToolApprovalMode` enum.
+- [ ] 1.5 Run `netclaw doctor` locally against an existing `netclaw.json` to confirm `ConfigSchemaDoctorCheck` still passes (schema addition is backward-compatible).
+
+## 2. Runtime Approval Policy
+
+- [ ] 2.1 Refactor `ToolAccessPolicy.ResolveApprovalMode` at `src/Netclaw.Actors/Tools/ToolAccessPolicy.cs:189-213` so that the no-custom-matcher-key case delegates to `ToolApprovalConfig.GetEffectiveMode(toolName)`. Preserve the existing matcher-specific key branch and the fail-closed-on-Personal escape.
+- [ ] 2.2 Add unit tests in `src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyApprovalTests.cs` (or the existing approval test file) that assert the three-step precedence for the runtime gate:
+  - Exact MCP override beats server default beats `DefaultMode`.
+  - `shell_execute` (no slash) does not match an MCP server default.
+  - `GetEffectiveMode` and `ResolveApprovalMode` return the same value for the same input.
+  - Fail-closed-on-Personal still fires when no override and no server default exist.
+- [ ] 2.3 Add unit tests in `src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs` (create file if missing) that cover `GetEffectiveMode` precedence for the four decision points in decision #2 of `design.md`.
+
+## 3. Fail-closed `netclaw mcp add`
+
+- [ ] 3.1 Add a private helper `ApplySecureDefaultsForNewServer(Dictionary<string, object> config, string serverName, bool grantAll)` to `src/Netclaw.Cli/Mcp/McpCommand.cs` that, for each audience profile under `Tools.AudienceProfiles`, writes `McpServerToolGrants[serverName] = []` (skipped when `grantAll` is true) and `ApprovalPolicy.McpServerDefaults[serverName]` per the decision matrix (Personal=Approval, Team=Approval, Public=Deny). Reuse `ConfigFileHelper.GetOrCreateSection` throughout.
+- [ ] 3.2 Wire the helper into `RunAdd` after the `mcpServers[name] = SerializeEntry(entry)` line at `McpCommand.cs:192`. Ensure the helper runs before `WriteConfigFile` so both config and secrets writes remain atomic.
+- [ ] 3.3 Parse a new `--grant-all` flag in the `RunAdd` positional/flag loop at `McpCommand.cs:72-123`. Default is false (fail-closed); when true, the helper skips the grant writes but still writes the approval defaults.
+- [ ] 3.4 Update the post-add output at `McpCommand.cs:211` to print a multi-line security hint identifying the number of granted tools (`0` without `--grant-all`, `all` with `--grant-all`) and the per-audience approval-default choices, and directing the operator to `netclaw mcp permissions`.
+- [ ] 3.5 Update `WriteHelp` at `McpCommand.cs:1197` to document the `--grant-all` flag and reference `netclaw mcp permissions` alongside `netclaw mcp tools`.
+- [ ] 3.6 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpCommandRunAddTests.cs` (create if missing) that exercise `RunAdd` against a temp `netclaw.json`:
+  - Default invocation writes empty grants and the correct server defaults on all three audiences.
+  - `--grant-all` invocation skips grants but still writes the server defaults.
+  - Pre-existing servers are untouched when adding a new server.
+  - Missing `ApprovalPolicy` section is created during the write.
+
+## 4. TUI: Per-tool approval column + server-default row
+
+- [ ] 4.1 Add two new pending-state dictionaries on `McpToolPermissionsViewModel` at `src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs` near the existing `_pendingGrants` field: `_pendingServerDefaults` keyed by `(string Audience, string Server)` and `_pendingToolOverrides` keyed by `(string Audience, string Server, string Tool)` with a nullable `ToolApprovalMode?` value where `null` is the `inherit` sentinel.
+- [ ] 4.2 Extend `HasUnsavedChanges` at line 47 to also return true when either new dictionary is non-empty.
+- [ ] 4.3 Extend `InitializePendingGrantsFromConfig` at lines 123-144 so that loading a server also seeds the view with the existing `ApprovalPolicy.McpServerDefaults[server]` values and any exact `ToolOverrides` entries keyed by `{server}/{tool}`.
+- [ ] 4.4 Add `CycleServerDefault()` method that advances the current audience/server pair through `Auto → Approval → Deny → Auto`, storing the result in `_pendingServerDefaults` and calling `NotifyStateChanged()`.
+- [ ] 4.5 Add `CycleToolOverride(string toolName)` method that advances `_pendingToolOverrides` through `inherit (null) → Auto → Approval → Deny → inherit` for the `(audience, server, tool)` tuple.
+- [ ] 4.6 Add `GetEffectiveMode(string toolName)` helper that returns `(ToolApprovalMode mode, bool isInherited)` by consulting, in order: pending tool override → config `ToolOverrides[server/tool]` → pending server default → config `McpServerDefaults[server]` → global `DefaultMode`. `isInherited` is true when the resolved value came from the server-default or global steps.
+- [ ] 4.7 Extend `Save()` at lines 290-358 with two new write loops, keeping grant writes unchanged:
+  - For each `_pendingServerDefaults` entry, write `ApprovalPolicy.McpServerDefaults[{server}]` under the target audience section. Allocate the `ApprovalPolicy` section via `ConfigFileHelper.GetOrCreateSection` if missing.
+  - For each `_pendingToolOverrides` entry: if the value is `null` (inherit), remove the exact key from `ApprovalPolicy.ToolOverrides`; otherwise write the exact mode. Do not normalize "matches the server default" to removal — explicit overrides stay explicit.
+  - Clear both pending dictionaries on successful save.
+- [ ] 4.8 Update the TUI page layout in `src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs`:
+  - Add a `[M] Server default: [mode]` row inside `BuildToolGrid` between the existing "Server enabled" row and the tool-list loop (around line 131). Render the mode name with the existing color convention (Color.White for Auto, Color.Yellow for Approval, Color.Red for Deny).
+  - Extend the tool-row rendering loop at lines 133-152 to append an effective-mode badge and a `(def)` / `(override)` suffix sourced from `ViewModel.GetEffectiveMode`. Use a fixed-width column so rows align even when tool names vary.
+- [ ] 4.9 Update the key handler at `McpToolPermissionsPage.cs:211-272`:
+  - Add `ConsoleKey.M` (and lowercase `'m'` KeyChar) branches that call `ViewModel.CycleServerDefault()`.
+  - Add `ConsoleKey.P` (and lowercase `'p'` KeyChar) branches that call `ViewModel.CycleToolOverride(DiscoveredTools[_toolCursor])` — gated on `IsServerAllowedForSelectedAudience() && DiscoveredTools.Count > 0` so the cycle does nothing when there is no tool under the cursor.
+- [ ] 4.10 Extend the footer hint builder at line 171 to include `[M] Server default  [P] Tool mode` alongside the existing hints.
+- [ ] 4.11 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs` covering:
+  - `CycleServerDefault` from `Auto` twice lands on `Deny`.
+  - `CycleToolOverride` from `inherit` cycles through `Auto → Approval → Deny → inherit`.
+  - `Save()` after mixed edits writes the correct combination of `McpServerDefaults`, `ToolOverrides`, and grant entries and removes inherited overrides rather than writing `"Auto"`.
+  - Loading a config with existing `McpServerDefaults` populates the view's effective-mode display.
+
+## 5. CLI Discoverability
+
+- [ ] 5.1 Add `"permissions"` to the subcommand switch in `McpCommand.RunAsync` at line 41 and route it to the same TUI path as bare `netclaw mcp tools`.
+- [ ] 5.2 Add a `mcpSubcommand is "permissions"` branch at `src/Netclaw.Cli/Program.cs:606` that falls through into the existing `AddTermina("/mcp-tools", …)` block at lines 609-621. Both commands should map to the same `McpToolPermissionsPage` route.
+- [ ] 5.3 Append `writer.WriteLine("Edit interactively: netclaw mcp permissions");` to the end of `RunToolsList` at `McpCommand.cs:966`.
+- [ ] 5.4 Update the TUI page title in `McpToolPermissionsPage.BuildHeader` at line 40 from "MCP Tool Permissions" to "MCP Permissions".
+- [ ] 5.5 Update the help text written by `WriteHelp` at `McpCommand.cs:1197` to list `permissions` as the recommended interactive command and describe `tools <server>` as the read-only CLI view.
+
+## 6. Doctor Warning
+
+- [ ] 6.1 Extend `src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs` with a new check method that iterates `Tools.McpServers`. For each enabled server, if Personal profile has `McpServersMode = All` AND no `ApprovalPolicy.McpServerDefaults[server]` entry AND no `ToolOverrides` entries whose key begins with `{server}/`, emit a warning-severity diagnostic pointing at `netclaw mcp permissions`.
+- [ ] 6.2 Leave the existing null-grants advisory at lines 113-120 unchanged — the new check lives alongside it.
+- [ ] 6.3 Add unit tests in `src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs` covering:
+  - Warning fires when the server has no Personal approval default and no per-tool overrides.
+  - Warning does not fire when `McpServerDefaults[server]` is set.
+  - Warning does not fire when at least one `ToolOverrides` entry matches `{server}/*`.
+  - Warning does not fire when the server is not in `McpServers`.
+  - Warning exit code path exercises the "warnings only" (2) branch rather than the error (1) branch when it is the sole finding.
+
+## 7. System Skill Sync
+
+- [ ] 7.1 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md` to document `netclaw mcp permissions`, the fail-closed `mcp add` semantics, and the per-audience approval-default model (Personal/Team=Approval, Public=Deny). Add a short "migrating existing MCP servers" section explaining the doctor warning and how to resolve it via the TUI.
+- [ ] 7.2 Bump `metadata.version` in the SKILL.md YAML frontmatter.
+- [ ] 7.3 Do NOT run `generate-skill-manifest.sh` locally. Confirm via `git diff` that no other skill area is touched (netclaw-identity, netclaw-memory, search-citation, skill-authoring, netclaw-projects).
+
+## 8. Quality Gates & Docs
+
+- [ ] 8.1 Run `dotnet build` against the changed projects and fix any warnings introduced by the additions.
+- [ ] 8.2 Run targeted `dotnet test` for `Netclaw.Configuration.Tests`, `Netclaw.Actors.Tests`, and `Netclaw.Cli.Tests` and confirm all new and existing tests pass. In particular verify `McpToolAudienceGrantsTests.EmptyGrantList_NoToolsExposed` still passes.
+- [ ] 8.3 Run `dotnet slopwatch analyze` and confirm no new violations. Add any unavoidable entries to `.slopwatch/baseline.json` with justification only as a last resort.
+- [ ] 8.4 Manual end-to-end verification per design.md §Migration Plan:
+  - Add a throwaway MCP server via `netclaw mcp add`, inspect `netclaw.json` for empty grants and the expected approval defaults, and confirm the post-add hint.
+  - Start the daemon, run `netclaw mcp permissions`, enable the server for Personal, grant two tools, cycle server default via `M`, cycle one tool override via `P`, save. Restart daemon.
+  - Invoke a granted-but-unoverridden tool from a Slack thread and confirm the approval prompt appears. Invoke the overridden tool and confirm it runs without prompting. Invoke an ungranted tool and confirm deny reason `mcp_tool_not_allowed_for_audience_profile`.
+  - Run `netclaw doctor` before and after setting a server default and confirm the new warning fires/clears as expected.
+- [ ] 8.5 Update `docs/spec/` only if any runtime behavior in the spec matches the new precedence rules — per CLAUDE.md discovery rules, specs in `openspec/specs` are the authoritative artifacts, and this change already writes delta specs. No `docs/spec` edits expected unless a doc file cross-references the old two-step lookup.
+- [ ] 8.6 Invoke `/opsx-verify` to confirm implementation matches the change artifacts.
+- [ ] 8.7 Invoke `/opsx-sync` to merge the delta specs into the main specs under `openspec/specs/`.
+- [ ] 8.8 Invoke `/opsx-archive` once the PR is merged to archive the change.

--- a/openspec/changes/mcp-server-approval-defaults/tasks.md
+++ b/openspec/changes/mcp-server-approval-defaults/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Config Model & Schema
 
-- [ ] 1.1 Add `McpServerDefaults: Dictionary<string, ToolApprovalMode>` property to `ToolApprovalConfig` in `src/Netclaw.Configuration/ToolApprovalConfig.cs` with XML doc explaining the inheritance semantics.
-- [ ] 1.2 Fix stale `mcp:server-name:tool-name` comment on `ToolOverrides` at `ToolApprovalConfig.cs:30-31` — the actual exact-key format is `{serverName}/{toolName}`.
-- [ ] 1.3 Extend `ToolApprovalConfig.GetEffectiveMode(string toolName)` with a three-step lookup: exact `ToolOverrides[toolName]` → `McpServerDefaults[serverName]` (when `toolName` contains `/`) → `DefaultMode`.
-- [ ] 1.4 Add `McpServerDefaults` to the `ToolApprovalConfig` definition in `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` with `"default": {}` and value type referencing the existing `ToolApprovalMode` enum.
-- [ ] 1.5 Run `netclaw doctor` locally against an existing `netclaw.json` to confirm `ConfigSchemaDoctorCheck` still passes (schema addition is backward-compatible).
+- [x] 1.1 Add `McpServerDefaults: Dictionary<string, ToolApprovalMode>` property to `ToolApprovalConfig` in `src/Netclaw.Configuration/ToolApprovalConfig.cs` with XML doc explaining the inheritance semantics.
+- [x] 1.2 Fix stale `mcp:server-name:tool-name` comment on `ToolOverrides` at `ToolApprovalConfig.cs:30-31` — the actual exact-key format is `{serverName}/{toolName}`.
+- [x] 1.3 Extend `ToolApprovalConfig.GetEffectiveMode(string toolName)` with a three-step lookup: exact `ToolOverrides[toolName]` → `McpServerDefaults[serverName]` (when `toolName` contains `/`) → `DefaultMode`.
+- [x] 1.4 Add `McpServerDefaults` to the `ToolApprovalConfig` definition in `src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json` with `"default": {}` and value type referencing the existing `ToolApprovalMode` enum.
+- [x] 1.5 Run `netclaw doctor` locally against an existing `netclaw.json` to confirm `ConfigSchemaDoctorCheck` still passes (schema addition is backward-compatible). *(Verified via `ConfigSchemaDoctorCheckTests` — 13/13 pass.)*
 
 ## 2. Runtime Approval Policy
 
-- [ ] 2.1 Refactor `ToolAccessPolicy.ResolveApprovalMode` at `src/Netclaw.Actors/Tools/ToolAccessPolicy.cs:189-213` so that the no-custom-matcher-key case delegates to `ToolApprovalConfig.GetEffectiveMode(toolName)`. Preserve the existing matcher-specific key branch and the fail-closed-on-Personal escape.
-- [ ] 2.2 Add unit tests in `src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyApprovalTests.cs` (or the existing approval test file) that assert the three-step precedence for the runtime gate:
+- [x] 2.1 Refactor `ToolAccessPolicy.ResolveApprovalMode` at `src/Netclaw.Actors/Tools/ToolAccessPolicy.cs:189-213` so that the no-custom-matcher-key case delegates to `ToolApprovalConfig.GetEffectiveMode(toolName)`. Preserve the existing matcher-specific key branch and the fail-closed-on-Personal escape.
+- [x] 2.2 Add unit tests in `src/Netclaw.Actors.Tests/Tools/ToolAccessPolicyApprovalTests.cs` (or the existing approval test file) that assert the three-step precedence for the runtime gate:
   - Exact MCP override beats server default beats `DefaultMode`.
   - `shell_execute` (no slash) does not match an MCP server default.
   - `GetEffectiveMode` and `ResolveApprovalMode` return the same value for the same input.
   - Fail-closed-on-Personal still fires when no override and no server default exist.
-- [ ] 2.3 Add unit tests in `src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs` (create file if missing) that cover `GetEffectiveMode` precedence for the four decision points in decision #2 of `design.md`.
+- [x] 2.3 Add unit tests in `src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs` (create file if missing) that cover `GetEffectiveMode` precedence for the four decision points in decision #2 of `design.md`.
 
 ## 3. Fail-closed `netclaw mcp add`
 
-- [ ] 3.1 Add a private helper `ApplySecureDefaultsForNewServer(Dictionary<string, object> config, string serverName, bool grantAll)` to `src/Netclaw.Cli/Mcp/McpCommand.cs` that, for each audience profile under `Tools.AudienceProfiles`, writes `McpServerToolGrants[serverName] = []` (skipped when `grantAll` is true) and `ApprovalPolicy.McpServerDefaults[serverName]` per the decision matrix (Personal=Approval, Team=Approval, Public=Deny). Reuse `ConfigFileHelper.GetOrCreateSection` throughout.
-- [ ] 3.2 Wire the helper into `RunAdd` after the `mcpServers[name] = SerializeEntry(entry)` line at `McpCommand.cs:192`. Ensure the helper runs before `WriteConfigFile` so both config and secrets writes remain atomic.
-- [ ] 3.3 Parse a new `--grant-all` flag in the `RunAdd` positional/flag loop at `McpCommand.cs:72-123`. Default is false (fail-closed); when true, the helper skips the grant writes but still writes the approval defaults.
-- [ ] 3.4 Update the post-add output at `McpCommand.cs:211` to print a multi-line security hint identifying the number of granted tools (`0` without `--grant-all`, `all` with `--grant-all`) and the per-audience approval-default choices, and directing the operator to `netclaw mcp permissions`.
-- [ ] 3.5 Update `WriteHelp` at `McpCommand.cs:1197` to document the `--grant-all` flag and reference `netclaw mcp permissions` alongside `netclaw mcp tools`.
-- [ ] 3.6 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpCommandRunAddTests.cs` (create if missing) that exercise `RunAdd` against a temp `netclaw.json`:
+- [x] 3.1 Add a private helper `ApplySecureDefaultsForNewServer(Dictionary<string, object> config, string serverName, bool grantAll)` to `src/Netclaw.Cli/Mcp/McpCommand.cs` that, for each audience profile under `Tools.AudienceProfiles`, writes `McpServerToolGrants[serverName] = []` (skipped when `grantAll` is true) and `ApprovalPolicy.McpServerDefaults[serverName]` per the decision matrix (Personal=Approval, Team=Approval, Public=Deny). Reuse `ConfigFileHelper.GetOrCreateSection` throughout.
+- [x] 3.2 Wire the helper into `RunAdd` after the `mcpServers[name] = SerializeEntry(entry)` line at `McpCommand.cs:192`. Ensure the helper runs before `WriteConfigFile` so both config and secrets writes remain atomic.
+- [x] 3.3 Parse a new `--grant-all` flag in the `RunAdd` positional/flag loop at `McpCommand.cs:72-123`. Default is false (fail-closed); when true, the helper skips the grant writes but still writes the approval defaults.
+- [x] 3.4 Update the post-add output at `McpCommand.cs:211` to print a multi-line security hint identifying the number of granted tools (`0` without `--grant-all`, `all` with `--grant-all`) and the per-audience approval-default choices, and directing the operator to `netclaw mcp permissions`.
+- [x] 3.5 Update `WriteHelp` at `McpCommand.cs:1197` to document the `--grant-all` flag and reference `netclaw mcp permissions` alongside `netclaw mcp tools`.
+- [x] 3.6 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpCommandRunAddTests.cs` (create if missing) that exercise `RunAdd` against a temp `netclaw.json`:
   - Default invocation writes empty grants and the correct server defaults on all three audiences.
   - `--grant-all` invocation skips grants but still writes the server defaults.
   - Pre-existing servers are untouched when adding a new server.
@@ -31,24 +31,24 @@
 
 ## 4. TUI: Per-tool approval column + server-default row
 
-- [ ] 4.1 Add two new pending-state dictionaries on `McpToolPermissionsViewModel` at `src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs` near the existing `_pendingGrants` field: `_pendingServerDefaults` keyed by `(string Audience, string Server)` and `_pendingToolOverrides` keyed by `(string Audience, string Server, string Tool)` with a nullable `ToolApprovalMode?` value where `null` is the `inherit` sentinel.
-- [ ] 4.2 Extend `HasUnsavedChanges` at line 47 to also return true when either new dictionary is non-empty.
-- [ ] 4.3 Extend `InitializePendingGrantsFromConfig` at lines 123-144 so that loading a server also seeds the view with the existing `ApprovalPolicy.McpServerDefaults[server]` values and any exact `ToolOverrides` entries keyed by `{server}/{tool}`.
-- [ ] 4.4 Add `CycleServerDefault()` method that advances the current audience/server pair through `Auto → Approval → Deny → Auto`, storing the result in `_pendingServerDefaults` and calling `NotifyStateChanged()`.
-- [ ] 4.5 Add `CycleToolOverride(string toolName)` method that advances `_pendingToolOverrides` through `inherit (null) → Auto → Approval → Deny → inherit` for the `(audience, server, tool)` tuple.
-- [ ] 4.6 Add `GetEffectiveMode(string toolName)` helper that returns `(ToolApprovalMode mode, bool isInherited)` by consulting, in order: pending tool override → config `ToolOverrides[server/tool]` → pending server default → config `McpServerDefaults[server]` → global `DefaultMode`. `isInherited` is true when the resolved value came from the server-default or global steps.
-- [ ] 4.7 Extend `Save()` at lines 290-358 with two new write loops, keeping grant writes unchanged:
+- [x] 4.1 Add two new pending-state dictionaries on `McpToolPermissionsViewModel` at `src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs` near the existing `_pendingGrants` field: `_pendingServerDefaults` keyed by `(string Audience, string Server)` and `_pendingToolOverrides` keyed by `(string Audience, string Server, string Tool)` with a nullable `ToolApprovalMode?` value where `null` is the `inherit` sentinel.
+- [x] 4.2 Extend `HasUnsavedChanges` at line 47 to also return true when either new dictionary is non-empty.
+- [x] 4.3 Extend `InitializePendingGrantsFromConfig` at lines 123-144 so that loading a server also seeds the view with the existing `ApprovalPolicy.McpServerDefaults[server]` values and any exact `ToolOverrides` entries keyed by `{server}/{tool}`.
+- [x] 4.4 Add `CycleServerDefault()` method that advances the current audience/server pair through `Auto → Approval → Deny → Auto`, storing the result in `_pendingServerDefaults` and calling `NotifyStateChanged()`.
+- [x] 4.5 Add `CycleToolOverride(string toolName)` method that advances `_pendingToolOverrides` through `inherit (null) → Auto → Approval → Deny → inherit` for the `(audience, server, tool)` tuple.
+- [x] 4.6 Add `GetEffectiveMode(string toolName)` helper that returns `(ToolApprovalMode mode, bool isInherited)` by consulting, in order: pending tool override → config `ToolOverrides[server/tool]` → pending server default → config `McpServerDefaults[server]` → global `DefaultMode`. `isInherited` is true when the resolved value came from the server-default or global steps.
+- [x] 4.7 Extend `Save()` at lines 290-358 with two new write loops, keeping grant writes unchanged:
   - For each `_pendingServerDefaults` entry, write `ApprovalPolicy.McpServerDefaults[{server}]` under the target audience section. Allocate the `ApprovalPolicy` section via `ConfigFileHelper.GetOrCreateSection` if missing.
   - For each `_pendingToolOverrides` entry: if the value is `null` (inherit), remove the exact key from `ApprovalPolicy.ToolOverrides`; otherwise write the exact mode. Do not normalize "matches the server default" to removal — explicit overrides stay explicit.
   - Clear both pending dictionaries on successful save.
-- [ ] 4.8 Update the TUI page layout in `src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs`:
+- [x] 4.8 Update the TUI page layout in `src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs`:
   - Add a `[M] Server default: [mode]` row inside `BuildToolGrid` between the existing "Server enabled" row and the tool-list loop (around line 131). Render the mode name with the existing color convention (Color.White for Auto, Color.Yellow for Approval, Color.Red for Deny).
   - Extend the tool-row rendering loop at lines 133-152 to append an effective-mode badge and a `(def)` / `(override)` suffix sourced from `ViewModel.GetEffectiveMode`. Use a fixed-width column so rows align even when tool names vary.
-- [ ] 4.9 Update the key handler at `McpToolPermissionsPage.cs:211-272`:
+- [x] 4.9 Update the key handler at `McpToolPermissionsPage.cs:211-272`:
   - Add `ConsoleKey.M` (and lowercase `'m'` KeyChar) branches that call `ViewModel.CycleServerDefault()`.
   - Add `ConsoleKey.P` (and lowercase `'p'` KeyChar) branches that call `ViewModel.CycleToolOverride(DiscoveredTools[_toolCursor])` — gated on `IsServerAllowedForSelectedAudience() && DiscoveredTools.Count > 0` so the cycle does nothing when there is no tool under the cursor.
-- [ ] 4.10 Extend the footer hint builder at line 171 to include `[M] Server default  [P] Tool mode` alongside the existing hints.
-- [ ] 4.11 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs` covering:
+- [x] 4.10 Extend the footer hint builder at line 171 to include `[M] Server default  [P] Tool mode` alongside the existing hints.
+- [x] 4.11 Add unit tests in `src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs` covering:
   - `CycleServerDefault` from `Auto` twice lands on `Deny`.
   - `CycleToolOverride` from `inherit` cycles through `Auto → Approval → Deny → inherit`.
   - `Save()` after mixed edits writes the correct combination of `McpServerDefaults`, `ToolOverrides`, and grant entries and removes inherited overrides rather than writing `"Auto"`.
@@ -56,17 +56,17 @@
 
 ## 5. CLI Discoverability
 
-- [ ] 5.1 Add `"permissions"` to the subcommand switch in `McpCommand.RunAsync` at line 41 and route it to the same TUI path as bare `netclaw mcp tools`.
-- [ ] 5.2 Add a `mcpSubcommand is "permissions"` branch at `src/Netclaw.Cli/Program.cs:606` that falls through into the existing `AddTermina("/mcp-tools", …)` block at lines 609-621. Both commands should map to the same `McpToolPermissionsPage` route.
-- [ ] 5.3 Append `writer.WriteLine("Edit interactively: netclaw mcp permissions");` to the end of `RunToolsList` at `McpCommand.cs:966`.
-- [ ] 5.4 Update the TUI page title in `McpToolPermissionsPage.BuildHeader` at line 40 from "MCP Tool Permissions" to "MCP Permissions".
-- [ ] 5.5 Update the help text written by `WriteHelp` at `McpCommand.cs:1197` to list `permissions` as the recommended interactive command and describe `tools <server>` as the read-only CLI view.
+- [x] 5.1 Add `"permissions"` to the subcommand switch in `McpCommand.RunAsync` at line 41 and route it to the same TUI path as bare `netclaw mcp tools`.
+- [x] 5.2 Add a `mcpSubcommand is "permissions"` branch at `src/Netclaw.Cli/Program.cs:606` that falls through into the existing `AddTermina("/mcp-tools", …)` block at lines 609-621. Both commands should map to the same `McpToolPermissionsPage` route.
+- [x] 5.3 Append `writer.WriteLine("Edit interactively: netclaw mcp permissions");` to the end of `RunToolsList` at `McpCommand.cs:966`.
+- [x] 5.4 Update the TUI page title in `McpToolPermissionsPage.BuildHeader` at line 40 from "MCP Tool Permissions" to "MCP Permissions".
+- [x] 5.5 Update the help text written by `WriteHelp` at `McpCommand.cs:1197` to list `permissions` as the recommended interactive command and describe `tools <server>` as the read-only CLI view.
 
 ## 6. Doctor Warning
 
-- [ ] 6.1 Extend `src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs` with a new check method that iterates `Tools.McpServers`. For each enabled server, if Personal profile has `McpServersMode = All` AND no `ApprovalPolicy.McpServerDefaults[server]` entry AND no `ToolOverrides` entries whose key begins with `{server}/`, emit a warning-severity diagnostic pointing at `netclaw mcp permissions`.
-- [ ] 6.2 Leave the existing null-grants advisory at lines 113-120 unchanged — the new check lives alongside it.
-- [ ] 6.3 Add unit tests in `src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs` covering:
+- [x] 6.1 Extend `src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs` with a new check method that iterates `Tools.McpServers`. For each enabled server, if Personal profile has `McpServersMode = All` AND no `ApprovalPolicy.McpServerDefaults[server]` entry AND no `ToolOverrides` entries whose key begins with `{server}/`, emit a warning-severity diagnostic pointing at `netclaw mcp permissions`.
+- [x] 6.2 Leave the existing null-grants advisory at lines 113-120 unchanged — the new check lives alongside it.
+- [x] 6.3 Add unit tests in `src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs` covering:
   - Warning fires when the server has no Personal approval default and no per-tool overrides.
   - Warning does not fire when `McpServerDefaults[server]` is set.
   - Warning does not fire when at least one `ToolOverrides` entry matches `{server}/*`.
@@ -75,15 +75,15 @@
 
 ## 7. System Skill Sync
 
-- [ ] 7.1 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md` to document `netclaw mcp permissions`, the fail-closed `mcp add` semantics, and the per-audience approval-default model (Personal/Team=Approval, Public=Deny). Add a short "migrating existing MCP servers" section explaining the doctor warning and how to resolve it via the TUI.
-- [ ] 7.2 Bump `metadata.version` in the SKILL.md YAML frontmatter.
-- [ ] 7.3 Do NOT run `generate-skill-manifest.sh` locally. Confirm via `git diff` that no other skill area is touched (netclaw-identity, netclaw-memory, search-citation, skill-authoring, netclaw-projects).
+- [x] 7.1 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md` to document `netclaw mcp permissions`, the fail-closed `mcp add` semantics, and the per-audience approval-default model (Personal/Team=Approval, Public=Deny). Add a short "migrating existing MCP servers" section explaining the doctor warning and how to resolve it via the TUI.
+- [x] 7.2 Bump `metadata.version` in the SKILL.md YAML frontmatter.
+- [x] 7.3 Do NOT run `generate-skill-manifest.sh` locally. Confirm via `git diff` that no other skill area is touched (netclaw-identity, netclaw-memory, search-citation, skill-authoring, netclaw-projects).
 
 ## 8. Quality Gates & Docs
 
-- [ ] 8.1 Run `dotnet build` against the changed projects and fix any warnings introduced by the additions.
-- [ ] 8.2 Run targeted `dotnet test` for `Netclaw.Configuration.Tests`, `Netclaw.Actors.Tests`, and `Netclaw.Cli.Tests` and confirm all new and existing tests pass. In particular verify `McpToolAudienceGrantsTests.EmptyGrantList_NoToolsExposed` still passes.
-- [ ] 8.3 Run `dotnet slopwatch analyze` and confirm no new violations. Add any unavoidable entries to `.slopwatch/baseline.json` with justification only as a last resort.
+- [x] 8.1 Run `dotnet build` against the changed projects and fix any warnings introduced by the additions.
+- [x] 8.2 Run targeted `dotnet test` for `Netclaw.Configuration.Tests`, `Netclaw.Actors.Tests`, and `Netclaw.Cli.Tests` and confirm all new and existing tests pass. In particular verify `McpToolAudienceGrantsTests.EmptyGrantList_NoToolsExposed` still passes.
+- [x] 8.3 Run `dotnet slopwatch analyze` and confirm no new violations. Add any unavoidable entries to `.slopwatch/baseline.json` with justification only as a last resort.
 - [ ] 8.4 Manual end-to-end verification per design.md §Migration Plan:
   - Add a throwaway MCP server via `netclaw mcp add`, inspect `netclaw.json` for empty grants and the expected approval defaults, and confirm the post-add hint.
   - Start the daemon, run `netclaw mcp permissions`, enable the server for Personal, grant two tools, cycle server default via `M`, cycle one tool override via `P`, save. Restart daemon.

--- a/scripts/smoke/cli-smoke.sh
+++ b/scripts/smoke/cli-smoke.sh
@@ -88,6 +88,26 @@ else
   fail "sessions --help: exit=$sessions_help_exit, missing --once in output"
 fi
 
+echo ""
+echo "=== netclaw mcp permissions --help ==="
+set +e
+mcp_permissions_help_exit=0
+if [[ -n "${NETCLAW_CLI:-}" ]]; then
+  mcp_permissions_help_output="$(timeout 15s "$NETCLAW_CLI" mcp permissions --help 2>&1)"
+else
+  mcp_permissions_help_output="$(timeout 15s dotnet run --project "$CLI_PROJECT" --no-build -c "$BUILD_CONFIG" -- mcp permissions --help 2>&1)"
+fi
+mcp_permissions_help_exit=$?
+set -e
+echo "$mcp_permissions_help_output"
+if [[ $mcp_permissions_help_exit -eq 0 && "$mcp_permissions_help_output" == *"Usage: netclaw mcp tools <server> [options]"* && "$mcp_permissions_help_output" == *"--audience <name>"* ]]; then
+  pass "mcp permissions --help: exits 0 and prints CLI help"
+elif [[ $mcp_permissions_help_exit -eq 124 ]]; then
+  fail "mcp permissions --help: timed out (possible TUI launch)"
+else
+  fail "mcp permissions --help: exit=$mcp_permissions_help_exit, expected CLI help output"
+fi
+
 # ── Daemon-requiring commands (non-zero on daemon unavailable is accepted) ───
 
 echo ""

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -341,4 +341,172 @@ public sealed class ToolApprovalGateTests
         Assert.True(decision.Allowed);
         Assert.False(decision.NeedsApproval);
     }
+
+    // ── MCP server default precedence ──
+
+    private static ToolAccessPolicy CreateMcpApprovalPolicy(ToolApprovalConfig approvalPolicy)
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.AllowedMcpServers.Add("notion");
+        config.AudienceProfiles.Personal.ApprovalPolicy = approvalPolicy;
+        return new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+    }
+
+    private static McpToolAdapter McpTool(string serverName, string toolName)
+    {
+        var func = AIFunctionFactory.Create(() => "result", toolName, toolName);
+        return new McpToolAdapter(func, serverName, toolName);
+    }
+
+    [Fact]
+    public void mcp_server_default_applies_when_no_exact_override()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+
+        var decision = policy.AuthorizeInvocation(
+            McpTool("notion", "create-pages"),
+            PersonalContext());
+
+        Assert.True(decision.NeedsApproval);
+        Assert.Equal("notion/create-pages", decision.ApprovalContext!.ToolName);
+    }
+
+    [Fact]
+    public void mcp_exact_override_beats_server_default()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Deny
+            },
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion/search"] = ToolApprovalMode.Auto
+            }
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+
+        var decision = policy.AuthorizeInvocation(
+            McpTool("notion", "search"),
+            PersonalContext());
+
+        Assert.True(decision.Allowed);
+        Assert.False(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void mcp_server_default_beats_default_mode()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Deny
+            }
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+
+        var decision = policy.AuthorizeInvocation(
+            McpTool("notion", "create-pages"),
+            PersonalContext());
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("tool_denied_by_approval_policy", decision.DenyReason);
+    }
+
+    [Fact]
+    public void shell_execute_does_not_match_mcp_server_default()
+    {
+        // shell_execute has no slash, so the MCP server default lookup
+        // SHALL NOT trigger. The existing fail-closed-on-Personal matcher
+        // must still fire instead.
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Deny
+            }
+        };
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = approvalPolicy;
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+
+        var args = new Dictionary<string, object?> { ["Command"] = "git pull --ff-only" };
+        var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(), args);
+
+        // Shell default matcher fails closed on Personal → approval, not deny.
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void resolve_approval_mode_and_get_effective_mode_agree_for_mcp_tool()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            },
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion/search"] = ToolApprovalMode.Auto
+            }
+        };
+
+        // GetEffectiveMode is the single source of truth.
+        Assert.Equal(ToolApprovalMode.Approval, approvalPolicy.GetEffectiveMode("notion/create-pages"));
+        Assert.Equal(ToolApprovalMode.Auto, approvalPolicy.GetEffectiveMode("notion/search"));
+
+        // Runtime path through ToolAccessPolicy must return the same modes.
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+
+        var approval = policy.AuthorizeInvocation(McpTool("notion", "create-pages"), PersonalContext());
+        Assert.True(approval.NeedsApproval);
+
+        var auto = policy.AuthorizeInvocation(McpTool("notion", "search"), PersonalContext());
+        Assert.True(auto.Allowed);
+        Assert.False(auto.NeedsApproval);
+    }
+
+    [Fact]
+    public void mcp_tool_without_server_default_falls_through_to_default_mode()
+    {
+        var approvalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto
+        };
+        var policy = CreateMcpApprovalPolicy(approvalPolicy);
+
+        var decision = policy.AuthorizeInvocation(
+            McpTool("notion", "create-pages"),
+            PersonalContext());
+
+        Assert.True(decision.Allowed);
+        Assert.False(decision.NeedsApproval);
+    }
 }

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -197,14 +197,22 @@ public sealed class ToolAccessPolicy
         if (approvalPolicy is null)
             return GetMissingApprovalPolicyDefaultMode(toolName, arguments, audience, matcher);
 
-        if (approvalPolicy.ToolOverrides.TryGetValue(approvalModeKey, out var mode))
-            return mode;
-
+        // Matcher-derived argument-aware key (e.g. "file_write:control-plane").
+        // This only fires when the matcher produced a distinct key; it is
+        // unrelated to MCP tool names and therefore never consults
+        // McpServerDefaults.
         if (!string.Equals(approvalModeKey, toolName, StringComparison.Ordinal)
-            && approvalPolicy.ToolOverrides.TryGetValue(toolName, out mode))
+            && approvalPolicy.ToolOverrides.TryGetValue(approvalModeKey, out var matcherMode))
         {
-            return mode;
+            return matcherMode;
         }
+
+        // No-matcher-key case shares the three-step precedence with
+        // ToolApprovalConfig.GetEffectiveMode: exact ToolOverrides[toolName]
+        // → McpServerDefaults[serverName] → fall-through. This keeps the
+        // two callers consistent by construction.
+        if (approvalPolicy.TryGetExplicitMode(toolName, out var explicitMode))
+            return explicitMode;
 
         if (audience == TrustAudience.Personal && matcher.IsFailClosedOnPersonal(toolName, arguments))
             return ToolApprovalMode.Approval;

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -274,6 +274,177 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
         Assert.DoesNotContain("without an explicit shell_execute approval gate", result.Message);
     }
 
+    // ── MCP server missing Personal approval-default warning ──
+
+    [Fact]
+    public async Task McpServerWithoutPersonalApprovalDefault_TriggersWarning()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "McpServerToolGrants": {
+                      "notion": ["create-pages"]
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "notion": { "Transport": "http", "Url": "https://mcp.notion.com/mcp", "Enabled": true }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("notion", result.Message);
+        Assert.Contains("approval default on Personal", result.Message);
+        Assert.Contains("netclaw mcp permissions", result.Message);
+    }
+
+    [Fact]
+    public async Task McpServerWithPersonalApprovalDefault_DoesNotTriggerWarning()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "McpServerToolGrants": { "notion": ["create-pages"] },
+                    "ApprovalPolicy": {
+                      "McpServerDefaults": { "notion": "Approval" }
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "notion": { "Transport": "http", "Url": "https://mcp.notion.com/mcp", "Enabled": true }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("approval default on Personal", result.Message);
+    }
+
+    [Fact]
+    public async Task McpServerWithPerToolOverride_DoesNotTriggerWarning()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "McpServerToolGrants": { "notion": ["create-pages"] },
+                    "ApprovalPolicy": {
+                      "ToolOverrides": { "notion/create-pages": "Approval" }
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              },
+              "McpServers": {
+                "notion": { "Transport": "http", "Url": "https://mcp.notion.com/mcp", "Enabled": true }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("approval default on Personal", result.Message);
+    }
+
+    [Fact]
+    public async Task MissingApprovalWarning_DoesNotFireForServerNotInMcpServers()
+    {
+        // Server is in AllowedMcpServers but not in McpServers (stale allowlist).
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "AllowedMcpServers": ["notion"],
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("approval default on Personal", result.Message);
+    }
+
+    [Fact]
+    public async Task MissingApprovalWarning_IsWarningSeverityNotError()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "ShellMode": "HostAllowed",
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "ApprovalPolicy": {
+                      "ToolOverrides": { "shell_execute": "Approval" }
+                    },
+                    "ReadFiles": { "Mode": "Roots", "Roots": ["/tmp"] },
+                    "WriteFiles": { "Mode": "Roots", "Roots": ["/tmp"] },
+                    "AttachFiles": { "Mode": "Roots", "Roots": ["/tmp"] }
+                  }
+                }
+              },
+              "McpServers": {
+                "notion": { "Transport": "http", "Url": "https://mcp.notion.com/mcp", "Enabled": true }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        // Warning, not error — tests the "warnings only (2)" exit code path.
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("approval default on Personal", result.Message);
+    }
+
     private void WriteConfig(object config)
     {
         File.WriteAllText(

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -101,6 +101,162 @@ public sealed class McpCommandTests : IDisposable
         Assert.Equal("Bearer tok-123", loaded["myapi"].Headers?["Authorization"]);
     }
 
+    // ── Fail-closed defaults for new MCP servers ──
+
+    [Fact]
+    public async Task Add_WritesEmptyGrantsAndApprovalDefaultsAcrossAudiences()
+    {
+        var args = new[] { "mcp", "add", "--transport", "http", "notion", "https://mcp.notion.com/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+
+        var doc = ReadConfigFile(_paths.NetclawConfigPath);
+        var profiles = doc.RootElement.GetProperty("Tools").GetProperty("AudienceProfiles");
+
+        foreach (var audience in new[] { "Personal", "Team", "Public" })
+        {
+            var profile = profiles.GetProperty(audience);
+            var grants = profile.GetProperty("McpServerToolGrants").GetProperty("notion");
+            Assert.Equal(JsonValueKind.Array, grants.ValueKind);
+            Assert.Equal(0, grants.GetArrayLength());
+
+            var approvalMode = profile
+                .GetProperty("ApprovalPolicy")
+                .GetProperty("McpServerDefaults")
+                .GetProperty("notion")
+                .GetString();
+
+            var expected = audience == "Public" ? "Deny" : "Approval";
+            Assert.Equal(expected, approvalMode);
+        }
+
+        var output = _output.ToString();
+        Assert.Contains("0 tools granted", output);
+        Assert.Contains("netclaw mcp permissions", output);
+        Assert.Contains("Personal=Approval", output);
+        Assert.Contains("Public=Deny", output);
+    }
+
+    [Fact]
+    public async Task Add_WithGrantAll_SkipsGrantsButWritesApprovalDefaults()
+    {
+        var args = new[] { "mcp", "add", "--grant-all", "--transport", "stdio", "trusted", "--", "/usr/local/bin/trusted" };
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+
+        var doc = ReadConfigFile(_paths.NetclawConfigPath);
+        var profiles = doc.RootElement.GetProperty("Tools").GetProperty("AudienceProfiles");
+
+        foreach (var audience in new[] { "Personal", "Team", "Public" })
+        {
+            var profile = profiles.GetProperty(audience);
+
+            // No grants written — either missing section or missing key.
+            var hasGrants = profile.TryGetProperty("McpServerToolGrants", out var grants)
+                && grants.ValueKind == JsonValueKind.Object
+                && grants.TryGetProperty("trusted", out _);
+            Assert.False(hasGrants);
+
+            var approvalMode = profile
+                .GetProperty("ApprovalPolicy")
+                .GetProperty("McpServerDefaults")
+                .GetProperty("trusted")
+                .GetString();
+            var expected = audience == "Public" ? "Deny" : "Approval";
+            Assert.Equal(expected, approvalMode);
+        }
+
+        Assert.Contains("legacy null-grants behavior", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Add_DoesNotMutateExistingServers()
+    {
+        // Pre-populate an existing server manually, with null grants.
+        var initial = new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["McpServers"] = new Dictionary<string, object>
+            {
+                ["old-server"] = new Dictionary<string, object>
+                {
+                    ["Transport"] = "stdio",
+                    ["Command"] = "npx",
+                    ["Enabled"] = true
+                }
+            }
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(_paths.NetclawConfigPath)!);
+        File.WriteAllText(_paths.NetclawConfigPath, JsonSerializer.Serialize(initial));
+
+        var args = new[] { "mcp", "add", "--transport", "http", "new-server", "https://new.example/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+
+        var doc = ReadConfigFile(_paths.NetclawConfigPath);
+        var profiles = doc.RootElement.GetProperty("Tools").GetProperty("AudienceProfiles");
+
+        foreach (var audience in new[] { "Personal", "Team", "Public" })
+        {
+            var profile = profiles.GetProperty(audience);
+
+            // old-server MUST NOT have defaults written.
+            Assert.True(profile.TryGetProperty("McpServerToolGrants", out var grants));
+            Assert.False(grants.TryGetProperty("old-server", out _));
+            Assert.True(grants.TryGetProperty("new-server", out _));
+
+            var approvalDefaults = profile
+                .GetProperty("ApprovalPolicy")
+                .GetProperty("McpServerDefaults");
+            Assert.False(approvalDefaults.TryGetProperty("old-server", out _));
+            Assert.True(approvalDefaults.TryGetProperty("new-server", out _));
+        }
+    }
+
+    [Fact]
+    public async Task Add_CreatesApprovalPolicySectionWhenMissing()
+    {
+        var initial = new Dictionary<string, object>
+        {
+            ["configVersion"] = 1,
+            ["Tools"] = new Dictionary<string, object>
+            {
+                ["AudienceProfiles"] = new Dictionary<string, object>
+                {
+                    ["Personal"] = new Dictionary<string, object>
+                    {
+                        // No ApprovalPolicy section yet.
+                        ["McpServersMode"] = "All"
+                    }
+                }
+            }
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(_paths.NetclawConfigPath)!);
+        File.WriteAllText(_paths.NetclawConfigPath, JsonSerializer.Serialize(initial));
+
+        var args = new[] { "mcp", "add", "--transport", "http", "notion", "https://mcp.notion.com/mcp" };
+        var exitCode = await McpCommand.RunAsync(args, _paths, output: _output);
+
+        Assert.Equal(0, exitCode);
+
+        var doc = ReadConfigFile(_paths.NetclawConfigPath);
+        var personal = doc.RootElement
+            .GetProperty("Tools")
+            .GetProperty("AudienceProfiles")
+            .GetProperty("Personal");
+
+        Assert.True(personal.TryGetProperty("ApprovalPolicy", out var approvalPolicy));
+        Assert.Equal(
+            "Approval",
+            approvalPolicy.GetProperty("McpServerDefaults").GetProperty("notion").GetString());
+
+        // Pre-existing property should still be there.
+        Assert.Equal("All", personal.GetProperty("McpServersMode").GetString());
+    }
+
     [Fact]
     public async Task List_NoServers_ShowsEmptyMessage()
     {

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -1,0 +1,163 @@
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Mcp;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Mcp;
+
+public sealed class McpToolPermissionsViewModelTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public McpToolPermissionsViewModelTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-vm-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private McpToolPermissionsViewModel CreateVm()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var daemonPaths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-vm-daemon-{Guid.NewGuid():N}"));
+        daemonPaths.EnsureDirectoriesExist();
+        var daemonApi = new DaemonApi(new NoopHttpClientFactory(), configuration, daemonPaths);
+        return new McpToolPermissionsViewModel(_paths, daemonApi);
+    }
+
+    [Fact]
+    public void CycleServerDefault_StartingFromAuto_LandsOnDenyAfterTwoCycles()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests("notion", new[] { "create-pages", "search" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        vm.CycleServerDefault();
+        Assert.Equal(ToolApprovalMode.Approval, vm.GetServerDefault());
+
+        vm.CycleServerDefault();
+        Assert.Equal(ToolApprovalMode.Deny, vm.GetServerDefault());
+
+        vm.CycleServerDefault();
+        Assert.Equal(ToolApprovalMode.Auto, vm.GetServerDefault());
+    }
+
+    [Fact]
+    public void CycleToolOverride_FromInherit_CyclesThroughAllModes()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests("notion", new[] { "create-pages" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Initial: inherit (effective mode resolves from server default / global default).
+        var (_, isInherited) = vm.GetEffectiveMode("create-pages");
+        Assert.True(isInherited);
+
+        vm.CycleToolOverride("create-pages");
+        var step1 = vm.GetEffectiveMode("create-pages");
+        Assert.Equal(ToolApprovalMode.Auto, step1.Mode);
+        Assert.False(step1.IsInherited);
+
+        vm.CycleToolOverride("create-pages");
+        var step2 = vm.GetEffectiveMode("create-pages");
+        Assert.Equal(ToolApprovalMode.Approval, step2.Mode);
+        Assert.False(step2.IsInherited);
+
+        vm.CycleToolOverride("create-pages");
+        var step3 = vm.GetEffectiveMode("create-pages");
+        Assert.Equal(ToolApprovalMode.Deny, step3.Mode);
+        Assert.False(step3.IsInherited);
+
+        vm.CycleToolOverride("create-pages");
+        var step4 = vm.GetEffectiveMode("create-pages");
+        Assert.True(step4.IsInherited);
+    }
+
+    [Fact]
+    public void Save_WritesServerDefaultsAndOverridesAndRemovesInheritedEntries()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests("notion", new[] { "create-pages", "search" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Cycle server default twice: Auto → Approval → Deny.
+        vm.CycleServerDefault();
+        vm.CycleServerDefault();
+
+        // Cycle create-pages once → Auto (explicit override).
+        vm.CycleToolOverride("create-pages");
+
+        // Cycle search four times back to inherit.
+        vm.CycleToolOverride("search");
+        vm.CycleToolOverride("search");
+        vm.CycleToolOverride("search");
+        vm.CycleToolOverride("search");
+
+        vm.Save();
+
+        var doc = JsonDocument.Parse(File.ReadAllText(_paths.NetclawConfigPath));
+        var approvalPolicy = doc.RootElement
+            .GetProperty("Tools")
+            .GetProperty("AudienceProfiles")
+            .GetProperty("Personal")
+            .GetProperty("ApprovalPolicy");
+
+        Assert.Equal(
+            "Deny",
+            approvalPolicy.GetProperty("McpServerDefaults").GetProperty("notion").GetString());
+
+        var toolOverrides = approvalPolicy.GetProperty("ToolOverrides");
+        Assert.Equal("Auto", toolOverrides.GetProperty("notion/create-pages").GetString());
+
+        // search was cycled back to inherit → it must NOT be persisted.
+        Assert.False(toolOverrides.TryGetProperty("notion/search", out _));
+
+        Assert.False(vm.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public void GetEffectiveMode_ReadsExistingMcpServerDefaultsFromConfig()
+    {
+        // Seed a netclaw.json with an existing McpServerDefaults entry.
+        var configJson = """
+        {
+          "configVersion": 1,
+          "Tools": {
+            "AudienceProfiles": {
+              "Personal": {
+                "ApprovalPolicy": {
+                  "DefaultMode": "Auto",
+                  "McpServerDefaults": { "notion": "Approval" }
+                }
+              }
+            }
+          }
+        }
+        """;
+        File.WriteAllText(_paths.NetclawConfigPath, configJson);
+
+        var vm = CreateVm();
+        vm.InitializeForTests("notion", new[] { "create-pages" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        var (mode, inherited) = vm.GetEffectiveMode("create-pages");
+        Assert.Equal(ToolApprovalMode.Approval, mode);
+        Assert.True(inherited);
+        Assert.Equal(ToolApprovalMode.Approval, vm.GetServerDefault());
+    }
+
+    private sealed class NoopHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -119,6 +119,15 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
                 "all discovered tools are exposed. Consider adding per-tool grants for supply-chain protection.");
         }
 
+        // Warning: MCP servers reachable for Personal with no approval default.
+        var missingApproval = FindMcpServersMissingPersonalApprovalDefault(toolConfig.AudienceProfiles, mcpServers);
+        if (missingApproval.Count > 0)
+        {
+            warnings.Add(
+                $"MCP server(s) {string.Join(", ", missingApproval)} have no approval default on Personal — " +
+                "tools invoke without prompting. Run `netclaw mcp permissions` to set a server default.");
+        }
+
         if (warnings.Count > 0)
         {
             return Task.FromResult(DoctorCheckResult.Warning(
@@ -192,6 +201,49 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         }
 
         return allowedServers.Except(grantedServers, StringComparer.OrdinalIgnoreCase).Order().ToList();
+    }
+
+    /// <summary>
+    /// Finds enabled MCP servers that are reachable by the Personal audience
+    /// (via <c>McpServersMode = All</c>) but have no
+    /// <c>ApprovalPolicy.McpServerDefaults[server]</c> entry AND no
+    /// <c>ToolOverrides</c> entries keyed by <c>{server}/*</c>. Such servers
+    /// invoke their tools without any approval prompt on Personal.
+    /// </summary>
+    private static List<string> FindMcpServersMissingPersonalApprovalDefault(
+        ToolAudienceProfiles profiles,
+        IReadOnlyDictionary<string, McpServerEntry> mcpServers)
+    {
+        var personal = profiles.Personal;
+        if (personal.McpServersMode != ToolProfileMode.All)
+            return [];
+
+        var result = new List<string>();
+        foreach (var (serverName, entry) in mcpServers)
+        {
+            if (!entry.Enabled)
+                continue;
+
+            var approvalPolicy = personal.ApprovalPolicy;
+            if (approvalPolicy is null)
+            {
+                result.Add(serverName);
+                continue;
+            }
+
+            if (approvalPolicy.McpServerDefaults.ContainsKey(serverName))
+                continue;
+
+            var serverPrefix = $"{serverName}/";
+            var hasPerToolOverride = approvalPolicy.ToolOverrides.Keys.Any(
+                k => k.StartsWith(serverPrefix, StringComparison.Ordinal));
+            if (hasPerToolOverride)
+                continue;
+
+            result.Add(serverName);
+        }
+
+        return result.Order(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private static void CheckApprovalMismatch(ToolConfig toolConfig, List<string> warnings)

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -48,19 +48,21 @@ internal static class McpCommand
             "enable" => RunToggle(args, paths, enabled: true, writer),
             "disable" => RunToggle(args, paths, enabled: false, writer),
             "tools" => await RunToolsAsync(args, paths, daemonApi, writer),
+            "permissions" => await RunToolsAsync(args, paths, daemonApi, writer),
             "help" or "-h" or "--help" => WriteHelp(writer),
             _ => WriteHelp(writer)
         };
     }
 
-    private static int RunAdd(string[] args, NetclawPaths paths, TextWriter writer)
+    internal static int RunAdd(string[] args, NetclawPaths paths, TextWriter writer)
     {
-        // Parse: netclaw mcp add [--transport <type>] [--client-id <id>] [--scope <scopes>] [--env KEY=VALUE]... [--header "Key: Value"]... <name> [command/url] [-- args...]
+        // Parse: netclaw mcp add [--transport <type>] [--client-id <id>] [--scope <scopes>] [--env KEY=VALUE]... [--header "Key: Value"]... [--grant-all] <name> [command/url] [-- args...]
         string? transport = null;
         string? oauthClientId = null;
         string? oauthScope = null;
         var envVars = new Dictionary<string, string>();
         var headers = new Dictionary<string, string>();
+        var grantAll = false;
         string? name = null;
         string? commandOrUrl = null;
         string[]? commandArgs = null;
@@ -80,6 +82,12 @@ internal static class McpCommand
             if (args[i] == "--")
             {
                 afterDash = true;
+                continue;
+            }
+
+            if (args[i] == "--grant-all")
+            {
+                grantAll = true;
                 continue;
             }
 
@@ -191,6 +199,8 @@ internal static class McpCommand
         var mcpServers = GetOrCreateSection(config, "McpServers");
         mcpServers[name] = SerializeEntry(entry);
 
+        ApplySecureDefaultsForNewServer(config, name, grantAll);
+
         WriteConfigFile(paths.NetclawConfigPath, config);
 
         // Write sensitive values to secrets.json
@@ -209,7 +219,57 @@ internal static class McpCommand
         }
 
         writer.WriteLine($"Added MCP server '{name}' ({transport})");
+        writer.WriteLine();
+        if (grantAll)
+        {
+            writer.WriteLine("Security: all tools are reachable for any audience that allows this server");
+            writer.WriteLine("          (legacy null-grants behavior — you passed --grant-all).");
+        }
+        else
+        {
+            writer.WriteLine("Security: 0 tools granted for any audience. Personal/Team/Public tool grants");
+            writer.WriteLine("          were written as empty lists to block all tools until you opt in.");
+        }
+        writer.WriteLine("Approval defaults: Personal=Approval, Team=Approval, Public=Deny");
+        writer.WriteLine($"Next: run `netclaw mcp permissions` to grant tools and adjust approvals for '{name}'.");
         return 0;
+    }
+
+    /// <summary>
+    /// Writes fail-closed defaults for a newly added MCP server across all
+    /// audience profiles: empty <c>McpServerToolGrants[serverName]</c> lists
+    /// (skipped when <paramref name="grantAll"/> is true) and
+    /// <c>ApprovalPolicy.McpServerDefaults[serverName]</c> per-audience
+    /// entries (Personal=Approval, Team=Approval, Public=Deny). The
+    /// <c>ApprovalPolicy</c> section is created if missing.
+    /// </summary>
+    private static void ApplySecureDefaultsForNewServer(
+        Dictionary<string, object> config, string serverName, bool grantAll)
+    {
+        var toolsSection = GetOrCreateSection(config, "Tools");
+        var profilesSection = GetOrCreateSection(toolsSection, "AudienceProfiles");
+
+        (string audience, string approvalMode)[] audiences =
+        [
+            ("Personal", "Approval"),
+            ("Team", "Approval"),
+            ("Public", "Deny"),
+        ];
+
+        foreach (var (audienceName, approvalMode) in audiences)
+        {
+            var audienceSection = GetOrCreateSection(profilesSection, audienceName);
+
+            if (!grantAll)
+            {
+                var grants = GetOrCreateSection(audienceSection, "McpServerToolGrants");
+                grants[serverName] = new List<string>();
+            }
+
+            var approvalPolicy = GetOrCreateSection(audienceSection, "ApprovalPolicy");
+            var serverDefaults = GetOrCreateSection(approvalPolicy, "McpServerDefaults");
+            serverDefaults[serverName] = approvalMode;
+        }
     }
 
     private static async Task<int> RunAuthAsync(string[] args, NetclawPaths paths, DaemonApi? daemonApi, TextWriter writer)
@@ -1011,6 +1071,8 @@ internal static class McpCommand
             }
         }
 
+        writer.WriteLine();
+        writer.WriteLine("Edit interactively: netclaw mcp permissions");
         return 0;
     }
 
@@ -1199,22 +1261,30 @@ internal static class McpCommand
         writer.WriteLine("Usage: netclaw mcp <subcommand>");
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
-        writer.WriteLine("  add        Add an MCP server profile");
-        writer.WriteLine("  auth       Authorize an OAuth-enabled MCP server");
-        writer.WriteLine("  list       List configured MCP servers with daemon-reported status");
-        writer.WriteLine("  get        Show details for an MCP server");
-        writer.WriteLine("  remove     Remove an MCP server profile");
-        writer.WriteLine("  enable     Enable a disabled MCP server");
-        writer.WriteLine("  disable    Disable an MCP server without removing it");
-        writer.WriteLine("  tools      Show and manage per-audience tool grants");
+        writer.WriteLine("  add          Add an MCP server profile (fail-closed by default)");
+        writer.WriteLine("  auth         Authorize an OAuth-enabled MCP server");
+        writer.WriteLine("  list         List configured MCP servers with daemon-reported status");
+        writer.WriteLine("  get          Show details for an MCP server");
+        writer.WriteLine("  remove       Remove an MCP server profile");
+        writer.WriteLine("  enable       Enable a disabled MCP server");
+        writer.WriteLine("  disable      Disable an MCP server without removing it");
+        writer.WriteLine("  permissions  Interactively edit per-audience tool grants and approval modes (recommended)");
+        writer.WriteLine("  tools        Read-only view of per-audience tool grants from the CLI");
+        writer.WriteLine();
+        writer.WriteLine("Flags for 'add':");
+        writer.WriteLine("  --grant-all  CI escape hatch. Skip the empty-grants writes and leave tool");
+        writer.WriteLine("               grants null (legacy \"all pass\" behavior). Approval defaults");
+        writer.WriteLine("               (Personal=Approval, Team=Approval, Public=Deny) are still written.");
         writer.WriteLine();
         writer.WriteLine("Examples:");
         writer.WriteLine("  netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server");
         writer.WriteLine("  netclaw mcp add --transport http --header \"Authorization: Bearer tok-...\" myapi https://api.example.com/mcp");
         writer.WriteLine("  netclaw mcp add --transport http textforge https://textforge.net/mcp");
+        writer.WriteLine("  netclaw mcp add --grant-all --transport stdio trusted -- /usr/local/bin/trusted");
         writer.WriteLine("  netclaw mcp auth forge");
         writer.WriteLine("  netclaw mcp list");
-        writer.WriteLine("  netclaw mcp tools memorizer");
+        writer.WriteLine("  netclaw mcp permissions                                    # interactive TUI editor");
+        writer.WriteLine("  netclaw mcp tools memorizer                                # read-only CLI view");
         writer.WriteLine("  netclaw mcp tools memorizer --snapshot --audience team");
         writer.WriteLine("  netclaw mcp tools memorizer --grant search_memories,get --audience team");
         return 0;

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -37,7 +37,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         return new PanelNode()
             .WithBorder(BorderStyle.Rounded)
             .WithBorderColor(Color.Cyan)
-            .WithContent(new TextNode("MCP Tool Permissions")
+            .WithContent(new TextNode("MCP Permissions")
                 .WithForeground(Color.White)
                 .Bold());
     }
@@ -122,13 +122,21 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         var serverAllowed = ViewModel.IsServerAllowedForSelectedAudience();
         var accessMarker = serverAllowed ? "\u2713" : " ";
 
+        var serverDefault = ViewModel.GetServerDefault();
+        var serverDefaultLabel = $"[{serverDefault}]";
+
         var layout = Layouts.Vertical()
             .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold())
             .WithChild(new TextNode($"  Audience: {audienceSelector}").WithForeground(Color.Cyan).Bold())
             .WithSpacing(1)
             .WithChild(new TextNode($"  [{accessMarker}] Server enabled for {audienceLabel}")
                 .WithForeground(serverAllowed ? Color.White : Color.Yellow))
+            .WithChild(new TextNode($"  [M] Server default: {serverDefaultLabel}")
+                .WithForeground(ColorForMode(serverDefault)))
             .WithSpacing(1);
+
+        // Find the longest tool name for column alignment.
+        var maxToolNameLen = tools.Count > 0 ? tools.Max(t => t.Length) : 0;
 
         for (var i = 0; i < tools.Count; i++)
         {
@@ -137,7 +145,11 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             var granted = serverAllowed && ViewModel.IsToolGranted(tool);
             var prefix = isFocused ? " \u25b6 " : "   ";
             var marker = granted ? "\u2713" : " ";
-            var line = $"{prefix}[{marker}] {tool}";
+            var paddedName = tool.PadRight(maxToolNameLen);
+            var (effectiveMode, inherited) = ViewModel.GetEffectiveMode(tool);
+            var modeBadge = $"[{effectiveMode}]";
+            var inheritSuffix = inherited ? "(def)" : "(override)";
+            var line = $"{prefix}[{marker}] {paddedName}  {modeBadge,-12} {inheritSuffix}";
 
             var node = new TextNode(line);
             if (!serverAllowed)
@@ -160,6 +172,13 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         return layout;
     }
 
+    private static Color ColorForMode(ToolApprovalMode mode) => mode switch
+    {
+        ToolApprovalMode.Approval => Color.Yellow,
+        ToolApprovalMode.Deny => Color.Red,
+        _ => Color.White
+    };
+
     private LayoutNode BuildFooter()
     {
         var footerNode = new DynamicLayoutNode(() =>
@@ -168,7 +187,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             {
                 ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [E] Enable/Disable  [S] Save  [Esc] Back" +
+                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [E] Enable/Disable  [M] Server default  [P] Tool mode  [S] Save  [Esc] Back" +
                     (ViewModel.HasUnsavedChanges ? "  *unsaved*" : ""),
                 _ => ""
             };
@@ -248,6 +267,16 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 case ConsoleKey.E:
                     ViewModel.ToggleServerAccess();
                     return;
+
+                case ConsoleKey.M:
+                    ViewModel.CycleServerDefault();
+                    return;
+
+                case ConsoleKey.P:
+                    if (ViewModel.IsServerAllowedForSelectedAudience()
+                        && ViewModel.DiscoveredTools.Count > 0)
+                        ViewModel.CycleToolOverride(ViewModel.DiscoveredTools[_toolCursor]);
+                    return;
             }
 
             if (keyInfo.KeyChar == 's')
@@ -265,6 +294,20 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             if (keyInfo.KeyChar == 'e')
             {
                 ViewModel.ToggleServerAccess();
+                return;
+            }
+
+            if (keyInfo.KeyChar == 'm')
+            {
+                ViewModel.CycleServerDefault();
+                return;
+            }
+
+            if (keyInfo.KeyChar == 'p'
+                && ViewModel.IsServerAllowedForSelectedAudience()
+                && ViewModel.DiscoveredTools.Count > 0)
+            {
+                ViewModel.CycleToolOverride(ViewModel.DiscoveredTools[_toolCursor]);
                 return;
             }
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -44,7 +44,18 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _pendingGrants = new();
     // Track pending server access changes: (audience, server) → allowed
     private readonly Dictionary<(string Audience, string Server), bool> _pendingServerAccess = new();
-    public bool HasUnsavedChanges => _pendingGrants.Count > 0 || _pendingServerAccess.Count > 0;
+    // Track pending server-level approval defaults: (audience, server) → mode
+    private readonly Dictionary<(string Audience, string Server), ToolApprovalMode> _pendingServerDefaults = new();
+    // Track pending per-tool approval overrides: (audience, server, tool) → mode.
+    // A null value is the "inherit" sentinel: the entry is removed from
+    // ToolOverrides on save so the effective mode falls through to the
+    // server default / global default.
+    private readonly Dictionary<(string Audience, string Server, string Tool), ToolApprovalMode?> _pendingToolOverrides = new();
+    public bool HasUnsavedChanges =>
+        _pendingGrants.Count > 0
+        || _pendingServerAccess.Count > 0
+        || _pendingServerDefaults.Count > 0
+        || _pendingToolOverrides.Count > 0;
 
     public override void OnActivated()
     {
@@ -92,6 +103,27 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     {
         SelectedServer = serverName;
         _ = LoadToolsForServerAsync(serverName);
+    }
+
+    /// <summary>
+    /// Test seam: wires up the view for a specific server and tool list
+    /// without touching the daemon. Reloads the audience profiles from
+    /// disk so tests can exercise <see cref="Save"/> end-to-end.
+    /// </summary>
+    internal void InitializeForTests(string serverName, IEnumerable<string> tools)
+    {
+        SelectedServer = serverName;
+        DiscoveredTools.Clear();
+        DiscoveredTools.AddRange(tools);
+        Profiles = LoadToolConfig().AudienceProfiles;
+        if (!_pendingGrants.ContainsKey(serverName))
+            InitializePendingGrantsFromConfig(serverName);
+        CurrentState.Value = ToolPermissionsState.ToolGrid;
+    }
+
+    internal void SetSelectedAudienceForTests(TrustAudience audience)
+    {
+        SelectedAudience = audience;
     }
 
     private async Task LoadToolsForServerAsync(string serverName)
@@ -158,6 +190,143 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         var idx = Array.IndexOf(AudienceValues, SelectedAudience);
         SelectedAudience = AudienceValues[(idx - 1 + AudienceValues.Length) % AudienceValues.Length];
         NotifyStateChanged();
+    }
+
+    private static readonly ToolApprovalMode[] ServerDefaultCycle =
+        [ToolApprovalMode.Auto, ToolApprovalMode.Approval, ToolApprovalMode.Deny];
+
+    /// <summary>
+    /// Advances the server-default approval mode for the current audience/server
+    /// pair through Auto → Approval → Deny → Auto. The starting point is the
+    /// currently resolved effective default (pending or config).
+    /// </summary>
+    public void CycleServerDefault()
+    {
+        if (SelectedServer is null)
+            return;
+
+        var audience = AudienceName(SelectedAudience);
+        var key = (audience, SelectedServer);
+
+        var current = _pendingServerDefaults.TryGetValue(key, out var pending)
+            ? pending
+            : ResolveProfile(SelectedAudience).ApprovalPolicy?.McpServerDefaults.TryGetValue(SelectedServer, out var configMode) == true
+                ? configMode
+                : ToolApprovalMode.Auto;
+
+        var idx = Array.IndexOf(ServerDefaultCycle, current);
+        var next = ServerDefaultCycle[(idx + 1) % ServerDefaultCycle.Length];
+        _pendingServerDefaults[key] = next;
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Advances the per-tool approval override for <paramref name="toolName"/>
+    /// under the current audience/server pair through
+    /// inherit (null) → Auto → Approval → Deny → inherit. The "inherit" state
+    /// removes any existing <c>ToolOverrides[{server}/{tool}]</c> entry on save.
+    /// </summary>
+    public void CycleToolOverride(string toolName)
+    {
+        if (SelectedServer is null)
+            return;
+
+        var audience = AudienceName(SelectedAudience);
+        var key = (audience, SelectedServer, toolName);
+
+        ToolApprovalMode? current;
+        if (_pendingToolOverrides.TryGetValue(key, out var pending))
+        {
+            current = pending;
+        }
+        else
+        {
+            var exactKey = $"{SelectedServer}/{toolName}";
+            current = ResolveProfile(SelectedAudience).ApprovalPolicy?.ToolOverrides.TryGetValue(exactKey, out var configMode) == true
+                ? configMode
+                : null;
+        }
+
+        // Cycle: inherit (null) → Auto → Approval → Deny → inherit
+        ToolApprovalMode? next = current switch
+        {
+            null => ToolApprovalMode.Auto,
+            ToolApprovalMode.Auto => ToolApprovalMode.Approval,
+            ToolApprovalMode.Approval => ToolApprovalMode.Deny,
+            ToolApprovalMode.Deny => null,
+            _ => null
+        };
+
+        _pendingToolOverrides[key] = next;
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Returns the effective approval mode for a tool under the currently
+    /// selected server and audience, plus a flag indicating whether the mode
+    /// was inherited from the server default / global default (true) or came
+    /// from an explicit per-tool entry (false).
+    /// </summary>
+    public (ToolApprovalMode Mode, bool IsInherited) GetEffectiveMode(string toolName)
+    {
+        if (SelectedServer is null)
+            return (ToolApprovalMode.Auto, true);
+
+        var audience = AudienceName(SelectedAudience);
+        var profile = ResolveProfile(SelectedAudience);
+        var approvalPolicy = profile.ApprovalPolicy;
+
+        // Step 1: pending per-tool override.
+        var toolKey = (audience, SelectedServer, toolName);
+        if (_pendingToolOverrides.TryGetValue(toolKey, out var pendingOverride))
+        {
+            if (pendingOverride is { } explicitMode)
+                return (explicitMode, false);
+            // null = inherit → skip and continue resolution.
+        }
+        else if (approvalPolicy is not null)
+        {
+            // Step 2: config ToolOverrides[{server}/{tool}]
+            var exactKey = $"{SelectedServer}/{toolName}";
+            if (approvalPolicy.ToolOverrides.TryGetValue(exactKey, out var configExact))
+                return (configExact, false);
+        }
+
+        // Step 3: pending server default.
+        var serverKey = (audience, SelectedServer);
+        if (_pendingServerDefaults.TryGetValue(serverKey, out var pendingDefault))
+            return (pendingDefault, true);
+
+        // Step 4: config McpServerDefaults[server]
+        if (approvalPolicy is not null
+            && approvalPolicy.McpServerDefaults.TryGetValue(SelectedServer, out var configDefault))
+            return (configDefault, true);
+
+        // Step 5: global DefaultMode (inherit).
+        return (approvalPolicy?.DefaultMode ?? ToolApprovalMode.Auto, true);
+    }
+
+    /// <summary>
+    /// Returns the server-default approval mode for the currently selected
+    /// audience/server pair, consulting pending edits first, then config.
+    /// </summary>
+    public ToolApprovalMode GetServerDefault()
+    {
+        if (SelectedServer is null)
+            return ToolApprovalMode.Auto;
+
+        var audience = AudienceName(SelectedAudience);
+        if (_pendingServerDefaults.TryGetValue((audience, SelectedServer), out var pending))
+            return pending;
+
+        var approvalPolicy = ResolveProfile(SelectedAudience).ApprovalPolicy;
+        if (approvalPolicy is not null
+            && approvalPolicy.McpServerDefaults.TryGetValue(SelectedServer, out var configMode))
+            return configMode;
+
+        return ToolApprovalMode.Auto;
     }
 
     public bool IsToolGranted(string toolName)
@@ -337,20 +506,65 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             foreach (var (audienceName, tools) in audienceGrants)
             {
                 var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
-
-                var grants = audienceSection.TryGetValue("McpServerToolGrants", out var existing)
-                    && existing is Dictionary<string, object> dict
-                        ? dict
-                        : new Dictionary<string, object>();
-
+                var grants = ConfigFileHelper.GetOrCreateSection(audienceSection, "McpServerToolGrants");
                 grants[serverName] = tools.Order(StringComparer.Ordinal).ToList();
-                audienceSection["McpServerToolGrants"] = grants;
+            }
+        }
+
+        // Write server-default approval modes (ApprovalPolicy.McpServerDefaults)
+        foreach (var ((audienceName, serverName), mode) in _pendingServerDefaults)
+        {
+            var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
+            var approvalPolicy = ConfigFileHelper.GetOrCreateSection(audienceSection, "ApprovalPolicy");
+            var serverDefaults = ConfigFileHelper.GetOrCreateSection(approvalPolicy, "McpServerDefaults");
+            serverDefaults[serverName] = mode.ToString();
+
+            // Mirror into in-memory profile so GetEffectiveMode / GetServerDefault
+            // reflect the saved value immediately without a config reload.
+            var profile = audienceName switch
+            {
+                "Public" => Profiles.Public,
+                "Team" => Profiles.Team,
+                _ => Profiles.Personal
+            };
+            profile.ApprovalPolicy ??= new ToolApprovalConfig();
+            profile.ApprovalPolicy.McpServerDefaults[serverName] = mode;
+        }
+
+        // Write per-tool approval overrides (ApprovalPolicy.ToolOverrides)
+        foreach (var ((audienceName, serverName, toolName), mode) in _pendingToolOverrides)
+        {
+            var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
+            var approvalPolicy = ConfigFileHelper.GetOrCreateSection(audienceSection, "ApprovalPolicy");
+            var toolOverrides = ConfigFileHelper.GetOrCreateSection(approvalPolicy, "ToolOverrides");
+            var exactKey = $"{serverName}/{toolName}";
+
+            var profile = audienceName switch
+            {
+                "Public" => Profiles.Public,
+                "Team" => Profiles.Team,
+                _ => Profiles.Personal
+            };
+            profile.ApprovalPolicy ??= new ToolApprovalConfig();
+
+            if (mode is null)
+            {
+                // Inherit sentinel: remove the exact override on disk and in memory.
+                toolOverrides.Remove(exactKey);
+                profile.ApprovalPolicy.ToolOverrides.Remove(exactKey);
+            }
+            else
+            {
+                toolOverrides[exactKey] = mode.Value.ToString();
+                profile.ApprovalPolicy.ToolOverrides[exactKey] = mode.Value;
             }
         }
 
         ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
         _pendingGrants.Clear();
         _pendingServerAccess.Clear();
+        _pendingServerDefaults.Clear();
+        _pendingToolOverrides.Clear();
 
         StatusMessage.Value = "Saved to netclaw.json. Restart daemon to apply changes.";
         CurrentState.Value = ToolPermissionsState.ToolGrid;

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -248,7 +248,6 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 : null;
         }
 
-        // Cycle: inherit (null) → Auto → Approval → Deny → inherit
         ToolApprovalMode? next = current switch
         {
             null => ToolApprovalMode.Auto,
@@ -274,37 +273,34 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         if (SelectedServer is null)
             return (ToolApprovalMode.Auto, true);
 
+        // Precedence mirrors ToolApprovalConfig.TryGetExplicitMode but layers
+        // pending edits on top of the config so the view reflects unsaved state.
         var audience = AudienceName(SelectedAudience);
         var profile = ResolveProfile(SelectedAudience);
         var approvalPolicy = profile.ApprovalPolicy;
 
-        // Step 1: pending per-tool override.
         var toolKey = (audience, SelectedServer, toolName);
         if (_pendingToolOverrides.TryGetValue(toolKey, out var pendingOverride))
         {
             if (pendingOverride is { } explicitMode)
                 return (explicitMode, false);
-            // null = inherit → skip and continue resolution.
+            // inherit sentinel (null) — fall through.
         }
         else if (approvalPolicy is not null)
         {
-            // Step 2: config ToolOverrides[{server}/{tool}]
             var exactKey = $"{SelectedServer}/{toolName}";
             if (approvalPolicy.ToolOverrides.TryGetValue(exactKey, out var configExact))
                 return (configExact, false);
         }
 
-        // Step 3: pending server default.
         var serverKey = (audience, SelectedServer);
         if (_pendingServerDefaults.TryGetValue(serverKey, out var pendingDefault))
             return (pendingDefault, true);
 
-        // Step 4: config McpServerDefaults[server]
         if (approvalPolicy is not null
             && approvalPolicy.McpServerDefaults.TryGetValue(SelectedServer, out var configDefault))
             return (configDefault, true);
 
-        // Step 5: global DefaultMode (inherit).
         return (approvalPolicy?.DefaultMode ?? ToolApprovalMode.Auto, true);
     }
 
@@ -511,52 +507,32 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             }
         }
 
-        // Write server-default approval modes (ApprovalPolicy.McpServerDefaults)
+        // Mirroring in-memory Profiles alongside the on-disk writes lets
+        // GetEffectiveMode / GetServerDefault reflect saved values without
+        // a full config reload.
         foreach (var ((audienceName, serverName), mode) in _pendingServerDefaults)
         {
-            var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
-            var approvalPolicy = ConfigFileHelper.GetOrCreateSection(audienceSection, "ApprovalPolicy");
-            var serverDefaults = ConfigFileHelper.GetOrCreateSection(approvalPolicy, "McpServerDefaults");
+            var (approvalSection, inMemoryPolicy) = GetOrCreateApprovalPolicy(profilesSection, audienceName);
+            var serverDefaults = ConfigFileHelper.GetOrCreateSection(approvalSection, "McpServerDefaults");
             serverDefaults[serverName] = mode.ToString();
-
-            // Mirror into in-memory profile so GetEffectiveMode / GetServerDefault
-            // reflect the saved value immediately without a config reload.
-            var profile = audienceName switch
-            {
-                "Public" => Profiles.Public,
-                "Team" => Profiles.Team,
-                _ => Profiles.Personal
-            };
-            profile.ApprovalPolicy ??= new ToolApprovalConfig();
-            profile.ApprovalPolicy.McpServerDefaults[serverName] = mode;
+            inMemoryPolicy.McpServerDefaults[serverName] = mode;
         }
 
-        // Write per-tool approval overrides (ApprovalPolicy.ToolOverrides)
         foreach (var ((audienceName, serverName, toolName), mode) in _pendingToolOverrides)
         {
-            var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
-            var approvalPolicy = ConfigFileHelper.GetOrCreateSection(audienceSection, "ApprovalPolicy");
-            var toolOverrides = ConfigFileHelper.GetOrCreateSection(approvalPolicy, "ToolOverrides");
+            var (approvalSection, inMemoryPolicy) = GetOrCreateApprovalPolicy(profilesSection, audienceName);
+            var toolOverrides = ConfigFileHelper.GetOrCreateSection(approvalSection, "ToolOverrides");
             var exactKey = $"{serverName}/{toolName}";
-
-            var profile = audienceName switch
-            {
-                "Public" => Profiles.Public,
-                "Team" => Profiles.Team,
-                _ => Profiles.Personal
-            };
-            profile.ApprovalPolicy ??= new ToolApprovalConfig();
 
             if (mode is null)
             {
-                // Inherit sentinel: remove the exact override on disk and in memory.
                 toolOverrides.Remove(exactKey);
-                profile.ApprovalPolicy.ToolOverrides.Remove(exactKey);
+                inMemoryPolicy.ToolOverrides.Remove(exactKey);
             }
             else
             {
                 toolOverrides[exactKey] = mode.Value.ToString();
-                profile.ApprovalPolicy.ToolOverrides[exactKey] = mode.Value;
+                inMemoryPolicy.ToolOverrides[exactKey] = mode.Value;
             }
         }
 
@@ -610,6 +586,21 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         }
 
         NotifyStateChanged();
+    }
+
+    private (Dictionary<string, object> ApprovalSection, ToolApprovalConfig InMemoryPolicy)
+        GetOrCreateApprovalPolicy(Dictionary<string, object> profilesSection, string audienceName)
+    {
+        var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
+        var approvalSection = ConfigFileHelper.GetOrCreateSection(audienceSection, "ApprovalPolicy");
+        var profile = audienceName switch
+        {
+            "Public" => Profiles.Public,
+            "Team" => Profiles.Team,
+            _ => Profiles.Personal
+        };
+        profile.ApprovalPolicy ??= new ToolApprovalConfig();
+        return (approvalSection, profile.ApprovalPolicy);
     }
 
     private static bool IsServerAllowed(string serverName, ToolAudienceProfile profile)

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -603,9 +603,9 @@ static async Task RunAsync(string[] args)
     {
         var mcpSubcommand = args.Length > 1 ? args[1] : "help";
 
-        if (mcpSubcommand is "tools" && args.Length <= 2)
+        if ((mcpSubcommand is "tools" && args.Length <= 2) || mcpSubcommand is "permissions")
         {
-            // Bare `netclaw mcp tools` → TUI mode
+            // Bare `netclaw mcp tools` or `netclaw mcp permissions` → TUI mode
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
             builder.Logging.ClearProviders();

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -603,7 +603,7 @@ static async Task RunAsync(string[] args)
     {
         var mcpSubcommand = args.Length > 1 ? args[1] : "help";
 
-        if ((mcpSubcommand is "tools" && args.Length <= 2) || mcpSubcommand is "permissions")
+        if ((mcpSubcommand is "tools" or "permissions") && args.Length <= 2)
         {
             // Bare `netclaw mcp tools` or `netclaw mcp permissions` → TUI mode
             var builder = Host.CreateApplicationBuilder(args);
@@ -621,9 +621,9 @@ static async Task RunAsync(string[] args)
             return;
         }
 
-        if (mcpSubcommand is "auth" or "list" or "tools")
+        if (mcpSubcommand is "auth" or "list" or "tools" or "permissions")
         {
-            // auth/list/tools need the daemon — spin up DI to get DaemonApi
+            // auth/list/tools/permissions need the daemon — spin up DI to get DaemonApi
             var builder = Host.CreateApplicationBuilder(args);
             ConfigureConfigServices(builder.Services, builder.Configuration);
             builder.Logging.ClearProviders();

--- a/src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/ToolApprovalConfigTests.cs
@@ -1,0 +1,123 @@
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class ToolApprovalConfigTests
+{
+    [Fact]
+    public void GetEffectiveMode_returns_default_mode_when_no_override()
+    {
+        var config = new ToolApprovalConfig { DefaultMode = ToolApprovalMode.Auto };
+
+        Assert.Equal(ToolApprovalMode.Auto, config.GetEffectiveMode("shell_execute"));
+        Assert.Equal(ToolApprovalMode.Auto, config.GetEffectiveMode("notion/create-pages"));
+    }
+
+    [Fact]
+    public void GetEffectiveMode_exact_override_beats_server_default_and_default_mode()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Deny
+            },
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion/search"] = ToolApprovalMode.Approval
+            }
+        };
+
+        Assert.Equal(ToolApprovalMode.Approval, config.GetEffectiveMode("notion/search"));
+    }
+
+    [Fact]
+    public void GetEffectiveMode_server_default_beats_default_mode_for_mcp_tools()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            }
+        };
+
+        Assert.Equal(ToolApprovalMode.Approval, config.GetEffectiveMode("notion/create-pages"));
+        Assert.Equal(ToolApprovalMode.Approval, config.GetEffectiveMode("notion/archive"));
+    }
+
+    [Fact]
+    public void GetEffectiveMode_server_default_does_not_leak_to_non_mcp_tools()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Deny
+            }
+        };
+
+        // No slash in name → server-default step is skipped.
+        Assert.Equal(ToolApprovalMode.Auto, config.GetEffectiveMode("shell_execute"));
+    }
+
+    [Fact]
+    public void GetEffectiveMode_server_default_does_not_leak_across_servers()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Deny
+            }
+        };
+
+        Assert.Equal(ToolApprovalMode.Auto, config.GetEffectiveMode("memorizer/search_memories"));
+    }
+
+    [Fact]
+    public void TryGetExplicitMode_reports_hit_when_override_present()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Approval,
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["file_write"] = ToolApprovalMode.Auto
+            }
+        };
+
+        Assert.True(config.TryGetExplicitMode("file_write", out var mode));
+        Assert.Equal(ToolApprovalMode.Auto, mode);
+    }
+
+    [Fact]
+    public void TryGetExplicitMode_reports_miss_when_no_override_or_server_default()
+    {
+        var config = new ToolApprovalConfig { DefaultMode = ToolApprovalMode.Approval };
+
+        Assert.False(config.TryGetExplicitMode("shell_execute", out _));
+        Assert.False(config.TryGetExplicitMode("notion/create-pages", out _));
+    }
+
+    [Fact]
+    public void TryGetExplicitMode_uses_server_default_for_slash_delimited_names()
+    {
+        var config = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Auto,
+            McpServerDefaults = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["notion"] = ToolApprovalMode.Approval
+            }
+        };
+
+        Assert.True(config.TryGetExplicitMode("notion/create-pages", out var mode));
+        Assert.Equal(ToolApprovalMode.Approval, mode);
+    }
+}

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -608,7 +608,17 @@
         },
         "ToolOverrides": {
           "type": "object",
-          "description": "Per-tool approval mode overrides. Keys are tool names (e.g., shell_execute, mcp:server:tool) or matcher-specific keys such as file_write:control-plane and file_edit:control-plane.",
+          "default": {},
+          "description": "Per-tool approval mode overrides. Keys are exact tool names (e.g., shell_execute, file_write) or MCP tool keys of the form {serverName}/{toolName} (e.g., notion/create-pages) or matcher-specific keys such as file_write:control-plane and file_edit:control-plane.",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["Auto", "Approval", "Deny"]
+          }
+        },
+        "McpServerDefaults": {
+          "type": "object",
+          "default": {},
+          "description": "Per-MCP-server approval mode defaults. Keys are MCP server names (e.g., notion). Applies to all tools exposed by that server unless an exact entry in ToolOverrides takes precedence. Tools discovered on the server after config was written inherit this default automatically.",
           "additionalProperties": {
             "type": "string",
             "enum": ["Auto", "Approval", "Deny"]

--- a/src/Netclaw.Configuration/ToolApprovalConfig.cs
+++ b/src/Netclaw.Configuration/ToolApprovalConfig.cs
@@ -27,16 +27,60 @@ public sealed class ToolApprovalConfig
     public ToolApprovalMode DefaultMode { get; set; } = ToolApprovalMode.Auto;
 
     /// <summary>
-    /// Per-tool approval mode overrides. Keys are tool names
-    /// (e.g., "shell_execute", "mcp:server-name:tool-name", "file_write").
+    /// Per-tool approval mode overrides. Keys are exact tool names
+    /// (e.g., "shell_execute", "file_write"). For MCP tools the key format is
+    /// "{serverName}/{toolName}" (for example "notion/create-pages"). An exact
+    /// entry here always wins over <see cref="McpServerDefaults"/> and
+    /// <see cref="DefaultMode"/>.
     /// </summary>
     public Dictionary<string, ToolApprovalMode> ToolOverrides { get; set; } = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Returns the effective approval mode for a tool, checking overrides first.
+    /// Per-MCP-server approval mode defaults. Keys are MCP server names
+    /// (e.g., "notion"). Applies to any tool whose name matches
+    /// "{serverName}/*" unless an exact entry in <see cref="ToolOverrides"/>
+    /// takes precedence. Tools discovered on the server after config was
+    /// written inherit this default automatically.
+    /// </summary>
+    public Dictionary<string, ToolApprovalMode> McpServerDefaults { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns the effective approval mode for a tool using the three-step
+    /// precedence: exact <see cref="ToolOverrides"/> entry →
+    /// <see cref="McpServerDefaults"/> entry (when the tool name is an MCP
+    /// tool of the form "{serverName}/{toolName}") → <see cref="DefaultMode"/>.
     /// </summary>
     public ToolApprovalMode GetEffectiveMode(string toolName)
     {
-        return ToolOverrides.TryGetValue(toolName, out var mode) ? mode : DefaultMode;
+        return TryGetExplicitMode(toolName, out var mode) ? mode : DefaultMode;
+    }
+
+    /// <summary>
+    /// Checks whether the tool has an explicit entry in either
+    /// <see cref="ToolOverrides"/> (exact match) or
+    /// <see cref="McpServerDefaults"/> (by server prefix). This is the
+    /// shared precedence logic used by both <see cref="GetEffectiveMode"/>
+    /// and the runtime <c>ToolAccessPolicy.ResolveApprovalMode</c> path so
+    /// the two callers cannot drift.
+    /// </summary>
+    public bool TryGetExplicitMode(string toolName, out ToolApprovalMode mode)
+    {
+        if (ToolOverrides.TryGetValue(toolName, out mode))
+        {
+            return true;
+        }
+
+        var slashIndex = toolName.IndexOf('/', StringComparison.Ordinal);
+        if (slashIndex > 0)
+        {
+            var serverName = toolName[..slashIndex];
+            if (McpServerDefaults.TryGetValue(serverName, out mode))
+            {
+                return true;
+            }
+        }
+
+        mode = default;
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Implements the `mcp-server-approval-defaults` OpenSpec change (proposal in 63df96b). Closes the three interlocking MCP permission gaps that caused `netclaw mcp add notion ...` to silently expose every Notion tool to Personal without an approval prompt:

1. **Fail-closed `mcp add`** — writes empty `McpServerToolGrants[name]` lists and per-audience `ApprovalPolicy.McpServerDefaults[name]` entries (Personal/Team = `Approval`, Public = `Deny`) for every newly added server. `--grant-all` is a CI escape hatch that skips the grant writes but still writes the approval defaults.
2. **Three-step approval precedence** — `ToolApprovalConfig.GetEffectiveMode` now resolves exact `ToolOverrides[toolName]` → `McpServerDefaults[serverName]` → `DefaultMode`. `ToolAccessPolicy.ResolveApprovalMode` shares the lookup via a new `TryGetExplicitMode` helper so the runtime gate and the config accessor cannot drift.
3. **`netclaw mcp permissions` TUI** — new alias for `netclaw mcp tools` (bare). The TUI gains a per-audience server-default row (`M` cycles `Auto → Approval → Deny`) and a per-tool approval column (`P` cycles `inherit → Auto → Approval → Deny → inherit`, where `inherit` removes the exact override on save). `Save` writes `McpServerDefaults` and `ToolOverrides` alongside existing `McpServerToolGrants`.
4. **Doctor warning** — `ToolAudienceProfilesDoctorCheck` warns (not errors) when an enabled MCP server is reachable by Personal (`McpServersMode = All`) but has no approval default and no per-tool override. No `--fix`: operators opt in via the TUI.

Backward compatible: existing `netclaw.json` files with null grants and no `McpServerDefaults` entries resolve exactly as before. Pre-existing MCP servers are not retroactively mutated.

## Commits

1. `63df96b spec(mcp): propose server-default approvals and fail-closed mcp add` — OpenSpec change artifacts (proposal, design, delta specs, tasks). Already on branch.
2. `2a1eae4 feat(mcp): fail-closed mcp add + server-default approvals + permissions TUI` — full implementation + tests + system skill update.
3. `1e67b21 refactor(mcp-tui): extract GetOrCreateApprovalPolicy helper and tighten GetEffectiveMode` — follow-up cleanup found during `/simplify` review.

## What changed

### Config model (`src/Netclaw.Configuration`)

- `ToolApprovalConfig.McpServerDefaults: Dictionary<string, ToolApprovalMode>` (new).
- `TryGetExplicitMode` helper shared with the runtime gate.
- `GetEffectiveMode` extended to three-step precedence.
- Schema (`netclaw-config.v1.schema.json`) gains `McpServerDefaults` under `ToolApprovalConfig`, `"default": {}`. Stale `mcp:server:tool` comment fixed to `{serverName}/{toolName}`.

### Runtime gate (`src/Netclaw.Actors/Tools/ToolAccessPolicy.cs`)

- `ResolveApprovalMode` delegates the no-matcher-key case to `TryGetExplicitMode`. Fail-closed-on-Personal escape preserved; matcher-specific key branch unchanged.

### CLI (`src/Netclaw.Cli`)

- `McpCommand.RunAdd`:
  - New `--grant-all` flag.
  - `ApplySecureDefaultsForNewServer(config, name, grantAll)` helper writes grants + approval defaults.
  - Post-add output now prints a security hint naming the grant count and directing the operator to `netclaw mcp permissions`.
- `McpCommand.RunAsync` routes `permissions` subcommand to the TUI.
- `RunToolsList` appends `Edit interactively: netclaw mcp permissions`.
- `WriteHelp` documents `permissions`, `tools`, and `--grant-all`.
- `Program.cs` routes `mcp permissions` to the same Termina host as bare `mcp tools`.

### TUI (`src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs` + `McpToolPermissionsPage.cs`)

- New pending-state dicts: `_pendingServerDefaults`, `_pendingToolOverrides` (nullable mode where `null` = inherit sentinel).
- `CycleServerDefault`, `CycleToolOverride`, `GetEffectiveMode`, `GetServerDefault` methods.
- `Save` persists both via the new `GetOrCreateApprovalPolicy` helper, mirroring into in-memory `Profiles` so the UI reflects saved state without a reload. `inherit` entries are removed from `ToolOverrides` rather than written.
- Page renders `[M] Server default: [mode]` row and per-tool `[mode] (def|override)` badge. `M`/`P` keybindings + footer hint.
- Page title changed from `"MCP Tool Permissions"` to `"MCP Permissions"`.

### Doctor (`src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs`)

- `FindMcpServersMissingPersonalApprovalDefault` — warning-severity check, no `--fix`.
- Existing null-grants advisory untouched.

### System skill (`feeds/skills/.system/files/netclaw-operations/SKILL.md`)

- Bumped to 1.14.0.
- New section `Adding MCP servers (fail-closed by default)` documents the flow, the audience matrix, `--grant-all`, the `M`/`P` keybindings, precedence rules, and a migration path for existing servers.

## Tests

- `Netclaw.Configuration.Tests/ToolApprovalConfigTests` — 8 new cases covering `GetEffectiveMode` / `TryGetExplicitMode` precedence.
- `Netclaw.Actors.Tests/Tools/ToolApprovalGateTests` — 6 new cases for `ResolveApprovalMode` MCP precedence (exact beats server default, server default beats `DefaultMode`, `shell_execute` does not match server default, runtime agrees with config accessor, fall-through behavior).
- `Netclaw.Cli.Tests/Mcp/McpCommandTests` — 4 new cases: default invocation writes correct grants + defaults, `--grant-all` skips grants only, pre-existing servers untouched, missing `ApprovalPolicy` section is created.
- `Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests` — new file, 4 cases: `CycleServerDefault` cycle, `CycleToolOverride` cycle, `Save` round-trip for server defaults + tool overrides + inherit removal, loading existing `McpServerDefaults` from config.
- `Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests` — 5 new cases: warning fires on missing default, suppressed by `McpServerDefaults`, suppressed by per-tool override, ignores stale allowlist entries, warning severity.

Suite status: Configuration 189/189, Actors 1052/1052, Cli 429/429, slopwatch 0 issues.

## Related issues

- Known pre-existing UX paper cut surfaced while reviewing this change: https://github.com/Aaronontheweb/netclaw/issues/678 (`HasUnsavedChanges` false positive on first server load due to eager `_pendingGrants` seeding). Not a regression, tracked separately.

## Test plan

- [ ] Manual e2e per design.md §Migration Plan: add a throwaway server via `mcp add`, inspect `netclaw.json` for empty grants + expected defaults, confirm post-add hint
- [ ] Start daemon, `netclaw mcp permissions`, enable server for Personal, grant two tools, cycle `M` + `P`, save, restart daemon
- [ ] From a Slack thread, invoke (a) a granted but inherited tool → approval prompt fires, (b) a tool cycled to `Auto` override → runs without prompting, (c) an ungranted tool → `mcp_tool_not_allowed_for_audience_profile` deny
- [ ] `netclaw doctor` before and after setting a default: confirm warning fires then clears

## Post-merge

- `/opsx-sync` to merge delta specs into `openspec/specs/`
- `/opsx-archive` after the PR lands