### PR TITLE
fix(tui): remove dead OwnerIdentity sub-step from Slack wizard

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
@@ -43,11 +43,11 @@ public sealed class SlackStepViewModelTests : IDisposable
     }
 
     [Fact]
-    public void SubStepCount_IsSeven_WhenEnabled()
+    public void SubStepCount_IsSix_WhenEnabled()
     {
         using var step = new SlackStepViewModel(_fakeProbe);
         step.SlackEnabled = true;
-        Assert.Equal(7, step.SubStepCount);
+        Assert.Equal(6, step.SubStepCount);
     }
 
     [Fact]
@@ -84,11 +84,7 @@ public sealed class SlackStepViewModelTests : IDisposable
         Assert.True(step.TryAdvance());
         Assert.Equal(5, step.CurrentSubStep);
 
-        // 5 → 6
-        Assert.True(step.TryAdvance());
-        Assert.Equal(6, step.CurrentSubStep);
-
-        // 6 → complete
+        // 5 → complete
         Assert.False(step.TryAdvance());
     }
 
@@ -125,13 +121,13 @@ public sealed class SlackStepViewModelTests : IDisposable
         step.SlackEnabled = true;
 
         // Advance through all sub-steps
-        for (var i = 0; i < 6; i++)
+        for (var i = 0; i < 5; i++)
             step.TryAdvance();
-        Assert.Equal(6, step.CurrentSubStep);
+        Assert.Equal(5, step.CurrentSubStep);
 
         // Re-enter from back
         step.OnEnter(_context, NavigationDirection.Back);
-        Assert.Equal(6, step.CurrentSubStep);
+        Assert.Equal(5, step.CurrentSubStep);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Termina view for the Slack wizard step.
-/// 7 sub-steps: enable → bot token → app token → channel names → DM → user IDs → owner identity.
+/// 6 sub-steps: enable → bot token → app token → channel names → DM → user IDs.
 /// </summary>
 public sealed class SlackStepView : IWizardStepView
 {
@@ -20,7 +20,6 @@ public sealed class SlackStepView : IWizardStepView
     private TextInputNode? _channelNamesInput;
     private SelectionListNode<string>? _dmEnabledList;
     private TextInputNode? _allowedUserIdsInput;
-    private TextInputNode? _ownerIdentityInput;
     private IFocusable? _lastFocusedList;
     private TextInputBaseNode? _lastFocusedInput;
 
@@ -38,7 +37,6 @@ public sealed class SlackStepView : IWizardStepView
             3 => BuildChannelNamesSubStep(vm, callbacks),
             4 => BuildDmEnabledSubStep(vm, callbacks),
             5 => BuildAllowedUserIdsSubStep(vm, callbacks),
-            6 => BuildOwnerIdentitySubStep(vm, callbacks),
             _ => Layouts.Empty()
         };
     }
@@ -229,36 +227,6 @@ public sealed class SlackStepView : IWizardStepView
                 .Height(3));
     }
 
-    private ILayoutNode BuildOwnerIdentitySubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
-    {
-        _ownerIdentityInput = new TextInputNode()
-            .WithPlaceholder("U01234ABCDE (your Slack user ID)");
-
-        if (!string.IsNullOrWhiteSpace(vm.OwnerIdentity))
-            _ownerIdentityInput.Text = vm.OwnerIdentity;
-
-        _ownerIdentityInput.OnFocused();
-        _lastFocusedInput = _ownerIdentityInput;
-        _lastFocusedList = null;
-
-        _ownerIdentityInput.Submitted
-            .Subscribe(text =>
-            {
-                vm.OwnerIdentity = string.IsNullOrWhiteSpace(text) ? null : text;
-                callbacks.AdvanceStep();
-            })
-            .DisposeWith(callbacks.Subscriptions);
-
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  Owner identity (press Enter to skip):").WithForeground(Color.White))
-            .WithChild(new PanelNode()
-                .WithTitle("Owner ID")
-                .WithBorder(BorderStyle.Rounded)
-                .WithBorderColor(Color.Gray)
-                .WithContent(_ownerIdentityInput)
-                .Height(3));
-    }
-
     public bool HandleKeyPress(KeyPressed key)
     {
         if (_lastFocusedList is not null)
@@ -289,6 +257,5 @@ public sealed class SlackStepView : IWizardStepView
         _channelNamesInput = null;
         _dmEnabledList = null;
         _allowedUserIdsInput = null;
-        _ownerIdentityInput = null;
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -6,7 +6,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Wizard step for configuring Slack integration.
-/// 7 sub-steps: enable → bot token → app token → channel names → DM enabled → allowed user IDs → owner identity.
+/// 6 sub-steps: enable → bot token → app token → channel names → DM enabled → allowed user IDs.
 /// </summary>
 public sealed class SlackStepViewModel : IWizardStepViewModel
 {
@@ -33,13 +33,12 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
     public string? ChannelNamesInput { get; set; }
     public bool AllowDirectMessages { get; set; }
     public string? AllowedUserIdsInput { get; set; }
-    public string? OwnerIdentity { get; set; }
     internal SlackChannelResolutionResult? LastChannelResolution { get; set; }
 
     public bool IsApplicable(WizardContext context) => true;
 
     public int CurrentSubStep => _currentSubStep;
-    public int SubStepCount => SlackEnabled ? 7 : 1;
+    public int SubStepCount => SlackEnabled ? 6 : 1;
 
     public string GetHelpText() => _currentSubStep switch
     {
@@ -49,7 +48,6 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
         3 => "  Channel names separated by commas. Bot needs channels:read scope to resolve.",
         4 => "  DMs create a private session per conversation. Each top-level DM starts a new session.",
         5 => "  Restrict Slack access to specific user IDs for both channels and DMs. Leave blank to allow all workspace members.",
-        6 => "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
         _ => ""
     };
 
@@ -62,14 +60,14 @@ public sealed class SlackStepViewModel : IWizardStepViewModel
             return true;
         }
 
-        if (_currentSubStep >= 1 && _currentSubStep < 6 && SlackEnabled)
+        if (_currentSubStep >= 1 && _currentSubStep < 5 && SlackEnabled)
         {
             _currentSubStep++;
             _highWaterSubStep = _currentSubStep;
             return true;
         }
 
-        return false; // step complete (disabled at sub-step 0, or sub-step 6 complete)
+        return false; // step complete (disabled at sub-step 0, or sub-step 5 complete)
     }
 
     public bool TryGoBack()


### PR DESCRIPTION
## Summary

Closes #761.

- Removed the dead `OwnerIdentity` sub-step (was sub-step 6) from the Slack wizard — the property was collected by the UI but never consumed by `ContributeConfig()`, `ContributeSecrets()`, or any other code path
- `SlackConfigSection` has no corresponding field; `AllowedUserIds` already covers the access-control use case
- Reduced Slack wizard from 7 sub-steps to 6

## Changes

- **`SlackStepViewModel.cs`**: Removed `OwnerIdentity` property, updated `SubStepCount` (7→6), removed stale help text entry, tightened `TryAdvance` boundary (`< 6` → `< 5`)
- **`SlackStepView.cs`**: Removed `BuildOwnerIdentitySubStep()` method, `_ownerIdentityInput` field, switch case, and cleanup reference
- **`SlackStepViewModelTests.cs`**: Updated three tests to reflect 6 sub-steps instead of 7

## Test plan

- [x] `grep -rn "OwnerIdentity" src/` returns zero results
- [x] `dotnet build src/Netclaw.Cli/Netclaw.Cli.csproj` succeeds
- [x] `dotnet test --filter "SlackStepViewModelTests"` — all 17 tests pass