### PR TITLE
feat(discord): clear approval buttons after decision

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -163,4 +163,70 @@ public sealed class DiscordApprovalPromptBuilderTests
         Assert.Equal(ApprovalOptionKeys.Deny, selectedKey);
         Assert.Null(requesterSenderId);
     }
+
+    [Fact]
+    public void BuildResolvedPromptText_approve_once_shows_checkmark()
+    {
+        var request = new ToolInteractionRequest
+        {
+            SessionId = new SessionId("test/session"),
+            Kind = "approval",
+            CallId = "call-r1",
+            ToolName = "git_push",
+            DisplayText = "push to origin/main",
+            Patterns = ["origin/main"],
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)]
+        };
+
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
+            request, ApprovalOptionKeys.ApproveOnce, "user-42");
+
+        Assert.Contains(":white_check_mark:", text);
+        Assert.Contains("git_push", text);
+        Assert.Contains("push to origin/main", text);
+        Assert.Contains("origin/main", text);
+        Assert.Contains(ApprovalOptionKeys.ApproveOnceLabel, text);
+        Assert.Contains("<@user-42>", text);
+    }
+
+    [Fact]
+    public void BuildResolvedPromptText_deny_shows_no_entry()
+    {
+        var request = new ToolInteractionRequest
+        {
+            SessionId = new SessionId("test/session"),
+            Kind = "approval",
+            CallId = "call-r2",
+            ToolName = "rm_file",
+            DisplayText = "delete /etc/passwd",
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)]
+        };
+
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
+            request, ApprovalOptionKeys.Deny, "user-99");
+
+        Assert.Contains(":no_entry:", text);
+        Assert.Contains(ApprovalOptionKeys.DenyLabel, text);
+        Assert.DoesNotContain(":white_check_mark:", text);
+    }
+
+    [Fact]
+    public void BuildResolvedPromptText_omits_patterns_when_empty()
+    {
+        var request = new ToolInteractionRequest
+        {
+            SessionId = new SessionId("test/session"),
+            Kind = "approval",
+            CallId = "call-r3",
+            ToolName = "read_file",
+            DisplayText = "read config.json",
+            Patterns = [],
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)]
+        };
+
+        var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
+            request, ApprovalOptionKeys.ApproveOnce, "user-1");
+
+        Assert.DoesNotContain("Pattern", text);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
@@ -404,17 +404,25 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
         {
             Posts.Add(message);
 
-            DiscordPostResult result = DiscordPostResult.Default;
+            DiscordPostResult result;
             if (message.CreateThreadOnMessage is not null)
             {
                 var threadId = new DiscordReplyChannelId($"thread-{message.CreateThreadOnMessage.Value.Value}");
                 result = new DiscordPostResult(CreatedThreadId: threadId);
+            }
+            else
+            {
+                result = DiscordPostResult.Default;
             }
 
             return Task.FromResult(result);
         }
 
         public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task UpdateMessageAsync(DiscordReplyChannelId channelId, DiscordMessageId messageId, string text,
+            bool removeComponents = false, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingDiscordReplyClient.cs
@@ -6,7 +6,10 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
 {
     public List<DiscordPostMessage> Posts { get; } = [];
     public List<(DiscordReplyChannelId ThreadId, string Name)> ThreadRenames { get; } = [];
+    public List<(DiscordReplyChannelId ChannelId, DiscordMessageId MessageId, string Text, bool RemoveComponents)> Updates { get; } = [];
     public Exception? ThrowOnPost { get; set; }
+
+    private int _messageCounter;
 
     public Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default)
     {
@@ -15,11 +18,16 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
 
         Posts.Add(message);
 
-        DiscordPostResult result = DiscordPostResult.Default;
+        var messageId = new DiscordMessageId($"msg-{Interlocked.Increment(ref _messageCounter)}");
+        DiscordPostResult result;
         if (message.CreateThreadOnMessage is not null)
         {
             var threadId = new DiscordReplyChannelId($"thread-{message.CreateThreadOnMessage.Value.Value}");
-            result = new DiscordPostResult(CreatedThreadId: threadId);
+            result = new DiscordPostResult(CreatedThreadId: threadId, MessageId: messageId);
+        }
+        else
+        {
+            result = new DiscordPostResult(MessageId: messageId);
         }
 
         return Task.FromResult(result);
@@ -28,6 +36,13 @@ internal sealed class RecordingDiscordReplyClient : IDiscordReplyClient
     public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
     {
         ThreadRenames.Add((threadChannelId, name));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateMessageAsync(DiscordReplyChannelId channelId, DiscordMessageId messageId, string text,
+        bool removeComponents = false, CancellationToken cancellationToken = default)
+    {
+        Updates.Add((channelId, messageId, text, removeComponents));
         return Task.CompletedTask;
     }
 }

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -29,22 +29,7 @@ internal static class DiscordApprovalPromptBuilder
     {
         var sb = new StringBuilder();
         sb.AppendLine(":lock: **Tool approval required**");
-        sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
-        sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
-
-        if (request.Patterns.Count > 0)
-        {
-            if (request.Patterns.Count == 1)
-            {
-                sb.Append("**Pattern:** `").Append(request.Patterns[0]).AppendLine("`");
-            }
-            else
-            {
-                sb.AppendLine("**Patterns:**");
-                foreach (var pattern in request.Patterns)
-                    sb.Append("  • `").Append(pattern).AppendLine("`");
-            }
-        }
+        AppendToolSummary(sb, request);
 
         sb.AppendLine();
         sb.Append("You can also reply with `A`, `B`, `C`, or `D` in this thread.");
@@ -77,6 +62,15 @@ internal static class DiscordApprovalPromptBuilder
 
         var sb = new StringBuilder();
         sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        AppendToolSummary(sb, request);
+
+        sb.Append("**Decision:** ").Append(decisionLabel);
+        sb.Append(" (by <@").Append(senderId).Append(">)");
+        return sb.ToString();
+    }
+
+    private static void AppendToolSummary(StringBuilder sb, ToolInteractionRequest request)
+    {
         sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
         sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
 
@@ -93,10 +87,6 @@ internal static class DiscordApprovalPromptBuilder
                     sb.Append("  • `").Append(pattern).AppendLine("`");
             }
         }
-
-        sb.Append("**Decision:** ").Append(decisionLabel);
-        sb.Append(" (by <@").Append(senderId).Append(">)");
-        return sb.ToString();
     }
 
     private static string GetDecisionLabel(string selectedKey)

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -61,7 +61,46 @@ internal static class DiscordApprovalPromptBuilder
 
     public static string BuildDecisionStatus(string selectedKey)
     {
-        var label = selectedKey switch
+        var label = GetDecisionLabel(selectedKey);
+        return $"Recorded approval decision: {label}.";
+    }
+
+    public static string BuildResolvedPromptText(
+        ToolInteractionRequest request,
+        string selectedKey,
+        string senderId)
+    {
+        var statusEmoji = selectedKey == ApprovalOptionKeys.Deny
+            ? ":no_entry:"
+            : ":white_check_mark:";
+        var decisionLabel = GetDecisionLabel(selectedKey);
+
+        var sb = new StringBuilder();
+        sb.Append(statusEmoji).AppendLine(" **Tool approval resolved**");
+        sb.Append("**Tool:** `").Append(request.ToolName).AppendLine("`");
+        sb.Append("**Action:** `").Append(request.DisplayText).AppendLine("`");
+
+        if (request.Patterns.Count > 0)
+        {
+            if (request.Patterns.Count == 1)
+            {
+                sb.Append("**Pattern:** `").Append(request.Patterns[0]).AppendLine("`");
+            }
+            else
+            {
+                sb.AppendLine("**Patterns:**");
+                foreach (var pattern in request.Patterns)
+                    sb.Append("  • `").Append(pattern).AppendLine("`");
+            }
+        }
+
+        sb.Append("**Decision:** ").Append(decisionLabel);
+        sb.Append(" (by <@").Append(senderId).Append(">)");
+        return sb.ToString();
+    }
+
+    private static string GetDecisionLabel(string selectedKey)
+        => selectedKey switch
         {
             ApprovalOptionKeys.ApproveOnce => ApprovalOptionKeys.ApproveOnceLabel,
             ApprovalOptionKeys.ApproveSession => ApprovalOptionKeys.ApproveSessionLabel,
@@ -69,9 +108,6 @@ internal static class DiscordApprovalPromptBuilder
             ApprovalOptionKeys.Deny => ApprovalOptionKeys.DenyLabel,
             _ => selectedKey
         };
-
-        return $"Recorded approval decision: {label}.";
-    }
 
     internal static string BuildButtonValue(ToolInteractionRequest request, ToolInteractionOption option)
         => ApprovalButtonValueCodec.Encode(request, option);

--- a/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
+++ b/src/Netclaw.Channels.Discord/DiscordIngressMessages.cs
@@ -33,8 +33,15 @@ public sealed record DiscordApprovalResponse(
     DiscordUserId SenderId,
     DiscordUserId? RequesterSenderId = null);
 
-internal sealed record PendingApprovalRequest(
-    string CallId,
-    DiscordUserId? RequesterSenderId,
-    PrincipalClassification? RequesterPrincipal);
+internal sealed class PendingApprovalRequest(ToolInteractionRequest request)
+{
+    public ToolInteractionRequest Request { get; } = request;
+    public string CallId => Request.CallId;
+
+    public DiscordUserId? RequesterSenderId { get; } =
+        request.RequesterSenderId is not null ? new DiscordUserId(request.RequesterSenderId) : null;
+
+    public PrincipalClassification? RequesterPrincipal => Request.RequesterPrincipal;
+    public DiscordMessageId? PromptMessageId { get; set; }
+}
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -491,7 +491,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             SenderId = message.SenderId.Value
         });
 
-        await SafeReplyAsync(DiscordApprovalPromptBuilder.BuildDecisionStatus(selectedKey));
+        await TryResolveApprovalPromptAsync(pending!, selectedKey, message.SenderId.Value);
         return true;
     }
 
@@ -522,7 +522,40 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             SenderId = message.SenderId.Value
         });
 
-        await SafeReplyAsync(DiscordApprovalPromptBuilder.BuildDecisionStatus(message.SelectedKey));
+        await TryResolveApprovalPromptAsync(pending!, message.SelectedKey, message.SenderId.Value);
+    }
+
+    private async Task TryResolveApprovalPromptAsync(
+        PendingApprovalRequest pending,
+        string selectedKey,
+        string senderId)
+    {
+        if (pending.PromptMessageId is not { } promptMessageId)
+            return;
+
+        try
+        {
+            var resolvedText = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
+                pending.Request,
+                selectedKey,
+                senderId);
+
+            using var cts = new CancellationTokenSource(OperationTimeout);
+            await _dependencies.ReplyClient.UpdateMessageAsync(
+                _replyChannelId,
+                promptMessageId,
+                resolvedText,
+                removeComponents: true,
+                cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(
+                ex,
+                "Failed to update resolved approval prompt for call {CallId} messageId={MessageId}",
+                pending.CallId,
+                pending.PromptMessageId?.Value);
+        }
     }
 
     private async Task HandleTrustedReminderAsync(DeliverTrustedSessionTurn message)
@@ -634,13 +667,18 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 break;
 
             case ToolInteractionRequest request when string.Equals(request.Kind, "approval", StringComparison.OrdinalIgnoreCase):
-                _pendingApprovalRequests.Add(new PendingApprovalRequest(
-                    request.CallId,
-                    request.RequesterSenderId is null ? null : new DiscordUserId(request.RequesterSenderId),
-                    request.RequesterPrincipal));
+                var pendingApproval = new PendingApprovalRequest(request);
+                _pendingApprovalRequests.Add(pendingApproval);
 
-                var (promptText, buttons) = DiscordApprovalPromptBuilder.BuildButtonPrompt(request);
-                await SafeReplyWithButtonsAsync(promptText, buttons, request);
+                var promptMessageId = await SafeReplyWithButtonsAsync(request);
+                if (promptMessageId is not null)
+                {
+                    pendingApproval.PromptMessageId = promptMessageId;
+                }
+                else
+                {
+                    _pendingApprovalRequests.Remove(pendingApproval);
+                }
                 break;
 
             case SessionTitleOutput titleOutput:
@@ -671,20 +709,19 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
     }
 
-    private async Task SafeReplyWithButtonsAsync(
-        string text,
-        IReadOnlyList<DiscordButtonSpec> buttons,
-        ToolInteractionRequest request)
+    private async Task<DiscordMessageId?> SafeReplyWithButtonsAsync(ToolInteractionRequest request)
     {
+        var (promptText, buttons) = DiscordApprovalPromptBuilder.BuildButtonPrompt(request);
         var startedAt = _dependencies.TimeProvider.GetTimestamp();
         try
         {
-            var postMessage = BuildPostMessage(text, buttons: buttons);
+            var postMessage = BuildPostMessage(promptText, buttons: buttons);
             var result = await _dependencies.ReplyClient.PostReplyAsync(postMessage);
             ApplyThreadPromotion(result);
             var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
             ChannelTelemetry.RecordDiscordReplyPosted(duration);
             ChannelTelemetry.RecordDiscordApprovalFallbackActivated("button_prompt");
+            return result.MessageId;
         }
         catch (Exception ex)
         {
@@ -696,11 +733,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 var postMessage = BuildPostMessage(fallbackText);
                 var result = await _dependencies.ReplyClient.PostReplyAsync(postMessage);
                 ApplyThreadPromotion(result);
+                return result.MessageId;
             }
             catch (Exception textEx)
             {
                 _log.Error(textEx, "Failed posting text-only approval fallback; auto-denying request");
                 await SendApprovalDenyOnFailureAsync(request.CallId);
+                return null;
             }
         }
     }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -554,7 +554,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 ex,
                 "Failed to update resolved approval prompt for call {CallId} messageId={MessageId}",
                 pending.CallId,
-                pending.PromptMessageId?.Value);
+                promptMessageId.Value);
         }
     }
 

--- a/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
+++ b/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
@@ -50,6 +50,13 @@ public interface IDiscordReplyClient
     Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default);
 
     Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default);
+
+    Task UpdateMessageAsync(
+        DiscordReplyChannelId channelId,
+        DiscordMessageId messageId,
+        string text,
+        bool removeComponents = false,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record DiscordPostMessage(
@@ -61,7 +68,8 @@ public sealed record DiscordPostMessage(
     string? ThreadName = null);
 
 public sealed record DiscordPostResult(
-    DiscordReplyChannelId? CreatedThreadId = null)
+    DiscordReplyChannelId? CreatedThreadId = null,
+    DiscordMessageId? MessageId = null)
 {
     public static readonly DiscordPostResult Default = new();
 }
@@ -121,4 +129,9 @@ public sealed class UnconfiguredDiscordReplyClient : IDiscordReplyClient
     public Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
         => throw new InvalidOperationException(
             "Discord channel attempted to set thread name, but no Discord reply client is configured.");
+
+    public Task UpdateMessageAsync(DiscordReplyChannelId channelId, DiscordMessageId messageId, string text,
+        bool removeComponents = false, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Discord channel attempted to update a message, but no Discord reply client is configured.");
 }

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
@@ -9,6 +9,7 @@ namespace Netclaw.Channels.Discord.Transport;
 internal sealed class DiscordNetReplyClient : IDiscordReplyClient
 {
     private const int MaxRestChannelCacheSize = 1000;
+    private static readonly MessageComponent EmptyComponents = new ComponentBuilder().Build();
 
     private readonly DiscordSocketClient _client;
     private readonly ConcurrentDictionary<ulong, IMessageChannel> _restChannelCache = new();
@@ -32,27 +33,7 @@ internal sealed class DiscordNetReplyClient : IDiscordReplyClient
     public async Task<DiscordPostResult> PostReplyAsync(DiscordPostMessage message, CancellationToken cancellationToken = default)
     {
         var channelId = ParseSnowflake(message.ReplyChannelId.Value, "reply channel ID");
-
-        // Socket cache misses for DM channels — fall back to REST API.
-        IMessageChannel? messageChannel = _client.GetChannel(channelId) as IMessageChannel;
-        if (messageChannel is null && !_restChannelCache.TryGetValue(channelId, out messageChannel))
-        {
-            var restChannel = await _client.Rest.GetChannelAsync(channelId);
-            messageChannel = restChannel as IMessageChannel;
-            if (messageChannel is not null)
-            {
-                // Safety valve — evict stale entries if the cache grows too large.
-                // Full clear is acceptable here because the cache repopulates lazily
-                // and only DM channels (socket cache misses) land here.
-                if (_restChannelCache.Count >= MaxRestChannelCacheSize)
-                    _restChannelCache.Clear();
-                _restChannelCache[channelId] = messageChannel;
-            }
-        }
-
-        if (messageChannel is null)
-            throw new InvalidOperationException(
-                $"Discord channel {message.ReplyChannelId.Value} not found or is not a message channel.");
+        var messageChannel = await ResolveMessageChannelAsync(channelId, message.ReplyChannelId.Value);
 
         IMessageChannel targetChannel = messageChannel;
         DiscordReplyChannelId? createdThreadId = null;
@@ -142,30 +123,37 @@ internal sealed class DiscordNetReplyClient : IDiscordReplyClient
     {
         var channelSnowflake = ParseSnowflake(channelId.Value, "reply channel ID");
         var messageSnowflake = ParseSnowflake(messageId.Value, "message ID");
-
-        IMessageChannel? messageChannel = _client.GetChannel(channelSnowflake) as IMessageChannel;
-        if (messageChannel is null && !_restChannelCache.TryGetValue(channelSnowflake, out messageChannel))
-        {
-            var restChannel = await _client.Rest.GetChannelAsync(channelSnowflake);
-            messageChannel = restChannel as IMessageChannel;
-            if (messageChannel is not null)
-            {
-                if (_restChannelCache.Count >= MaxRestChannelCacheSize)
-                    _restChannelCache.Clear();
-                _restChannelCache[channelSnowflake] = messageChannel;
-            }
-        }
-
-        if (messageChannel is null)
-            throw new InvalidOperationException(
-                $"Discord channel {channelId.Value} not found or is not a message channel.");
+        var messageChannel = await ResolveMessageChannelAsync(channelSnowflake, channelId.Value);
 
         await messageChannel.ModifyMessageAsync(messageSnowflake, props =>
         {
             props.Content = text;
             if (removeComponents)
-                props.Components = new ComponentBuilder().Build();
+                props.Components = EmptyComponents;
         }, new RequestOptions { CancelToken = cancellationToken });
+    }
+
+    private async Task<IMessageChannel> ResolveMessageChannelAsync(ulong channelSnowflake, string channelIdForError)
+    {
+        // Socket cache misses for DM channels — fall back to REST API.
+        IMessageChannel? channel = _client.GetChannel(channelSnowflake) as IMessageChannel;
+        if (channel is null && !_restChannelCache.TryGetValue(channelSnowflake, out channel))
+        {
+            var restChannel = await _client.Rest.GetChannelAsync(channelSnowflake);
+            channel = restChannel as IMessageChannel;
+            if (channel is not null)
+            {
+                if (_restChannelCache.Count >= MaxRestChannelCacheSize)
+                    _restChannelCache.Clear();
+                _restChannelCache[channelSnowflake] = channel;
+            }
+        }
+
+        if (channel is null)
+            throw new InvalidOperationException(
+                $"Discord channel {channelIdForError} not found or is not a message channel.");
+
+        return channel;
     }
 
     private static ulong ParseSnowflake(string value, string label)

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetReplyClient.cs
@@ -108,12 +108,16 @@ internal sealed class DiscordNetReplyClient : IDiscordReplyClient
         if (message.CreateThreadOnMessage is null && message.RootMessageId is { } rootId)
             rootRef = new MessageReference(ParseSnowflake(rootId.Value, "root message ID"));
 
-        await targetChannel.SendMessageAsync(
+        var sentMessage = await targetChannel.SendMessageAsync(
             text: message.Text,
             messageReference: rootRef,
             components: components);
 
-        return new DiscordPostResult(CreatedThreadId: createdThreadId);
+        var sentMessageId = sentMessage is not null
+            ? new DiscordMessageId(sentMessage.Id.ToString())
+            : (DiscordMessageId?)null;
+
+        return new DiscordPostResult(CreatedThreadId: createdThreadId, MessageId: sentMessageId);
     }
 
     public async Task SetThreadNameAsync(DiscordReplyChannelId threadChannelId, string name, CancellationToken cancellationToken = default)
@@ -126,6 +130,41 @@ internal sealed class DiscordNetReplyClient : IDiscordReplyClient
         await thread.ModifyAsync(props =>
         {
             props.Name = name.Length > 100 ? name[..100] : name;
+        }, new RequestOptions { CancelToken = cancellationToken });
+    }
+
+    public async Task UpdateMessageAsync(
+        DiscordReplyChannelId channelId,
+        DiscordMessageId messageId,
+        string text,
+        bool removeComponents = false,
+        CancellationToken cancellationToken = default)
+    {
+        var channelSnowflake = ParseSnowflake(channelId.Value, "reply channel ID");
+        var messageSnowflake = ParseSnowflake(messageId.Value, "message ID");
+
+        IMessageChannel? messageChannel = _client.GetChannel(channelSnowflake) as IMessageChannel;
+        if (messageChannel is null && !_restChannelCache.TryGetValue(channelSnowflake, out messageChannel))
+        {
+            var restChannel = await _client.Rest.GetChannelAsync(channelSnowflake);
+            messageChannel = restChannel as IMessageChannel;
+            if (messageChannel is not null)
+            {
+                if (_restChannelCache.Count >= MaxRestChannelCacheSize)
+                    _restChannelCache.Clear();
+                _restChannelCache[channelSnowflake] = messageChannel;
+            }
+        }
+
+        if (messageChannel is null)
+            throw new InvalidOperationException(
+                $"Discord channel {channelId.Value} not found or is not a message channel.");
+
+        await messageChannel.ModifyMessageAsync(messageSnowflake, props =>
+        {
+            props.Content = text;
+            if (removeComponents)
+                props.Components = new ComponentBuilder().Build();
         }, new RequestOptions { CancelToken = cancellationToken });
     }
 


### PR DESCRIPTION
## Summary

- Update Discord approval prompt messages in-place after a user clicks an approval button or types a text response (A/B/C/D), matching Slack's existing behavior
- Add `UpdateMessageAsync` to `IDiscordReplyClient` using Discord.Net's `ModifyMessageAsync` API
- Capture sent message ID from `SendMessageAsync` and track it in `PendingApprovalRequest` so the original prompt can be edited on resolution
- Replace buttons with a resolved status showing tool name, action, decision, and who approved

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Discord"` — 121 tests pass
- [x] `dotnet test --filter "FullyQualifiedName~SessionBindingContract"` — 48 contract tests pass (both Slack and Discord)
- [ ] Manual test in Docker container: trigger tool approval, click button, verify original message updates with resolved status and buttons removed
- [ ] Manual test: verify text-based approval ("A", "B", "C", "D") also updates the original message