### PR TITLE
fix(security): single-token approval patterns require exact match

### DIFF
--- a/openspec/specs/tool-approval-gates/spec.md
+++ b/openspec/specs/tool-approval-gates/spec.md
@@ -199,11 +199,19 @@ a custom matcher. New tool types MAY provide their own matchers.
 - **WHEN** the approval system extracts the pattern
 - **THEN** `DefaultApprovalMatcher` extracts `memorizer/store` (the tool name)
 
-#### Scenario: Approved pattern matches invocation
+#### Scenario: Multi-token pattern prefix matches invocation
 
 - **GIVEN** `git push` is in the Personal approval list for `shell_execute`
 - **WHEN** the agent runs `git push --tags origin main`
-- **THEN** `ShellApprovalMatcher.IsApproved` returns true (prefix match)
+- **THEN** `ShellApprovalMatcher.IsApproved` returns true (prefix match on word boundary)
+
+#### Scenario: Single-token pattern requires exact match
+
+- **GIVEN** `gh` is in the Personal approval list for `shell_execute`
+- **WHEN** the agent runs `gh pr create`
+- **THEN** `ShellApprovalMatcher.IsApproved` returns false
+- **AND** single-token patterns do NOT prefix-match multi-token verb chains
+- **NOTE** This prevents approving `gh --help` from also approving `gh pr create`
 
 ### Requirement: Mid-turn approval pause
 

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
@@ -68,15 +68,31 @@ public sealed class ToolApprovalActorTests : TestKit
     }
 
     [Fact]
-    public async Task Prefix_match_broader_approval_covers_specific()
+    public async Task Single_token_approval_requires_exact_match()
     {
         var ct = TestContext.Current.CancellationToken;
         var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
         var service = CreateService(actor);
 
-        await service.RecordApprovalAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git"], persistent: false, ct);
+        await service.RecordApprovalAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["gh"], persistent: false, ct);
 
-        var unapproved = await service.GetUnapprovedPatternsAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], ct);
+        // Single-token "gh" should NOT match "gh pr" — prevents approving
+        // "gh --help" from also approving "gh pr create"
+        var unapproved = await service.GetUnapprovedPatternsAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["gh pr"], ct);
+        Assert.Equal(["gh pr"], unapproved);
+    }
+
+    [Fact]
+    public async Task Multi_token_approval_prefix_matches()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
+        var service = CreateService(actor);
+
+        await service.RecordApprovalAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], persistent: false, ct);
+
+        // Multi-token "git push" should match "git push origin" via prefix
+        var unapproved = await service.GetUnapprovedPatternsAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git push origin"], ct);
         Assert.Empty(unapproved);
     }
 

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -80,12 +80,18 @@ public sealed class ShellApprovalMatcherTests
             Args("git add . && git commit -m fix && git push"), approved));
     }
 
-    [Fact]
-    public void IsApproved_prefix_match()
+    [Theory]
+    [InlineData("gh", "gh --help", true)]        // Single-token exact match
+    [InlineData("gh", "gh pr create", false)]    // Single-token should NOT prefix match
+    [InlineData("git push", "git push origin main", true)]  // Multi-token prefix match
+    [InlineData("git push", "git pull", false)]  // Multi-token no match
+    [InlineData("git pu", "git push", false)]    // Partial token no match (word boundary)
+    [InlineData("gh pr", "gh pr create", true)]  // Multi-token prefix match
+    [InlineData("gh pr", "gh issue list", false)] // Multi-token no match
+    public void IsApproved_pattern_matching(string pattern, string command, bool expected)
     {
-        var approved = new[] { "git" };
-        Assert.True(_matcher.IsApproved(new ToolName("shell_execute"),
-            Args("git push origin main"), approved));
+        var approved = new[] { pattern };
+        Assert.Equal(expected, _matcher.IsApproved(new ToolName("shell_execute"), Args(command), approved));
     }
 
     [Fact]

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -14,7 +14,10 @@ public static class ApprovalPatternMatching
             if (string.Equals(candidate, approved, StringComparison.OrdinalIgnoreCase))
                 return true;
 
-            if (candidate.StartsWith(approved, StringComparison.OrdinalIgnoreCase)
+            // Only do prefix matching for multi-token patterns (contains space).
+            // Single-token patterns like "gh" should not match "gh pr".
+            if (approved.Contains(" ", StringComparison.Ordinal)
+                && candidate.StartsWith(approved, StringComparison.OrdinalIgnoreCase)
                 && candidate.Length > approved.Length
                 && candidate[approved.Length] == ' ')
             {


### PR DESCRIPTION
## Summary
- Single-token patterns like `gh` now require exact match only
- Prevents approving `gh --help` from also approving `gh pr create`
- Multi-token patterns still prefix-match as before (`git push` matches `git push origin main`)

## Test plan
- [x] Updated `ShellApprovalMatcherTests` with Theory covering both cases
- [x] Updated `ToolApprovalActorTests` to verify actor-level behavior
- [x] All 404 tool-related tests pass
- [x] All 262 security tests pass