### PR TITLE
release: v0.14.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,17 +7,26 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.14.1</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.14.1
+    <VersionPrefix>0.14.2</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.14.2 — Structured reminder delivery, protobuf serialization, subagent robustness, and web-content-retrieval skill
 
-**Security**
-* fix(security): single-token approval patterns require exact match (#695)
+**Features**
+
+* Added structured reminder delivery contract — `set_reminder` now uses a `delivery` object with a required `kind` field (`current_session`, `channel`, or `none`) that directly selects the execution mode, replacing the previous implicit inference from optional fields. A new `deliveryRequired` boolean controls policy; `deliveryInstructions` carries content guidance only. Transport-keyed resolver dispatch uses `ChannelType.ToWireValue()` for reliable routing across Slack and future transports. Closes [#690](https://github.com/Aaronontheweb/netclaw/issues/690). ([#692](https://github.com/Aaronontheweb/netclaw/pull/692))
+
+* Added protobuf-net serializer with stable manifests — `NetclawProtobufSerializer` uses constant manifest strings (`sid-v1`, `sum-v1`, `tr-v1`, etc.) decoupled from .NET type names, enabling safe schema evolution without migration steps. The `WithNetclawSerialization()` extension disables the `System.Object` JSON fallback so unregistered types fail loudly instead of silently falling back. Existing persisted events remain readable; new events use the more efficient binary format. ([#705](https://github.com/Aaronontheweb/netclaw/pull/705))
+
+* Added `web-content-retrieval` system skill — the agent now loads a built-in skill covering URL handling, browser automation guidance, and social media content retrieval so it can advise on web fetch workflows without requiring a custom skill. ([#702](https://github.com/Aaronontheweb/netclaw/pull/702))
+
+* Made subagent tools optional — omitting the `tools` field in a subagent's YAML frontmatter now causes the subagent to inherit all session tools, including MCP tools (Notion, GitHub, etc.). Previously the field was required and restricted to four built-in tools, making MCP-powered subagents impossible to define. When `tools` is specified it acts as a whitelist; when omitted all session tools are available. ([#703](https://github.com/Aaronontheweb/netclaw/pull/703))
+
+* Migrated webhook notification policy to `deliveryRequired` boolean — the `NotifyPolicy` enum on `set_webhook` and webhook config is replaced by a `deliveryRequired` boolean that is consistent with the reminder delivery contract. ([#704](https://github.com/Aaronontheweb/netclaw/pull/704))
 
 **Bug Fixes**
-* fix: filter conversational stopwords from lexical recall terms (#694)
 
-**Documentation**
-* docs: document memory retrieval diagnostic log events (#669) (#693)</PackageReleaseNotes>
+* Fixed daemon crash on subagent timeout — the subagent cancellation callback was capturing `Self` at registration time instead of before registration, causing a `NotSupportedException` when the callback fired on a thread-pool thread with no active actor context. The resulting unhandled `AggregateException` terminated the entire daemon, killing all active sessions. The fix also converts the scheduling to the `IWithTimers` pattern per project conventions. ([#707](https://github.com/Aaronontheweb/netclaw/pull/707))
+
+* Fixed `netclaw-operations` skill hidden from agent skill index — the skill had an incorrect `disable-model-invocation: true` flag that prevented it from appearing in the agent's skill discovery index, causing the agent to be unaware of operations guidance. ([#702](https://github.com/Aaronontheweb/netclaw/pull/702))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+#### 0.14.2 2026-04-21 ####
+
+Netclaw v0.14.2 — Structured reminder delivery, protobuf serialization, subagent robustness, and web-content-retrieval skill
+
+**Features**
+
+* Added structured reminder delivery contract — `set_reminder` now uses a `delivery` object with a required `kind` field (`current_session`, `channel`, or `none`) that directly selects the execution mode, replacing the previous implicit inference from optional fields. A new `deliveryRequired` boolean controls policy; `deliveryInstructions` carries content guidance only. Transport-keyed resolver dispatch uses `ChannelType.ToWireValue()` for reliable routing across Slack and future transports. Closes [#690](https://github.com/Aaronontheweb/netclaw/issues/690). ([#692](https://github.com/Aaronontheweb/netclaw/pull/692))
+
+* Added protobuf-net serializer with stable manifests — `NetclawProtobufSerializer` uses constant manifest strings (`sid-v1`, `sum-v1`, `tr-v1`, etc.) decoupled from .NET type names, enabling safe schema evolution without migration steps. The `WithNetclawSerialization()` extension disables the `System.Object` JSON fallback so unregistered types fail loudly instead of silently falling back. Existing persisted events remain readable; new events use the more efficient binary format. ([#705](https://github.com/Aaronontheweb/netclaw/pull/705))
+
+* Added `web-content-retrieval` system skill — the agent now loads a built-in skill covering URL handling, browser automation guidance, and social media content retrieval so it can advise on web fetch workflows without requiring a custom skill. ([#702](https://github.com/Aaronontheweb/netclaw/pull/702))
+
+* Made subagent tools optional — omitting the `tools` field in a subagent's YAML frontmatter now causes the subagent to inherit all session tools, including MCP tools (Notion, GitHub, etc.). Previously the field was required and restricted to four built-in tools, making MCP-powered subagents impossible to define. When `tools` is specified it acts as a whitelist; when omitted all session tools are available. ([#703](https://github.com/Aaronontheweb/netclaw/pull/703))
+
+* Migrated webhook notification policy to `deliveryRequired` boolean — the `NotifyPolicy` enum on `set_webhook` and webhook config is replaced by a `deliveryRequired` boolean that is consistent with the reminder delivery contract. ([#704](https://github.com/Aaronontheweb/netclaw/pull/704))
+
+**Bug Fixes**
+
+* Fixed daemon crash on subagent timeout — the subagent cancellation callback was capturing `Self` at registration time instead of before registration, causing a `NotSupportedException` when the callback fired on a thread-pool thread with no active actor context. The resulting unhandled `AggregateException` terminated the entire daemon, killing all active sessions. The fix also converts the scheduling to the `IWithTimers` pattern per project conventions. ([#707](https://github.com/Aaronontheweb/netclaw/pull/707))
+
+* Fixed `netclaw-operations` skill hidden from agent skill index — the skill had an incorrect `disable-model-invocation: true` flag that prevented it from appearing in the agent's skill discovery index, causing the agent to be unaware of operations guidance. ([#702](https://github.com/Aaronontheweb/netclaw/pull/702))
+
 #### 0.14.0 2026-04-15 ####
 
 Netclaw v0.14.0 — Skill-defined subagent routing, Mode B reminder session re-entry, fail-closed MCP add, and security patch


### PR DESCRIPTION
## v0.14.2 Release

Version bump and release notes for v0.14.2.

### What's included

- Structured reminder delivery contract (`delivery.kind` enum, `deliveryRequired` boolean)
- Protobuf-net serializer with stable manifests
- `web-content-retrieval` system skill
- Subagent tools optional (inherits session tools when omitted)
- Webhook `NotifyPolicy` → `deliveryRequired` boolean migration
- Fix: daemon crash on subagent timeout (cancellation callback thread-safety)
- Fix: `netclaw-operations` skill hidden from agent skill index

## Test plan

- [ ] CI passes
- [ ] `VersionPrefix` in `Directory.Build.props` reads `0.14.2`
- [ ] Top entry in `RELEASE_NOTES.md` is `0.14.2`