### PR TITLE
feat: proactive check-back guidance + gate scheduling tools by audience

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/SchedulingToolAudienceTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SchedulingToolAudienceTests.cs
@@ -1,0 +1,91 @@
+using Netclaw.Actors.Tests.Memory;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+/// <summary>
+/// Verifies that scheduling tools are profile-managed and therefore blocked
+/// for Public and Team audiences by default, while Personal retains access.
+/// </summary>
+public sealed class SchedulingToolAudienceTests
+{
+    private static readonly string[] SchedulingToolNames =
+        ["set_reminder", "list_reminders", "cancel_reminder", "get_reminder_history"];
+
+    private static readonly EffectivePolicyDefaults Defaults = new(
+        DeploymentPosture.Personal,
+        TrustAudience.Personal,
+        ShellExecutionMode.HostAllowed,
+        UsedStrictFallback: false);
+
+    [Theory]
+    [InlineData("set_reminder")]
+    [InlineData("list_reminders")]
+    [InlineData("cancel_reminder")]
+    [InlineData("get_reminder_history")]
+    public void SchedulingTools_BlockedForPublicAudience_ByDefault(string toolName)
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool(toolName, "scheduling");
+
+        Assert.False(policy.IsToolExposed(tool, CreateContext(TrustAudience.Public)));
+    }
+
+    [Theory]
+    [InlineData("set_reminder")]
+    [InlineData("list_reminders")]
+    [InlineData("cancel_reminder")]
+    [InlineData("get_reminder_history")]
+    public void SchedulingTools_BlockedForTeamAudience_ByDefault(string toolName)
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool(toolName, "scheduling");
+
+        Assert.False(policy.IsToolExposed(tool, CreateContext(TrustAudience.Team)));
+    }
+
+    [Theory]
+    [InlineData("set_reminder")]
+    [InlineData("list_reminders")]
+    [InlineData("cancel_reminder")]
+    [InlineData("get_reminder_history")]
+    public void SchedulingTools_AllowedForPersonalAudience_ByDefault(string toolName)
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool(toolName, "scheduling");
+
+        Assert.True(policy.IsToolExposed(tool, CreateContext(TrustAudience.Personal)));
+    }
+
+    [Theory]
+    [InlineData("set_reminder")]
+    [InlineData("list_reminders")]
+    [InlineData("cancel_reminder")]
+    [InlineData("get_reminder_history")]
+    public void SchedulingTools_AllowedForTeam_WhenExplicitlyGranted(string toolName)
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Team.AllowedTools.Add(toolName);
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool(toolName, "scheduling");
+
+        Assert.True(policy.IsToolExposed(tool, CreateContext(TrustAudience.Team)));
+    }
+
+    private static FakeNetclawTool CreateFakeTool(string name, string grantCategory)
+        => new(name, "ok", grantCategory);
+
+    private static ToolExecutionContext CreateContext(TrustAudience audience)
+        => new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = audience.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
+            ChannelType = "slack"
+        };
+}

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -175,5 +175,9 @@ internal sealed class ToolAudienceProfileResolver
             or "skill_manage"
             or "set_webhook"
             or "list_webhooks"
-            or "delete_webhook";
+            or "delete_webhook"
+            or "set_reminder"
+            or "list_reminders"
+            or "cancel_reminder"
+            or "get_reminder_history";
 }

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -175,9 +175,5 @@ internal sealed class ToolAudienceProfileResolver
             or "skill_manage"
             or "set_webhook"
             or "list_webhooks"
-            or "delete_webhook"
-            or "set_reminder"
-            or "list_reminders"
-            or "cancel_reminder"
-            or "get_reminder_history";
+            or "delete_webhook";
 }

--- a/src/Netclaw.Cli/Resources/identity/AGENTS.template.md
+++ b/src/Netclaw.Cli/Resources/identity/AGENTS.template.md
@@ -63,6 +63,26 @@ reminders work — create the reminder.
 **Full scheduling parameters, CLI commands, and Netclaw operations:**
 `file_read("{{SYSTEM_SKILLS_DIR}}/netclaw-operations/SKILL.md")`
 
+## Proactive Check-Back
+
+When you kick off work that will complete asynchronously — builds, CI pipelines,
+deployments, long-running shell commands, or external jobs — schedule a check-back
+reminder before reporting that the job started. Do not wait for the user to ask
+"is it done yet?"
+
+Use `current_session` delivery so the follow-up lands in the same thread:
+1. Start the job
+2. Estimate completion time from context (build size, typical CI duration, history)
+3. Call `set_reminder` with `schedule: once`, `delivery_kind: current_session`,
+   and `delivery_instructions` describing what to check
+4. Tell the user the job is running and when you'll report back
+
+If the check-back finds the job still running, schedule another — do not leave the
+user hanging. If the user re-engages before the timer fires, cancel the reminder.
+
+Do not schedule check-backs for synchronous operations, commands under ~30 seconds,
+or one-off lookups where the user is actively waiting.
+
 ## Subagent Delegation
 
 Use spawn_agent to delegate bounded, self-contained tasks to specialist subagents.


### PR DESCRIPTION
## Summary

- **Proactive check-back guidance**: Adds a "Proactive Check-Back" section to `AGENTS.template.md` so the agent automatically schedules `current_session` reminders when it kicks off async work (builds, CI pipelines, deployments) instead of waiting for the user to ask for status.
- **Scheduling audience gating**: Adds `set_reminder`, `list_reminders`, `cancel_reminder`, and `get_reminder_history` to `IsProfileManagedTool` so they respect audience `AllowedTools` lists. Public and Team no longer have scheduling access by default; only Personal (`ToolsMode=All`) retains it. Operators can opt Team in explicitly by adding the tool names to `AllowedTools`.

Closes #710

## Test plan

- [ ] Confirm Public/Team sessions do not see scheduling tools in `search_tools` output
- [ ] Confirm Personal sessions still see scheduling tools
- [ ] Confirm operator can re-enable for Team by adding `set_reminder` etc. to `AllowedTools`
- [ ] Run eval suite: `./evals/run-evals.sh`