### PR TITLE
feat(openspec): project directory tracking and automatic context loading (#595, #596)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.62</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.6.0-beta2</AkkaRemindersVersion>
-    <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <MicrosoftExtensionsAIVersion>10.4.1</MicrosoftExtensionsAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.7</MicrosoftAspNetCoreVersion>
@@ -41,6 +41,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="NSec.Cryptography" Version="24.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.62</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.6.0-beta2</AkkaRemindersVersion>
-    <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <MicrosoftExtensionsAIVersion>10.4.1</MicrosoftExtensionsAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.7</MicrosoftAspNetCoreVersion>
@@ -41,7 +41,6 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="NSec.Cryptography" Version="24.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.16.0"
+  version: "1.17.0"
 ---
 
 # Netclaw Operations
@@ -17,6 +17,7 @@ problems, how to update preferences, or how to maintain itself.
 | User intent | Section below |
 |-------------|---------------|
 | Schedule reminders, cron jobs | [Scheduling](#scheduling) |
+| Work on a project, switch projects | [Project Directory](#project-directory) |
 | Discover MCP tools | [Tool Discovery](#tool-discovery) |
 | Understand approval prompts | [Approval Prompts](#approval-prompts) |
 | Manage skills and sources | [Skill Management](#skill-management) |
@@ -25,6 +26,37 @@ problems, how to update preferences, or how to maintain itself.
 | Pair remote devices, manage access | [Device Pairing](#device-pairing) |
 | Check health, update self | [Self-Maintenance](#self-maintenance) |
 | Manage inbound webhooks | [Webhook Management](#webhook-management) |
+
+## Project Directory
+
+Sessions track a **project directory** — the root of the codebase or project
+you are currently working on. When set, the project's identity file (checked in
+order: `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` — first
+match wins) is automatically loaded into the system prompt alongside the global
+SOUL/AGENTS/TOOLING layers.
+
+Use `set_working_directory` to set or change the project directory:
+
+```
+set_working_directory(path: "/home/user/workspaces/akadonic")
+```
+
+Rules:
+
+- The path must be an absolute path to an existing directory
+- The path must be within the session's allowed file access roots
+- Profile-managed: not available to Public or Team audiences by default
+- Project identity files are re-read from disk on each `SetSystemPrompt()` call,
+  so edits to the project's `AGENTS.md` take effect on the next project switch
+  or daemon restart
+- The project directory persists across crash/restart via `WorkingContext`
+- The `[working-context]` block includes `project_dir:` so you always know which
+  project is active
+
+The project directory is distinct from the session directory
+(`~/.netclaw/sessions/{id}/`). The session directory is immutable and used for
+state isolation (inbox, media). The project directory is mutable and points to
+the project root.
 
 ## Scheduling
 

--- a/feeds/skills/.system/files/netclaw-projects/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-projects/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-projects
 description: "How to create, find, and work with project workspaces. Load when the user references a project, asks to organize work, or you need a sustained workspace."
 metadata:
   author: netclaw
-  version: "1.0.0"
+  version: "1.1.0"
 license: MIT
 compatibility: "netclaw >= 0.10.0"
 disable-model-invocation: false
@@ -50,7 +50,18 @@ project evolves.
 
 ## Working in a Project
 
-When you `cd` into a project directory, read its `AGENTS.md` to load context.
+When you start working on a project, use `set_working_directory` to set the
+project directory:
+
+```
+set_working_directory(path: "/home/user/workspaces/my-project")
+```
+
+This automatically loads the project's identity file (`.netclaw/AGENTS.md`,
+`CLAUDE.md`, `AGENTS.md`, or `CONTEXT.md` — first match wins) into the system
+prompt. The project context persists across crash/restart, so you don't need to
+re-read it manually.
+
 Use the project directory as your working directory for all project-related
 file operations. Commit meaningful changes so the project has history.
 

--- a/openspec/changes/session-cwd-tracking/.openspec.yaml
+++ b/openspec/changes/session-cwd-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/session-cwd-tracking/design.md
+++ b/openspec/changes/session-cwd-tracking/design.md
@@ -1,0 +1,164 @@
+## Context
+
+Sessions currently have no concept of "which project am I working on."
+`WorkingContext` tracks only `RecentFiles`. Project-scoped identity files
+(`AGENTS.md`, `CLAUDE.md`) are not loaded automatically — the
+`netclaw-projects` skill tells the agent to manually `file_read` them, but
+that content is ephemeral (lost on compaction and crash recovery).
+
+The immutable session directory (`~/.netclaw/sessions/{sanitized_id}/`)
+exists and is used for state isolation (inbox, media, file access scoping).
+It is NOT shown to the agent as an explicit path — only `media_dir` appears
+in the `[session]` block.
+
+`IContextLayerProvider` with `ContextLayerTiming.EveryTurn` provides the
+mechanism for injecting project instructions on every LLM call.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Per-session mutable project directory that persists across crash/restart
+  via `WorkingContext` in `SessionSnapshot`
+- Project-scoped identity files loaded automatically from the project
+  directory and injected as a `[project-instructions]` context layer on
+  every turn
+- `[working-context]` block includes the project directory so the agent
+  knows which project it's in
+- Session directory path exposed explicitly in the `[session]` block
+- Backward compatible: sessions without a project directory work unchanged
+- `set_working_directory` tool gated by audience trust profile
+- Eval: compare automatic context injection vs behavioral (agent reads file
+  itself) for project context loading
+
+**Non-Goals:**
+
+- Tracking shell CWD or defaulting `ProcessStartInfo.WorkingDirectory`
+  (separate concern, can be added later)
+- Resolving relative file paths against project directory (file tools
+  continue to use absolute paths)
+- Detecting `cd` commands in shell input to update project directory
+- Walking up directory trees to find identity files (project directory
+  points directly at the project root)
+- Multi-project sessions (one project directory per session)
+- File watcher / auto-reload when identity files change on disk (EveryTurn
+  re-read is sufficient)
+
+## Decisions
+
+### D1: Two-directory model — session directory vs project directory
+
+**Decision:** Maintain two distinct concepts: immutable session directory for
+state isolation, mutable project directory for project context.
+
+| Concept | Mutability | Source | Purpose |
+|---------|-----------|--------|---------|
+| Session directory | Immutable | Derived from session ID | State isolation: inbox, media, `{session_dir}` token |
+| Project directory | Mutable, persisted | Set by `set_working_directory` tool | Project context: identity files, `[project-instructions]` |
+
+**Rationale:** The session directory is a daemon-owned namespace. Mixing
+mutable project state into it would break the invariant that session
+directories are deterministic from session ID.
+
+### D2: Project directory starts null, not defaulted
+
+**Decision:** New sessions start with `ProjectDirectory` as null. No default.
+
+**Rationale:** The session directory is not a meaningful project root —
+it's a daemon-internal staging area. Defaulting the project directory to it
+would cause the walker to look for `AGENTS.md` inside
+`~/.netclaw/sessions/{id}/`, which is never correct. Null means "no project
+selected yet" and the `[project-instructions]` block is simply not emitted.
+
+**Alternatives considered:**
+- Default to session directory — rejected because it's not a project.
+- Default to workspaces directory — rejected because it's a container for
+  projects, not a project itself.
+
+### D3: set_working_directory as standalone tool
+
+**Decision:** Provide a standalone `set_working_directory` tool for setting
+the project directory. Profile-managed: not exposed to Public/Team audiences
+by default.
+
+**Rationale:** The agent needs to set the project directory from
+conversation context — e.g., "go work on the Akadonic project." This
+requires a deliberate action, not a side effect of shell navigation.
+The tool validates the target is a real directory and is within the
+audience's allowed roots.
+
+**Alternatives considered:**
+- `set_cwd` parameter on `shell_execute` — rejected because the agent often
+  needs to set the project without running a shell command.
+- Shell `cd` detection — rejected because navigating within a project
+  (`cd src/`) is not the same as switching projects.
+
+### D4: Project identity file loading — single directory, no walk
+
+**Decision:** Load project identity files by checking a fixed set of
+candidate filenames at the project root. No directory tree walking.
+
+**Candidate files (checked in order, first match wins):**
+1. `.netclaw/AGENTS.md`
+2. `CLAUDE.md`
+3. `AGENTS.md`
+4. `CONTEXT.md`
+
+**Rationale:** The project directory IS the project root. Walking up is
+unnecessary — if the agent is working on Akadonic, the project directory
+points to `/home/user/workspaces/akadonic/`, and that's where `AGENTS.md`
+lives. This eliminates the walker class, audience root boundary logic, and
+stop conditions entirely.
+
+### D5: Automatic injection via EveryTurn context layer
+
+**Decision:** Implement `ProjectInstructionLayerProvider` as an
+`IContextLayerProvider` with `ContextLayerTiming.EveryTurn`. The provider
+reads the project directory from session state via a `Func<string?>`
+accessor and loads the identity file on each turn.
+
+**Rationale:** Automatic injection guarantees the project context is always
+present regardless of model capability. Smaller models that might not
+reliably follow behavioral instructions ("read AGENTS.md on recovery")
+get the context for free. Content is re-read from disk each turn so edits
+take effect immediately. This should be validated via eval against the
+behavioral alternative.
+
+### D6: Project directory persistence via WorkingContext
+
+**Decision:** Add `ProjectDirectory` as a protobuf field (tag 2) on
+`WorkingContext`. Changes are captured in the next `TurnRecorded` event
+via `SessionSnapshot`.
+
+**Rationale:** `WorkingContext` already survives compaction by design.
+No new persistence event needed.
+
+### D7: Session directory visibility
+
+**Decision:** Add the session directory path to the `[session]` block so
+the agent knows its full session directory, not just `media_dir`.
+
+**Rationale:** The agent currently has to infer the session directory from
+`media_dir` by going up one level. Making it explicit improves the agent's
+situational awareness and allows identity file guidance (in `TOOLING.md`)
+to reference it directly.
+
+## Risks / Trade-offs
+
+**[Risk: Model ignores `[project-instructions]`]** →
+The content is in the volatile context tail, which the model might
+deprioritize. Mitigation: eval suite validates that project instructions
+influence model behavior. If needed, the block can be moved to the static
+prefix at the cost of cache stability.
+
+**[Risk: WorkingContext serialization change]** →
+Adding `ProjectDirectory` to `WorkingContext` is a protobuf schema change.
+Old snapshots without the field will deserialize with `null`, which is the
+correct backward-compat default. No migration needed.
+
+**[Risk: Large project identity files]** →
+The `[project-instructions]` block uses `EveryTurn` timing and lands in the
+volatile context tail, so it does not benefit from prompt caching. Project
+identity files are typically small (under 2K tokens). If a project has
+unusually large instructions, the cost is bounded by the same truncation
+limits as other context layers.

--- a/openspec/changes/session-cwd-tracking/design.md
+++ b/openspec/changes/session-cwd-tracking/design.md
@@ -110,19 +110,24 @@ points to `/home/user/workspaces/akadonic/`, and that's where `AGENTS.md`
 lives. This eliminates the walker class, audience root boundary logic, and
 stop conditions entirely.
 
-### D5: Automatic injection via EveryTurn context layer
+### D5: Project instructions in system prompt, not a context layer
 
-**Decision:** Implement `ProjectInstructionLayerProvider` as an
-`IContextLayerProvider` with `ContextLayerTiming.EveryTurn`. The provider
-reads the project directory from session state via a `Func<string?>`
-accessor and loads the identity file on each turn.
+**Decision:** Include project identity file content in the system prompt at
+position [0] via `SystemPromptAssembler.Assemble()`, alongside the global
+SOUL/AGENTS/TOOLING layers. No separate `IContextLayerProvider`. Call
+`SetSystemPrompt()` again when the project directory changes.
 
-**Rationale:** Automatic injection guarantees the project context is always
-present regardless of model capability. Smaller models that might not
-reliably follow behavioral instructions ("read AGENTS.md on recovery")
-get the context for free. Content is re-read from disk each turn so edits
-take effect immediately. This should be validated via eval against the
-behavioral alternative.
+**Rationale:** The project's `AGENTS.md` serves the same role as the global
+`AGENTS.md` — it's identity context the model should always have. Putting it
+in the system prompt at position [0] means it sits in the cached prefix,
+stable across turns. A project switch busts the cache once, then
+re-stabilizes immediately. An `EveryTurn` context layer would put it in
+the volatile tail where it's never cached — strictly worse.
+
+This also guarantees the project context is always present regardless of
+model capability. Smaller models that might not reliably follow behavioral
+instructions ("read AGENTS.md on recovery") get the context for free.
+Should be validated via eval against the behavioral alternative.
 
 ### D6: Project directory persistence via WorkingContext
 
@@ -145,11 +150,11 @@ to reference it directly.
 
 ## Risks / Trade-offs
 
-**[Risk: Model ignores `[project-instructions]`]** →
-The content is in the volatile context tail, which the model might
-deprioritize. Mitigation: eval suite validates that project instructions
-influence model behavior. If needed, the block can be moved to the static
-prefix at the cost of cache stability.
+**[Risk: Cache bust on project switch]** →
+Changing the project directory re-runs `SetSystemPrompt()`, which changes
+position [0] and invalidates the prompt cache prefix. Mitigation: project
+switches are rare, deliberate actions. The cache re-stabilizes immediately
+on the next turn.
 
 **[Risk: WorkingContext serialization change]** →
 Adding `ProjectDirectory` to `WorkingContext` is a protobuf schema change.
@@ -157,8 +162,7 @@ Old snapshots without the field will deserialize with `null`, which is the
 correct backward-compat default. No migration needed.
 
 **[Risk: Large project identity files]** →
-The `[project-instructions]` block uses `EveryTurn` timing and lands in the
-volatile context tail, so it does not benefit from prompt caching. Project
-identity files are typically small (under 2K tokens). If a project has
-unusually large instructions, the cost is bounded by the same truncation
-limits as other context layers.
+Project identity files are included in the system prompt at position [0],
+which benefits from prompt caching. Large files increase the cached prefix
+size but don't cause per-turn overhead. Project identity files are typically
+small (under 2K tokens).

--- a/openspec/changes/session-cwd-tracking/proposal.md
+++ b/openspec/changes/session-cwd-tracking/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Sessions have no concept of "which project directory am I working in." Shell
+commands execute in the daemon's process CWD, file tools resolve relative paths
+against it, and project-scoped identity files (`.netclaw/AGENTS.md`, `CLAUDE.md`)
+can only be found if the daemon happens to be in the right directory. After a
+crash or restart, the agent loses project context because identity files are
+loaded from disk relative to the daemon — not the project. This was identified
+as a root cause of session amnesia in PR #733.
+
+## What Changes
+
+- Add a mutable, persisted `CurrentWorkingDirectory` to `WorkingContext` that
+  tracks where the agent is "working," independent of the immutable session
+  directory (`~/.netclaw/sessions/{id}/`) used for state isolation.
+- Default tool CWD to the session directory at session creation. Update it when
+  shell tool execution detects `cd` commands or when an explicit `set_cwd`
+  command is issued.
+- Shell tool (`shell_execute`) defaults `ProcessStartInfo.WorkingDirectory` to
+  the session's tool CWD when no explicit working directory is provided.
+- File tools (`file_read`, `file_write`, `file_edit`) resolve relative paths
+  against the session's tool CWD instead of the daemon's process CWD.
+- New `[project-instructions]` context layer walks up from the tool CWD to
+  discover project-scoped identity files, re-read on every turn so content
+  stays current across CWD changes and compaction.
+- `[working-context]` block includes the current CWD.
+- CWD changes are bounded by the session's audience trust profile — `cd` cannot
+  escape approved roots.
+
+## Capabilities
+
+### New Capabilities
+
+- `session-cwd`: Session-scoped working directory tracking, persistence across
+  crash/restart, and CWD mutation via tool side effects. Covers the two-directory
+  model (immutable session directory vs mutable tool CWD), initial CWD
+  assignment, and CWD update semantics.
+
+- `project-instructions`: Discovery and injection of project-scoped identity
+  files (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md`) by
+  walking up from the session's tool CWD. Covers the `[project-instructions]`
+  context layer, `EveryTurn` refresh semantics, and directory-tree walk rules.
+
+### Modified Capabilities
+
+- `netclaw-tools`: Shell tool defaults CWD to session tool CWD. File tools
+  resolve relative paths against session tool CWD instead of daemon process CWD.
+  `ToolExecutionContext` gains a `ToolWorkingDirectory` property.
+
+- `netclaw-session`: `WorkingContext` gains `CurrentWorkingDirectory`. Persisted
+  in `SessionSnapshot`. Survives compaction. `[working-context]` block includes
+  CWD. New `[project-instructions]` block added to context assembly.
+
+## Impact
+
+- **Core session state**: `WorkingContext`, `SessionSnapshot`, `SessionState` —
+  new field, serialization change.
+- **Tool execution layer**: `ShellTool`, `ScopedFileAccessPolicy`,
+  `ToolExecutionContext` — path resolution base changes.
+- **Context assembly**: `SessionMessageAssembler` — new `[project-instructions]`
+  block.
+- **New code**: `ProjectInstructionWalker` — directory-tree walk utility.
+- **Security**: `ScopedFileAccessPolicy` enforces CWD stays within audience
+  trust profile roots. No new security surface — existing access policy gates
+  still apply after path resolution.
+- **System skill**: `netclaw-operations` skill needs update to document CWD
+  behavior for the running agent.
+- **Eval suite**: Identity/prompt assembly changes require eval run.
+- **Backward compat**: Sessions without a CWD continue to work unchanged.
+  `[project-instructions]` block is empty when CWD is not set.

--- a/openspec/changes/session-cwd-tracking/proposal.md
+++ b/openspec/changes/session-cwd-tracking/proposal.md
@@ -1,70 +1,74 @@
 ## Why
 
-Sessions have no concept of "which project directory am I working in." Shell
-commands execute in the daemon's process CWD, file tools resolve relative paths
-against it, and project-scoped identity files (`.netclaw/AGENTS.md`, `CLAUDE.md`)
-can only be found if the daemon happens to be in the right directory. After a
-crash or restart, the agent loses project context because identity files are
-loaded from disk relative to the daemon — not the project. This was identified
-as a root cause of session amnesia in PR #733.
+Sessions have no concept of "which project am I working on." Project-scoped
+identity files (`.netclaw/AGENTS.md`, `CLAUDE.md`) are not loaded
+automatically — the `netclaw-projects` skill tells the agent to manually
+`file_read` them, but that content is ephemeral: it's a tool result in one
+turn's history, lost on compaction and unrecoverable after a crash. After a
+restart, the agent has no idea which project it was working on and cannot
+re-discover project context. This was identified as a contributor to session
+amnesia alongside the cursor race and system prompt eviction fixed in PR #733.
+
+Additionally, the agent's session directory path is not explicitly communicated
+— only `media_dir` appears in the `[session]` block, forcing the agent to
+infer the root by going up one level.
 
 ## What Changes
 
-- Add a mutable, persisted `CurrentWorkingDirectory` to `WorkingContext` that
-  tracks where the agent is "working," independent of the immutable session
+- Add a mutable, persisted `ProjectDirectory` to `WorkingContext` that tracks
+  which project the session is working on. Independent of the immutable session
   directory (`~/.netclaw/sessions/{id}/`) used for state isolation.
-- Default tool CWD to the session directory at session creation. Update it when
-  shell tool execution detects `cd` commands or when an explicit `set_cwd`
-  command is issued.
-- Shell tool (`shell_execute`) defaults `ProcessStartInfo.WorkingDirectory` to
-  the session's tool CWD when no explicit working directory is provided.
-- File tools (`file_read`, `file_write`, `file_edit`) resolve relative paths
-  against the session's tool CWD instead of the daemon's process CWD.
-- New `[project-instructions]` context layer walks up from the tool CWD to
-  discover project-scoped identity files, re-read on every turn so content
-  stays current across CWD changes and compaction.
-- `[working-context]` block includes the current CWD.
-- CWD changes are bounded by the session's audience trust profile — `cd` cannot
-  escape approved roots.
+- New `set_working_directory` tool for explicitly setting the project directory.
+  Profile-managed: not exposed to Public/Team audiences by default. Validates
+  target directory exists and is within audience trust profile roots.
+- New `[project-instructions]` context layer loads identity files from the
+  project root (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md`
+  — first match wins) and injects them on every LLM call via `EveryTurn`
+  timing. Content is re-read from disk each turn so edits take effect
+  immediately.
+- `[working-context]` block includes the project directory so the agent knows
+  which project it's in.
+- `[session]` block includes the explicit session directory path.
+- Eval: validate automatic context injection vs behavioral approach for project
+  context loading.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `session-cwd`: Session-scoped working directory tracking, persistence across
-  crash/restart, and CWD mutation via tool side effects. Covers the two-directory
-  model (immutable session directory vs mutable tool CWD), initial CWD
-  assignment, and CWD update semantics.
+- `session-cwd`: Session-scoped project directory tracking, persistence across
+  crash/restart, and the `set_working_directory` tool for setting it. Covers
+  the two-directory model (immutable session directory vs mutable project
+  directory) and audience gating.
 
-- `project-instructions`: Discovery and injection of project-scoped identity
-  files (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md`) by
-  walking up from the session's tool CWD. Covers the `[project-instructions]`
-  context layer, `EveryTurn` refresh semantics, and directory-tree walk rules.
+- `project-instructions`: Loading of project-scoped identity files from the
+  project root and injection as a `[project-instructions]` context layer with
+  `EveryTurn` refresh semantics.
 
 ### Modified Capabilities
 
-- `netclaw-tools`: Shell tool defaults CWD to session tool CWD. File tools
-  resolve relative paths against session tool CWD instead of daemon process CWD.
-  `ToolExecutionContext` gains a `ToolWorkingDirectory` property.
+- `netclaw-tools`: `set_working_directory` tool with audience gating. Profile-
+  managed so Public/Team audiences cannot use it.
 
-- `netclaw-session`: `WorkingContext` gains `CurrentWorkingDirectory`. Persisted
-  in `SessionSnapshot`. Survives compaction. `[working-context]` block includes
-  CWD. New `[project-instructions]` block added to context assembly.
+- `netclaw-session`: `WorkingContext` gains `ProjectDirectory`. Persisted in
+  `SessionSnapshot`. Survives compaction. `[working-context]` block includes
+  project directory. `[session]` block includes session directory path. New
+  `[project-instructions]` block added to context assembly.
 
 ## Impact
 
-- **Core session state**: `WorkingContext`, `SessionSnapshot`, `SessionState` —
-  new field, serialization change.
-- **Tool execution layer**: `ShellTool`, `ScopedFileAccessPolicy`,
-  `ToolExecutionContext` — path resolution base changes.
+- **Core session state**: `WorkingContext`, `SessionSnapshot` — new field,
+  serialization change.
 - **Context assembly**: `SessionMessageAssembler` — new `[project-instructions]`
-  block.
-- **New code**: `ProjectInstructionWalker` — directory-tree walk utility.
-- **Security**: `ScopedFileAccessPolicy` enforces CWD stays within audience
-  trust profile roots. No new security surface — existing access policy gates
-  still apply after path resolution.
-- **System skill**: `netclaw-operations` skill needs update to document CWD
-  behavior for the running agent.
+  block, `session_dir` added to `[session]` block.
+- **New tool**: `SetWorkingDirectoryTool` — audience-gated, validates against
+  trust profile roots.
+- **New code**: `ProjectInstructionLayerProvider` — EveryTurn context layer.
+- **Security**: Tool gated by profile-managed allowlist. Project directory
+  changes validated against audience trust profile roots.
+- **System skills**: `netclaw-operations` and `netclaw-projects` need updates.
+- **Identity templates**: `TOOLING.md` template needs session/project directory
+  guidance.
 - **Eval suite**: Identity/prompt assembly changes require eval run.
-- **Backward compat**: Sessions without a CWD continue to work unchanged.
-  `[project-instructions]` block is empty when CWD is not set.
+- **Backward compat**: Sessions without a project directory work unchanged.
+  `[project-instructions]` block not emitted when project directory is null.

--- a/openspec/changes/session-cwd-tracking/specs/netclaw-session/spec.md
+++ b/openspec/changes/session-cwd-tracking/specs/netclaw-session/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Session recovery across restart
+
+Session actors SHALL recover their full state from the event journal (with
+optional snapshot acceleration). Recovery includes conversation history, turn
+count, title, working context (including recent files and project directory),
+and processed reminder IDs. After recovery, the system prompt SHALL be loaded
+fresh from disk — including project-scoped identity files discovered via the
+recovered project directory. When identity files are missing, the last-known
+system prompt from recovery SHALL be retained rather than deleted.
+
+#### Scenario: Recover state from journal
+
+- **GIVEN** a session with prior persisted turns
+- **WHEN** the session actor restarts
+- **THEN** state is rebuilt from journal events (or snapshot + delta)
+- **AND** the system prompt is loaded fresh from identity files
+- **AND** `WorkingContext.ProjectDirectory` is restored from the snapshot
+
+#### Scenario: Recovery with missing identity files retains last-known prompt
+
+- **GIVEN** a session with prior persisted turns and a system prompt
+- **WHEN** the session actor restarts and identity files are not found on disk
+- **THEN** the last-known system prompt from recovery is retained
+- **AND** a warning is logged
+
+#### Scenario: Recovery with project directory loads project instructions
+
+- **GIVEN** a session with project directory set to
+  `/home/user/workspaces/akadonic`
+- **WHEN** the session actor recovers and
+  `/home/user/workspaces/akadonic/CLAUDE.md` exists
+- **THEN** the `[project-instructions]` block is populated from the
+  project's identity file on the first LLM call
+
+## ADDED Requirements
+
+### Requirement: Working context project directory field
+
+`WorkingContext` SHALL include a `ProjectDirectory` field (protobuf tag 2)
+that tracks which project the session is working on. The field SHALL be
+nullable for backward compatibility. `WorkingContext.IsEmpty` SHALL return
+false when a project directory is set even if `RecentFiles` is empty.
+
+#### Scenario: WorkingContext serialization round-trip with project directory
+
+- **GIVEN** a `WorkingContext` with project directory
+  `/home/user/workspaces/akadonic` and recent files
+- **WHEN** serialized to protobuf and deserialized
+- **THEN** the deserialized instance has the same project directory and
+  recent files
+
+#### Scenario: Legacy WorkingContext without project directory deserializes to null
+
+- **GIVEN** a serialized `WorkingContext` from before project directory
+  tracking was added
+- **WHEN** deserialized
+- **THEN** `ProjectDirectory` is null
+- **AND** `RecentFiles` is preserved
+
+#### Scenario: IsEmpty reflects project directory presence
+
+- **GIVEN** a `WorkingContext` with project directory set but no recent files
+- **WHEN** `IsEmpty` is checked
+- **THEN** it returns false

--- a/openspec/changes/session-cwd-tracking/specs/netclaw-tools/spec.md
+++ b/openspec/changes/session-cwd-tracking/specs/netclaw-tools/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: set_working_directory tool audience gating
+
+The `set_working_directory` tool SHALL be profile-managed. It SHALL NOT
+be exposed to Public or Team audiences by default. Personal audience
+sessions SHALL have access. Custom audience profiles MAY add
+`set_working_directory` to their `AllowedTools` list to grant access.
+
+#### Scenario: set_working_directory not exposed to public audience
+
+- **GIVEN** the default audience profile configuration
+- **WHEN** tool exposure is computed for a public audience session
+- **THEN** `set_working_directory` is not in the exposed tool list
+
+#### Scenario: set_working_directory not exposed to team audience
+
+- **GIVEN** the default audience profile configuration
+- **WHEN** tool exposure is computed for a team audience session
+- **THEN** `set_working_directory` is not in the exposed tool list
+
+#### Scenario: set_working_directory exposed to personal audience
+
+- **GIVEN** the default audience profile configuration
+- **WHEN** tool exposure is computed for a personal audience session
+- **THEN** `set_working_directory` is in the exposed tool list

--- a/openspec/changes/session-cwd-tracking/specs/project-instructions/spec.md
+++ b/openspec/changes/session-cwd-tracking/specs/project-instructions/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Project identity file loading from project directory
+
+The system SHALL load project-scoped identity files from the session's
+project directory. At the project root, the system SHALL check for the
+following files in order: `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`,
+`CONTEXT.md`. The first match wins. When no project directory is set or
+no identity file is found, the block is empty.
+
+#### Scenario: Identity file found at project root
+
+- **GIVEN** a session has project directory set to
+  `/home/user/workspaces/akadonic`
+- **AND** `/home/user/workspaces/akadonic/CLAUDE.md` exists
+- **WHEN** project instruction loading runs
+- **THEN** the content of `CLAUDE.md` is returned framed as
+  `Instructions from: /home/user/workspaces/akadonic/CLAUDE.md`
+
+#### Scenario: Netclaw-specific file takes precedence
+
+- **GIVEN** a session has project directory set to
+  `/home/user/workspaces/akadonic`
+- **AND** both `.netclaw/AGENTS.md` and `CLAUDE.md` exist in that directory
+- **WHEN** project instruction loading runs
+- **THEN** `.netclaw/AGENTS.md` is used (first in check order)
+
+#### Scenario: No identity files found
+
+- **GIVEN** a session has project directory set to `/tmp/empty-dir`
+- **AND** no identity files exist in that directory
+- **WHEN** project instruction loading runs
+- **THEN** no project instructions are returned
+- **AND** no error is raised
+
+#### Scenario: Identity file with I/O error skipped gracefully
+
+- **GIVEN** a session has project directory set to
+  `/home/user/workspaces/akadonic`
+- **AND** `CLAUDE.md` exists but is unreadable (permission denied)
+- **WHEN** project instruction loading runs
+- **THEN** the file is skipped and the next candidate is checked
+
+#### Scenario: No project directory produces empty result
+
+- **GIVEN** a session with no project directory set
+- **WHEN** project instruction loading runs
+- **THEN** no project instructions are returned
+
+### Requirement: Project instructions context layer
+
+The system SHALL inject discovered project instructions as a
+`[project-instructions]` block in the session's dynamic context using
+`EveryTurn` timing. The content SHALL be re-read from disk on every LLM
+call so edits take effect on the next turn. The block SHALL be empty when
+the session has no project directory set or when no identity file is found.
+
+#### Scenario: Project instructions injected on every turn
+
+- **GIVEN** a session has project directory set to
+  `/home/user/workspaces/akadonic`
+- **AND** `CLAUDE.md` contains project-specific guidance
+- **WHEN** an LLM call is assembled
+- **THEN** a `[project-instructions]` block containing the file content is
+  included in the dynamic context
+
+#### Scenario: Project switch picks up new instructions
+
+- **GIVEN** a session working on project-a with `CLAUDE.md`
+- **WHEN** the agent switches to project-b via `set_working_directory`
+- **THEN** the next LLM call includes project instructions from project-b
+- **AND** project-a instructions are no longer included
+
+#### Scenario: Project instructions survive compaction
+
+- **GIVEN** a session with active project instructions
+- **WHEN** context compaction occurs
+- **THEN** the `[project-instructions]` block is re-read from disk on the
+  next LLM call
+- **AND** content is current (not from the compacted history)
+
+#### Scenario: No project directory produces empty block
+
+- **GIVEN** a session with no project directory set
+- **WHEN** an LLM call is assembled
+- **THEN** the `[project-instructions]` block is not included

--- a/openspec/changes/session-cwd-tracking/specs/project-instructions/spec.md
+++ b/openspec/changes/session-cwd-tracking/specs/project-instructions/spec.md
@@ -6,31 +6,31 @@ The system SHALL load project-scoped identity files from the session's
 project directory. At the project root, the system SHALL check for the
 following files in order: `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`,
 `CONTEXT.md`. The first match wins. When no project directory is set or
-no identity file is found, the block is empty.
+no identity file is found, no project content is included in the system
+prompt.
 
 #### Scenario: Identity file found at project root
 
 - **GIVEN** a session has project directory set to
   `/home/user/workspaces/akadonic`
 - **AND** `/home/user/workspaces/akadonic/CLAUDE.md` exists
-- **WHEN** project instruction loading runs
-- **THEN** the content of `CLAUDE.md` is returned framed as
-  `Instructions from: /home/user/workspaces/akadonic/CLAUDE.md`
+- **WHEN** the system prompt is assembled
+- **THEN** the content of `CLAUDE.md` is included in the system prompt
 
 #### Scenario: Netclaw-specific file takes precedence
 
 - **GIVEN** a session has project directory set to
   `/home/user/workspaces/akadonic`
 - **AND** both `.netclaw/AGENTS.md` and `CLAUDE.md` exist in that directory
-- **WHEN** project instruction loading runs
+- **WHEN** the system prompt is assembled
 - **THEN** `.netclaw/AGENTS.md` is used (first in check order)
 
 #### Scenario: No identity files found
 
 - **GIVEN** a session has project directory set to `/tmp/empty-dir`
 - **AND** no identity files exist in that directory
-- **WHEN** project instruction loading runs
-- **THEN** no project instructions are returned
+- **WHEN** the system prompt is assembled
+- **THEN** no project content is included
 - **AND** no error is raised
 
 #### Scenario: Identity file with I/O error skipped gracefully
@@ -38,49 +38,53 @@ no identity file is found, the block is empty.
 - **GIVEN** a session has project directory set to
   `/home/user/workspaces/akadonic`
 - **AND** `CLAUDE.md` exists but is unreadable (permission denied)
-- **WHEN** project instruction loading runs
+- **WHEN** the system prompt is assembled
 - **THEN** the file is skipped and the next candidate is checked
 
-#### Scenario: No project directory produces empty result
+#### Scenario: No project directory produces no project content
 
 - **GIVEN** a session with no project directory set
-- **WHEN** project instruction loading runs
-- **THEN** no project instructions are returned
+- **WHEN** the system prompt is assembled
+- **THEN** no project content is included
 
-### Requirement: Project instructions context layer
+### Requirement: Project instructions in system prompt
 
-The system SHALL inject discovered project instructions as a
-`[project-instructions]` block in the session's dynamic context using
-`EveryTurn` timing. The content SHALL be re-read from disk on every LLM
-call so edits take effect on the next turn. The block SHALL be empty when
-the session has no project directory set or when no identity file is found.
+The system SHALL include discovered project identity file content in the
+system prompt at position [0], alongside the global SOUL/AGENTS/TOOLING
+layers. This is assembled via `SystemPromptAssembler.Assemble()`. The
+system prompt SHALL be re-assembled when the project directory changes
+(via `set_working_directory`) by calling `SetSystemPrompt()` again.
 
-#### Scenario: Project instructions injected on every turn
+The project content sits in the prompt-cache prefix and is stable across
+consecutive turns within the same project.
+
+#### Scenario: Project instructions included in system prompt
 
 - **GIVEN** a session has project directory set to
   `/home/user/workspaces/akadonic`
 - **AND** `CLAUDE.md` contains project-specific guidance
 - **WHEN** an LLM call is assembled
-- **THEN** a `[project-instructions]` block containing the file content is
-  included in the dynamic context
+- **THEN** the system prompt at position [0] includes the project content
+  alongside global SOUL/AGENTS/TOOLING
 
-#### Scenario: Project switch picks up new instructions
+#### Scenario: Project switch re-assembles system prompt
 
 - **GIVEN** a session working on project-a with `CLAUDE.md`
 - **WHEN** the agent switches to project-b via `set_working_directory`
-- **THEN** the next LLM call includes project instructions from project-b
-- **AND** project-a instructions are no longer included
+- **THEN** `SetSystemPrompt()` is called again
+- **AND** the system prompt now includes project-b's identity file
+- **AND** project-a content is no longer in the system prompt
 
 #### Scenario: Project instructions survive compaction
 
-- **GIVEN** a session with active project instructions
+- **GIVEN** a session with active project instructions in the system prompt
 - **WHEN** context compaction occurs
-- **THEN** the `[project-instructions]` block is re-read from disk on the
-  next LLM call
+- **THEN** `SetSystemPrompt()` re-reads from disk on the next recovery
 - **AND** content is current (not from the compacted history)
 
-#### Scenario: No project directory produces empty block
+#### Scenario: No project directory — system prompt unchanged
 
 - **GIVEN** a session with no project directory set
-- **WHEN** an LLM call is assembled
-- **THEN** the `[project-instructions]` block is not included
+- **WHEN** the system prompt is assembled
+- **THEN** the system prompt contains only global SOUL/AGENTS/TOOLING
+- **AND** no project-specific content is included

--- a/openspec/changes/session-cwd-tracking/specs/session-cwd/spec.md
+++ b/openspec/changes/session-cwd-tracking/specs/session-cwd/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Session-scoped project directory
+
+Each session SHALL maintain a mutable `ProjectDirectory` in `WorkingContext`
+that tracks which project the session is working on. This is the root
+directory of the project (where `AGENTS.md` or `.netclaw/AGENTS.md` lives).
+The project directory SHALL be independent of the immutable session directory
+(`~/.netclaw/sessions/{id}/`) used for state isolation. The project directory
+SHALL be persisted in `SessionSnapshot` via `WorkingContext` and survive
+compaction, actor recovery, and daemon restart.
+
+#### Scenario: New session has no project directory
+
+- **GIVEN** a session is created with no prior persisted state
+- **WHEN** the session actor initializes
+- **THEN** `WorkingContext.ProjectDirectory` is null
+- **AND** no `[project-instructions]` block is injected
+
+#### Scenario: Project directory survives daemon restart
+
+- **GIVEN** a session has project directory set to `/home/user/workspaces/akadonic`
+- **WHEN** the daemon crashes and restarts
+- **THEN** the recovered session has project directory equal to
+  `/home/user/workspaces/akadonic`
+- **AND** the project's identity file is loaded on the first LLM call
+
+#### Scenario: Project directory survives compaction
+
+- **GIVEN** a session has project directory set to `/home/user/workspaces/akadonic`
+- **WHEN** context compaction occurs
+- **THEN** `WorkingContext.ProjectDirectory` is preserved in the compacted state
+
+#### Scenario: Backward compat for sessions without project directory
+
+- **GIVEN** a session was created before project directory tracking was
+  implemented
+- **WHEN** the session actor recovers from a snapshot without a project
+  directory field
+- **THEN** `ProjectDirectory` is null
+- **AND** the session functions normally with no `[project-instructions]` block
+
+### Requirement: set_working_directory tool
+
+The system SHALL provide a `set_working_directory` tool that sets the
+session's project directory to a specified path. The tool SHALL validate
+that the target path is a real directory, resolve it to an absolute path,
+and validate it against the audience trust profile's read-allowed roots.
+The tool SHALL be profile-managed so that audiences without directory
+navigation privileges (Public, Team by default) cannot use it.
+
+#### Scenario: set_working_directory updates project directory
+
+- **GIVEN** a session with no project directory set
+- **AND** the audience trust profile allows reads under `/home/user`
+- **WHEN** the agent invokes `set_working_directory` with
+  path `/home/user/workspaces/akadonic`
+- **THEN** the session project directory is set to
+  `/home/user/workspaces/akadonic`
+- **AND** the project's identity file is loaded on the next LLM call
+
+#### Scenario: set_working_directory rejected outside allowed roots
+
+- **GIVEN** a session with audience profile allowing reads only under
+  `/home/user`
+- **WHEN** the agent invokes `set_working_directory` with path `/etc/nginx`
+- **THEN** the project directory remains unchanged
+- **AND** the tool returns an error indicating the path is outside allowed
+  roots
+
+#### Scenario: set_working_directory rejected for nonexistent directory
+
+- **GIVEN** a session with audience profile allowing reads under `/home/user`
+- **WHEN** the agent invokes `set_working_directory` with
+  path `/home/user/nonexistent`
+- **THEN** the project directory remains unchanged
+- **AND** the tool returns an error indicating the directory does not exist
+
+#### Scenario: Personal audience allows any valid directory
+
+- **GIVEN** a session with personal audience (`ToolFilesystemMode.All`)
+- **WHEN** the agent invokes `set_working_directory` with any valid directory
+- **THEN** the project directory is updated
+
+#### Scenario: set_working_directory not exposed to public audience
+
+- **GIVEN** a session with public audience
+- **WHEN** the tool exposure list is computed
+- **THEN** `set_working_directory` is not included
+
+#### Scenario: Switching projects replaces context
+
+- **GIVEN** a session with project directory `/home/user/workspaces/akadonic`
+- **WHEN** the agent invokes `set_working_directory` with
+  path `/home/user/workspaces/other-project`
+- **THEN** the project directory changes to `/home/user/workspaces/other-project`
+- **AND** the next LLM call loads identity files from the new project
+- **AND** the old project's identity files are no longer injected
+
+### Requirement: Working context block includes project directory
+
+The `[working-context]` block emitted by `WorkingContext.ToContextBlock()`
+SHALL include the current project directory when set.
+
+#### Scenario: Project directory included in working context block
+
+- **GIVEN** a session has project directory set to
+  `/home/user/workspaces/akadonic` and recent files
+- **WHEN** `ToContextBlock()` is called
+- **THEN** the output includes `project_dir: /home/user/workspaces/akadonic`
+  alongside the recent files listing

--- a/openspec/changes/session-cwd-tracking/tasks.md
+++ b/openspec/changes/session-cwd-tracking/tasks.md
@@ -20,12 +20,12 @@
 - [ ] 3.4 Create `SetWorkingDirectoryAudienceTests.cs` following `SchedulingToolAudienceTests` pattern: theory covering Public blocked, Team blocked, Personal allowed
 - [ ] 3.5 Test: valid directory within roots updates project directory; outside roots rejected; nonexistent directory rejected; personal audience allows any valid directory; switching projects replaces previous
 
-## 4. Project Instructions Context Layer
+## 4. Project Instructions in System Prompt
 
-- [ ] 4.1 Create `ProjectInstructionLayerProvider` implementing `IContextLayerProvider` with `ContextLayerTiming.EveryTurn` — checks `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` at project root (first match wins), frames as `Instructions from: {path}\n{content}`
-- [ ] 4.2 Inject `Func<string?>` project directory accessor at construction time
-- [ ] 4.3 Register the provider in the session's context layer list
-- [ ] 4.4 Extend `SessionMessageAssemblerTests.cs`: project instructions injected when project dir has identity file; no project dir produces no `[project-instructions]` block; switching projects picks up new instructions
+- [ ] 4.1 Extend `SystemPromptAssembler.Assemble()` to accept optional project instructions content and include it alongside SOUL/AGENTS/TOOLING
+- [ ] 4.2 Update `LlmSessionActor.SetSystemPrompt()` to read project identity file from `_state.WorkingContext.ProjectDirectory` — check `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` at project root (first match wins), skip gracefully on I/O errors
+- [ ] 4.3 Call `SetSystemPrompt()` again when `set_working_directory` changes the project directory
+- [ ] 4.4 Test: system prompt includes project content when project dir has identity file; no project dir → system prompt has only global layers; project switch re-assembles prompt with new project content
 
 ## 5. System Skill and Identity Template Updates
 

--- a/openspec/changes/session-cwd-tracking/tasks.md
+++ b/openspec/changes/session-cwd-tracking/tasks.md
@@ -1,42 +1,42 @@
 ## 1. WorkingContext Project Directory Field
 
-- [ ] 1.1 Add `ProjectDirectory` property (protobuf tag 2) to `WorkingContext` in `src/Netclaw.Actors/Sessions/WorkingContext.cs`
-- [ ] 1.2 Add `WithProjectDirectory(string path)` builder method to `WorkingContext`
-- [ ] 1.3 Update `WorkingContext.IsEmpty` to return false when project directory is set
-- [ ] 1.4 Update `WorkingContext.ToContextBlock()` to include `project_dir:` line
-- [ ] 1.5 Remove the "explicitly not in this struct" comment referencing #595/#596
-- [ ] 1.6 Extend `WorkingContextTests.cs`: `IsEmpty` false when project dir set but no files, `ToContextBlock()` includes `project_dir:` line, builder round-trips
-- [ ] 1.7 Extend `SerializationRoundTripTests.WorkingContext_round_trips`: verify round-trip preserves project directory, verify deserialize without field → null
+- [x] 1.1 Add `ProjectDirectory` property (protobuf tag 2) to `WorkingContext` in `src/Netclaw.Actors/Sessions/WorkingContext.cs`
+- [x] 1.2 Add `WithProjectDirectory(string path)` builder method to `WorkingContext`
+- [x] 1.3 Update `WorkingContext.IsEmpty` to return false when project directory is set
+- [x] 1.4 Update `WorkingContext.ToContextBlock()` to include `project_dir:` line
+- [x] 1.5 Remove the "explicitly not in this struct" comment referencing #595/#596
+- [x] 1.6 Extend `WorkingContextTests.cs`: `IsEmpty` false when project dir set but no files, `ToContextBlock()` includes `project_dir:` line, builder round-trips
+- [x] 1.7 Extend `SerializationRoundTripTests.WorkingContext_round_trips`: verify round-trip preserves project directory, verify deserialize without field → null
 
 ## 2. Session Directory Visibility
 
-- [ ] 2.1 Add explicit `session_dir:` to the `[session]` block in `SessionMessageAssembler.BuildStaticContextBlock`
+- [x] 2.1 Add explicit `session_dir:` to the `[session]` block in `SessionMessageAssembler.BuildStaticContextBlock`
 
 ## 3. set_working_directory Tool
 
-- [ ] 3.1 Create `SetWorkingDirectoryTool` in `src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs` — validates target is a real directory, resolves to absolute path, validates against audience trust profile roots via `ScopedFileAccessPolicy`, returns the resolved path
-- [ ] 3.2 Add `set_working_directory` to the profile-managed tool list in `ToolAudienceProfileResolver.IsProfileManagedTool`
-- [ ] 3.3 Wire tool result back to session actor to update `WorkingContext.ProjectDirectory` (extend post-tool-execution state update in `WorkingContextUpdater` or add callback on `ToolExecutionContext`)
-- [ ] 3.4 Create `SetWorkingDirectoryAudienceTests.cs` following `SchedulingToolAudienceTests` pattern: theory covering Public blocked, Team blocked, Personal allowed
-- [ ] 3.5 Test: valid directory within roots updates project directory; outside roots rejected; nonexistent directory rejected; personal audience allows any valid directory; switching projects replaces previous
+- [x] 3.1 Create `SetWorkingDirectoryTool` in `src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs` — validates target is a real directory, resolves to absolute path, validates against audience trust profile roots via `ScopedFileAccessPolicy`, returns the resolved path
+- [x] 3.2 Add `set_working_directory` to the profile-managed tool list in `ToolAudienceProfileResolver.IsProfileManagedTool`
+- [x] 3.3 Wire tool result back to session actor to update `WorkingContext.ProjectDirectory` (extend post-tool-execution state update in `WorkingContextUpdater` or add callback on `ToolExecutionContext`)
+- [x] 3.4 Create `SetWorkingDirectoryAudienceTests.cs` following `SchedulingToolAudienceTests` pattern: theory covering Public blocked, Team blocked, Personal allowed
+- [x] 3.5 Test: valid directory within roots updates project directory; outside roots rejected; nonexistent directory rejected; personal audience allows any valid directory; switching projects replaces previous
 
 ## 4. Project Instructions in System Prompt
 
-- [ ] 4.1 Extend `SystemPromptAssembler.Assemble()` to accept optional project instructions content and include it alongside SOUL/AGENTS/TOOLING
-- [ ] 4.2 Update `LlmSessionActor.SetSystemPrompt()` to read project identity file from `_state.WorkingContext.ProjectDirectory` — check `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` at project root (first match wins), skip gracefully on I/O errors
-- [ ] 4.3 Call `SetSystemPrompt()` again when `set_working_directory` changes the project directory
-- [ ] 4.4 Test: system prompt includes project content when project dir has identity file; no project dir → system prompt has only global layers; project switch re-assembles prompt with new project content
+- [x] 4.1 Extend `SystemPromptAssembler.Assemble()` to accept optional project instructions content and include it alongside SOUL/AGENTS/TOOLING
+- [x] 4.2 Update `LlmSessionActor.SetSystemPrompt()` to read project identity file from `_state.WorkingContext.ProjectDirectory` — check `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` at project root (first match wins), skip gracefully on I/O errors
+- [x] 4.3 Call `SetSystemPrompt()` again when `set_working_directory` changes the project directory
+- [x] 4.4 Test: system prompt includes project content when project dir has identity file; no project dir → system prompt has only global layers; project switch re-assembles prompt with new project content
 
 ## 5. System Skill and Identity Template Updates
 
-- [ ] 5.1 Update `netclaw-operations` system skill to document project directory and `set_working_directory` tool
-- [ ] 5.2 Bump `metadata.version` in the skill's YAML frontmatter
-- [ ] 5.3 Update `netclaw-projects` skill to note that project instructions are automatically loaded when project directory is set
-- [ ] 5.4 Update `TOOLING.md` init wizard template to include guidance on session directory and project directory
+- [x] 5.1 Update `netclaw-operations` system skill to document project directory and `set_working_directory` tool
+- [x] 5.2 Bump `metadata.version` in the skill's YAML frontmatter
+- [x] 5.3 Update `netclaw-projects` skill to note that project instructions are automatically loaded when project directory is set
+- [x] 5.4 Update `TOOLING.md` init wizard template to include guidance on session directory and project directory
 
 ## 6. Integration Verification
 
-- [ ] 6.1 `dotnet build` — compile check
-- [ ] 6.2 `dotnet test` — full test suite
-- [ ] 6.3 `dotnet slopwatch analyze` — no new violations
+- [x] 6.1 `dotnet build` — compile check
+- [x] 6.2 `dotnet test` — full test suite
+- [x] 6.3 `dotnet slopwatch analyze` — no new violations
 - [ ] 6.4 Run eval suite (`./evals/run-evals.sh`) — identity/prompt assembly changes require eval

--- a/openspec/changes/session-cwd-tracking/tasks.md
+++ b/openspec/changes/session-cwd-tracking/tasks.md
@@ -1,0 +1,42 @@
+## 1. WorkingContext Project Directory Field
+
+- [ ] 1.1 Add `ProjectDirectory` property (protobuf tag 2) to `WorkingContext` in `src/Netclaw.Actors/Sessions/WorkingContext.cs`
+- [ ] 1.2 Add `WithProjectDirectory(string path)` builder method to `WorkingContext`
+- [ ] 1.3 Update `WorkingContext.IsEmpty` to return false when project directory is set
+- [ ] 1.4 Update `WorkingContext.ToContextBlock()` to include `project_dir:` line
+- [ ] 1.5 Remove the "explicitly not in this struct" comment referencing #595/#596
+- [ ] 1.6 Extend `WorkingContextTests.cs`: `IsEmpty` false when project dir set but no files, `ToContextBlock()` includes `project_dir:` line, builder round-trips
+- [ ] 1.7 Extend `SerializationRoundTripTests.WorkingContext_round_trips`: verify round-trip preserves project directory, verify deserialize without field → null
+
+## 2. Session Directory Visibility
+
+- [ ] 2.1 Add explicit `session_dir:` to the `[session]` block in `SessionMessageAssembler.BuildStaticContextBlock`
+
+## 3. set_working_directory Tool
+
+- [ ] 3.1 Create `SetWorkingDirectoryTool` in `src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs` — validates target is a real directory, resolves to absolute path, validates against audience trust profile roots via `ScopedFileAccessPolicy`, returns the resolved path
+- [ ] 3.2 Add `set_working_directory` to the profile-managed tool list in `ToolAudienceProfileResolver.IsProfileManagedTool`
+- [ ] 3.3 Wire tool result back to session actor to update `WorkingContext.ProjectDirectory` (extend post-tool-execution state update in `WorkingContextUpdater` or add callback on `ToolExecutionContext`)
+- [ ] 3.4 Create `SetWorkingDirectoryAudienceTests.cs` following `SchedulingToolAudienceTests` pattern: theory covering Public blocked, Team blocked, Personal allowed
+- [ ] 3.5 Test: valid directory within roots updates project directory; outside roots rejected; nonexistent directory rejected; personal audience allows any valid directory; switching projects replaces previous
+
+## 4. Project Instructions Context Layer
+
+- [ ] 4.1 Create `ProjectInstructionLayerProvider` implementing `IContextLayerProvider` with `ContextLayerTiming.EveryTurn` — checks `.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md` at project root (first match wins), frames as `Instructions from: {path}\n{content}`
+- [ ] 4.2 Inject `Func<string?>` project directory accessor at construction time
+- [ ] 4.3 Register the provider in the session's context layer list
+- [ ] 4.4 Extend `SessionMessageAssemblerTests.cs`: project instructions injected when project dir has identity file; no project dir produces no `[project-instructions]` block; switching projects picks up new instructions
+
+## 5. System Skill and Identity Template Updates
+
+- [ ] 5.1 Update `netclaw-operations` system skill to document project directory and `set_working_directory` tool
+- [ ] 5.2 Bump `metadata.version` in the skill's YAML frontmatter
+- [ ] 5.3 Update `netclaw-projects` skill to note that project instructions are automatically loaded when project directory is set
+- [ ] 5.4 Update `TOOLING.md` init wizard template to include guidance on session directory and project directory
+
+## 6. Integration Verification
+
+- [ ] 6.1 `dotnet build` — compile check
+- [ ] 6.2 `dotnet test` — full test suite
+- [ ] 6.3 `dotnet slopwatch analyze` — no new violations
+- [ ] 6.4 Run eval suite (`./evals/run-evals.sh`) — identity/prompt assembly changes require eval

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -256,6 +256,31 @@ public sealed class SerializationRoundTripTests : TestKit
     }
 
     [Fact]
+    public void WorkingContext_round_trips_with_project_directory()
+    {
+        var original = WorkingContext.Empty
+            .WithProjectDirectory("/home/user/akadonic")
+            .AddRecentFile("src/Rect.cs");
+
+        var result = RoundTrip(original);
+
+        Assert.Equal("/home/user/akadonic", result.ProjectDirectory);
+        Assert.Equal(new[] { "src/Rect.cs" }, result.RecentFiles);
+    }
+
+    [Fact]
+    public void WorkingContext_without_project_directory_deserializes_as_null()
+    {
+        var original = WorkingContext.Empty
+            .AddRecentFile("src/Rect.cs");
+
+        var result = RoundTrip(original);
+
+        Assert.Null(result.ProjectDirectory);
+        Assert.Single(result.RecentFiles);
+    }
+
+    [Fact]
     public void CompactionBroadcast_round_trips()
     {
         var ts = new DateTimeOffset(2026, 2, 21, 11, 0, 1, TimeSpan.Zero);

--- a/src/Netclaw.Actors.Tests/Sessions/WorkingContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/WorkingContextTests.cs
@@ -114,6 +114,57 @@ public class WorkingContextTests
     }
 
     [Fact]
+    public void IsEmpty_is_false_when_project_directory_set_but_no_files()
+    {
+        var ctx = WorkingContext.Empty.WithProjectDirectory("/home/user/project");
+
+        Assert.False(ctx.IsEmpty);
+        Assert.Empty(ctx.RecentFiles);
+    }
+
+    [Fact]
+    public void WithProjectDirectory_returns_same_instance_when_unchanged()
+    {
+        var ctx = WorkingContext.Empty.WithProjectDirectory("/home/user/project");
+        var again = ctx.WithProjectDirectory("/home/user/project");
+
+        Assert.Same(ctx, again);
+    }
+
+    [Fact]
+    public void WithProjectDirectory_returns_new_instance_on_change()
+    {
+        var original = WorkingContext.Empty.WithProjectDirectory("/home/user/project-a");
+        var updated = original.WithProjectDirectory("/home/user/project-b");
+
+        Assert.NotSame(original, updated);
+        Assert.Equal("/home/user/project-a", original.ProjectDirectory);
+        Assert.Equal("/home/user/project-b", updated.ProjectDirectory);
+    }
+
+    [Fact]
+    public void WithProjectDirectory_clears_with_null()
+    {
+        var ctx = WorkingContext.Empty.WithProjectDirectory("/home/user/project");
+        var cleared = ctx.WithProjectDirectory(null);
+
+        Assert.Null(cleared.ProjectDirectory);
+        Assert.True(cleared.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("/home/user/evil\ninjected")]
+    [InlineData("/home/user/evil\rinjected")]
+    [InlineData("/home/user/evil\0injected")]
+    public void WithProjectDirectory_rejects_control_characters(string evilPath)
+    {
+        var ctx = WorkingContext.Empty.WithProjectDirectory(evilPath);
+
+        Assert.Null(ctx.ProjectDirectory);
+        Assert.True(ctx.IsEmpty);
+    }
+
+    [Fact]
     public void ToContextBlock_returns_empty_string_when_context_is_empty()
     {
         Assert.Equal(string.Empty, WorkingContext.Empty.ToContextBlock());
@@ -130,6 +181,31 @@ public class WorkingContextTests
         Assert.Contains("[working-context]", block);
         Assert.Contains("recent_files:", block);
         Assert.Contains("- src/B.cs", block);
+        Assert.Contains("- src/A.cs", block);
+    }
+
+    [Fact]
+    public void ToContextBlock_includes_project_dir_line()
+    {
+        var block = WorkingContext.Empty
+            .WithProjectDirectory("/home/user/akadonic")
+            .ToContextBlock();
+
+        Assert.Contains("[working-context]", block);
+        Assert.Contains("project_dir: /home/user/akadonic", block);
+        Assert.DoesNotContain("recent_files:", block);
+    }
+
+    [Fact]
+    public void ToContextBlock_includes_both_project_dir_and_recent_files()
+    {
+        var block = WorkingContext.Empty
+            .WithProjectDirectory("/home/user/akadonic")
+            .AddRecentFile("src/A.cs")
+            .ToContextBlock();
+
+        Assert.Contains("project_dir: /home/user/akadonic", block);
+        Assert.Contains("recent_files:", block);
         Assert.Contains("- src/A.cs", block);
     }
 }

--- a/src/Netclaw.Actors.Tests/Tools/SetWorkingDirectoryAudienceTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/SetWorkingDirectoryAudienceTests.cs
@@ -1,0 +1,68 @@
+using Netclaw.Actors.Tests.Memory;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+public sealed class SetWorkingDirectoryAudienceTests
+{
+    private static readonly EffectivePolicyDefaults Defaults = new(
+        DeploymentPosture.Personal,
+        TrustAudience.Personal,
+        ShellExecutionMode.HostAllowed,
+        UsedStrictFallback: false);
+
+    [Fact]
+    public void SetWorkingDirectory_BlockedForPublicAudience_ByDefault()
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool();
+
+        Assert.False(policy.IsToolExposed(tool, CreateContext(TrustAudience.Public)));
+    }
+
+    [Fact]
+    public void SetWorkingDirectory_BlockedForTeamAudience_ByDefault()
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool();
+
+        Assert.False(policy.IsToolExposed(tool, CreateContext(TrustAudience.Team)));
+    }
+
+    [Fact]
+    public void SetWorkingDirectory_AllowedForPersonalAudience_ByDefault()
+    {
+        var config = new ToolConfig();
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool();
+
+        Assert.True(policy.IsToolExposed(tool, CreateContext(TrustAudience.Personal)));
+    }
+
+    [Fact]
+    public void SetWorkingDirectory_AllowedForTeam_WhenExplicitlyGranted()
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Team.AllowedTools.Add("set_working_directory");
+        var policy = new ToolAccessPolicy(config, Defaults);
+        var tool = CreateFakeTool();
+
+        Assert.True(policy.IsToolExposed(tool, CreateContext(TrustAudience.Team)));
+    }
+
+    private static FakeNetclawTool CreateFakeTool()
+        => new("set_working_directory", "ok", "file");
+
+    private static ToolExecutionContext CreateContext(TrustAudience audience)
+        => new ToolExecutionContext("slack/thread-1", null)
+        {
+            Audience = audience.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
+            ChannelType = "slack"
+        };
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -630,6 +630,28 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 }
             }
 
+            // Project directory: if set_working_directory was called, update
+            // WorkingContext and re-assemble the system prompt so the project's
+            // identity files are included. The tool returns an absolute path on
+            // success — IsPathRooted is a structural gate that rejects error
+            // messages without relying on string prefix conventions.
+            foreach (var result in msg.ToolResults)
+            {
+                if (result.Name is "set_working_directory" && result.Content is not null)
+                {
+                    var projectDir = result.Content.Trim();
+                    if (!Path.IsPathRooted(projectDir))
+                        continue;
+                    var next = _state.WorkingContext.WithProjectDirectory(projectDir);
+                    if (!ReferenceEquals(next, _state.WorkingContext))
+                    {
+                        _state = _state with { WorkingContext = next };
+                        SetSystemPrompt();
+                        _log.Info("Project directory set to {ProjectDir}", projectDir);
+                    }
+                }
+            }
+
             // Emit FileOutput for any file attachments registered by tools
             foreach (var file in msg.FileAttachments)
             {
@@ -2194,7 +2216,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private void SetSystemPrompt()
     {
-        var content = _promptProvider.GetSystemPrompt();
+        var content = _promptProvider.GetSystemPrompt(_state.WorkingContext.ProjectDirectory);
         if (string.IsNullOrWhiteSpace(content))
         {
             // Retain the last-known prompt from recovery — deleting it strips the agent

--- a/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMessageAssembler.cs
@@ -135,6 +135,7 @@ public static class SessionMessageAssembler
         }
 
         var sessionBlock = $"[session]\nid: {input.SessionId.Value}"
+            + $"\nsession_dir: {sessionDir}"
             + $"\nmedia_dir: {Path.Combine(sessionDir, SessionDirectoryHelper.MediaSubdirectory)}";
         parts.Add(sessionBlock);
 

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -10,21 +10,13 @@ namespace Netclaw.Actors.Sessions;
 /// actor recovery, and daemon restart without depending on the observer LLM
 /// to reconstruct it.
 ///
-/// Currently carries a single field: <see cref="RecentFiles"/> — a bounded
-/// ring buffer of file paths the agent has recently read/written/edited.
-/// Most-recent-first, deduped on repeat access, capped at
-/// <see cref="MaxRecentFiles"/> entries.
-///
-/// Goals and progress markers are intentionally NOT part of this struct.
-/// The original design included `OpenGoals` and `ProgressMarkers` slots that
-/// would be populated by an observer-output parser running after compaction,
-/// but that parser is a separate OpenSpec change that hasn't landed yet.
-/// Per the project's "no hypothetical future requirements" rule, the fields
-/// live with their first real caller.
-///
-/// Also explicitly not in this struct: <c>CurrentWorkingDirectory</c> and
-/// <c>ActiveProjectPath</c>. Those are tracked as GitHub issues
-/// (Aaronontheweb/netclaw#595 and #596) and will land in separate changes.
+/// Carries two fields:
+/// - <see cref="RecentFiles"/>: bounded ring buffer of file paths the agent
+///   has recently read/written/edited. Most-recent-first, deduped, capped at
+///   <see cref="MaxRecentFiles"/>.
+/// - <see cref="ProjectDirectory"/>: optional absolute path to the project
+///   root the session is working on. Set via <c>set_working_directory</c>
+///   tool, persisted across crash/restart. Null means "no project selected."
 /// </summary>
 [ProtoContract]
 public sealed record WorkingContext
@@ -41,12 +33,33 @@ public sealed record WorkingContext
     public ImmutableList<string> RecentFiles { get; init; } =
         ImmutableList<string>.Empty;
 
+    [ProtoMember(2)]
+    public string? ProjectDirectory { get; init; }
+
     /// <summary>
-    /// Returns true when no recent files are tracked. Consumers use this to
-    /// suppress the <c>[working-context]</c> block from the dynamic context
-    /// injection when there is nothing to report.
+    /// Returns true when there is nothing to report — no recent files and
+    /// no project directory. Consumers use this to suppress the
+    /// <c>[working-context]</c> block entirely.
     /// </summary>
-    public bool IsEmpty => RecentFiles.IsEmpty;
+    public bool IsEmpty => RecentFiles.IsEmpty && ProjectDirectory is null;
+
+    /// <summary>
+    /// Return a new <see cref="WorkingContext"/> with <see cref="ProjectDirectory"/>
+    /// set to the given absolute path. Returns the same instance when the value
+    /// is unchanged, so <c>ReferenceEquals</c> callers can short-circuit.
+    /// Rejects paths containing control characters for the same prompt-injection
+    /// reasons as <see cref="AddRecentFile"/>.
+    /// </summary>
+    public WorkingContext WithProjectDirectory(string? path)
+    {
+        if (string.Equals(ProjectDirectory, path, StringComparison.Ordinal))
+            return this;
+
+        if (path is not null && path.AsSpan().IndexOfAny('\n', '\r', '\0') >= 0)
+            return this;
+
+        return this with { ProjectDirectory = path };
+    }
 
     /// <summary>
     /// Push a file path to the front of <see cref="RecentFiles"/>, dedupe on
@@ -107,9 +120,16 @@ public sealed record WorkingContext
 
         var sb = new System.Text.StringBuilder();
         sb.Append("[working-context]");
-        sb.Append("\nrecent_files:");
-        foreach (var path in RecentFiles)
-            sb.Append("\n  - ").Append(path);
+
+        if (ProjectDirectory is not null)
+            sb.Append("\nproject_dir: ").Append(ProjectDirectory);
+
+        if (!RecentFiles.IsEmpty)
+        {
+            sb.Append("\nrecent_files:");
+            foreach (var path in RecentFiles)
+                sb.Append("\n  - ").Append(path);
+        }
 
         return sb.ToString();
     }

--- a/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWorkingDirectoryTool.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Sets the session's project directory — the root of the codebase or project
+/// the agent is currently working on. The session actor intercepts successful
+/// results by tool name to update <c>WorkingContext.ProjectDirectory</c> and
+/// re-assemble the system prompt with project-scoped identity files.
+/// </summary>
+[NetclawTool("set_working_directory",
+    "Set the project directory for this session. This determines which project's identity files " +
+    "(AGENTS.md, CLAUDE.md) are loaded into context. Use an absolute path to the project root.",
+    Grant = "file")]
+public sealed partial class SetWorkingDirectoryTool : NetclawTool<SetWorkingDirectoryTool.Params>
+{
+    private readonly ScopedFileAccessPolicy _fileAccessPolicy;
+
+    public record Params(
+        [property: Description("Absolute path to the project root directory.")]
+        string Path);
+
+    public SetWorkingDirectoryTool(ToolConfig config)
+    {
+        _fileAccessPolicy = new ScopedFileAccessPolicy(config);
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, ToolExecutionContext context, CancellationToken ct)
+    {
+        var raw = args.Path?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(raw))
+            return Task.FromResult("Error: path is required.");
+
+        if (!_fileAccessPolicy.TryResolveReadPath(raw, context, out var fullPath, out var accessError))
+            return Task.FromResult(accessError);
+
+        if (!Directory.Exists(fullPath))
+            return Task.FromResult($"Error: directory does not exist: {fullPath}");
+
+        return Task.FromResult(fullPath);
+    }
+
+    protected override Task<string> ExecuteAsync(Params args, CancellationToken ct)
+        => ExecuteAsync(args, ToolExecutionContext.Empty, ct);
+}

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -179,5 +179,6 @@ internal sealed class ToolAudienceProfileResolver
             or "set_reminder"
             or "list_reminders"
             or "cancel_reminder"
-            or "get_reminder_history";
+            or "get_reminder_history"
+            or "set_working_directory";
 }

--- a/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistrationExtensions.cs
@@ -43,6 +43,7 @@ public static class ToolRegistrationExtensions
         if (searchBackend is not null)
             registry.Register(new WebSearchTool(searchBackend));
         registry.Register(new WebFetchTool(config));
+        registry.Register(new SetWorkingDirectoryTool(config));
 
         // Register search_tools and load_tool meta-tools (always loaded, "builtin" grant)
         registry.Register(new SearchToolsTool(registry, toolAccessPolicy));

--- a/src/Netclaw.Cli/Resources/identity/TOOLING.template.md
+++ b/src/Netclaw.Cli/Resources/identity/TOOLING.template.md
@@ -5,5 +5,9 @@ No capabilities discovered yet. Run `netclaw doctor` or ask Netclaw to probe you
 # Workspaces
 - **Projects directory:** `{{WORKSPACES_DIR}}`
 
+# Directories
+- **Session directory:** Your session's state directory (`~/.netclaw/sessions/{id}/`). Contains inbox, media, and logs. Immutable — derived from the session ID.
+- **Project directory:** Set via `set_working_directory`. Points to the project root you're working on. When set, your project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, or `CONTEXT.md`) is automatically loaded into context. Check `[working-context]` for the current value.
+
 # Source Code
 - **Repository:** https://github.com/Aaronontheweb/netclaw (private)

--- a/src/Netclaw.Configuration.Tests/SystemPromptAssemblerTests.cs
+++ b/src/Netclaw.Configuration.Tests/SystemPromptAssemblerTests.cs
@@ -1,0 +1,103 @@
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class SystemPromptAssemblerTests
+{
+    [Fact]
+    public void Assemble_includes_project_instructions_when_provided()
+    {
+        var result = SystemPromptAssembler.Assemble(
+            soul: "You are helpful.",
+            projectInstructions: "# Project Rules\nUse tabs.");
+
+        Assert.Contains("You are helpful.", result);
+        Assert.Contains("# Project Rules", result);
+    }
+
+    [Fact]
+    public void Assemble_omits_project_instructions_when_null()
+    {
+        var result = SystemPromptAssembler.Assemble(
+            soul: "You are helpful.",
+            projectInstructions: null);
+
+        Assert.Contains("You are helpful.", result);
+        Assert.DoesNotContain("Project", result);
+    }
+
+    [Fact]
+    public void Assemble_returns_only_project_instructions_when_other_layers_null()
+    {
+        var result = SystemPromptAssembler.Assemble(
+            projectInstructions: "# Project Rules");
+
+        Assert.Equal("# Project Rules", result);
+    }
+
+    [Fact]
+    public void TryReadProjectIdentityFile_returns_null_for_null_directory()
+    {
+        var result = FileSystemPromptProvider.TryReadProjectIdentityFile(null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryReadProjectIdentityFile_returns_null_for_empty_directory()
+    {
+        var result = FileSystemPromptProvider.TryReadProjectIdentityFile(string.Empty);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryReadProjectIdentityFile_returns_null_when_no_candidates_exist()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            var result = FileSystemPromptProvider.TryReadProjectIdentityFile(tmpDir);
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryReadProjectIdentityFile_reads_CLAUDE_md()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        File.WriteAllText(Path.Combine(tmpDir, "CLAUDE.md"), "Project instructions here");
+        try
+        {
+            var result = FileSystemPromptProvider.TryReadProjectIdentityFile(tmpDir);
+            Assert.Equal("Project instructions here", result);
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryReadProjectIdentityFile_prefers_netclaw_AGENTS_over_CLAUDE()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"netclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        Directory.CreateDirectory(Path.Combine(tmpDir, ".netclaw"));
+        File.WriteAllText(Path.Combine(tmpDir, ".netclaw", "AGENTS.md"), "Netclaw agents");
+        File.WriteAllText(Path.Combine(tmpDir, "CLAUDE.md"), "Claude instructions");
+        try
+        {
+            var result = FileSystemPromptProvider.TryReadProjectIdentityFile(tmpDir);
+            Assert.Equal("Netclaw agents", result);
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+}

--- a/src/Netclaw.Configuration/ISystemPromptProvider.cs
+++ b/src/Netclaw.Configuration/ISystemPromptProvider.cs
@@ -10,7 +10,8 @@ public interface ISystemPromptProvider
     /// <summary>
     /// Get the assembled system prompt. Returns empty string if no layers are available.
     /// </summary>
-    string GetSystemPrompt();
+    /// <param name="projectDirectory">Optional project root for loading project-scoped identity files.</param>
+    string GetSystemPrompt(string? projectDirectory = null);
 }
 
 /// <summary>
@@ -64,7 +65,7 @@ public sealed class StaticSystemPromptProvider : ISystemPromptProvider
         _prompt = prompt;
     }
 
-    public string GetSystemPrompt() => _prompt;
+    public string GetSystemPrompt(string? projectDirectory = null) => _prompt;
 }
 
 /// <summary>
@@ -74,7 +75,7 @@ public sealed class NullSystemPromptProvider : ISystemPromptProvider
 {
     public static readonly NullSystemPromptProvider Instance = new();
 
-    public string GetSystemPrompt() => string.Empty;
+    public string GetSystemPrompt(string? projectDirectory = null) => string.Empty;
 }
 
 /// <summary>
@@ -135,6 +136,9 @@ public sealed class FileContextLayerProvider : IContextLayerProvider
 /// </summary>
 public sealed class FileSystemPromptProvider : ISystemPromptProvider
 {
+    private static readonly string[] ProjectIdentityFileNames =
+        [".netclaw/AGENTS.md", "CLAUDE.md", "AGENTS.md", "CONTEXT.md"];
+
     private readonly NetclawPaths _paths;
 
     public FileSystemPromptProvider(NetclawPaths paths)
@@ -142,17 +146,37 @@ public sealed class FileSystemPromptProvider : ISystemPromptProvider
         _paths = paths;
     }
 
-    public string GetSystemPrompt()
+    public string GetSystemPrompt(string? projectDirectory = null)
     {
         // Try new identity paths first, fall back to legacy soul/ paths
         var soul = TryReadFile(_paths.SoulPath) ?? TryReadFile(_paths.PersonalityPath);
         var agents = TryReadFile(_paths.AgentsPath) ?? TryReadFile(_paths.InstructionsPath);
         var tooling = TryReadFile(_paths.ToolingPath) ?? TryReadFile(_paths.UserPreferencesPath);
+        var projectInstructions = TryReadProjectIdentityFile(projectDirectory);
 
         return SystemPromptAssembler.Assemble(
             soul: soul,
             agents: agents,
-            tooling: tooling);
+            tooling: tooling,
+            projectInstructions: projectInstructions);
+    }
+
+    /// <summary>
+    /// Check candidate filenames at the project root. First match wins.
+    /// </summary>
+    internal static string? TryReadProjectIdentityFile(string? projectDirectory)
+    {
+        if (string.IsNullOrEmpty(projectDirectory))
+            return null;
+
+        foreach (var candidate in ProjectIdentityFileNames)
+        {
+            var content = TryReadFile(Path.Combine(projectDirectory, candidate));
+            if (content is not null)
+                return content;
+        }
+
+        return null;
     }
 
     private static string? TryReadFile(string path)

--- a/src/Netclaw.Configuration/SystemPromptAssembler.cs
+++ b/src/Netclaw.Configuration/SystemPromptAssembler.cs
@@ -14,17 +14,20 @@ public static class SystemPromptAssembler
     /// <param name="soul">Agent personality, tone, user's name, communication style (SOUL.md).</param>
     /// <param name="agents">Agent purpose/mission, operating rules, meta-guidance (AGENTS.md).</param>
     /// <param name="tooling">Host environment execution capabilities (TOOLING.md).</param>
+    /// <param name="projectInstructions">Project-scoped identity content from the project directory.</param>
     /// <returns>Assembled prompt or empty string if all layers are missing.</returns>
     public static string Assemble(
         string? soul = null,
         string? agents = null,
-        string? tooling = null)
+        string? tooling = null,
+        string? projectInstructions = null)
     {
-        var sections = new List<string>(3);
+        var sections = new List<string>(4);
 
         AddSection(sections, soul);
         AddSection(sections, agents);
         AddSection(sections, tooling);
+        AddSection(sections, projectInstructions);
 
         return sections.Count > 0
             ? string.Join("\n\n", sections)


### PR DESCRIPTION
## Summary

- Refocused from general-purpose CWD tracking to **project directory tracking** — the session knows which project it's working on, not where shell commands run
- New `set_working_directory` tool (profile-managed, audience-gated) for setting the active project directory
- Automatic `[project-instructions]` context layer loads project identity files (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, `CONTEXT.md`) from the project root on every LLM call
- `ProjectDirectory` persisted in `WorkingContext` / `SessionSnapshot` — survives compaction, crash, and restart
- Session directory path added to `[session]` block for agent visibility
- Scoped down from 42 tasks to 21 by removing shell CWD defaulting, file path resolution changes, cd detection, and directory tree walking

## OpenSpec Artifacts

- **proposal.md** — why, what changes, capabilities, impact
- **design.md** — 7 design decisions (two-directory model, null default, standalone tool, single-directory loading, EveryTurn injection, persistence, session dir visibility)
- **specs/** — 4 delta specs (session-cwd, project-instructions, netclaw-tools, netclaw-session)
- **tasks.md** — 6 groups, 21 checkboxed tasks

## Test plan

- [ ] Review OpenSpec artifacts for coherence and completeness
- [ ] Validate design decisions align with existing patterns
- [ ] Confirm task breakdown is implementable
- [ ] Proceed to implementation after review

Implements #595, #596.