### PR TITLE
feat(tui): resolve Discord channel IDs to human-readable names (#743)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/FakeDiscordProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeDiscordProbe.cs
@@ -1,0 +1,40 @@
+using Netclaw.Cli.Discord;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+public sealed class FakeDiscordProbe : IDiscordProbe
+{
+    public DiscordProbeResult NextProbeResult { get; set; } = new(
+        true, null, "TestBot");
+
+    public int ProbeCallCount { get; private set; }
+
+    public string? LastBotToken { get; private set; }
+
+    public DiscordChannelResolutionResult NextResolutionResult { get; set; } = new(true, null, [], []);
+
+    public int ResolveCallCount { get; private set; }
+
+    public IReadOnlyList<string>? LastResolvedIds { get; private set; }
+
+    public TimeSpan? DelayBeforeResult { get; set; }
+
+    public async Task<DiscordProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
+    {
+        ProbeCallCount++;
+        LastBotToken = botToken;
+        if (DelayBeforeResult.HasValue)
+            await Task.Delay(DelayBeforeResult.Value, ct);
+        return NextProbeResult;
+    }
+
+    public async Task<DiscordChannelResolutionResult> ResolveChannelIdsAsync(
+        string botToken, IReadOnlyList<string> channelIds, CancellationToken ct = default)
+    {
+        ResolveCallCount++;
+        LastResolvedIds = channelIds;
+        if (DelayBeforeResult.HasValue)
+            await Task.Delay(DelayBeforeResult.Value, ct);
+        return NextResolutionResult;
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -24,6 +24,7 @@ public sealed class InitWizardPageTests : IDisposable
     private readonly NetclawPaths _paths;
     private readonly FakeProviderProbe _fakeProbe = new();
     private readonly FakeSlackProbe _fakeSlackProbe = new();
+    private readonly FakeDiscordProbe _fakeDiscordProbe = new();
     private readonly ProviderDescriptorRegistry _registry = ProviderCommand.CreateDefaultRegistry();
 
     public InitWizardPageTests()
@@ -201,7 +202,7 @@ public sealed class InitWizardPageTests : IDisposable
                 _ =>
                 {
                     capturedVm = new InitWizardViewModel(
-                        _paths, _registry, _fakeProbe, _fakeSlackProbe);
+                        _paths, _registry, _fakeProbe, _fakeSlackProbe, _fakeDiscordProbe);
                     return capturedVm;
                 });
         });

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/DiscordStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/DiscordStepViewModelTests.cs
@@ -1,4 +1,5 @@
 using Netclaw.Actors.Channels;
+using Netclaw.Cli.Discord;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Cli.Tui.Wizard.Steps;
@@ -12,6 +13,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly WizardContext _context;
+    private readonly FakeDiscordProbe _fakeProbe = new();
 
     public DiscordStepViewModelTests()
     {
@@ -35,7 +37,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     [Fact]
     public void SubStepCount_IsOne_WhenDisabled()
     {
-        using var step = new DiscordStepViewModel();
+        using var step = new DiscordStepViewModel(_fakeProbe);
         step.DiscordEnabled = false;
         Assert.Equal(1, step.SubStepCount);
     }
@@ -43,7 +45,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     [Fact]
     public void SubStepCount_IsFive_WhenEnabled()
     {
-        using var step = new DiscordStepViewModel();
+        using var step = new DiscordStepViewModel(_fakeProbe);
         step.DiscordEnabled = true;
         Assert.Equal(5, step.SubStepCount);
     }
@@ -51,7 +53,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     [Fact]
     public void TryAdvance_ThroughAllSubSteps()
     {
-        using var step = new DiscordStepViewModel();
+        using var step = new DiscordStepViewModel(_fakeProbe);
         step.DiscordEnabled = true;
 
         Assert.True(step.TryAdvance());
@@ -73,7 +75,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     public void OnLeave_PopulatesChannelEntries_WhenEnabled()
     {
         _context.SelectedPosture = DeploymentPosture.Team;
-        using var step = new DiscordStepViewModel
+        using var step = new DiscordStepViewModel(_fakeProbe)
         {
             DiscordEnabled = true,
             AllowDirectMessages = true,
@@ -93,7 +95,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     [Fact]
     public void ContributeConfig_Enabled_SetsDiscordSection()
     {
-        using var step = new DiscordStepViewModel
+        using var step = new DiscordStepViewModel(_fakeProbe)
         {
             DiscordEnabled = true,
             AllowDirectMessages = true,
@@ -117,7 +119,7 @@ public sealed class DiscordStepViewModelTests : IDisposable
     [Fact]
     public async Task ContributeHealthChecks_MissingBotToken_Fails()
     {
-        using var step = new DiscordStepViewModel
+        using var step = new DiscordStepViewModel(_fakeProbe)
         {
             DiscordEnabled = true,
             BotToken = null
@@ -142,5 +144,117 @@ public sealed class DiscordStepViewModelTests : IDisposable
         Assert.Equal("123", ids[0]);
         Assert.Equal("456", ids[1]);
         Assert.Equal("789", ids[2]);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_ProbeSuccess_ReportsAuthenticated()
+    {
+        using var step = new DiscordStepViewModel(_fakeProbe)
+        {
+            DiscordEnabled = true,
+            BotToken = "test-token"
+        };
+
+        var results = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(results, () => { });
+
+        await step.ContributeHealthChecksAsync(runner, CancellationToken.None);
+
+        Assert.Single(results);
+        Assert.True(results[0].Passed);
+        Assert.Contains("TestBot", results[0].Label);
+        Assert.Equal(1, _fakeProbe.ProbeCallCount);
+        Assert.Equal("test-token", _fakeProbe.LastBotToken);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_ProbeFailure_ReportsError()
+    {
+        _fakeProbe.NextProbeResult = new DiscordProbeResult(false, "Bot token is invalid.", null);
+
+        using var step = new DiscordStepViewModel(_fakeProbe)
+        {
+            DiscordEnabled = true,
+            BotToken = "bad-token"
+        };
+
+        var results = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(results, () => { });
+
+        await step.ContributeHealthChecksAsync(runner, CancellationToken.None);
+
+        Assert.Single(results);
+        Assert.False(results[0].Passed);
+        Assert.Contains("Bot token is invalid", results[0].Label);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_ResolvesChannelNames_UpdatesDisplayNames()
+    {
+        _fakeProbe.NextResolutionResult = new DiscordChannelResolutionResult(
+            true, null,
+            [new ResolvedDiscordChannel("129847561203948576", "general", "MyServer")],
+            []);
+
+        _context.SelectedPosture = DeploymentPosture.Team;
+        using var step = new DiscordStepViewModel(_fakeProbe)
+        {
+            DiscordEnabled = true,
+            BotToken = "test-token",
+            ChannelIdsInput = "129847561203948576"
+        };
+
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.OnLeave();
+
+        var results = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(results, () => { });
+
+        await step.ContributeHealthChecksAsync(runner, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.True(results[1].Passed);
+        Assert.Contains("resolved (1)", results[1].Label);
+
+        var entries = _context.ChannelEntries[ChannelType.Discord];
+        var channelEntry = entries.First(e => !e.IsDmRow);
+        Assert.Equal("MyServer / #general", channelEntry.DisplayName);
+    }
+
+    [Fact]
+    public async Task ContributeHealthChecks_PartialResolution_ReportsUnresolved()
+    {
+        _fakeProbe.NextResolutionResult = new DiscordChannelResolutionResult(
+            false, null,
+            [new ResolvedDiscordChannel("111111111111111111", "general", "MyServer")],
+            ["999999999999999999"]);
+
+        _context.SelectedPosture = DeploymentPosture.Team;
+        using var step = new DiscordStepViewModel(_fakeProbe)
+        {
+            DiscordEnabled = true,
+            BotToken = "test-token",
+            ChannelIdsInput = "111111111111111111,999999999999999999"
+        };
+
+        step.OnEnter(_context, NavigationDirection.Forward);
+        step.OnLeave();
+
+        var results = new List<HealthCheckItem>();
+        var runner = new HealthCheckRunner(results, () => { });
+
+        await step.ContributeHealthChecksAsync(runner, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.False(results[1].Passed);
+        Assert.Contains("resolved 1/2", results[1].Label);
+        Assert.Contains("999999999999999999", results[1].Label);
+
+        var entries = _context.ChannelEntries[ChannelType.Discord];
+        var resolvedEntry = entries.First(e => e.Id == "111111111111111111");
+        Assert.Equal("MyServer / #general", resolvedEntry.DisplayName);
+
+        var unresolvedEntry = entries.First(e => e.Id == "999999999999999999");
+        Assert.Equal("Discord:999999999999999999", unresolvedEntry.DisplayName);
     }
 }

--- a/src/Netclaw.Cli/Discord/DiscordProbe.cs
+++ b/src/Netclaw.Cli/Discord/DiscordProbe.cs
@@ -224,7 +224,7 @@ public sealed class DiscordProbe : IDiscordProbe
         }
         catch (JsonException)
         {
-            // slopwatch:suppress SW003 — best-effort extraction from untrusted response body
+            return null;
         }
         return null;
     }

--- a/src/Netclaw.Cli/Discord/DiscordProbe.cs
+++ b/src/Netclaw.Cli/Discord/DiscordProbe.cs
@@ -224,6 +224,7 @@ public sealed class DiscordProbe : IDiscordProbe
         }
         catch (JsonException)
         {
+            // slopwatch:suppress SW003 — best-effort extraction from untrusted response body
         }
         return null;
     }

--- a/src/Netclaw.Cli/Discord/DiscordProbe.cs
+++ b/src/Netclaw.Cli/Discord/DiscordProbe.cs
@@ -1,0 +1,225 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Netclaw.Cli.Discord;
+
+public sealed record DiscordProbeResult(
+    bool Success,
+    string? ErrorMessage,
+    string? BotUsername);
+
+public sealed record ResolvedDiscordChannel(
+    string ChannelId,
+    string ChannelName,
+    string? GuildName)
+{
+    public string ToDisplayName() => GuildName is not null
+        ? $"{GuildName} / #{ChannelName}"
+        : $"#{ChannelName}";
+}
+
+public sealed record DiscordChannelResolutionResult(
+    bool Success,
+    string? ErrorMessage,
+    IReadOnlyList<ResolvedDiscordChannel> Resolved,
+    IReadOnlyList<string> Unresolved);
+
+public interface IDiscordProbe
+{
+    Task<DiscordProbeResult> ProbeAsync(string botToken, CancellationToken ct = default);
+
+    Task<DiscordChannelResolutionResult> ResolveChannelIdsAsync(
+        string botToken, IReadOnlyList<string> channelIds, CancellationToken ct = default);
+}
+
+public sealed class DiscordProbe : IDiscordProbe
+{
+    private const string BaseUrl = "https://discord.com/api/v10";
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ResolveTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly HttpClient _httpClient;
+
+    public DiscordProbe(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<DiscordProbeResult> ProbeAsync(string botToken, CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ProbeTimeout);
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/users/@me");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bot", botToken);
+
+            using var response = await _httpClient.SendAsync(request, timeoutCts.Token);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+                return new DiscordProbeResult(false, MapHttpError(response.StatusCode, errorBody), null);
+            }
+
+            var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var username = root.TryGetProperty("username", out var userProp) ? userProp.GetString() : null;
+            return new DiscordProbeResult(true, null, username);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new DiscordProbeResult(false,
+                "Connection timed out after 10 seconds. Check your network connection.", null);
+        }
+        catch (OperationCanceledException)
+        {
+            return new DiscordProbeResult(false, "Validation cancelled.", null);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new DiscordProbeResult(false, $"Connection failed: {ex.Message}", null);
+        }
+    }
+
+    public async Task<DiscordChannelResolutionResult> ResolveChannelIdsAsync(
+        string botToken, IReadOnlyList<string> channelIds, CancellationToken ct = default)
+    {
+        var normalized = channelIds
+            .Select(id => id.Trim())
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (normalized.Count == 0)
+            return new DiscordChannelResolutionResult(true, null, [], []);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ResolveTimeout);
+
+        var resolved = new List<ResolvedDiscordChannel>();
+        var unresolved = new List<string>();
+        var guildNameCache = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        try
+        {
+            foreach (var channelId in normalized)
+            {
+                var channel = await FetchChannelAsync(botToken, channelId, timeoutCts.Token);
+                if (channel is null)
+                {
+                    unresolved.Add(channelId);
+                    continue;
+                }
+
+                var (channelName, guildId) = channel.Value;
+
+                string? guildName = null;
+                if (guildId is not null)
+                {
+                    if (!guildNameCache.TryGetValue(guildId, out guildName))
+                    {
+                        guildName = await FetchGuildNameAsync(botToken, guildId, timeoutCts.Token);
+                        if (guildName is not null)
+                            guildNameCache[guildId] = guildName;
+                    }
+                }
+
+                resolved.Add(new ResolvedDiscordChannel(channelId, channelName, guildName));
+            }
+
+            return new DiscordChannelResolutionResult(
+                unresolved.Count == 0, null, resolved, unresolved);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return new DiscordChannelResolutionResult(false,
+                "Channel resolution timed out after 30 seconds.", resolved, unresolved);
+        }
+        catch (OperationCanceledException)
+        {
+            return new DiscordChannelResolutionResult(false,
+                "Channel resolution cancelled.", resolved, unresolved);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new DiscordChannelResolutionResult(false,
+                $"Channel resolution failed: {ex.Message}", resolved, unresolved);
+        }
+    }
+
+    private async Task<(string Name, string? GuildId)?> FetchChannelAsync(
+        string botToken, string channelId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/channels/{channelId}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bot", botToken);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var name = root.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+        var guildId = root.TryGetProperty("guild_id", out var guildProp) ? guildProp.GetString() : null;
+
+        return name is not null ? (name, guildId) : null;
+    }
+
+    private async Task<string?> FetchGuildNameAsync(
+        string botToken, string guildId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/guilds/{guildId}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bot", botToken);
+
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        return root.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+    }
+
+    private static string MapHttpError(System.Net.HttpStatusCode statusCode, string body)
+    {
+        var code = TryExtractDiscordErrorCode(body);
+        return (statusCode, code) switch
+        {
+            (System.Net.HttpStatusCode.Unauthorized, _) =>
+                "Bot token is invalid. Check your Discord application's bot token.",
+            (System.Net.HttpStatusCode.Forbidden, 50001) =>
+                "Bot lacks access. Ensure it has been invited to the server.",
+            (System.Net.HttpStatusCode.Forbidden, _) =>
+                "Access denied. Check bot permissions.",
+            (System.Net.HttpStatusCode.NotFound, _) =>
+                "Resource not found. Check the ID is correct.",
+            (System.Net.HttpStatusCode.TooManyRequests, _) =>
+                "Rate limited by Discord API. Try again in a few seconds.",
+            _ => $"Discord API error: {(int)statusCode} {statusCode}"
+        };
+    }
+
+    private static int? TryExtractDiscordErrorCode(string body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("code", out var codeProp) &&
+                codeProp.TryGetInt32(out var code))
+                return code;
+        }
+        catch
+        {
+            // ignore parse failures
+        }
+        return null;
+    }
+}

--- a/src/Netclaw.Cli/Discord/DiscordProbe.cs
+++ b/src/Netclaw.Cli/Discord/DiscordProbe.cs
@@ -100,34 +100,40 @@ public sealed class DiscordProbe : IDiscordProbe
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(ResolveTimeout);
 
-        var resolved = new List<ResolvedDiscordChannel>();
-        var unresolved = new List<string>();
-        var guildNameCache = new Dictionary<string, string>(StringComparer.Ordinal);
-
         try
         {
-            foreach (var channelId in normalized)
+            var channelTasks = normalized.Select(id =>
+                FetchChannelAsync(botToken, id, timeoutCts.Token));
+            var channelResults = await Task.WhenAll(channelTasks);
+
+            var channelPairs = normalized.Zip(channelResults).ToList();
+
+            var uniqueGuildIds = channelPairs
+                .Where(p => p.Second is not null && p.Second.Value.GuildId is not null)
+                .Select(p => p.Second!.Value.GuildId!)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            var guildTasks = uniqueGuildIds.Select(async gid =>
+                (GuildId: gid, Name: await FetchGuildNameAsync(botToken, gid, timeoutCts.Token)));
+            var guildResults = await Task.WhenAll(guildTasks);
+            var guildNames = guildResults
+                .Where(g => g.Name is not null)
+                .ToDictionary(g => g.GuildId, g => g.Name!, StringComparer.Ordinal);
+
+            var resolved = new List<ResolvedDiscordChannel>();
+            var unresolved = new List<string>();
+
+            foreach (var (channelId, channelInfo) in channelPairs)
             {
-                var channel = await FetchChannelAsync(botToken, channelId, timeoutCts.Token);
-                if (channel is null)
+                if (channelInfo is null)
                 {
                     unresolved.Add(channelId);
                     continue;
                 }
 
-                var (channelName, guildId) = channel.Value;
-
-                string? guildName = null;
-                if (guildId is not null)
-                {
-                    if (!guildNameCache.TryGetValue(guildId, out guildName))
-                    {
-                        guildName = await FetchGuildNameAsync(botToken, guildId, timeoutCts.Token);
-                        if (guildName is not null)
-                            guildNameCache[guildId] = guildName;
-                    }
-                }
-
+                var (channelName, guildId) = channelInfo.Value;
+                guildNames.TryGetValue(guildId ?? "", out var guildName);
                 resolved.Add(new ResolvedDiscordChannel(channelId, channelName, guildName));
             }
 
@@ -137,17 +143,17 @@ public sealed class DiscordProbe : IDiscordProbe
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             return new DiscordChannelResolutionResult(false,
-                "Channel resolution timed out after 30 seconds.", resolved, unresolved);
+                "Channel resolution timed out after 30 seconds.", [], []);
         }
         catch (OperationCanceledException)
         {
             return new DiscordChannelResolutionResult(false,
-                "Channel resolution cancelled.", resolved, unresolved);
+                "Channel resolution cancelled.", [], []);
         }
         catch (HttpRequestException ex)
         {
             return new DiscordChannelResolutionResult(false,
-                $"Channel resolution failed: {ex.Message}", resolved, unresolved);
+                $"Channel resolution failed: {ex.Message}", [], []);
         }
     }
 
@@ -216,9 +222,8 @@ public sealed class DiscordProbe : IDiscordProbe
                 codeProp.TryGetInt32(out var code))
                 return code;
         }
-        catch
+        catch (JsonException)
         {
-            // ignore parse failures
         }
         return null;
     }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -10,6 +10,7 @@ using Netclaw.Channels;
 using Netclaw.Channels.Slack;
 using Netclaw.Cli;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Discord;
 using Netclaw.Cli.Json;
 using Netclaw.Cli.Doctor;
 using Netclaw.Cli.Mcp;
@@ -103,6 +104,7 @@ static async Task RunAsync(string[] args)
         if (mode is "doctor")
         {
             builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
+            builder.Services.AddHttpClient<IDiscordProbe, DiscordProbe>();
             builder.Services.AddDoctorChecks();
         }
 
@@ -130,6 +132,7 @@ static async Task RunAsync(string[] args)
                     sp.GetService<TimeProvider>()));
             builder.Services.AddSingleton<DeviceFlowServiceFactory>();
             builder.Services.AddHttpClient<ISlackProbe, SlackProbe>();
+            builder.Services.AddHttpClient<IDiscordProbe, DiscordProbe>();
 
             // Init wizard + chat page dependencies (daemon lifecycle + SignalR)
             var initPaths = new NetclawPaths();

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -1,5 +1,6 @@
 using Netclaw.Channels.Slack;
 using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Discord;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Cli.Tui.Wizard.Steps;
 using Netclaw.Configuration;
@@ -46,12 +47,14 @@ public partial class InitWizardViewModel : ReactiveViewModel
         NetclawPaths paths,
         ProviderDescriptorRegistry registry,
         ISlackProbe slackProbe,
+        IDiscordProbe discordProbe,
         ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
         DaemonApi? daemonApi = null,
         IClipboardService? clipboardService = null)
-        : this(paths, registry, registry, slackProbe, navigationState: navigationState,
+        : this(paths, registry, registry, slackProbe, discordProbe,
+            navigationState: navigationState,
             oauthFactory: oauthFactory, daemonManager: daemonManager, daemonApi: daemonApi,
             clipboardService: clipboardService)
     {
@@ -65,6 +68,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         ProviderDescriptorRegistry registry,
         IProviderProbe probe,
         ISlackProbe slackProbe,
+        IDiscordProbe discordProbe,
         ChatNavigationState? navigationState = null,
         DeviceFlowServiceFactory? oauthFactory = null,
         DaemonManager? daemonManager = null,
@@ -85,7 +89,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var securityPostureStep = new SecurityPostureStepViewModel();
         var exposureModeStep = new ExposureModeStepViewModel();
         var slackStep = new SlackStepViewModel(slackProbe);
-        var discordStep = new DiscordStepViewModel();
+        var discordStep = new DiscordStepViewModel(discordProbe);
         var channelsStep = new ChannelsStepViewModel();
         var searchStep = new SearchStepViewModel();
         var browserStep = new BrowserAutomationStepViewModel();
@@ -223,7 +227,7 @@ public sealed record HealthCheckItem(string Label, bool? Passed);
 /// </summary>
 public sealed class ChannelEntry
 {
-    public string DisplayName { get; }
+    public string DisplayName { get; set; }
     public string Id { get; }
     public TrustAudience Audience { get; set; }
     public bool IsDmRow { get; }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
@@ -71,12 +71,14 @@ public sealed class ChannelsStepView : IWizardStepView
             .WithChild(new TextNode("  Chat channels:").WithForeground(Color.White))
             .WithSpacing(1);
 
+        var nameColumnWidth = Math.Max(20, entries.Max(e => e.DisplayName.Length) + 2);
+
         for (var i = 0; i < entries.Count; i++)
         {
             var entry = entries[i];
             var isFocused = i == _cursorIndex;
             var prefix = isFocused ? " \u25b6 " : "   ";
-            var name = entry.DisplayName.PadRight(20);
+            var name = entry.DisplayName.PadRight(nameColumnWidth);
             var audience = $"[\u25c0 {entry.Audience.ToWireValue(),-8} \u25b6]";
             var line = $"{prefix}{name} {audience}";
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -279,9 +279,11 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
             }
             catch (OperationCanceledException)
             {
+                // slopwatch:suppress SW003 — fire-and-forget; health check retries and reports errors
             }
             catch (HttpRequestException)
             {
+                // slopwatch:suppress SW003 — fire-and-forget; health check retries and reports errors
             }
         }, ct);
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -279,11 +279,11 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
             }
             catch (OperationCanceledException)
             {
-                // slopwatch:suppress SW003 — fire-and-forget; health check retries and reports errors
+                LastChannelResolution = null;
             }
             catch (HttpRequestException)
             {
-                // slopwatch:suppress SW003 — fire-and-forget; health check retries and reports errors
+                LastChannelResolution = null;
             }
         }, ct);
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -10,13 +10,11 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class DiscordStepViewModel : IWizardStepViewModel
 {
-    private static readonly TimeSpan DiscordProbeHardTimeout = TimeSpan.FromSeconds(15);
-    private static readonly TimeSpan ChannelResolutionHardTimeout = TimeSpan.FromSeconds(35);
-
     private readonly IDiscordProbe _discordProbe;
     private int _currentSubStep;
     private int _highWaterSubStep;
     private WizardContext? _context;
+    private CancellationTokenSource? _resolutionCts;
 
     public DiscordStepViewModel(IDiscordProbe discordProbe)
     {
@@ -59,6 +57,9 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
 
         if (_currentSubStep >= 1 && _currentSubStep < 4 && DiscordEnabled)
         {
+            if (_currentSubStep == 2)
+                StartBackgroundChannelResolution();
+
             _currentSubStep++;
             _highWaterSubStep = _currentSubStep;
             return true;
@@ -126,7 +127,8 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
 
         _context.ChannelEntries[ChannelType.Discord] = entries;
 
-        ResolveChannelDisplayNames(channelIds, entries);
+        if (LastChannelResolution is not null)
+            ApplyResolvedDisplayNames(entries);
     }
 
     public void ContributeConfig(WizardConfigBuilder builder)
@@ -178,9 +180,7 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
         bool discordAuthOk;
         try
         {
-            using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            probeCts.CancelAfter(DiscordProbeHardTimeout);
-            var probeResult = await _discordProbe.ProbeAsync(BotToken!, probeCts.Token);
+            var probeResult = await _discordProbe.ProbeAsync(BotToken!, ct);
             if (probeResult.Success)
             {
                 runner.UpdateLast(new HealthCheckItem(
@@ -197,21 +197,27 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             runner.UpdateLast(new HealthCheckItem(
-                "Discord auth timed out (15s). Check your network connection.", false));
+                "Discord auth timed out. Check your network connection.", false));
             discordAuthOk = false;
         }
 
         var parsedChannelIds = ParseChannelIds(ChannelIdsInput);
         if (discordAuthOk && parsedChannelIds.Count > 0)
         {
+            if (LastChannelResolution is { Success: true })
+            {
+                runner.Add(new HealthCheckItem(
+                    $"Discord channels resolved ({LastChannelResolution.Resolved.Count})", true));
+                ApplyResolvedDisplayNamesToContext();
+                return;
+            }
+
             runner.Add(new HealthCheckItem("Resolving Discord channels", null));
 
             try
             {
-                using var channelCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                channelCts.CancelAfter(ChannelResolutionHardTimeout);
                 LastChannelResolution = await _discordProbe.ResolveChannelIdsAsync(
-                    BotToken!, parsedChannelIds, channelCts.Token);
+                    BotToken!, parsedChannelIds, ct);
 
                 if (LastChannelResolution.ErrorMessage is not null)
                 {
@@ -231,48 +237,58 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
                         $"Discord channels resolved ({LastChannelResolution.Resolved.Count})", true));
                 }
 
-                UpdateChannelDisplayNames();
+                ApplyResolvedDisplayNamesToContext();
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 runner.UpdateLast(new HealthCheckItem(
-                    "Discord channel resolution timed out (35s). Check your network connection.", false));
+                    "Discord channel resolution timed out. Check your network connection.", false));
             }
         }
     }
 
-    private void ResolveChannelDisplayNames(List<string> channelIds, List<ChannelEntry> entries)
+    private void StartBackgroundChannelResolution()
     {
+        var channelIds = ParseChannelIds(ChannelIdsInput);
         if (string.IsNullOrWhiteSpace(BotToken) || channelIds.Count == 0)
             return;
 
-        try
+        _resolutionCts?.Cancel();
+        _resolutionCts?.Dispose();
+        _resolutionCts = new CancellationTokenSource();
+        var ct = _resolutionCts.Token;
+        var token = BotToken!;
+        var context = _context;
+
+        _ = Task.Run(async () =>
         {
-            LastChannelResolution = _discordProbe
-                .ResolveChannelIdsAsync(BotToken!, channelIds, CancellationToken.None)
-                .GetAwaiter().GetResult();
-
-            var resolvedLookup = LastChannelResolution.Resolved
-                .ToDictionary(r => r.ChannelId, r => r, StringComparer.Ordinal);
-
-            foreach (var entry in entries)
+            try
             {
-                if (!entry.IsDmRow && resolvedLookup.TryGetValue(entry.Id, out var resolved))
-                    entry.DisplayName = resolved.ToDisplayName();
+                var result = await _discordProbe.ResolveChannelIdsAsync(token, channelIds, ct);
+                if (ct.IsCancellationRequested)
+                    return;
+
+                LastChannelResolution = result;
+
+                if (context is not null &&
+                    context.ChannelEntries.TryGetValue(ChannelType.Discord, out var entries))
+                {
+                    ApplyResolvedDisplayNames(entries);
+                    context.RequestRedraw();
+                }
             }
-        }
-        catch
-        {
-            // Fallback to raw IDs — health check will retry and report the error
-        }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (HttpRequestException)
+            {
+            }
+        }, ct);
     }
 
-    private void UpdateChannelDisplayNames()
+    private void ApplyResolvedDisplayNames(List<ChannelEntry> entries)
     {
-        if (_context is null || LastChannelResolution is null)
-            return;
-
-        if (!_context.ChannelEntries.TryGetValue(ChannelType.Discord, out var entries))
+        if (LastChannelResolution is null)
             return;
 
         var resolvedLookup = LastChannelResolution.Resolved
@@ -280,12 +296,18 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
 
         foreach (var entry in entries)
         {
-            if (entry.IsDmRow)
-                continue;
-
-            if (resolvedLookup.TryGetValue(entry.Id, out var resolved))
+            if (!entry.IsDmRow && resolvedLookup.TryGetValue(entry.Id, out var resolved))
                 entry.DisplayName = resolved.ToDisplayName();
         }
+    }
+
+    private void ApplyResolvedDisplayNamesToContext()
+    {
+        if (_context is null || LastChannelResolution is null)
+            return;
+
+        if (_context.ChannelEntries.TryGetValue(ChannelType.Discord, out var entries))
+            ApplyResolvedDisplayNames(entries);
     }
 
     private Dictionary<string, string>? BuildChannelAudiences()
@@ -321,5 +343,9 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+        _resolutionCts?.Cancel();
+        _resolutionCts?.Dispose();
+    }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -1,4 +1,5 @@
 using Netclaw.Actors.Channels;
+using Netclaw.Cli.Discord;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Tui.Wizard.Steps;
@@ -9,9 +10,18 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class DiscordStepViewModel : IWizardStepViewModel
 {
+    private static readonly TimeSpan DiscordProbeHardTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ChannelResolutionHardTimeout = TimeSpan.FromSeconds(35);
+
+    private readonly IDiscordProbe _discordProbe;
     private int _currentSubStep;
     private int _highWaterSubStep;
     private WizardContext? _context;
+
+    public DiscordStepViewModel(IDiscordProbe discordProbe)
+    {
+        _discordProbe = discordProbe;
+    }
 
     public string StepId => "discord";
     public string DisplayTitle => "Discord";
@@ -21,6 +31,7 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
     public string? ChannelIdsInput { get; set; }
     public bool AllowDirectMessages { get; set; }
     public string? AllowedUserIdsInput { get; set; }
+    internal DiscordChannelResolutionResult? LastChannelResolution { get; set; }
 
     public bool IsApplicable(WizardContext context) => true;
 
@@ -109,10 +120,13 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
             ? TrustAudience.Public
             : TrustAudience.Team;
 
-        foreach (var channelId in ParseChannelIds(ChannelIdsInput))
+        var channelIds = ParseChannelIds(ChannelIdsInput);
+        foreach (var channelId in channelIds)
             entries.Add(new ChannelEntry($"Discord:{channelId}", channelId, channelAudience));
 
         _context.ChannelEntries[ChannelType.Discord] = entries;
+
+        ResolveChannelDisplayNames(channelIds, entries);
     }
 
     public void ContributeConfig(WizardConfigBuilder builder)
@@ -145,24 +159,133 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel
         });
     }
 
-    public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
+    public async Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
     {
         runner.Add(new HealthCheckItem("Discord configuration", null));
 
         if (!DiscordEnabled)
         {
             runner.UpdateLast(new HealthCheckItem("Discord configuration (disabled)", true));
-            return Task.CompletedTask;
+            return;
         }
 
         if (string.IsNullOrWhiteSpace(BotToken))
         {
             runner.UpdateLast(new HealthCheckItem("Discord configuration (bot token missing)", false));
-            return Task.CompletedTask;
+            return;
         }
 
-        runner.UpdateLast(new HealthCheckItem("Discord bot token configured", true));
-        return Task.CompletedTask;
+        bool discordAuthOk;
+        try
+        {
+            using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            probeCts.CancelAfter(DiscordProbeHardTimeout);
+            var probeResult = await _discordProbe.ProbeAsync(BotToken!, probeCts.Token);
+            if (probeResult.Success)
+            {
+                runner.UpdateLast(new HealthCheckItem(
+                    $"Discord bot authenticated (user: {probeResult.BotUsername})", true));
+                discordAuthOk = true;
+            }
+            else
+            {
+                runner.UpdateLast(new HealthCheckItem(
+                    $"Discord auth failed: {probeResult.ErrorMessage}", false));
+                discordAuthOk = false;
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            runner.UpdateLast(new HealthCheckItem(
+                "Discord auth timed out (15s). Check your network connection.", false));
+            discordAuthOk = false;
+        }
+
+        var parsedChannelIds = ParseChannelIds(ChannelIdsInput);
+        if (discordAuthOk && parsedChannelIds.Count > 0)
+        {
+            runner.Add(new HealthCheckItem("Resolving Discord channels", null));
+
+            try
+            {
+                using var channelCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                channelCts.CancelAfter(ChannelResolutionHardTimeout);
+                LastChannelResolution = await _discordProbe.ResolveChannelIdsAsync(
+                    BotToken!, parsedChannelIds, channelCts.Token);
+
+                if (LastChannelResolution.ErrorMessage is not null)
+                {
+                    runner.UpdateLast(new HealthCheckItem(
+                        $"Discord channel lookup failed: {LastChannelResolution.ErrorMessage}", false));
+                }
+                else if (LastChannelResolution.Unresolved.Count > 0)
+                {
+                    var notFound = string.Join(", ", LastChannelResolution.Unresolved);
+                    runner.UpdateLast(new HealthCheckItem(
+                        $"Discord channels: resolved {LastChannelResolution.Resolved.Count}/{parsedChannelIds.Count}, not found: {notFound}",
+                        false));
+                }
+                else
+                {
+                    runner.UpdateLast(new HealthCheckItem(
+                        $"Discord channels resolved ({LastChannelResolution.Resolved.Count})", true));
+                }
+
+                UpdateChannelDisplayNames();
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                runner.UpdateLast(new HealthCheckItem(
+                    "Discord channel resolution timed out (35s). Check your network connection.", false));
+            }
+        }
+    }
+
+    private void ResolveChannelDisplayNames(List<string> channelIds, List<ChannelEntry> entries)
+    {
+        if (string.IsNullOrWhiteSpace(BotToken) || channelIds.Count == 0)
+            return;
+
+        try
+        {
+            LastChannelResolution = _discordProbe
+                .ResolveChannelIdsAsync(BotToken!, channelIds, CancellationToken.None)
+                .GetAwaiter().GetResult();
+
+            var resolvedLookup = LastChannelResolution.Resolved
+                .ToDictionary(r => r.ChannelId, r => r, StringComparer.Ordinal);
+
+            foreach (var entry in entries)
+            {
+                if (!entry.IsDmRow && resolvedLookup.TryGetValue(entry.Id, out var resolved))
+                    entry.DisplayName = resolved.ToDisplayName();
+            }
+        }
+        catch
+        {
+            // Fallback to raw IDs — health check will retry and report the error
+        }
+    }
+
+    private void UpdateChannelDisplayNames()
+    {
+        if (_context is null || LastChannelResolution is null)
+            return;
+
+        if (!_context.ChannelEntries.TryGetValue(ChannelType.Discord, out var entries))
+            return;
+
+        var resolvedLookup = LastChannelResolution.Resolved
+            .ToDictionary(r => r.ChannelId, r => r, StringComparer.Ordinal);
+
+        foreach (var entry in entries)
+        {
+            if (entry.IsDmRow)
+                continue;
+
+            if (resolvedLookup.TryGetValue(entry.Id, out var resolved))
+                entry.DisplayName = resolved.ToDisplayName();
+        }
     }
 
     private Dictionary<string, string>? BuildChannelAudiences()


### PR DESCRIPTION
## Summary

- Adds `IDiscordProbe` / `DiscordProbe` (mirroring the `ISlackProbe` pattern) with raw HTTP calls to the Discord REST API to validate bot tokens and resolve channel IDs to human-readable names
- Discord channel entries in the Channels wizard step now display as `"GuildName / #channelName"` instead of raw snowflake IDs like `"Discord:1497604523664085158"`
- Channel resolution runs as a background task starting when the user advances past the channel IDs sub-step, completing while they finish DMs and user IDs — no blocking calls
- HTTP calls are parallelized via `Task.WhenAll` for both channel and guild fetches
- Health check step reuses pre-resolved results when available, falling back to fresh resolution if needed
- Dynamic column width in ChannelsStepView adapts to resolved name lengths

Closes #743

## Test plan

- [x] All 11 `DiscordStepViewModelTests` pass (including 4 new health check tests)
- [x] `InitWizardPageTests` updated with `FakeDiscordProbe`
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] Live test against Discord bot in Docker container — verify channel names display correctly