### PR TITLE
feat(stats): configuration-driven channel statistics (#773)

### DIFF
--- a/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordConversationActor.cs
@@ -69,7 +69,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         {
             var reason = aclDecision.DenyReason ?? "acl_denied";
             _log.Info("discord_event_dropped event={0} reason={1}", message.EventId.Value, reason);
-            ChannelTelemetry.RecordDiscordEventDropped(reason);
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped(reason);
             return;
         }
 
@@ -77,7 +77,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         if (message.IsBotMessage)
         {
             _log.Info("discord_event_filtered event={0} reason=bot_message", message.EventId.Value);
-            ChannelTelemetry.RecordDiscordEventFiltered("bot_message");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("bot_message");
             return;
         }
 
@@ -85,7 +85,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         if (_dependencies.IngressGate?.ClosedReason is { } closedReason)
         {
             _log.Info("discord_event_filtered event={0} reason=restart_drain_active", message.EventId.Value);
-            ChannelTelemetry.RecordDiscordEventFiltered("restart_drain_active");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("restart_drain_active");
             // Safe fire-and-forget: PostIngressClosedReplyAsync wraps everything in try/catch,
             // and no synchronous code precedes the first await, so exceptions cannot escape.
             _ = PostIngressClosedReplyAsync(message.ReplyChannelId, closedReason);
@@ -112,7 +112,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
                 "discord_event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
                 message.EventId.Value,
                 ignoreReason);
-            ChannelTelemetry.RecordDiscordEventFiltered(
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered(
                 DiscordRoutingDecision.TelemetryLabelFor(ignoreReason));
             return;
         }
@@ -120,7 +120,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         if (decision.Kind is DiscordRoutingDecisionKind.ContinueOnly && !threadExists)
         {
             _log.Info("discord_event_dropped event={0} reason=thread_not_initialized", message.EventId.Value);
-            ChannelTelemetry.RecordDiscordEventDropped("thread_not_initialized");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped("thread_not_initialized");
             return;
         }
 
@@ -136,7 +136,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
         if (string.IsNullOrWhiteSpace(normalizedText) && !hasAttachments)
         {
             _log.Info("discord_event_filtered event={0} reason=empty_text", message.EventId.Value);
-            ChannelTelemetry.RecordDiscordEventFiltered("empty_text");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("empty_text");
             return;
         }
 
@@ -165,7 +165,7 @@ internal sealed class DiscordConversationActor : ReceiveActor
             message.EventId.Value,
             normalizedText.Length);
 
-        ChannelTelemetry.RecordDiscordEventRouted("message");
+        ChannelTelemetry.For(ChannelType.Discord).RecordEventRouted("message");
         sessionBinding.Forward(new DiscordThreadInbound(
             SessionId: sessionId,
             ChannelId: _channelId,
@@ -192,11 +192,11 @@ internal sealed class DiscordConversationActor : ReceiveActor
                 "Ignoring Discord interaction for missing session binding channel={0} threadOrMessage={1}",
                 _channelId.Value,
                 interaction.ThreadOrMessageId.Value);
-            ChannelTelemetry.RecordDiscordInteractionError("missing_session_binding");
+            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("interactionErrors", "missing_session_binding");
             return;
         }
 
-        ChannelTelemetry.RecordDiscordEventRouted("interaction");
+        ChannelTelemetry.For(ChannelType.Discord).RecordEventRouted("interaction");
         sessionBinding.Forward(new DiscordApprovalResponse(
             ChannelId: _channelId,
             ThreadOrMessageId: interaction.ThreadOrMessageId,

--- a/src/Netclaw.Channels.Discord/DiscordGatewayActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordGatewayActor.cs
@@ -24,12 +24,12 @@ public sealed class DiscordGatewayActor : ReceiveActor
 
         Receive<DiscordGatewayMessage>(message =>
         {
-            ChannelTelemetry.RecordDiscordEventReceived("message");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventReceived("message");
 
             if (!TryMarkEventProcessed(message.EventId))
             {
                 _log.Debug("Dropping duplicate Discord event {0}", message.EventId.Value);
-                ChannelTelemetry.RecordDiscordEventFiltered("duplicate_event");
+                ChannelTelemetry.For(ChannelType.Discord).RecordEventFiltered("duplicate_event");
                 return;
             }
 
@@ -41,7 +41,7 @@ public sealed class DiscordGatewayActor : ReceiveActor
 
         Receive<DiscordGatewayInteraction>(interaction =>
         {
-            ChannelTelemetry.RecordDiscordEventReceived("interaction");
+            ChannelTelemetry.For(ChannelType.Discord).RecordEventReceived("interaction");
 
             var conversation = GetOrCreateConversationActor(interaction.ChannelId);
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -246,13 +246,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             {
                 case ClassificationOutcome.Block:
                     _log.Warning("Blocked Discord message due to prompt injection risk: {Reason}", classification.Reason);
-                    ChannelTelemetry.RecordDiscordEventDropped("prompt_injection_high");
+                    ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped("prompt_injection_high");
                     await SafeReplyAsync(LiveInjectionBlockedWarning);
                     return;
 
                 case ClassificationOutcome.DetectorUnavailable:
                     _log.Warning("Prompt injection detector unavailable for live message — dropping");
-                    ChannelTelemetry.RecordDiscordEventDropped("prompt_injection_detector_unavailable");
+                    ChannelTelemetry.For(ChannelType.Discord).RecordEventDropped("prompt_injection_detector_unavailable");
                     await SafeReplyAsync(LiveDetectorUnavailableWarning);
                     return;
 
@@ -300,7 +300,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             using var writeCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await writer.WriteAsync(input, writeCts.Token);
-            ChannelTelemetry.RecordDiscordMessageEnqueued();
+            ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
 
             if (TryParseSnowflake(message.EventId.Value) is { } eventSnowflake)
             {
@@ -508,7 +508,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (result is ApprovalLookupResult.NotFound)
         {
             _log.Info("Ignoring Discord approval response for unknown call id {0}", message.CallId);
-            ChannelTelemetry.RecordDiscordInteractionError("unknown_call_id");
+            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("interactionErrors", "unknown_call_id");
             return;
         }
 
@@ -719,14 +719,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             var result = await _dependencies.ReplyClient.PostReplyAsync(postMessage);
             ApplyThreadPromotion(result);
             var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-            ChannelTelemetry.RecordDiscordReplyPosted(duration);
-            ChannelTelemetry.RecordDiscordApprovalFallbackActivated("button_prompt");
+            ChannelTelemetry.For(ChannelType.Discord).RecordReplyPosted(duration);
+            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("approvalFallbackActivated", "button_prompt");
             return result.MessageId;
         }
         catch (Exception ex)
         {
             _log.Warning(ex, "Failed posting Discord button prompt; falling back to text-only");
-            ChannelTelemetry.RecordDiscordApprovalFallbackActivated("text_prompt");
+            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("approvalFallbackActivated", "text_prompt");
             try
             {
                 var fallbackText = DiscordApprovalPromptBuilder.BuildTextPrompt(request);
@@ -756,13 +756,13 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                 var result = await _dependencies.ReplyClient.PostReplyAsync(postMessage);
                 ApplyThreadPromotion(result);
                 var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
-                ChannelTelemetry.RecordDiscordReplyPosted(duration);
+                ChannelTelemetry.For(ChannelType.Discord).RecordReplyPosted(duration);
             }
             catch (Exception ex)
             {
                 var duration = _dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds;
                 _log.Warning(ex, "Failed posting Discord reply for session {0}", _sessionId.Value);
-                ChannelTelemetry.RecordDiscordReplyFailed(duration);
+                ChannelTelemetry.For(ChannelType.Discord).RecordReplyFailed(duration);
                 await NotifyDeliveryFailedAsync(DeliveryFailureKind.TransportFailure, ex.Message);
                 return;
             }

--- a/src/Netclaw.Channels.Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackConversationActor.cs
@@ -38,14 +38,14 @@ public sealed class SlackConversationActor : ReceiveActor
             if (!aclDecision.IsAllowed)
             {
                 _log.Info("slack_event_dropped event={0} reason={1}", message.EventId, aclDecision.DenyReason ?? "acl_denied");
-                ChannelTelemetry.RecordSlackEventDropped(aclDecision.DenyReason ?? "acl_denied");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped(aclDecision.DenyReason ?? "acl_denied");
                 return;
             }
 
             if (IsBotMessage(message))
             {
                 _log.Info("slack_event_filtered event={0} reason=bot_message", message.EventId);
-                ChannelTelemetry.RecordSlackEventFiltered("bot_message");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("bot_message");
                 return;
             }
 
@@ -72,7 +72,7 @@ public sealed class SlackConversationActor : ReceiveActor
                     "slack_event_filtered event={0} reason=routing_policy_ignore ignoreReason={1}",
                     message.EventId,
                     ignoreReason);
-                ChannelTelemetry.RecordSlackEventFiltered(
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered(
                     SlackRoutingDecision.TelemetryLabelFor(ignoreReason));
                 return;
             }
@@ -80,7 +80,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (decision.Kind is SlackRoutingDecisionKind.ContinueOnly && !threadExists)
             {
                 _log.Info("slack_event_dropped event={0} reason=thread_not_initialized", message.EventId);
-                ChannelTelemetry.RecordSlackEventDropped("thread_not_initialized");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped("thread_not_initialized");
                 return;
             }
 
@@ -88,7 +88,7 @@ public sealed class SlackConversationActor : ReceiveActor
             {
                 var replyThreadTs = message.ThreadTs ?? SlackThreadTs.FromEventTs(message.EventTs);
                 _log.Info("slack_event_filtered event={0} reason=restart_drain_active", message.EventId);
-                ChannelTelemetry.RecordSlackEventFiltered("restart_drain_active");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("restart_drain_active");
                 _ = PostIngressClosedReplyAsync(message.ChannelId, replyThreadTs, ingressClosedReason);
                 return;
             }
@@ -101,7 +101,7 @@ public sealed class SlackConversationActor : ReceiveActor
             if (string.IsNullOrWhiteSpace(normalized) && message.Files is not { Count: > 0 })
             {
                 _log.Info("slack_event_filtered event={0} reason=empty_text", message.EventId);
-                ChannelTelemetry.RecordSlackEventFiltered("empty_text");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("empty_text");
                 return;
             }
 

--- a/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
@@ -24,12 +24,12 @@ public sealed class SlackGatewayActor : ReceiveActor
 
         Receive<SlackInboundMessage>(message =>
         {
-            ChannelTelemetry.RecordSlackEventReceived(message.Kind.ToString());
+            ChannelTelemetry.For(ChannelType.Slack).RecordEventReceived(message.Kind.ToString());
 
             if (!TryMarkEventProcessed(message.EventId))
             {
                 _log.Debug("Dropping duplicate Slack event {0}", message.EventId);
-                ChannelTelemetry.RecordSlackEventFiltered("duplicate_event");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventFiltered("duplicate_event");
                 return;
             }
 
@@ -42,7 +42,7 @@ public sealed class SlackGatewayActor : ReceiveActor
                     actorName));
 
             _log.Debug("Routing Slack event {0} to conversation {1}", message.EventId, message.ChannelId);
-            ChannelTelemetry.RecordSlackEventRouted(message.Kind.ToString());
+            ChannelTelemetry.For(ChannelType.Slack).RecordEventRouted(message.Kind.ToString());
             conversation.Forward(message);
         });
 

--- a/src/Netclaw.Channels.Slack/SlackRoutingPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackRoutingPolicy.cs
@@ -102,7 +102,7 @@ internal sealed record SlackRoutingDecision(
     /// Pre-computed telemetry labels keyed by <see cref="SlackRoutingIgnoreReason"/>
     /// so the <see cref="SlackConversationActor"/> drop path does not allocate a
     /// new string per dropped event. Matches the shape produced by the other
-    /// <c>ChannelTelemetry.RecordSlackEventFiltered</c> callers (bucket-prefixed
+    /// <c>ChannelTelemetry.For(Slack).RecordEventFiltered</c> callers (bucket-prefixed
     /// reason labels) so existing dashboards continue to work.
     /// </summary>
     public static string TelemetryLabelFor(SlackRoutingIgnoreReason reason) =>

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -254,13 +254,13 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 {
                     case ClassificationOutcome.Block:
                         _log.Warning("Blocked Slack message due to prompt injection risk: {Reason}", classification.Reason);
-                        ChannelTelemetry.RecordSlackEventDropped("prompt_injection_high");
+                        ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped("prompt_injection_high");
                         await SafePostAsync(LiveInjectionBlockedWarning);
                         return;
 
                     case ClassificationOutcome.DetectorUnavailable:
                         _log.Warning("Prompt injection detector unavailable for live message — dropping");
-                        ChannelTelemetry.RecordSlackEventDropped("prompt_injection_detector_unavailable");
+                        ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped("prompt_injection_detector_unavailable");
                         await SafePostAsync(LiveDetectorUnavailableWarning);
                         return;
 
@@ -308,7 +308,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 _log.Info("Dropping stale Slack inbound event eventId={EventId} cursor={Cursor}",
                     message.EventId.Value,
                     _cursorTs?.Value ?? "none");
-                ChannelTelemetry.RecordSlackEventDropped("stale_event");
+                ChannelTelemetry.For(ChannelType.Slack).RecordEventDropped("stale_event");
                 return;
             }
 
@@ -347,7 +347,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             }
 
             inboundLog.Info("slack_turn_enqueued contentItems={ContentCount}", input.Contents.Count);
-            ChannelTelemetry.RecordSlackMessageEnqueued();
+            ChannelTelemetry.For(ChannelType.Slack).RecordMessageEnqueued();
         }
         catch (OperationCanceledException ex)
         {
@@ -1184,26 +1184,26 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 Text: text), cts.Token);
 
             _log.Info("Posted Slack reply message");
-            ChannelTelemetry.RecordSlackReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyPosted(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return PostResult.Ok;
         }
         catch (OperationCanceledException ex)
         {
             _log.Error(ex, "Timed out posting Slack reply for session {0}", _sessionId.Value);
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return new PostResult($"Timed out posting reply: {ex.Message}", DeliveryFailureKind.TransportFailure);
         }
         catch (SlackMessageDeliveryException ex)
         {
             _log.Warning("Slack delivery rejected for session {SessionId} error={ErrorCode} kind={FailureKind}",
                 _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
-            ChannelTelemetry.RecordSlackReplyRejected(ex.ErrorCode);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed posting Slack reply for session {0}", _sessionId.Value);
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return new PostResult(ex.Message, DeliveryFailureKind.Unknown);
         }
     }
@@ -1347,20 +1347,20 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         catch (OperationCanceledException ex)
         {
             _log.Error(ex, "Timed out uploading file {FileName} to Slack thread", file.FileName);
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return new PostResult($"Timed out uploading file: {ex.Message}", DeliveryFailureKind.TransportFailure);
         }
         catch (SlackMessageDeliveryException ex)
         {
             _log.Warning("Slack delivery rejected for file upload {FileName} session={SessionId} error={ErrorCode} kind={FailureKind}",
                 file.FileName, _sessionId.Value, ex.ErrorCode ?? "unknown", ex.FailureKind);
-            ChannelTelemetry.RecordSlackReplyRejected(ex.ErrorCode);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyRejected(ex.ErrorCode);
             return new PostResult(ex.Message, ex.FailureKind);
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to upload file {FileName} to Slack thread", file.FileName);
-            ChannelTelemetry.RecordSlackReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
+            ChannelTelemetry.For(ChannelType.Slack).RecordReplyFailed(_dependencies.TimeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             return new PostResult(ex.Message, DeliveryFailureKind.Unknown);
         }
     }

--- a/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
@@ -1,265 +1,191 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using System.Threading;
+using Netclaw.Actors.Channels;
 
 namespace Netclaw.Channels.Telemetry;
 
+/// <summary>
+/// Per-channel metrics instance. Each channel type gets its own counters
+/// via <see cref="ChannelTelemetry.For"/>. Standard counters are shared
+/// across all channel types; channel-specific counters use <see cref="RecordExtra"/>.
+/// </summary>
+public sealed class ChannelMetrics
+{
+    private static readonly Meter Meter = new(ChannelTelemetry.MeterName);
+
+    private readonly string _channelWireValue;
+
+    private readonly Counter<long> _eventsReceived;
+    private readonly Counter<long> _eventsDropped;
+    private readonly Counter<long> _eventsFiltered;
+    private readonly Counter<long> _eventsRouted;
+    private readonly Counter<long> _messagesEnqueued;
+    private readonly Counter<long> _repliesPosted;
+    private readonly Counter<long> _repliesRejected;
+    private readonly Counter<long> _repliesFailed;
+    private readonly Histogram<double> _replyDurationMs;
+
+    private long _eventsReceivedTotal;
+    private long _eventsDroppedTotal;
+    private long _eventsFilteredTotal;
+    private long _eventsRoutedTotal;
+    private long _messagesEnqueuedTotal;
+    private long _repliesPostedTotal;
+    private long _repliesRejectedTotal;
+    private long _repliesFailedTotal;
+
+    private readonly ConcurrentDictionary<string, long> _extras = new(StringComparer.Ordinal);
+
+    internal ChannelMetrics(ChannelType channelType)
+    {
+        ChannelType = channelType;
+        _channelWireValue = channelType.ToWireValue();
+        DisplayName = channelType.ToString();
+
+        var prefix = $"netclaw.channel.{_channelWireValue}";
+        _eventsReceived = Meter.CreateCounter<long>($"{prefix}.events.received");
+        _eventsDropped = Meter.CreateCounter<long>($"{prefix}.events.dropped");
+        _eventsFiltered = Meter.CreateCounter<long>($"{prefix}.events.filtered");
+        _eventsRouted = Meter.CreateCounter<long>($"{prefix}.events.routed");
+        _messagesEnqueued = Meter.CreateCounter<long>($"{prefix}.messages.enqueued");
+        _repliesPosted = Meter.CreateCounter<long>($"{prefix}.replies.posted");
+        _repliesRejected = Meter.CreateCounter<long>($"{prefix}.replies.rejected");
+        _repliesFailed = Meter.CreateCounter<long>($"{prefix}.replies.failed");
+        _replyDurationMs = Meter.CreateHistogram<double>($"{prefix}.reply.duration.ms", unit: "ms");
+    }
+
+    public ChannelType ChannelType { get; }
+
+    public string DisplayName { get; }
+
+    public void RecordEventReceived(string kind)
+    {
+        Interlocked.Increment(ref _eventsReceivedTotal);
+        _eventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    }
+
+    public void RecordEventDropped(string reason)
+    {
+        Interlocked.Increment(ref _eventsDroppedTotal);
+        _eventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    public void RecordEventFiltered(string reason)
+    {
+        Interlocked.Increment(ref _eventsFilteredTotal);
+        _eventsFiltered.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    public void RecordEventRouted(string kind)
+    {
+        Interlocked.Increment(ref _eventsRoutedTotal);
+        _eventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
+    }
+
+    public void RecordMessageEnqueued()
+    {
+        Interlocked.Increment(ref _messagesEnqueuedTotal);
+        _messagesEnqueued.Add(1);
+    }
+
+    public void RecordReplyPosted(double durationMs)
+    {
+        Interlocked.Increment(ref _repliesPostedTotal);
+        _repliesPosted.Add(1);
+        _replyDurationMs.Record(durationMs);
+    }
+
+    public void RecordReplyRejected(string? errorCode)
+    {
+        Interlocked.Increment(ref _repliesRejectedTotal);
+        _repliesRejected.Add(1, new KeyValuePair<string, object?>("error_code", errorCode ?? "unknown"));
+    }
+
+    public void RecordReplyFailed(double durationMs)
+    {
+        Interlocked.Increment(ref _repliesFailedTotal);
+        _repliesFailed.Add(1);
+        _replyDurationMs.Record(durationMs);
+    }
+
+    /// <summary>
+    /// Record a channel-specific counter that doesn't exist on the standard base.
+    /// </summary>
+    public void RecordExtra(string metricName, string? tag = null)
+    {
+        _extras.AddOrUpdate(metricName, 1, (_, existing) => existing + 1);
+    }
+
+    public ChannelMetricsSnapshot GetSnapshot()
+        => new(
+            ChannelType: ChannelType,
+            DisplayName: DisplayName,
+            EventsReceived: Interlocked.Read(ref _eventsReceivedTotal),
+            EventsDropped: Interlocked.Read(ref _eventsDroppedTotal),
+            EventsFiltered: Interlocked.Read(ref _eventsFilteredTotal),
+            EventsRouted: Interlocked.Read(ref _eventsRoutedTotal),
+            MessagesEnqueued: Interlocked.Read(ref _messagesEnqueuedTotal),
+            RepliesPosted: Interlocked.Read(ref _repliesPostedTotal),
+            RepliesRejected: Interlocked.Read(ref _repliesRejectedTotal),
+            RepliesFailed: Interlocked.Read(ref _repliesFailedTotal),
+            Extras: _extras.IsEmpty
+                ? new Dictionary<string, long>()
+                : new Dictionary<string, long>(_extras));
+
+    internal void Reset()
+    {
+        Interlocked.Exchange(ref _eventsReceivedTotal, 0);
+        Interlocked.Exchange(ref _eventsDroppedTotal, 0);
+        Interlocked.Exchange(ref _eventsFilteredTotal, 0);
+        Interlocked.Exchange(ref _eventsRoutedTotal, 0);
+        Interlocked.Exchange(ref _messagesEnqueuedTotal, 0);
+        Interlocked.Exchange(ref _repliesPostedTotal, 0);
+        Interlocked.Exchange(ref _repliesRejectedTotal, 0);
+        Interlocked.Exchange(ref _repliesFailedTotal, 0);
+        _extras.Clear();
+    }
+}
+
+public sealed record ChannelMetricsSnapshot(
+    ChannelType ChannelType,
+    string DisplayName,
+    long EventsReceived,
+    long EventsDropped,
+    long EventsFiltered,
+    long EventsRouted,
+    long MessagesEnqueued,
+    long RepliesPosted,
+    long RepliesRejected,
+    long RepliesFailed,
+    IReadOnlyDictionary<string, long> Extras);
+
+/// <summary>
+/// Static registry of per-channel metrics instances. Call <see cref="For"/>
+/// to get a channel's <see cref="ChannelMetrics"/> — instances are created
+/// on first access and cached for the process lifetime.
+/// </summary>
 public static class ChannelTelemetry
 {
     public const string MeterName = "Netclaw.Channels";
 
-    private static readonly Meter Meter = new(MeterName);
+    private static readonly ConcurrentDictionary<ChannelType, ChannelMetrics> Registry = new();
 
-    private static readonly Counter<long> SlackEventsReceived =
-        Meter.CreateCounter<long>("netclaw.slack.events.received");
+    /// <summary>
+    /// Get the metrics instance for a channel type. Creates on first call.
+    /// </summary>
+    public static ChannelMetrics For(ChannelType channelType)
+        => Registry.GetOrAdd(channelType, static ct => new ChannelMetrics(ct));
 
-    private static readonly Counter<long> SlackEventsDropped =
-        Meter.CreateCounter<long>("netclaw.slack.events.dropped");
-
-    private static readonly Counter<long> SlackEventsFiltered =
-        Meter.CreateCounter<long>("netclaw.slack.events.filtered");
-
-    private static readonly Counter<long> SlackEventsRouted =
-        Meter.CreateCounter<long>("netclaw.slack.events.routed");
-
-    private static readonly Counter<long> SlackMessagesEnqueued =
-        Meter.CreateCounter<long>("netclaw.slack.messages.enqueued");
-
-    private static readonly Counter<long> SlackRepliesPosted =
-        Meter.CreateCounter<long>("netclaw.slack.replies.posted");
-
-    private static readonly Counter<long> SlackRepliesRejected =
-        Meter.CreateCounter<long>("netclaw.slack.replies.rejected");
-
-    private static readonly Counter<long> SlackRepliesFailed =
-        Meter.CreateCounter<long>("netclaw.slack.replies.failed");
-
-    private static readonly Histogram<double> SlackReplyDurationMs =
-        Meter.CreateHistogram<double>("netclaw.slack.reply.duration.ms", unit: "ms");
-
-    private static readonly Counter<long> DiscordEventsReceived =
-        Meter.CreateCounter<long>("netclaw.discord.events.received");
-
-    private static readonly Counter<long> DiscordEventsDropped =
-        Meter.CreateCounter<long>("netclaw.discord.events.dropped");
-
-    private static readonly Counter<long> DiscordEventsFiltered =
-        Meter.CreateCounter<long>("netclaw.discord.events.filtered");
-
-    private static readonly Counter<long> DiscordEventsRouted =
-        Meter.CreateCounter<long>("netclaw.discord.events.routed");
-
-    private static readonly Counter<long> DiscordMessagesEnqueued =
-        Meter.CreateCounter<long>("netclaw.discord.messages.enqueued");
-
-    private static readonly Counter<long> DiscordRepliesPosted =
-        Meter.CreateCounter<long>("netclaw.discord.replies.posted");
-
-    private static readonly Counter<long> DiscordRepliesRejected =
-        Meter.CreateCounter<long>("netclaw.discord.replies.rejected");
-
-    private static readonly Counter<long> DiscordRepliesFailed =
-        Meter.CreateCounter<long>("netclaw.discord.replies.failed");
-
-    private static readonly Counter<long> DiscordInteractionErrors =
-        Meter.CreateCounter<long>("netclaw.discord.interactions.errors");
-
-    private static readonly Counter<long> DiscordApprovalFallbackActivated =
-        Meter.CreateCounter<long>("netclaw.discord.approval.fallback_activated");
-
-    private static readonly Histogram<double> DiscordReplyDurationMs =
-        Meter.CreateHistogram<double>("netclaw.discord.reply.duration.ms", unit: "ms");
-
-    private static long _slackEventsReceivedTotal;
-    private static long _slackEventsDroppedTotal;
-    private static long _slackEventsFilteredTotal;
-    private static long _slackEventsRoutedTotal;
-    private static long _slackMessagesEnqueuedTotal;
-    private static long _slackRepliesPostedTotal;
-    private static long _slackRepliesRejectedTotal;
-    private static long _slackRepliesFailedTotal;
-    private static long _discordEventsReceivedTotal;
-    private static long _discordEventsDroppedTotal;
-    private static long _discordEventsFilteredTotal;
-    private static long _discordEventsRoutedTotal;
-    private static long _discordMessagesEnqueuedTotal;
-    private static long _discordRepliesPostedTotal;
-    private static long _discordRepliesRejectedTotal;
-    private static long _discordRepliesFailedTotal;
-    private static long _discordInteractionErrorsTotal;
-    private static long _discordApprovalFallbackActivatedTotal;
-
-    public sealed record Snapshot(
-        long SlackEventsReceived,
-        long SlackEventsDropped,
-        long SlackEventsFiltered,
-        long SlackEventsRouted,
-        long SlackMessagesEnqueued,
-        long SlackRepliesPosted,
-        long SlackRepliesRejected,
-        long SlackRepliesFailed,
-        long DiscordEventsReceived,
-        long DiscordEventsDropped,
-        long DiscordEventsFiltered,
-        long DiscordEventsRouted,
-        long DiscordMessagesEnqueued,
-        long DiscordRepliesPosted,
-        long DiscordRepliesRejected,
-        long DiscordRepliesFailed,
-        long DiscordInteractionErrors,
-        long DiscordApprovalFallbackActivated);
-
-    public static void RecordSlackEventReceived(string kind)
-    {
-        Interlocked.Increment(ref _slackEventsReceivedTotal);
-        SlackEventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
-    }
-
-    public static void RecordSlackEventDropped(string reason)
-    {
-        Interlocked.Increment(ref _slackEventsDroppedTotal);
-        SlackEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static void RecordSlackEventFiltered(string reason)
-    {
-        Interlocked.Increment(ref _slackEventsFilteredTotal);
-        SlackEventsFiltered.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static void RecordSlackEventRouted(string kind)
-    {
-        Interlocked.Increment(ref _slackEventsRoutedTotal);
-        SlackEventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
-    }
-
-    public static void RecordSlackMessageEnqueued()
-    {
-        Interlocked.Increment(ref _slackMessagesEnqueuedTotal);
-        SlackMessagesEnqueued.Add(1);
-    }
-
-    public static void RecordSlackReplyPosted(double durationMs)
-    {
-        Interlocked.Increment(ref _slackRepliesPostedTotal);
-        SlackRepliesPosted.Add(1);
-        SlackReplyDurationMs.Record(durationMs);
-    }
-
-    public static void RecordSlackReplyRejected(string? errorCode)
-    {
-        Interlocked.Increment(ref _slackRepliesRejectedTotal);
-        SlackRepliesRejected.Add(1, new KeyValuePair<string, object?>("error_code", errorCode ?? "unknown"));
-    }
-
-    public static void RecordSlackReplyFailed(double durationMs)
-    {
-        Interlocked.Increment(ref _slackRepliesFailedTotal);
-        SlackRepliesFailed.Add(1);
-        SlackReplyDurationMs.Record(durationMs);
-    }
-
-    public static void RecordDiscordEventReceived(string kind)
-    {
-        Interlocked.Increment(ref _discordEventsReceivedTotal);
-        DiscordEventsReceived.Add(1, new KeyValuePair<string, object?>("kind", kind));
-    }
-
-    public static void RecordDiscordEventDropped(string reason)
-    {
-        Interlocked.Increment(ref _discordEventsDroppedTotal);
-        DiscordEventsDropped.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static void RecordDiscordEventFiltered(string reason)
-    {
-        Interlocked.Increment(ref _discordEventsFilteredTotal);
-        DiscordEventsFiltered.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static void RecordDiscordEventRouted(string kind)
-    {
-        Interlocked.Increment(ref _discordEventsRoutedTotal);
-        DiscordEventsRouted.Add(1, new KeyValuePair<string, object?>("kind", kind));
-    }
-
-    public static void RecordDiscordMessageEnqueued()
-    {
-        Interlocked.Increment(ref _discordMessagesEnqueuedTotal);
-        DiscordMessagesEnqueued.Add(1);
-    }
-
-    public static void RecordDiscordReplyPosted(double durationMs)
-    {
-        Interlocked.Increment(ref _discordRepliesPostedTotal);
-        DiscordRepliesPosted.Add(1);
-        DiscordReplyDurationMs.Record(durationMs);
-    }
-
-    public static void RecordDiscordReplyRejected(string? errorCode)
-    {
-        Interlocked.Increment(ref _discordRepliesRejectedTotal);
-        DiscordRepliesRejected.Add(1, new KeyValuePair<string, object?>("error_code", errorCode ?? "unknown"));
-    }
-
-    public static void RecordDiscordReplyFailed(double durationMs)
-    {
-        Interlocked.Increment(ref _discordRepliesFailedTotal);
-        DiscordRepliesFailed.Add(1);
-        DiscordReplyDurationMs.Record(durationMs);
-    }
-
-    public static void RecordDiscordInteractionError(string reason)
-    {
-        Interlocked.Increment(ref _discordInteractionErrorsTotal);
-        DiscordInteractionErrors.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static void RecordDiscordApprovalFallbackActivated(string reason)
-    {
-        Interlocked.Increment(ref _discordApprovalFallbackActivatedTotal);
-        DiscordApprovalFallbackActivated.Add(1, new KeyValuePair<string, object?>("reason", reason));
-    }
-
-    public static Snapshot GetSnapshot()
-        => new(
-            SlackEventsReceived: Interlocked.Read(ref _slackEventsReceivedTotal),
-            SlackEventsDropped: Interlocked.Read(ref _slackEventsDroppedTotal),
-            SlackEventsFiltered: Interlocked.Read(ref _slackEventsFilteredTotal),
-            SlackEventsRouted: Interlocked.Read(ref _slackEventsRoutedTotal),
-            SlackMessagesEnqueued: Interlocked.Read(ref _slackMessagesEnqueuedTotal),
-            SlackRepliesPosted: Interlocked.Read(ref _slackRepliesPostedTotal),
-            SlackRepliesRejected: Interlocked.Read(ref _slackRepliesRejectedTotal),
-            SlackRepliesFailed: Interlocked.Read(ref _slackRepliesFailedTotal),
-            DiscordEventsReceived: Interlocked.Read(ref _discordEventsReceivedTotal),
-            DiscordEventsDropped: Interlocked.Read(ref _discordEventsDroppedTotal),
-            DiscordEventsFiltered: Interlocked.Read(ref _discordEventsFilteredTotal),
-            DiscordEventsRouted: Interlocked.Read(ref _discordEventsRoutedTotal),
-            DiscordMessagesEnqueued: Interlocked.Read(ref _discordMessagesEnqueuedTotal),
-            DiscordRepliesPosted: Interlocked.Read(ref _discordRepliesPostedTotal),
-            DiscordRepliesRejected: Interlocked.Read(ref _discordRepliesRejectedTotal),
-            DiscordRepliesFailed: Interlocked.Read(ref _discordRepliesFailedTotal),
-            DiscordInteractionErrors: Interlocked.Read(ref _discordInteractionErrorsTotal),
-            DiscordApprovalFallbackActivated: Interlocked.Read(ref _discordApprovalFallbackActivatedTotal));
+    /// <summary>
+    /// Returns snapshots for all channel types that have been accessed.
+    /// </summary>
+    public static IReadOnlyList<ChannelMetricsSnapshot> GetAllSnapshots()
+        => Registry.Values.Select(m => m.GetSnapshot()).ToList();
 
     internal static void ResetForTests()
     {
-        Interlocked.Exchange(ref _slackEventsReceivedTotal, 0);
-        Interlocked.Exchange(ref _slackEventsDroppedTotal, 0);
-        Interlocked.Exchange(ref _slackEventsFilteredTotal, 0);
-        Interlocked.Exchange(ref _slackEventsRoutedTotal, 0);
-        Interlocked.Exchange(ref _slackMessagesEnqueuedTotal, 0);
-        Interlocked.Exchange(ref _slackRepliesPostedTotal, 0);
-        Interlocked.Exchange(ref _slackRepliesRejectedTotal, 0);
-        Interlocked.Exchange(ref _slackRepliesFailedTotal, 0);
-        Interlocked.Exchange(ref _discordEventsReceivedTotal, 0);
-        Interlocked.Exchange(ref _discordEventsDroppedTotal, 0);
-        Interlocked.Exchange(ref _discordEventsFilteredTotal, 0);
-        Interlocked.Exchange(ref _discordEventsRoutedTotal, 0);
-        Interlocked.Exchange(ref _discordMessagesEnqueuedTotal, 0);
-        Interlocked.Exchange(ref _discordRepliesPostedTotal, 0);
-        Interlocked.Exchange(ref _discordRepliesRejectedTotal, 0);
-        Interlocked.Exchange(ref _discordRepliesFailedTotal, 0);
-        Interlocked.Exchange(ref _discordInteractionErrorsTotal, 0);
-        Interlocked.Exchange(ref _discordApprovalFallbackActivatedTotal, 0);
+        foreach (var metrics in Registry.Values)
+            metrics.Reset();
     }
 }

--- a/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
+++ b/src/Netclaw.Channels/Telemetry/ChannelTelemetry.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using System.Threading;
 using Netclaw.Actors.Channels;
+using Netclaw.Configuration;
 
 namespace Netclaw.Channels.Telemetry;
 
@@ -13,8 +14,6 @@ namespace Netclaw.Channels.Telemetry;
 public sealed class ChannelMetrics
 {
     private static readonly Meter Meter = new(ChannelTelemetry.MeterName);
-
-    private readonly string _channelWireValue;
 
     private readonly Counter<long> _eventsReceived;
     private readonly Counter<long> _eventsDropped;
@@ -40,10 +39,10 @@ public sealed class ChannelMetrics
     internal ChannelMetrics(ChannelType channelType)
     {
         ChannelType = channelType;
-        _channelWireValue = channelType.ToWireValue();
         DisplayName = channelType.ToString();
 
-        var prefix = $"netclaw.channel.{_channelWireValue}";
+        var wireValue = channelType.ToWireValue();
+        var prefix = $"netclaw.channel.{wireValue}";
         _eventsReceived = Meter.CreateCounter<long>($"{prefix}.events.received");
         _eventsDropped = Meter.CreateCounter<long>($"{prefix}.events.dropped");
         _eventsFiltered = Meter.CreateCounter<long>($"{prefix}.events.filtered");
@@ -111,11 +110,16 @@ public sealed class ChannelMetrics
 
     /// <summary>
     /// Record a channel-specific counter that doesn't exist on the standard base.
+    /// When <paramref name="tag"/> is provided, the key becomes "metricName:tag".
     /// </summary>
     public void RecordExtra(string metricName, string? tag = null)
     {
-        _extras.AddOrUpdate(metricName, 1, (_, existing) => existing + 1);
+        var key = tag is null ? metricName : $"{metricName}:{tag}";
+        _extras.AddOrUpdate(key, 1, (_, existing) => existing + 1);
     }
+
+    private static readonly IReadOnlyDictionary<string, long> EmptyExtras =
+        new Dictionary<string, long>();
 
     public ChannelMetricsSnapshot GetSnapshot()
         => new(
@@ -130,7 +134,7 @@ public sealed class ChannelMetrics
             RepliesRejected: Interlocked.Read(ref _repliesRejectedTotal),
             RepliesFailed: Interlocked.Read(ref _repliesFailedTotal),
             Extras: _extras.IsEmpty
-                ? new Dictionary<string, long>()
+                ? EmptyExtras
                 : new Dictionary<string, long>(_extras));
 
     internal void Reset()
@@ -158,7 +162,21 @@ public sealed record ChannelMetricsSnapshot(
     long RepliesPosted,
     long RepliesRejected,
     long RepliesFailed,
-    IReadOnlyDictionary<string, long> Extras);
+    IReadOnlyDictionary<string, long> Extras)
+{
+    public DaemonStats.ChannelActivity ToWireActivity() => new()
+    {
+        ChannelType = ChannelType.ToWireValue(),
+        DisplayName = DisplayName,
+        EventsReceived = EventsReceived,
+        EventsRouted = EventsRouted,
+        EventsDropped = EventsDropped,
+        RepliesPosted = RepliesPosted,
+        RepliesRejected = RepliesRejected,
+        RepliesFailed = RepliesFailed,
+        Extras = Extras.Count > 0 ? new Dictionary<string, long>(Extras) : null
+    };
+}
 
 /// <summary>
 /// Static registry of per-channel metrics instances. Call <see cref="For"/>

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1381,10 +1381,10 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
                           ? $" ({status.Telemetry.OtlpEndpoint})"
                           : string.Empty));
 
-    if (status.Telemetry.SlackCounters is { } counters)
+    foreach (var channel in status.Telemetry.Channels)
     {
         Console.WriteLine(
-            $"slack counters: recv={counters.EventsReceived} routed={counters.EventsRouted} dropped={counters.EventsDropped} enqueued={counters.MessagesEnqueued} replied={counters.RepliesPosted} rejected={counters.RepliesRejected} reply_failed={counters.RepliesFailed}");
+            $"{channel.ChannelType} counters: recv={channel.EventsReceived} routed={channel.EventsRouted} dropped={channel.EventsDropped} replied={channel.RepliesPosted} rejected={channel.RepliesRejected} reply_failed={channel.RepliesFailed}");
     }
 
     if (status.Model is { } model)
@@ -1564,11 +1564,19 @@ static void WriteStatsResult(DaemonStats.Response stats, int? days)
     Console.WriteLine($"  available: {stats.Skills.TotalAvailable}");
     Console.WriteLine();
 
-    Console.WriteLine("slack:");
-    Console.WriteLine($"  events: recv={stats.SlackActivity.EventsReceived} routed={stats.SlackActivity.EventsRouted} dropped={stats.SlackActivity.EventsDropped}");
-    Console.WriteLine($"  replies: posted={stats.SlackActivity.RepliesPosted} rejected={stats.SlackActivity.RepliesRejected} failed={stats.SlackActivity.RepliesFailed}");
+    foreach (var channel in stats.Channels)
+    {
+        Console.WriteLine($"{channel.ChannelType}:");
+        Console.WriteLine($"  events: recv={channel.EventsReceived} routed={channel.EventsRouted} dropped={channel.EventsDropped}");
+        Console.WriteLine($"  replies: posted={channel.RepliesPosted} rejected={channel.RepliesRejected} failed={channel.RepliesFailed}");
+        if (channel.Extras is { Count: > 0 })
+        {
+            var extras = string.Join(" ", channel.Extras.Select(kv => $"{kv.Key}={kv.Value}"));
+            Console.WriteLine($"  extras: {extras}");
+        }
+        Console.WriteLine();
+    }
 
-    Console.WriteLine();
     Console.WriteLine("webhooks:");
     Console.WriteLine($"  routes: total={stats.Webhooks.TotalRoutes} enabled={stats.Webhooks.EnabledRoutes} disabled={stats.Webhooks.DisabledRoutes} invalid={stats.Webhooks.InvalidRoutes}");
     Console.WriteLine($"  deliveries: accepted={stats.Webhooks.Accepted} filtered={stats.Webhooks.EventFiltered} duplicate={stats.Webhooks.DuplicateDelivery}");

--- a/src/Netclaw.Cli/Tui/StatsPage.cs
+++ b/src/Netclaw.Cli/Tui/StatsPage.cs
@@ -93,7 +93,7 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         }
         else
         {
-            // Middle row: Memory + Slack side by side
+            // Middle row: Memory + channel panels side by side
             var middleRow = Layouts.Horizontal();
 
             middleRow.WithChild(
@@ -104,13 +104,16 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
                     .WithContent(BuildMemoryPanel(stats))
                     .Fill());
 
-            middleRow.WithChild(
-                new PanelNode()
-                    .WithTitle("Slack")
-                    .WithBorder(BorderStyle.Rounded)
-                    .WithBorderColor(Color.Cyan)
-                    .WithContent(BuildSlackPanel(stats))
-                    .Fill());
+            foreach (var channel in stats.Channels)
+            {
+                middleRow.WithChild(
+                    new PanelNode()
+                        .WithTitle(channel.DisplayName)
+                        .WithBorder(BorderStyle.Rounded)
+                        .WithBorderColor(GetChannelColor(channel.ChannelType))
+                        .WithContent(BuildChannelPanel(channel))
+                        .Fill());
+            }
 
             root.WithChild(middleRow.Height(6));
 
@@ -176,14 +179,27 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         return content;
     }
 
-    private static ILayoutNode BuildSlackPanel(DaemonStats.Response stats)
+    private static ILayoutNode BuildChannelPanel(DaemonStats.ChannelActivity channel)
     {
-        var sl = stats.SlackActivity;
         var content = Layouts.Vertical();
-        content.WithChild(new TextNode($"  Events: recv={sl.EventsReceived} routed={sl.EventsRouted} dropped={sl.EventsDropped}").WithForeground(Color.White).Height(1));
-        content.WithChild(new TextNode($"  Replies: posted={sl.RepliesPosted} rejected={sl.RepliesRejected} failed={sl.RepliesFailed}").WithForeground(sl.RepliesFailed > 0 || sl.RepliesRejected > 0 ? Color.Yellow : Color.White).Height(1));
+        content.WithChild(new TextNode($"  Events: recv={channel.EventsReceived} routed={channel.EventsRouted} dropped={channel.EventsDropped}").WithForeground(Color.White).Height(1));
+        content.WithChild(new TextNode($"  Replies: posted={channel.RepliesPosted} rejected={channel.RepliesRejected} failed={channel.RepliesFailed}").WithForeground(channel.RepliesFailed > 0 || channel.RepliesRejected > 0 ? Color.Yellow : Color.White).Height(1));
+
+        if (channel.Extras is { Count: > 0 })
+        {
+            var extraLine = string.Join("  ", channel.Extras.Select(kv => $"{kv.Key}={kv.Value}"));
+            content.WithChild(new TextNode($"  {extraLine}").WithForeground(Color.White).Height(1));
+        }
+
         return content;
     }
+
+    private static Color GetChannelColor(string channelType) => channelType switch
+    {
+        "slack" => Color.Cyan,
+        "discord" => Color.Magenta,
+        _ => Color.White
+    };
 
     private static ILayoutNode BuildWebhooksPanel(DaemonStats.Response stats)
     {

--- a/src/Netclaw.Cli/Tui/StatsPage.cs
+++ b/src/Netclaw.Cli/Tui/StatsPage.cs
@@ -1,3 +1,4 @@
+using Netclaw.Actors.Channels;
 using Netclaw.Configuration;
 using R3;
 using Termina.Extensions;
@@ -194,12 +195,18 @@ public sealed class StatsPage : ReactivePage<StatsViewModel>
         return content;
     }
 
-    private static Color GetChannelColor(string channelType) => channelType switch
+    private static Color GetChannelColor(string channelType)
     {
-        "slack" => Color.Cyan,
-        "discord" => Color.Magenta,
-        _ => Color.White
-    };
+        if (!ChannelTypeExtensions.TryFromWireValue(channelType, out var ct))
+            return Color.White;
+
+        return ct switch
+        {
+            ChannelType.Slack => Color.Cyan,
+            ChannelType.Discord => Color.Magenta,
+            _ => Color.White
+        };
+    }
 
     private static ILayoutNode BuildWebhooksPanel(DaemonStats.Response stats)
     {

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -71,47 +71,7 @@ public static class DaemonRuntimeStatus
 
         public string? OtlpEndpoint { get; init; }
 
-        public SlackCounters? SlackCounters { get; init; }
-
-        public DiscordCounters? DiscordCounters { get; init; }
-    }
-
-    public sealed class SlackCounters : IWireType
-    {
-        public long EventsReceived { get; init; }
-
-        public long EventsDropped { get; init; }
-
-        public long EventsRouted { get; init; }
-
-        public long MessagesEnqueued { get; init; }
-
-        public long RepliesPosted { get; init; }
-
-        public long RepliesRejected { get; init; }
-
-        public long RepliesFailed { get; init; }
-    }
-
-    public sealed class DiscordCounters : IWireType
-    {
-        public long EventsReceived { get; init; }
-
-        public long EventsDropped { get; init; }
-
-        public long EventsRouted { get; init; }
-
-        public long MessagesEnqueued { get; init; }
-
-        public long RepliesPosted { get; init; }
-
-        public long RepliesRejected { get; init; }
-
-        public long RepliesFailed { get; init; }
-
-        public long InteractionErrors { get; init; }
-
-        public long ApprovalFallbackActivated { get; init; }
+        public List<DaemonStats.ChannelActivity> Channels { get; init; } = [];
     }
 
     public sealed class Model : IWireType

--- a/src/Netclaw.Configuration/DaemonStats.cs
+++ b/src/Netclaw.Configuration/DaemonStats.cs
@@ -18,7 +18,7 @@ public static class DaemonStats
 
         public required Skills Skills { get; init; }
 
-        public required SlackActivity SlackActivity { get; init; }
+        public List<ChannelActivity> Channels { get; init; } = [];
 
         public required Webhooks Webhooks { get; init; }
 
@@ -88,8 +88,12 @@ public static class DaemonStats
         public int TotalAvailable { get; init; }
     }
 
-    public sealed class SlackActivity : IWireType
+    public sealed class ChannelActivity : IWireType
     {
+        public required string ChannelType { get; init; }
+
+        public required string DisplayName { get; init; }
+
         public long EventsReceived { get; init; }
 
         public long EventsRouted { get; init; }
@@ -101,6 +105,8 @@ public static class DaemonStats
         public long RepliesRejected { get; init; }
 
         public long RepliesFailed { get; init; }
+
+        public Dictionary<string, long>? Extras { get; init; }
     }
 
     public sealed class Webhooks : IWireType

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -276,22 +276,23 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task StatusIncludesSlackCountersSnapshot()
+    public async Task StatusIncludesChannelCountersForEnabledChannels()
     {
-        var before = ChannelTelemetry.GetSnapshot();
+        var slack = ChannelTelemetry.For(Netclaw.Actors.Channels.ChannelType.Slack);
+        var before = slack.GetSnapshot();
 
-        ChannelTelemetry.RecordSlackEventReceived("message");
-        ChannelTelemetry.RecordSlackEventDropped("channel_not_allowed");
-        ChannelTelemetry.RecordSlackEventRouted("message");
-        ChannelTelemetry.RecordSlackMessageEnqueued();
-        ChannelTelemetry.RecordSlackReplyPosted(42);
-        ChannelTelemetry.RecordSlackReplyFailed(77);
+        slack.RecordEventReceived("message");
+        slack.RecordEventDropped("channel_not_allowed");
+        slack.RecordEventRouted("message");
+        slack.RecordMessageEnqueued();
+        slack.RecordReplyPosted(42);
+        slack.RecordReplyFailed(77);
 
         var service = new DaemonRuntimeStatusService(
             new DaemonStartClock(TimeProvider.System),
             TimeProvider.System,
             channels: Array.Empty<IChannel>(),
-            slackOptions: new SlackChannelOptions { Enabled = false },
+            slackOptions: new SlackChannelOptions { Enabled = true },
             discordOptions: new DiscordChannelOptions { Enabled = false },
             persistenceOptions: new DaemonPersistenceOptions(),
             telemetryOptions: Options.Create(new TelemetryOptions()),
@@ -301,12 +302,12 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
 
         var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
 
-        Assert.NotNull(status.Telemetry.SlackCounters);
-        Assert.True(status.Telemetry.SlackCounters!.EventsReceived >= before.SlackEventsReceived + 1);
-        Assert.True(status.Telemetry.SlackCounters.EventsDropped >= before.SlackEventsDropped + 1);
-        Assert.True(status.Telemetry.SlackCounters.EventsRouted >= before.SlackEventsRouted + 1);
-        Assert.True(status.Telemetry.SlackCounters.MessagesEnqueued >= before.SlackMessagesEnqueued + 1);
-        Assert.True(status.Telemetry.SlackCounters.RepliesPosted >= before.SlackRepliesPosted + 1);
-        Assert.True(status.Telemetry.SlackCounters.RepliesFailed >= before.SlackRepliesFailed + 1);
+        var slackActivity = Assert.Single(status.Telemetry.Channels);
+        Assert.Equal("slack", slackActivity.ChannelType);
+        Assert.True(slackActivity.EventsReceived >= before.EventsReceived + 1);
+        Assert.True(slackActivity.EventsDropped >= before.EventsDropped + 1);
+        Assert.True(slackActivity.EventsRouted >= before.EventsRouted + 1);
+        Assert.True(slackActivity.RepliesPosted >= before.RepliesPosted + 1);
+        Assert.True(slackActivity.RepliesFailed >= before.RepliesFailed + 1);
     }
 }

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.Options;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Reminders;
@@ -90,33 +91,31 @@ internal sealed class DaemonRuntimeStatusService(
 
     private DaemonRuntimeStatus.Telemetry BuildTelemetry()
     {
-        var snapshot = ChannelTelemetry.GetSnapshot();
+        var enabledChannelTypes = new HashSet<Actors.Channels.ChannelType>();
+        if (slackOptions.Enabled) enabledChannelTypes.Add(Actors.Channels.ChannelType.Slack);
+        if (discordOptions.Enabled) enabledChannelTypes.Add(Actors.Channels.ChannelType.Discord);
+
+        var channelActivities = ChannelTelemetry.GetAllSnapshots()
+            .Where(s => enabledChannelTypes.Contains(s.ChannelType))
+            .Select(s => new DaemonStats.ChannelActivity
+            {
+                ChannelType = s.ChannelType.ToWireValue(),
+                DisplayName = s.DisplayName,
+                EventsReceived = s.EventsReceived,
+                EventsRouted = s.EventsRouted,
+                EventsDropped = s.EventsDropped,
+                RepliesPosted = s.RepliesPosted,
+                RepliesRejected = s.RepliesRejected,
+                RepliesFailed = s.RepliesFailed,
+                Extras = s.Extras.Count > 0 ? new Dictionary<string, long>(s.Extras) : null
+            })
+            .ToList();
+
         return new DaemonRuntimeStatus.Telemetry
         {
             Enabled = telemetryOptions.Value.Enabled,
             OtlpEndpoint = telemetryOptions.Value.Otlp.Endpoint,
-            SlackCounters = new DaemonRuntimeStatus.SlackCounters
-            {
-                EventsReceived = snapshot.SlackEventsReceived,
-                EventsDropped = snapshot.SlackEventsDropped,
-                EventsRouted = snapshot.SlackEventsRouted,
-                MessagesEnqueued = snapshot.SlackMessagesEnqueued,
-                RepliesPosted = snapshot.SlackRepliesPosted,
-                RepliesRejected = snapshot.SlackRepliesRejected,
-                RepliesFailed = snapshot.SlackRepliesFailed
-            },
-            DiscordCounters = new DaemonRuntimeStatus.DiscordCounters
-            {
-                EventsReceived = snapshot.DiscordEventsReceived,
-                EventsDropped = snapshot.DiscordEventsDropped,
-                EventsRouted = snapshot.DiscordEventsRouted,
-                MessagesEnqueued = snapshot.DiscordMessagesEnqueued,
-                RepliesPosted = snapshot.DiscordRepliesPosted,
-                RepliesRejected = snapshot.DiscordRepliesRejected,
-                RepliesFailed = snapshot.DiscordRepliesFailed,
-                InteractionErrors = snapshot.DiscordInteractionErrors,
-                ApprovalFallbackActivated = snapshot.DiscordApprovalFallbackActivated
-            }
+            Channels = channelActivities
         };
     }
 

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -97,18 +97,7 @@ internal sealed class DaemonRuntimeStatusService(
 
         var channelActivities = ChannelTelemetry.GetAllSnapshots()
             .Where(s => enabledChannelTypes.Contains(s.ChannelType))
-            .Select(s => new DaemonStats.ChannelActivity
-            {
-                ChannelType = s.ChannelType.ToWireValue(),
-                DisplayName = s.DisplayName,
-                EventsReceived = s.EventsReceived,
-                EventsRouted = s.EventsRouted,
-                EventsDropped = s.EventsDropped,
-                RepliesPosted = s.RepliesPosted,
-                RepliesRejected = s.RepliesRejected,
-                RepliesFailed = s.RepliesFailed,
-                Extras = s.Extras.Count > 0 ? new Dictionary<string, long>(s.Extras) : null
-            })
+            .Select(s => s.ToWireActivity())
             .ToList();
 
         return new DaemonRuntimeStatus.Telemetry

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -139,18 +139,7 @@ internal sealed class DaemonStatsService(
 
         return ChannelTelemetry.GetAllSnapshots()
             .Where(s => enabledChannelTypes.Contains(s.ChannelType))
-            .Select(s => new DaemonStats.ChannelActivity
-            {
-                ChannelType = s.ChannelType.ToWireValue(),
-                DisplayName = s.DisplayName,
-                EventsReceived = s.EventsReceived,
-                EventsRouted = s.EventsRouted,
-                EventsDropped = s.EventsDropped,
-                RepliesPosted = s.RepliesPosted,
-                RepliesRejected = s.RepliesRejected,
-                RepliesFailed = s.RepliesFailed,
-                Extras = s.Extras.Count > 0 ? new Dictionary<string, long>(s.Extras) : null
-            })
+            .Select(s => s.ToWireActivity())
             .ToList();
     }
 

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -4,6 +4,9 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Skills;
+using Netclaw.Actors.Channels;
+using Netclaw.Channels.Slack;
+using Netclaw.Channels.Discord;
 using Netclaw.Channels.Telemetry;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Services;
@@ -18,6 +21,8 @@ internal sealed class DaemonStatsService(
     SkillRegistry skillRegistry,
     IRequiredActor<DailyStatsActorKey> dailyStatsActor,
     WebhookRouteCatalog webhookRouteCatalog,
+    SlackChannelOptions slackOptions,
+    DiscordChannelOptions discordOptions,
     SQLiteMemoryStore? sqliteMemoryStore = null,
     IRequiredActor<ReminderManagerActorKey>? reminderManagerActor = null)
 {
@@ -38,7 +43,6 @@ internal sealed class DaemonStatsService(
         var processStats = await processTask;
         var dailyBreakdown = await dailyTask;
 
-        var slackSnapshot = ChannelTelemetry.GetSnapshot();
         var sessionStats = sessionCatalog.GetStats();
         var allSkills = skillRegistry.GetAll();
 
@@ -69,15 +73,7 @@ internal sealed class DaemonStatsService(
             {
                 TotalAvailable = allSkills.Count
             },
-            SlackActivity = new DaemonStats.SlackActivity
-            {
-                EventsReceived = slackSnapshot.SlackEventsReceived,
-                EventsRouted = slackSnapshot.SlackEventsRouted,
-                EventsDropped = slackSnapshot.SlackEventsDropped,
-                RepliesPosted = slackSnapshot.SlackRepliesPosted,
-                RepliesRejected = slackSnapshot.SlackRepliesRejected,
-                RepliesFailed = slackSnapshot.SlackRepliesFailed
-            },
+            Channels = BuildChannelActivityList(),
             Webhooks = BuildWebhookStats(),
             Reminders = await BuildReminderStatsAsync(ct),
             DailyBreakdown = dailyBreakdown
@@ -133,6 +129,29 @@ internal sealed class DaemonStatsService(
         {
             Daily = daily
         };
+    }
+
+    private List<DaemonStats.ChannelActivity> BuildChannelActivityList()
+    {
+        var enabledChannelTypes = new HashSet<ChannelType>();
+        if (slackOptions.Enabled) enabledChannelTypes.Add(ChannelType.Slack);
+        if (discordOptions.Enabled) enabledChannelTypes.Add(ChannelType.Discord);
+
+        return ChannelTelemetry.GetAllSnapshots()
+            .Where(s => enabledChannelTypes.Contains(s.ChannelType))
+            .Select(s => new DaemonStats.ChannelActivity
+            {
+                ChannelType = s.ChannelType.ToWireValue(),
+                DisplayName = s.DisplayName,
+                EventsReceived = s.EventsReceived,
+                EventsRouted = s.EventsRouted,
+                EventsDropped = s.EventsDropped,
+                RepliesPosted = s.RepliesPosted,
+                RepliesRejected = s.RepliesRejected,
+                RepliesFailed = s.RepliesFailed,
+                Extras = s.Extras.Count > 0 ? new Dictionary<string, long>(s.Extras) : null
+            })
+            .ToList();
     }
 
     private static async Task<List<DaemonStats.DailyRow>> QueryDailyStatsAsync(IActorRef actorRef, int days, CancellationToken ct)


### PR DESCRIPTION
## Summary

- **Refactored `ChannelTelemetry`** from a static class with 18 duplicated `RecordSlack*`/`RecordDiscord*` methods into a registry pattern (`ChannelTelemetry.For(ChannelType)`) where each channel gets its own `ChannelMetrics` instance with standard counters + an `Extras` dictionary for channel-specific metrics
- **Unified wire types**: replaced hardcoded `SlackActivity`/`SlackCounters`/`DiscordCounters` with a generic `ChannelActivity` type used by both `DaemonStats` and `DaemonRuntimeStatus`
- **Made stats output configuration-driven**: `netclaw stats` and `netclaw status` now only show channel panels for channels that are actually enabled — no more hardcoded Slack section showing zeros when only Discord is configured

Closes #773

## Changes

| Layer | What changed |
|-------|-------------|
| Telemetry | `ChannelTelemetry` → registry + `ChannelMetrics` instances with `RecordExtra` for channel-specific counters |
| Wire types | `DaemonStats.SlackActivity` → `DaemonStats.ChannelActivity` (polymorphic); `DaemonRuntimeStatus.SlackCounters`/`DiscordCounters` → reuses `ChannelActivity` |
| Services | `DaemonStatsService` + `DaemonRuntimeStatusService` filter `GetAllSnapshots()` by enabled channels |
| CLI | `Program.cs` + `StatsPage.cs` dynamically render per-channel panels |
| Actors | ~46 call sites migrated from `RecordSlack*`/`RecordDiscord*` → `ChannelTelemetry.For(type).*` |

## Test plan

- [x] `dotnet build` — zero warnings
- [x] `dotnet test` — all `DaemonRuntimeStatusServiceTests` pass (7/7)
- [x] `dotnet slopwatch analyze` — no new violations
- [x] Docker test: Discord-only config → `netclaw stats` shows no Slack section, Discord connector healthy
- [ ] Docker test: send Discord message → verify Discord channel activity populates in stats