### PR TITLE
fix(ci): remove --remote flag incompatible with wrangler 3.90.0

### DIFF
--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -59,8 +59,7 @@ jobs:
             echo "Uploading $r2_key"
             wrangler r2 object put "netclaw-skills/$r2_key" \
               --file="$local_path" \
-              --content-type=text/markdown \
-              --remote
+              --content-type=text/markdown
           done < "$UPLOAD_LIST"
 
       - name: Deploy manifest to Cloudflare Pages


### PR DESCRIPTION
## Summary

- `--remote` was added to the `wrangler r2 object put` call in `publish_skills.yml` but it's not a valid flag in wrangler 3.90.0, causing the skills feed upload to fail with `Unknown argument: remote`.
- Remove the flag — wrangler 3.x always operates against real Cloudflare R2 by default; `--remote` was introduced in a later version to distinguish from local dev emulation.