### PR TITLE
release: prepare v0.15.1 release notes and version bump

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,22 +7,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.15.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.15.0 — Session crash recovery hardening, unified streaming timeout, and dependency security updates
+    <VersionPrefix>0.15.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.15.1 — Project directory tracking and automatic context loading
 
-**Bug Fixes**
+**Features**
 
-* Fixed session amnesia after daemon crash — `SlackThreadBindingActor` was advancing its persistence cursor (marking messages as "seen") at enqueue time via `PersistAsync`, before the downstream `LlmSessionActor` durably recorded the completed turn. On a crash between those two writes the message was permanently lost: the cursor said "seen" but no turn was recorded, and thread history hydration skipped it on restart. The cursor now advances only when `TurnCompleted(Completed)` confirms the turn is durably persisted. Additionally, when identity files are missing on recovery, the last-known system prompt is retained as a fallback instead of being actively deleted. Fixes #733. (#733)
-
-* Fixed false streaming timeout on GPU-contended inference servers — the two-phase watchdog (`FirstTokenTimeout` 600 s + `StreamIdleTimeout` 120 s) was causing spurious timeouts on self-hosted inference servers where requests are preempted mid-stream by concurrent sessions, triggering the 120-second idle cutoff even while tokens were actively generating. The two timers are now unified into a single `FirstTokenTimeout` (600 s) that resets on every streaming delta, eliminating false positives under load. `StreamIdleTimeout` / `StreamIdleTimeoutSeconds` are removed from config; `netclaw doctor --fix` auto-removes the stale key from existing configurations. Fixes #731. (#732)
+* Added `set_working_directory` tool and project directory tracking — sessions now track a mutable `ProjectDirectory` in `WorkingContext` that persists across crash and restart. When a project directory is set, the session automatically discovers and loads the project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, or `CONTEXT.md` — first match wins) into the system prompt alongside global identity layers. The loaded project context is stable across turns and benefits from prompt caching. The `set_working_directory` tool validates that the target path exists and is within the audience's allowed file access roots; Public and Team audiences cannot use it by default. Also adds `session_dir` to the `[session]` context block so the agent knows its full session directory path. Closes [#595](https://github.com/Aaronontheweb/netclaw/issues/595), [#596](https://github.com/Aaronontheweb/netclaw/issues/596). ([#734](https://github.com/Aaronontheweb/netclaw/pull/734))
 
 **Dependencies**
 
-* Bumped OpenTelemetry packages from 1.13.1 to 1.15.3 — resolves three moderate-severity GitHub Security Advisories (GHSA-g94r-2vxg-569j, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933) affecting `OpenTelemetry.Api` and `OpenTelemetry.Exporter.OpenTelemetryProtocol`. (#737)
-
-* Bumped Anthropic SDK from 12.13.0 to 12.16.0. (#724)
-
-* Bumped `Microsoft.AspNetCore.DataProtection` and `System.Security.Cryptography.Xml` to 10.0.7. (#725)</PackageReleaseNotes>
+* Bumped `Microsoft.Extensions.AI.Abstractions` from 10.4.1 to 10.5.0. ([#736](https://github.com/Aaronontheweb/netclaw/pull/736))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 0.15.1 2026-04-24 ####
+
+Netclaw v0.15.1 — Project directory tracking and automatic context loading
+
+**Features**
+
+* Added `set_working_directory` tool and project directory tracking — sessions now track a mutable `ProjectDirectory` in `WorkingContext` that persists across crash and restart. When a project directory is set, the session automatically discovers and loads the project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, or `CONTEXT.md` — first match wins) into the system prompt alongside global identity layers. The loaded project context is stable across turns and benefits from prompt caching. The `set_working_directory` tool validates that the target path exists and is within the audience's allowed file access roots; Public and Team audiences cannot use it by default. Also adds `session_dir` to the `[session]` context block so the agent knows its full session directory path. Closes [#595](https://github.com/Aaronontheweb/netclaw/issues/595), [#596](https://github.com/Aaronontheweb/netclaw/issues/596). ([#734](https://github.com/Aaronontheweb/netclaw/pull/734))
+
+**Dependencies**
+
+* Bumped `Microsoft.Extensions.AI.Abstractions` from 10.4.1 to 10.5.0. ([#736](https://github.com/Aaronontheweb/netclaw/pull/736))
+
 #### 0.15.0 2026-04-24 ####
 
 Netclaw v0.15.0 — Session crash recovery hardening, unified streaming timeout, and dependency security updates


### PR DESCRIPTION
## Summary

Netclaw v0.15.1 — Project directory tracking and automatic context loading

- Added `set_working_directory` tool and project directory tracking: sessions now track a mutable `ProjectDirectory` in `WorkingContext` that persists across crash and restart. When a project directory is set, the session automatically discovers and loads the project's identity file (`.netclaw/AGENTS.md`, `CLAUDE.md`, `AGENTS.md`, or `CONTEXT.md` — first match wins) into the system prompt alongside global identity layers. The loaded project context is stable across turns and benefits from prompt caching. The `set_working_directory` tool validates that the target path exists and is within the audience's allowed file access roots; Public and Team audiences cannot use it by default. Also adds `session_dir` to the `[session]` context block. Closes #595, #596. (#734)
- Bumped `Microsoft.Extensions.AI.Abstractions` from 10.4.1 to 10.5.0. (#736)

## Test plan

- [ ] CI passes on this PR
- [ ] Tag `v0.15.1` will be pushed post-merge to trigger the release workflow