### PR TITLE
fix(ci): install wrangler locally to avoid global npm permission error

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -176,7 +176,9 @@ jobs:
         files: 'archives/*'
 
     - name: Install Wrangler
-      run: npm install --global wrangler@3.90.0 --include=optional
+      run: |
+        npm install wrangler@3.90.0 --include=optional
+        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
 
     - name: Upload CLI archive to R2
       env:
@@ -382,7 +384,9 @@ jobs:
         cp scripts/install.ps1 ./feeds/releases/install.ps1
 
     - name: Install Wrangler
-      run: npm install --global wrangler@3.90.0 --include=optional
+      run: |
+        npm install wrangler@3.90.0 --include=optional
+        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
 
     - name: Upload release manifest to R2
       env:

--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -39,7 +39,9 @@ jobs:
             --existing-manifest ./feeds/skills/.system/existing-manifest.json
 
       - name: Install Wrangler
-        run: npm install --global wrangler@3.90.0 --include=optional
+        run: |
+          npm install wrangler@3.90.0 --include=optional
+          echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
 
       - name: Upload skill files to R2
         env:


### PR DESCRIPTION
## Summary

- Follow-up to #698: `npm install --global` fails on the self-hosted `arc-netclaw` runner with `EACCES: permission denied, mkdir '/usr/lib/node_modules/wrangler'` — the runner user doesn't have write access to the system npm prefix.
- Switch to a local install (`npm install wrangler@3.90.0 --include=optional`) and append `node_modules/.bin` to `$GITHUB_PATH` so subsequent steps can call `wrangler` directly without requiring elevated permissions.
- Applied to both install steps in `publish_release_binaries.yml` and the one in `publish_skills.yml`.