### PR TITLE
fix(ci): replace wrangler-action with direct wrangler install in release pipelines

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -175,28 +175,28 @@ jobs:
         release-tag: ${{ github.ref_name }}
         files: 'archives/*'
 
-      # Upload each archive individually
+    - name: Install Wrangler
+      run: npm install --global wrangler@3.90.0 --include=optional
+
     - name: Upload CLI archive to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/${{ github.ref_name }}/netclaw-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
-          --file=./archives/netclaw-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
-          --content-type=application/octet-stream
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/${{ github.ref_name }}/netclaw-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
+        --file=./archives/netclaw-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
+        --content-type=application/octet-stream
 
     - name: Upload Daemon archive to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/${{ github.ref_name }}/netclawd-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
-          --file=./archives/netclawd-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
-          --content-type=application/octet-stream
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/${{ github.ref_name }}/netclawd-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
+        --file=./archives/netclawd-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive_ext }}
+        --content-type=application/octet-stream
 
     - name: Upload checksum artifacts
       uses: actions/upload-artifact@v7
@@ -381,60 +381,58 @@ jobs:
         cp scripts/install.sh ./feeds/releases/install.sh
         cp scripts/install.ps1 ./feeds/releases/install.ps1
 
+    - name: Install Wrangler
+      run: npm install --global wrangler@3.90.0 --include=optional
+
     - name: Upload release manifest to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/manifest.json
-          --file=./feeds/releases/manifest.json
-          --content-type=application/json
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/manifest.json
+        --file=./feeds/releases/manifest.json
+        --content-type=application/json
 
     - name: Upload release manifest signature to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/manifest.json.sig
-          --file=./feeds/releases/manifest.json.sig
-          --content-type=text/plain
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/manifest.json.sig
+        --file=./feeds/releases/manifest.json.sig
+        --content-type=text/plain
 
     - name: Upload manifest public key to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/manifest.pub
-          --file=./feeds/releases/manifest.pub
-          --content-type=text/plain
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/manifest.pub
+        --file=./feeds/releases/manifest.pub
+        --content-type=text/plain
 
     - name: Upload Linux install script to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/install.sh
-          --file=./feeds/releases/install.sh
-          --content-type=text/x-shellscript
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/install.sh
+        --file=./feeds/releases/install.sh
+        --content-type=text/x-shellscript
 
     - name: Upload Windows install script to R2
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: >
-          r2 object put
-          netclaw-releases/install.ps1
-          --file=./feeds/releases/install.ps1
-          --content-type=text/plain
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: >
+        wrangler r2 object put
+        netclaw-releases/install.ps1
+        --file=./feeds/releases/install.ps1
+        --content-type=text/plain
 
     - name: Cleanup signing key
       if: always()

--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -38,6 +38,9 @@ jobs:
             --base-url https://skills.netclaw.dev \
             --existing-manifest ./feeds/skills/.system/existing-manifest.json
 
+      - name: Install Wrangler
+        run: npm install --global wrangler@3.90.0 --include=optional
+
       - name: Upload skill files to R2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -52,23 +55,22 @@ jobs:
           while IFS=' ' read -r local_path r2_key; do
             [ -z "$local_path" ] && continue
             echo "Uploading $r2_key"
-            npx wrangler r2 object put "netclaw-skills/$r2_key" \
+            wrangler r2 object put "netclaw-skills/$r2_key" \
               --file="$local_path" \
               --content-type=text/markdown \
               --remote
           done < "$UPLOAD_LIST"
 
       - name: Deploy manifest to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Pin --branch=dev so release-tag builds (detached HEAD) still
-          # deploy to the production branch instead of a preview alias.
-          # Without this, wrangler infers the branch name from git state
-          # and tag builds land on head.netclaw-feeds.pages.dev while
-          # feeds.netclaw.dev stays frozen on the last dev-branch deploy.
-          command: pages deploy feeds/ --project-name=netclaw-feeds --branch=dev
+        # Pin --branch=dev so release-tag builds (detached HEAD) still
+        # deploy to the production branch instead of a preview alias.
+        # Without this, wrangler infers the branch name from git state
+        # and tag builds land on head.netclaw-feeds.pages.dev while
+        # feeds.netclaw.dev stays frozen on the last dev-branch deploy.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy feeds/ --project-name=netclaw-feeds --branch=dev
 
       - name: Validate R2 uploads
         run: |


### PR DESCRIPTION
## Summary

- `cloudflare/wrangler-action@v3` silently updated (v3.15.0, Apr 15) to support wrangler version ranges, which changed the default resolution to wrangler 4.84.0. When not found on the runner, the action falls back to installing wrangler 3.90.0 — but without optional dependencies, so `@cloudflare/workerd-linux-64` is never installed and every `wrangler` invocation crashes.
- Removed all 7 uses of `cloudflare/wrangler-action@v3` across `publish_release_binaries.yml` and `publish_skills.yml`. Each job now installs `wrangler@3.90.0` explicitly via `npm install --global --include=optional`, then calls `wrangler` directly with credentials passed as env vars.
- This eliminates the broken fallback path entirely and gives full control over the wrangler version.

## Test plan

- [ ] Verify `publish_release_binaries.yml` workflow runs cleanly on next release tag (no wrangler install failures)
- [ ] Verify `publish_skills.yml` R2 uploads and Pages deploy succeed
- [ ] Confirm no `@cloudflare/workerd-linux-64` missing errors in logs