### PR TITLE
fix(discord): rehydrate thread sessions after daemon restart

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordRoutingPolicyTests.cs
@@ -57,7 +57,7 @@ public class DiscordRoutingPolicyTests
     }
 
     [Fact]
-    public void ThreadReply_RequiresMention_WhenNoExistingActor()
+    public void ThreadReply_RehydratesSession_WhenNoExistingActor()
     {
         var message = CreateMessage(text: "follow up", rootMessageId: null, isThread: true);
 
@@ -69,8 +69,8 @@ public class DiscordRoutingPolicyTests
             threadExists: false,
             containsBotMention: false);
 
-        Assert.Equal(DiscordRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(DiscordRoutingIgnoreReason.ChannelMentionRequired, decision.IgnoreReason);
+        Assert.Equal(DiscordRoutingDecisionKind.StartOrContinue, decision.Kind);
+        Assert.Null(decision.IgnoreReason);
     }
 
     [Fact]
@@ -227,6 +227,7 @@ public class DiscordRoutingPolicyTests
             IsDirectMessage: isDirectMessage,
             ContainsBotMention: false,
             Text: text,
-            ReceivedAt: DateTimeOffset.UtcNow);
+            ReceivedAt: DateTimeOffset.UtcNow,
+            IsInThread: isThread);
     }
 }

--- a/src/Netclaw.Channels.Discord/DiscordRoutingPolicy.cs
+++ b/src/Netclaw.Channels.Discord/DiscordRoutingPolicy.cs
@@ -26,6 +26,12 @@ internal static class DiscordRoutingPolicy
         if (threadExists)
             return DiscordRoutingDecision.ContinueOnly;
 
+        // Thread reply where the actor was lost (e.g. daemon restart):
+        // the message is in a Discord thread, so re-create the session
+        // binding and continue the persisted session.
+        if (message.IsInThread)
+            return DiscordRoutingDecision.StartOrContinue;
+
         if (!mentionOnly)
             return DiscordRoutingDecision.StartOrContinue;
 

--- a/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
+++ b/src/Netclaw.Channels.Discord/DiscordTransportContracts.cs
@@ -16,7 +16,8 @@ public sealed record DiscordGatewayMessage(
     bool ContainsBotMention,
     string Text,
     DateTimeOffset ReceivedAt,
-    IReadOnlyList<DiscordFileReference>? Attachments = null);
+    IReadOnlyList<DiscordFileReference>? Attachments = null,
+    bool IsInThread = false);
 
 /// <summary>
 /// Normalized Discord interaction response payload emitted by the transport client.

--- a/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordNetGatewayClient.cs
@@ -119,7 +119,8 @@ internal sealed class DiscordNetGatewayClient : IDiscordGatewayClient, IDisposab
             ContainsBotMention: containsMention,
             Text: message.Content,
             ReceivedAt: _timeProvider.GetUtcNow(),
-            Attachments: attachments);
+            Attachments: attachments,
+            IsInThread: isThread);
 
         try
         {


### PR DESCRIPTION
## Summary

- After a daemon restart, messages sent to an existing Discord thread were silently dropped unless the user @mentioned the bot again. This matched the `ChannelMentionRequired` routing policy path because the in-memory session binding actor was lost on restart and `threadExists` was false.
- Added `IsInThread` field to `DiscordGatewayMessage` (surfacing the `SocketThreadChannel` check already computed in the gateway client) and a thread rehydration branch in `DiscordRoutingPolicy` that returns `StartOrContinue` for in-thread messages — matching the existing Slack behavior (`SlackRoutingPolicy.cs:52-59`).
- The session binding actor is recreated, Akka Persistence recovers the prior session state, and the conversation continues seamlessly without requiring a mention.

## Test plan

- [x] Updated `ThreadReply_RehydratesSession_WhenNoExistingActor` test to verify `StartOrContinue` for in-thread messages with no actor and no mention
- [x] All 2,964 tests pass (0 failures)
- [x] Rebuilt Docker image, restarted container, verified bot responds to existing thread without @mention