### PR TITLE
docs: document memory retrieval diagnostic log events (#669)

### DIFF
--- a/.claude/skills/netclaw-session-diagnosis.md
+++ b/.claude/skills/netclaw-session-diagnosis.md
@@ -69,6 +69,7 @@ Output: `Recovery complete (turns=N, history=N)`
 
 ### Step 4: Check memory recall
 
+**Summary event:**
 ```bash
 grep "turn_memory_recall" ~/.netclaw/logs/daemon-${DATE}.log | grep "D0AC6CKBK5K/1774023557.531309"
 ```
@@ -79,6 +80,23 @@ Key fields:
 - `itemCount=N` → N memories recalled, check `itemIds`
 - `durationMs=0` → instant return (possibly empty store or fast search)
 - `durationMs>300` → approaching the 300ms timeout
+
+**Detailed retrieval events** (for diagnosing recall quality issues):
+```bash
+grep "D0AC6CKBK5K/1774023557.531309" ~/.netclaw/logs/daemon-${DATE}.log | grep "memory_retrieval"
+```
+
+| Event | Purpose |
+|-------|---------|
+| `memory_retrieval_request_plan` | Query tokenization: `lexicalTerms`, `facets`, `softScopes`, `anchorHints` |
+| `memory_retrieval_candidate_selection` | All candidates with selector scores: `rawCount`, `selectedCount`, `scored={id=score\|...}` |
+| `memory_retrieval_final` | Floor filtering: `injectedCount`, `filteredByFloor`, `appliedFloor`, `items={id=score\|...}` |
+| `progressive_recall_exhausted` | When all candidates were already injected in prior turns |
+
+**Diagnosing recall poisoning** (irrelevant memories injected):
+- Check `lexicalTerms` in `memory_retrieval_request_plan` — generic words like `ok|can|that|this` cause false positives
+- Check `filteredByFloor` in `memory_retrieval_final` — if 0 with high `rawCount`, floor isn't filtering
+- Look at earlier turns in the session to find when irrelevant memories were first injected
 
 ### Step 5: Check skill auto-loading
 

--- a/feeds/skills/.system/files/netclaw-memory/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-memory/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-memory
 description: "REQUIRED before using find_memories, get_memories, store_memory, or update_memory. Read this first when the user asks what you remember, wants something saved, or asks about past conversations."
 metadata:
   author: netclaw
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Netclaw Memory
@@ -103,11 +103,15 @@ When memory behavior looks wrong:
 
 Useful log events:
 
-- `memory_recall_plan_resolved`
-- `memory_recall_plan_fallback`
+**Recall pipeline** (grep for `memory_retrieval`):
+- `memory_retrieval_request_plan` — query tokenization, facets, soft scopes, anchor hints
+- `memory_retrieval_candidate_selection` — all candidates with selector scores
+- `memory_retrieval_final` — floor filtering results, final injected items
+- `turn_memory_recall` — summary event with item count and duration
+
+**Formation pipeline** (grep for `memory_observation`):
 - `memory_observation_sidecar_completed`
 - `memory_observation_gate_result`
-- `turn_memory_recall`
 
 ## Eval Gate
 


### PR DESCRIPTION
## Summary

The recall pipeline already emits detailed logging events (`memory_retrieval_*`), but they weren't documented in the diagnostic skills. This made it difficult to diagnose memory recall quality issues like context poisoning.

**Root cause investigation** revealed that session `D0AC6CKBK5K/1776383538.110289` was poisoned because generic conversational words (`ok`, `can`, `that`, `this`) became lexical search terms that matched unrelated memories. The existing logs captured this, but nobody knew where to look.

## Changes

- **netclaw-session-diagnosis.md**: Expand Step 4 with detailed retrieval events and a poisoning diagnostic workflow
- **netclaw-memory/SKILL.md**: Fix incorrect log event names (`memory_recall_plan_resolved` doesn't exist) and organize by pipeline (recall vs formation)

## Log Events Documented

| Event | Purpose |
|-------|---------|
| `memory_retrieval_request_plan` | Query tokenization: lexicalTerms, facets, softScopes, anchorHints |
| `memory_retrieval_candidate_selection` | All candidates with selector scores |
| `memory_retrieval_final` | Floor filtering: injectedCount, filteredByFloor, appliedFloor |
| `progressive_recall_exhausted` | When all candidates were already injected |

## Related

- Closes observability portion of #669
- Follow-up PR will address the actual fix (stopword filtering for lexical terms)