### PR TITLE
feat(tui): make AllowedUserIds an explicit allow/restrict choice (#760)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/DiscordStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/DiscordStepViewModelTests.cs
@@ -51,6 +51,15 @@ public sealed class DiscordStepViewModelTests : IDisposable
     }
 
     [Fact]
+    public void SubStepCount_IsSix_WhenEnabled_WithRestrict()
+    {
+        using var step = new DiscordStepViewModel(_fakeProbe);
+        step.DiscordEnabled = true;
+        step.RestrictToSpecificUsers = true;
+        Assert.Equal(6, step.SubStepCount);
+    }
+
+    [Fact]
     public void TryAdvance_ThroughAllSubSteps()
     {
         using var step = new DiscordStepViewModel(_fakeProbe);
@@ -68,7 +77,43 @@ public sealed class DiscordStepViewModelTests : IDisposable
         Assert.True(step.TryAdvance());
         Assert.Equal(4, step.CurrentSubStep);
 
+        // Sub-step 4 is UserAccessChoice; default RestrictToSpecificUsers=false completes the step
         Assert.False(step.TryAdvance());
+    }
+
+    [Fact]
+    public void TryAdvance_WithRestrict_AdvancesToAllowedUserIds()
+    {
+        using var step = new DiscordStepViewModel(_fakeProbe);
+        step.DiscordEnabled = true;
+
+        // Advance to sub-step 4 (UserAccessChoice)
+        for (var i = 0; i < 4; i++)
+            step.TryAdvance();
+        Assert.Equal(4, step.CurrentSubStep);
+
+        step.RestrictToSpecificUsers = true;
+        Assert.True(step.TryAdvance());
+        Assert.Equal(5, step.CurrentSubStep);
+
+        // Sub-step 5 (AllowedUserIds) completes the step
+        Assert.False(step.TryAdvance());
+    }
+
+    [Fact]
+    public void TryAdvance_AllowAnyone_ClearsAllowedUserIds()
+    {
+        using var step = new DiscordStepViewModel(_fakeProbe);
+        step.DiscordEnabled = true;
+        step.AllowedUserIdsInput = "129847561203948576";
+
+        // Advance to sub-step 4 (UserAccessChoice)
+        for (var i = 0; i < 4; i++)
+            step.TryAdvance();
+
+        step.RestrictToSpecificUsers = false;
+        Assert.False(step.TryAdvance());
+        Assert.Null(step.AllowedUserIdsInput);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/SlackStepViewModelTests.cs
@@ -51,6 +51,15 @@ public sealed class SlackStepViewModelTests : IDisposable
     }
 
     [Fact]
+    public void SubStepCount_IsSeven_WhenEnabled_WithRestrict()
+    {
+        using var step = new SlackStepViewModel(_fakeProbe);
+        step.SlackEnabled = true;
+        step.RestrictToSpecificUsers = true;
+        Assert.Equal(7, step.SubStepCount);
+    }
+
+    [Fact]
     public void TryAdvance_ReturnsFalse_WhenDisabled()
     {
         using var step = new SlackStepViewModel(_fakeProbe);
@@ -84,8 +93,43 @@ public sealed class SlackStepViewModelTests : IDisposable
         Assert.True(step.TryAdvance());
         Assert.Equal(5, step.CurrentSubStep);
 
-        // 5 → complete
+        // Sub-step 5 is UserAccessChoice; default RestrictToSpecificUsers=false completes the step
         Assert.False(step.TryAdvance());
+    }
+
+    [Fact]
+    public void TryAdvance_WithRestrict_AdvancesToAllowedUserIds()
+    {
+        using var step = new SlackStepViewModel(_fakeProbe);
+        step.SlackEnabled = true;
+
+        // Advance to sub-step 5 (UserAccessChoice)
+        for (var i = 0; i < 5; i++)
+            step.TryAdvance();
+        Assert.Equal(5, step.CurrentSubStep);
+
+        step.RestrictToSpecificUsers = true;
+        Assert.True(step.TryAdvance());
+        Assert.Equal(6, step.CurrentSubStep);
+
+        // Sub-step 6 (AllowedUserIds) completes the step
+        Assert.False(step.TryAdvance());
+    }
+
+    [Fact]
+    public void TryAdvance_AllowAnyone_ClearsAllowedUserIds()
+    {
+        using var step = new SlackStepViewModel(_fakeProbe);
+        step.SlackEnabled = true;
+        step.AllowedUserIdsInput = "U01ABC123";
+
+        // Advance to sub-step 5 (UserAccessChoice)
+        for (var i = 0; i < 5; i++)
+            step.TryAdvance();
+
+        step.RestrictToSpecificUsers = false;
+        Assert.False(step.TryAdvance());
+        Assert.Null(step.AllowedUserIdsInput);
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepView.cs
@@ -160,31 +160,14 @@ public sealed class DiscordStepView : IWizardStepView
 
     private ILayoutNode BuildUserAccessChoiceSubStep(DiscordStepViewModel vm, StepViewCallbacks callbacks)
     {
-        var restrictLabel = "Restrict to specific users (recommended)";
-        var allowLabel = "Allow anyone in allowed channels";
+        var (list, layout) = WizardStepHelpers.BuildUserAccessChoiceSubStep(
+            restrict => vm.RestrictToSpecificUsers = restrict, callbacks);
 
-        _userAccessChoiceList = Layouts.SelectionList(restrictLabel, allowLabel)
-            .WithMode(SelectionMode.Single)
-            .WithHighlightColors(Color.Black, Color.Cyan);
-
-        _userAccessChoiceList.OnFocused();
-        _lastFocusedList = _userAccessChoiceList;
+        _userAccessChoiceList = list;
+        _lastFocusedList = list;
         _lastFocusedInput = null;
 
-        _userAccessChoiceList.SelectionConfirmed
-            .Subscribe(selected =>
-            {
-                if (selected.Count == 0)
-                    return;
-
-                vm.RestrictToSpecificUsers = selected[0] == restrictLabel;
-                callbacks.AdvanceStep();
-            })
-            .DisposeWith(callbacks.Subscriptions);
-
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  Who can interact with the bot?").WithForeground(Color.White))
-            .WithChild(_userAccessChoiceList);
+        return layout;
     }
 
     private ILayoutNode BuildAllowedUserIdsSubStep(DiscordStepViewModel vm, StepViewCallbacks callbacks)

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepView.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Termina view for the Discord wizard step.
-/// 5 sub-steps: enable -> bot token -> channel IDs -> DM enabled -> allowed user IDs.
+/// 6 sub-steps: enable -> bot token -> channel IDs -> DM enabled -> user access choice -> allowed user IDs (conditional).
 /// </summary>
 public sealed class DiscordStepView : IWizardStepView
 {
@@ -18,6 +18,7 @@ public sealed class DiscordStepView : IWizardStepView
     private TextInputNode? _botTokenInput;
     private TextInputNode? _channelIdsInput;
     private SelectionListNode<string>? _dmEnabledList;
+    private SelectionListNode<string>? _userAccessChoiceList;
     private TextInputNode? _allowedUserIdsInput;
     private IFocusable? _lastFocusedList;
     private TextInputBaseNode? _lastFocusedInput;
@@ -34,7 +35,8 @@ public sealed class DiscordStepView : IWizardStepView
             1 => BuildBotTokenSubStep(vm, callbacks),
             2 => BuildChannelIdsSubStep(vm, callbacks),
             3 => BuildDmEnabledSubStep(vm, callbacks),
-            4 => BuildAllowedUserIdsSubStep(vm, callbacks),
+            4 => BuildUserAccessChoiceSubStep(vm, callbacks),
+            5 => BuildAllowedUserIdsSubStep(vm, callbacks),
             _ => Layouts.Empty()
         };
     }
@@ -156,6 +158,35 @@ public sealed class DiscordStepView : IWizardStepView
             .WithChild(_dmEnabledList);
     }
 
+    private ILayoutNode BuildUserAccessChoiceSubStep(DiscordStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        var restrictLabel = "Restrict to specific users (recommended)";
+        var allowLabel = "Allow anyone in allowed channels";
+
+        _userAccessChoiceList = Layouts.SelectionList(restrictLabel, allowLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _userAccessChoiceList.OnFocused();
+        _lastFocusedList = _userAccessChoiceList;
+        _lastFocusedInput = null;
+
+        _userAccessChoiceList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                vm.RestrictToSpecificUsers = selected[0] == restrictLabel;
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Who can interact with the bot?").WithForeground(Color.White))
+            .WithChild(_userAccessChoiceList);
+    }
+
     private ILayoutNode BuildAllowedUserIdsSubStep(DiscordStepViewModel vm, StepViewCallbacks callbacks)
     {
         _allowedUserIdsInput = new TextInputNode()
@@ -169,15 +200,16 @@ public sealed class DiscordStepView : IWizardStepView
         _lastFocusedList = null;
 
         _allowedUserIdsInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
             .Subscribe(text =>
             {
-                vm.AllowedUserIdsInput = string.IsNullOrWhiteSpace(text) ? null : text;
+                vm.AllowedUserIdsInput = text;
                 callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode("  Allowed user IDs (press Enter to skip):").WithForeground(Color.White))
+            .WithChild(new TextNode("  Allowed user IDs (at least one required):").WithForeground(Color.White))
             .WithChild(new PanelNode()
                 .WithTitle("Allowed User IDs")
                 .WithBorder(BorderStyle.Rounded)
@@ -216,6 +248,7 @@ public sealed class DiscordStepView : IWizardStepView
         _botTokenInput = null;
         _channelIdsInput = null;
         _dmEnabledList = null;
+        _userAccessChoiceList = null;
         _allowedUserIdsInput = null;
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -385,13 +385,7 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
                 .ToList();
 
     private static List<string> ParseUserIds(string? input)
-        => string.IsNullOrWhiteSpace(input)
-            ? []
-            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(x => x.Trim())
-                .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
+        => WizardStepHelpers.ParseUserIds(input);
 
     public void Dispose()
     {

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -6,7 +6,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Wizard step for configuring Discord integration.
-/// 5 sub-steps: enable -> bot token -> allowed channel IDs -> DM enabled -> allowed user IDs.
+/// 6 sub-steps: enable -> bot token -> allowed channel IDs -> DM enabled -> user access choice -> allowed user IDs (conditional).
 /// </summary>
 public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapterViewModel
 {
@@ -38,6 +38,7 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
     public string? BotToken { get; set; }
     public string? ChannelIdsInput { get; set; }
     public bool AllowDirectMessages { get; set; }
+    public bool RestrictToSpecificUsers { get; set; }
     public string? AllowedUserIdsInput { get; set; }
     internal DiscordChannelResolutionResult? LastChannelResolution { get; set; }
 
@@ -46,7 +47,9 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
     public bool IsApplicable(WizardContext context) => true;
 
     public int CurrentSubStep => _currentSubStep;
-    public int SubStepCount => DiscordEnabled ? (SkipEnableSubStep ? 4 : 5) : 1;
+    public int SubStepCount => DiscordEnabled
+        ? (SkipEnableSubStep ? 4 : 5) + (RestrictToSpecificUsers ? 1 : 0)
+        : 1;
 
     public string GetHelpText() => _currentSubStep switch
     {
@@ -54,7 +57,8 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
         1 => "  Enter the Discord bot token from your application settings.",
         2 => "  Allowed channel IDs are comma-separated. Leave blank for no guild channel ingress.",
         3 => "  Enable DMs only when you want Discord direct messages to be accepted.",
-        4 => "  Restrict Discord DM/message access to specific user IDs. Leave blank to allow any user in allowed conversations.",
+        4 => "  Choose whether to restrict bot interactions to specific Discord user IDs.",
+        5 => "  Enter the Discord user IDs who should have access. At least one ID is required.",
         _ => ""
     };
 
@@ -75,6 +79,20 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
             _currentSubStep++;
             _highWaterSubStep = _currentSubStep;
             return true;
+        }
+
+        if (_currentSubStep == 4 && DiscordEnabled)
+        {
+            if (RestrictToSpecificUsers)
+            {
+                _currentSubStep = 5;
+                _highWaterSubStep = 5;
+                return true;
+            }
+
+            AllowedUserIdsInput = null;
+            _highWaterSubStep = 4;
+            return false;
         }
 
         return false;
@@ -110,6 +128,7 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
         BotToken = null;
         ChannelIdsInput = null;
         AllowDirectMessages = false;
+        RestrictToSpecificUsers = false;
         AllowedUserIdsInput = null;
         LastChannelResolution = null;
         var startSubStep = SkipEnableSubStep ? 1 : 0;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Termina view for the Slack wizard step.
-/// 6 sub-steps: enable → bot token → app token → channel names → DM → user IDs.
+/// 7 sub-steps: enable → bot token → app token → channel names → DM → user access choice → user IDs (conditional).
 /// </summary>
 public sealed class SlackStepView : IWizardStepView
 {
@@ -19,6 +19,7 @@ public sealed class SlackStepView : IWizardStepView
     private TextInputNode? _appTokenInput;
     private TextInputNode? _channelNamesInput;
     private SelectionListNode<string>? _dmEnabledList;
+    private SelectionListNode<string>? _userAccessChoiceList;
     private TextInputNode? _allowedUserIdsInput;
     private IFocusable? _lastFocusedList;
     private TextInputBaseNode? _lastFocusedInput;
@@ -36,7 +37,8 @@ public sealed class SlackStepView : IWizardStepView
             2 => BuildAppTokenSubStep(vm, callbacks),
             3 => BuildChannelNamesSubStep(vm, callbacks),
             4 => BuildDmEnabledSubStep(vm, callbacks),
-            5 => BuildAllowedUserIdsSubStep(vm, callbacks),
+            5 => BuildUserAccessChoiceSubStep(vm, callbacks),
+            6 => BuildAllowedUserIdsSubStep(vm, callbacks),
             _ => Layouts.Empty()
         };
     }
@@ -197,6 +199,35 @@ public sealed class SlackStepView : IWizardStepView
             .WithChild(_dmEnabledList);
     }
 
+    private ILayoutNode BuildUserAccessChoiceSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        var restrictLabel = "Restrict to specific users (recommended)";
+        var allowLabel = "Allow anyone in allowed channels";
+
+        _userAccessChoiceList = Layouts.SelectionList(restrictLabel, allowLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _userAccessChoiceList.OnFocused();
+        _lastFocusedList = _userAccessChoiceList;
+        _lastFocusedInput = null;
+
+        _userAccessChoiceList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                vm.RestrictToSpecificUsers = selected[0] == restrictLabel;
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Who can interact with the bot?").WithForeground(Color.White))
+            .WithChild(_userAccessChoiceList);
+    }
+
     private ILayoutNode BuildAllowedUserIdsSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
     {
         _allowedUserIdsInput = new TextInputNode()
@@ -210,15 +241,16 @@ public sealed class SlackStepView : IWizardStepView
         _lastFocusedList = null;
 
         _allowedUserIdsInput.Submitted
+            .Where(text => !string.IsNullOrWhiteSpace(text))
             .Subscribe(text =>
             {
-                vm.AllowedUserIdsInput = string.IsNullOrWhiteSpace(text) ? null : text;
+                vm.AllowedUserIdsInput = text;
                 callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode("  Allowed user IDs (press Enter to skip):").WithForeground(Color.White))
+            .WithChild(new TextNode("  Allowed user IDs (at least one required):").WithForeground(Color.White))
             .WithChild(new PanelNode()
                 .WithTitle("Allowed User IDs")
                 .WithBorder(BorderStyle.Rounded)
@@ -256,6 +288,7 @@ public sealed class SlackStepView : IWizardStepView
         _appTokenInput = null;
         _channelNamesInput = null;
         _dmEnabledList = null;
+        _userAccessChoiceList = null;
         _allowedUserIdsInput = null;
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepView.cs
@@ -201,31 +201,14 @@ public sealed class SlackStepView : IWizardStepView
 
     private ILayoutNode BuildUserAccessChoiceSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)
     {
-        var restrictLabel = "Restrict to specific users (recommended)";
-        var allowLabel = "Allow anyone in allowed channels";
+        var (list, layout) = WizardStepHelpers.BuildUserAccessChoiceSubStep(
+            restrict => vm.RestrictToSpecificUsers = restrict, callbacks);
 
-        _userAccessChoiceList = Layouts.SelectionList(restrictLabel, allowLabel)
-            .WithMode(SelectionMode.Single)
-            .WithHighlightColors(Color.Black, Color.Cyan);
-
-        _userAccessChoiceList.OnFocused();
-        _lastFocusedList = _userAccessChoiceList;
+        _userAccessChoiceList = list;
+        _lastFocusedList = list;
         _lastFocusedInput = null;
 
-        _userAccessChoiceList.SelectionConfirmed
-            .Subscribe(selected =>
-            {
-                if (selected.Count == 0)
-                    return;
-
-                vm.RestrictToSpecificUsers = selected[0] == restrictLabel;
-                callbacks.AdvanceStep();
-            })
-            .DisposeWith(callbacks.Subscriptions);
-
-        return Layouts.Vertical()
-            .WithChild(new TextNode("  Who can interact with the bot?").WithForeground(Color.White))
-            .WithChild(_userAccessChoiceList);
+        return layout;
     }
 
     private ILayoutNode BuildAllowedUserIdsSubStep(SlackStepViewModel vm, StepViewCallbacks callbacks)

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -6,7 +6,7 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Wizard step for configuring Slack integration.
-/// 6 sub-steps: enable → bot token → app token → channel names → DM enabled → allowed user IDs.
+/// 7 sub-steps: enable → bot token → app token → channel names → DM enabled → user access choice → allowed user IDs (conditional).
 /// </summary>
 public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterViewModel
 {
@@ -41,6 +41,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
     public string? AppToken { get; set; }
     public string? ChannelNamesInput { get; set; }
     public bool AllowDirectMessages { get; set; }
+    public bool RestrictToSpecificUsers { get; set; }
     public string? AllowedUserIdsInput { get; set; }
     internal SlackChannelResolutionResult? LastChannelResolution { get; set; }
 
@@ -49,7 +50,9 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
     public bool IsApplicable(WizardContext context) => true;
 
     public int CurrentSubStep => _currentSubStep;
-    public int SubStepCount => SlackEnabled ? (SkipEnableSubStep ? 5 : 6) : 1;
+    public int SubStepCount => SlackEnabled
+        ? (SkipEnableSubStep ? 5 : 6) + (RestrictToSpecificUsers ? 1 : 0)
+        : 1;
 
     public string GetHelpText() => _currentSubStep switch
     {
@@ -58,7 +61,8 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
         2 => "  Socket Mode requires both tokens. See: https://api.slack.com/apis/socket-mode",
         3 => "  Channel names separated by commas. Bot needs channels:read scope to resolve.",
         4 => "  DMs create a private session per conversation. Each top-level DM starts a new session.",
-        5 => "  Restrict Slack access to specific user IDs for both channels and DMs. Leave blank to allow all workspace members.",
+        5 => "  Choose whether to restrict bot interactions to specific Slack user IDs.",
+        6 => "  Enter the Slack user IDs who should have access. At least one ID is required.",
         _ => ""
     };
 
@@ -78,7 +82,21 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
             return true;
         }
 
-        return false; // step complete (disabled at sub-step 0, or sub-step 5 complete)
+        if (_currentSubStep == 5 && SlackEnabled)
+        {
+            if (RestrictToSpecificUsers)
+            {
+                _currentSubStep = 6;
+                _highWaterSubStep = 6;
+                return true;
+            }
+
+            AllowedUserIdsInput = null;
+            _highWaterSubStep = 5;
+            return false;
+        }
+
+        return false;
     }
 
     public bool TryGoBack()
@@ -111,6 +129,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
         AppToken = null;
         ChannelNamesInput = null;
         AllowDirectMessages = false;
+        RestrictToSpecificUsers = false;
         AllowedUserIdsInput = null;
         LastChannelResolution = null;
         var startSubStep = SkipEnableSubStep ? 1 : 0;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -329,11 +329,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
                 .ToList();
 
     private static List<string> ParseUserIds(string? input)
-        => string.IsNullOrWhiteSpace(input)
-            ? []
-            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .ToList();
+        => WizardStepHelpers.ParseUserIds(input);
 
     public void Dispose() { }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/WizardStepHelpers.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/WizardStepHelpers.cs
@@ -1,0 +1,50 @@
+using R3;
+using Termina.Extensions;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui.Wizard.Steps;
+
+internal static class WizardStepHelpers
+{
+    internal static (SelectionListNode<string> List, ILayoutNode Layout) BuildUserAccessChoiceSubStep(
+        Action<bool> setRestrict, StepViewCallbacks callbacks)
+    {
+        var restrictLabel = "Restrict to specific users (recommended)";
+        var allowLabel = "Allow anyone in allowed channels";
+
+        var list = Layouts.SelectionList(restrictLabel, allowLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        list.OnFocused();
+
+        list.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                setRestrict(selected[0] == restrictLabel);
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        var layout = Layouts.Vertical()
+            .WithChild(new TextNode("  Who can interact with the bot?").WithForeground(Color.White))
+            .WithChild(list);
+
+        return (list, layout);
+    }
+
+    internal static List<string> ParseUserIds(string? input)
+        => string.IsNullOrWhiteSpace(input)
+            ? []
+            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+}


### PR DESCRIPTION
## Summary

- Replaces the plain text AllowedUserIds input in both Discord and Slack init wizard steps with a two-phase flow: an explicit binary selection ("Restrict to specific users" vs "Allow anyone in allowed channels"), then conditionally a mandatory user ID text input
- Prevents users from accidentally opting into open access by pressing Enter on a blank field — enforces the default-deny security posture
- Extracts shared `BuildUserAccessChoiceSubStep` and `ParseUserIds` into `WizardStepHelpers` to eliminate duplication between Discord and Slack views
- Fixes pre-existing `ParseUserIds` inconsistency where Slack's version was missing trim and deduplication

Closes #760

## Test plan

- [ ] Verify `dotnet test --filter "DiscordStepViewModel|SlackStepViewModel"` passes (34 tests including 6 new)
- [ ] Run `netclaw init`, walk through Discord flow: confirm selection list appears, "Allow anyone" completes step, "Restrict" shows mandatory text input
- [ ] Run `netclaw init`, walk through Slack flow: same verification
- [ ] Test backward navigation from text input → returns to choice selection
- [ ] Test changing from "Restrict" → "Allow anyone" on re-visit clears stale user IDs