### PR TITLE
fix: prevent false StreamIdleTimeout when ToolCallTextFilter suppresses SSE events

### DIFF
--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
@@ -69,6 +69,7 @@ internal static class SessionLlmInvoker
         await foreach (var update in client.GetStreamingResponseAsync(messages, options, cancellationToken))
         {
             updates.Add(update);
+            var dispatched = false;
 
             if (update.Contents is not null)
             {
@@ -95,6 +96,7 @@ internal static class SessionLlmInvoker
                                 }
 
                                 self.Tell(new LlmResponseDeltaReceived { Content = content, CallId = callId });
+                                dispatched = true;
                             }
                             break;
 
@@ -117,6 +119,7 @@ internal static class SessionLlmInvoker
                                 }
 
                                 self.Tell(new LlmResponseDeltaReceived { Content = content, CallId = callId });
+                                dispatched = true;
                             }
                             break;
 
@@ -127,6 +130,17 @@ internal static class SessionLlmInvoker
                 }
             }
 
+            // Stream is alive but no content was dispatched (text suppressed by
+            // the tool call filter, empty keepalive, or 1-delta hold). Signal
+            // activity so the watchdog timer resets.
+            if (!dispatched)
+            {
+                self.Tell(new LlmResponseDeltaReceived
+                {
+                    Content = new TextContent(string.Empty),
+                    CallId = callId
+                });
+            }
         }
 
         if (thinkingBuilder.Length > 0)

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
@@ -12,6 +12,7 @@ namespace Netclaw.Actors.Sessions.Pipelines;
 /// </summary>
 internal static class SessionLlmInvoker
 {
+    private static readonly TextContent EmptyTextContent = new(string.Empty);
     public static async Task InvokeAsync(
         IChatClient client,
         List<AiChatMessage> messages,
@@ -130,14 +131,12 @@ internal static class SessionLlmInvoker
                 }
             }
 
-            // Stream is alive but no content was dispatched (text suppressed by
-            // the tool call filter, empty keepalive, or 1-delta hold). Signal
-            // activity so the watchdog timer resets.
+            // No content dispatched — send keepalive to refresh the idle timeout watchdog.
             if (!dispatched)
             {
                 self.Tell(new LlmResponseDeltaReceived
                 {
-                    Content = new TextContent(string.Empty),
+                    Content = EmptyTextContent,
                     CallId = callId
                 });
             }

--- a/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/OpenAiCompatibleChatClientTests.cs
@@ -823,6 +823,106 @@ data: [DONE]
         Assert.True(root.GetProperty("stream_options").GetProperty("include_usage").GetBoolean());
     }
 
+    [Fact]
+    public async Task StreamingYieldsKeepaliveUpdates_WhenToolCallFilterSuppressesText()
+    {
+        // Simulate a model that emits normal text, then switches to <tool_call> XML.
+        // After the filter activates, the client should yield empty keepalive updates
+        // instead of silently dropping SSE events.
+        const string sse = """
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Let me "}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":"help. "}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":"<tool_call>\n<function=search>\n"}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":"<parameter=Query>test</parameter>\n"}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":"</function>\n</tool_call>"}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+""";
+
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sse, Encoding.UTF8, "text/event-stream")
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000/api/v1");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "help")],
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            updates.Add(update);
+        }
+
+        // Should have received updates for every SSE event — not just the non-suppressed ones.
+        // 2 normal text deltas + 3 suppressed (yielded as keepalives) + 1 finish + 1 tool call = 7
+        Assert.True(updates.Count >= 5,
+            $"Expected at least 5 updates (2 text + 3 keepalives), got {updates.Count}");
+
+        // The first two streaming updates have visible text content.
+        // The end-of-stream fallback also emits a cleaned text update (non-tool-call preamble),
+        // so expect 3 total text updates.
+        var textUpdates = updates
+            .Where(u => u.Contents.OfType<TextContent>().Any(t => !string.IsNullOrEmpty(t.Text)))
+            .ToList();
+        Assert.Equal(3, textUpdates.Count);
+
+        // Suppressed updates should be content-free keepalives (Role set, no text content)
+        var keepaliveUpdates = updates
+            .Where(u => u.Role == ChatRole.Assistant
+                        && !u.Contents.OfType<TextContent>().Any(t => !string.IsNullOrEmpty(t.Text))
+                        && !u.Contents.OfType<FunctionCallContent>().Any()
+                        && u.FinishReason is null)
+            .ToList();
+        Assert.True(keepaliveUpdates.Count >= 2,
+            $"Expected at least 2 keepalive updates for suppressed tool call text, got {keepaliveUpdates.Count}");
+    }
+
+    [Fact]
+    public async Task StreamingKeepalive_ToolCallStillExtracted_AfterSuppression()
+    {
+        // Verify that the end-of-stream tool call extraction still works when text
+        // was suppressed and keepalive updates were yielded instead.
+        const string sse = """
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"<tool_call>\n<function=store_memory>\n<parameter=Content>note</parameter>\n<parameter=Domain>test</parameter>\n</function>\n</tool_call>"}}]}
+
+data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+""";
+
+        using var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sse, Encoding.UTF8, "text/event-stream")
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8000") };
+        var endpoint = OpenAiCompatibleEndpoint.FromBaseUrl("http://localhost:8000/api/v1");
+        var client = new OpenAiCompatibleChatClient(httpClient, endpoint, "test-model");
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "save")],
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            updates.Add(update);
+        }
+
+        // Tool call should still be extracted at end-of-stream
+        var toolCallUpdate = updates.FirstOrDefault(u => u.FinishReason == ChatFinishReason.ToolCalls);
+        Assert.NotNull(toolCallUpdate);
+        var toolCall = Assert.Single(toolCallUpdate.Contents.OfType<FunctionCallContent>());
+        Assert.Equal("store_memory", toolCall.Name);
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -93,9 +93,13 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                 if (update.FinishReason is not null)
                     finalUpdate = update;
 
-                // Suppress text updates that contain tool call XML
+                // Suppress text updates that contain tool call XML, but yield a
+                // content-free keepalive so the caller knows the stream is alive.
                 if (suppressThisUpdate)
+                {
+                    yield return new ChatResponseUpdate { Role = ChatRole.Assistant };
                     continue;
+                }
 
                 yield return update;
             }

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -97,7 +97,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                 // content-free keepalive so the caller knows the stream is alive.
                 if (suppressThisUpdate)
                 {
-                    yield return new ChatResponseUpdate { Role = ChatRole.Assistant };
+                    yield return KeepaliveUpdate;
                     continue;
                 }
 
@@ -715,6 +715,8 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
 
         public StringBuilder Arguments { get; } = new();
     }
+
+    private static readonly ChatResponseUpdate KeepaliveUpdate = new() { Role = ChatRole.Assistant };
 
     internal sealed class ToolCallTextFilter
     {


### PR DESCRIPTION
## Summary

Fixes #717

- When the `ToolCallTextFilter` detects `<tool_call>` XML in streaming text, it suppresses all subsequent SSE updates via `continue`, bypassing `yield return`. This creates a watchdog blackout — no `LlmResponseDeltaReceived` messages reach the session actor, so `ProcessingWatchdog.Refresh()` is never called and the `StreamIdleTimeout` (default 120s) fires even though the GPU is actively generating tokens.
- The fix yields a content-free keepalive `ChatResponseUpdate` when text is suppressed, and sends a keepalive `LlmResponseDeltaReceived` with empty `TextContent` when no content is dispatched for an SSE event. The actor's delta handler refreshes the watchdog unconditionally before the content-type switch, so empty `TextContent` resets the timer without emitting visible output.

## Changes

| File | Change |
|------|--------|
| `OpenAiCompatibleChatClient.cs` | Yield keepalive `ChatResponseUpdate` when `ToolCallTextFilter` suppresses text |
| `SessionLlmInvoker.cs` | Add `dispatched` flag; send keepalive delta when no content dispatched |
| `OpenAiCompatibleChatClientTests.cs` | Two new tests verifying keepalive behavior during suppression |

## Test plan

- [x] `StreamingYieldsKeepaliveUpdates_WhenToolCallFilterSuppressesText` — verifies keepalive updates are yielded when filter suppresses text
- [x] `StreamingKeepalive_ToolCallStillExtracted_AfterSuppression` — verifies tool call extraction still works with keepalives
- [x] All 40 existing `OpenAiCompatibleChatClientTests` pass
- [x] Both existing `LlmSessionWatchdogTests` pass (watchdog integration)