### PR TITLE
fix(daemon): swallow SlackNet ReconnectingWebSocket dispose race

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/KnownBenignExceptionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/KnownBenignExceptionsTests.cs
@@ -1,0 +1,87 @@
+using Netclaw.Daemon.Services;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Services;
+
+public sealed class KnownBenignExceptionsTests
+{
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_Null_ReturnsFalse()
+    {
+        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(null));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_UnrelatedExceptionType_ReturnsFalse()
+    {
+        var exception = new InvalidOperationException("boom");
+        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithoutMarker_ReturnsFalse()
+    {
+        var exception = new FakeObjectDisposedException(
+            objectName: "CancellationTokenSource",
+            stackTrace: "at SomeOther.Library.Foo()\nat SomeOther.Library.Bar()");
+
+        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithMarker_ReturnsTrue()
+    {
+        var exception = new FakeObjectDisposedException(
+            objectName: "CancellationTokenSource",
+            stackTrace:
+                "at System.Threading.CancellationTokenSource.get_Token()\n" +
+                "at SlackNet.ReconnectingWebSocket.Connect(Func`1 getWebSocketUrl, CancellationToken cancellationToken)\n" +
+                "at SlackNet.ReconnectingWebSocket.ReconnectOnClose(Func`1 getWebSocketUrl, CancellationToken cancellationToken)");
+
+        Assert.True(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_AggregateWrappingMatchingOde_ReturnsTrue()
+    {
+        var inner = new FakeObjectDisposedException(
+            objectName: "CancellationTokenSource",
+            stackTrace: "at SlackNet.ReconnectingWebSocket.Connect(...)");
+
+        var aggregate = new AggregateException(inner);
+
+        Assert.True(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(aggregate));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_AggregateWrappingUnrelatedException_ReturnsFalse()
+    {
+        var inner = new InvalidOperationException("not slacknet");
+        var aggregate = new AggregateException(inner);
+
+        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(aggregate));
+    }
+
+    [Fact]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithNullStackTrace_ReturnsFalse()
+    {
+        var exception = new FakeObjectDisposedException(
+            objectName: "CancellationTokenSource",
+            stackTrace: null);
+
+        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+    }
+
+    private sealed class FakeObjectDisposedException : ObjectDisposedException
+    {
+        private readonly string? _stackTrace;
+
+        public FakeObjectDisposedException(string objectName, string? stackTrace)
+            : base(objectName)
+        {
+            _stackTrace = stackTrace;
+        }
+
+        public override string? StackTrace => _stackTrace;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Services/KnownBenignExceptionsTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/KnownBenignExceptionsTests.cs
@@ -5,71 +5,61 @@ namespace Netclaw.Daemon.Tests.Services;
 
 public sealed class KnownBenignExceptionsTests
 {
+    private const string RealStackMarker =
+        "at SlackNet.ReconnectingWebSocket.Connect(Func`1 getWebSocketUrl, CancellationToken cancellationToken)";
+
     [Fact]
     public void IsSlackNetReconnectingWebSocketDisposeRace_Null_ReturnsFalse()
     {
         Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(null));
     }
 
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_UnrelatedExceptionType_ReturnsFalse()
+    [Theory]
+    [MemberData(nameof(PredicateCases))]
+    public void IsSlackNetReconnectingWebSocketDisposeRace_MatchesExpected(
+        Exception exception,
+        bool expected)
     {
-        var exception = new InvalidOperationException("boom");
-        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+        Assert.Equal(expected, KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
     }
 
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithoutMarker_ReturnsFalse()
+    public static IEnumerable<object[]> PredicateCases()
     {
-        var exception = new FakeObjectDisposedException(
-            objectName: "CancellationTokenSource",
-            stackTrace: "at SomeOther.Library.Foo()\nat SomeOther.Library.Bar()");
+        yield return [new InvalidOperationException("unrelated"), false];
 
-        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
-    }
+        yield return [
+            new FakeObjectDisposedException("cts", "at SomeOther.Library.Foo()"),
+            false];
 
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithMarker_ReturnsTrue()
-    {
-        var exception = new FakeObjectDisposedException(
-            objectName: "CancellationTokenSource",
-            stackTrace:
-                "at System.Threading.CancellationTokenSource.get_Token()\n" +
-                "at SlackNet.ReconnectingWebSocket.Connect(Func`1 getWebSocketUrl, CancellationToken cancellationToken)\n" +
-                "at SlackNet.ReconnectingWebSocket.ReconnectOnClose(Func`1 getWebSocketUrl, CancellationToken cancellationToken)");
+        yield return [
+            new FakeObjectDisposedException("cts", stackTrace: null),
+            false];
 
-        Assert.True(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
-    }
+        yield return [
+            new FakeObjectDisposedException("cts", RealStackMarker),
+            true];
 
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_AggregateWrappingMatchingOde_ReturnsTrue()
-    {
-        var inner = new FakeObjectDisposedException(
-            objectName: "CancellationTokenSource",
-            stackTrace: "at SlackNet.ReconnectingWebSocket.Connect(...)");
+        yield return [
+            new AggregateException(new FakeObjectDisposedException("cts", RealStackMarker)),
+            true];
 
-        var aggregate = new AggregateException(inner);
+        yield return [
+            new AggregateException(new InvalidOperationException("not slacknet")),
+            false];
 
-        Assert.True(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(aggregate));
-    }
+        // Multiple inners, one matches — Flatten().InnerExceptions must find it.
+        yield return [
+            new AggregateException(
+                new InvalidOperationException("unrelated"),
+                new FakeObjectDisposedException("cts", RealStackMarker)),
+            true];
 
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_AggregateWrappingUnrelatedException_ReturnsFalse()
-    {
-        var inner = new InvalidOperationException("not slacknet");
-        var aggregate = new AggregateException(inner);
-
-        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(aggregate));
-    }
-
-    [Fact]
-    public void IsSlackNetReconnectingWebSocketDisposeRace_OdeWithNullStackTrace_ReturnsFalse()
-    {
-        var exception = new FakeObjectDisposedException(
-            objectName: "CancellationTokenSource",
-            stackTrace: null);
-
-        Assert.False(KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace(exception));
+        // Nested aggregate with the match buried two levels deep.
+        yield return [
+            new AggregateException(
+                new AggregateException(
+                    new FakeObjectDisposedException("cts", RealStackMarker))),
+            true];
     }
 
     private sealed class FakeObjectDisposedException : ObjectDisposedException

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -43,6 +43,8 @@ using static Microsoft.Extensions.Logging.LogLevel;
 var bootstrapPaths = new NetclawPaths();
 bootstrapPaths.EnsureDirectoriesExist();
 using var crashMonitor = DaemonCrashMonitor.Register(bootstrapPaths);
+crashMonitor.RegisterBenignUnobservedExceptionFilter(
+    KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace);
 
 try
 {

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -42,9 +42,9 @@ using static Microsoft.Extensions.Logging.LogLevel;
 
 var bootstrapPaths = new NetclawPaths();
 bootstrapPaths.EnsureDirectoriesExist();
-using var crashMonitor = DaemonCrashMonitor.Register(bootstrapPaths);
-crashMonitor.RegisterBenignUnobservedExceptionFilter(
-    KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace);
+using var crashMonitor = DaemonCrashMonitor.Register(
+    bootstrapPaths,
+    benignUnobservedFilters: [KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace]);
 
 try
 {

--- a/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
+++ b/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
@@ -12,6 +12,7 @@ internal sealed class DaemonCrashMonitor : IDisposable
     private readonly string _logsDirectory;
     private readonly UnhandledExceptionEventHandler _unhandledHandler;
     private readonly EventHandler<UnobservedTaskExceptionEventArgs> _unobservedTaskHandler;
+    private readonly List<Func<Exception, bool>> _benignUnobservedFilters = new();
     private IServiceProvider? _services;
 
     private DaemonCrashMonitor(string logsDirectory, TimeProvider? timeProvider = null)
@@ -28,6 +29,23 @@ internal sealed class DaemonCrashMonitor : IDisposable
 
     public static DaemonCrashMonitor Register(NetclawPaths paths, TimeProvider? timeProvider = null)
         => new(paths.LogsDirectory, timeProvider);
+
+    /// <summary>
+    /// Registers a predicate that marks an unobserved task exception as benign.
+    /// Benign exceptions are observed (so the finalizer does not escalate) and
+    /// logged as a warning instead of being recorded as a daemon crash.
+    ///
+    /// <para>
+    /// Filters must be cheap and must not throw. They run on the finalizer
+    /// thread inside the <see cref="TaskScheduler.UnobservedTaskException"/>
+    /// handler.
+    /// </para>
+    /// </summary>
+    public void RegisterBenignUnobservedExceptionFilter(Func<Exception, bool> filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        _benignUnobservedFilters.Add(filter);
+    }
 
     public void AttachServices(IServiceProvider services)
     {
@@ -60,8 +78,51 @@ internal sealed class DaemonCrashMonitor : IDisposable
 
     private void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs args)
     {
+        if (IsBenignUnobservedException(args.Exception))
+        {
+            TryLogBenignUnobserved(args.Exception);
+            args.SetObserved();
+            return;
+        }
+
         HandleCrash("daemon-unobserved", args.Exception, isTerminating: false, isUnobservedTask: true);
         args.SetObserved();
+    }
+
+    private bool IsBenignUnobservedException(Exception exception)
+    {
+        foreach (var filter in _benignUnobservedFilters)
+        {
+            try
+            {
+                if (filter(exception))
+                    return true;
+            }
+            catch (Exception filterFailure)
+            {
+                TryLogMonitorFailure("Benign-unobserved filter threw while inspecting an exception.", filterFailure);
+            }
+        }
+
+        return false;
+    }
+
+    private void TryLogBenignUnobserved(Exception exception)
+    {
+        var services = _services;
+
+        try
+        {
+            var loggerFactory = services?.GetService<ILoggerFactory>();
+            var logger = loggerFactory?.CreateLogger("Netclaw.Daemon.CrashMonitor");
+            logger?.LogWarning(
+                exception,
+                "Observed a known-benign unobserved task exception; skipping crash report.");
+        }
+        catch
+        {
+            // Best-effort logging; must never throw from the finalizer thread.
+        }
     }
 
     private void HandleCrash(string reason, Exception exception, bool isTerminating, bool isUnobservedTask)

--- a/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
+++ b/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
@@ -12,13 +12,20 @@ internal sealed class DaemonCrashMonitor : IDisposable
     private readonly string _logsDirectory;
     private readonly UnhandledExceptionEventHandler _unhandledHandler;
     private readonly EventHandler<UnobservedTaskExceptionEventArgs> _unobservedTaskHandler;
-    private readonly List<Func<Exception, bool>> _benignUnobservedFilters = new();
+    // Passed in at construction so the array is fully published before the
+    // TaskScheduler.UnobservedTaskException handler subscribes below — no
+    // memory-model race with the finalizer thread.
+    private readonly Func<Exception, bool>[] _benignUnobservedFilters;
     private IServiceProvider? _services;
 
-    private DaemonCrashMonitor(string logsDirectory, TimeProvider? timeProvider = null)
+    private DaemonCrashMonitor(
+        string logsDirectory,
+        TimeProvider? timeProvider,
+        Func<Exception, bool>[] benignUnobservedFilters)
     {
         _logsDirectory = logsDirectory;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _benignUnobservedFilters = benignUnobservedFilters;
 
         _unhandledHandler = HandleUnhandledException;
         _unobservedTaskHandler = HandleUnobservedTaskException;
@@ -27,25 +34,14 @@ internal sealed class DaemonCrashMonitor : IDisposable
         TaskScheduler.UnobservedTaskException += _unobservedTaskHandler;
     }
 
-    public static DaemonCrashMonitor Register(NetclawPaths paths, TimeProvider? timeProvider = null)
-        => new(paths.LogsDirectory, timeProvider);
-
-    /// <summary>
-    /// Registers a predicate that marks an unobserved task exception as benign.
-    /// Benign exceptions are observed (so the finalizer does not escalate) and
-    /// logged as a warning instead of being recorded as a daemon crash.
-    ///
-    /// <para>
-    /// Filters must be cheap and must not throw. They run on the finalizer
-    /// thread inside the <see cref="TaskScheduler.UnobservedTaskException"/>
-    /// handler.
-    /// </para>
-    /// </summary>
-    public void RegisterBenignUnobservedExceptionFilter(Func<Exception, bool> filter)
-    {
-        ArgumentNullException.ThrowIfNull(filter);
-        _benignUnobservedFilters.Add(filter);
-    }
+    public static DaemonCrashMonitor Register(
+        NetclawPaths paths,
+        TimeProvider? timeProvider = null,
+        IReadOnlyList<Func<Exception, bool>>? benignUnobservedFilters = null)
+        => new(
+            paths.LogsDirectory,
+            timeProvider,
+            benignUnobservedFilters is null ? [] : benignUnobservedFilters.ToArray());
 
     public void AttachServices(IServiceProvider services)
     {
@@ -80,7 +76,9 @@ internal sealed class DaemonCrashMonitor : IDisposable
     {
         if (IsBenignUnobservedException(args.Exception))
         {
-            TryLogBenignUnobserved(args.Exception);
+            TryLogMonitorFailure(
+                "Observed a known-benign unobserved task exception; skipping crash report.",
+                args.Exception);
             args.SetObserved();
             return;
         }
@@ -105,24 +103,6 @@ internal sealed class DaemonCrashMonitor : IDisposable
         }
 
         return false;
-    }
-
-    private void TryLogBenignUnobserved(Exception exception)
-    {
-        var services = _services;
-
-        try
-        {
-            var loggerFactory = services?.GetService<ILoggerFactory>();
-            var logger = loggerFactory?.CreateLogger("Netclaw.Daemon.CrashMonitor");
-            logger?.LogWarning(
-                exception,
-                "Observed a known-benign unobserved task exception; skipping crash report.");
-        }
-        catch
-        {
-            // Best-effort logging; must never throw from the finalizer thread.
-        }
     }
 
     private void HandleCrash(string reason, Exception exception, bool isTerminating, bool isUnobservedTask)

--- a/src/Netclaw.Daemon/Services/KnownBenignExceptions.cs
+++ b/src/Netclaw.Daemon/Services/KnownBenignExceptions.cs
@@ -1,0 +1,61 @@
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Predicates for identifying unobserved task exceptions that are known to be
+/// benign and must not be reported as daemon crashes.
+///
+/// <para>
+/// Each entry documents (a) which upstream component produces the exception,
+/// (b) why it is safe to observe without a crash report, and (c) the delete
+/// criteria for removing the filter once the upstream bug is fixed.
+/// </para>
+/// </summary>
+internal static class KnownBenignExceptions
+{
+    private const string ReconnectingWebSocketConnectMarker =
+        "SlackNet.ReconnectingWebSocket.Connect";
+
+    /// <summary>
+    /// SlackNet 0.17.10's <c>ReconnectingWebSocket.Dispose()</c> cancels and
+    /// synchronously disposes its internal <see cref="System.Threading.CancellationTokenSource"/>
+    /// while its background reconnect loop may still re-enter <c>Connect()</c>,
+    /// which reads <c>_disposed.Token</c> and throws
+    /// <see cref="System.ObjectDisposedException"/>. The task is fire-and-forget
+    /// from <c>ConnectInternal</c>, so the exception surfaces on the finalizer
+    /// thread as an unobserved task exception.
+    ///
+    /// <para>
+    /// Netclaw's hot-reload restart path (<see cref="DaemonRestartCoordinator"/>)
+    /// disposes the DI container between host iterations, which is what triggers
+    /// the race in the first place. By the time the exception fires, the old
+    /// Slack client has already been torn down and replaced, so there is no
+    /// state for Netclaw to salvage and no user-visible behavior to protect.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Delete criteria:</b> remove this filter after bumping the SlackNet
+    /// package past the version that fixes the race upstream.
+    /// </para>
+    /// </summary>
+    public static bool IsSlackNetReconnectingWebSocketDisposeRace(Exception? exception)
+    {
+        if (exception is null)
+            return false;
+
+        var candidate = UnwrapAggregate(exception);
+        if (candidate is not ObjectDisposedException)
+            return false;
+
+        var stackTrace = candidate.StackTrace;
+        return stackTrace is not null
+            && stackTrace.Contains(ReconnectingWebSocketConnectMarker, StringComparison.Ordinal);
+    }
+
+    private static Exception UnwrapAggregate(Exception exception)
+    {
+        if (exception is AggregateException aggregate && aggregate.InnerExceptions.Count == 1)
+            return aggregate.InnerExceptions[0];
+
+        return exception;
+    }
+}

--- a/src/Netclaw.Daemon/Services/KnownBenignExceptions.cs
+++ b/src/Netclaw.Daemon/Services/KnownBenignExceptions.cs
@@ -1,61 +1,44 @@
 namespace Netclaw.Daemon.Services;
 
-/// <summary>
-/// Predicates for identifying unobserved task exceptions that are known to be
-/// benign and must not be reported as daemon crashes.
-///
-/// <para>
-/// Each entry documents (a) which upstream component produces the exception,
-/// (b) why it is safe to observe without a crash report, and (c) the delete
-/// criteria for removing the filter once the upstream bug is fixed.
-/// </para>
-/// </summary>
 internal static class KnownBenignExceptions
 {
     private const string ReconnectingWebSocketConnectMarker =
         "SlackNet.ReconnectingWebSocket.Connect";
 
     /// <summary>
-    /// SlackNet 0.17.10's <c>ReconnectingWebSocket.Dispose()</c> cancels and
-    /// synchronously disposes its internal <see cref="System.Threading.CancellationTokenSource"/>
-    /// while its background reconnect loop may still re-enter <c>Connect()</c>,
-    /// which reads <c>_disposed.Token</c> and throws
-    /// <see cref="System.ObjectDisposedException"/>. The task is fire-and-forget
-    /// from <c>ConnectInternal</c>, so the exception surfaces on the finalizer
-    /// thread as an unobserved task exception.
-    ///
-    /// <para>
-    /// Netclaw's hot-reload restart path (<see cref="DaemonRestartCoordinator"/>)
-    /// disposes the DI container between host iterations, which is what triggers
-    /// the race in the first place. By the time the exception fires, the old
-    /// Slack client has already been torn down and replaced, so there is no
-    /// state for Netclaw to salvage and no user-visible behavior to protect.
-    /// </para>
-    ///
-    /// <para>
-    /// <b>Delete criteria:</b> remove this filter after bumping the SlackNet
-    /// package past the version that fixes the race upstream.
-    /// </para>
+    /// SlackNet 0.17.10 race: <c>ReconnectingWebSocket.Dispose()</c> cancels and
+    /// synchronously disposes its internal CTS while the background reconnect
+    /// loop may still re-enter <c>Connect()</c> and touch <c>_disposed.Token</c>.
+    /// Surfaces as an unobserved task exception on Netclaw's hot-reload path,
+    /// after the old Slack client has already been replaced.
+    /// Delete after upgrading past the SlackNet version that fixes this upstream.
     /// </summary>
     public static bool IsSlackNetReconnectingWebSocketDisposeRace(Exception? exception)
     {
         if (exception is null)
             return false;
 
-        var candidate = UnwrapAggregate(exception);
-        if (candidate is not ObjectDisposedException)
-            return false;
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.Flatten().InnerExceptions)
+            {
+                if (MatchesRace(inner))
+                    return true;
+            }
 
-        var stackTrace = candidate.StackTrace;
-        return stackTrace is not null
-            && stackTrace.Contains(ReconnectingWebSocketConnectMarker, StringComparison.Ordinal);
+            return false;
+        }
+
+        return MatchesRace(exception);
     }
 
-    private static Exception UnwrapAggregate(Exception exception)
+    private static bool MatchesRace(Exception exception)
     {
-        if (exception is AggregateException aggregate && aggregate.InnerExceptions.Count == 1)
-            return aggregate.InnerExceptions[0];
+        if (exception is not ObjectDisposedException)
+            return false;
 
-        return exception;
+        var stackTrace = exception.StackTrace;
+        return stackTrace is not null
+            && stackTrace.Contains(ReconnectingWebSocketConnectMarker, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

- SlackNet 0.17.10 has a race in `ReconnectingWebSocket.Dispose()`: it cancels and synchronously disposes its internal `CancellationTokenSource` while the background reconnect loop may still re-enter `Connect()`, which reads `_disposed.Token` and throws `ObjectDisposedException` on the finalizer thread.
- Netclaw's hot-reload restart path (`DaemonRestartCoordinator` → `_appLifetime.StopApplication()` inside the `Program.cs` restart loop) disposes the DI container between host iterations, reliably triggering the race. Result: every config reload risks a spurious `daemon-unobserved` crash log and a lifecycle-notifier alarm, even though `DaemonCrashMonitor` already calls `SetObserved()` and the process survives.
- This PR adds a targeted benign-unobserved-exception filter on `DaemonCrashMonitor` plus a `KnownBenignExceptions.IsSlackNetReconnectingWebSocketDisposeRace` predicate that matches the specific race by exception type and stack marker. Matched exceptions are logged as a warning (via the existing `TryLogMonitorFailure` helper, so they inherit the Console.Error fallback) and observed without being recorded as a crash.

## What this does not fix

This PR does not recover the SlackNet reconnect loop after the race fires — Slack remains silently down on that daemon instance until the next restart. That requires the upstream fix (tracked separately; will open a PR against `soxtoby/SlackNet`).

## Design notes

- The filter array is passed through `DaemonCrashMonitor`'s constructor as a `readonly Func<Exception,bool>[]` so it is fully published before the `TaskScheduler.UnobservedTaskException` handler subscribes. No write-before-subscribe race with the finalizer thread.
- Filter registration is wired at process start, outside the `do/while (restartSignal.RestartRequested)` loop in `Program.cs`, so it persists across hot-reload iterations.
- The predicate uses `AggregateException.Flatten().InnerExceptions` so nested and multi-inner aggregates match too, not just single-inner.
- Delete criteria for the filter are documented on the predicate: remove after bumping past the SlackNet version that fixes this upstream.

## Test plan

- [x] Unit test `KnownBenignExceptionsTests` covers: null, unrelated exception type, ODE without marker, ODE with marker, ODE with null stack trace, aggregate wrapping a match, aggregate wrapping an unrelated inner, **multi-inner aggregate where one matches**, **nested aggregate two levels deep**. Uses a `FakeObjectDisposedException` subclass to inject a synthetic stack trace.
- [x] `dotnet build src/Netclaw.Daemon/Netclaw.Daemon.csproj` → 0 warnings, 0 errors.
- [x] `dotnet test src/Netclaw.Daemon.Tests --filter "FullyQualifiedName~KnownBenignExceptionsTests"` → 9/9 passing.
- [x] `dotnet slopwatch analyze` → 0 issues.
- [ ] CI (full suite) on this PR.

## Evidence

Five crash logs on the host reproducing the same stack, all during hot-reload windows (process uptime significantly longer than `daemon_started_at_utc`):

```
System.AggregateException: A Task's exception(s) were not observed...
 ---> System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.get_Token()
   at SlackNet.ReconnectingWebSocket.Connect(...)
   at SlackNet.ReconnectingWebSocket.ReconnectOnClose(...)
```

Timeline from `daemon-2026-04-15.log`:

```
02:44:45.186  Config change detected (hot-reload)
02:44:45.188  Config valid. Starting coordinated daemon restart.
02:44:45.384  Netclaw daemon stopping (reason: config-reload)
02:44:45.414  Akka CoordinatedShutdown invoked
02:44:47.472  NEW daemon instance starts (same process)
02:49:03.680  CRASH — unobserved ObjectDisposedException from SlackNet
```

Root cause verified by decompiling SlackNet 0.17.10's `ReconnectingWebSocket.Dispose()` and `Connect()` with ilspycmd.