### PR TITLE
feat(docker): block self-update in containers, harden NSec

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ ARG NETCLAW_VERSION=unknown
 #   Data/JSON:   jq, sqlite3
 #   VCS/GitHub:  git, gh
 #   Python:      python3, python3-pip, python3-venv
+#   Crypto:      libsodium23 (required by NSec for Ed25519 signature verification)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
@@ -47,6 +48,7 @@ RUN apt-get update \
       python3-venv \
       gh \
       libicu74 \
+      libsodium23 \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/netclaw
@@ -62,6 +64,9 @@ RUN chmod +x /opt/netclaw/cli/netclaw /opt/netclaw/daemon/netclawd /opt/netclaw/
  && ln -s /opt/netclaw/daemon/netclawd /usr/local/bin/netclawd
 
 ENV NETCLAW_DAEMON_PATH=/opt/netclaw/daemon/netclawd
+# Block in-place binary self-update — the image tag IS the version.
+# Update availability checks still run so operators see when a new version exists.
+ENV NETCLAW_Daemon__DisableSelfUpdate=true
 
 # Persist identity, config, data, and session state on an operator-mounted
 # volume. Real operators must `netclaw init` (or bind-mount a pre-initialized

--- a/src/Netclaw.Cli.Tests/Cli/StatusUpdateCheckerTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/StatusUpdateCheckerTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Netclaw.Cli.Tests.Cli;
 
+[Collection("Update verification")]
 public sealed class StatusUpdateCheckerTests : IDisposable
 {
     private readonly Key _testSigningKey;

--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Netclaw.Cli.Update;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Feeds;
+using Netclaw.Configuration.Security;
+using NSec.Cryptography;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+[Collection("Update verification")]
+public sealed class UpdateCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+    private readonly Key _testSigningKey;
+    private readonly byte[] _testPublicKeyBlob;
+
+    public UpdateCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-update-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+
+        _testSigningKey = Key.Create(SignatureAlgorithm.Ed25519,
+            new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
+
+        var pubKeyRaw = _testSigningKey.Export(KeyBlobFormat.RawPublicKey);
+        _testPublicKeyBlob = new byte[42];
+        _testPublicKeyBlob[0] = 0x45;
+        _testPublicKeyBlob[1] = 0x64;
+        byte[] testKeyId = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        Array.Copy(testKeyId, 0, _testPublicKeyBlob, 2, 8);
+        Array.Copy(pubKeyRaw, 0, _testPublicKeyBlob, 10, 32);
+
+        MinisignVerifier.TestPublicKeyOverride = _testPublicKeyBlob;
+        UpdateCheckService.ResetCache();
+    }
+
+    public void Dispose()
+    {
+        MinisignVerifier.TestPublicKeyOverride = null;
+        UpdateCommand.TestHttpMessageHandlerFactory = null;
+        UpdateCheckService.ResetCache();
+        _testSigningKey.Dispose();
+
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort temp cleanup for tests.
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_BlocksInstall_WhenDisableSelfUpdateIsConfigured()
+    {
+        var manifest = CreateManifest("99.0.0", UpdateCheckService.GetCurrentRid());
+        UpdateCommand.TestHttpMessageHandlerFactory = () => CreateSignedHandler(manifest);
+
+        using var stdout = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(stdout);
+
+        try
+        {
+            var exitCode = await UpdateCommand.RunAsync(["update"], _paths, selfUpdateDisabled: true);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("Self-update is disabled", stdout.ToString());
+            Assert.Contains("Pull a newer container image to upgrade.", stdout.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    private FakeHttpHandler CreateSignedHandler(BinaryFeedManifest manifest)
+    {
+        var handler = new FakeHttpHandler();
+        var json = JsonSerializer.Serialize(manifest);
+        handler.AddResponse(FeedConstants.BinaryManifestUrl, HttpStatusCode.OK, json, "application/json");
+
+        var sigContent = SignContent(json);
+        handler.AddResponse(FeedConstants.BinaryManifestSignatureUrl, HttpStatusCode.OK, sigContent, "text/plain");
+
+        return handler;
+    }
+
+    private string SignContent(string content)
+    {
+        var data = Encoding.UTF8.GetBytes(content);
+        var signature = SignatureAlgorithm.Ed25519.Sign(_testSigningKey, data);
+
+        var sigBlob = new byte[74];
+        sigBlob[0] = 0x45;
+        sigBlob[1] = 0x44;
+        Array.Copy(_testPublicKeyBlob, 2, sigBlob, 2, 8);
+        Array.Copy(signature, 0, sigBlob, 10, 64);
+
+        return $"untrusted comment: test signature\n{Convert.ToBase64String(sigBlob)}\ntrusted comment: test\ndGVzdA==\n";
+    }
+
+    private static BinaryFeedManifest CreateManifest(string version, string rid)
+    {
+        return new BinaryFeedManifest
+        {
+            Latest = version,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Releases =
+            [
+                new BinaryRelease
+                {
+                    Version = version,
+                    ReleasedAt = DateTimeOffset.UtcNow,
+                    Assets =
+                    [
+                        new BinaryAsset
+                        {
+                            Component = "netclaw",
+                            Rid = rid,
+                            Url = $"https://releases.netclaw.dev/{version}/netclaw-{version}-{rid}.tar.gz",
+                            Sha256 = "abc123",
+                            SizeBytes = 50_000_000
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, (HttpStatusCode Status, string Content, string ContentType)> _responses = new();
+
+        public void AddResponse(string url, HttpStatusCode status, string content, string contentType)
+        {
+            _responses[url] = (status, content, contentType);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            if (!_responses.TryGetValue(url, out var entry))
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            return Task.FromResult(new HttpResponseMessage(entry.Status)
+            {
+                Content = new StringContent(entry.Content, Encoding.UTF8, entry.ContentType)
+            });
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -46,15 +46,8 @@ public sealed class UpdateCommandTests : IDisposable
         UpdateCheckService.ResetCache();
         _testSigningKey.Dispose();
 
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch (IOException)
-        {
-            // Best-effort temp cleanup — locked files on Windows are expected.
-        }
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateCommandTests.cs
@@ -51,9 +51,9 @@ public sealed class UpdateCommandTests : IDisposable
             if (Directory.Exists(_tempDir))
                 Directory.Delete(_tempDir, recursive: true);
         }
-        catch
+        catch (IOException)
         {
-            // Best-effort temp cleanup for tests.
+            // Best-effort temp cleanup — locked files on Windows are expected.
         }
     }
 

--- a/src/Netclaw.Cli.Tests/Cli/UpdateVerificationCollection.cs
+++ b/src/Netclaw.Cli.Tests/Cli/UpdateVerificationCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Cli;
+
+[CollectionDefinition("Update verification", DisableParallelization = true)]
+public sealed class UpdateVerificationCollection;

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1275,7 +1275,8 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
         }
         else
         {
-            WriteStatusResult(status, api.Endpoint, cliUpdate);
+            WriteStatusResult(status, api.Endpoint, cliUpdate,
+                selfUpdateDisabled: DaemonConfig.IsSelfUpdateDisabledByEnv());
         }
 
         return status.Overall.ToLowerInvariant() switch
@@ -1363,7 +1364,7 @@ static void WriteSessionsHelp()
     Console.WriteLine("  1  daemon unavailable or request failed");
 }
 
-static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoint, StatusUpdateResult? cliUpdate = null)
+static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoint, StatusUpdateResult? cliUpdate = null, bool selfUpdateDisabled = false)
 {
     Console.WriteLine($"overall: {status.Overall}");
     Console.WriteLine($"version: {status.Build.Version} (commit {status.Build.CommitHash}, built {status.Build.BuildTimestamp})");
@@ -1414,7 +1415,9 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
     {
         case "update-available":
             Console.WriteLine($"update: UPDATE AVAILABLE — v{updateCurrentVersion} → v{updateLatestVersion}");
-            Console.WriteLine("  Run: netclaw update");
+            Console.WriteLine(selfUpdateDisabled
+                ? "  Pull a newer container image to upgrade."
+                : "  Run: netclaw update");
             if (updateReleaseNotesUrl is not null)
                 Console.WriteLine($"  Release notes: {updateReleaseNotesUrl}");
             break;

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -72,7 +72,11 @@ static async Task RunAsync(string[] args)
     // TUI modes (chat, sessions, headless, init) must not run background checks
     // that write to Console, as it corrupts the terminal UI.
     if (mode is not ("chat" or "sessions" or "headless" or "init"))
-        _ = UpdateCommand.BackgroundUpdateCheckAsync();
+    {
+        var backgroundUpdateConfig = BuildCliConfig();
+        var backgroundDaemonConfig = DaemonConfig.BindFromConfiguration(backgroundUpdateConfig.GetSection("Daemon"));
+        _ = UpdateCommand.BackgroundUpdateCheckAsync(backgroundDaemonConfig.DisableSelfUpdate);
+    }
 
     // ── Lightweight modes (no Akka, no persistence) ──
     if (mode is "init" or "doctor")
@@ -801,9 +805,15 @@ static async Task RunAsync(string[] args)
     // ── Self-update ──
     if (mode is "update")
     {
-        var paths = new NetclawPaths();
-        paths.EnsureDirectoriesExist();
-        Environment.ExitCode = await UpdateCommand.RunAsync(args, paths);
+        var builder = Host.CreateApplicationBuilder(args);
+        ConfigureConfigServices(builder.Services, builder.Configuration);
+        builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        using var host = builder.Build();
+        var paths = host.Services.GetRequiredService<NetclawPaths>();
+        var daemonConfig = host.Services.GetRequiredService<DaemonConfig>();
+        Environment.ExitCode = await UpdateCommand.RunAsync(args, paths, daemonConfig.DisableSelfUpdate);
         return;
     }
 
@@ -1275,8 +1285,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
         }
         else
         {
-            WriteStatusResult(status, api.Endpoint, cliUpdate,
-                selfUpdateDisabled: DaemonConfig.IsSelfUpdateDisabledByEnv());
+            WriteStatusResult(status, api.Endpoint, cliUpdate);
         }
 
         return status.Overall.ToLowerInvariant() switch
@@ -1364,7 +1373,7 @@ static void WriteSessionsHelp()
     Console.WriteLine("  1  daemon unavailable or request failed");
 }
 
-static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoint, StatusUpdateResult? cliUpdate = null, bool selfUpdateDisabled = false)
+static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoint, StatusUpdateResult? cliUpdate = null)
 {
     Console.WriteLine($"overall: {status.Overall}");
     Console.WriteLine($"version: {status.Build.Version} (commit {status.Build.CommitHash}, built {status.Build.BuildTimestamp})");
@@ -1415,7 +1424,7 @@ static void WriteStatusResult(DaemonRuntimeStatus.Response status, string endpoi
     {
         case "update-available":
             Console.WriteLine($"update: UPDATE AVAILABLE — v{updateCurrentVersion} → v{updateLatestVersion}");
-            Console.WriteLine(selfUpdateDisabled
+            Console.WriteLine((status.Update?.SelfUpdateDisabled).GetValueOrDefault()
                 ? "  Pull a newer container image to upgrade."
                 : "  Run: netclaw update");
             if (updateReleaseNotesUrl is not null)
@@ -1685,6 +1694,8 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
         .AddJsonFile(paths.SecretsPath, optional: true, reloadOnChange: false)
         .AddEnvironmentVariables("NETCLAW_");
 
+    services.AddSingleton(DaemonConfig.BindFromConfiguration(configuration.GetSection("Daemon")));
+
     // TimeProvider (virtualized for testing)
     services.AddSingleton(TimeProvider.System);
 
@@ -1693,6 +1704,18 @@ static NetclawPaths ConfigureConfigServices(IServiceCollection services, IConfig
     services.AddSingleton<DaemonApi>();
 
     return paths;
+}
+
+static IConfigurationRoot BuildCliConfig()
+{
+    var paths = new NetclawPaths();
+    paths.EnsureDirectoriesExist();
+
+    return new ConfigurationBuilder()
+        .AddJsonFile(paths.NetclawConfigPath, optional: true, reloadOnChange: false)
+        .AddJsonFile(paths.SecretsPath, optional: true, reloadOnChange: false)
+        .AddEnvironmentVariables("NETCLAW_")
+        .Build();
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -11,7 +11,9 @@ namespace Netclaw.Cli.Update;
 /// </summary>
 internal static class UpdateCommand
 {
-    public static async Task<int> RunAsync(string[] args, NetclawPaths paths)
+    internal static Func<HttpMessageHandler>? TestHttpMessageHandlerFactory { get; set; }
+
+    public static async Task<int> RunAsync(string[] args, NetclawPaths paths, bool selfUpdateDisabled = false)
     {
         var checkOnly = false;
         var force = false;
@@ -38,7 +40,9 @@ internal static class UpdateCommand
 
         var currentVersion = BuildInfo.Version;
 
-        using var httpClient = new HttpClient();
+        using var httpClient = TestHttpMessageHandlerFactory is { } createHandler
+            ? new HttpClient(createHandler())
+            : new HttpClient();
 
         // Fetch manifest with signature verification
         var fetchResult = await UpdateCheckService.FetchVerifiedManifestAsync(
@@ -46,10 +50,12 @@ internal static class UpdateCommand
 
         if (!fetchResult.IsSuccess)
         {
-            if (fetchResult.Status == ManifestFetchStatus.SignatureFailure)
+            if (fetchResult.Status is ManifestFetchStatus.SignatureFailure or ManifestFetchStatus.PlatformUnavailable)
             {
                 Console.Error.WriteLine($"Error: {fetchResult.ErrorMessage}");
-                Console.Error.WriteLine("The update manifest could not be verified. This may indicate tampering.");
+                Console.Error.WriteLine(fetchResult.Status == ManifestFetchStatus.PlatformUnavailable
+                    ? "The update manifest could not be verified because signature verification is unavailable on this platform."
+                    : "The update manifest could not be verified. This may indicate tampering.");
                 Console.Error.WriteLine("If this persists, report the issue at https://github.com/stannardlabs/netclaw/issues");
                 return 1;
             }
@@ -74,7 +80,7 @@ internal static class UpdateCommand
         if (checkOnly)
             return 0;
 
-        if (DaemonConfig.IsSelfUpdateDisabledByEnv())
+        if (selfUpdateDisabled)
         {
             Console.WriteLine();
             Console.WriteLine("Self-update is disabled (Daemon.DisableSelfUpdate=true).");
@@ -345,7 +351,7 @@ internal static class UpdateCommand
     /// Quick background update check for CLI startup.
     /// Prints a one-line notification if an update is available.
     /// </summary>
-    internal static async Task BackgroundUpdateCheckAsync()
+    internal static async Task BackgroundUpdateCheckAsync(bool selfUpdateDisabled = false)
     {
         try
         {
@@ -356,7 +362,7 @@ internal static class UpdateCommand
 
             if (result.IsUpdateAvailable)
             {
-                var hint = DaemonConfig.IsSelfUpdateDisabledByEnv()
+                var hint = selfUpdateDisabled
                     ? "pull a newer container image to upgrade"
                     : "run 'netclaw update'";
                 Console.Error.WriteLine(

--- a/src/Netclaw.Cli/Update/UpdateCommand.cs
+++ b/src/Netclaw.Cli/Update/UpdateCommand.cs
@@ -74,6 +74,14 @@ internal static class UpdateCommand
         if (checkOnly)
             return 0;
 
+        if (DaemonConfig.IsSelfUpdateDisabledByEnv())
+        {
+            Console.WriteLine();
+            Console.WriteLine("Self-update is disabled (Daemon.DisableSelfUpdate=true).");
+            Console.WriteLine("Pull a newer container image to upgrade.");
+            return 1;
+        }
+
         // Show what will be downloaded
         Console.WriteLine();
         foreach (var asset in result.MatchingAssets)
@@ -348,8 +356,11 @@ internal static class UpdateCommand
 
             if (result.IsUpdateAvailable)
             {
+                var hint = DaemonConfig.IsSelfUpdateDisabledByEnv()
+                    ? "pull a newer container image to upgrade"
+                    : "run 'netclaw update'";
                 Console.Error.WriteLine(
-                    $"Update available: v{result.CurrentVersion} → v{result.LatestVersion} — run 'netclaw update'");
+                    $"Update available: v{result.CurrentVersion} → v{result.LatestVersion} — {hint}");
             }
         }
         catch (Exception ex)

--- a/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
@@ -21,6 +21,7 @@ public sealed class DaemonConfigTests
         Assert.Equal("127.0.0.1", result.Host);
         Assert.Equal(5199, result.Port);
         Assert.Equal(ExposureMode.Local, result.ExposureMode);
+        Assert.False(result.DisableSelfUpdate);
     }
 
     [Fact]
@@ -31,6 +32,7 @@ public sealed class DaemonConfigTests
         Assert.Equal("127.0.0.1", result.Host);
         Assert.Equal(5199, result.Port);
         Assert.Equal(ExposureMode.Local, result.ExposureMode);
+        Assert.False(result.DisableSelfUpdate);
     }
 
     [Theory]
@@ -82,6 +84,21 @@ public sealed class DaemonConfigTests
     public void ParseExposureMode_returns_local_for_null()
     {
         Assert.Equal(ExposureMode.Local, DaemonConfig.ParseExposureMode(null));
+    }
+
+    [Fact]
+    public void BindFromConfiguration_reads_DisableSelfUpdate_true()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Daemon:DisableSelfUpdate"] = "true"
+            })
+            .Build();
+
+        var result = DaemonConfig.BindFromConfiguration(config.GetSection("Daemon"));
+
+        Assert.True(result.DisableSelfUpdate);
     }
 
     // ── System.Text.Json serialization path ──────────────────────────────────

--- a/src/Netclaw.Configuration.Tests/Security/MinisignVerifierTests.cs
+++ b/src/Netclaw.Configuration.Tests/Security/MinisignVerifierTests.cs
@@ -149,4 +149,22 @@ public class MinisignVerifierTests
         Assert.True(parsed.Key.AsSpan().SequenceEqual(MinisignVerifier.EmbeddedPublicKey));
         Assert.True(parsed.KeyId.AsSpan().SequenceEqual(MinisignVerifier.EmbeddedKeyId));
     }
+
+    [Fact]
+    public void Verify_ReturnsPlatformUnavailable_WhenTestOverrideForcesIt()
+    {
+        MinisignVerifier.TestVerifyResultOverride = MinisignVerifier.VerifyResult.PlatformUnavailable;
+
+        try
+        {
+            var data = System.Text.Encoding.UTF8.GetBytes("test");
+            var result = MinisignVerifier.Verify(data, TestSignatureFile);
+
+            Assert.Equal(MinisignVerifier.VerifyResult.PlatformUnavailable, result);
+        }
+        finally
+        {
+            MinisignVerifier.TestVerifyResultOverride = null;
+        }
+    }
 }

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -53,17 +53,6 @@ public sealed record DaemonConfig
     }
 
     /// <summary>
-    /// Checks whether self-update is disabled via the <c>NETCLAW_Daemon__DisableSelfUpdate</c>
-    /// environment variable. Used by CLI paths that run before full configuration
-    /// infrastructure is available.
-    /// </summary>
-    public static bool IsSelfUpdateDisabledByEnv()
-    {
-        var value = Environment.GetEnvironmentVariable("NETCLAW_Daemon__DisableSelfUpdate");
-        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
     /// Parses an <see cref="ExposureMode"/> from a config string value.
     /// Accepts kebab-case (<c>tailscale-serve</c>) and PascalCase (<c>TailscaleServe</c>).
     /// Returns <see cref="ExposureMode.Local"/> for null/empty input.

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -26,6 +26,14 @@ public sealed record DaemonConfig
     public ExposureMode ExposureMode { get; init; } = ExposureMode.Local;
 
     /// <summary>
+    /// When true, in-place binary self-update via <c>netclaw update</c> is blocked.
+    /// Update availability checks still run so operators see when a new version exists.
+    /// Intended for container deployments where the image tag IS the version.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool DisableSelfUpdate { get; init; }
+
+    /// <summary>
     /// Bind <see cref="DaemonConfig"/> from an <see cref="IConfigurationSection"/>.
     /// Handles kebab-case <c>ExposureMode</c> values (e.g., <c>tailscale-serve</c>).
     /// Returns defaults when the section is missing or empty.
@@ -39,8 +47,20 @@ public sealed record DaemonConfig
         var port = section.GetValue<int?>("Port") ?? 5199;
         var modeStr = section["ExposureMode"];
         var mode = ParseExposureMode(modeStr);
+        var disableSelfUpdate = section.GetValue<bool?>("DisableSelfUpdate") ?? false;
 
-        return new DaemonConfig { Host = host, Port = port, ExposureMode = mode };
+        return new DaemonConfig { Host = host, Port = port, ExposureMode = mode, DisableSelfUpdate = disableSelfUpdate };
+    }
+
+    /// <summary>
+    /// Checks whether self-update is disabled via the <c>NETCLAW_Daemon__DisableSelfUpdate</c>
+    /// environment variable. Used by CLI paths that run before full configuration
+    /// infrastructure is available.
+    /// </summary>
+    public static bool IsSelfUpdateDisabledByEnv()
+    {
+        var value = Environment.GetEnvironmentVariable("NETCLAW_Daemon__DisableSelfUpdate");
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
+++ b/src/Netclaw.Configuration/DaemonRuntimeStatus.cs
@@ -97,6 +97,8 @@ public static class DaemonRuntimeStatus
     {
         public bool Available { get; init; }
 
+        public bool SelfUpdateDisabled { get; init; }
+
         /// <summary>
         /// Update availability state: "up-to-date", "update-available", or "unknown" (check failed or not yet run).
         /// </summary>

--- a/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
+++ b/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
@@ -174,6 +174,15 @@ public static class UpdateCheckService
 
         var verifyResult = MinisignVerifier.Verify(manifestBytes, signatureContent);
 
+        if (verifyResult == MinisignVerifier.VerifyResult.PlatformUnavailable)
+        {
+            return new ManifestFetchResult
+            {
+                Status = ManifestFetchStatus.NetworkFailure,
+                ErrorMessage = "Cryptographic library unavailable on this platform — signature verification skipped",
+            };
+        }
+
         if (verifyResult != MinisignVerifier.VerifyResult.Valid)
         {
             return new ManifestFetchResult

--- a/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
+++ b/src/Netclaw.Configuration/Feeds/UpdateCheckService.cs
@@ -51,6 +51,9 @@ public enum ManifestFetchStatus
 
     /// <summary>Manifest signature verification failed — possible tampering.</summary>
     SignatureFailure,
+
+    /// <summary>Cryptographic signature verification is unavailable on this platform.</summary>
+    PlatformUnavailable,
 }
 
 /// <summary>
@@ -178,8 +181,8 @@ public static class UpdateCheckService
         {
             return new ManifestFetchResult
             {
-                Status = ManifestFetchStatus.NetworkFailure,
-                ErrorMessage = "Cryptographic library unavailable on this platform — signature verification skipped",
+                Status = ManifestFetchStatus.PlatformUnavailable,
+                ErrorMessage = "Cryptographic library unavailable on this platform — signature verification could not run",
             };
         }
 

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -546,6 +546,11 @@
           "enum": ["local", "tailscale-serve", "tailscale-funnel", "cloudflare-tunnel"],
           "default": "local",
           "description": "Tunnel infrastructure in front of the daemon. Defaults to local (loopback only, no tunnel)."
+        },
+        "DisableSelfUpdate": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, in-place binary self-update via 'netclaw update' is blocked. Update availability checks still run. Intended for container deployments where the image tag is the version."
         }
       },
       "additionalProperties": false

--- a/src/Netclaw.Configuration/Security/MinisignVerifier.cs
+++ b/src/Netclaw.Configuration/Security/MinisignVerifier.cs
@@ -178,17 +178,10 @@ public static class MinisignVerifier
             return VerifyResult.KeyMismatch;
 
         // Try raw Ed25519 first (works with test keys and legacy minisign).
-        bool rawResult;
-        try
-        {
-            rawResult = VerifyEd25519(activePublicKey, data, sig.Signature);
-        }
-        catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException or PlatformNotSupportedException)
-        {
-            return VerifyResult.PlatformUnavailable;
-        }
-
-        if (rawResult)
+        var (rawSuccess, rawEarlyReturn) = TryVerifyEd25519(activePublicKey, data, sig.Signature);
+        if (rawEarlyReturn is not null)
+            return rawEarlyReturn.Value;
+        if (rawSuccess)
             return VerifyResult.Valid;
 
         // Modern minisign (1.0.18+) always prehashes with BLAKE2b-512 before
@@ -197,15 +190,22 @@ public static class MinisignVerifier
         Span<byte> hash = stackalloc byte[64];
         Blake2b512(data, hash);
 
+        var (hashSuccess, hashEarlyReturn) = TryVerifyEd25519(activePublicKey, hash, sig.Signature);
+        if (hashEarlyReturn is not null)
+            return hashEarlyReturn.Value;
+        return hashSuccess ? VerifyResult.Valid : VerifyResult.InvalidSignature;
+    }
+
+    private static (bool success, VerifyResult? earlyReturn) TryVerifyEd25519(
+        ReadOnlySpan<byte> publicKey, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature)
+    {
         try
         {
-            return VerifyEd25519(activePublicKey, hash, sig.Signature)
-                ? VerifyResult.Valid
-                : VerifyResult.InvalidSignature;
+            return (VerifyEd25519(publicKey, data, signature), null);
         }
         catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException or PlatformNotSupportedException)
         {
-            return VerifyResult.PlatformUnavailable;
+            return (false, VerifyResult.PlatformUnavailable);
         }
     }
 

--- a/src/Netclaw.Configuration/Security/MinisignVerifier.cs
+++ b/src/Netclaw.Configuration/Security/MinisignVerifier.cs
@@ -64,6 +64,12 @@ public static class MinisignVerifier
 
         /// <summary>Signature does not match the provided data.</summary>
         InvalidSignature,
+
+        /// <summary>
+        /// The cryptographic platform (NSec) failed to initialize.
+        /// Non-fatal — callers should treat this as equivalent to a network error.
+        /// </summary>
+        PlatformUnavailable,
     }
 
     /// <summary>
@@ -172,7 +178,17 @@ public static class MinisignVerifier
             return VerifyResult.KeyMismatch;
 
         // Try raw Ed25519 first (works with test keys and legacy minisign).
-        if (VerifyEd25519(activePublicKey, data, sig.Signature))
+        bool rawResult;
+        try
+        {
+            rawResult = VerifyEd25519(activePublicKey, data, sig.Signature);
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException or PlatformNotSupportedException)
+        {
+            return VerifyResult.PlatformUnavailable;
+        }
+
+        if (rawResult)
             return VerifyResult.Valid;
 
         // Modern minisign (1.0.18+) always prehashes with BLAKE2b-512 before
@@ -181,9 +197,16 @@ public static class MinisignVerifier
         Span<byte> hash = stackalloc byte[64];
         Blake2b512(data, hash);
 
-        return VerifyEd25519(activePublicKey, hash, sig.Signature)
-            ? VerifyResult.Valid
-            : VerifyResult.InvalidSignature;
+        try
+        {
+            return VerifyEd25519(activePublicKey, hash, sig.Signature)
+                ? VerifyResult.Valid
+                : VerifyResult.InvalidSignature;
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or TypeInitializationException or PlatformNotSupportedException)
+        {
+            return VerifyResult.PlatformUnavailable;
+        }
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/Security/MinisignVerifier.cs
+++ b/src/Netclaw.Configuration/Security/MinisignVerifier.cs
@@ -36,6 +36,12 @@ public static class MinisignVerifier
     internal static byte[]? TestPublicKeyOverride { get; set; }
 
     /// <summary>
+    /// Test seam: forces <see cref="Verify"/> to return this result before any parsing
+    /// or cryptographic work. Reset to null after tests.
+    /// </summary>
+    internal static VerifyResult? TestVerifyResultOverride { get; set; }
+
+    /// <summary>
     /// The embedded Ed25519 public key ID (8 bytes) for matching against signatures.
     /// </summary>
     internal static ReadOnlySpan<byte> EmbeddedKeyId => EmbeddedPublicKeyBlob.Slice(2, 8);
@@ -150,6 +156,9 @@ public static class MinisignVerifier
     /// <returns>The verification result.</returns>
     public static VerifyResult Verify(ReadOnlySpan<byte> data, string signatureFileContent)
     {
+        if (TestVerifyResultOverride is { } overrideResult)
+            return overrideResult;
+
         var sig = ParseSignature(signatureFileContent);
         if (sig is null)
             return VerifyResult.MalformedSignature;

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -93,6 +93,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             telemetryOptions: Options.Create(new TelemetryOptions()),
             modelCapabilities: DefaultModelCapabilities,
             modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
             paths: CreatePaths());
 
         var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
@@ -115,6 +116,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             telemetryOptions: Options.Create(new TelemetryOptions()),
             modelCapabilities: DefaultModelCapabilities,
             modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
             paths: CreatePaths());
 
         var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
@@ -137,6 +139,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             telemetryOptions: Options.Create(new TelemetryOptions()),
             modelCapabilities: DefaultModelCapabilities,
             modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
             paths: CreatePaths());
 
         var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
@@ -198,6 +201,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
                 telemetryOptions: Options.Create(new TelemetryOptions()),
                 modelCapabilities: DefaultModelCapabilities,
                 modelSelection: DefaultModelSelection,
+                daemonConfig: new DaemonConfig(),
                 paths: CreatePaths(),
                 mcpClientManager: manager);
 
@@ -263,6 +267,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             telemetryOptions: Options.Create(new TelemetryOptions()),
             modelCapabilities: DefaultModelCapabilities,
             modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
             paths: paths,
             sqliteMemoryStore: sqliteStore);
 
@@ -298,6 +303,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
             telemetryOptions: Options.Create(new TelemetryOptions()),
             modelCapabilities: DefaultModelCapabilities,
             modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig(),
             paths: CreatePaths());
 
         var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
@@ -309,5 +315,27 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         Assert.True(slackActivity.EventsRouted >= before.EventsRouted + 1);
         Assert.True(slackActivity.RepliesPosted >= before.RepliesPosted + 1);
         Assert.True(slackActivity.RepliesFailed >= before.RepliesFailed + 1);
+    }
+
+    [Fact]
+    public async Task StatusIncludesSelfUpdateDisabledFlag()
+    {
+        var service = new DaemonRuntimeStatusService(
+            new DaemonStartClock(TimeProvider.System),
+            TimeProvider.System,
+            channels: Array.Empty<IChannel>(),
+            slackOptions: new SlackChannelOptions { Enabled = false },
+            discordOptions: new DiscordChannelOptions { Enabled = false },
+            persistenceOptions: new DaemonPersistenceOptions(),
+            telemetryOptions: Options.Create(new TelemetryOptions()),
+            modelCapabilities: DefaultModelCapabilities,
+            modelSelection: DefaultModelSelection,
+            daemonConfig: new DaemonConfig { DisableSelfUpdate = true },
+            paths: CreatePaths());
+
+        var status = await service.GetStatusAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(status.Update);
+        Assert.True(status.Update!.SelfUpdateDisabled);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
@@ -415,6 +415,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
             httpClient,
             NullLogger<BinaryUpdateCheckService>.Instance,
             currentVersion,
+            selfUpdateDisabled: false,
             sink);
     }
 

--- a/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/BinaryUpdateCheckServiceTests.cs
@@ -241,6 +241,20 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchVerifiedManifestAsync_ReturnsPlatformUnavailableWhenVerifierCannotRun()
+    {
+        MinisignVerifier.TestVerifyResultOverride = MinisignVerifier.VerifyResult.PlatformUnavailable;
+        var manifest = CreateManifest("0.2.0", UpdateCheckService.GetCurrentRid());
+        var handler = CreateSignedHandler(manifest);
+
+        using var httpClient = new HttpClient(handler);
+        var result = await UpdateCheckService.FetchVerifiedManifestAsync(httpClient, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ManifestFetchStatus.PlatformUnavailable, result.Status);
+    }
+
+    [Fact]
     public void EvaluateManifest_MatchesAssetsByRid()
     {
         var manifest = new BinaryFeedManifest
@@ -395,6 +409,7 @@ public sealed class BinaryUpdateCheckServiceTests : IDisposable
     public void Dispose()
     {
         MinisignVerifier.TestPublicKeyOverride = null;
+        MinisignVerifier.TestVerifyResultOverride = null;
         UpdateCheckService.ResetCache();
         _testSigningKey.Dispose();
         if (Directory.Exists(_tempDir))

--- a/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonRuntimeStatusService.cs
@@ -29,6 +29,7 @@ internal sealed class DaemonRuntimeStatusService(
     IOptions<TelemetryOptions> telemetryOptions,
     ModelCapabilities modelCapabilities,
     ModelSelection modelSelection,
+    DaemonConfig daemonConfig,
     NetclawPaths paths,
     McpClientManager? mcpClientManager = null,
     SQLiteMemoryStore? sqliteMemoryStore = null,
@@ -249,7 +250,7 @@ internal sealed class DaemonRuntimeStatusService(
         };
     }
 
-    private static DaemonRuntimeStatus.Update BuildUpdateStatus()
+    private DaemonRuntimeStatus.Update BuildUpdateStatus()
     {
         var result = UpdateCheckService.GetLastResult();
         if (result is null)
@@ -259,6 +260,7 @@ internal sealed class DaemonRuntimeStatusService(
                 Available = false,
                 State = "unknown",
                 CurrentVersion = BuildInfo.Version,
+                SelfUpdateDisabled = daemonConfig.DisableSelfUpdate,
             };
         }
 
@@ -272,6 +274,7 @@ internal sealed class DaemonRuntimeStatusService(
         return new DaemonRuntimeStatus.Update
         {
             Available = result.IsUpdateAvailable,
+            SelfUpdateDisabled = daemonConfig.DisableSelfUpdate,
             State = state,
             CurrentVersion = result.CurrentVersion,
             LatestVersion = result.IsUpdateAvailable ? result.LatestVersion : null,

--- a/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
+++ b/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
@@ -25,13 +25,15 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
     private readonly IOperationalNotificationSink? _notificationSink;
     private readonly TimeProvider _timeProvider;
     private readonly string _currentVersion;
+    private readonly bool _selfUpdateDisabled;
 
     public BinaryUpdateCheckService(
         HttpClient httpClient,
         ILogger<BinaryUpdateCheckService> logger,
+        DaemonConfig daemonConfig,
         IOperationalNotificationSink? notificationSink = null,
         TimeProvider? timeProvider = null)
-        : this(httpClient, logger, BuildInfo.Version, notificationSink, timeProvider)
+        : this(httpClient, logger, BuildInfo.Version, daemonConfig.DisableSelfUpdate, notificationSink, timeProvider)
     {
     }
 
@@ -40,12 +42,14 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
         HttpClient httpClient,
         ILogger<BinaryUpdateCheckService> logger,
         string currentVersion,
+        bool selfUpdateDisabled = false,
         IOperationalNotificationSink? notificationSink = null,
         TimeProvider? timeProvider = null)
     {
         _httpClient = httpClient;
         _logger = logger;
         _currentVersion = currentVersion;
+        _selfUpdateDisabled = selfUpdateDisabled;
         _notificationSink = notificationSink;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -72,9 +76,13 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
 
             if (result.IsUpdateAvailable)
             {
+                var upgradeHint = _selfUpdateDisabled
+                    ? "Pull a newer container image to upgrade."
+                    : "Run 'netclaw update' to upgrade.";
+
                 _logger.LogWarning(
-                    "Netclaw update available: {CurrentVersion} → {LatestVersion}. Run 'netclaw update' to upgrade.",
-                    result.CurrentVersion, result.LatestVersion);
+                    "Netclaw update available: {CurrentVersion} → {LatestVersion}. {UpgradeHint}",
+                    result.CurrentVersion, result.LatestVersion, upgradeHint);
 
                 EmitUpdateAlert(result);
             }
@@ -91,11 +99,15 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
 
     private void EmitUpdateAlert(UpdateCheckResult result)
     {
+        var upgradeHint = _selfUpdateDisabled
+            ? "Pull a newer container image to upgrade."
+            : "Run 'netclaw update' to upgrade.";
+
         _notificationSink?.Emit(OperationalAlert.Create(
             _timeProvider,
             "update.available",
             AlertType.UpdateAvailable,
-            $"Netclaw update available: {result.CurrentVersion} → {result.LatestVersion}. Run 'netclaw update' to upgrade.",
+            $"Netclaw update available: {result.CurrentVersion} → {result.LatestVersion}. {upgradeHint}",
             AlertSeverity.Info,
             source: result.LatestVersion,
             context: new Dictionary<string, string>

--- a/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
+++ b/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
@@ -84,6 +84,10 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
 
                 EmitUpdateAlert(result);
             }
+            else if (!result.CheckSucceeded)
+            {
+                _logger.LogInformation("Netclaw update check failed: {ErrorDetail}", result.ErrorDetail);
+            }
             else
             {
                 _logger.LogInformation("Netclaw is up to date (v{Version})", _currentVersion);

--- a/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
+++ b/src/Netclaw.Daemon/Services/BinaryUpdateCheckService.cs
@@ -25,7 +25,7 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
     private readonly IOperationalNotificationSink? _notificationSink;
     private readonly TimeProvider _timeProvider;
     private readonly string _currentVersion;
-    private readonly bool _selfUpdateDisabled;
+    private readonly string _upgradeHint;
 
     public BinaryUpdateCheckService(
         HttpClient httpClient,
@@ -49,7 +49,9 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
         _httpClient = httpClient;
         _logger = logger;
         _currentVersion = currentVersion;
-        _selfUpdateDisabled = selfUpdateDisabled;
+        _upgradeHint = selfUpdateDisabled
+            ? "Pull a newer container image to upgrade."
+            : "Run 'netclaw update' to upgrade.";
         _notificationSink = notificationSink;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -76,13 +78,9 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
 
             if (result.IsUpdateAvailable)
             {
-                var upgradeHint = _selfUpdateDisabled
-                    ? "Pull a newer container image to upgrade."
-                    : "Run 'netclaw update' to upgrade.";
-
                 _logger.LogWarning(
                     "Netclaw update available: {CurrentVersion} → {LatestVersion}. {UpgradeHint}",
-                    result.CurrentVersion, result.LatestVersion, upgradeHint);
+                    result.CurrentVersion, result.LatestVersion, _upgradeHint);
 
                 EmitUpdateAlert(result);
             }
@@ -99,15 +97,11 @@ internal sealed class BinaryUpdateCheckService : BackgroundService
 
     private void EmitUpdateAlert(UpdateCheckResult result)
     {
-        var upgradeHint = _selfUpdateDisabled
-            ? "Pull a newer container image to upgrade."
-            : "Run 'netclaw update' to upgrade.";
-
         _notificationSink?.Emit(OperationalAlert.Create(
             _timeProvider,
             "update.available",
             AlertType.UpdateAvailable,
-            $"Netclaw update available: {result.CurrentVersion} → {result.LatestVersion}. {upgradeHint}",
+            $"Netclaw update available: {result.CurrentVersion} → {result.LatestVersion}. {_upgradeHint}",
             AlertSeverity.Info,
             source: result.LatestVersion,
             context: new Dictionary<string, string>


### PR DESCRIPTION
## Summary

- Add `Daemon.DisableSelfUpdate` config option that blocks `netclaw update` from replacing binaries in-place while keeping update availability checks running so operators see when a new version exists
- Harden `MinisignVerifier.Verify()` to catch NSec platform initialization failures (`DllNotFoundException`, `TypeInitializationException`, `PlatformNotSupportedException`) and return `PlatformUnavailable` instead of throwing
- Add `libsodium23` to the Dockerfile so NSec Ed25519 signature verification works in Ubuntu 24.04 self-contained containers
- Set `NETCLAW_Daemon__DisableSelfUpdate=true` in the Dockerfile — operators upgrade by pulling a new image tag, not by running `netclaw update` inside the container
- Adjust all notification messages to say "pull a newer container image to upgrade" when self-update is disabled (daemon logs, operational alerts, CLI background check, `netclaw status`)

Closes #772, closes #771.

## Test plan

- [x] `dotnet build` — compiles clean
- [x] `dotnet test --filter DaemonConfigTests` — new and existing tests pass (default false, reads true from config)
- [x] `dotnet test --filter BinaryUpdateCheckServiceTests` — existing tests pass with updated constructor
- [x] Docker image build succeeds with `libsodium23` and new env var
- [x] `docker exec <container> env | grep NETCLAW` shows `NETCLAW_Daemon__DisableSelfUpdate=true`
- [x] `docker exec <container> netclaw update --check` completes without NSec error (libsodium23 fix)
- [x] `docker exec <container> netclaw status` shows update state without crash
- [ ] `netclaw update` when a newer version exists prints "Self-update is disabled" and exits 1 (can't trigger until next release)