### PR TITLE
feat(serialization): disable System.Object serialization fallback

### DIFF
--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -374,4 +374,17 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.NotNull(ex);
         Assert.Contains("Unknown manifest", ex.Message);
     }
+
+    [Fact]
+    public void Unregistered_type_throws_on_serialize()
+    {
+        var serialization = Sys.Serialization;
+
+        // UnregisteredMessage is NOT in the boundTypes list for NetclawProtobufSerializer,
+        // so strict serialization mode should throw instead of falling back to JSON.
+        Assert.Throws<System.Runtime.Serialization.SerializationException>(
+            () => serialization.FindSerializerFor(new UnregisteredMessage("test")));
+    }
+
+    private sealed record UnregisteredMessage(string Value);
 }

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -180,9 +180,11 @@ public static class NetclawAkkaHostingExtensions
             typeof(ReminderPayload),
         };
 
-        return builder.WithCustomSerializer(
-            serializerIdentifier: "netclaw-protobuf",
-            boundTypes: boundTypes,
-            serializerFactory: system => new NetclawProtobufSerializer(system));
+        return builder
+            .WithCustomSerializer(
+                serializerIdentifier: "netclaw-protobuf",
+                boundTypes: boundTypes,
+                serializerFactory: system => new NetclawProtobufSerializer(system))
+            .WithStrictSerialization();
     }
 }


### PR DESCRIPTION
## Summary

Closes #706

- Adds `WithStrictSerialization()` to `WithNetclawSerialization()` to disable the JSON fallback for unregistered types
- Adds test verifying unregistered types throw `SerializationException` instead of silently falling back

## Test plan

- [x] All 19 serialization round-trip tests pass
- [x] New `Unregistered_type_throws_on_serialize` test verifies strict mode behavior