### PR TITLE
fix(session): prevent amnesia on crash by deferring cursor advance

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2197,11 +2197,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var content = _promptProvider.GetSystemPrompt();
         if (string.IsNullOrWhiteSpace(content))
         {
-            // Clear stale prompt from snapshot recovery rather than silently keeping it
+            // Retain the last-known prompt from recovery if we have one.
+            // Deleting the prompt strips the agent of all identity and project context,
+            // which is worse than a potentially stale prompt. The proper fix for
+            // stale project context is CWD tracking (#595).
             if (_state.History.Count > 0 && _state.History[0].Role == Protocol.ChatRole.System)
             {
-                _state = _state with { History = _state.History.RemoveAt(0) };
-                _log.Warning("Identity files missing — cleared stale system prompt from snapshot");
+                _log.Warning("Identity files missing — retaining last-known system prompt from recovery");
             }
             else
             {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2197,10 +2197,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var content = _promptProvider.GetSystemPrompt();
         if (string.IsNullOrWhiteSpace(content))
         {
-            // Retain the last-known prompt from recovery if we have one.
-            // Deleting the prompt strips the agent of all identity and project context,
-            // which is worse than a potentially stale prompt. The proper fix for
-            // stale project context is CWD tracking (#595).
+            // Retain the last-known prompt from recovery — deleting it strips the agent
+            // of all identity and project context, which is worse than a stale prompt.
             if (_state.History.Count > 0 && _state.History[0].Role == Protocol.ChatRole.System)
             {
                 _log.Warning("Identity files missing — retaining last-known system prompt from recovery");

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -34,6 +34,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private readonly SessionPipelineHandle _handle;
     private bool _threadHistoryFetchAttempted;
     private SlackEventTs? _cursorTs;
+    private SlackEventTs? _pendingCursorTs;
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan InboundProcessingTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(10);
@@ -323,8 +324,15 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
                 await writer.WriteAsync(input, queueWriteCts.Token);
 
+                // Track the highest enqueued timestamp but do NOT persist the cursor yet.
+                // The cursor advances only when TurnCompleted confirms the session actor
+                // has durably recorded the turn — see HandleOutputAsync. This prevents
+                // message loss when the daemon crashes between cursor persist and turn persist.
                 if (currentTs is { } ts)
-                    AdvanceCursor(ts);
+                {
+                    if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
+                        _pendingCursorTs = ts;
+                }
             }
             catch (OperationCanceledException ex)
             {
@@ -877,10 +885,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private bool IsStaleInboundEvent(SlackEventTs? eventTs)
     {
-        if (_cursorTs is not { } c || eventTs is not { } ts)
+        if (eventTs is not { } ts)
             return false;
 
-        return ts.CompareTo(c) <= 0;
+        if (_cursorTs is { } c && ts.CompareTo(c) <= 0)
+            return true;
+
+        if (_pendingCursorTs is { } p && ts.CompareTo(p) <= 0)
+            return true;
+
+        return false;
     }
 
     private void ApplyCursorAdvanced(CursorAdvanced advanced)
@@ -1066,6 +1080,13 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 break;
 
             case TurnCompleted completed:
+                // Advance the cursor now that the session actor has durably persisted the turn.
+                if (completed.Outcome == TurnOutcome.Completed && _pendingCursorTs is { } pendingTs)
+                {
+                    AdvanceCursor(pendingTs);
+                    _pendingCursorTs = null;
+                }
+
                 if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && (_postedThisTurn || _uploadedFileThisTurn))
                 {
                     Context.System.EventStream.Publish(new ReminderDeliveryObserved(

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -324,10 +324,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
                 await writer.WriteAsync(input, queueWriteCts.Token);
 
-                // Track the highest enqueued timestamp but do NOT persist the cursor yet.
-                // The cursor advances only when TurnCompleted confirms the session actor
-                // has durably recorded the turn — see HandleOutputAsync. This prevents
-                // message loss when the daemon crashes between cursor persist and turn persist.
+                // Defer cursor persistence until TurnCompleted confirms durable turn recording,
+                // otherwise a crash between cursor and turn persist loses messages.
                 if (currentTs is { } ts)
                 {
                     if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
@@ -1016,6 +1014,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private async Task ReinitializePipelineAsync(string reason)
     {
+        _pendingCursorTs = null;
         await _handle.ReinitializeAsync(
             reason,
             () => Timers.StartSingleTimer(
@@ -1080,12 +1079,9 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 break;
 
             case TurnCompleted completed:
-                // Advance the cursor now that the session actor has durably persisted the turn.
                 if (completed.Outcome == TurnOutcome.Completed && _pendingCursorTs is { } pendingTs)
-                {
                     AdvanceCursor(pendingTs);
-                    _pendingCursorTs = null;
-                }
+                _pendingCursorTs = null;
 
                 if (!string.IsNullOrWhiteSpace(completed.SourceReminderId) && (_postedThisTurn || _uploadedFileThisTurn))
                 {


### PR DESCRIPTION
## Summary

Fixes two independent amnesia vectors that cause sessions to lose all state after daemon crashes and restarts:

- **Cursor advancement race (Slack):** `SlackThreadBindingActor` persisted its cursor (marking messages as "seen") at enqueue time via `PersistAsync`, before the downstream `LlmSessionActor` persisted the completed turn via `Persist`. On crash between those two writes, the message was permanently lost — the cursor said "seen" but no turn was recorded, and thread history hydration skipped it on restart. Now the cursor advances only when `TurnCompleted(Completed)` confirms the turn is durably recorded. `_pendingCursorTs` provides transient stale-event dedup within a single runtime and is cleared on failed/skipped turns and pipeline reinitialization.

- **System prompt eviction:** When identity files (SOUL.md, AGENTS.md, TOOLING.md) were missing on recovery, `SetSystemPrompt()` actively deleted the last-known system prompt from state. Now it retains the recovered prompt as a fallback and logs a warning. The proper long-term fix is CWD-aware prompt resolution (#595).

### Discord adapter note
The Discord adapter (`DiscordConversationActor` on PR #713) is a plain `ReceiveActor` with no cursor persistence — it won't replicate the Slack cursor race bug, but also has zero crash recovery for thread state. If Discord ever adds cursor-based dedup, it should follow the deferred-advance pattern from this fix.

## Test plan

- [x] All 11 `SlackThread*` tests pass
- [x] All 5 `Backfill`/`SessionBinding` tests pass
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Manual verification: crash daemon mid-turn, verify session resumes with full context on restart
- [x] Verify hydration gap-fill includes the un-persisted message after crash recovery