### PR TITLE
feat(channels): stream attachment downloads to disk instead of buffering in memory

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -795,6 +795,7 @@ public abstract class SessionBindingContractTests : TestKit
             Contents =
             [
                 .. baseItem.Contents,
+                new TextContent("[attachment] name=\"image.png\" mime=\"image/png\" size=3 path=\"inbox/image_hist_deadbeef.png\" inlined=\"true\""),
                 new DataContent(new byte[] { 1, 2, 3 }, "image/png")
             ]
         };
@@ -817,7 +818,8 @@ public abstract class SessionBindingContractTests : TestKit
             Assert.Contains(input.Contents, c => c is DataContent d && d.MediaType == "image/png");
 
             var textContent = string.Join("\n", input.Contents.OfType<TextContent>().Select(t => t.Text));
-            Assert.Contains("image attachments", textContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[attachment]", textContent, StringComparison.Ordinal);
+            Assert.Contains("path=\"inbox/image_hist_deadbeef.png\"", textContent, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -781,6 +781,47 @@ public abstract class SessionBindingContractTests : TestKit
     }
 
     [Fact]
+    public async Task Thread_history_preserves_inline_attachment_content()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hydration-attachment");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        var baseItem = Assert.Single(CreateHistoryItems(1));
+        var historyWithAttachment = baseItem with
+        {
+            Contents =
+            [
+                .. baseItem.Contents,
+                new DataContent(new byte[] { 1, 2, 3 }, "image/png")
+            ]
+        };
+        historyFetcher.SetHistory([historyWithAttachment]);
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "hydrated reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        actor.Tell(CreateHydrationTriggerInboundMessage("live message", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
+            Assert.Contains(input.Contents, c => c is DataContent d && d.MediaType == "image/png");
+
+            var textContent = string.Join("\n", input.Contents.OfType<TextContent>().Select(t => t.Text));
+            Assert.Contains("image attachments", textContent, StringComparison.OrdinalIgnoreCase);
+        }, cancellationToken: ct);
+    }
+
+    [Fact]
     public async Task Empty_history_delivers_live_message_without_merge()
     {
         if (!SupportsThreadHydration) return;

--- a/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
@@ -230,6 +230,12 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
 
         Assert.Contains(_replyClient.Posts,
             m => m.Text.Contains("Couldn't scan `drawing.png`", StringComparison.Ordinal));
+
+        var sessionId = new SessionId("ch-3/msg-3000");
+        var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(sessionId, _paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(sessionId, _paths.SessionsDirectory);
+        Assert.Empty(Directory.GetFiles(inboxDir));
+        Assert.Empty(Directory.GetFiles(stagingDir));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Protocol;
+using Netclaw.Channels.Discord;
+using Netclaw.Channels.Discord.Transport;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class DiscordThreadHistoryFetcherTests
+{
+    [Fact]
+    public async Task Attachment_only_historical_message_is_preserved_and_inlined()
+    {
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1001",
+                    SenderId: "user-1",
+                    IsBot: false,
+                    Text: string.Empty,
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "screenshot.png",
+                            "image/png",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/screenshot.png")
+                    ])
+            ]));
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("ch-public/100000000000000001"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Contains(item.Contents, c => c is DataContent d && d.MediaType == "image/png");
+    }
+
+    [Fact]
+    public async Task Historical_non_image_file_is_announced_path_only()
+    {
+        var options = new DiscordChannelOptions
+        {
+            AllowedChannelIds = ["ch-team"]
+        };
+
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1002",
+                    SenderId: "user-2",
+                    IsBot: false,
+                    Text: "see attached",
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "report.pdf",
+                            "application/pdf",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/report.pdf")
+                    ])
+            ]),
+            options: options);
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("ch-team/100000000000000002"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.DoesNotContain(item.Contents, c => c is DataContent);
+        Assert.Contains(item.Contents.OfType<TextContent>(), t => t.Text.Contains("see attached", StringComparison.Ordinal));
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
+              && t.Text.Contains("report.pdf", StringComparison.Ordinal)
+              && t.Text.Contains("path=\"inbox/report", StringComparison.Ordinal)
+              && t.Text.Contains("inlined=\"false\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Historical_scan_failure_is_rejected_fail_closed()
+    {
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1003",
+                    SenderId: "user-3",
+                    IsBot: false,
+                    Text: "please inspect",
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "drawing.png",
+                            "image/png",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/drawing.png")
+                    ])
+            ]),
+            scanner: new FailingContentScanner());
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("ch-public/100000000000000003"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.DoesNotContain(item.Contents, c => c is DataContent);
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("attachment rejected", StringComparison.OrdinalIgnoreCase)
+              && t.Text.Contains("content scanning", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static DiscordThreadHistoryFetcher CreateFetcher(
+        DiscordThreadHistoryFetcher.MessageFetcher? messageFetcher = null,
+        HttpMessageHandler? handler = null,
+        IContentScanner? scanner = null,
+        ToolAudienceProfiles? profiles = null,
+        ModelCapabilities? modelCapabilities = null,
+        DiscordChannelOptions? options = null)
+    {
+        return new DiscordThreadHistoryFetcher(
+            messageFetcher ?? ((_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>([])),
+            options ?? new DiscordChannelOptions(),
+            new HttpClient(handler ?? new FakeHttpHandler()),
+            scanner ?? new NullContentScanner(),
+            profiles ?? ToolAudienceProfileDefaults.CreateProfiles(),
+            modelCapabilities ?? TestDiscordGatewayDeps.DefaultVisionCapableModel,
+            new NetclawPaths(Path.GetTempPath()),
+            NullLogger<DiscordThreadHistoryFetcher>.Instance);
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            });
+        }
+    }
+
+    private sealed class FailingContentScanner : IContentScanner
+    {
+        public Task<ContentScanResult> ScanAsync(
+            ReadOnlyMemory<byte> content,
+            string filename,
+            string declaredMimeType,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ContentScanResult.Rejected(
+                ContentScanError.ScanFailure,
+                "Content scan failed: scanner unavailable"));
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
@@ -40,6 +40,10 @@ public sealed class DiscordThreadHistoryFetcherTests
 
         var item = Assert.Single(result);
         Assert.Contains(item.Contents, c => c is DataContent d && d.MediaType == "image/png");
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
+              && t.Text.Contains("screenshot.png", StringComparison.Ordinal)
+              && t.Text.Contains("inlined=\"true\"", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -118,13 +122,104 @@ public sealed class DiscordThreadHistoryFetcherTests
               && t.Text.Contains("content scanning", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task Historical_dm_attachment_uses_dm_audience_policy()
+    {
+        var profiles = ToolAudienceProfileDefaults.CreateProfiles();
+        profiles.Team.ChannelAttachments = new ChannelAttachmentPolicy
+        {
+            AllowedCategories = [AttachmentCategory.Pdf],
+            MaxFileBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes,
+            MaxFilesPerMessage = ChannelAttachmentPolicy.DefaultMaxFilesPerMessage
+        };
+        profiles.Public.ChannelAttachments = ChannelAttachmentPolicy.Empty;
+
+        var options = new DiscordChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dm"] = "team"
+            }
+        };
+
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1004",
+                    SenderId: "user-4",
+                    IsBot: false,
+                    Text: string.Empty,
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "report.pdf",
+                            "application/pdf",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/report.pdf")
+                    ])
+            ]),
+            profiles: profiles,
+            options: options);
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("dm-channel/100000000000000004"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
+              && t.Text.Contains("report.pdf", StringComparison.Ordinal)
+              && t.Text.Contains("inlined=\"false\"", StringComparison.Ordinal));
+        Assert.DoesNotContain(item.Contents, c => c is DataContent);
+    }
+
+    [Fact]
+    public async Task Historical_attachment_reuse_skips_repeat_downloads()
+    {
+        var sessionsRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var handler = new FakeHttpHandler();
+
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1005",
+                    SenderId: "user-5",
+                    IsBot: false,
+                    Text: string.Empty,
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "repeat.png",
+                            "image/png",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/repeat.png")
+                    ])
+            ]),
+            handler: handler,
+            paths: new NetclawPaths(sessionsRoot));
+
+        var sessionId = new SessionId("ch-public/100000000000000005");
+        var first = await fetcher.FetchThreadHistoryAsync(sessionId, TestContext.Current.CancellationToken);
+        var second = await fetcher.FetchThreadHistoryAsync(sessionId, TestContext.Current.CancellationToken);
+
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
     private static DiscordThreadHistoryFetcher CreateFetcher(
         DiscordThreadHistoryFetcher.MessageFetcher? messageFetcher = null,
         HttpMessageHandler? handler = null,
         IContentScanner? scanner = null,
         ToolAudienceProfiles? profiles = null,
         ModelCapabilities? modelCapabilities = null,
-        DiscordChannelOptions? options = null)
+        DiscordChannelOptions? options = null,
+        NetclawPaths? paths = null)
     {
         return new DiscordThreadHistoryFetcher(
             messageFetcher ?? ((_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>([])),
@@ -133,16 +228,21 @@ public sealed class DiscordThreadHistoryFetcherTests
             scanner ?? new NullContentScanner(),
             profiles ?? ToolAudienceProfileDefaults.CreateProfiles(),
             modelCapabilities ?? TestDiscordGatewayDeps.DefaultVisionCapableModel,
-            new NetclawPaths(Path.GetTempPath()),
+            paths ?? new NetclawPaths(Path.GetTempPath()),
             NullLogger<DiscordThreadHistoryFetcher>.Instance);
     }
 
     private sealed class FakeHttpHandler : HttpMessageHandler
     {
+        private int _requestCount;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref _requestCount);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent([1, 2, 3])

--- a/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
@@ -165,7 +165,7 @@ public sealed class DiscordThreadHistoryFetcherTests
             options: options);
 
         var result = await fetcher.FetchThreadHistoryAsync(
-            new SessionId("dm-channel/100000000000000004"),
+            new SessionId("100000000000000004/100000000000000004"),
             TestContext.Current.CancellationToken);
 
         var item = Assert.Single(result);
@@ -174,6 +174,58 @@ public sealed class DiscordThreadHistoryFetcherTests
               && t.Text.Contains("report.pdf", StringComparison.Ordinal)
               && t.Text.Contains("inlined=\"false\"", StringComparison.Ordinal));
         Assert.DoesNotContain(item.Contents, c => c is DataContent);
+    }
+
+    [Fact]
+    public async Task Unknown_channel_is_not_treated_as_dm_when_dm_enabled()
+    {
+        var profiles = ToolAudienceProfileDefaults.CreateProfiles();
+        profiles.Team.ChannelAttachments = new ChannelAttachmentPolicy
+        {
+            AllowedCategories = [AttachmentCategory.Pdf],
+            MaxFileBytes = ChannelAttachmentPolicy.DefaultMaxFileBytes,
+            MaxFilesPerMessage = ChannelAttachmentPolicy.DefaultMaxFilesPerMessage
+        };
+        profiles.Public.ChannelAttachments = ChannelAttachmentPolicy.Empty;
+
+        var options = new DiscordChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dm"] = "team"
+            }
+        };
+
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "1006",
+                    SenderId: "user-6",
+                    IsBot: false,
+                    Text: string.Empty,
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments:
+                    [
+                        new DiscordFileReference(
+                            "report.pdf",
+                            "application/pdf",
+                            3,
+                            "https://cdn.discordapp.com/attachments/1/2/report.pdf")
+                    ])
+            ]),
+            profiles: profiles,
+            options: options);
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("100000000000000006/100000000000000007"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("attachment rejected", StringComparison.OrdinalIgnoreCase)
+              && t.Text.Contains("exceed the 0 per-message limit", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/HistoricalAttachmentInboxTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/HistoricalAttachmentInboxTests.cs
@@ -1,0 +1,30 @@
+using Netclaw.Channels;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class HistoricalAttachmentInboxTests
+{
+    [Fact]
+    public void PromoteOrReuse_returns_existing_target_when_concurrent_writer_wins()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        const string rawFilename = "report.pdf";
+        const string sourceKey = "slack:F123";
+
+        var firstStage = Path.Combine(root, "stage-1.tmp");
+        var secondStage = Path.Combine(root, "stage-2.tmp");
+        File.WriteAllBytes(firstStage, [1, 2, 3]);
+        File.WriteAllBytes(secondStage, [4, 5, 6]);
+
+        var firstPath = HistoricalAttachmentInbox.PromoteOrReuse(root, rawFilename, sourceKey, firstStage);
+        var secondPath = HistoricalAttachmentInbox.PromoteOrReuse(root, rawFilename, sourceKey, secondStage);
+
+        Assert.Equal(firstPath, secondPath);
+        Assert.True(File.Exists(firstPath));
+        Assert.False(File.Exists(secondStage));
+        Assert.Equal([1, 2, 3], File.ReadAllBytes(firstPath));
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentLineTests.cs
@@ -1,11 +1,11 @@
-using Netclaw.Channels.Slack;
+using Netclaw.Channels;
 using Xunit;
 
 namespace Netclaw.Actors.Tests.Channels;
 
 /// <summary>
-/// Unit tests for <see cref="SlackThreadBindingActor.EscapeQuoted"/> and
-/// <see cref="SlackThreadBindingActor.BuildAttachmentLine"/> covering
+/// Unit tests for <see cref="AttachmentIngressFormatting.EscapeQuoted"/> and
+/// <see cref="AttachmentIngressFormatting.BuildAttachmentLine"/> covering
 /// control-character sanitization and quote/backslash escaping.
 /// </summary>
 public sealed class SlackAttachmentLineTests
@@ -18,22 +18,22 @@ public sealed class SlackAttachmentLineTests
     [InlineData("inject\u0001\u0002control.pdf", "inject  control.pdf")]
     public void EscapeQuoted_normalizes_control_chars_to_spaces(string input, string expected)
     {
-        var result = SlackThreadBindingActor.EscapeQuoted(input);
+        var result = AttachmentIngressFormatting.EscapeQuoted(input);
         Assert.Equal(expected, result);
     }
 
     [Fact]
     public void EscapeQuoted_escapes_backslash_and_double_quote()
     {
-        Assert.Equal("has \\\"quotes\\\"", SlackThreadBindingActor.EscapeQuoted("has \"quotes\""));
-        Assert.Equal("has \\\\backslash", SlackThreadBindingActor.EscapeQuoted("has \\backslash"));
+        Assert.Equal("has \\\"quotes\\\"", AttachmentIngressFormatting.EscapeQuoted("has \"quotes\""));
+        Assert.Equal("has \\\\backslash", AttachmentIngressFormatting.EscapeQuoted("has \\backslash"));
     }
 
     [Fact]
     public void EscapeQuoted_passes_through_normal_text_unchanged()
     {
         const string plain = "report-Q4_2025 final.pdf";
-        Assert.Equal(plain, SlackThreadBindingActor.EscapeQuoted(plain));
+        Assert.Equal(plain, AttachmentIngressFormatting.EscapeQuoted(plain));
     }
 
     [Theory]
@@ -42,7 +42,7 @@ public sealed class SlackAttachmentLineTests
     public void BuildAttachmentLine_with_hostile_metadata_produces_single_parseable_line(
         string name, string mimeType, string? note)
     {
-        var line = SlackThreadBindingActor.BuildAttachmentLine(
+        var line = AttachmentIngressFormatting.BuildAttachmentLine(
             name: name,
             mimeType: mimeType,
             size: 1234,

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -1235,6 +1235,12 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
 
         Assert.Contains(_replyClient.PostedMessages,
             m => m.Text.Contains("Couldn't scan `drawing.png`", StringComparison.Ordinal));
+
+        var sessionId = new SessionId("D_FS/11000.1");
+        var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(sessionId, _paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(sessionId, _paths.SessionsDirectory);
+        Assert.Empty(Directory.GetFiles(inboxDir));
+        Assert.Empty(Directory.GetFiles(stagingDir));
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -104,6 +104,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
             httpClient,
             new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -187,6 +188,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
             httpClient,
             new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -322,6 +324,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
             httpClient,
             new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -387,6 +390,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
             httpClient,
             new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -493,6 +497,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
             httpClient,
             new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var profiles = ToolAudienceProfileDefaults.CreateProfiles();

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -169,7 +169,10 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
         Assert.Contains("can you help with this?", mergedText);
         Assert.Equal(1, CountOccurrences(mergedText, "can you help with this?"));
 
-        Assert.Contains("[image attachments:", mergedText);
+        Assert.Contains("[attachment]", mergedText, StringComparison.Ordinal);
+        Assert.Contains("screenshot.png", mergedText, StringComparison.Ordinal);
+        Assert.Contains("path=\"inbox/screenshot", mergedText, StringComparison.Ordinal);
+        Assert.Contains("inlined=\"true\"", mergedText, StringComparison.Ordinal);
         Assert.True(mergedUserTurn.Contents.OfType<DataContent>().Any(),
             "Expected merged user turn to include image DataContent from backfill");
     }

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -105,6 +105,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             httpClient,
             new NullContentScanner(),
             new NetclawPaths(Path.GetTempPath()),
+            ToolAudienceProfileDefaults.CreateProfiles(),
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -189,6 +191,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             httpClient,
             new NullContentScanner(),
             new NetclawPaths(Path.GetTempPath()),
+            ToolAudienceProfileDefaults.CreateProfiles(),
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -325,6 +329,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             httpClient,
             new NullContentScanner(),
             new NetclawPaths(Path.GetTempPath()),
+            ToolAudienceProfileDefaults.CreateProfiles(),
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -391,6 +397,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             httpClient,
             new NullContentScanner(),
             new NetclawPaths(Path.GetTempPath()),
+            ToolAudienceProfileDefaults.CreateProfiles(),
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
 
         var deps = new SlackGatewayDependencies(
@@ -459,6 +467,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
     {
         var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
         var httpClient = new HttpClient(_httpHandler);
+        var profiles = ToolAudienceProfileDefaults.CreateProfiles();
+        profiles.Public.ChannelAttachments = ToolAudienceProfileDefaults.CreatePublicChannelAttachments();
 
         var fetcher = new SlackThreadHistoryFetcher(
             (channelId, threadTs, limit, cursor, ct) =>
@@ -498,10 +508,9 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             httpClient,
             new NullContentScanner(),
             new NetclawPaths(Path.GetTempPath()),
+            profiles,
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
-
-        var profiles = ToolAudienceProfileDefaults.CreateProfiles();
-        profiles.Public.ChannelAttachments = ToolAudienceProfileDefaults.CreatePublicChannelAttachments();
 
         var deps = new SlackGatewayDependencies(
             Pipeline: pipeline,

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -26,6 +26,7 @@ public sealed class SlackThreadHistoryFetcherTests
         _options,
         new HttpClient(new FakeHttpHandler()),
         new NullContentScanner(),
+        new NetclawPaths(Path.GetTempPath()),
         NullLogger<SlackThreadHistoryFetcher>.Instance);
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -21,13 +21,19 @@ public sealed class SlackThreadHistoryFetcherTests
         BotToken = new SensitiveString("xoxb-test")
     };
 
-    private SlackThreadHistoryFetcher CreateFetcher() => new(
-        _replies.FetchAsync,
-        _options,
-        new HttpClient(new FakeHttpHandler()),
-        new NullContentScanner(),
-        new NetclawPaths(Path.GetTempPath()),
-        NullLogger<SlackThreadHistoryFetcher>.Instance);
+    private SlackThreadHistoryFetcher CreateFetcher(
+        HttpMessageHandler? handler = null,
+        IContentScanner? scanner = null,
+        ToolAudienceProfiles? profiles = null,
+        ModelCapabilities? modelCapabilities = null) => new(
+            _replies.FetchAsync,
+            _options,
+            new HttpClient(handler ?? new FakeHttpHandler()),
+            scanner ?? new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
+            profiles ?? ToolAudienceProfileDefaults.CreateProfiles(),
+            modelCapabilities ?? TestSlackGatewayDeps.DefaultVisionCapableModel,
+            NullLogger<SlackThreadHistoryFetcher>.Instance);
 
     [Fact]
     public async Task Fetches_text_messages_from_thread()
@@ -91,12 +97,9 @@ public sealed class SlackThreadHistoryFetcherTests
     }
 
     [Fact]
-    public async Task Historical_non_image_files_are_downloaded_and_included()
+    public async Task Historical_non_image_files_are_downloaded_and_announced_path_only()
     {
-        // Verify that PDFs and other non-image attachments in thread history are
-        // no longer hard-filtered to image/* — they should be downloaded and
-        // returned as DataContent just like images.
-        _replies.Set("C1", "2000.0", null, new ConversationMessagesResponse
+        _replies.Set("D1", "2000.0", null, new ConversationMessagesResponse
         {
             Messages =
             [
@@ -122,13 +125,99 @@ public sealed class SlackThreadHistoryFetcherTests
         });
 
         var result = await CreateFetcher().FetchThreadHistoryAsync(
-            new SessionId("C1/2000.0"), TestContext.Current.CancellationToken);
+            new SessionId("D1/2000.0"), TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.Count);
-        var messageWithPdf = result.First(r =>
-            r.Contents.OfType<DataContent>().Any());
-        Assert.Contains(messageWithPdf.Contents,
-            c => c is DataContent d && d.MediaType == "application/pdf");
+        var messageWithPdf = result.First(r => r.MessageId == "D1:2000.1");
+        Assert.DoesNotContain(messageWithPdf.Contents, c => c is DataContent);
+        var attachmentText = Assert.Single(
+            messageWithPdf.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("[attachment]", StringComparison.Ordinal));
+        Assert.Contains("report.pdf", attachmentText.Text, StringComparison.Ordinal);
+        Assert.Contains("inlined=\"false\"", attachmentText.Text, StringComparison.Ordinal);
+        Assert.Contains("path=\"inbox/report", attachmentText.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Historical_scan_failure_is_rejected_fail_closed()
+    {
+        _replies.Set("C1", "2100.0", null, new ConversationMessagesResponse
+        {
+            Messages =
+            [
+                new MessageEvent
+                {
+                    Ts = "2100.1",
+                    User = "U2",
+                    Text = "look at this",
+                    Files =
+                    [
+                        new SlackNet.File
+                        {
+                            Id = "F_IMG",
+                            Name = "photo.png",
+                            Mimetype = "image/png",
+                            Size = 3,
+                            UrlPrivateDownload = "https://files.slack.com/fake/photo.png"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var result = await CreateFetcher(scanner: new FailingContentScanner()).FetchThreadHistoryAsync(
+            new SessionId("C1/2100.0"), TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.DoesNotContain(item.Contents, c => c is DataContent);
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("attachment rejected", StringComparison.OrdinalIgnoreCase)
+              && t.Text.Contains("content scanning", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Historical_attachment_size_limit_uses_resolved_audience_policy()
+    {
+        var handler = new FakeHttpHandler();
+        var profiles = ToolAudienceProfileDefaults.CreateProfiles();
+        profiles.Public.ChannelAttachments = new ChannelAttachmentPolicy
+        {
+            AllowedCategories = [AttachmentCategory.Pdf],
+            MaxFileBytes = 1,
+            MaxFilesPerMessage = ChannelAttachmentPolicy.DefaultMaxFilesPerMessage
+        };
+
+        _replies.Set("C1", "2200.0", null, new ConversationMessagesResponse
+        {
+            Messages =
+            [
+                new MessageEvent
+                {
+                    Ts = "2200.1",
+                    User = "U2",
+                    Files =
+                    [
+                        new SlackNet.File
+                        {
+                            Id = "F_PDF",
+                            Name = "report.pdf",
+                            Mimetype = "application/pdf",
+                            Size = 3,
+                            UrlPrivateDownload = "https://files.slack.com/fake/report.pdf"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var result = await CreateFetcher(handler: handler, profiles: profiles).FetchThreadHistoryAsync(
+            new SessionId("C1/2200.0"), TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Equal(0, handler.RequestCount);
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("attachment rejected", StringComparison.OrdinalIgnoreCase)
+              && t.Text.Contains("per-file limit", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -161,13 +250,32 @@ public sealed class SlackThreadHistoryFetcherTests
 
     private sealed class FakeHttpHandler : HttpMessageHandler
     {
+        private int _requestCount;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref _requestCount);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent([1, 2, 3])
             });
+        }
+    }
+
+    private sealed class FailingContentScanner : IContentScanner
+    {
+        public Task<ContentScanResult> ScanAsync(
+            ReadOnlyMemory<byte> content,
+            string filename,
+            string declaredMimeType,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ContentScanResult.Rejected(
+                ContentScanError.ScanFailure,
+                "Content scan failed: scanner unavailable"));
         }
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -25,12 +25,13 @@ public sealed class SlackThreadHistoryFetcherTests
         HttpMessageHandler? handler = null,
         IContentScanner? scanner = null,
         ToolAudienceProfiles? profiles = null,
-        ModelCapabilities? modelCapabilities = null) => new(
+        ModelCapabilities? modelCapabilities = null,
+        NetclawPaths? paths = null) => new(
             _replies.FetchAsync,
             _options,
             new HttpClient(handler ?? new FakeHttpHandler()),
             scanner ?? new NullContentScanner(),
-            new NetclawPaths(Path.GetTempPath()),
+            paths ?? new NetclawPaths(Path.GetTempPath()),
             profiles ?? ToolAudienceProfileDefaults.CreateProfiles(),
             modelCapabilities ?? TestSlackGatewayDeps.DefaultVisionCapableModel,
             NullLogger<SlackThreadHistoryFetcher>.Instance);
@@ -176,6 +177,43 @@ public sealed class SlackThreadHistoryFetcherTests
     }
 
     [Fact]
+    public async Task Historical_inline_image_includes_attachment_line_and_data_content()
+    {
+        _replies.Set("D2", "2150.0", null, new ConversationMessagesResponse
+        {
+            Messages =
+            [
+                new MessageEvent
+                {
+                    Ts = "2150.1",
+                    User = "U2",
+                    Files =
+                    [
+                        new SlackNet.File
+                        {
+                            Id = "F_IMG",
+                            Name = "photo.png",
+                            Mimetype = "image/png",
+                            Size = 3,
+                            UrlPrivateDownload = "https://files.slack.com/fake/photo.png"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var result = await CreateFetcher().FetchThreadHistoryAsync(
+            new SessionId("D2/2150.0"), TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Contains(item.Contents, c => c is DataContent d && d.MediaType == "image/png");
+        Assert.Contains(item.Contents.OfType<TextContent>(),
+            t => t.Text.Contains("[attachment]", StringComparison.Ordinal)
+              && t.Text.Contains("photo.png", StringComparison.Ordinal)
+              && t.Text.Contains("inlined=\"true\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Historical_attachment_size_limit_uses_resolved_audience_policy()
     {
         var handler = new FakeHttpHandler();
@@ -218,6 +256,46 @@ public sealed class SlackThreadHistoryFetcherTests
         Assert.Contains(item.Contents.OfType<TextContent>(),
             t => t.Text.Contains("attachment rejected", StringComparison.OrdinalIgnoreCase)
               && t.Text.Contains("per-file limit", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Historical_attachment_reuse_skips_repeat_downloads()
+    {
+        var sessionsRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var handler = new FakeHttpHandler();
+
+        _replies.Set("D3", "2300.0", null, new ConversationMessagesResponse
+        {
+            Messages =
+            [
+                new MessageEvent
+                {
+                    Ts = "2300.1",
+                    User = "U2",
+                    Files =
+                    [
+                        new SlackNet.File
+                        {
+                            Id = "F_REUSE",
+                            Name = "reuse.png",
+                            Mimetype = "image/png",
+                            Size = 3,
+                            UrlPrivateDownload = "https://files.slack.com/fake/reuse.png"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        var fetcher = CreateFetcher(handler: handler, paths: new NetclawPaths(sessionsRoot));
+        var sessionId = new SessionId("D3/2300.0");
+
+        var first = await fetcher.FetchThreadHistoryAsync(sessionId, TestContext.Current.CancellationToken);
+        var second = await fetcher.FetchThreadHistoryAsync(sessionId, TestContext.Current.CancellationToken);
+
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Equal(1, handler.RequestCount);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Protocol/InboxWriter.cs
+++ b/src/Netclaw.Actors/Protocol/InboxWriter.cs
@@ -135,4 +135,21 @@ public static class InboxWriter
         await WriteAtomicAsync(targetPath, bytes, ct).ConfigureAwait(false);
         return targetPath;
     }
+
+    /// <summary>
+    /// Moves an existing temp file into the inbox with filename sanitization
+    /// and collision resolution. Used by the streaming download path where the
+    /// file is already fully written to a temp path in the same directory.
+    /// The move is an atomic rename (same filesystem guaranteed by caller).
+    /// </summary>
+    public static string SanitizeReserveAndMove(
+        string inboxDir,
+        string rawFilename,
+        string sourceTempPath)
+    {
+        var safeName = FilenameSanitizer.Sanitize(rawFilename);
+        var targetPath = ReserveUniquePath(inboxDir, safeName);
+        File.Move(sourceTempPath, targetPath);
+        return targetPath;
+    }
 }

--- a/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
@@ -7,6 +7,13 @@ namespace Netclaw.Actors.Protocol;
 public static class SessionDirectoryHelper
 {
     /// <summary>
+    /// Name of the hidden root directory under the sessions base path where
+    /// attachments are staged before they pass content scanning and are moved
+    /// into the agent-visible session inbox.
+    /// </summary>
+    public const string AttachmentStagingRootSubdirectory = ".attachment-staging";
+
+    /// <summary>
     /// Name of the subdirectory under a session directory where inbound
     /// user-uploaded attachments are written by channel adapters.
     /// </summary>
@@ -40,6 +47,20 @@ public static class SessionDirectoryHelper
         var inboxDir = Path.Combine(sessionDir, InboxSubdirectory);
         Directory.CreateDirectory(inboxDir);
         return inboxDir;
+    }
+
+    /// <summary>
+    /// Computes and creates the hidden per-session staging directory used for
+    /// streamed attachment downloads before they are accepted into
+    /// <c>inbox/</c>. This directory lives outside the session working
+    /// directory so rejected files never appear under <c>{session_dir}</c>.
+    /// </summary>
+    public static string GetOrCreateAttachmentStagingDirectory(SessionId sessionId, string basePath)
+    {
+        var stagingRoot = Path.Combine(basePath, AttachmentStagingRootSubdirectory);
+        var stagingDir = Path.Combine(stagingRoot, SanitizeSessionId(sessionId.Value));
+        Directory.CreateDirectory(stagingDir);
+        return stagingDir;
     }
 
     /// <summary>

--- a/src/Netclaw.Channels.Discord/DiscordAttachmentUrlTrust.cs
+++ b/src/Netclaw.Channels.Discord/DiscordAttachmentUrlTrust.cs
@@ -1,0 +1,10 @@
+namespace Netclaw.Channels.Discord;
+
+internal static class DiscordAttachmentUrlTrust
+{
+    public static bool IsAllowedAttachmentDomain(string url)
+    {
+        return url.StartsWith("https://cdn.discordapp.com/", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("https://media.discordapp.net/", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
+using Netclaw.Channels;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -427,46 +428,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static List<AIContent> MergeHistoryWithLiveContents(
         IReadOnlyList<ChannelInput> history,
         IReadOnlyList<AIContent> liveContents)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("[thread history — messages exchanged before this inbound event]");
-        sb.AppendLine();
-
-        foreach (var item in history)
-        {
-            var ts = item.ReceivedAt == default ? string.Empty : $", {item.ReceivedAt:yyyy-MM-dd HH:mm} UTC";
-            sb.AppendLine($"<user: {item.SenderId}{ts}>");
-
-            foreach (var content in item.Contents)
-            {
-                if (content is TextContent text && !string.IsNullOrWhiteSpace(text.Text))
-                    sb.AppendLine(text.Text);
-            }
-
-            sb.AppendLine();
-        }
-
-        sb.AppendLine("[end thread history]");
-
-        var liveText = string.Join("\n", liveContents
-            .OfType<TextContent>()
-            .Select(t => t.Text)
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
-
-        var mergedText = string.IsNullOrWhiteSpace(liveText)
-            ? sb.ToString()
-            : $"{sb}\n\n{liveText}";
-
-        var merged = new List<AIContent> { new TextContent(mergedText) };
-
-        foreach (var content in liveContents)
-        {
-            if (content is not TextContent)
-                merged.Add(content);
-        }
-
-        return merged;
-    }
+        => ThreadHistoryContentMerger.MergeHistoryWithLiveContents(history, liveContents);
 
     private async Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message, string selectedKey)
     {
@@ -897,11 +859,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         var rejections = new List<string>();
 
         var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(_sessionId, _dependencies.Paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(_sessionId, _dependencies.Paths.SessionsDirectory);
 
         foreach (var file in files)
         {
             var attachmentResult = await TryIngestSingleAttachmentAsync(
-                file, audience, policy, inlineImages, inboxDir, cancellationToken);
+                file, audience, policy, inlineImages, inboxDir, stagingDir, cancellationToken);
 
             switch (attachmentResult)
             {
@@ -938,6 +901,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         ChannelAttachmentPolicy policy,
         bool inlineImages,
         string inboxDir,
+        string stagingDir,
         CancellationToken cancellationToken)
     {
         var category = AttachmentCategories.FromMime(file.MimeType);
@@ -961,7 +925,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 $"`{file.Name}` ({FormatBytes(file.Size)}) exceeds the {FormatBytes(policy.MaxFileBytes)} per-file limit.");
         }
 
-        if (!IsAllowedAttachmentDomain(file.Url))
+        if (!DiscordAttachmentUrlTrust.IsAllowedAttachmentDomain(file.Url))
         {
             _log.Warning(
                 "discord_attachment_rejected name={Name} url={Url} reason=untrusted-domain",
@@ -977,7 +941,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             downloadCts.CancelAfter(OperationTimeout);
             downloadResult = await StreamingAttachmentDownloader.DownloadToFileAsync(
                 _dependencies.HttpClient!, file.Url, configureRequest: null,
-                inboxDir, policy.MaxFileBytes, downloadCts.Token);
+                stagingDir, policy.MaxFileBytes, downloadCts.Token,
+                (ex, path) => _log.Error(ex, "Failed to clean up staged download file {0}", path));
         }
         catch (AttachmentTooLargeException ex)
         {
@@ -1017,8 +982,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         ContentScanResult scanResult;
         try
         {
+            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            scanCts.CancelAfter(OperationTimeout);
             scanResult = await _dependencies.ContentScanner.ScanFileAsync(
-                downloadResult.FilePath, file.Name, file.MimeType, cancellationToken);
+                downloadResult.FilePath, file.Name, file.MimeType, scanCts.Token);
         }
         catch (Exception ex)
         {
@@ -1073,10 +1040,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 $"Couldn't save `{file.Name}` — please try again later.");
         }
 
-        var (inlined, note) = ResolveInlineDecision(category, inlineImages);
+        var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
 
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{IOPath.GetFileName(inboxPath)}";
-        var line = BuildAttachmentLine(file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
+        var line = AttachmentIngressFormatting.BuildAttachmentLine(
+            file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
 
         DataContent? inlineContent = null;
         if (inlined)
@@ -1101,89 +1069,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
         catch (Exception ex)
         {
-            _log.Debug(ex, "Failed to clean up temp download file {Path}", tempPath);
+            _log.Error(ex, "Failed to clean up staged attachment file {Path}", tempPath);
         }
     }
 
-    private static (bool Inlined, string? Note) ResolveInlineDecision(
-        AttachmentCategory category,
-        bool inlineImages)
-    {
-        return category switch
-        {
-            AttachmentCategory.Image when inlineImages => (true, null),
-            AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
-            AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
-            _ => (false, AttachmentNotes.FormatNotInlineable)
-        };
-    }
-
-    internal static string BuildAttachmentLine(
-        string name,
-        string mimeType,
-        long size,
-        string relativePath,
-        bool inlined,
-        string? note)
-    {
-        var inlinedWire = inlined ? "true" : "false";
-        var sb = new StringBuilder(128);
-        sb.Append("[attachment] name=\"").Append(EscapeQuoted(name)).Append('"');
-        sb.Append(" mime=\"").Append(EscapeQuoted(mimeType)).Append('"');
-        sb.Append(" size=").Append(size);
-        sb.Append(" path=\"").Append(EscapeQuoted(relativePath)).Append('"');
-        sb.Append(" inlined=\"").Append(inlinedWire).Append('"');
-        if (!string.IsNullOrEmpty(note))
-            sb.Append(" note=\"").Append(EscapeQuoted(note)).Append('"');
-        return sb.ToString();
-    }
-
-    internal static string EscapeQuoted(string value)
-    {
-        var needsProcessing = false;
-        foreach (var c in value)
-        {
-            if (c < ' ' || c == '\\' || c == '"')
-            {
-                needsProcessing = true;
-                break;
-            }
-        }
-
-        if (!needsProcessing)
-            return value;
-
-        var sb = new StringBuilder(value.Length + 8);
-        foreach (var c in value)
-        {
-            if (c < ' ')
-                sb.Append(' ');
-            else if (c == '\\')
-                sb.Append("\\\\");
-            else if (c == '"')
-                sb.Append("\\\"");
-            else
-                sb.Append(c);
-        }
-        return sb.ToString();
-    }
-
-    private static bool IsAllowedAttachmentDomain(string url)
-    {
-        return url.StartsWith("https://cdn.discordapp.com/", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("https://media.discordapp.net/", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string FormatBytes(long size)
-    {
-        const long Mib = 1024 * 1024;
-        const long Kib = 1024;
-        if (size >= Mib)
-            return $"{size / (double)Mib:F1} MiB";
-        if (size >= Kib)
-            return $"{size / (double)Kib:F1} KiB";
-        return $"{size} bytes";
-    }
+    private static string FormatBytes(long size) => AttachmentIngressFormatting.FormatBytes(size);
 
     private abstract record AttachmentIngestResult
     {

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -931,12 +931,22 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 $"`{file.Name}` has an untrusted URL domain and was skipped.");
         }
 
-        ReadOnlyMemory<byte> bytes;
+        AttachmentDownloadResult downloadResult;
         try
         {
             using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             downloadCts.CancelAfter(OperationTimeout);
-            bytes = await _dependencies.HttpClient!.GetByteArrayAsync(file.Url, downloadCts.Token);
+            downloadResult = await StreamingAttachmentDownloader.DownloadToFileAsync(
+                _dependencies.HttpClient!, file.Url, configureRequest: null,
+                inboxDir, policy.MaxFileBytes, downloadCts.Token);
+        }
+        catch (AttachmentTooLargeException ex)
+        {
+            _log.Warning(
+                "discord_attachment_rejected name={Name} mime={Mime} audience={Audience} size={Size} limit={Limit} reason=too-large-during-download",
+                file.Name, file.MimeType, audience, ex.BytesReceived, ex.MaxBytes);
+            return new AttachmentIngestResult.Rejected(
+                $"`{file.Name}` ({FormatBytes(ex.BytesReceived)}) exceeds the {FormatBytes(ex.MaxBytes)} per-file limit.");
         }
         catch (OperationCanceledException ex)
         {
@@ -955,11 +965,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 $"Couldn't download `{file.Name}` — please try again later.");
         }
 
-        if (bytes.Length == 0)
+        if (downloadResult.BytesWritten == 0)
         {
             _log.Warning(
                 "discord_attachment_rejected name={Name} mime={Mime} reason=empty-download",
                 file.Name, file.MimeType);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"`{file.Name}` downloaded as zero bytes.");
         }
@@ -967,16 +978,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         ContentScanResult scanResult;
         try
         {
-            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            scanCts.CancelAfter(OperationTimeout);
-            scanResult = await _dependencies.ContentScanner.ScanAsync(
-                bytes, file.Name, file.MimeType, scanCts.Token);
+            scanResult = await _dependencies.ContentScanner.ScanFileAsync(
+                downloadResult.FilePath, file.Name, file.MimeType, cancellationToken);
         }
         catch (Exception ex)
         {
             _log.Warning(ex,
                 "discord_attachment_rejected name={Name} mime={Mime} reason=scan-exception",
                 file.Name, file.MimeType);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Couldn't scan `{file.Name}` — please try again later.");
         }
@@ -986,6 +996,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _log.Warning(
                 "discord_attachment_rejected name={Name} mime={Mime} reason=scan-blocked error={ScanError} message={ScanMessage}",
                 file.Name, file.MimeType, scanResult.Error?.ToString(), scanResult.Message ?? scanResult.Error?.ToString());
+
+            TryDeleteTemp(downloadResult.FilePath);
 
             if (scanResult.Error == ContentScanError.ScanFailure)
             {
@@ -1000,14 +1012,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         string inboxPath;
         try
         {
-            inboxPath = await InboxWriter.SanitizeReserveAndWriteAsync(
-                inboxDir, file.Name, bytes, cancellationToken);
+            inboxPath = InboxWriter.SanitizeReserveAndMove(
+                inboxDir, file.Name, downloadResult.FilePath);
         }
         catch (InboxWriter.CollisionExhaustedException ex)
         {
             _log.Warning(ex,
                 "discord_attachment_rejected name={Name} reason=collision-exhausted",
                 file.Name);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Too many attachments named `{file.Name}` in this session — please rename and try again.");
         }
@@ -1016,6 +1029,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             _log.Error(ex,
                 "discord_attachment_rejected name={Name} reason=inbox-write-failed",
                 file.Name);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Couldn't save `{file.Name}` — please try again later.");
         }
@@ -1023,17 +1037,33 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         var (inlined, note) = ResolveInlineDecision(category, inlineImages);
 
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{IOPath.GetFileName(inboxPath)}";
-        var line = BuildAttachmentLine(file.Name, file.MimeType, bytes.Length, relativePath, inlined, note);
+        var line = BuildAttachmentLine(file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
 
         DataContent? inlineContent = null;
         if (inlined)
-            inlineContent = new DataContent(bytes, file.MimeType);
+        {
+            var inlineBytes = await File.ReadAllBytesAsync(inboxPath, cancellationToken);
+            inlineContent = new DataContent(inlineBytes, file.MimeType);
+        }
 
         _log.Info(
             "discord_attachment_accepted name={Name} mime={Mime} size={Size} audience={Audience} category={Category} inlined={Inlined}",
-            file.Name, file.MimeType, bytes.Length, audience, category, inlined);
+            file.Name, file.MimeType, downloadResult.BytesWritten, audience, category, inlined);
 
         return new AttachmentIngestResult.Accepted(line, inlineContent);
+    }
+
+    private void TryDeleteTemp(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to clean up temp download file {Path}", tempPath);
+        }
     }
 
     private static (bool Inlined, string? Note) ResolveInlineDecision(

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -95,7 +95,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
             return [];
         }
 
-        var audienceResult = ResolveHistoricalAudience(channelId);
+        var audienceResult = ResolveHistoricalAudience(channelId, threadOrMessageId);
         if (audienceResult.Error is { } audienceError)
         {
             _logger.LogWarning(
@@ -402,18 +402,18 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         return [line, new DataContent(bytes, mimeType)];
     }
 
-    private AudienceResult ResolveHistoricalAudience(DiscordChannelId channelId)
+    private AudienceResult ResolveHistoricalAudience(
+        DiscordChannelId channelId,
+        DiscordThreadOrMessageId threadOrMessageId)
     {
-        var isDefaultChannel = !string.IsNullOrWhiteSpace(_options.DefaultChannelId)
-            && string.Equals(channelId.Value, _options.DefaultChannelId, StringComparison.Ordinal);
         var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
-        var isDirectMessage = !isDefaultChannel && !isExplicitChannel && _options.AllowDirectMessages;
+        var isDirectMessage = string.Equals(channelId.Value, threadOrMessageId.Value, StringComparison.Ordinal);
         var syntheticMessage = new DiscordGatewayMessage(
             EventId: new DiscordEventId($"history-{channelId.Value}"),
             ChannelId: channelId,
-            ReplyChannelId: new DiscordReplyChannelId(channelId.Value),
+            ReplyChannelId: new DiscordReplyChannelId(threadOrMessageId.Value),
             MessageId: new DiscordMessageId($"history-{channelId.Value}"),
-            ThreadOrMessageId: new DiscordThreadOrMessageId($"history-{channelId.Value}"),
+            ThreadOrMessageId: threadOrMessageId,
             RootMessageId: null,
             SenderId: new DiscordUserId("history"),
             IsBotMessage: false,

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -126,6 +126,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
 
                 var input = await ConvertMessageAsync(
                     message,
+                    channelId,
                     threadChannelId,
                     audience,
                     attachmentPolicy,
@@ -149,6 +150,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
 
     private async Task<ChannelInput?> ConvertMessageAsync(
         HistoricalMessage message,
+        DiscordChannelId channelId,
         ulong threadChannelId,
         TrustAudience audience,
         ChannelAttachmentPolicy attachmentPolicy,
@@ -178,6 +180,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
             else
             {
                 var attachmentTasks = message.Attachments.Select(file => DownloadAndProjectAttachmentAsync(
+                    message.MessageId,
                     file,
                     audience,
                     attachmentPolicy,
@@ -198,7 +201,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         return new ChannelInput
         {
             SenderId = message.SenderId,
-            ChannelId = threadChannelId.ToString(),
+            ChannelId = channelId.Value,
             MessageId = message.MessageId,
             Audience = audience,
             Principal = PrincipalClassification.UntrustedExternal,
@@ -215,6 +218,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
     }
 
     private async Task<IReadOnlyList<AIContent>> DownloadAndProjectAttachmentAsync(
+        string messageId,
         DiscordFileReference file,
         TrustAudience audience,
         ChannelAttachmentPolicy policy,
@@ -224,6 +228,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         CancellationToken cancellationToken)
     {
         var category = AttachmentCategories.FromMime(file.MimeType);
+        var sourceKey = BuildHistoricalAttachmentSourceKey(messageId, file);
 
         if (!policy.Allows(category))
         {
@@ -246,6 +251,16 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
             return [BuildHistoricalAttachmentRejected(
                 $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" exceeds the {AttachmentIngressFormatting.FormatBytes(policy.MaxFileBytes)} per-file limit")];
         }
+
+        if (HistoricalAttachmentInbox.TryGetExistingFile(inboxDir, file.Name, sourceKey, out var existingPath, out var existingSize))
+            return await BuildAcceptedAttachmentContentsAsync(
+                existingPath,
+                file.Name,
+                file.MimeType,
+                category,
+                inlineImages,
+                existingSize,
+                cancellationToken);
 
         if (!DiscordAttachmentUrlTrust.IsAllowedAttachmentDomain(file.Url))
         {
@@ -335,7 +350,11 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         string inboxPath;
         try
         {
-            inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, file.Name, downloadResult.FilePath);
+            inboxPath = HistoricalAttachmentInbox.PromoteOrReuse(
+                inboxDir,
+                file.Name,
+                sourceKey,
+                downloadResult.FilePath);
         }
         catch (Exception ex)
         {
@@ -345,29 +364,50 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
                 $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" could not be saved to the session inbox")];
         }
 
+        return await BuildAcceptedAttachmentContentsAsync(
+            inboxPath,
+            file.Name,
+            file.MimeType,
+            category,
+            inlineImages,
+            downloadResult.BytesWritten,
+            cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<AIContent>> BuildAcceptedAttachmentContentsAsync(
+        string inboxPath,
+        string filename,
+        string mimeType,
+        AttachmentCategory category,
+        bool inlineImages,
+        long size,
+        CancellationToken cancellationToken)
+    {
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
         var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
+        var line = new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
+            filename,
+            mimeType,
+            size,
+            relativePath,
+            inlined,
+            note));
+
         if (!inlined)
         {
-            return
-            [
-                new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
-                    file.Name,
-                    file.MimeType,
-                    downloadResult.BytesWritten,
-                    relativePath,
-                    false,
-                    note))
-            ];
+            return [line];
         }
 
         var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
-        return [new DataContent(bytes, file.MimeType)];
+        return [line, new DataContent(bytes, mimeType)];
     }
 
     private AudienceResult ResolveHistoricalAudience(DiscordChannelId channelId)
     {
+        var isDefaultChannel = !string.IsNullOrWhiteSpace(_options.DefaultChannelId)
+            && string.Equals(channelId.Value, _options.DefaultChannelId, StringComparison.Ordinal);
         var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
+        var isDirectMessage = !isDefaultChannel && !isExplicitChannel && _options.AllowDirectMessages;
         var syntheticMessage = new DiscordGatewayMessage(
             EventId: new DiscordEventId($"history-{channelId.Value}"),
             ChannelId: channelId,
@@ -377,7 +417,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
             RootMessageId: null,
             SenderId: new DiscordUserId("history"),
             IsBotMessage: false,
-            IsDirectMessage: false,
+            IsDirectMessage: isDirectMessage,
             ContainsBotMention: false,
             Text: string.Empty,
             ReceivedAt: TimeProvider.System.GetUtcNow());
@@ -465,4 +505,7 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
 
     private static TextContent BuildHistoricalAttachmentRejected(string detail)
         => new($"[attachment rejected: {detail}]");
+
+    private static string BuildHistoricalAttachmentSourceKey(string messageId, DiscordFileReference file)
+        => $"discord:{messageId}:{file.Url}";
 }

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -4,22 +4,78 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels;
 using Netclaw.Configuration;
+using Netclaw.Security;
+using IOFile = System.IO.File;
 
 namespace Netclaw.Channels.Discord.Transport;
 
 public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
 {
     private const int MaxMessages = 200;
+    private static readonly TimeSpan FileDownloadTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ContentScanTimeout = TimeSpan.FromSeconds(5);
 
-    private readonly DiscordSocketClient _client;
+    internal sealed record HistoricalMessage(
+        string MessageId,
+        string SenderId,
+        bool IsBot,
+        string Text,
+        DateTimeOffset Timestamp,
+        IReadOnlyList<DiscordFileReference> Attachments);
+
+    internal delegate Task<IReadOnlyList<HistoricalMessage>> MessageFetcher(
+        ulong threadChannelId,
+        CancellationToken cancellationToken);
+
+    private readonly MessageFetcher _messageFetcher;
+    private readonly DiscordChannelOptions _options;
+    private readonly HttpClient _httpClient;
+    private readonly IContentScanner _contentScanner;
+    private readonly ToolAudienceProfiles _audienceProfiles;
+    private readonly ModelCapabilities _modelCapabilities;
+    private readonly NetclawPaths _paths;
     private readonly ILogger<DiscordThreadHistoryFetcher> _logger;
 
     public DiscordThreadHistoryFetcher(
         DiscordSocketClient client,
+        DiscordChannelOptions options,
+        HttpClient httpClient,
+        IContentScanner contentScanner,
+        ToolAudienceProfiles audienceProfiles,
+        ModelCapabilities modelCapabilities,
+        NetclawPaths paths,
+        ILogger<DiscordThreadHistoryFetcher> logger)
+        : this(
+            (threadChannelId, cancellationToken) => FetchRawMessagesAsync(client, threadChannelId, cancellationToken, logger),
+            options,
+            httpClient,
+            contentScanner,
+            audienceProfiles,
+            modelCapabilities,
+            paths,
+            logger)
+    {
+    }
+
+    internal DiscordThreadHistoryFetcher(
+        MessageFetcher messageFetcher,
+        DiscordChannelOptions options,
+        HttpClient httpClient,
+        IContentScanner contentScanner,
+        ToolAudienceProfiles audienceProfiles,
+        ModelCapabilities modelCapabilities,
+        NetclawPaths paths,
         ILogger<DiscordThreadHistoryFetcher> logger)
     {
-        _client = client;
+        _messageFetcher = messageFetcher;
+        _options = options;
+        _httpClient = httpClient;
+        _contentScanner = contentScanner;
+        _audienceProfiles = audienceProfiles;
+        _modelCapabilities = modelCapabilities;
+        _paths = paths;
         _logger = logger;
     }
 
@@ -27,22 +83,62 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         SessionId sessionId,
         CancellationToken cancellationToken = default)
     {
-        var parts = sessionId.Value.Split('/', 2);
-        if (parts.Length != 2)
+        if (!DiscordGatewayActor.TryParseDiscordSessionId(sessionId, out var channelId, out var threadOrMessageId))
         {
             _logger.LogWarning("Cannot extract channel/thread from session ID {SessionId}", sessionId.Value);
             return [];
         }
 
-        if (!ulong.TryParse(parts[1], out var threadChannelId))
+        if (!ulong.TryParse(threadOrMessageId.Value, out var threadChannelId))
         {
             _logger.LogWarning("Thread portion of session ID is not a valid snowflake: {SessionId}", sessionId.Value);
             return [];
         }
 
+        var audienceResult = ResolveHistoricalAudience(channelId);
+        if (audienceResult.Error is { } audienceError)
+        {
+            _logger.LogWarning(
+                "Invalid Discord audience configuration while fetching history for {SessionId}: {Error}",
+                sessionId.Value,
+                audienceError);
+            return [];
+        }
+
+        var audience = audienceResult.Audience;
+        var profile = ToolAudienceProfileDefaults.GetResolvedProfile(_audienceProfiles, audience);
+        var attachmentPolicy = profile.ChannelAttachments ?? ChannelAttachmentPolicy.Empty;
+        var inlineImages = _modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
+        var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(sessionId, _paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(sessionId, _paths.SessionsDirectory);
+
         try
         {
-            return await FetchMessagesAsync(threadChannelId, cancellationToken);
+            var history = await _messageFetcher(threadChannelId, cancellationToken);
+            var results = new List<ChannelInput>(history.Count);
+
+            foreach (var message in history)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (message.IsBot)
+                    continue;
+
+                var input = await ConvertMessageAsync(
+                    message,
+                    threadChannelId,
+                    audience,
+                    attachmentPolicy,
+                    inlineImages,
+                    inboxDir,
+                    stagingDir,
+                    cancellationToken);
+                if (input is not null)
+                    results.Add(input);
+            }
+
+            _logger.LogInformation("Fetched {Count} thread history messages for thread {ThreadId}", results.Count, threadChannelId);
+            return results;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -51,23 +147,263 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
         }
     }
 
-    private async Task<IReadOnlyList<ChannelInput>> FetchMessagesAsync(
+    private async Task<ChannelInput?> ConvertMessageAsync(
+        HistoricalMessage message,
         ulong threadChannelId,
+        TrustAudience audience,
+        ChannelAttachmentPolicy attachmentPolicy,
+        bool inlineImages,
+        string inboxDir,
+        string stagingDir,
         CancellationToken cancellationToken)
     {
-        var channel = _client.GetChannel(threadChannelId) as IMessageChannel;
+        var contents = new List<AIContent>();
+
+        if (!string.IsNullOrWhiteSpace(message.Text))
+            contents.Add(new TextContent(message.Text));
+
+        if (message.Attachments.Count > 0)
+        {
+            if (message.Attachments.Count > attachmentPolicy.MaxFilesPerMessage)
+            {
+                _logger.LogWarning(
+                    "Skipping {Count} historical Discord attachments on thread {ThreadId}; limit is {Limit} for audience {Audience}",
+                    message.Attachments.Count,
+                    threadChannelId,
+                    attachmentPolicy.MaxFilesPerMessage,
+                    audience);
+                contents.Add(BuildHistoricalAttachmentRejected(
+                    $"{message.Attachments.Count} historical attachments exceed the {attachmentPolicy.MaxFilesPerMessage} per-message limit"));
+            }
+            else
+            {
+                var attachmentTasks = message.Attachments.Select(file => DownloadAndProjectAttachmentAsync(
+                    file,
+                    audience,
+                    attachmentPolicy,
+                    inlineImages,
+                    inboxDir,
+                    stagingDir,
+                    cancellationToken));
+                var attachmentResults = await Task.WhenAll(attachmentTasks);
+
+                foreach (var result in attachmentResults)
+                    contents.AddRange(result);
+            }
+        }
+
+        if (contents.Count == 0)
+            return null;
+
+        return new ChannelInput
+        {
+            SenderId = message.SenderId,
+            ChannelId = threadChannelId.ToString(),
+            MessageId = message.MessageId,
+            Audience = audience,
+            Principal = PrincipalClassification.UntrustedExternal,
+            Provenance = new SourceProvenance
+            {
+                TransportAuthenticity = TransportAuthenticity.Verified,
+                PayloadTaint = PayloadTaint.Public,
+                SourceKind = "discord",
+                SourceScope = threadChannelId.ToString()
+            },
+            Contents = contents,
+            ReceivedAt = message.Timestamp
+        };
+    }
+
+    private async Task<IReadOnlyList<AIContent>> DownloadAndProjectAttachmentAsync(
+        DiscordFileReference file,
+        TrustAudience audience,
+        ChannelAttachmentPolicy policy,
+        bool inlineImages,
+        string inboxDir,
+        string stagingDir,
+        CancellationToken cancellationToken)
+    {
+        var category = AttachmentCategories.FromMime(file.MimeType);
+
+        if (!policy.Allows(category))
+        {
+            _logger.LogWarning(
+                "Historical Discord attachment {Name} rejected: category {Category} not allowed for {Audience}",
+                file.Name,
+                category,
+                audience);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment ({file.MimeType}) category not allowed in {audience}")];
+        }
+
+        if (file.Size > policy.MaxFileBytes)
+        {
+            _logger.LogWarning(
+                "Historical Discord attachment {Name} rejected: size {Size} exceeds {Limit}",
+                file.Name,
+                file.Size,
+                policy.MaxFileBytes);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" exceeds the {AttachmentIngressFormatting.FormatBytes(policy.MaxFileBytes)} per-file limit")];
+        }
+
+        if (!DiscordAttachmentUrlTrust.IsAllowedAttachmentDomain(file.Url))
+        {
+            _logger.LogWarning(
+                "Historical Discord attachment {Name} rejected: untrusted domain {Url}",
+                file.Name,
+                file.Url);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" has an untrusted download URL")];
+        }
+
+        AttachmentDownloadResult downloadResult;
+        try
+        {
+            using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            downloadCts.CancelAfter(FileDownloadTimeout);
+            downloadResult = await StreamingAttachmentDownloader.DownloadToFileAsync(
+                _httpClient,
+                file.Url,
+                configureRequest: null,
+                stagingDir,
+                policy.MaxFileBytes,
+                downloadCts.Token,
+                (ex, path) => _logger.LogError(ex, "Failed to clean up staged download file {Path}", path));
+        }
+        catch (AttachmentTooLargeException ex)
+        {
+            _logger.LogWarning(
+                "Historical Discord attachment {Name} rejected during download: {Size} exceeds {Limit}",
+                file.Name,
+                ex.BytesReceived,
+                ex.MaxBytes);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" exceeded the {AttachmentIngressFormatting.FormatBytes(ex.MaxBytes)} per-file limit during download")];
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Timed out downloading historical Discord attachment {Name}", file.Name);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" timed out during download")];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed downloading historical Discord attachment {Name}", file.Name);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" could not be downloaded")];
+        }
+
+        if (downloadResult.BytesWritten == 0)
+        {
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" downloaded as zero bytes")];
+        }
+
+        ContentScanResult scanResult;
+        try
+        {
+            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            scanCts.CancelAfter(ContentScanTimeout);
+            scanResult = await _contentScanner.ScanFileAsync(
+                downloadResult.FilePath,
+                file.Name,
+                file.MimeType,
+                scanCts.Token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Historical Discord attachment scan threw for {Name}", file.Name);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" could not be scanned")];
+        }
+
+        if (!scanResult.IsAllowed)
+        {
+            _logger.LogWarning(
+                "Historical Discord attachment {Name} rejected by scanner: {Error} {Message}",
+                file.Name,
+                scanResult.Error?.ToString(),
+                scanResult.Message ?? string.Empty);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" was rejected by content scanning: {AttachmentIngressFormatting.EscapeQuoted(scanResult.Message ?? scanResult.Error?.ToString() ?? "unknown error")}")];
+        }
+
+        string inboxPath;
+        try
+        {
+            inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, file.Name, downloadResult.FilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to promote historical Discord attachment {Name} into inbox", file.Name);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(file.Name)}\" could not be saved to the session inbox")];
+        }
+
+        var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
+        var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
+        if (!inlined)
+        {
+            return
+            [
+                new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
+                    file.Name,
+                    file.MimeType,
+                    downloadResult.BytesWritten,
+                    relativePath,
+                    false,
+                    note))
+            ];
+        }
+
+        var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
+        return [new DataContent(bytes, file.MimeType)];
+    }
+
+    private AudienceResult ResolveHistoricalAudience(DiscordChannelId channelId)
+    {
+        var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
+        var syntheticMessage = new DiscordGatewayMessage(
+            EventId: new DiscordEventId($"history-{channelId.Value}"),
+            ChannelId: channelId,
+            ReplyChannelId: new DiscordReplyChannelId(channelId.Value),
+            MessageId: new DiscordMessageId($"history-{channelId.Value}"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId($"history-{channelId.Value}"),
+            RootMessageId: null,
+            SenderId: new DiscordUserId("history"),
+            IsBotMessage: false,
+            IsDirectMessage: false,
+            ContainsBotMention: false,
+            Text: string.Empty,
+            ReceivedAt: TimeProvider.System.GetUtcNow());
+
+        return DiscordAclPolicy.ResolveAudience(
+            syntheticMessage,
+            _options,
+            isExplicitUser: false,
+            isExplicitChannel: isExplicitChannel);
+    }
+
+    private static async Task<IReadOnlyList<HistoricalMessage>> FetchRawMessagesAsync(
+        DiscordSocketClient client,
+        ulong threadChannelId,
+        CancellationToken cancellationToken,
+        ILogger logger)
+    {
+        var channel = client.GetChannel(threadChannelId) as IMessageChannel;
         if (channel is null)
         {
-            _logger.LogWarning("Discord channel {ChannelId} not found or is not a message channel", threadChannelId);
+            logger.LogWarning("Discord channel {ChannelId} not found or is not a message channel", threadChannelId);
             return [];
         }
 
-        var results = new List<ChannelInput>();
+        var results = new List<HistoricalMessage>();
 
-        // Discord threads are separate channels — GetMessagesAsync only returns
-        // messages posted IN the thread, not the parent message that started it.
-        // The thread channel ID equals the parent message's snowflake, so fetch
-        // that message from the parent channel and prepend it to the history.
         if (channel is SocketThreadChannel threadChannel)
         {
             var parentChannel = threadChannel.ParentChannel as IMessageChannel;
@@ -79,15 +415,12 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
                         threadChannelId,
                         options: new RequestOptions { CancelToken = cancellationToken });
 
-                    if (rootMessage is not null && !rootMessage.Author.IsBot
-                        && !string.IsNullOrWhiteSpace(rootMessage.Content))
-                    {
-                        results.Add(ToChannelInput(rootMessage, threadChannelId));
-                    }
+                    if (rootMessage is not null && !rootMessage.Author.IsBot && HasUsableContent(rootMessage))
+                        results.Add(ToHistoricalMessage(rootMessage));
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    _logger.LogWarning(ex, "Failed to fetch root message for thread {ThreadId}", threadChannelId);
+                    logger.LogWarning(ex, "Failed to fetch root message for thread {ThreadId}", threadChannelId);
                 }
             }
         }
@@ -103,31 +436,33 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
             if (message.Author.IsBot)
                 continue;
 
-            if (string.IsNullOrWhiteSpace(message.Content))
+            if (!HasUsableContent(message))
                 continue;
 
-            results.Add(ToChannelInput(message, threadChannelId));
+            results.Add(ToHistoricalMessage(message));
         }
 
-        _logger.LogInformation("Fetched {Count} thread history messages for thread {ThreadId}", results.Count, threadChannelId);
         return results;
     }
 
-    private static ChannelInput ToChannelInput(IMessage message, ulong threadChannelId) => new()
-    {
-        SenderId = message.Author.Id.ToString(),
-        ChannelId = threadChannelId.ToString(),
-        MessageId = message.Id.ToString(),
-        Audience = TrustAudience.Public,
-        Principal = PrincipalClassification.UntrustedExternal,
-        Provenance = new SourceProvenance
-        {
-            TransportAuthenticity = TransportAuthenticity.Verified,
-            PayloadTaint = PayloadTaint.Public,
-            SourceKind = "discord",
-            SourceScope = threadChannelId.ToString()
-        },
-        Contents = [new TextContent(message.Content)],
-        ReceivedAt = message.Timestamp
-    };
+    private static HistoricalMessage ToHistoricalMessage(IMessage message)
+        => new(
+            MessageId: message.Id.ToString(),
+            SenderId: message.Author.Id.ToString(),
+            IsBot: message.Author.IsBot,
+            Text: message.Content ?? string.Empty,
+            Timestamp: message.Timestamp,
+            Attachments: message.Attachments
+                .Select(a => new DiscordFileReference(
+                    a.Filename,
+                    a.ContentType ?? "application/octet-stream",
+                    a.Size,
+                    a.Url))
+                .ToArray());
+
+    private static bool HasUsableContent(IMessage message)
+        => !string.IsNullOrWhiteSpace(message.Content) || message.Attachments.Count > 0;
+
+    private static TextContent BuildHistoricalAttachmentRejected(string detail)
+        => new($"[attachment rejected: {detail}]");
 }

--- a/src/Netclaw.Channels.Slack/SlackFileDownloader.cs
+++ b/src/Netclaw.Channels.Slack/SlackFileDownloader.cs
@@ -16,7 +16,8 @@ internal static class SlackFileDownloader
         SensitiveString? botToken,
         string targetDirectory,
         long maxBytes,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<Exception, string>? onCleanupFailure = null)
     {
         return StreamingAttachmentDownloader.DownloadToFileAsync(
             httpClient, url,
@@ -27,6 +28,7 @@ internal static class SlackFileDownloader
             },
             targetDirectory,
             maxBytes,
-            cancellationToken);
+            cancellationToken,
+            onCleanupFailure);
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackFileDownloader.cs
+++ b/src/Netclaw.Channels.Slack/SlackFileDownloader.cs
@@ -1,27 +1,32 @@
 using System.Net.Http.Headers;
+using Netclaw.Channels;
 using Netclaw.Configuration;
 
 namespace Netclaw.Channels.Slack;
 
 /// <summary>
 /// Shared helper for downloading files from Slack's private file API with bot token auth.
+/// Delegates to <see cref="StreamingAttachmentDownloader"/> for streamed-to-disk downloads.
 /// </summary>
 internal static class SlackFileDownloader
 {
-    public static async Task<ReadOnlyMemory<byte>> DownloadAsync(
+    public static Task<AttachmentDownloadResult> DownloadToFileAsync(
         HttpClient httpClient,
         string url,
         SensitiveString? botToken,
+        string targetDirectory,
+        long maxBytes,
         CancellationToken cancellationToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        if (botToken is { Value: { Length: > 0 } token })
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        using var response = await httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-        return bytes;
+        return StreamingAttachmentDownloader.DownloadToFileAsync(
+            httpClient, url,
+            request =>
+            {
+                if (botToken is { Value: { Length: > 0 } token })
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            },
+            targetDirectory,
+            maxBytes,
+            cancellationToken);
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
+using Netclaw.Channels;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -359,11 +360,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
     }
 
-    private Task<AttachmentDownloadResult> DownloadSlackFileToInboxAsync(
+    private Task<AttachmentDownloadResult> DownloadSlackFileToDirectoryAsync(
         SlackFileReference file, string targetDirectory, long maxBytes, CancellationToken ct)
         => SlackFileDownloader.DownloadToFileAsync(
             _dependencies.HttpClient!, file.UrlPrivateDownload, _dependencies.Options.BotToken,
-            targetDirectory, maxBytes, ct);
+            targetDirectory, maxBytes, ct,
+            onCleanupFailure: (ex, path) => _log.Error(ex, "Failed to clean up staged download file {0}", path));
 
     /// <summary>
     /// Applies the canonical cross-channel attachment ingress pipeline to
@@ -419,6 +421,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var rejections = new List<string>();
 
         var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(_sessionId, _dependencies.Paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(_sessionId, _dependencies.Paths.SessionsDirectory);
 
         foreach (var file in files)
         {
@@ -428,6 +431,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 policy,
                 inlineImages,
                 inboxDir,
+                stagingDir,
                 cancellationToken);
 
             switch (attachmentResult)
@@ -465,6 +469,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         ChannelAttachmentPolicy policy,
         bool inlineImages,
         string inboxDir,
+        string stagingDir,
         CancellationToken cancellationToken)
     {
         var category = AttachmentCategories.FromMime(file.MimeType);
@@ -495,8 +500,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         {
             using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             downloadCts.CancelAfter(OperationTimeout);
-            downloadResult = await DownloadSlackFileToInboxAsync(
-                file, inboxDir, policy.MaxFileBytes, downloadCts.Token);
+            downloadResult = await DownloadSlackFileToDirectoryAsync(
+                file, stagingDir, policy.MaxFileBytes, downloadCts.Token);
         }
         catch (AttachmentTooLargeException ex)
         {
@@ -536,8 +541,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         ContentScanResult scanResult;
         try
         {
+            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            scanCts.CancelAfter(OperationTimeout);
             scanResult = await _dependencies.ContentScanner.ScanFileAsync(
-                downloadResult.FilePath, file.Name, file.MimeType, cancellationToken);
+                downloadResult.FilePath, file.Name, file.MimeType, scanCts.Token);
         }
         catch (Exception ex)
         {
@@ -594,10 +601,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
 
         // Decide inlining based on model modalities and category.
-        var (inlined, note) = ResolveInlineDecision(category, inlineImages);
+        var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
 
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
-        var line = BuildAttachmentLine(file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
+        var line = AttachmentIngressFormatting.BuildAttachmentLine(
+            file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
 
         DataContent? inlineContent = null;
         if (inlined)
@@ -613,6 +621,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         return new AttachmentIngestResult.Accepted(line, inlineContent);
     }
 
+    /// <summary>
+    /// Formats a single <c>[attachment]</c> announcement line in the
+    /// canonical cross-channel shape defined in netclaw-input-adapters.
+    /// </summary>
     private void TryDeleteTemp(string tempPath)
     {
         try
@@ -622,95 +634,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
         catch (Exception ex)
         {
-            _log.Debug(ex, "Failed to clean up temp download file {Path}", tempPath);
+            _log.Error(ex, "Failed to clean up staged attachment file {Path}", tempPath);
         }
     }
 
-    private static (bool Inlined, string? Note) ResolveInlineDecision(
-        AttachmentCategory category,
-        bool inlineImages)
-    {
-        return category switch
-        {
-            AttachmentCategory.Image when inlineImages => (true, null),
-            AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
-            AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
-            _ => (false, AttachmentNotes.FormatNotInlineable)
-        };
-    }
-
-    /// <summary>
-    /// Formats a single <c>[attachment]</c> announcement line in the
-    /// canonical cross-channel shape defined in netclaw-input-adapters.
-    /// </summary>
-    internal static string BuildAttachmentLine(
-        string name,
-        string mimeType,
-        long size,
-        string relativePath,
-        bool inlined,
-        string? note)
-    {
-        var inlinedWire = inlined ? "true" : "false";
-        var sb = new StringBuilder(128);
-        sb.Append("[attachment] name=\"").Append(EscapeQuoted(name)).Append('"');
-        sb.Append(" mime=\"").Append(EscapeQuoted(mimeType)).Append('"');
-        sb.Append(" size=").Append(size);
-        sb.Append(" path=\"").Append(EscapeQuoted(relativePath)).Append('"');
-        sb.Append(" inlined=\"").Append(inlinedWire).Append('"');
-        if (!string.IsNullOrEmpty(note))
-            sb.Append(" note=\"").Append(EscapeQuoted(note)).Append('"');
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Escapes a metadata value for safe embedding inside a double-quoted
-    /// attribute on an attachment announcement line. Control characters
-    /// (including CR/LF) are replaced with spaces so hostile filenames
-    /// cannot embed newlines in the single-line format.
-    /// </summary>
-    internal static string EscapeQuoted(string value)
-    {
-        // Fast path: skip allocation when no special characters are present.
-        // This covers the common case of ordinary filenames.
-        var needsProcessing = false;
-        foreach (var c in value)
-        {
-            if (c < ' ' || c == '\\' || c == '"')
-            {
-                needsProcessing = true;
-                break;
-            }
-        }
-
-        if (!needsProcessing)
-            return value;
-
-        var sb = new StringBuilder(value.Length + 8);
-        foreach (var c in value)
-        {
-            if (c < ' ')
-                sb.Append(' ');
-            else if (c == '\\')
-                sb.Append("\\\\");
-            else if (c == '"')
-                sb.Append("\\\"");
-            else
-                sb.Append(c);
-        }
-        return sb.ToString();
-    }
-
-    private static string FormatBytes(long size)
-    {
-        const long Mib = 1024 * 1024;
-        const long Kib = 1024;
-        if (size >= Mib)
-            return $"{size / (double)Mib:F1} MiB";
-        if (size >= Kib)
-            return $"{size / (double)Kib:F1} KiB";
-        return $"{size} bytes";
-    }
+    private static string FormatBytes(long size) => AttachmentIngressFormatting.FormatBytes(size);
 
     private abstract record AttachmentIngestResult
     {
@@ -856,12 +784,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         if (gap.Count == 0)
             return new InboundBuildResult(baseInput, detectorUnavailable);
 
-        var mergedContents = MergeGapWithLiveContents(
-            gap,
-            liveContents,
-            triggeringMessage.Audience,
-            _dependencies.AudienceProfiles,
-            _dependencies.ModelCapabilities);
+        var mergedContents = MergeGapWithLiveContents(gap, liveContents);
         return new InboundBuildResult(baseInput with { Contents = mergedContents }, detectorUnavailable);
     }
 
@@ -917,97 +840,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private static List<AIContent> MergeGapWithLiveContents(
         IReadOnlyList<ChannelInput> gap,
-        IReadOnlyList<AIContent> liveContents,
-        TrustAudience audience,
-        ToolAudienceProfiles? audienceProfiles,
-        ModelCapabilities modelCapabilities)
-    {
-        var profile = ToolAudienceProfileDefaults.GetResolvedProfile(audienceProfiles, audience);
-        var attachmentPolicy = profile.ChannelAttachments ?? ChannelAttachmentPolicy.Empty;
-        var inlineImages = modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
-
-        var sb = new StringBuilder();
-        sb.AppendLine("[thread history — messages exchanged before this inbound event]");
-        sb.AppendLine();
-
-        var merged = new List<AIContent>();
-        var acceptedBackfillData = new List<AIContent>();
-
-        foreach (var item in gap)
-        {
-            var ts = item.ReceivedAt == default ? string.Empty : $", {item.ReceivedAt:yyyy-MM-dd HH:mm} UTC";
-            sb.AppendLine($"<user: {item.SenderId}{ts}>");
-
-            var imageCount = 0;
-            foreach (var content in item.Contents)
-            {
-                switch (content)
-                {
-                    case TextContent text when !string.IsNullOrWhiteSpace(text.Text):
-                        sb.AppendLine(text.Text);
-                        break;
-
-                    case DataContent data:
-                        var mimeType = data.MediaType ?? "application/octet-stream";
-                        var category = AttachmentCategories.FromMime(mimeType);
-
-                        if (!attachmentPolicy.Allows(category))
-                        {
-                            sb.AppendLine(
-                                $"[attachment rejected: historical attachment ({EscapeQuoted(mimeType)}) category not allowed in {audience}]");
-                            break;
-                        }
-
-                        var (inlined, note) = ResolveInlineDecision(category, inlineImages);
-                        if (!inlined)
-                        {
-                            var effectiveNote = note ?? AttachmentNotes.FormatNotInlineable;
-                            sb.AppendLine(
-                                $"[attachment] mime=\"{EscapeQuoted(mimeType)}\" inlined=\"false\" note=\"{EscapeQuoted(effectiveNote)}\"");
-                            break;
-                        }
-
-                        acceptedBackfillData.Add(data);
-                        if (category == AttachmentCategory.Image)
-                        {
-                            imageCount++;
-                        }
-                        else
-                        {
-                            sb.AppendLine($"[attachment] mime=\"{EscapeQuoted(mimeType)}\" inlined=\"true\"");
-                        }
-                        break;
-                }
-            }
-
-            if (imageCount > 0)
-                sb.AppendLine($"[image attachments: {imageCount}]");
-
-            sb.AppendLine();
-        }
-
-        sb.AppendLine("[end thread history]");
-
-        var liveText = string.Join("\n", liveContents
-            .OfType<TextContent>()
-            .Select(t => t.Text)
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
-
-        var mergedText = string.IsNullOrWhiteSpace(liveText)
-            ? sb.ToString()
-            : $"{sb}\n\n{liveText}";
-
-        merged.Add(new TextContent(mergedText));
-        merged.AddRange(acceptedBackfillData);
-
-        foreach (var content in liveContents)
-        {
-            if (content is not TextContent)
-                merged.Add(content);
-        }
-
-        return merged;
-    }
+        IReadOnlyList<AIContent> liveContents)
+        => ThreadHistoryContentMerger.MergeHistoryWithLiveContents(gap, liveContents);
 
     private async Task ReinitializePipelineAsync(string reason)
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -359,8 +359,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
     }
 
-    private Task<ReadOnlyMemory<byte>> DownloadSlackFileAsync(SlackFileReference file, CancellationToken ct)
-        => SlackFileDownloader.DownloadAsync(_dependencies.HttpClient!, file.UrlPrivateDownload, _dependencies.Options.BotToken, ct);
+    private Task<AttachmentDownloadResult> DownloadSlackFileToInboxAsync(
+        SlackFileReference file, string targetDirectory, long maxBytes, CancellationToken ct)
+        => SlackFileDownloader.DownloadToFileAsync(
+            _dependencies.HttpClient!, file.UrlPrivateDownload, _dependencies.Options.BotToken,
+            targetDirectory, maxBytes, ct);
 
     /// <summary>
     /// Applies the canonical cross-channel attachment ingress pipeline to
@@ -487,12 +490,21 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 $"`{file.Name}` ({FormatBytes(file.Size)}) exceeds the {FormatBytes(policy.MaxFileBytes)} per-file limit.");
         }
 
-        ReadOnlyMemory<byte> bytes;
+        AttachmentDownloadResult downloadResult;
         try
         {
             using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             downloadCts.CancelAfter(OperationTimeout);
-            bytes = await DownloadSlackFileAsync(file, downloadCts.Token);
+            downloadResult = await DownloadSlackFileToInboxAsync(
+                file, inboxDir, policy.MaxFileBytes, downloadCts.Token);
+        }
+        catch (AttachmentTooLargeException ex)
+        {
+            _log.Warning(
+                "slack_attachment_rejected name={Name} mime={Mime} audience={Audience} size={Size} limit={Limit} reason=too-large-during-download",
+                file.Name, file.MimeType, audience, ex.BytesReceived, ex.MaxBytes);
+            return new AttachmentIngestResult.Rejected(
+                $"`{file.Name}` ({FormatBytes(ex.BytesReceived)}) exceeds the {FormatBytes(ex.MaxBytes)} per-file limit.");
         }
         catch (OperationCanceledException ex)
         {
@@ -511,11 +523,12 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 $"Couldn't download `{file.Name}` — please try again later.");
         }
 
-        if (bytes.Length == 0)
+        if (downloadResult.BytesWritten == 0)
         {
             _log.Warning(
                 "slack_attachment_rejected name={Name} mime={Mime} reason=empty-download",
                 file.Name, file.MimeType);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"`{file.Name}` downloaded as zero bytes.");
         }
@@ -523,16 +536,15 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         ContentScanResult scanResult;
         try
         {
-            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            scanCts.CancelAfter(OperationTimeout);
-            scanResult = await _dependencies.ContentScanner.ScanAsync(
-                bytes, file.Name, file.MimeType, scanCts.Token);
+            scanResult = await _dependencies.ContentScanner.ScanFileAsync(
+                downloadResult.FilePath, file.Name, file.MimeType, cancellationToken);
         }
         catch (Exception ex)
         {
             _log.Warning(ex,
                 "slack_attachment_rejected name={Name} mime={Mime} reason=scan-exception",
                 file.Name, file.MimeType);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Couldn't scan `{file.Name}` — please try again later.");
         }
@@ -542,6 +554,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _log.Warning(
                 "slack_attachment_rejected name={Name} mime={Mime} reason=scan-blocked error={ScanError} message={ScanMessage}",
                 file.Name, file.MimeType, scanResult.Error?.ToString(), scanResult.Message ?? scanResult.Error?.ToString());
+
+            TryDeleteTemp(downloadResult.FilePath);
 
             if (scanResult.Error == ContentScanError.ScanFailure)
             {
@@ -553,21 +567,19 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 $"Content scanner rejected `{file.Name}`: {scanResult.Message ?? scanResult.Error?.ToString()}.");
         }
 
-        // Write to inbox with filesystem-level collision suffixing and atomic move.
+        // Move temp file to final inbox path with collision suffixing.
         string inboxPath;
         try
         {
-            inboxPath = await InboxWriter.SanitizeReserveAndWriteAsync(
-                inboxDir,
-                file.Name,
-                bytes,
-                cancellationToken);
+            inboxPath = InboxWriter.SanitizeReserveAndMove(
+                inboxDir, file.Name, downloadResult.FilePath);
         }
         catch (InboxWriter.CollisionExhaustedException ex)
         {
             _log.Warning(ex,
                 "slack_attachment_rejected name={Name} reason=collision-exhausted",
                 file.Name);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Too many attachments named `{file.Name}` in this session — please rename and try again.");
         }
@@ -576,6 +588,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             _log.Error(ex,
                 "slack_attachment_rejected name={Name} reason=inbox-write-failed",
                 file.Name);
+            TryDeleteTemp(downloadResult.FilePath);
             return new AttachmentIngestResult.Rejected(
                 $"Couldn't save `{file.Name}` — please try again later.");
         }
@@ -584,17 +597,33 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var (inlined, note) = ResolveInlineDecision(category, inlineImages);
 
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
-        var line = BuildAttachmentLine(file.Name, file.MimeType, bytes.Length, relativePath, inlined, note);
+        var line = BuildAttachmentLine(file.Name, file.MimeType, downloadResult.BytesWritten, relativePath, inlined, note);
 
         DataContent? inlineContent = null;
         if (inlined)
-            inlineContent = new DataContent(bytes, file.MimeType);
+        {
+            var inlineBytes = await File.ReadAllBytesAsync(inboxPath, cancellationToken);
+            inlineContent = new DataContent(inlineBytes, file.MimeType);
+        }
 
         _log.Info(
             "slack_attachment_accepted name={Name} mime={Mime} size={Size} audience={Audience} category={Category} inlined={Inlined}",
-            file.Name, file.MimeType, bytes.Length, audience, category, inlined);
+            file.Name, file.MimeType, downloadResult.BytesWritten, audience, category, inlined);
 
         return new AttachmentIngestResult.Accepted(line, inlineContent);
+    }
+
+    private void TryDeleteTemp(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Failed to clean up temp download file {Path}", tempPath);
+        }
     }
 
     private static (bool Inlined, string? Note) ResolveInlineDecision(

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -254,6 +254,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         var filename = file.Name ?? "attachment";
         var mimeType = file.Mimetype ?? "application/octet-stream";
         var category = AttachmentCategories.FromMime(mimeType);
+        var sourceKey = BuildHistoricalAttachmentSourceKey(file, downloadUrl);
 
         if (!policy.Allows(category))
         {
@@ -276,6 +277,16 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
             return [BuildHistoricalAttachmentRejected(
                 $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" exceeds the {AttachmentIngressFormatting.FormatBytes(policy.MaxFileBytes)} per-file limit")];
         }
+
+        if (HistoricalAttachmentInbox.TryGetExistingFile(inboxDir, filename, sourceKey, out var existingPath, out var existingSize))
+            return await BuildAcceptedAttachmentContentsAsync(
+                existingPath,
+                filename,
+                mimeType,
+                category,
+                inlineImages,
+                existingSize,
+                cancellationToken);
 
         AttachmentDownloadResult downloadResult;
         try
@@ -356,7 +367,11 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         string inboxPath;
         try
         {
-            inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, filename, downloadResult.FilePath);
+            inboxPath = HistoricalAttachmentInbox.PromoteOrReuse(
+                inboxDir,
+                filename,
+                sourceKey,
+                downloadResult.FilePath);
         }
         catch (Exception ex)
         {
@@ -366,24 +381,42 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
                 $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" could not be saved to the session inbox")];
         }
 
+        return await BuildAcceptedAttachmentContentsAsync(
+            inboxPath,
+            filename,
+            mimeType,
+            category,
+            inlineImages,
+            downloadResult.BytesWritten,
+            cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<AIContent>> BuildAcceptedAttachmentContentsAsync(
+        string inboxPath,
+        string filename,
+        string mimeType,
+        AttachmentCategory category,
+        bool inlineImages,
+        long size,
+        CancellationToken cancellationToken)
+    {
         var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
         var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
+        var line = new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
+            filename,
+            mimeType,
+            size,
+            relativePath,
+            inlined,
+            note));
+
         if (!inlined)
         {
-            return
-            [
-                new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
-                    filename,
-                    mimeType,
-                    downloadResult.BytesWritten,
-                    relativePath,
-                    false,
-                    note))
-            ];
+            return [line];
         }
 
         var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
-        return [new DataContent(bytes, mimeType)];
+        return [line, new DataContent(bytes, mimeType)];
     }
 
     private AudienceResult ResolveHistoricalAudience(SlackChannelId channelId, SlackThreadTs threadTs)
@@ -411,4 +444,9 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 
     private static TextContent BuildHistoricalAttachmentRejected(string detail)
         => new($"[attachment rejected: {detail}]");
+
+    private static string BuildHistoricalAttachmentSourceKey(SlackNet.File file, string downloadUrl)
+        => !string.IsNullOrWhiteSpace(file.Id)
+            ? $"slack:{file.Id}"
+            : $"slack-url:{downloadUrl}";
 }

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
+using Netclaw.Channels;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using SlackNet;
@@ -13,11 +14,14 @@ namespace Netclaw.Channels.Slack;
 /// <summary>
 /// Fetches prior messages from a Slack thread via <c>conversations.replies</c>
 /// and returns them as <see cref="ChannelInput"/> items in chronological order.
+/// Historical attachments reuse the live ingress security pipeline: policy gates,
+/// staged download, content scan, and inbox promotion before inclusion.
 /// </summary>
 public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 {
     private const int PageSize = 200;
     private static readonly TimeSpan FileDownloadTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ContentScanTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Thin abstraction over <c>conversations.replies</c> to keep the fetcher testable
@@ -31,6 +35,8 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
     private readonly HttpClient _httpClient;
     private readonly IContentScanner _contentScanner;
     private readonly NetclawPaths _paths;
+    private readonly ToolAudienceProfiles _audienceProfiles;
+    private readonly ModelCapabilities _modelCapabilities;
     private readonly ILogger<SlackThreadHistoryFetcher> _logger;
 
     public SlackThreadHistoryFetcher(
@@ -39,6 +45,8 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         HttpClient httpClient,
         IContentScanner contentScanner,
         NetclawPaths paths,
+        ToolAudienceProfiles audienceProfiles,
+        ModelCapabilities modelCapabilities,
         ILogger<SlackThreadHistoryFetcher> logger)
     {
         _repliesFetcher = repliesFetcher;
@@ -46,6 +54,8 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         _httpClient = httpClient;
         _contentScanner = contentScanner;
         _paths = paths;
+        _audienceProfiles = audienceProfiles;
+        _modelCapabilities = modelCapabilities;
         _logger = logger;
     }
 
@@ -58,11 +68,13 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         HttpClient httpClient,
         IContentScanner contentScanner,
         NetclawPaths paths,
+        ToolAudienceProfiles audienceProfiles,
+        ModelCapabilities modelCapabilities,
         ILogger<SlackThreadHistoryFetcher> logger)
         : this(
             (channelId, threadTs, limit, cursor, ct) =>
                 conversationsApi.Replies(channelId.Value, threadTs.Value, limit: limit, cursor: cursor, cancellationToken: ct),
-            options, httpClient, contentScanner, paths, logger)
+            options, httpClient, contentScanner, paths, audienceProfiles, modelCapabilities, logger)
     {
     }
 
@@ -70,7 +82,6 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         SessionId sessionId,
         CancellationToken cancellationToken = default)
     {
-        // SessionId format: {channelId}/{threadTs}
         var parts = sessionId.Value.Split('/', 2);
         if (parts.Length != 2)
         {
@@ -103,9 +114,26 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         SlackThreadTs threadTs,
         CancellationToken cancellationToken)
     {
+        var audienceResult = ResolveHistoricalAudience(channelId, threadTs);
+        if (audienceResult.Error is { } audienceError)
+        {
+            _logger.LogWarning(
+                "Invalid Slack audience configuration while fetching history for {ChannelId}/{ThreadTs}: {Error}",
+                channelId.Value,
+                threadTs.Value,
+                audienceError);
+            return [];
+        }
+
+        var audience = audienceResult.Audience;
+        var profile = ToolAudienceProfileDefaults.GetResolvedProfile(_audienceProfiles, audience);
+        var attachmentPolicy = profile.ChannelAttachments ?? ChannelAttachmentPolicy.Empty;
+        var inlineImages = _modelCapabilities.InputModalities.HasFlag(ModelModality.Image);
+
         var results = new List<ChannelInput>();
         string? cursor = null;
         var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(sessionId, _paths.SessionsDirectory);
+        var stagingDir = SessionDirectoryHelper.GetOrCreateAttachmentStagingDirectory(sessionId, _paths.SessionsDirectory);
 
         do
         {
@@ -118,14 +146,21 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 
             foreach (var message in response.Messages)
             {
-                // Include only human-authored thread messages.
                 if (!string.IsNullOrWhiteSpace(message.BotId))
                     continue;
 
                 if (string.IsNullOrWhiteSpace(message.User))
                     continue;
 
-                var input = await ConvertMessageAsync(message, channelId, inboxDir, cancellationToken);
+                var input = await ConvertMessageAsync(
+                    message,
+                    channelId,
+                    audience,
+                    attachmentPolicy,
+                    inlineImages,
+                    inboxDir,
+                    stagingDir,
+                    cancellationToken);
                 if (input is not null)
                     results.Add(input);
             }
@@ -133,35 +168,61 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
             cursor = response.ResponseMetadata?.NextCursor;
         } while (!string.IsNullOrEmpty(cursor));
 
-        _logger.LogInformation("Fetched {Count} thread history messages for {ChannelId}/{ThreadTs}", results.Count, channelId, threadTs);
+        _logger.LogInformation(
+            "Fetched {Count} thread history messages for {ChannelId}/{ThreadTs}",
+            results.Count,
+            channelId,
+            threadTs);
         return results;
     }
 
     private async Task<ChannelInput?> ConvertMessageAsync(
         SlackNet.Events.MessageEvent message,
         SlackChannelId channelId,
+        TrustAudience audience,
+        ChannelAttachmentPolicy attachmentPolicy,
+        bool inlineImages,
         string inboxDir,
+        string stagingDir,
         CancellationToken cancellationToken)
     {
         var contents = new List<AIContent>();
 
-        if (!string.IsNullOrEmpty(message.Text))
+        if (!string.IsNullOrWhiteSpace(message.Text))
             contents.Add(new TextContent(message.Text));
 
-        if (message.Files is { Count: > 0 })
+        if (message.Files is { Count: > 0 } files)
         {
-            var downloadableFiles = message.Files
-                .Where(f => f.Mimetype is not null
-                    && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate));
-
-            var downloadTasks = downloadableFiles.Select(
-                file => DownloadAndScanFileAsync(file, inboxDir, cancellationToken));
-            var results = await Task.WhenAll(downloadTasks);
-
-            foreach (var result in results)
+            if (files.Count > attachmentPolicy.MaxFilesPerMessage)
             {
-                if (result is not null)
-                    contents.Add(result);
+                _logger.LogWarning(
+                    "Skipping {Count} historical Slack attachments on {ChannelId}; limit is {Limit} for audience {Audience}",
+                    files.Count,
+                    channelId.Value,
+                    attachmentPolicy.MaxFilesPerMessage,
+                    audience);
+                contents.Add(BuildHistoricalAttachmentRejected(
+                    $"{files.Count} historical attachments exceed the {attachmentPolicy.MaxFilesPerMessage} per-message limit"));
+            }
+            else
+            {
+                var downloadableFiles = files
+                    .Where(f => f.Mimetype is not null
+                        && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate))
+                    .ToArray();
+
+                var downloadTasks = downloadableFiles.Select(file => DownloadAndProjectFileAsync(
+                    file,
+                    audience,
+                    attachmentPolicy,
+                    inlineImages,
+                    inboxDir,
+                    stagingDir,
+                    cancellationToken));
+                var results = await Task.WhenAll(downloadTasks);
+
+                foreach (var result in results)
+                    contents.AddRange(result);
             }
         }
 
@@ -180,68 +241,174 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         };
     }
 
-    private async Task<DataContent?> DownloadAndScanFileAsync(
-        SlackNet.File file, string inboxDir, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<AIContent>> DownloadAndProjectFileAsync(
+        SlackNet.File file,
+        TrustAudience audience,
+        ChannelAttachmentPolicy policy,
+        bool inlineImages,
+        string inboxDir,
+        string stagingDir,
+        CancellationToken cancellationToken)
     {
         var downloadUrl = file.UrlPrivateDownload ?? file.UrlPrivate!;
         var filename = file.Name ?? "attachment";
+        var mimeType = file.Mimetype ?? "application/octet-stream";
+        var category = AttachmentCategories.FromMime(mimeType);
+
+        if (!policy.Allows(category))
+        {
+            _logger.LogWarning(
+                "Historical Slack attachment {Name} rejected: category {Category} not allowed for {Audience}",
+                filename,
+                category,
+                audience);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment ({mimeType}) category not allowed in {audience}")];
+        }
+
+        if (file.Size > policy.MaxFileBytes)
+        {
+            _logger.LogWarning(
+                "Historical Slack attachment {Name} rejected: size {Size} exceeds {Limit}",
+                filename,
+                file.Size,
+                policy.MaxFileBytes);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" exceeds the {AttachmentIngressFormatting.FormatBytes(policy.MaxFileBytes)} per-file limit")];
+        }
+
+        AttachmentDownloadResult downloadResult;
         try
         {
             using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             downloadCts.CancelAfter(FileDownloadTimeout);
 
-            var downloadResult = await SlackFileDownloader.DownloadToFileAsync(
-                _httpClient, downloadUrl, _options.BotToken,
-                inboxDir, ChannelAttachmentPolicy.DefaultMaxFileBytes, downloadCts.Token);
-
-            if (downloadResult.BytesWritten == 0)
-            {
-                TryDeleteTemp(downloadResult.FilePath);
-                return null;
-            }
-
-            var scanResult = await _contentScanner.ScanFileAsync(
-                downloadResult.FilePath, filename, file.Mimetype!, cancellationToken);
-
-            if (!scanResult.IsAllowed && scanResult.Error != ContentScanError.ScanFailure)
-            {
-                _logger.LogWarning("Content scan rejected backfill file {Name}: {Message}",
-                    file.Name, scanResult.Message ?? scanResult.Error?.ToString());
-                TryDeleteTemp(downloadResult.FilePath);
-                return null;
-            }
-
-            var inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, filename, downloadResult.FilePath);
-            var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
-            return new DataContent(bytes, file.Mimetype!);
+            downloadResult = await SlackFileDownloader.DownloadToFileAsync(
+                _httpClient,
+                downloadUrl,
+                _options.BotToken,
+                stagingDir,
+                policy.MaxFileBytes,
+                downloadCts.Token,
+                (ex, path) => _logger.LogError(ex, "Failed to clean up staged download file {Path}", path));
         }
-        catch (AttachmentTooLargeException)
+        catch (AttachmentTooLargeException ex)
         {
-            _logger.LogWarning("Backfill file {Name} exceeded size limit, skipping", file.Name);
-            return null;
+            _logger.LogWarning(
+                "Historical Slack attachment {Name} rejected during download: {Size} exceeds {Limit}",
+                filename,
+                ex.BytesReceived,
+                ex.MaxBytes);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" exceeded the {AttachmentIngressFormatting.FormatBytes(ex.MaxBytes)} per-file limit during download")];
         }
         catch (OperationCanceledException)
         {
-            _logger.LogWarning("Timed out downloading backfill file {Name}, skipping", file.Name);
-            return null;
+            _logger.LogWarning("Timed out downloading historical Slack attachment {Name}", filename);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" timed out during download")];
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to download backfill file {Name}, skipping", file.Name);
-            return null;
+            _logger.LogWarning(ex, "Failed downloading historical Slack attachment {Name}", filename);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" could not be downloaded")];
         }
-    }
 
-    private static void TryDeleteTemp(string tempPath)
-    {
+        if (downloadResult.BytesWritten == 0)
+        {
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" downloaded as zero bytes")];
+        }
+
+        ContentScanResult scanResult;
         try
         {
-            if (IOFile.Exists(tempPath))
-                IOFile.Delete(tempPath);
+            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            scanCts.CancelAfter(ContentScanTimeout);
+            scanResult = await _contentScanner.ScanFileAsync(
+                downloadResult.FilePath,
+                filename,
+                mimeType,
+                scanCts.Token);
         }
-        catch (IOException)
+        catch (Exception ex)
         {
-            // best-effort cleanup during backfill; file will be orphaned but harmless
+            _logger.LogWarning(ex, "Historical Slack attachment scan threw for {Name}", filename);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" could not be scanned")];
         }
+
+        if (!scanResult.IsAllowed)
+        {
+            _logger.LogWarning(
+                "Historical Slack attachment {Name} rejected by scanner: {Error} {Message}",
+                filename,
+                scanResult.Error?.ToString(),
+                scanResult.Message ?? string.Empty);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" was rejected by content scanning: {AttachmentIngressFormatting.EscapeQuoted(scanResult.Message ?? scanResult.Error?.ToString() ?? "unknown error")}")];
+        }
+
+        string inboxPath;
+        try
+        {
+            inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, filename, downloadResult.FilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to promote historical Slack attachment {Name} into inbox", filename);
+            AttachmentStagingCleanup.TryDelete(downloadResult.FilePath, _logger);
+            return [BuildHistoricalAttachmentRejected(
+                $"historical attachment \"{AttachmentIngressFormatting.EscapeQuoted(filename)}\" could not be saved to the session inbox")];
+        }
+
+        var relativePath = $"{SessionDirectoryHelper.InboxSubdirectory}/{Path.GetFileName(inboxPath)}";
+        var (inlined, note) = AttachmentIngressFormatting.ResolveInlineDecision(category, inlineImages);
+        if (!inlined)
+        {
+            return
+            [
+                new TextContent(AttachmentIngressFormatting.BuildAttachmentLine(
+                    filename,
+                    mimeType,
+                    downloadResult.BytesWritten,
+                    relativePath,
+                    false,
+                    note))
+            ];
+        }
+
+        var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
+        return [new DataContent(bytes, mimeType)];
     }
+
+    private AudienceResult ResolveHistoricalAudience(SlackChannelId channelId, SlackThreadTs threadTs)
+    {
+        var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
+        var syntheticMessage = new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId($"history:{threadTs.Value}"),
+            ChannelId: channelId,
+            ThreadTs: threadTs,
+            EventTs: new SlackEventTs(threadTs.Value),
+            UserId: null,
+            BotId: null,
+            Text: string.Empty,
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: channelId.Value.StartsWith("D", StringComparison.Ordinal));
+
+        return SlackAclPolicy.ResolveAudience(
+            syntheticMessage,
+            _options,
+            isExplicitUser: false,
+            isExplicitChannel: isExplicitChannel);
+    }
+
+    private static TextContent BuildHistoricalAttachmentRejected(string detail)
+        => new($"[attachment rejected: {detail}]");
 }

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -6,6 +6,7 @@ using Netclaw.Configuration;
 using Netclaw.Security;
 using SlackNet;
 using SlackNet.WebApi;
+using IOFile = System.IO.File;
 
 namespace Netclaw.Channels.Slack;
 
@@ -17,7 +18,6 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 {
     private const int PageSize = 200;
     private static readonly TimeSpan FileDownloadTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan ContentScanTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Thin abstraction over <c>conversations.replies</c> to keep the fetcher testable
@@ -30,6 +30,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
     private readonly SlackChannelOptions _options;
     private readonly HttpClient _httpClient;
     private readonly IContentScanner _contentScanner;
+    private readonly NetclawPaths _paths;
     private readonly ILogger<SlackThreadHistoryFetcher> _logger;
 
     public SlackThreadHistoryFetcher(
@@ -37,12 +38,14 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         SlackChannelOptions options,
         HttpClient httpClient,
         IContentScanner contentScanner,
+        NetclawPaths paths,
         ILogger<SlackThreadHistoryFetcher> logger)
     {
         _repliesFetcher = repliesFetcher;
         _options = options;
         _httpClient = httpClient;
         _contentScanner = contentScanner;
+        _paths = paths;
         _logger = logger;
     }
 
@@ -54,11 +57,12 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         SlackChannelOptions options,
         HttpClient httpClient,
         IContentScanner contentScanner,
+        NetclawPaths paths,
         ILogger<SlackThreadHistoryFetcher> logger)
         : this(
             (channelId, threadTs, limit, cursor, ct) =>
                 conversationsApi.Replies(channelId.Value, threadTs.Value, limit: limit, cursor: cursor, cancellationToken: ct),
-            options, httpClient, contentScanner, logger)
+            options, httpClient, contentScanner, paths, logger)
     {
     }
 
@@ -79,7 +83,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
 
         try
         {
-            return await FetchRepliesAsync(channelId, threadTs, cancellationToken);
+            return await FetchRepliesAsync(sessionId, channelId, threadTs, cancellationToken);
         }
         catch (SlackException ex)
         {
@@ -94,12 +98,14 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
     }
 
     private async Task<IReadOnlyList<ChannelInput>> FetchRepliesAsync(
+        SessionId sessionId,
         SlackChannelId channelId,
         SlackThreadTs threadTs,
         CancellationToken cancellationToken)
     {
         var results = new List<ChannelInput>();
         string? cursor = null;
+        var inboxDir = SessionDirectoryHelper.GetOrCreateInboxDirectory(sessionId, _paths.SessionsDirectory);
 
         do
         {
@@ -119,7 +125,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
                 if (string.IsNullOrWhiteSpace(message.User))
                     continue;
 
-                var input = await ConvertMessageAsync(message, channelId, cancellationToken);
+                var input = await ConvertMessageAsync(message, channelId, inboxDir, cancellationToken);
                 if (input is not null)
                     results.Add(input);
             }
@@ -134,6 +140,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
     private async Task<ChannelInput?> ConvertMessageAsync(
         SlackNet.Events.MessageEvent message,
         SlackChannelId channelId,
+        string inboxDir,
         CancellationToken cancellationToken)
     {
         var contents = new List<AIContent>();
@@ -147,7 +154,8 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
                 .Where(f => f.Mimetype is not null
                     && !string.IsNullOrWhiteSpace(f.UrlPrivateDownload ?? f.UrlPrivate));
 
-            var downloadTasks = downloadableFiles.Select(file => DownloadAndScanFileAsync(file, cancellationToken));
+            var downloadTasks = downloadableFiles.Select(
+                file => DownloadAndScanFileAsync(file, inboxDir, cancellationToken));
             var results = await Task.WhenAll(downloadTasks);
 
             foreach (var result in results)
@@ -172,28 +180,45 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         };
     }
 
-    private async Task<DataContent?> DownloadAndScanFileAsync(SlackNet.File file, CancellationToken cancellationToken)
+    private async Task<DataContent?> DownloadAndScanFileAsync(
+        SlackNet.File file, string inboxDir, CancellationToken cancellationToken)
     {
         var downloadUrl = file.UrlPrivateDownload ?? file.UrlPrivate!;
+        var filename = file.Name ?? "attachment";
         try
         {
-            var bytes = await DownloadFileAsync(downloadUrl, cancellationToken);
-            if (bytes.Length == 0)
-                return null;
+            using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            downloadCts.CancelAfter(FileDownloadTimeout);
 
-            using var scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            scanCts.CancelAfter(ContentScanTimeout);
-            var scanResult = await _contentScanner.ScanAsync(
-                bytes, file.Name ?? "attachment", file.Mimetype!, scanCts.Token);
+            var downloadResult = await SlackFileDownloader.DownloadToFileAsync(
+                _httpClient, downloadUrl, _options.BotToken,
+                inboxDir, ChannelAttachmentPolicy.DefaultMaxFileBytes, downloadCts.Token);
+
+            if (downloadResult.BytesWritten == 0)
+            {
+                TryDeleteTemp(downloadResult.FilePath);
+                return null;
+            }
+
+            var scanResult = await _contentScanner.ScanFileAsync(
+                downloadResult.FilePath, filename, file.Mimetype!, cancellationToken);
 
             if (!scanResult.IsAllowed && scanResult.Error != ContentScanError.ScanFailure)
             {
                 _logger.LogWarning("Content scan rejected backfill file {Name}: {Message}",
                     file.Name, scanResult.Message ?? scanResult.Error?.ToString());
+                TryDeleteTemp(downloadResult.FilePath);
                 return null;
             }
 
-            return new DataContent(bytes.ToArray(), file.Mimetype!);
+            var inboxPath = InboxWriter.SanitizeReserveAndMove(inboxDir, filename, downloadResult.FilePath);
+            var bytes = await IOFile.ReadAllBytesAsync(inboxPath, cancellationToken);
+            return new DataContent(bytes, file.Mimetype!);
+        }
+        catch (AttachmentTooLargeException)
+        {
+            _logger.LogWarning("Backfill file {Name} exceeded size limit, skipping", file.Name);
+            return null;
         }
         catch (OperationCanceledException)
         {
@@ -207,10 +232,16 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
         }
     }
 
-    private async Task<ReadOnlyMemory<byte>> DownloadFileAsync(string url, CancellationToken cancellationToken)
+    private static void TryDeleteTemp(string tempPath)
     {
-        using var downloadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        downloadCts.CancelAfter(FileDownloadTimeout);
-        return await SlackFileDownloader.DownloadAsync(_httpClient, url, _options.BotToken, downloadCts.Token);
+        try
+        {
+            if (IOFile.Exists(tempPath))
+                IOFile.Delete(tempPath);
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup during backfill; file will be orphaned but harmless
+        }
     }
 }

--- a/src/Netclaw.Channels/AttachmentDownloadResult.cs
+++ b/src/Netclaw.Channels/AttachmentDownloadResult.cs
@@ -1,0 +1,8 @@
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Result of a streamed attachment download. The file resides on disk
+/// at <see cref="FilePath"/> and is ready for content scanning and
+/// inbox finalization.
+/// </summary>
+public sealed record AttachmentDownloadResult(string FilePath, long BytesWritten);

--- a/src/Netclaw.Channels/AttachmentIngressFormatting.cs
+++ b/src/Netclaw.Channels/AttachmentIngressFormatting.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using Netclaw.Configuration;
+using System.Text;
+
+namespace Netclaw.Channels;
+
+public static class AttachmentIngressFormatting
+{
+    public static string BuildAttachmentLine(
+        string name,
+        string mimeType,
+        long size,
+        string relativePath,
+        bool inlined,
+        string? note)
+    {
+        var inlinedWire = inlined ? "true" : "false";
+        var sb = new StringBuilder(128);
+        sb.Append("[attachment] name=\"").Append(EscapeQuoted(name)).Append('"');
+        sb.Append(" mime=\"").Append(EscapeQuoted(mimeType)).Append('"');
+        sb.Append(" size=").Append(size);
+        sb.Append(" path=\"").Append(EscapeQuoted(relativePath)).Append('"');
+        sb.Append(" inlined=\"").Append(inlinedWire).Append('"');
+        if (!string.IsNullOrEmpty(note))
+            sb.Append(" note=\"").Append(EscapeQuoted(note)).Append('"');
+        return sb.ToString();
+    }
+
+    public static string EscapeQuoted(string value)
+    {
+        var needsProcessing = false;
+        foreach (var c in value)
+        {
+            if (c < ' ' || c == '\\' || c == '"')
+            {
+                needsProcessing = true;
+                break;
+            }
+        }
+
+        if (!needsProcessing)
+            return value;
+
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var c in value)
+        {
+            if (c < ' ')
+                sb.Append(' ');
+            else if (c == '\\')
+                sb.Append("\\\\");
+            else if (c == '"')
+                sb.Append("\\\"");
+            else
+                sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    public static (bool Inlined, string? Note) ResolveInlineDecision(
+        AttachmentCategory category,
+        bool inlineImages)
+    {
+        return category switch
+        {
+            AttachmentCategory.Image when inlineImages => (true, null),
+            AttachmentCategory.Image => (false, AttachmentNotes.ModelMissingImage),
+            AttachmentCategory.Pdf => (false, AttachmentNotes.ModelMissingPdf),
+            _ => (false, AttachmentNotes.FormatNotInlineable)
+        };
+    }
+
+    public static string FormatBytes(long size)
+    {
+        const long Mib = 1024 * 1024;
+        const long Kib = 1024;
+        if (size >= Mib)
+            return $"{size / (double)Mib:F1} MiB";
+        if (size >= Kib)
+            return $"{size / (double)Kib:F1} KiB";
+        return $"{size} bytes";
+    }
+}

--- a/src/Netclaw.Channels/AttachmentStagingCleanup.cs
+++ b/src/Netclaw.Channels/AttachmentStagingCleanup.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Logging;
+
+namespace Netclaw.Channels;
+
+public static class AttachmentStagingCleanup
+{
+    public static void TryDelete(string path, ILogger logger)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to clean up staged attachment file {Path}", path);
+        }
+    }
+}

--- a/src/Netclaw.Channels/AttachmentTooLargeException.cs
+++ b/src/Netclaw.Channels/AttachmentTooLargeException.cs
@@ -2,10 +2,8 @@ namespace Netclaw.Channels;
 
 /// <summary>
 /// Thrown by <see cref="StreamingAttachmentDownloader"/> when a download
-/// exceeds the configured byte ceiling (either the per-policy limit or
-/// the hardcoded <see cref="Configuration.ChannelAttachmentPolicy.AbsoluteMaxFileBytes"/>
-/// safety valve). Channel actors catch this and convert to a user-visible
-/// rejection reply.
+/// exceeds the operator-configured byte ceiling. Channel actors catch this
+/// and convert to a user-visible rejection reply.
 /// </summary>
 public sealed class AttachmentTooLargeException(long bytesReceived, long maxBytes)
     : InvalidOperationException(

--- a/src/Netclaw.Channels/AttachmentTooLargeException.cs
+++ b/src/Netclaw.Channels/AttachmentTooLargeException.cs
@@ -1,0 +1,16 @@
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Thrown by <see cref="StreamingAttachmentDownloader"/> when a download
+/// exceeds the configured byte ceiling (either the per-policy limit or
+/// the hardcoded <see cref="Configuration.ChannelAttachmentPolicy.AbsoluteMaxFileBytes"/>
+/// safety valve). Channel actors catch this and convert to a user-visible
+/// rejection reply.
+/// </summary>
+public sealed class AttachmentTooLargeException(long bytesReceived, long maxBytes)
+    : InvalidOperationException(
+        $"Attachment download exceeded {maxBytes} byte ceiling (received {bytesReceived} bytes)")
+{
+    public long BytesReceived { get; } = bytesReceived;
+    public long MaxBytes { get; } = maxBytes;
+}

--- a/src/Netclaw.Channels/HistoricalAttachmentInbox.cs
+++ b/src/Netclaw.Channels/HistoricalAttachmentInbox.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using System.Text;
+using Netclaw.Actors.Protocol;
+using Netclaw.Security;
+
+namespace Netclaw.Channels;
+
+public static class HistoricalAttachmentInbox
+{
+    public static bool TryGetExistingFile(
+        string inboxDir,
+        string rawFilename,
+        string sourceKey,
+        out string existingPath,
+        out long existingSize)
+    {
+        existingPath = BuildStablePath(inboxDir, rawFilename, sourceKey);
+        existingSize = 0;
+
+        if (!File.Exists(existingPath))
+            return false;
+
+        var info = new FileInfo(existingPath);
+        if (info.Length <= 0)
+            return false;
+
+        existingSize = info.Length;
+        return true;
+    }
+
+    public static string PromoteOrReuse(
+        string inboxDir,
+        string rawFilename,
+        string sourceKey,
+        string stagedFilePath)
+    {
+        var targetPath = BuildStablePath(inboxDir, rawFilename, sourceKey);
+        if (File.Exists(targetPath))
+        {
+            File.Delete(stagedFilePath);
+            return targetPath;
+        }
+
+        File.Move(stagedFilePath, targetPath);
+        return targetPath;
+    }
+
+    private static string BuildStablePath(string inboxDir, string rawFilename, string sourceKey)
+    {
+        var safeName = FilenameSanitizer.Sanitize(rawFilename);
+        var nameOnly = Path.GetFileNameWithoutExtension(safeName);
+        var extension = Path.GetExtension(safeName);
+        var stableSuffix = ComputeStableSuffix(sourceKey);
+        return Path.Combine(inboxDir, $"{nameOnly}_hist_{stableSuffix}{extension}");
+    }
+
+    private static string ComputeStableSuffix(string sourceKey)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sourceKey));
+        return Convert.ToHexString(bytes[..8]).ToLowerInvariant();
+    }
+}

--- a/src/Netclaw.Channels/HistoricalAttachmentInbox.cs
+++ b/src/Netclaw.Channels/HistoricalAttachmentInbox.cs
@@ -41,8 +41,16 @@ public static class HistoricalAttachmentInbox
             return targetPath;
         }
 
-        File.Move(stagedFilePath, targetPath);
-        return targetPath;
+        try
+        {
+            File.Move(stagedFilePath, targetPath);
+            return targetPath;
+        }
+        catch (IOException) when (File.Exists(targetPath))
+        {
+            File.Delete(stagedFilePath);
+            return targetPath;
+        }
     }
 
     private static string BuildStablePath(string inboxDir, string rawFilename, string sourceKey)

--- a/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
+++ b/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace Netclaw.Channels;
 
 /// <summary>
@@ -42,6 +44,7 @@ public static class StreamingAttachmentDownloader
         }
 
         var tempPath = Path.Combine(targetDirectory, $".download.{Guid.NewGuid():N}.tmp");
+        var buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         try
         {
             await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -49,11 +52,10 @@ public static class StreamingAttachmentDownloader
                 tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
                 bufferSize: DefaultBufferSize, useAsync: true);
 
-            var buffer = new byte[DefaultBufferSize];
             long totalBytesWritten = 0;
             int bytesRead;
 
-            while ((bytesRead = await responseStream.ReadAsync(buffer, cancellationToken)) > 0)
+            while ((bytesRead = await responseStream.ReadAsync(buffer.AsMemory(0, DefaultBufferSize), cancellationToken)) > 0)
             {
                 totalBytesWritten += bytesRead;
                 if (totalBytesWritten > maxBytes)
@@ -72,6 +74,10 @@ public static class StreamingAttachmentDownloader
             TryDeleteTemp(tempPath);
             throw;
         }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     private static void TryDeleteTemp(string tempPath)
@@ -81,9 +87,11 @@ public static class StreamingAttachmentDownloader
             if (File.Exists(tempPath))
                 File.Delete(tempPath);
         }
-        catch
+        catch (IOException)
         {
-            // best-effort cleanup; do not mask the original exception
+            // Best-effort cleanup during error recovery — the file may be locked
+            // by antivirus or another process. The original exception propagates
+            // regardless; this orphaned temp file is harmless.
         }
     }
 }

--- a/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
+++ b/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
@@ -1,0 +1,89 @@
+namespace Netclaw.Channels;
+
+/// <summary>
+/// Streams HTTP file downloads directly to disk with a fixed-size buffer,
+/// enforcing a byte ceiling during the copy. Channel adapters use this
+/// instead of <c>HttpClient.GetByteArrayAsync</c> to avoid holding entire
+/// attachments in managed memory.
+/// </summary>
+public static class StreamingAttachmentDownloader
+{
+    public const int DefaultBufferSize = 81_920;
+
+    /// <summary>
+    /// Downloads the resource at <paramref name="url"/> directly into a temp
+    /// file in <paramref name="targetDirectory"/>. Returns the temp file path
+    /// and actual bytes written on success. Deletes the temp file on any failure.
+    /// </summary>
+    /// <param name="httpClient">Pre-configured HttpClient (e.g., from IHttpClientFactory).</param>
+    /// <param name="url">Remote file URL.</param>
+    /// <param name="configureRequest">Optional callback to set auth headers (e.g., Bearer token for Slack).</param>
+    /// <param name="targetDirectory">Directory to write the temp file into (typically the session inbox).</param>
+    /// <param name="maxBytes">Operator-configured per-policy byte limit.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task<AttachmentDownloadResult> DownloadToFileAsync(
+        HttpClient httpClient,
+        string url,
+        Action<HttpRequestMessage>? configureRequest,
+        string targetDirectory,
+        long maxBytes,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        configureRequest?.Invoke(request);
+
+        using var response = await httpClient.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        if (response.Content.Headers.ContentLength is { } contentLength && contentLength > maxBytes)
+        {
+            throw new AttachmentTooLargeException(contentLength, maxBytes);
+        }
+
+        var tempPath = Path.Combine(targetDirectory, $".download.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await using var fileStream = new FileStream(
+                tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                bufferSize: DefaultBufferSize, useAsync: true);
+
+            var buffer = new byte[DefaultBufferSize];
+            long totalBytesWritten = 0;
+            int bytesRead;
+
+            while ((bytesRead = await responseStream.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                totalBytesWritten += bytesRead;
+                if (totalBytesWritten > maxBytes)
+                {
+                    throw new AttachmentTooLargeException(totalBytesWritten, maxBytes);
+                }
+
+                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+            }
+
+            await fileStream.FlushAsync(cancellationToken);
+            return new AttachmentDownloadResult(tempPath, totalBytesWritten);
+        }
+        catch
+        {
+            TryDeleteTemp(tempPath);
+            throw;
+        }
+    }
+
+    private static void TryDeleteTemp(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch
+        {
+            // best-effort cleanup; do not mask the original exception
+        }
+    }
+}

--- a/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
+++ b/src/Netclaw.Channels/StreamingAttachmentDownloader.cs
@@ -15,12 +15,14 @@ public static class StreamingAttachmentDownloader
     /// <summary>
     /// Downloads the resource at <paramref name="url"/> directly into a temp
     /// file in <paramref name="targetDirectory"/>. Returns the temp file path
-    /// and actual bytes written on success. Deletes the temp file on any failure.
+    /// and actual bytes written on success. Callers typically pass a hidden
+    /// staging directory and only promote the file into the session inbox after
+    /// content scanning succeeds.
     /// </summary>
     /// <param name="httpClient">Pre-configured HttpClient (e.g., from IHttpClientFactory).</param>
     /// <param name="url">Remote file URL.</param>
     /// <param name="configureRequest">Optional callback to set auth headers (e.g., Bearer token for Slack).</param>
-    /// <param name="targetDirectory">Directory to write the temp file into (typically the session inbox).</param>
+    /// <param name="targetDirectory">Directory to write the temp file into (typically a hidden staging directory).</param>
     /// <param name="maxBytes">Operator-configured per-policy byte limit.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<AttachmentDownloadResult> DownloadToFileAsync(
@@ -29,7 +31,8 @@ public static class StreamingAttachmentDownloader
         Action<HttpRequestMessage>? configureRequest,
         string targetDirectory,
         long maxBytes,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<Exception, string>? onCleanupFailure = null)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         configureRequest?.Invoke(request);
@@ -71,7 +74,7 @@ public static class StreamingAttachmentDownloader
         }
         catch
         {
-            TryDeleteTemp(tempPath);
+            TryDeleteTemp(tempPath, onCleanupFailure);
             throw;
         }
         finally
@@ -80,18 +83,16 @@ public static class StreamingAttachmentDownloader
         }
     }
 
-    private static void TryDeleteTemp(string tempPath)
+    private static void TryDeleteTemp(string tempPath, Action<Exception, string>? onCleanupFailure)
     {
         try
         {
             if (File.Exists(tempPath))
                 File.Delete(tempPath);
         }
-        catch (IOException)
+        catch (Exception ex)
         {
-            // Best-effort cleanup during error recovery — the file may be locked
-            // by antivirus or another process. The original exception propagates
-            // regardless; this orphaned temp file is harmless.
+            onCleanupFailure?.Invoke(ex, tempPath);
         }
     }
 }

--- a/src/Netclaw.Channels/ThreadHistoryContentMerger.cs
+++ b/src/Netclaw.Channels/ThreadHistoryContentMerger.cs
@@ -22,6 +22,7 @@ public static class ThreadHistoryContentMerger
             var ts = item.ReceivedAt == default ? string.Empty : $", {item.ReceivedAt:yyyy-MM-dd HH:mm} UTC";
             sb.AppendLine($"<user: {item.SenderId}{ts}>");
 
+            var hasAttachmentAnnouncement = ContainsAttachmentAnnouncement(item.Contents);
             var imageCount = 0;
             foreach (var content in item.Contents)
             {
@@ -33,6 +34,9 @@ public static class ThreadHistoryContentMerger
 
                     case DataContent data:
                         historicalData.Add(data);
+                        if (hasAttachmentAnnouncement)
+                            break;
+
                         if (data.MediaType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
                         {
                             imageCount++;
@@ -74,5 +78,20 @@ public static class ThreadHistoryContentMerger
         }
 
         return merged;
+    }
+
+    private static bool ContainsAttachmentAnnouncement(IReadOnlyList<AIContent> contents)
+    {
+        foreach (var text in contents.OfType<TextContent>())
+        {
+            var lines = text.Text.Split('\n');
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("[attachment]", StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Netclaw.Channels/ThreadHistoryContentMerger.cs
+++ b/src/Netclaw.Channels/ThreadHistoryContentMerger.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Channels;
+using System.Text;
+
+namespace Netclaw.Channels;
+
+public static class ThreadHistoryContentMerger
+{
+    public static List<AIContent> MergeHistoryWithLiveContents(
+        IReadOnlyList<ChannelInput> history,
+        IReadOnlyList<AIContent> liveContents)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("[thread history — messages exchanged before this inbound event]");
+        sb.AppendLine();
+
+        var merged = new List<AIContent>();
+        var historicalData = new List<AIContent>();
+
+        foreach (var item in history)
+        {
+            var ts = item.ReceivedAt == default ? string.Empty : $", {item.ReceivedAt:yyyy-MM-dd HH:mm} UTC";
+            sb.AppendLine($"<user: {item.SenderId}{ts}>");
+
+            var imageCount = 0;
+            foreach (var content in item.Contents)
+            {
+                switch (content)
+                {
+                    case TextContent text when !string.IsNullOrWhiteSpace(text.Text):
+                        sb.AppendLine(text.Text);
+                        break;
+
+                    case DataContent data:
+                        historicalData.Add(data);
+                        if (data.MediaType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            imageCount++;
+                        }
+                        else
+                        {
+                            sb.AppendLine(
+                                $"[attachment] mime=\"{AttachmentIngressFormatting.EscapeQuoted(data.MediaType ?? "application/octet-stream")}\" inlined=\"true\"");
+                        }
+
+                        break;
+                }
+            }
+
+            if (imageCount > 0)
+                sb.AppendLine($"[image attachments: {imageCount}]");
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("[end thread history]");
+
+        var liveText = string.Join("\n", liveContents
+            .OfType<TextContent>()
+            .Select(t => t.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t)));
+
+        var mergedText = string.IsNullOrWhiteSpace(liveText)
+            ? sb.ToString()
+            : $"{sb}\n\n{liveText}";
+
+        merged.Add(new TextContent(mergedText));
+        merged.AddRange(historicalData);
+
+        foreach (var content in liveContents)
+        {
+            if (content is not TextContent)
+                merged.Add(content);
+        }
+
+        return merged;
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/DiscordChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/DiscordChannelRegistrationExtensions.cs
@@ -4,6 +4,8 @@ using Netclaw.Actors.Reminders;
 using Netclaw.Channels;
 using Netclaw.Channels.Discord;
 using Netclaw.Channels.Discord.Transport;
+using Netclaw.Configuration;
+using Netclaw.Security;
 
 namespace Netclaw.Daemon.Configuration;
 
@@ -35,7 +37,26 @@ public static class DiscordChannelRegistrationExtensions
         services.AddHttpClient("discord-files");
         services.AddSingleton<IDiscordGatewayClient, DiscordNetGatewayClient>();
         services.AddSingleton<IDiscordReplyClient, DiscordNetReplyClient>();
-        services.AddSingleton<IThreadHistoryFetcher, DiscordThreadHistoryFetcher>();
+        services.AddSingleton<IThreadHistoryFetcher>(sp =>
+        {
+            var client = sp.GetRequiredService<DiscordSocketClient>();
+            var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+            var contentScanner = sp.GetRequiredService<IContentScanner>();
+            var toolConfig = sp.GetRequiredService<ToolConfig>();
+            var modelCapabilities = sp.GetRequiredService<ModelCapabilities>();
+            var paths = sp.GetRequiredService<NetclawPaths>();
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<DiscordThreadHistoryFetcher>();
+
+            return new DiscordThreadHistoryFetcher(
+                client,
+                discordOptions,
+                httpFactory.CreateClient("discord-files"),
+                contentScanner,
+                toolConfig.AudienceProfiles,
+                modelCapabilities,
+                paths,
+                logger);
+        });
         services.AddSingleton<IReminderTargetResolver, DiscordReminderTargetResolver>();
 
         services.AddKeyedSingleton<IChannel, DiscordChannel>(DiscordChannelKey);

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -37,8 +37,18 @@ public static class SlackChannelRegistrationExtensions
             var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
             var contentScanner = sp.GetRequiredService<Netclaw.Security.IContentScanner>();
             var paths = sp.GetRequiredService<NetclawPaths>();
+            var toolConfig = sp.GetRequiredService<ToolConfig>();
+            var modelCapabilities = sp.GetRequiredService<ModelCapabilities>();
             var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<SlackThreadHistoryFetcher>();
-            return new SlackThreadHistoryFetcher(slackApi.Conversations, slackOptions, httpFactory.CreateClient("slack-files"), contentScanner, paths, logger);
+            return new SlackThreadHistoryFetcher(
+                slackApi.Conversations,
+                slackOptions,
+                httpFactory.CreateClient("slack-files"),
+                contentScanner,
+                paths,
+                toolConfig.AudienceProfiles,
+                modelCapabilities,
+                logger);
         });
         services.AddSingleton<ISlackOutboundClient, SlackOutboundClient>();
         services.AddSingleton<ISlackTargetLookupClient, SlackApiTargetLookupClient>();

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -2,6 +2,7 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Reminders;
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
+using Netclaw.Configuration;
 using Netclaw.Channels.Slack.Tools;
 using Netclaw.Tools;
 using SlackNet.Events;
@@ -35,8 +36,9 @@ public static class SlackChannelRegistrationExtensions
             var slackApi = sp.GetRequiredService<SlackNet.ISlackApiClient>();
             var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
             var contentScanner = sp.GetRequiredService<Netclaw.Security.IContentScanner>();
+            var paths = sp.GetRequiredService<NetclawPaths>();
             var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<SlackThreadHistoryFetcher>();
-            return new SlackThreadHistoryFetcher(slackApi.Conversations, slackOptions, httpFactory.CreateClient("slack-files"), contentScanner, logger);
+            return new SlackThreadHistoryFetcher(slackApi.Conversations, slackOptions, httpFactory.CreateClient("slack-files"), contentScanner, paths, logger);
         });
         services.AddSingleton<ISlackOutboundClient, SlackOutboundClient>();
         services.AddSingleton<ISlackTargetLookupClient, SlackApiTargetLookupClient>();

--- a/src/Netclaw.Security/IContentScanner.cs
+++ b/src/Netclaw.Security/IContentScanner.cs
@@ -11,4 +11,20 @@ public interface IContentScanner
         string filename,
         string declaredMimeType,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Scans a file already on disk. Default implementation reads the entire
+    /// file into memory and delegates to the byte-based overload.
+    /// Implementations may override for more efficient handling (e.g.,
+    /// reading only the file header for magic-byte validation).
+    /// </summary>
+    Task<ContentScanResult> ScanFileAsync(
+        string filePath,
+        string filename,
+        string declaredMimeType,
+        CancellationToken cancellationToken = default)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        return ScanAsync(bytes, filename, declaredMimeType, cancellationToken);
+    }
 }

--- a/src/Netclaw.Security/MagicByteContentScanner.cs
+++ b/src/Netclaw.Security/MagicByteContentScanner.cs
@@ -44,16 +44,17 @@ public sealed class MagicByteContentScanner(ContentPolicy policy) : IContentScan
 
         try
         {
-            var info = new FileInfo(filePath);
             Span<byte> header = stackalloc byte[HeaderReadSize];
             int bytesRead;
+            long fileSize;
             using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
+                fileSize = fs.Length;
                 bytesRead = fs.Read(header);
             }
 
             var result = MagicByteValidator.ValidateFromHeader(
-                header[..bytesRead], info.Length, declaredMimeType, filename, _policy);
+                header[..bytesRead], fileSize, declaredMimeType, filename, _policy);
             return Task.FromResult(result);
         }
         catch (OperationCanceledException)

--- a/src/Netclaw.Security/MagicByteContentScanner.cs
+++ b/src/Netclaw.Security/MagicByteContentScanner.cs
@@ -6,6 +6,7 @@ namespace Netclaw.Security;
 /// </summary>
 public sealed class MagicByteContentScanner(ContentPolicy policy) : IContentScanner
 {
+    private const int HeaderReadSize = 64;
     private readonly ContentPolicy _policy = policy;
 
     public Task<ContentScanResult> ScanAsync(
@@ -19,6 +20,40 @@ public sealed class MagicByteContentScanner(ContentPolicy policy) : IContentScan
         try
         {
             var result = MagicByteValidator.Validate(content.Span, declaredMimeType, filename, _policy);
+            return Task.FromResult(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ContentScanResult.Rejected(
+                ContentScanError.ScanFailure,
+                $"Content scan failed: {ex.Message}"));
+        }
+    }
+
+    public Task<ContentScanResult> ScanFileAsync(
+        string filePath,
+        string filename,
+        string declaredMimeType,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var info = new FileInfo(filePath);
+            Span<byte> header = stackalloc byte[HeaderReadSize];
+            int bytesRead;
+            using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                bytesRead = fs.Read(header);
+            }
+
+            var result = MagicByteValidator.ValidateFromHeader(
+                header[..bytesRead], info.Length, declaredMimeType, filename, _policy);
             return Task.FromResult(result);
         }
         catch (OperationCanceledException)

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -160,10 +160,7 @@ public static class MagicByteValidator
 
     /// <summary>
     /// Validates file content against its declared MIME type and filename.
-    /// Rejects empty content, oversized content, executables, unknown or
-    /// disallowed MIME types, filenames whose extension doesn't match the
-    /// declared MIME type, and content whose magic bytes don't match the
-    /// declared signature family.
+    /// Delegates to <see cref="ValidateFromHeader"/> using the full content as the header.
     /// </summary>
     public static ContentScanResult Validate(
         ReadOnlySpan<byte> content,
@@ -171,87 +168,7 @@ public static class MagicByteValidator
         string filename,
         ContentPolicy? policy = null)
     {
-        if (content.Length == 0)
-        {
-            return ContentScanResult.Rejected(
-                ContentScanError.EmptyContent,
-                "File is empty");
-        }
-
-        var effectivePolicy = policy ?? new ContentPolicy();
-
-        if (content.Length > effectivePolicy.MaxFileSizeBytes)
-        {
-            return ContentScanResult.Rejected(
-                ContentScanError.FileTooLarge,
-                $"File exceeds maximum size of {effectivePolicy.MaxFileSizeBytes / (1024 * 1024)} MiB");
-        }
-
-        if (HasExecutableSignature(content))
-        {
-            var detectedType = DetectMimeType(content);
-            return ContentScanResult.Rejected(
-                ContentScanError.ExecutableContent,
-                "Executable content detected",
-                detectedType is not null ? new MimeType(detectedType) : null);
-        }
-
-        var extension = Path.GetExtension(filename);
-        if (string.IsNullOrEmpty(extension))
-        {
-            return ContentScanResult.Rejected(
-                ContentScanError.UnrecognizedFileType,
-                "File has no extension");
-        }
-
-        // Normalize known MIME type mismatches (e.g., Slack reports .md as text/plain)
-        var effectiveMimeType = NormalizeMimeType(declaredMimeType, extension);
-
-        if (!RulesByMime.TryGetValue(effectiveMimeType, out var rule))
-        {
-            return ContentScanResult.Rejected(
-                ContentScanError.UnrecognizedFileType,
-                $"MIME type '{effectiveMimeType}' is not supported by the content scanner");
-        }
-
-        if (!effectivePolicy.AllowedMimeTypes.Contains(effectiveMimeType))
-        {
-            return ContentScanResult.Rejected(
-                ContentScanError.UnrecognizedFileType,
-                $"MIME type '{effectiveMimeType}' is not allowed by policy");
-        }
-
-        if (!rule.Extensions.Contains(extension))
-        {
-            // Extension disagrees with declared MIME — Discord CDN declares
-            // image/webp for .png files. Use magic bytes as ground truth:
-            // if they confirm a type matching the extension, accept it.
-            // https://github.com/Aaronontheweb/netclaw/issues/754
-            var detected = DetectMimeType(content);
-            if (detected is not null
-                && RulesByMime.TryGetValue(detected, out var detectedRule)
-                && detectedRule.Extensions.Contains(extension)
-                && effectivePolicy.AllowedMimeTypes.Contains(detected))
-            {
-                return ContentScanResult.Allowed(new MimeType(detected));
-            }
-
-            return ContentScanResult.Rejected(
-                ContentScanError.MimeTypeMismatch,
-                $"Extension '{extension}' does not match declared type '{effectiveMimeType}'",
-                detected is not null ? new MimeType(detected) : null);
-        }
-
-        if (!rule.Matches(content))
-        {
-            var detectedMimeType = DetectMimeType(content);
-            return ContentScanResult.Rejected(
-                ContentScanError.MimeTypeMismatch,
-                $"Content is not a valid {effectiveMimeType} file",
-                detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
-        }
-
-        return ContentScanResult.Allowed(new MimeType(effectiveMimeType));
+        return ValidateFromHeader(content, content.Length, declaredMimeType, filename, policy);
     }
 
     /// <summary>

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -64,6 +64,101 @@ public static class MagicByteValidator
         BuildMimeNormalizationRules().ToFrozenDictionary(new ExtensionMimePairComparer());
 
     /// <summary>
+    /// Validates a file using only its header bytes and total size. Used by
+    /// the streaming download path where the full file is on disk and only
+    /// the first N bytes are read into memory for signature checking.
+    /// </summary>
+    /// <param name="header">First N bytes of the file (64 bytes is sufficient for all known signatures).</param>
+    /// <param name="totalFileSize">Total file size from <see cref="System.IO.FileInfo.Length"/>.</param>
+    /// <param name="declaredMimeType">MIME type declared by the channel transport.</param>
+    /// <param name="filename">Original filename including extension.</param>
+    /// <param name="policy">Content policy; null uses default.</param>
+    public static ContentScanResult ValidateFromHeader(
+        ReadOnlySpan<byte> header,
+        long totalFileSize,
+        string declaredMimeType,
+        string filename,
+        ContentPolicy? policy = null)
+    {
+        if (totalFileSize == 0)
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.EmptyContent,
+                "File is empty");
+        }
+
+        var effectivePolicy = policy ?? new ContentPolicy();
+
+        if (totalFileSize > effectivePolicy.MaxFileSizeBytes)
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.FileTooLarge,
+                $"File exceeds maximum size of {effectivePolicy.MaxFileSizeBytes / (1024 * 1024)} MiB");
+        }
+
+        if (HasExecutableSignature(header))
+        {
+            var detectedType = DetectMimeType(header);
+            return ContentScanResult.Rejected(
+                ContentScanError.ExecutableContent,
+                "Executable content detected",
+                detectedType is not null ? new MimeType(detectedType) : null);
+        }
+
+        var extension = Path.GetExtension(filename);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.UnrecognizedFileType,
+                "File has no extension");
+        }
+
+        var effectiveMimeType = NormalizeMimeType(declaredMimeType, extension);
+
+        if (!RulesByMime.TryGetValue(effectiveMimeType, out var rule))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.UnrecognizedFileType,
+                $"MIME type '{effectiveMimeType}' is not supported by the content scanner");
+        }
+
+        if (!effectivePolicy.AllowedMimeTypes.Contains(effectiveMimeType))
+        {
+            return ContentScanResult.Rejected(
+                ContentScanError.UnrecognizedFileType,
+                $"MIME type '{effectiveMimeType}' is not allowed by policy");
+        }
+
+        if (!rule.Extensions.Contains(extension))
+        {
+            var detected = DetectMimeType(header);
+            if (detected is not null
+                && RulesByMime.TryGetValue(detected, out var detectedRule)
+                && detectedRule.Extensions.Contains(extension)
+                && effectivePolicy.AllowedMimeTypes.Contains(detected))
+            {
+                return ContentScanResult.Allowed(new MimeType(detected));
+            }
+
+            return ContentScanResult.Rejected(
+                ContentScanError.MimeTypeMismatch,
+                $"Extension '{extension}' does not match declared type '{effectiveMimeType}'",
+                detected is not null ? new MimeType(detected) : null);
+        }
+
+        if (!rule.Matches(header))
+        {
+            var detectedMimeType = DetectMimeType(header);
+            return ContentScanResult.Rejected(
+                ContentScanError.MimeTypeMismatch,
+                $"Content is not a valid {effectiveMimeType} file",
+                detectedMimeType is not null ? new MimeType(detectedMimeType) : null);
+        }
+
+        return ContentScanResult.Allowed(new MimeType(effectiveMimeType));
+    }
+
+    /// <summary>
     /// Validates file content against its declared MIME type and filename.
     /// Rejects empty content, oversized content, executables, unknown or
     /// disallowed MIME types, filenames whose extension doesn't match the


### PR DESCRIPTION
## Summary

Resolves #757 — attachment downloads no longer buffer entire files in managed memory.

- **New `StreamingAttachmentDownloader`** — shared static helper that streams HTTP responses directly to disk using an 81 KB pooled buffer (`ArrayPool<byte>.Shared`), enforcing the operator-configured byte ceiling mid-stream via Content-Length header check + byte counting fallback.
- **Unified live + backfill paths** — both `SlackThreadBindingActor`, `SlackThreadHistoryFetcher`, and `DiscordSessionBindingActor` use the same streaming infrastructure, eliminating a potential security bypass where backfill could skip size/content checks.
- **Header-only content scanning** — `MagicByteContentScanner.ScanFileAsync` reads only 64 bytes from disk (all magic-byte signatures need ≤12 bytes), avoiding the need to load the full file for validation.
- **`MagicByteValidator` deduplication** — `Validate()` now delegates to `ValidateFromHeader()`, removing ~80 lines of duplicate logic.
- **Atomic file placement** — `InboxWriter.SanitizeReserveAndMove` does a same-filesystem `File.Move` from the temp download path to the final inbox path (no redundant byte copy).

### Design decisions

- **No hardcoded ceiling** — the operator controls `MaxFileBytes` via policy configuration. The streaming downloader enforces whatever ceiling is passed to it.
- **`Action<HttpRequestMessage>?` callback** — channels provide their own auth (Bearer token for Slack, nothing for Discord) without needing an interface.
- **`DataContent` inlining** — only images when `inlineImages=true` read back from disk after persist; all other files stay on disk.

## Test plan

- [x] All 2,881 existing tests pass (no behavioral change for correctly-sized files)
- [x] `dotnet slopwatch analyze` — zero violations
- [ ] Manual: upload a >1 MB file via Slack, verify it arrives in inbox without full-buffer allocation
- [ ] Manual: upload a file exceeding `MaxFileBytes`, verify rejection message