### PR TITLE
feat(cli): add webhooks management commands

### DIFF
--- a/src/Netclaw.Actors/Tools/DeleteWebhookTool.cs
+++ b/src/Netclaw.Actors/Tools/DeleteWebhookTool.cs
@@ -22,10 +22,9 @@ public sealed partial class DeleteWebhookTool : NetclawTool<DeleteWebhookTool.Pa
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(args.RouteName))
-            return Task.FromResult("Error: 'routeName' is required.");
+        if (!WebhookRouteStore.TryNormalizeRouteName(args.RouteName, out var routeName, out var routeError))
+            return Task.FromResult($"Error: {routeError}");
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args.RouteName);
         return Task.FromResult(_store.Delete(routeName)
             ? $"Webhook route '{routeName}' deleted."
             : $"Webhook route '{routeName}' not found.");

--- a/src/Netclaw.Actors/Tools/DeleteWebhookTool.cs
+++ b/src/Netclaw.Actors/Tools/DeleteWebhookTool.cs
@@ -25,11 +25,9 @@ public sealed partial class DeleteWebhookTool : NetclawTool<DeleteWebhookTool.Pa
         if (string.IsNullOrWhiteSpace(args.RouteName))
             return Task.FromResult("Error: 'routeName' is required.");
 
-        return Task.FromResult(_store.Delete(NormalizeRouteName(args.RouteName))
-            ? $"Webhook route '{NormalizeRouteName(args.RouteName)}' deleted."
-            : $"Webhook route '{NormalizeRouteName(args.RouteName)}' not found.");
+        var routeName = WebhookRouteStore.NormalizeRouteName(args.RouteName);
+        return Task.FromResult(_store.Delete(routeName)
+            ? $"Webhook route '{routeName}' deleted."
+            : $"Webhook route '{routeName}' not found.");
     }
-
-    private static string NormalizeRouteName(string value)
-        => value.Trim().ToLowerInvariant();
 }

--- a/src/Netclaw.Actors/Tools/SetWebhookTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWebhookTool.cs
@@ -67,7 +67,7 @@ public sealed partial class SetWebhookTool : NetclawTool<SetWebhookTool.Params>
         if (!TryParseAudience(args.Audience, out var audience, out var audienceError))
             return Task.FromResult(audienceError!);
 
-        var routeName = NormalizeRouteName(args.RouteName);
+        var routeName = WebhookRouteStore.NormalizeRouteName(args.RouteName);
         var definition = new WebhookRouteConfig
         {
             Enabled = args.Enabled ?? true,
@@ -102,9 +102,6 @@ public sealed partial class SetWebhookTool : NetclawTool<SetWebhookTool.Params>
         _store.Save(routeName, definition);
         return Task.FromResult($"Webhook route '{routeName}' saved at /api/webhooks/{routeName}. Secret stored in the route file; keep it aligned with the sender configuration.");
     }
-
-    private static string NormalizeRouteName(string value)
-        => value.Trim().ToLowerInvariant();
 
     private static bool TryParseAudience(string? value, out TrustAudience audience, out string? error)
     {

--- a/src/Netclaw.Actors/Tools/SetWebhookTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWebhookTool.cs
@@ -54,8 +54,9 @@ public sealed partial class SetWebhookTool : NetclawTool<SetWebhookTool.Params>
 
     protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(args.RouteName))
-            return Task.FromResult("Error: 'routeName' is required.");
+        if (!WebhookRouteStore.TryNormalizeRouteName(args.RouteName, out var routeName, out var routeError))
+            return Task.FromResult($"Error: {routeError}");
+
         if (string.IsNullOrWhiteSpace(args.Prompt))
             return Task.FromResult("Error: 'prompt' is required.");
         if (string.IsNullOrWhiteSpace(args.Secret))
@@ -67,7 +68,6 @@ public sealed partial class SetWebhookTool : NetclawTool<SetWebhookTool.Params>
         if (!TryParseAudience(args.Audience, out var audience, out var audienceError))
             return Task.FromResult(audienceError!);
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args.RouteName);
         var definition = new WebhookRouteConfig
         {
             Enabled = args.Enabled ?? true,

--- a/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
@@ -48,6 +48,8 @@ public sealed class CliArgsParserTests
     [InlineData("update")]
     [InlineData("init")]
     [InlineData("pair")]
+    [InlineData("skill")]
+    [InlineData("webhooks")]
     public void Parse_known_commands_returns_Known_with_mode(string command)
     {
         var result = CliArgsParser.Parse([command]);
@@ -82,7 +84,7 @@ public sealed class CliArgsParserTests
         {
             "chat", "sessions", "init", "doctor", "status", "stats",
             "daemon", "mcp", "provider", "model", "reminder",
-            "secrets", "config", "update", "pair", "skill",
+            "secrets", "config", "update", "pair", "skill", "webhooks",
         };
 
         Assert.Equal(expected, CliArgsParser.KnownCommands);

--- a/src/Netclaw.Cli.Tests/Doctor/InboundWebhookRoutesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/InboundWebhookRoutesDoctorCheckTests.cs
@@ -85,7 +85,7 @@ public sealed class InboundWebhookRoutesDoctorCheckTests : IDisposable
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
-        Assert.Contains("missing a Prompt", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Prompt is required", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     private void WriteRouteFile(string routeName, WebhookRouteConfig route)

--- a/src/Netclaw.Cli.Tests/Doctor/InboundWebhookRoutesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/InboundWebhookRoutesDoctorCheckTests.cs
@@ -88,6 +88,51 @@ public sealed class InboundWebhookRoutesDoctorCheckTests : IDisposable
         Assert.Contains("Prompt is required", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task ReturnsError_WhenRouteNameIsInvalid()
+    {
+        File.WriteAllText(Path.Combine(_paths.WebhooksDirectory, "Bad_Route.json"), """
+{
+  "prompt": "triage this event",
+  "verification": {
+    "kind": "Hmac",
+    "secret": "secret"
+  }
+}
+""");
+
+        var check = new InboundWebhookRoutesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("lowercase kebab-case", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenVerificationIsNull()
+    {
+        File.WriteAllText(Path.Combine(_paths.WebhooksDirectory, "github-issues.json"), """
+{
+  "enabled": true,
+  "verification": null,
+  "events": [],
+  "audience": "Public",
+  "prompt": "triage",
+  "notifyInstructions": "",
+  "deliveryRequired": true,
+  "notificationTarget": null,
+  "maxBodyBytes": 1024,
+  "rateLimitPerMinute": 1
+}
+""");
+
+        var check = new InboundWebhookRoutesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("Verification settings are required", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private void WriteRouteFile(string routeName, WebhookRouteConfig route)
     {
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)

--- a/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Netclaw.Cli.Json;
 using Netclaw.Cli.Webhooks;
 using Netclaw.Configuration;
 using Xunit;
@@ -40,6 +42,67 @@ public sealed class WebhooksCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task List_InvalidRouteWithNullVerification_DoesNotCrash()
+    {
+        WriteRouteText("bad", """
+{
+  "enabled": true,
+  "verification": null,
+  "events": [],
+  "audience": "Public",
+  "prompt": "x",
+  "notifyInstructions": "",
+  "deliveryRequired": true,
+  "notificationTarget": null,
+  "maxBodyBytes": 1024,
+  "rateLimitPerMinute": 1
+}
+""");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "list"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task List_Json_MarksInvalidRouteAsInvalid()
+    {
+        WriteRouteText("bad", """
+{
+  "enabled": true,
+  "verification": null,
+  "events": [],
+  "audience": "Public",
+  "prompt": "x",
+  "notifyInstructions": "",
+  "deliveryRequired": true,
+  "notificationTarget": null,
+  "maxBodyBytes": 1024,
+  "rateLimitPerMinute": 1
+}
+""");
+
+        using var stdout = new StringWriter();
+        var original = Console.Out;
+        Console.SetOut(stdout);
+        try
+        {
+            var result = await WebhooksCommand.RunAsync(["webhooks", "list", "--json"], _paths);
+            Assert.Equal(0, result);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        var list = JsonSerializer.Deserialize<List<RouteListItem>>(stdout.ToString(), JsonDefaults.ConfigRead);
+        Assert.NotNull(list);
+        var item = Assert.Single(list!);
+        Assert.Equal("bad", item.Name);
+        Assert.Equal("invalid", item.Status);
+        Assert.Equal("unknown", item.Verification);
+    }
+
+    [Fact]
     public async Task Show_ExistingRoute_ReturnsZero()
     {
         CreateValidRoute("test-route");
@@ -63,6 +126,28 @@ public sealed class WebhooksCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Show_InvalidRouteWithNullVerification_ReturnsOne()
+    {
+        WriteRouteText("bad", """
+{
+  "enabled": true,
+  "verification": null,
+  "events": [],
+  "audience": "Public",
+  "prompt": "x",
+  "notifyInstructions": "",
+  "deliveryRequired": true,
+  "notificationTarget": null,
+  "maxBodyBytes": 1024,
+  "rateLimitPerMinute": 1
+}
+""");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "show", "bad"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
     public async Task Set_NewRoute_CreatesFile()
     {
         var result = await WebhooksCommand.RunAsync([
@@ -73,6 +158,19 @@ public sealed class WebhooksCommandTests : IDisposable
 
         Assert.Equal(0, result);
         Assert.True(File.Exists(Path.Combine(_paths.WebhooksDirectory, "new-route.json")));
+    }
+
+    [Fact]
+    public async Task Set_WithUppercaseRoute_NormalizesToLowercase()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "GitHub-Issues",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(0, result);
+        Assert.True(File.Exists(Path.Combine(_paths.WebhooksDirectory, "github-issues.json")));
     }
 
     [Fact]
@@ -140,6 +238,48 @@ public sealed class WebhooksCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Set_ConflictingCreateAndUpdateOnly_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--create-only",
+            "--update-only"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_ConflictingEnabledFlags_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--enabled",
+            "--disabled"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_ConflictingDeliveryFlags_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--delivery-required",
+            "--no-delivery-required"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
     public async Task Set_InvalidVerificationKind_ReturnsOne()
     {
         var result = await WebhooksCommand.RunAsync([
@@ -160,6 +300,135 @@ public sealed class WebhooksCommandTests : IDisposable
             "--prompt", "Test prompt",
             "--secret", "test-secret",
             "--audience", "invalid"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_InvalidRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "../secrets",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+        Assert.False(File.Exists(Path.Combine(_paths.ConfigDirectory, "secrets.json")));
+    }
+
+    [Fact]
+    public async Task Set_MissingPromptValue_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt",
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+        Assert.False(File.Exists(Path.Combine(_paths.WebhooksDirectory, "test-route.json")));
+    }
+
+    [Fact]
+    public async Task Set_MissingSecretFlagValue_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+        Assert.False(File.Exists(Path.Combine(_paths.WebhooksDirectory, "test-route.json")));
+    }
+
+    [Fact]
+    public async Task Set_MissingVerificationKindValue_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--verification-kind"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_MissingNotificationChannelValue_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--notification-channel"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_MissingPromptFile_DoesNotPartiallyUpdateExistingRoute()
+    {
+        CreateValidRoute("test-route", secret: "before-secret", prompt: "before-prompt");
+
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt-file", Path.Combine(_tempDir, "missing.txt"),
+            "--secret", "after-secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+
+        var route = ReadRoute("test-route");
+        Assert.Equal("before-prompt", route.Prompt);
+        Assert.Equal("before-secret", route.Verification.Secret!.Value);
+    }
+
+    [Fact]
+    public async Task Set_MultipleSecretSources_ReturnsOne()
+    {
+        var secretFile = Path.Combine(_tempDir, "secret.txt");
+        File.WriteAllText(secretFile, "file-secret");
+
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "inline-secret",
+            "--secret-file", secretFile
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_MultiplePromptSources_ReturnsOne()
+    {
+        var promptFile = Path.Combine(_tempDir, "prompt.txt");
+        File.WriteAllText(promptFile, "file prompt");
+
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "inline prompt",
+            "--prompt-file", promptFile,
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_MissingSecretEnvVariable_ReturnsOne()
+    {
+        Environment.SetEnvironmentVariable("NETCLAW_WEBHOOK_TEST_MISSING_SECRET", null);
+
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret-env", "NETCLAW_WEBHOOK_TEST_MISSING_SECRET"
         ], _paths);
 
         Assert.Equal(1, result);
@@ -191,6 +460,13 @@ public sealed class WebhooksCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Delete_InvalidRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "delete", "../secrets", "--force"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
     public async Task Validate_ValidRoute_ReturnsZero()
     {
         CreateValidRoute("valid-route");
@@ -214,6 +490,35 @@ public sealed class WebhooksCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Validate_InvalidRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "validate", "../secrets"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Validate_InvalidRouteWithNullVerification_ReturnsOne()
+    {
+        WriteRouteText("bad", """
+{
+  "enabled": true,
+  "verification": null,
+  "events": [],
+  "audience": "Public",
+  "prompt": "x",
+  "notifyInstructions": "",
+  "deliveryRequired": true,
+  "notificationTarget": null,
+  "maxBodyBytes": 1024,
+  "rateLimitPerMinute": 1
+}
+""");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "validate", "bad"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
     public async Task Help_ReturnsZero()
     {
         var result = await WebhooksCommand.RunAsync(["webhooks", "help"], _paths);
@@ -227,20 +532,40 @@ public sealed class WebhooksCommandTests : IDisposable
         Assert.Equal(0, result);
     }
 
-    private void CreateValidRoute(string routeName)
+    private void CreateValidRoute(string routeName, string secret = "test-secret", string prompt = "Test prompt")
     {
         var route = new WebhookRouteConfig
         {
             Enabled = true,
-            Prompt = "Test prompt",
+            Prompt = prompt,
             Verification = new WebhookVerificationConfig
             {
                 Kind = WebhookVerifierKind.Hmac,
-                Secret = new SensitiveString("test-secret")
+                Secret = new SensitiveString(secret)
             }
         };
 
         var store = new WebhookRouteStore(_paths);
         store.Save(routeName, route);
+    }
+
+    private WebhookRouteConfig ReadRoute(string routeName)
+    {
+        var store = new WebhookRouteStore(_paths);
+        Assert.True(store.TryGet(routeName, out var match));
+        Assert.NotNull(match.Definition);
+        return match.Definition!;
+    }
+
+    private void WriteRouteText(string routeName, string text)
+    {
+        File.WriteAllText(Path.Combine(_paths.WebhooksDirectory, $"{routeName}.json"), text);
+    }
+
+    private sealed class RouteListItem
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Verification { get; set; } = string.Empty;
     }
 }

--- a/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Webhooks/WebhooksCommandTests.cs
@@ -1,0 +1,246 @@
+using Netclaw.Cli.Webhooks;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Webhooks;
+
+public sealed class WebhooksCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public WebhooksCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task List_NoRoutes_ReturnsZero()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "list"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task List_WithRoutes_ReturnsZero()
+    {
+        CreateValidRoute("test-route");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "list"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Show_ExistingRoute_ReturnsZero()
+    {
+        CreateValidRoute("test-route");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "show", "test-route"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Show_NonexistentRoute_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "show", "nonexistent"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Show_MissingRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "show"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_NewRoute_CreatesFile()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "new-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(0, result);
+        Assert.True(File.Exists(Path.Combine(_paths.WebhooksDirectory, "new-route.json")));
+    }
+
+    [Fact]
+    public async Task Set_MissingPrompt_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--secret", "test-secret"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_MissingSecret_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_DryRun_DoesNotCreateFile()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "dry-run-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--dry-run"
+        ], _paths);
+
+        Assert.Equal(0, result);
+        Assert.False(File.Exists(Path.Combine(_paths.WebhooksDirectory, "dry-run-route.json")));
+    }
+
+    [Fact]
+    public async Task Set_CreateOnly_FailsIfExists()
+    {
+        CreateValidRoute("existing-route");
+
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "existing-route",
+            "--prompt", "Updated prompt",
+            "--secret", "updated-secret",
+            "--create-only"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_UpdateOnly_FailsIfNotExists()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "nonexistent-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--update-only"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_InvalidVerificationKind_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--verification-kind", "invalid"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Set_InvalidAudience_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync([
+            "webhooks", "set", "test-route",
+            "--prompt", "Test prompt",
+            "--secret", "test-secret",
+            "--audience", "invalid"
+        ], _paths);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Delete_ExistingRoute_ReturnsZero()
+    {
+        CreateValidRoute("delete-me");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "delete", "delete-me", "--force"], _paths);
+
+        Assert.Equal(0, result);
+        Assert.False(File.Exists(Path.Combine(_paths.WebhooksDirectory, "delete-me.json")));
+    }
+
+    [Fact]
+    public async Task Delete_NonexistentRoute_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "delete", "nonexistent", "--force"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Delete_MissingRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "delete"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Validate_ValidRoute_ReturnsZero()
+    {
+        CreateValidRoute("valid-route");
+
+        var result = await WebhooksCommand.RunAsync(["webhooks", "validate", "valid-route"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Validate_NonexistentRoute_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "validate", "nonexistent"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Validate_MissingRouteName_ReturnsOne()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "validate"], _paths);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Help_ReturnsZero()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "help"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task HelpFlag_ReturnsZero()
+    {
+        var result = await WebhooksCommand.RunAsync(["webhooks", "--help"], _paths);
+        Assert.Equal(0, result);
+    }
+
+    private void CreateValidRoute(string routeName)
+    {
+        var route = new WebhookRouteConfig
+        {
+            Enabled = true,
+            Prompt = "Test prompt",
+            Verification = new WebhookVerificationConfig
+            {
+                Kind = WebhookVerifierKind.Hmac,
+                Secret = new SensitiveString("test-secret")
+            }
+        };
+
+        var store = new WebhookRouteStore(_paths);
+        store.Save(routeName, route);
+    }
+}

--- a/src/Netclaw.Cli/CliArgsParser.cs
+++ b/src/Netclaw.Cli/CliArgsParser.cs
@@ -27,7 +27,7 @@ public static class CliArgsParser
     {
         "chat", "sessions", "init", "doctor", "status", "stats",
         "daemon", "mcp", "provider", "model", "reminder",
-        "secrets", "config", "update", "pair", "skill",
+        "secrets", "config", "update", "pair", "skill", "webhooks",
     };
 
     /// <summary>Returns <c>true</c> if the token is a help flag (<c>help</c>, <c>-h</c>, <c>--help</c>).</summary>

--- a/src/Netclaw.Cli/Doctor/InboundWebhookRoutesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/InboundWebhookRoutesDoctorCheck.cs
@@ -28,7 +28,7 @@ public sealed class InboundWebhookRoutesDoctorCheck(NetclawPaths paths) : IDocto
                 var route = JsonSerializer.Deserialize<WebhookRouteConfig>(File.ReadAllText(filePath), JsonDefaults.ConfigRead)
                     ?? throw new InvalidOperationException($"Webhook route '{routeName}' could not be parsed.");
 
-                ValidateRoute(routeName, route);
+                WebhookRouteValidator.ValidateOrThrow(routeName, route);
             }
             catch (Exception ex)
             {
@@ -47,41 +47,5 @@ public sealed class InboundWebhookRoutesDoctorCheck(NetclawPaths paths) : IDocto
             CheckName,
             $"Invalid inbound webhook route files: {string.Join("; ", invalidRoutes)}",
             $"Fix or remove invalid files under {paths.WebhooksDirectory}. Netclaw fails these routes closed at runtime."));
-    }
-
-    private static void ValidateRoute(string routeName, WebhookRouteConfig route)
-    {
-        if (string.IsNullOrWhiteSpace(routeName))
-            throw new InvalidOperationException("Webhook route filename must not be empty.");
-
-        if (string.IsNullOrWhiteSpace(route.Prompt))
-            throw new InvalidOperationException($"Webhook route '{routeName}' is missing a Prompt.");
-
-        if (route.Verification.Secret is null || string.IsNullOrWhiteSpace(route.Verification.Secret.Value))
-            throw new InvalidOperationException($"Webhook route '{routeName}' is missing a verification secret.");
-
-        if (route.MaxBodyBytes < 1)
-            throw new InvalidOperationException($"Webhook route '{routeName}' must set MaxBodyBytes >= 1.");
-
-        if (route.RateLimitPerMinute < 1)
-            throw new InvalidOperationException($"Webhook route '{routeName}' must set RateLimitPerMinute >= 1.");
-
-        if (route.Events.Any(string.IsNullOrWhiteSpace))
-            throw new InvalidOperationException($"Webhook route '{routeName}' contains a blank event filter.");
-
-        if (route.DeliveryRequired
-            && route.NotificationTarget is null
-            && !string.IsNullOrWhiteSpace(route.NotifyInstructions))
-        {
-            throw new InvalidOperationException(
-                $"Webhook route '{routeName}' must set NotificationTarget when DeliveryRequired is true and NotifyInstructions are provided.");
-        }
-
-        if (route.NotificationTarget is { Kind: NotificationTargetKind.Slack } target
-            && string.IsNullOrWhiteSpace(target.ChannelId))
-        {
-            throw new InvalidOperationException(
-                $"Webhook route '{routeName}' must set NotificationTarget.ChannelId for Slack targets.");
-        }
     }
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -20,6 +20,7 @@ using Netclaw.Cli.Provider;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Skills;
 using Netclaw.Cli.Update;
+using Netclaw.Cli.Webhooks;
 using Netclaw.Configuration;
 using Netclaw.Providers;
 using Netclaw.Providers.OAuth;
@@ -760,6 +761,15 @@ static async Task RunAsync(string[] args)
         return;
     }
 
+    // ── Webhook management ──
+    if (mode is "webhooks")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+        Environment.ExitCode = await WebhooksCommand.RunAsync(args, paths);
+        return;
+    }
+
     // ── Secrets management ──
     if (mode is "secrets")
     {
@@ -991,6 +1001,7 @@ static void WriteGeneralHelp()
     Console.WriteLine("  model                    Manage model assignments (TUI) or use subcommands");
     Console.WriteLine("  reminder                 Manage scheduled reminders (daemon-required)");
     Console.WriteLine("  skill                    Manage skills and skill sources");
+    Console.WriteLine("  webhooks                 Manage inbound webhook routes");
     Console.WriteLine("  secrets                  Manage encrypted secrets (set key/value pairs)");
     Console.WriteLine("  init                     First-run setup wizard");
     Console.WriteLine("  update                   Check for and install updates");

--- a/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
+++ b/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
@@ -1,0 +1,639 @@
+using System.Text.Json;
+using Netclaw.Cli.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Webhooks;
+
+/// <summary>
+/// Handles <c>netclaw webhooks &lt;subcommand&gt;</c> CLI subcommands.
+/// All commands are offline — no daemon required.
+/// </summary>
+internal static class WebhooksCommand
+{
+    public static Task<int> RunAsync(string[] args, NetclawPaths paths)
+    {
+        var subcommand = args.Length > 1 ? args[1] : "list";
+
+        if (subcommand is "help" or "-h" or "--help")
+            return Task.FromResult(WriteHelp());
+
+        var store = new WebhookRouteStore(paths);
+
+        return Task.FromResult(subcommand switch
+        {
+            "list" => RunList(args, store, paths),
+            "show" => RunShow(args, store, paths),
+            "set" => RunSet(args, store, paths),
+            "delete" => RunDelete(args, store),
+            "validate" => RunValidate(args, paths),
+            _ => WriteHelp()
+        });
+    }
+
+    // ── list ──
+
+    private static int RunList(string[] args, WebhookRouteStore store, NetclawPaths paths)
+    {
+        var json = HasFlag(args, "--json");
+        var all = HasFlag(args, "--all");
+
+        var routes = store.ListRouteFiles();
+
+        if (routes.Count == 0)
+        {
+            if (json)
+            {
+                Console.WriteLine("[]");
+            }
+            else
+            {
+                Console.WriteLine("No webhook routes configured.");
+                Console.WriteLine($"Routes are stored in: {paths.WebhooksDirectory}");
+            }
+            return 0;
+        }
+
+        if (json)
+        {
+            var items = routes
+                .Where(r => all || r.Definition?.Enabled != false)
+                .Select(r => new
+                {
+                    name = r.RouteName,
+                    status = r.Definition is null ? "invalid" : (r.Definition.Enabled ? "enabled" : "disabled"),
+                    audience = r.Definition?.Audience.ToString().ToLowerInvariant() ?? "unknown",
+                    verification = r.Definition?.Verification.Kind.ToString().ToLowerInvariant() ?? "unknown",
+                    deliveryRequired = r.Definition?.DeliveryRequired ?? false
+                })
+                .ToList();
+            Console.WriteLine(JsonSerializer.Serialize(items, JsonDefaults.IndentedCamelCase));
+            return 0;
+        }
+
+        const int colName = 24;
+        const int colStatus = 10;
+        const int colAudience = 10;
+        const int colVerification = 14;
+
+        Console.WriteLine(
+            $"{"NAME",-colName}  {"STATUS",-colStatus}  {"AUDIENCE",-colAudience}  {"VERIFICATION",-colVerification}  DELIVERY");
+        Console.WriteLine(new string('-', colName + colStatus + colAudience + colVerification + 18));
+
+        foreach (var route in routes)
+        {
+            var status = route.Definition is null ? "invalid" : (route.Definition.Enabled ? "enabled" : "disabled");
+
+            if (!all && status == "disabled")
+                continue;
+
+            var audience = route.Definition?.Audience.ToString().ToLowerInvariant() ?? "-";
+            var verification = route.Definition?.Verification.Kind.ToString().ToLowerInvariant() ?? "-";
+            var delivery = route.Definition?.DeliveryRequired == true ? "required" : "optional";
+
+            Console.WriteLine(
+                $"{route.RouteName,-colName}  {status,-colStatus}  {audience,-colAudience}  {verification,-colVerification}  {delivery}");
+        }
+
+        return 0;
+    }
+
+    // ── show ──
+
+    private static int RunShow(string[] args, WebhookRouteStore store, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw webhooks show <route> [--json] [--show-secret]");
+            return 1;
+        }
+
+        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        var json = HasFlag(args, "--json");
+        var showSecret = HasFlag(args, "--show-secret");
+
+        if (!store.TryGet(routeName, out var match))
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' not found.");
+            Console.Error.WriteLine($"       Routes are stored in: {paths.WebhooksDirectory}");
+            return 1;
+        }
+
+        if (match.Definition is null)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' could not be parsed.");
+            Console.Error.WriteLine($"       Run 'netclaw webhooks validate {routeName}' for details.");
+            return 1;
+        }
+
+        var route = match.Definition;
+
+        if (json)
+        {
+            var output = new
+            {
+                name = routeName,
+                file = match.FilePath,
+                endpoint = $"/api/webhooks/{routeName}",
+                enabled = route.Enabled,
+                verification = new
+                {
+                    kind = route.Verification.Kind.ToString().ToLowerInvariant(),
+                    secret = showSecret ? route.Verification.Secret?.Value : "********",
+                    hmacAlgorithm = route.Verification.HmacAlgorithm.ToString().ToLowerInvariant(),
+                    signatureHeader = route.Verification.SignatureHeaderName,
+                    signaturePrefix = route.Verification.SignaturePrefix,
+                    secretHeader = route.Verification.SecretHeaderName,
+                    eventHeader = route.Verification.EventHeaderName,
+                    deliveryIdHeader = route.Verification.DeliveryIdHeaderName
+                },
+                audience = route.Audience.ToString().ToLowerInvariant(),
+                events = route.Events,
+                prompt = route.Prompt,
+                notifyInstructions = route.NotifyInstructions,
+                deliveryRequired = route.DeliveryRequired,
+                notificationTarget = route.NotificationTarget is null ? null : new
+                {
+                    kind = route.NotificationTarget.Kind.ToString().ToLowerInvariant(),
+                    channelId = route.NotificationTarget.ChannelId
+                },
+                maxBodyBytes = route.MaxBodyBytes,
+                rateLimitPerMinute = route.RateLimitPerMinute
+            };
+            Console.WriteLine(JsonSerializer.Serialize(output, JsonDefaults.IndentedCamelCase));
+            return 0;
+        }
+
+        Console.WriteLine($"Route:              {routeName}");
+        Console.WriteLine($"File:               {match.FilePath}");
+        Console.WriteLine($"Status:             {(route.Enabled ? "enabled" : "disabled")}");
+        Console.WriteLine($"Endpoint:           /api/webhooks/{routeName}");
+        Console.WriteLine();
+        Console.WriteLine("Verification:");
+        Console.WriteLine($"  Kind:             {route.Verification.Kind.ToString().ToLowerInvariant()}");
+        Console.WriteLine($"  Secret:           {(showSecret ? route.Verification.Secret?.Value ?? "(not set)" : "********** (use --show-secret to reveal)")}");
+        if (route.Verification.Kind == WebhookVerifierKind.Hmac)
+        {
+            Console.WriteLine($"  Algorithm:        {route.Verification.HmacAlgorithm.ToString().ToLowerInvariant()}");
+            Console.WriteLine($"  Signature Header: {route.Verification.SignatureHeaderName ?? "(default)"}");
+            Console.WriteLine($"  Signature Prefix: {route.Verification.SignaturePrefix ?? "(none)"}");
+        }
+        else
+        {
+            Console.WriteLine($"  Secret Header:    {route.Verification.SecretHeaderName ?? "(default)"}");
+        }
+        Console.WriteLine($"  Event Header:     {route.Verification.EventHeaderName ?? "(default)"}");
+        Console.WriteLine($"  Delivery Header:  {route.Verification.DeliveryIdHeaderName ?? "(default)"}");
+        Console.WriteLine();
+        Console.WriteLine("Behavior:");
+        Console.WriteLine($"  Audience:         {route.Audience.ToString().ToLowerInvariant()}");
+        Console.WriteLine($"  Events:           {(route.Events.Count > 0 ? string.Join(", ", route.Events) : "(all)")}");
+        Console.WriteLine($"  Rate Limit:       {route.RateLimitPerMinute} req/min");
+        Console.WriteLine($"  Max Body:         {route.MaxBodyBytes} bytes ({route.MaxBodyBytes / 1024 / 1024} MB)");
+        Console.WriteLine();
+        Console.WriteLine("Notification:");
+        Console.WriteLine($"  Delivery:         {(route.DeliveryRequired ? "required" : "optional")}");
+        if (route.NotificationTarget is not null)
+        {
+            Console.WriteLine($"  Target:           {route.NotificationTarget.Kind.ToString().ToLowerInvariant()} (channel: {route.NotificationTarget.ChannelId ?? "(not set)"})");
+        }
+        else
+        {
+            Console.WriteLine("  Target:           (not configured)");
+        }
+        if (!string.IsNullOrWhiteSpace(route.NotifyInstructions))
+        {
+            var truncated = route.NotifyInstructions.Length > 60
+                ? route.NotifyInstructions[..60] + "..."
+                : route.NotifyInstructions;
+            Console.WriteLine($"  Instructions:     {truncated.Replace("\n", " ")}");
+        }
+        Console.WriteLine();
+        Console.WriteLine("Prompt:");
+        if (string.IsNullOrWhiteSpace(route.Prompt))
+        {
+            Console.WriteLine("  (empty)");
+        }
+        else if (route.Prompt.Length > 200)
+        {
+            Console.WriteLine($"  {route.Prompt[..200].Replace("\n", " ")}...");
+            Console.WriteLine("  (truncated; run with --json for full prompt)");
+        }
+        else
+        {
+            foreach (var line in route.Prompt.Split('\n'))
+            {
+                Console.WriteLine($"  {line}");
+            }
+        }
+
+        return 0;
+    }
+
+    // ── set ──
+
+    private static int RunSet(string[] args, WebhookRouteStore store, NetclawPaths paths)
+    {
+        if (args.Length < 3 || HasFlag(args, "--help") || HasFlag(args, "-h"))
+        {
+            WriteSetHelp();
+            return args.Length < 3 ? 1 : 0;
+        }
+
+        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        var dryRun = HasFlag(args, "--dry-run");
+        var createOnly = HasFlag(args, "--create-only");
+        var updateOnly = HasFlag(args, "--update-only");
+
+        var exists = store.TryGet(routeName, out var existing);
+
+        if (createOnly && exists)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' already exists (--create-only specified).");
+            return 1;
+        }
+
+        if (updateOnly && !exists)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' does not exist (--update-only specified).");
+            return 1;
+        }
+
+        // Start with existing config or defaults
+        var route = existing.Definition ?? new WebhookRouteConfig();
+
+        // Parse prompt
+        var prompt = ResolveTextInput(args, "--prompt", "--prompt-file");
+        if (prompt is not null)
+            route.Prompt = prompt;
+
+        // Parse secret
+        var secret = ResolveSecret(args);
+        if (secret is not null)
+            route.Verification.Secret = new SensitiveString(secret);
+
+        // Parse verification kind
+        var verificationKind = GetFlagValue(args, "--verification-kind");
+        if (verificationKind is not null)
+        {
+            if (!Enum.TryParse<WebhookVerifierKind>(verificationKind, ignoreCase: true, out var kind))
+            {
+                Console.Error.WriteLine($"[FAIL] Invalid verification kind: '{verificationKind}'. Use 'hmac' or 'header-secret'.");
+                return 1;
+            }
+            route.Verification.Kind = kind;
+        }
+
+        // Parse verification headers
+        var signatureHeader = GetFlagValue(args, "--signature-header");
+        if (signatureHeader is not null)
+            route.Verification.SignatureHeaderName = signatureHeader;
+
+        var signaturePrefix = GetFlagValue(args, "--signature-prefix");
+        if (signaturePrefix is not null)
+            route.Verification.SignaturePrefix = signaturePrefix;
+
+        var secretHeader = GetFlagValue(args, "--secret-header");
+        if (secretHeader is not null)
+            route.Verification.SecretHeaderName = secretHeader;
+
+        var eventHeader = GetFlagValue(args, "--event-header");
+        if (eventHeader is not null)
+            route.Verification.EventHeaderName = eventHeader;
+
+        var deliveryHeader = GetFlagValue(args, "--delivery-header");
+        if (deliveryHeader is not null)
+            route.Verification.DeliveryIdHeaderName = deliveryHeader;
+
+        // Parse events
+        var events = GetFlagValue(args, "--events");
+        if (events is not null)
+        {
+            route.Events = events.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        }
+
+        // Parse audience
+        var audience = GetFlagValue(args, "--audience");
+        if (audience is not null)
+        {
+            if (!Enum.TryParse<TrustAudience>(audience, ignoreCase: true, out var aud))
+            {
+                Console.Error.WriteLine($"[FAIL] Invalid audience: '{audience}'. Use 'public', 'team', or 'personal'.");
+                return 1;
+            }
+            route.Audience = aud;
+        }
+
+        // Parse notification settings
+        var notifyInstructions = ResolveTextInput(args, "--notify-instructions", "--notify-instructions-file");
+        if (notifyInstructions is not null)
+            route.NotifyInstructions = notifyInstructions;
+
+        if (HasFlag(args, "--delivery-required"))
+            route.DeliveryRequired = true;
+        if (HasFlag(args, "--no-delivery-required"))
+            route.DeliveryRequired = false;
+
+        var notificationChannel = GetFlagValue(args, "--notification-channel");
+        if (notificationChannel is not null)
+        {
+            route.NotificationTarget ??= new NotificationTargetConfig();
+            route.NotificationTarget.ChannelId = notificationChannel;
+        }
+
+        // Parse limits
+        var maxBody = GetFlagValue(args, "--max-body");
+        if (maxBody is not null)
+        {
+            if (!int.TryParse(maxBody, out var bytes) || bytes < 1)
+            {
+                Console.Error.WriteLine($"[FAIL] Invalid max body size: '{maxBody}'. Must be a positive integer.");
+                return 1;
+            }
+            route.MaxBodyBytes = bytes;
+        }
+
+        var rateLimit = GetFlagValue(args, "--rate-limit");
+        if (rateLimit is not null)
+        {
+            if (!int.TryParse(rateLimit, out var limit) || limit < 1)
+            {
+                Console.Error.WriteLine($"[FAIL] Invalid rate limit: '{rateLimit}'. Must be a positive integer.");
+                return 1;
+            }
+            route.RateLimitPerMinute = limit;
+        }
+
+        // Parse enabled/disabled
+        if (HasFlag(args, "--enabled"))
+            route.Enabled = true;
+        if (HasFlag(args, "--disabled"))
+            route.Enabled = false;
+
+        // Validate
+        var errors = WebhookRouteValidator.Validate(routeName, route);
+        if (errors.Count > 0)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' has validation errors:");
+            foreach (var error in errors)
+            {
+                Console.Error.WriteLine($"  - {error}");
+            }
+            return 1;
+        }
+
+        if (dryRun)
+        {
+            Console.WriteLine($"[OK] Webhook route '{routeName}' is valid (dry run, not saved).");
+            Console.WriteLine($"     Endpoint: /api/webhooks/{routeName}");
+            return 0;
+        }
+
+        // Save
+        store.Save(routeName, route);
+
+        var action = exists ? "Updated" : "Created";
+        Console.WriteLine($"[OK] {action} webhook route '{routeName}'.");
+        Console.WriteLine($"     File: {Path.Combine(paths.WebhooksDirectory, $"{routeName}.json")}");
+        Console.WriteLine($"     Endpoint: /api/webhooks/{routeName}");
+
+        return 0;
+    }
+
+    // ── delete ──
+
+    private static int RunDelete(string[] args, WebhookRouteStore store)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw webhooks delete <route> [--force]");
+            return 1;
+        }
+
+        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        var force = HasFlag(args, "--force") || HasFlag(args, "-f");
+
+        if (!force)
+        {
+            Console.Write($"Delete webhook route '{routeName}'? [y/N]: ");
+            var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+            if (response is not "y" and not "yes")
+            {
+                Console.WriteLine("Cancelled.");
+                return 0;
+            }
+        }
+
+        if (!store.Delete(routeName))
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' not found.");
+            return 1;
+        }
+
+        Console.WriteLine($"[OK] Deleted webhook route '{routeName}'.");
+        return 0;
+    }
+
+    // ── validate ──
+
+    private static int RunValidate(string[] args, NetclawPaths paths)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw webhooks validate <route>");
+            return 1;
+        }
+
+        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        var filePath = Path.Combine(paths.WebhooksDirectory, $"{routeName}.json");
+
+        if (!File.Exists(filePath))
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route file not found: {filePath}");
+            return 1;
+        }
+
+        WebhookRouteConfig route;
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            route = JsonSerializer.Deserialize<WebhookRouteConfig>(json, JsonDefaults.ConfigRead)
+                ?? throw new InvalidOperationException("Deserialization returned null.");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[FAIL] Could not parse webhook route file:");
+            Console.Error.WriteLine($"       {ex.Message}");
+            return 1;
+        }
+
+        var errors = WebhookRouteValidator.Validate(routeName, route);
+        if (errors.Count > 0)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' has validation errors:");
+            foreach (var error in errors)
+            {
+                Console.Error.WriteLine($"  - {error}");
+            }
+            return 1;
+        }
+
+        Console.WriteLine($"[OK] Webhook route '{routeName}' is valid.");
+        Console.WriteLine($"     Endpoint: /api/webhooks/{routeName}");
+        Console.WriteLine($"     Verification: {route.Verification.Kind.ToString().ToLowerInvariant()}");
+        Console.WriteLine($"     Audience: {route.Audience.ToString().ToLowerInvariant()}");
+        return 0;
+    }
+
+    // ── Helpers ──
+
+    private static bool HasFlag(string[] args, string flag)
+        => args.Any(a => string.Equals(a, flag, StringComparison.OrdinalIgnoreCase));
+
+    private static string? GetFlagValue(string[] args, string flag)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i].StartsWith($"{flag}=", StringComparison.OrdinalIgnoreCase))
+                return args[i][(flag.Length + 1)..];
+
+            if (i < args.Length - 1 && string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        }
+        return null;
+    }
+
+    private static string? ResolveTextInput(string[] args, string inlineFlag, string fileFlag)
+    {
+        var fileValue = GetFlagValue(args, fileFlag);
+        if (fileValue is not null)
+        {
+            if (!File.Exists(fileValue))
+            {
+                Console.Error.WriteLine($"[FAIL] File not found: {fileValue}");
+                return null;
+            }
+            return File.ReadAllText(fileValue).Trim();
+        }
+
+        return GetFlagValue(args, inlineFlag);
+    }
+
+    private static string? ResolveSecret(string[] args)
+    {
+        var secretFile = GetFlagValue(args, "--secret-file");
+        if (secretFile is not null)
+        {
+            if (!File.Exists(secretFile))
+            {
+                Console.Error.WriteLine($"[FAIL] Secret file not found: {secretFile}");
+                return null;
+            }
+            return File.ReadAllText(secretFile).Trim();
+        }
+
+        var secretEnv = GetFlagValue(args, "--secret-env");
+        if (secretEnv is not null)
+        {
+            var value = Environment.GetEnvironmentVariable(secretEnv);
+            if (string.IsNullOrEmpty(value))
+            {
+                Console.Error.WriteLine($"[FAIL] Environment variable '{secretEnv}' is not set or empty.");
+                return null;
+            }
+            return value;
+        }
+
+        var inlineSecret = GetFlagValue(args, "--secret");
+        if (inlineSecret is not null)
+        {
+            Console.Error.WriteLine("warning: --secret exposes the value in shell history; consider --secret-file or --secret-env");
+            return inlineSecret;
+        }
+
+        return null;
+    }
+
+    // ── Help ──
+
+    private static int WriteHelp()
+    {
+        Console.WriteLine("Usage: netclaw webhooks <subcommand>");
+        Console.WriteLine();
+        Console.WriteLine("Manage inbound webhook routes. Routes define how external services");
+        Console.WriteLine("(GitHub, Slack, etc.) can trigger agent actions via HTTP webhooks.");
+        Console.WriteLine();
+        Console.WriteLine("Subcommands:");
+        Console.WriteLine("  list                     List configured webhook routes");
+        Console.WriteLine("  show <route>             Show route details");
+        Console.WriteLine("  set <route> [options]    Create or update a route");
+        Console.WriteLine("  delete <route>           Delete a route");
+        Console.WriteLine("  validate <route>         Validate a route file");
+        Console.WriteLine();
+        Console.WriteLine("Options for list:");
+        Console.WriteLine("  --json                   Output as JSON");
+        Console.WriteLine("  --all                    Include disabled routes");
+        Console.WriteLine();
+        Console.WriteLine("Options for show:");
+        Console.WriteLine("  --json                   Output full config as JSON");
+        Console.WriteLine("  --show-secret            Reveal verification secret");
+        Console.WriteLine();
+        Console.WriteLine("Run 'netclaw webhooks set --help' for set command options.");
+        Console.WriteLine();
+        Console.WriteLine("Routes are stored in ~/.netclaw/config/webhooks/<route>.json");
+        Console.WriteLine("and served at /api/webhooks/<route> by the daemon.");
+        Console.WriteLine();
+        Console.WriteLine("Note: This command manages INBOUND webhook routes (external services");
+        Console.WriteLine("calling Netclaw). For OUTBOUND notifications (Netclaw posting to Slack),");
+        Console.WriteLine("see `netclaw secrets set Slack.BotToken` and notification target config.");
+        return 0;
+    }
+
+    private static void WriteSetHelp()
+    {
+        Console.WriteLine("Usage: netclaw webhooks set <route> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Create or update an inbound webhook route.");
+        Console.WriteLine();
+        Console.WriteLine("Required (for new routes):");
+        Console.WriteLine("  --prompt <text>              Prompt instructions for the agent");
+        Console.WriteLine("  --prompt-file <path>         Read prompt from file");
+        Console.WriteLine("  --secret <value>             Verification secret (visible in shell history!)");
+        Console.WriteLine("  --secret-file <path>         Read secret from file");
+        Console.WriteLine("  --secret-env <VAR>           Read secret from environment variable");
+        Console.WriteLine();
+        Console.WriteLine("Verification:");
+        Console.WriteLine("  --verification-kind <kind>   'hmac' (default) or 'header-secret'");
+        Console.WriteLine("  --signature-header <name>    HMAC signature header (e.g., X-Hub-Signature-256)");
+        Console.WriteLine("  --signature-prefix <prefix>  HMAC signature prefix (e.g., sha256=)");
+        Console.WriteLine("  --secret-header <name>       Header-secret header name");
+        Console.WriteLine("  --event-header <name>        Event type header");
+        Console.WriteLine("  --delivery-header <name>     Delivery ID header");
+        Console.WriteLine();
+        Console.WriteLine("Behavior:");
+        Console.WriteLine("  --events <list>              Comma-separated event allowlist");
+        Console.WriteLine("  --audience <level>           'public' (default), 'team', or 'personal'");
+        Console.WriteLine("  --max-body <bytes>           Max request body size (default: 1048576)");
+        Console.WriteLine("  --rate-limit <req/min>       Rate limit per minute (default: 30)");
+        Console.WriteLine("  --enabled / --disabled       Enable or disable the route");
+        Console.WriteLine();
+        Console.WriteLine("Notification:");
+        Console.WriteLine("  --notify-instructions <text>     Notification instructions");
+        Console.WriteLine("  --notify-instructions-file <path>");
+        Console.WriteLine("  --delivery-required              Require notification delivery");
+        Console.WriteLine("  --no-delivery-required           Make notification optional");
+        Console.WriteLine("  --notification-channel <id>      Slack channel ID for notifications");
+        Console.WriteLine();
+        Console.WriteLine("Modifiers:");
+        Console.WriteLine("  --dry-run                    Validate without saving");
+        Console.WriteLine("  --create-only                Fail if route already exists");
+        Console.WriteLine("  --update-only                Fail if route doesn't exist");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  netclaw webhooks set github-issues \\");
+        Console.WriteLine("    --prompt \"Triage incoming GitHub issues\" \\");
+        Console.WriteLine("    --secret-env GITHUB_WEBHOOK_SECRET \\");
+        Console.WriteLine("    --signature-header X-Hub-Signature-256 \\");
+        Console.WriteLine("    --signature-prefix \"sha256=\" \\");
+        Console.WriteLine("    --events issues.opened,issues.closed");
+    }
+}

--- a/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
+++ b/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
@@ -37,7 +37,23 @@ internal static class WebhooksCommand
         var json = HasFlag(args, "--json");
         var all = HasFlag(args, "--all");
 
-        var routes = store.ListRouteFiles();
+        var routes = store.ListRouteFiles()
+            .Select(route =>
+            {
+                var validationErrors = route.Definition is null
+                    ? ["Webhook route file could not be parsed."]
+                    : WebhookRouteValidator.Validate(route.RouteName, route.Definition);
+                var isValid = validationErrors.Count == 0;
+
+                return new
+                {
+                    route.RouteName,
+                    route.Definition,
+                    IsValid = isValid,
+                    Status = !isValid ? "invalid" : (route.Definition!.Enabled ? "enabled" : "disabled"),
+                };
+            })
+            .ToList();
 
         if (routes.Count == 0)
         {
@@ -56,14 +72,14 @@ internal static class WebhooksCommand
         if (json)
         {
             var items = routes
-                .Where(r => all || r.Definition?.Enabled != false)
+                .Where(r => all || r.Status != "disabled")
                 .Select(r => new
                 {
                     name = r.RouteName,
-                    status = r.Definition is null ? "invalid" : (r.Definition.Enabled ? "enabled" : "disabled"),
-                    audience = r.Definition?.Audience.ToString().ToLowerInvariant() ?? "unknown",
-                    verification = r.Definition?.Verification.Kind.ToString().ToLowerInvariant() ?? "unknown",
-                    deliveryRequired = r.Definition?.DeliveryRequired ?? false
+                    status = r.Status,
+                    audience = r.IsValid ? r.Definition!.Audience.ToString().ToLowerInvariant() : "unknown",
+                    verification = r.IsValid ? r.Definition!.Verification.Kind.ToString().ToLowerInvariant() : "unknown",
+                    deliveryRequired = r.IsValid && r.Definition!.DeliveryRequired
                 })
                 .ToList();
             Console.WriteLine(JsonSerializer.Serialize(items, JsonDefaults.IndentedCamelCase));
@@ -81,14 +97,14 @@ internal static class WebhooksCommand
 
         foreach (var route in routes)
         {
-            var status = route.Definition is null ? "invalid" : (route.Definition.Enabled ? "enabled" : "disabled");
+            var status = route.Status;
 
             if (!all && status == "disabled")
                 continue;
 
-            var audience = route.Definition?.Audience.ToString().ToLowerInvariant() ?? "-";
-            var verification = route.Definition?.Verification.Kind.ToString().ToLowerInvariant() ?? "-";
-            var delivery = route.Definition?.DeliveryRequired == true ? "required" : "optional";
+            var audience = route.IsValid ? route.Definition!.Audience.ToString().ToLowerInvariant() : "-";
+            var verification = route.IsValid ? route.Definition!.Verification.Kind.ToString().ToLowerInvariant() : "-";
+            var delivery = route.IsValid && route.Definition!.DeliveryRequired ? "required" : "optional";
 
             Console.WriteLine(
                 $"{route.RouteName,-colName}  {status,-colStatus}  {audience,-colAudience}  {verification,-colVerification}  {delivery}");
@@ -107,7 +123,9 @@ internal static class WebhooksCommand
             return 1;
         }
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        if (!TryParseRouteName(args[2], out var routeName))
+            return 1;
+
         var json = HasFlag(args, "--json");
         var showSecret = HasFlag(args, "--show-secret");
 
@@ -126,6 +144,16 @@ internal static class WebhooksCommand
         }
 
         var route = match.Definition;
+        var validationErrors = WebhookRouteValidator.Validate(routeName, route);
+        if (validationErrors.Count > 0)
+        {
+            Console.Error.WriteLine($"[FAIL] Webhook route '{routeName}' has validation errors:");
+            foreach (var error in validationErrors)
+                Console.Error.WriteLine($"  - {error}");
+
+            Console.Error.WriteLine($"       Run 'netclaw webhooks validate {routeName}' for details.");
+            return 1;
+        }
 
         if (json)
         {
@@ -239,10 +267,18 @@ internal static class WebhooksCommand
             return args.Length < 3 ? 1 : 0;
         }
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        if (!TryParseRouteName(args[2], out var routeName))
+            return 1;
+
         var dryRun = HasFlag(args, "--dry-run");
         var createOnly = HasFlag(args, "--create-only");
         var updateOnly = HasFlag(args, "--update-only");
+
+        if (createOnly && updateOnly)
+        {
+            Console.Error.WriteLine("[FAIL] --create-only and --update-only cannot be used together.");
+            return 1;
+        }
 
         var exists = store.TryGet(routeName, out var existing);
 
@@ -260,20 +296,28 @@ internal static class WebhooksCommand
 
         // Start with existing config or defaults
         var route = existing.Definition ?? new WebhookRouteConfig();
+        route.Verification ??= new WebhookVerificationConfig();
+        route.Events ??= [];
 
         // Parse prompt
-        var prompt = ResolveTextInput(args, "--prompt", "--prompt-file");
-        if (prompt is not null)
+        if (!TryResolveTextInput(args, "--prompt", "--prompt-file", out var prompt, out var hasPrompt))
+            return 1;
+
+        if (hasPrompt)
             route.Prompt = prompt;
 
         // Parse secret
-        var secret = ResolveSecret(args);
-        if (secret is not null)
+        if (!TryResolveSecret(args, out var secret, out var hasSecret))
+            return 1;
+
+        if (hasSecret)
             route.Verification.Secret = new SensitiveString(secret);
 
         // Parse verification kind
-        var verificationKind = GetFlagValue(args, "--verification-kind");
-        if (verificationKind is not null)
+        if (!TryGetFlagValue(args, "--verification-kind", out var verificationKind, out var hasVerificationKind))
+            return 1;
+
+        if (hasVerificationKind)
         {
             if (!Enum.TryParse<WebhookVerifierKind>(verificationKind, ignoreCase: true, out var kind))
             {
@@ -284,36 +328,50 @@ internal static class WebhooksCommand
         }
 
         // Parse verification headers
-        var signatureHeader = GetFlagValue(args, "--signature-header");
-        if (signatureHeader is not null)
+        if (!TryGetFlagValue(args, "--signature-header", out var signatureHeader, out var hasSignatureHeader))
+            return 1;
+
+        if (hasSignatureHeader)
             route.Verification.SignatureHeaderName = signatureHeader;
 
-        var signaturePrefix = GetFlagValue(args, "--signature-prefix");
-        if (signaturePrefix is not null)
+        if (!TryGetFlagValue(args, "--signature-prefix", out var signaturePrefix, out var hasSignaturePrefix))
+            return 1;
+
+        if (hasSignaturePrefix)
             route.Verification.SignaturePrefix = signaturePrefix;
 
-        var secretHeader = GetFlagValue(args, "--secret-header");
-        if (secretHeader is not null)
+        if (!TryGetFlagValue(args, "--secret-header", out var secretHeader, out var hasSecretHeader))
+            return 1;
+
+        if (hasSecretHeader)
             route.Verification.SecretHeaderName = secretHeader;
 
-        var eventHeader = GetFlagValue(args, "--event-header");
-        if (eventHeader is not null)
+        if (!TryGetFlagValue(args, "--event-header", out var eventHeader, out var hasEventHeader))
+            return 1;
+
+        if (hasEventHeader)
             route.Verification.EventHeaderName = eventHeader;
 
-        var deliveryHeader = GetFlagValue(args, "--delivery-header");
-        if (deliveryHeader is not null)
+        if (!TryGetFlagValue(args, "--delivery-header", out var deliveryHeader, out var hasDeliveryHeader))
+            return 1;
+
+        if (hasDeliveryHeader)
             route.Verification.DeliveryIdHeaderName = deliveryHeader;
 
         // Parse events
-        var events = GetFlagValue(args, "--events");
-        if (events is not null)
+        if (!TryGetFlagValue(args, "--events", out var events, out var hasEvents))
+            return 1;
+
+        if (hasEvents)
         {
             route.Events = events.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
         }
 
         // Parse audience
-        var audience = GetFlagValue(args, "--audience");
-        if (audience is not null)
+        if (!TryGetFlagValue(args, "--audience", out var audience, out var hasAudience))
+            return 1;
+
+        if (hasAudience)
         {
             if (!Enum.TryParse<TrustAudience>(audience, ignoreCase: true, out var aud))
             {
@@ -324,25 +382,39 @@ internal static class WebhooksCommand
         }
 
         // Parse notification settings
-        var notifyInstructions = ResolveTextInput(args, "--notify-instructions", "--notify-instructions-file");
-        if (notifyInstructions is not null)
+        if (!TryResolveTextInput(args, "--notify-instructions", "--notify-instructions-file", out var notifyInstructions, out var hasNotifyInstructions))
+            return 1;
+
+        if (hasNotifyInstructions)
             route.NotifyInstructions = notifyInstructions;
 
-        if (HasFlag(args, "--delivery-required"))
+        var deliveryRequired = HasFlag(args, "--delivery-required");
+        var noDeliveryRequired = HasFlag(args, "--no-delivery-required");
+        if (deliveryRequired && noDeliveryRequired)
+        {
+            Console.Error.WriteLine("[FAIL] --delivery-required and --no-delivery-required cannot be used together.");
+            return 1;
+        }
+
+        if (deliveryRequired)
             route.DeliveryRequired = true;
-        if (HasFlag(args, "--no-delivery-required"))
+        if (noDeliveryRequired)
             route.DeliveryRequired = false;
 
-        var notificationChannel = GetFlagValue(args, "--notification-channel");
-        if (notificationChannel is not null)
+        if (!TryGetFlagValue(args, "--notification-channel", out var notificationChannel, out var hasNotificationChannel))
+            return 1;
+
+        if (hasNotificationChannel)
         {
             route.NotificationTarget ??= new NotificationTargetConfig();
             route.NotificationTarget.ChannelId = notificationChannel;
         }
 
         // Parse limits
-        var maxBody = GetFlagValue(args, "--max-body");
-        if (maxBody is not null)
+        if (!TryGetFlagValue(args, "--max-body", out var maxBody, out var hasMaxBody))
+            return 1;
+
+        if (hasMaxBody)
         {
             if (!int.TryParse(maxBody, out var bytes) || bytes < 1)
             {
@@ -352,8 +424,10 @@ internal static class WebhooksCommand
             route.MaxBodyBytes = bytes;
         }
 
-        var rateLimit = GetFlagValue(args, "--rate-limit");
-        if (rateLimit is not null)
+        if (!TryGetFlagValue(args, "--rate-limit", out var rateLimit, out var hasRateLimit))
+            return 1;
+
+        if (hasRateLimit)
         {
             if (!int.TryParse(rateLimit, out var limit) || limit < 1)
             {
@@ -364,9 +438,17 @@ internal static class WebhooksCommand
         }
 
         // Parse enabled/disabled
-        if (HasFlag(args, "--enabled"))
+        var enabled = HasFlag(args, "--enabled");
+        var disabled = HasFlag(args, "--disabled");
+        if (enabled && disabled)
+        {
+            Console.Error.WriteLine("[FAIL] --enabled and --disabled cannot be used together.");
+            return 1;
+        }
+
+        if (enabled)
             route.Enabled = true;
-        if (HasFlag(args, "--disabled"))
+        if (disabled)
             route.Enabled = false;
 
         // Validate
@@ -409,7 +491,9 @@ internal static class WebhooksCommand
             return 1;
         }
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
+        if (!TryParseRouteName(args[2], out var routeName))
+            return 1;
+
         var force = HasFlag(args, "--force") || HasFlag(args, "-f");
 
         if (!force)
@@ -443,8 +527,10 @@ internal static class WebhooksCommand
             return 1;
         }
 
-        var routeName = WebhookRouteStore.NormalizeRouteName(args[2]);
-        var filePath = Path.Combine(paths.WebhooksDirectory, $"{routeName}.json");
+        if (!TryParseRouteName(args[2], out var routeName))
+            return 1;
+
+        var filePath = Path.GetFullPath(Path.Combine(paths.WebhooksDirectory, $"{routeName}.json"));
 
         if (!File.Exists(filePath))
         {
@@ -489,69 +575,160 @@ internal static class WebhooksCommand
     private static bool HasFlag(string[] args, string flag)
         => args.Any(a => string.Equals(a, flag, StringComparison.OrdinalIgnoreCase));
 
-    private static string? GetFlagValue(string[] args, string flag)
+    private static bool TryGetFlagValue(string[] args, string flag, out string value, out bool isSpecified)
     {
+        value = string.Empty;
+        isSpecified = false;
+
         for (var i = 0; i < args.Length; i++)
         {
             if (args[i].StartsWith($"{flag}=", StringComparison.OrdinalIgnoreCase))
-                return args[i][(flag.Length + 1)..];
+            {
+                value = args[i][(flag.Length + 1)..];
+                isSpecified = true;
+                return true;
+            }
 
             if (i < args.Length - 1 && string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
-                return args[i + 1];
+            {
+                if (LooksLikeFlagToken(args[i + 1]))
+                {
+                    Console.Error.WriteLine($"[FAIL] Missing value for {flag}.");
+                    return false;
+                }
+
+                value = args[i + 1];
+                isSpecified = true;
+                return true;
+            }
+
+            if (i == args.Length - 1 && string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine($"[FAIL] Missing value for {flag}.");
+                return false;
+            }
         }
-        return null;
+
+        return true;
     }
 
-    private static string? ResolveTextInput(string[] args, string inlineFlag, string fileFlag)
+    private static bool TryResolveTextInput(
+        string[] args,
+        string inlineFlag,
+        string fileFlag,
+        out string value,
+        out bool isSpecified)
     {
-        var fileValue = GetFlagValue(args, fileFlag);
-        if (fileValue is not null)
+        value = string.Empty;
+        isSpecified = false;
+
+        if (!TryGetFlagValue(args, inlineFlag, out var inlineValue, out var hasInlineValue))
+            return false;
+
+        if (!TryGetFlagValue(args, fileFlag, out var fileValue, out var hasFileValue))
+            return false;
+
+        if (hasInlineValue && hasFileValue)
+        {
+            Console.Error.WriteLine($"[FAIL] Use either {inlineFlag} or {fileFlag}, not both.");
+            return false;
+        }
+
+        if (hasFileValue)
         {
             if (!File.Exists(fileValue))
             {
                 Console.Error.WriteLine($"[FAIL] File not found: {fileValue}");
-                return null;
+                return false;
             }
-            return File.ReadAllText(fileValue).Trim();
+
+            value = File.ReadAllText(fileValue).Trim();
+            isSpecified = true;
+            return true;
         }
 
-        return GetFlagValue(args, inlineFlag);
+        if (hasInlineValue)
+        {
+            value = inlineValue;
+            isSpecified = true;
+        }
+
+        return true;
     }
 
-    private static string? ResolveSecret(string[] args)
+    private static bool TryResolveSecret(string[] args, out string value, out bool isSpecified)
     {
-        var secretFile = GetFlagValue(args, "--secret-file");
-        if (secretFile is not null)
+        value = string.Empty;
+        isSpecified = false;
+
+        if (!TryGetFlagValue(args, "--secret-file", out var secretFile, out var hasSecretFile))
+            return false;
+
+        if (!TryGetFlagValue(args, "--secret-env", out var secretEnv, out var hasSecretEnv))
+            return false;
+
+        if (!TryGetFlagValue(args, "--secret", out var inlineSecret, out var hasInlineSecret))
+            return false;
+
+        var sourceCount = (hasSecretFile ? 1 : 0) + (hasSecretEnv ? 1 : 0) + (hasInlineSecret ? 1 : 0);
+        if (sourceCount > 1)
+        {
+            Console.Error.WriteLine("[FAIL] Use only one secret source: --secret, --secret-file, or --secret-env.");
+            return false;
+        }
+
+        if (hasSecretFile)
         {
             if (!File.Exists(secretFile))
             {
                 Console.Error.WriteLine($"[FAIL] Secret file not found: {secretFile}");
-                return null;
+                return false;
             }
-            return File.ReadAllText(secretFile).Trim();
+
+            value = File.ReadAllText(secretFile).Trim();
+            isSpecified = true;
+            return true;
         }
 
-        var secretEnv = GetFlagValue(args, "--secret-env");
-        if (secretEnv is not null)
+        if (hasSecretEnv)
         {
-            var value = Environment.GetEnvironmentVariable(secretEnv);
+            value = Environment.GetEnvironmentVariable(secretEnv) ?? string.Empty;
             if (string.IsNullOrEmpty(value))
             {
                 Console.Error.WriteLine($"[FAIL] Environment variable '{secretEnv}' is not set or empty.");
-                return null;
+                return false;
             }
-            return value;
+
+            isSpecified = true;
+            return true;
         }
 
-        var inlineSecret = GetFlagValue(args, "--secret");
-        if (inlineSecret is not null)
+        if (hasInlineSecret)
         {
             Console.Error.WriteLine("warning: --secret exposes the value in shell history; consider --secret-file or --secret-env");
-            return inlineSecret;
+            value = inlineSecret;
+            isSpecified = true;
+            return true;
         }
 
-        return null;
+        return true;
     }
+
+    private static bool TryParseRouteName(string rawRouteName, out string routeName)
+    {
+        routeName = string.Empty;
+
+        if (!WebhookRouteStore.TryNormalizeRouteName(rawRouteName, out routeName, out var error))
+        {
+            Console.Error.WriteLine($"[FAIL] {error}");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool LooksLikeFlagToken(string token)
+        => token.StartsWith("-", StringComparison.Ordinal);
 
     // ── Help ──
 

--- a/src/Netclaw.Configuration.Tests/WebhookRouteStoreTests.cs
+++ b/src/Netclaw.Configuration.Tests/WebhookRouteStoreTests.cs
@@ -1,0 +1,104 @@
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class WebhookRouteStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public WebhookRouteStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-webhook-route-store-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Theory]
+    [InlineData("github-issues")]
+    [InlineData("x")]
+    [InlineData("route-2")]
+    public void TryNormalizeRouteName_AcceptsValidKebabCase(string value)
+    {
+        var ok = WebhookRouteStore.TryNormalizeRouteName(value, out var normalized, out var error);
+
+        Assert.True(ok);
+        Assert.Equal(value, normalized);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("../secrets")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    [InlineData("/tmp/evil")]
+    [InlineData("foo bar")]
+    [InlineData("foo_bar")]
+    [InlineData("foo..bar")]
+    [InlineData("-foo")]
+    [InlineData("foo-")]
+    [InlineData("foo--bar")]
+    public void TryNormalizeRouteName_RejectsInvalidNames(string value)
+    {
+        var ok = WebhookRouteStore.TryNormalizeRouteName(value, out _, out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void Save_RejectsTraversalRouteName()
+    {
+        var store = new WebhookRouteStore(_paths);
+        var route = CreateValidRoute();
+
+        Assert.Throws<ArgumentException>(() => store.Save("../secrets", route));
+    }
+
+    [Fact]
+    public void Delete_RejectsTraversalRouteName()
+    {
+        var store = new WebhookRouteStore(_paths);
+
+        Assert.Throws<ArgumentException>(() => store.Delete("../secrets"));
+    }
+
+    [Fact]
+    public void TryGet_RejectsTraversalRouteName()
+    {
+        var store = new WebhookRouteStore(_paths);
+
+        Assert.Throws<ArgumentException>(() => store.TryGet("../secrets", out _));
+    }
+
+    [Fact]
+    public void Save_NormalizesTrimAndCase()
+    {
+        var store = new WebhookRouteStore(_paths);
+        var route = CreateValidRoute();
+
+        store.Save("  github-issues  ", route);
+
+        Assert.True(File.Exists(Path.Combine(_paths.WebhooksDirectory, "github-issues.json")));
+    }
+
+    private static WebhookRouteConfig CreateValidRoute()
+        => new()
+        {
+            Prompt = "triage",
+            Verification = new WebhookVerificationConfig
+            {
+                Kind = WebhookVerifierKind.Hmac,
+                Secret = new SensitiveString("secret")
+            }
+        };
+}

--- a/src/Netclaw.Configuration/WebhookRouteStore.cs
+++ b/src/Netclaw.Configuration/WebhookRouteStore.cs
@@ -1,10 +1,15 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace Netclaw.Configuration;
 
 public sealed class WebhookRouteStore
 {
+    private static readonly Regex RouteNamePattern = new(
+        "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNameCaseInsensitive = true,
@@ -25,7 +30,35 @@ public sealed class WebhookRouteStore
     /// Normalizes a route name to lowercase kebab-case format.
     /// </summary>
     public static string NormalizeRouteName(string value)
-        => value.Trim().ToLowerInvariant();
+    {
+        if (!TryNormalizeRouteName(value, out var normalized, out var error))
+            throw new ArgumentException(error, nameof(value));
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Attempts to normalize and validate a route name.
+    /// </summary>
+    public static bool TryNormalizeRouteName(string value, out string normalized, out string? error)
+    {
+        normalized = value.Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            error = "Webhook route name is required.";
+            return false;
+        }
+
+        if (!RouteNamePattern.IsMatch(normalized))
+        {
+            error =
+                "Webhook route name must be lowercase kebab-case (letters, numbers, single dashes).";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
 
     /// <summary>
     /// Attempts to read a single route by name. More efficient than <see cref="ListRouteFiles"/>
@@ -96,5 +129,18 @@ public sealed class WebhookRouteStore
     }
 
     private string GetPath(string routeName)
-        => Path.Combine(_paths.WebhooksDirectory, $"{routeName}.json");
+    {
+        var normalizedRouteName = NormalizeRouteName(routeName);
+        var webhooksRootPath = Path.GetFullPath(_paths.WebhooksDirectory);
+        var path = Path.GetFullPath(Path.Combine(webhooksRootPath, $"{normalizedRouteName}.json"));
+
+        var rootPrefix = webhooksRootPath.EndsWith(Path.DirectorySeparatorChar)
+            ? webhooksRootPath
+            : webhooksRootPath + Path.DirectorySeparatorChar;
+
+        if (!path.StartsWith(rootPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException("Webhook route path resolved outside the webhooks directory.");
+
+        return path;
+    }
 }

--- a/src/Netclaw.Configuration/WebhookRouteStore.cs
+++ b/src/Netclaw.Configuration/WebhookRouteStore.cs
@@ -21,6 +21,31 @@ public sealed class WebhookRouteStore
         Directory.CreateDirectory(_paths.WebhooksDirectory);
     }
 
+    /// <summary>
+    /// Normalizes a route name to lowercase kebab-case format.
+    /// </summary>
+    public static string NormalizeRouteName(string value)
+        => value.Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Attempts to read a single route by name. More efficient than <see cref="ListRouteFiles"/>
+    /// when you only need one route.
+    /// </summary>
+    public bool TryGet(string routeName, out (string FilePath, WebhookRouteConfig? Definition) result)
+    {
+        lock (_sync)
+        {
+            var filePath = GetPath(routeName);
+            if (!File.Exists(filePath))
+            {
+                result = default;
+                return false;
+            }
+            result = (filePath, TryRead(filePath));
+            return true;
+        }
+    }
+
     public IReadOnlyList<(string RouteName, string FilePath, WebhookRouteConfig? Definition)> ListRouteFiles()
     {
         lock (_sync)

--- a/src/Netclaw.Configuration/WebhookRouteValidator.cs
+++ b/src/Netclaw.Configuration/WebhookRouteValidator.cs
@@ -1,0 +1,61 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Shared validation logic for webhook route configurations.
+/// Used by both CLI commands and doctor checks.
+/// </summary>
+public static class WebhookRouteValidator
+{
+    /// <summary>
+    /// Validates a webhook route configuration and returns a list of validation errors.
+    /// Returns an empty list if the route is valid.
+    /// </summary>
+    public static IReadOnlyList<string> Validate(string routeName, WebhookRouteConfig route)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(routeName))
+            errors.Add("Route name must not be empty.");
+
+        if (string.IsNullOrWhiteSpace(route.Prompt))
+            errors.Add("Prompt is required.");
+
+        if (route.Verification.Secret is null || string.IsNullOrWhiteSpace(route.Verification.Secret.Value))
+            errors.Add("Verification secret is required.");
+
+        if (route.MaxBodyBytes < 1)
+            errors.Add("MaxBodyBytes must be >= 1.");
+
+        if (route.RateLimitPerMinute < 1)
+            errors.Add("RateLimitPerMinute must be >= 1.");
+
+        if (route.Events.Any(string.IsNullOrWhiteSpace))
+            errors.Add("Events list contains a blank entry.");
+
+        if (route.DeliveryRequired
+            && route.NotificationTarget is null
+            && !string.IsNullOrWhiteSpace(route.NotifyInstructions))
+        {
+            errors.Add("NotificationTarget is required when DeliveryRequired is true and NotifyInstructions are provided.");
+        }
+
+        if (route.NotificationTarget is { Kind: NotificationTargetKind.Slack } target
+            && string.IsNullOrWhiteSpace(target.ChannelId))
+        {
+            errors.Add("NotificationTarget.ChannelId is required for Slack targets.");
+        }
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Validates a webhook route and throws an <see cref="InvalidOperationException"/>
+    /// with the first validation error if invalid.
+    /// </summary>
+    public static void ValidateOrThrow(string routeName, WebhookRouteConfig route)
+    {
+        var errors = Validate(routeName, route);
+        if (errors.Count > 0)
+            throw new InvalidOperationException(errors[0]);
+    }
+}

--- a/src/Netclaw.Configuration/WebhookRouteValidator.cs
+++ b/src/Netclaw.Configuration/WebhookRouteValidator.cs
@@ -14,8 +14,20 @@ public static class WebhookRouteValidator
     {
         var errors = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(routeName))
-            errors.Add("Route name must not be empty.");
+        if (route is null)
+        {
+            errors.Add("Webhook route definition is missing.");
+            return errors;
+        }
+
+        if (!WebhookRouteStore.TryNormalizeRouteName(routeName, out _, out var routeNameError))
+            errors.Add(routeNameError!);
+
+        if (route.Verification is null)
+        {
+            errors.Add("Verification settings are required.");
+            return errors;
+        }
 
         if (string.IsNullOrWhiteSpace(route.Prompt))
             errors.Add("Prompt is required.");
@@ -58,4 +70,12 @@ public static class WebhookRouteValidator
         if (errors.Count > 0)
             throw new InvalidOperationException(errors[0]);
     }
+
+    /// <summary>
+    /// Validates a route name and returns a user-facing error if invalid.
+    /// </summary>
+    public static string? ValidateRouteName(string routeName)
+        => WebhookRouteStore.TryNormalizeRouteName(routeName, out _, out var error)
+            ? null
+            : error;
 }

--- a/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookRouteCatalog.cs
@@ -191,42 +191,7 @@ public sealed class WebhookRouteCatalog
 
     private static void ValidateRoute(string routeName, WebhookRouteConfig route)
     {
-        if (string.IsNullOrWhiteSpace(route.Prompt))
-            throw new InvalidOperationException($"Webhook route '{routeName}' is missing a Prompt.");
-
-        if (route.Verification.Secret is null || string.IsNullOrWhiteSpace(route.Verification.Secret.Value))
-            throw new InvalidOperationException($"Webhook route '{routeName}' is missing a verification secret.");
-
-        if (route.MaxBodyBytes < 1)
-            throw new InvalidOperationException($"Webhook route '{routeName}' must set MaxBodyBytes >= 1.");
-
-        if (route.RateLimitPerMinute < 1)
-            throw new InvalidOperationException($"Webhook route '{routeName}' must set RateLimitPerMinute >= 1.");
-
-        if (route.Events.Any(string.IsNullOrWhiteSpace))
-            throw new InvalidOperationException($"Webhook route '{routeName}' contains a blank event filter.");
-
-        if (route.DeliveryRequired
-            && route.NotificationTarget is null
-            && !string.IsNullOrWhiteSpace(route.NotifyInstructions))
-        {
-            throw new InvalidOperationException(
-                $"Webhook route '{routeName}' must set NotificationTarget when DeliveryRequired is true and NotifyInstructions are provided.");
-        }
-
-        if (route.NotificationTarget is { Kind: NotificationTargetKind.Slack } target
-            && string.IsNullOrWhiteSpace(target.ChannelId))
-        {
-            throw new InvalidOperationException(
-                $"Webhook route '{routeName}' must set NotificationTarget.ChannelId for Slack targets.");
-        }
-
-        if (route.Verification.Kind == WebhookVerifierKind.Hmac
-            && string.IsNullOrWhiteSpace(route.Verification.SignatureHeaderName)
-            && string.IsNullOrWhiteSpace(route.Verification.SignaturePrefix))
-        {
-            return;
-        }
+        WebhookRouteValidator.ValidateOrThrow(routeName, route);
     }
 
     private void RemoveRoute(string routeName, string reason, string filePath, bool emitAlert)


### PR DESCRIPTION
## Summary

Adds a `netclaw webhooks` CLI command group for managing inbound webhook routes, addressing #529.

- **`netclaw webhooks list [--json]`** - List configured webhook routes
- **`netclaw webhooks show <route> [--json] [--show-secret]`** - Show route details
- **`netclaw webhooks set <route> [options]`** - Create or update a route
- **`netclaw webhooks delete <route> [--force]`** - Delete a route
- **`netclaw webhooks validate <route>`** - Validate a route configuration

### Key Features

- Multiple secret input methods to avoid shell history exposure: `--secret`, `--secret-file`, `--secret-env`
- Prompt input via `--prompt` or `--prompt-file` for longer prompts
- `--dry-run` mode for previewing changes without writing
- `--create-only` / `--update-only` flags for explicit upsert control
- Shared validation logic via `WebhookRouteValidator` (also used by `netclaw doctor`)
- Consistent JSON output with `--json` flag

### Refactoring

- Extracted `WebhookRouteValidator` to `Netclaw.Configuration` for shared validation
- Added `NormalizeRouteName()` and `TryGet()` to `WebhookRouteStore` for reuse
- Updated `SetWebhookTool`, `DeleteWebhookTool`, and `InboundWebhookRoutesDoctorCheck` to use shared utilities

Closes #529

## Test plan

- [x] `dotnet test` - 21 new unit tests covering all subcommands
- [ ] Manual: `netclaw webhooks list` with no routes configured
- [ ] Manual: `netclaw webhooks set test-route --prompt "Test" --secret-env TEST_SECRET`
- [ ] Manual: `netclaw webhooks show test-route --show-secret`
- [ ] Manual: `netclaw webhooks validate test-route`
- [ ] Manual: `netclaw webhooks delete test-route --force`
- [ ] Manual: `netclaw doctor` still validates webhook routes correctly