### PR TITLE
fix(deps): bump OpenTelemetry to 1.15.3 to resolve CVE advisories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,12 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Nuget package versions -->
     <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.62</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.6.0-beta2</AkkaRemindersVersion>
-    <OpenTelemetryVersion>1.13.1</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <MicrosoftExtensionsAIVersion>10.4.1</MicrosoftExtensionsAIVersion>
     <MicrosoftAspNetCoreVersion>10.0.7</MicrosoftAspNetCoreVersion>
@@ -41,6 +42,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="NSec.Cryptography" Version="24.4.0" />
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />


### PR DESCRIPTION
## Summary

Bump OpenTelemetry packages from 1.13.1 → 1.15.3 and enable transitive pinning to resolve three moderate-severity GitHub Security Advisories blocking CI.

## Advisories Resolved

| Advisory | Package | Issue |
|----------|---------|-------|
| GHSA-g94r-2vxg-569j | OpenTelemetry.Api | Affected 1.13.1 (direct) and 1.9.0 (transitive via Akka.Hosting) |
| GHSA-mr8r-92fq-pj8p | OpenTelemetry.Exporter.OpenTelemetryProtocol | Affected 1.13.1 |
| GHSA-q834-8qmm-v933 | OpenTelemetry.Exporter.OpenTelemetryProtocol | Affected 1.13.1 |

## Changes

- **Version bump**: `OpenTelemetryVersion` from `1.13.1` → `1.15.3`
- **Transitive pinning**: Enabled `CentralPackageTransitivePinningEnabled` and added explicit pin for `OpenTelemetry.Api` to override the 1.9.0 transitive dependency from Akka.Hosting 1.5.65

## Affected CI Jobs

- Test-ubuntu-latest
- Validate Docker Build
- Smoke Sandbox

Build and all 2,606 tests pass locally.