### PR TITLE
feat(skills): private skill server feed sync via Netclaw.SkillClient

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="SlackNet" Version="$(SlackNetVersion)" />
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.12.0" />
+    <PackageVersion Include="Netclaw.SkillClient" Version="0.2.0" />
     <PackageVersion Include="Termina" Version="0.8.0" />
   </ItemGroup>
   <!-- Serialization -->

--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -195,6 +195,18 @@ public static partial class SkillScanner
     public static MergedSkillScanResult ScanAndMerge(
         string nativeSkillsDirectory,
         IReadOnlyList<ResolvedExternalSource> externalSources)
+        => ScanAndMerge(nativeSkillsDirectory, Array.Empty<ResolvedExternalSource>(), externalSources);
+
+    /// <summary>
+    /// Scans the native skills directory, server feed sources, and external sources,
+    /// merging results with three-tier precedence: native &gt; server feeds &gt; external.
+    /// Server feed sources are org-managed private skill servers that take precedence
+    /// over local external directories but yield to native user skills.
+    /// </summary>
+    public static MergedSkillScanResult ScanAndMerge(
+        string nativeSkillsDirectory,
+        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
     {
         var nativeScan = Scan(nativeSkillsDirectory, allowSymlinks: false, strictNameMatch: true);
         var allAccepted = new List<SkillEntry>(nativeScan.AcceptedSkills);
@@ -203,7 +215,23 @@ public static partial class SkillScanner
         var knownNames = new HashSet<string>(
             nativeScan.AcceptedSkills.Select(s => s.Name), StringComparer.OrdinalIgnoreCase);
 
-        foreach (var source in externalSources)
+        // Server feed sources (second tier — org-managed private skill servers)
+        MergeSources(serverFeedSources, allAccepted, allIssues, knownNames, allowFrontmatterlessFlatFiles: false);
+
+        // External filesystem sources (third tier — Claude Code, Open Code, custom paths)
+        MergeSources(externalSources, allAccepted, allIssues, knownNames, allowFrontmatterlessFlatFiles: true);
+
+        return new MergedSkillScanResult(allAccepted, allIssues);
+    }
+
+    private static void MergeSources(
+        IReadOnlyList<ResolvedExternalSource> sources,
+        List<SkillEntry> allAccepted,
+        List<SkillScanIssue> allIssues,
+        HashSet<string> knownNames,
+        bool allowFrontmatterlessFlatFiles)
+    {
+        foreach (var source in sources)
         {
             foreach (var path in source.Paths)
             {
@@ -211,7 +239,7 @@ public static partial class SkillScanner
                     path,
                     allowSymlinks: source.AllowSymlinks,
                     strictNameMatch: false,
-                    allowFrontmatterlessFlatFiles: IsClaudeCommandsDirectory(path));
+                    allowFrontmatterlessFlatFiles: allowFrontmatterlessFlatFiles && IsClaudeCommandsDirectory(path));
                 allIssues.AddRange(externalScan.Issues);
 
                 foreach (var skill in externalScan.AcceptedSkills)
@@ -230,8 +258,6 @@ public static partial class SkillScanner
                 }
             }
         }
-
-        return new MergedSkillScanResult(allAccepted, allIssues);
     }
 
     private static SkillEntry? ParseSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false, bool strictNameMatch = true)
@@ -659,12 +685,15 @@ public static partial class SkillScanner
         return null;
     }
 
+    private const string ServerFeedsCategory = ".server-feeds";
+
     /// <summary>
-    /// Only <c>.system</c> is scanned as a hidden directory (system skills from CDN).
-    /// All other hidden directories are ignored.
+    /// Hidden directories that are scanned for skills. <c>.system</c> holds CDN-synced
+    /// system skills; <c>.server-feeds</c> holds skills synced from private skill servers.
     /// </summary>
     private static bool IsAllowedHiddenDirectory(string dirName)
-        => string.Equals(dirName, SystemCategory, StringComparison.Ordinal);
+        => string.Equals(dirName, SystemCategory, StringComparison.Ordinal)
+        || string.Equals(dirName, ServerFeedsCategory, StringComparison.Ordinal);
 
     private static bool IsClaudeCommandsDirectory(string path)
     {

--- a/src/Netclaw.Cli/Netclaw.Cli.csproj
+++ b/src/Netclaw.Cli/Netclaw.Cli.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" />
     <PackageReference Include="ModelContextProtocol.Core" />
+    <PackageReference Include="Netclaw.SkillClient" />
     <PackageReference Include="Termina" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
   </ItemGroup>

--- a/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardViewModel.cs
@@ -95,6 +95,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
         var browserStep = new BrowserAutomationStepViewModel();
         var identityStep = new IdentityStepViewModel();
         var externalSkillsStep = new ExternalSkillsStepViewModel();
+        var skillFeedsStep = new SkillFeedsStepViewModel();
         _healthCheckStep = new HealthCheckStepViewModel(daemonManager, daemonApi, navigationState);
 
         var steps = new List<IWizardStepViewModel>
@@ -108,6 +109,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             browserStep,
             identityStep,
             externalSkillsStep,
+            skillFeedsStep,
             exposureModeStep,
             _healthCheckStep
         };
@@ -137,6 +139,7 @@ public partial class InitWizardViewModel : ReactiveViewModel
             ["browser-automation"] = new BrowserAutomationStepView(),
             ["identity"] = new IdentityStepView(),
             ["external-skills"] = new ExternalSkillsStepView(),
+            ["skill-feeds"] = new SkillFeedsStepView(),
             ["health-check"] = new HealthCheckStepView()
         };
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
@@ -70,11 +70,7 @@ public sealed class SkillFeedsStepView : IWizardStepView
                     return;
 
                 _vm!.SetWantsToConnect(selected[0] == yesLabel);
-
-                if (!_vm.WantsToConnect)
-                    callbacks.AdvanceStep();
-                else
-                    callbacks.AdvanceStep();
+                callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
@@ -1,0 +1,324 @@
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui.Wizard.Steps;
+
+/// <summary>
+/// Termina view for the Skill Feeds wizard step.
+/// Sub-step 0: Yes/No selection to connect.
+/// Sub-step 1: URL text input.
+/// Sub-step 2: Probe result (spinner during probe, result/error after).
+/// Sub-step 3: Name input (auto-suggested from hostname).
+/// Sub-step 4: Add another or continue.
+/// </summary>
+public sealed class SkillFeedsStepView : IWizardStepView
+{
+    private static readonly string[] SpinnerFrames = ["⠋", "⠙", "⠸", "⠴", "⠦", "⠇"];
+
+    private SelectionListNode<string>? _connectList;
+    private TextInputNode? _urlInput;
+    private TextInputNode? _nameInput;
+    private SelectionListNode<string>? _errorActionList;
+    private SelectionListNode<string>? _addAnotherList;
+    private IFocusable? _lastFocusedList;
+    private TextInputBaseNode? _lastFocusedInput;
+    private StepViewCallbacks? _callbacks;
+    private SkillFeedsStepViewModel? _vm;
+    private int _spinnerTick;
+
+    public string StepId => "skill-feeds";
+
+    public ILayoutNode BuildContent(IWizardStepViewModel stepVm, StepViewCallbacks callbacks)
+    {
+        _callbacks = callbacks;
+        _vm = (SkillFeedsStepViewModel)stepVm;
+
+        return _vm.CurrentSubStep switch
+        {
+            0 => BuildConnectPrompt(callbacks),
+            1 => BuildUrlInput(callbacks),
+            2 => BuildProbeResult(callbacks),
+            3 => BuildNameInput(callbacks),
+            4 => BuildAddAnotherPrompt(callbacks),
+            _ => Layouts.Empty()
+        };
+    }
+
+    private ILayoutNode BuildConnectPrompt(StepViewCallbacks callbacks)
+    {
+        _lastFocusedInput = null;
+
+        var yesLabel = "Yes — add a skill server URL";
+        var noLabel = "No — skip";
+
+        _connectList = Layouts.SelectionList(yesLabel, noLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _connectList.OnFocused();
+        _lastFocusedList = _connectList;
+
+        _connectList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0)
+                    return;
+
+                _vm!.SetWantsToConnect(selected[0] == yesLabel);
+
+                if (!_vm.WantsToConnect)
+                    callbacks.AdvanceStep();
+                else
+                    callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Connect to a private skill server?").WithForeground(Color.White))
+            .WithChild(new TextNode("  Organizations can host skill servers to distribute").WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("  skills to all Netclaw instances automatically.").WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(_connectList);
+    }
+
+    private ILayoutNode BuildUrlInput(StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+
+        _urlInput = new TextInputNode()
+            .WithPlaceholder("https://skills.example.com");
+
+        if (!string.IsNullOrWhiteSpace(_vm!.CurrentUrl))
+            _urlInput.Text = _vm.CurrentUrl;
+
+        _urlInput.OnFocused();
+        _lastFocusedInput = _urlInput;
+
+        _urlInput.Submitted
+            .Subscribe(text =>
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                    return;
+
+                _vm.SetUrl(text);
+                callbacks.AdvanceStep();
+
+                _ = Task.Run(async () =>
+                {
+                    await _vm.ProbeAsync(CancellationToken.None);
+                    callbacks.InvalidateAndRedraw();
+
+                    if (_vm.ProbeSucceeded && _vm.LastProbeError is null)
+                        callbacks.AdvanceStep();
+                });
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Enter the skill server URL:").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("URL")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_urlInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildProbeResult(StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+        _lastFocusedInput = null;
+
+        if (_vm!.IsProbing)
+        {
+            var frame = SpinnerFrames[_spinnerTick++ % SpinnerFrames.Length];
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  {frame} Discovering skills at {_vm.CurrentUrl} ...")
+                    .WithForeground(Color.Cyan));
+        }
+
+        if (_vm.LastProbeError is not null)
+        {
+            var retryLabel = "Try again";
+            var editLabel = "Edit URL";
+            var skipLabel = "Skip this step";
+
+            _errorActionList = Layouts.SelectionList(retryLabel, editLabel, skipLabel)
+                .WithMode(SelectionMode.Single)
+                .WithHighlightColors(Color.Black, Color.Cyan);
+
+            _errorActionList.OnFocused();
+            _lastFocusedList = _errorActionList;
+
+            _errorActionList.SelectionConfirmed
+                .Subscribe(selected =>
+                {
+                    if (selected.Count == 0) return;
+                    var choice = selected[0];
+
+                    if (choice == retryLabel)
+                    {
+                        callbacks.InvalidateAndRedraw();
+                        _ = Task.Run(async () =>
+                        {
+                            await _vm.ProbeAsync(CancellationToken.None);
+                            callbacks.InvalidateAndRedraw();
+                            if (_vm.ProbeSucceeded && _vm.LastProbeError is null)
+                                callbacks.AdvanceStep();
+                        });
+                    }
+                    else if (choice == editLabel)
+                    {
+                        _vm.TryGoBack();
+                        callbacks.InvalidateAndRedraw();
+                    }
+                    else
+                    {
+                        _vm.SetWantsToConnect(false);
+                        callbacks.AdvanceStep();
+                    }
+                })
+                .DisposeWith(callbacks.Subscriptions);
+
+            return Layouts.Vertical()
+                .WithChild(new TextNode($"  ✗ Could not reach {_vm.CurrentUrl}").WithForeground(Color.Red))
+                .WithChild(new TextNode($"    {_vm.LastProbeError}").WithForeground(Color.BrightBlack))
+                .WithSpacing(1)
+                .WithChild(_errorActionList);
+        }
+
+        // Success — auto-advance handled by probe callback, but render success state
+        callbacks.AdvanceStep();
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  ✓ Connected to {_vm.CurrentUrl}").WithForeground(Color.Green))
+            .WithChild(new TextNode($"    Found {_vm.LastProbeSkillCount} skills").WithForeground(Color.White));
+    }
+
+    private ILayoutNode BuildNameInput(StepViewCallbacks callbacks)
+    {
+        _lastFocusedList = null;
+
+        _nameInput = new TextInputNode()
+            .WithPlaceholder("feed-name");
+
+        _nameInput.Text = _vm!.CurrentName;
+
+        _nameInput.OnFocused();
+        _lastFocusedInput = _nameInput;
+
+        _nameInput.Submitted
+            .Subscribe(text =>
+            {
+                if (!string.IsNullOrWhiteSpace(text))
+                    _vm.SetName(text);
+
+                _vm.SaveCurrentFeed();
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  ✓ Connected to {_vm.CurrentUrl}").WithForeground(Color.Green))
+            .WithChild(new TextNode($"    Found {_vm.LastProbeSkillCount} skills").WithForeground(Color.White))
+            .WithSpacing(1)
+            .WithChild(new TextNode("  Feed name (used in config):").WithForeground(Color.White))
+            .WithChild(new PanelNode()
+                .WithTitle("Name")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(_nameInput)
+                .Height(3));
+    }
+
+    private ILayoutNode BuildAddAnotherPrompt(StepViewCallbacks callbacks)
+    {
+        _lastFocusedInput = null;
+
+        var continueLabel = "Continue to next step";
+        var addLabel = "Add another skill server";
+
+        _addAnotherList = Layouts.SelectionList(continueLabel, addLabel)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _addAnotherList.OnFocused();
+        _lastFocusedList = _addAnotherList;
+
+        _addAnotherList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0) return;
+
+                if (selected[0] == addLabel)
+                {
+                    _vm!.StartAddAnother();
+                    callbacks.InvalidateAndRedraw();
+                }
+                else
+                {
+                    callbacks.AdvanceStep();
+                }
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        var layout = Layouts.Vertical()
+            .WithChild(new TextNode("  Configured feeds:").WithForeground(Color.White));
+
+        foreach (var feed in _vm!.ConfiguredFeeds)
+        {
+            layout = layout.WithChild(
+                new TextNode($"    ✓ {feed.Name} ({feed.SkillCount} skills)")
+                    .WithForeground(Color.Green));
+        }
+
+        layout = layout
+            .WithSpacing(1)
+            .WithChild(_addAnotherList);
+
+        return layout;
+    }
+
+    public bool HandleKeyPress(KeyPressed key)
+    {
+        if (_vm is null)
+            return false;
+
+        var keyInfo = key.KeyInfo;
+
+        if (_lastFocusedInput is not null)
+        {
+            _lastFocusedInput.HandleInput(keyInfo);
+            return true;
+        }
+
+        if (_lastFocusedList is not null)
+        {
+            _lastFocusedList.HandleInput(keyInfo);
+            return true;
+        }
+
+        return false;
+    }
+
+    public void HandlePaste(PasteEvent paste)
+    {
+        _lastFocusedInput?.HandlePaste(paste);
+    }
+
+    public void ClearFocusState()
+    {
+        _lastFocusedList = null;
+        _lastFocusedInput = null;
+        _connectList = null;
+        _urlInput = null;
+        _nameInput = null;
+        _errorActionList = null;
+        _addAnotherList = null;
+        _spinnerTick = 0;
+    }
+}

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
@@ -102,6 +102,7 @@ public sealed class SkillFeedsStepView : IWizardStepView
                     return;
 
                 _vm.SetUrl(text);
+                _vm.BeginProbe();
                 callbacks.AdvanceStep();
 
                 _ = Task.Run(async () =>
@@ -109,7 +110,7 @@ public sealed class SkillFeedsStepView : IWizardStepView
                     await _vm.ProbeAsync(CancellationToken.None);
                     callbacks.InvalidateAndRedraw();
 
-                    if (_vm.ProbeSucceeded && _vm.LastProbeError is null)
+                    if (_vm.ProbeSucceeded)
                         callbacks.AdvanceStep();
                 });
             })
@@ -159,12 +160,13 @@ public sealed class SkillFeedsStepView : IWizardStepView
 
                     if (choice == retryLabel)
                     {
+                        _vm.BeginProbe();
                         callbacks.InvalidateAndRedraw();
                         _ = Task.Run(async () =>
                         {
                             await _vm.ProbeAsync(CancellationToken.None);
                             callbacks.InvalidateAndRedraw();
-                            if (_vm.ProbeSucceeded && _vm.LastProbeError is null)
+                            if (_vm.ProbeSucceeded)
                                 callbacks.AdvanceStep();
                         });
                     }
@@ -188,8 +190,7 @@ public sealed class SkillFeedsStepView : IWizardStepView
                 .WithChild(_errorActionList);
         }
 
-        // Success — auto-advance handled by probe callback, but render success state
-        callbacks.AdvanceStep();
+        // Success — probe callback handles AdvanceStep(); this is a transient render state
         return Layouts.Vertical()
             .WithChild(new TextNode($"  ✓ Connected to {_vm.CurrentUrl}").WithForeground(Color.Green))
             .WithChild(new TextNode($"    Found {_vm.LastProbeSkillCount} skills").WithForeground(Color.White));

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepView.cs
@@ -74,10 +74,20 @@ public sealed class SkillFeedsStepView : IWizardStepView
             })
             .DisposeWith(callbacks.Subscriptions);
 
+        var infoContent = Layouts.Vertical()
+            .WithChild(new TextNode("Any server implementing the Cloudflare Agents Skills Discovery protocol can distribute skills to Netclaw. Use ours or bring your own:")
+                .WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("https://github.com/netclaw-dev/skill-server")
+                .WithForeground(Color.Cyan));
+
         return Layouts.Vertical()
             .WithChild(new TextNode("  Connect to a private skill server?").WithForeground(Color.White))
-            .WithChild(new TextNode("  Organizations can host skill servers to distribute").WithForeground(Color.BrightBlack))
-            .WithChild(new TextNode("  skills to all Netclaw instances automatically.").WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(new PanelNode()
+                .WithTitle("ℹ  What's a skill server?")
+                .WithBorder(BorderStyle.Rounded)
+                .WithBorderColor(Color.Gray)
+                .WithContent(infoContent))
             .WithSpacing(1)
             .WithChild(_connectList);
     }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
@@ -1,0 +1,216 @@
+using Netclaw.Configuration;
+using Netclaw.SkillClient;
+
+namespace Netclaw.Cli.Tui.Wizard.Steps;
+
+/// <summary>
+/// Wizard step for configuring private skill server feeds.
+/// Sub-step 0: Yes/No to connect.
+/// Sub-step 1: URL text input.
+/// Sub-step 2: Probe (async).
+/// Sub-step 3: Name input (auto-suggested from hostname).
+/// Sub-step 4: Add another or continue.
+/// </summary>
+public sealed class SkillFeedsStepViewModel : IWizardStepViewModel, IDisposable
+{
+    private int _currentSubStep;
+    private int _highWaterSubStep;
+    private bool _wantsToConnect;
+
+    private string _currentUrl = "";
+    private string _currentName = "";
+    private int _lastProbeSkillCount;
+    private string? _lastProbeError;
+    private bool _probing;
+
+    private readonly List<ConfiguredFeed> _feeds = [];
+
+    public string StepId => "skill-feeds";
+    public string DisplayTitle => "Skill Feeds";
+
+    public int CurrentSubStep => _currentSubStep;
+    public bool WantsToConnect => _wantsToConnect;
+    public string CurrentUrl => _currentUrl;
+    public string CurrentName => _currentName;
+    public int LastProbeSkillCount => _lastProbeSkillCount;
+    public string? LastProbeError => _lastProbeError;
+    public bool IsProbing => _probing;
+    public IReadOnlyList<ConfiguredFeed> ConfiguredFeeds => _feeds;
+
+    public int SubStepCount => _wantsToConnect ? 5 : 1;
+
+    public bool IsApplicable(WizardContext context) => true;
+
+    public void SetWantsToConnect(bool value)
+    {
+        _wantsToConnect = value;
+    }
+
+    public void SetUrl(string url)
+    {
+        _currentUrl = url.Trim();
+        _currentName = SuggestNameFromUrl(_currentUrl);
+    }
+
+    public void SetName(string name)
+    {
+        _currentName = name.Trim();
+    }
+
+    public async Task ProbeAsync(CancellationToken ct)
+    {
+        _probing = true;
+        _lastProbeError = null;
+        _lastProbeSkillCount = 0;
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
+
+            using var client = new SkillServerClient(_currentUrl);
+            var index = await client.GetRfcIndexAsync(cts.Token);
+
+            if (index is null)
+            {
+                _lastProbeError = "Server returned empty response";
+                return;
+            }
+
+            _lastProbeSkillCount = index.Skills.Count;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _lastProbeError = "Connection timed out";
+        }
+        catch (HttpRequestException ex)
+        {
+            _lastProbeError = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            _lastProbeError = ex.Message;
+        }
+        finally
+        {
+            _probing = false;
+        }
+    }
+
+    public bool ProbeSucceeded => _lastProbeError is null && _lastProbeSkillCount >= 0 && !_probing;
+
+    public void SaveCurrentFeed()
+    {
+        if (string.IsNullOrWhiteSpace(_currentName) || string.IsNullOrWhiteSpace(_currentUrl))
+            return;
+
+        _feeds.Add(new ConfiguredFeed(_currentName, _currentUrl, _lastProbeSkillCount));
+        _currentUrl = "";
+        _currentName = "";
+        _lastProbeSkillCount = 0;
+        _lastProbeError = null;
+    }
+
+    public void StartAddAnother()
+    {
+        _currentSubStep = 1;
+        _highWaterSubStep = 1;
+    }
+
+    public string GetHelpText() => _currentSubStep switch
+    {
+        0 => "  Connect to a private skill server to automatically sync skills.",
+        1 => "  Enter the base URL of your skill server.",
+        2 when _probing => "  Discovering skills...",
+        2 when _lastProbeError is not null => "  Connection failed. Try again, edit URL, or skip.",
+        2 => "  Connected successfully.",
+        3 => "  Give this feed a short name for your config file.",
+        4 => "  Add more feeds or continue to the next step.",
+        _ => ""
+    };
+
+    public bool TryAdvance()
+    {
+        if (_currentSubStep == 0 && !_wantsToConnect)
+            return false;
+
+        if (_currentSubStep < SubStepCount - 1)
+        {
+            _currentSubStep++;
+            if (_currentSubStep > _highWaterSubStep)
+                _highWaterSubStep = _currentSubStep;
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryGoBack()
+    {
+        if (_currentSubStep > 0)
+        {
+            _currentSubStep--;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void OnEnter(WizardContext context, NavigationDirection direction)
+    {
+        if (direction == NavigationDirection.Back)
+            _currentSubStep = _highWaterSubStep;
+        else
+            _currentSubStep = 0;
+    }
+
+    public void OnLeave() { }
+
+    public void ContributeConfig(WizardConfigBuilder builder)
+    {
+        if (_feeds.Count == 0)
+            return;
+
+        builder.SkillFeedSources = _feeds
+            .Select(f => new SkillFeedSource
+            {
+                Name = f.Name,
+                Url = f.Url,
+                Enabled = true
+            })
+            .ToList();
+    }
+
+    public void ContributeSecrets(WizardSecretsBuilder builder) { }
+
+    public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
+        => Task.CompletedTask;
+
+    public void Dispose() { }
+
+    internal static string SuggestNameFromUrl(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var host = uri.Host;
+
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
+                || host.StartsWith("127.", StringComparison.Ordinal)
+                || string.Equals(host, "::1", StringComparison.Ordinal))
+            {
+                return "localhost";
+            }
+
+            return host
+                .Replace('.', '-')
+                .ToLowerInvariant();
+        }
+        catch
+        {
+            return "custom";
+        }
+    }
+
+    public sealed record ConfiguredFeed(string Name, string Url, int SkillCount);
+}

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
@@ -54,7 +54,18 @@ public sealed class SkillFeedsStepViewModel : IWizardStepViewModel, IDisposable
 
     public void SetName(string name)
     {
-        _currentName = name.Trim();
+        _currentName = SanitizeFeedName(name.Trim());
+    }
+
+    /// <summary>
+    /// Marks the probe as in-progress synchronously so the render path
+    /// sees <see cref="IsProbing"/> == true before the background task starts.
+    /// </summary>
+    public void BeginProbe()
+    {
+        _probing = true;
+        _lastProbeError = null;
+        _lastProbeSkillCount = 0;
     }
 
     public async Task ProbeAsync(CancellationToken ct)
@@ -210,6 +221,24 @@ public sealed class SkillFeedsStepViewModel : IWizardStepViewModel, IDisposable
         {
             return "custom";
         }
+    }
+
+    internal static string SanitizeFeedName(string name)
+    {
+        var sanitized = new char[name.Length];
+        var len = 0;
+
+        foreach (var c in name)
+        {
+            if (char.IsLetterOrDigit(c) || c == '-')
+                sanitized[len++] = char.ToLowerInvariant(c);
+            else if (c is ' ' or '_' or '.')
+                sanitized[len++] = '-';
+        }
+
+        // Trim leading/trailing hyphens
+        var span = sanitized.AsSpan(0, len).Trim('-');
+        return span.Length > 0 ? new string(span) : "custom";
     }
 
     public sealed record ConfiguredFeed(string Name, string Url, int SkillCount);

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
@@ -97,7 +97,7 @@ public sealed class SkillFeedsStepViewModel : IWizardStepViewModel, IDisposable
         }
     }
 
-    public bool ProbeSucceeded => _lastProbeError is null && _lastProbeSkillCount >= 0 && !_probing;
+    public bool ProbeSucceeded => _lastProbeError is null && !_probing;
 
     public void SaveCurrentFeed()
     {

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -34,6 +34,7 @@ public sealed class WizardConfigBuilder
     public WorkspacesConfigSection? Workspaces { get; set; }
     public NotificationsConfigSection? Notifications { get; set; }
     public List<ExternalSkillSource>? ExternalSkillSources { get; set; }
+    public List<SkillFeedSource>? SkillFeedSources { get; set; }
     public DaemonConfigSection? Daemon { get; set; }
     public WebhooksConfigSection? Webhooks { get; set; }
     public FeatureSelectionsConfigSection? FeatureSelections { get; set; }
@@ -219,6 +220,26 @@ public sealed class WizardConfigBuilder
             config["ExternalSkills"] = new Dictionary<string, object>
             {
                 ["Sources"] = sourcesArray
+            };
+        }
+
+        // Skill feeds (private skill servers)
+        if (SkillFeedSources is { Count: > 0 })
+        {
+            var feedsArray = SkillFeedSources.Select(f =>
+            {
+                var entry = new Dictionary<string, object>
+                {
+                    ["Name"] = f.Name,
+                    ["Url"] = f.Url,
+                    ["Enabled"] = f.Enabled
+                };
+                return (object)entry;
+            }).ToArray();
+
+            config["SkillFeeds"] = new Dictionary<string, object>
+            {
+                ["Feeds"] = feedsArray
             };
         }
 

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -33,6 +33,15 @@ public sealed class NetclawPaths
     public string SystemSkillsDirectory => Path.Combine(SkillsDirectory, ".system");
     public string SkillSyncStatePath => Path.Combine(SystemSkillsDirectory, ".sync-state.json");
 
+    // ── Server feed skills (from private skill-server instances) ──
+    public string ServerFeedsDirectory => Path.Combine(SkillsDirectory, ".server-feeds");
+
+    public string ServerFeedDirectory(string feedName)
+        => Path.Combine(ServerFeedsDirectory, feedName);
+
+    public string ServerFeedSyncStatePath(string feedName)
+        => Path.Combine(ServerFeedDirectory(feedName), ".sync-state.json");
+
     // ── Cache directory ──
     public string CacheDirectory => Path.Combine(BasePath, "cache");
     public string RestartManifestPath => Path.Combine(CacheDirectory, "restart-manifest.json");
@@ -112,6 +121,7 @@ public sealed class NetclawPaths
         Directory.CreateDirectory(McpShadowDirectory);
         Directory.CreateDirectory(SkillsDirectory);
         Directory.CreateDirectory(SystemSkillsDirectory);
+        Directory.CreateDirectory(ServerFeedsDirectory);
         Directory.CreateDirectory(ProjectsDirectory);
         Directory.CreateDirectory(ClientDirectory);
         Directory.CreateDirectory(EnvironmentDirectory);

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -414,8 +414,15 @@
     },
     "SkillFeeds": {
       "type": "object",
-      "description": "Private skill server feeds. Skills are synced from these servers at startup.",
+      "description": "Private skill server feeds. Skills are synced from these servers at startup and periodically.",
       "properties": {
+        "SyncIntervalMinutes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1440,
+          "default": 60,
+          "description": "How often (in minutes) to re-check feeds for updated skills. 0 disables periodic sync."
+        },
         "Feeds": {
           "type": "array",
           "description": "Ordered list of skill server feeds. Earlier feeds win on name collisions.",

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -412,6 +412,49 @@
       },
       "additionalProperties": false
     },
+    "SkillFeeds": {
+      "type": "object",
+      "description": "Private skill server feeds. Skills are synced from these servers at startup.",
+      "properties": {
+        "Feeds": {
+          "type": "array",
+          "description": "Ordered list of skill server feeds. Earlier feeds win on name collisions.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Name": {
+                "type": "string",
+                "description": "Unique feed identifier (used as directory name). Lowercase alphanumeric and hyphens."
+              },
+              "Url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Skill server base URL (e.g., https://skills.corp.com)."
+              },
+              "ApiKey": {
+                "type": ["string", "null"],
+                "description": "Optional Bearer token for authenticated access. Supports ENC: prefix."
+              },
+              "Enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this feed is active."
+              },
+              "TimeoutSeconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 300,
+                "default": 30,
+                "description": "HTTP timeout in seconds for requests to this feed."
+              }
+            },
+            "required": ["Name", "Url"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "SubAgents": {
       "type": "object",
       "description": "Timeout configuration for subagent execution (seconds).",

--- a/src/Netclaw.Configuration/SkillFeedsConfig.cs
+++ b/src/Netclaw.Configuration/SkillFeedsConfig.cs
@@ -3,7 +3,7 @@ namespace Netclaw.Configuration;
 /// <summary>
 /// Configuration for private skill server feeds. Organizations can host
 /// skill-server instances and have Netclaw daemons automatically discover
-/// and sync skills from them at startup.
+/// and sync skills at startup and periodically thereafter.
 /// </summary>
 public sealed class SkillFeedsConfig
 {
@@ -13,6 +13,13 @@ public sealed class SkillFeedsConfig
     /// system skills always take highest precedence regardless of order.
     /// </summary>
     public List<SkillFeedSource> Feeds { get; set; } = [];
+
+    /// <summary>
+    /// How often (in minutes) to re-check feeds for updated skills.
+    /// Default: 60 (once per hour). Set to 0 to disable periodic sync
+    /// and only sync at daemon startup.
+    /// </summary>
+    public int SyncIntervalMinutes { get; set; } = 60;
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/SkillFeedsConfig.cs
+++ b/src/Netclaw.Configuration/SkillFeedsConfig.cs
@@ -1,0 +1,50 @@
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Configuration for private skill server feeds. Organizations can host
+/// skill-server instances and have Netclaw daemons automatically discover
+/// and sync skills from them at startup.
+/// </summary>
+public sealed class SkillFeedsConfig
+{
+    /// <summary>
+    /// Ordered list of skill server feeds. Precedence follows list order —
+    /// earlier feeds win on name collisions. Native Netclaw skills and
+    /// system skills always take highest precedence regardless of order.
+    /// </summary>
+    public List<SkillFeedSource> Feeds { get; set; } = [];
+}
+
+/// <summary>
+/// A single skill server feed source.
+/// </summary>
+public sealed class SkillFeedSource
+{
+    /// <summary>
+    /// Unique identifier for this feed (used as directory name and display label).
+    /// Must be filesystem-safe: lowercase alphanumeric and hyphens.
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Base URL of the skill server (e.g., "https://skills.corp.com").
+    /// The daemon appends <c>/.well-known/agent-skills/index.json</c> for RFC discovery.
+    /// </summary>
+    public string Url { get; set; } = "";
+
+    /// <summary>
+    /// Optional API key for authenticated access to the skill server.
+    /// Supports <c>ENC:</c> prefix for encrypted storage in secrets.json.
+    /// </summary>
+    public SensitiveString? ApiKey { get; set; }
+
+    /// <summary>
+    /// Whether this feed is active. Default: <c>true</c>.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// HTTP timeout in seconds for requests to this feed. Default: 30.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 30;
+}

--- a/src/Netclaw.Daemon/Netclaw.Daemon.csproj
+++ b/src/Netclaw.Daemon/Netclaw.Daemon.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Akka.Persistence.Sql.Hosting" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="ModelContextProtocol.Core" />
+    <PackageReference Include="Netclaw.SkillClient" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -660,8 +660,25 @@ static void ConfigureDaemonServices(
     services.AddSingleton(externalSkillsConfig);
     services.AddSingleton(resolvedExternalSources);
 
-    // Scan native skills first (highest precedence), then external sources
-    var initialSkillScan = SkillScanner.ScanAndMerge(paths.SkillsDirectory, resolvedExternalSources);
+    // Server feed skill sources (private skill-server instances)
+    var skillFeedsConfig = configuration.GetSection("SkillFeeds")
+        .Get<SkillFeedsConfig>() ?? new SkillFeedsConfig();
+    services.AddSingleton(skillFeedsConfig);
+
+    var resolvedServerFeedSources = new List<ResolvedExternalSource>();
+    foreach (var feed in skillFeedsConfig.Feeds.Where(f => f.Enabled))
+    {
+        var feedDir = paths.ServerFeedDirectory(feed.Name);
+        if (Directory.Exists(feedDir))
+            resolvedServerFeedSources.Add(new ResolvedExternalSource(
+                $"server-feed:{feed.Name}", [feedDir], AllowSymlinks: false));
+    }
+    IReadOnlyList<ResolvedExternalSource> serverFeeds = resolvedServerFeedSources;
+    services.AddKeyedSingleton("server-feeds", serverFeeds);
+
+    // Scan native skills first (highest precedence), then server feeds, then external sources
+    var initialSkillScan = SkillScanner.ScanAndMerge(
+        paths.SkillsDirectory, serverFeeds, resolvedExternalSources);
     skillRegistry.ReplaceAll(initialSkillScan.AcceptedSkills, initialSkillScan.Issues);
     services.AddSingleton(skillRegistry);
 
@@ -825,9 +842,16 @@ static void ConfigureDaemonServices(
         services.AddHostedService<SystemSkillSyncService>();
     }
 
+    // Server feed sync — syncs skills from private skill-server instances at startup.
+    // Runs after SystemSkillSyncService; each feed syncs independently.
+    if (skillFeedsConfig.Feeds.Any(f => f.Enabled))
+    {
+        services.AddHostedService<ServerFeedSkillSyncService>();
+    }
+
     // Skill directory watcher — auto-rescan when skill files change on disk.
-    // Covers native skills directory and all external sources.
-    // Registered after SystemSkillSyncService so initial sync completes first.
+    // Covers native skills directory, server feeds, and all external sources.
+    // Registered after sync services so initial sync completes first.
     services.AddSingleton<SkillDirectoryWatcherService>();
     services.AddHostedService(sp => sp.GetRequiredService<SkillDirectoryWatcherService>());
 

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -24,7 +24,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
     private readonly TimeProvider _timeProvider;
     private readonly ISkillContentScanner _scanner;
     private readonly ILogger<ServerFeedSkillSyncService> _logger;
-    private readonly IReadOnlyList<ResolvedExternalSource> _serverFeedSources;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
 
     public ServerFeedSkillSyncService(
@@ -35,8 +34,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         TimeProvider timeProvider,
         ISkillContentScanner scanner,
         ILogger<ServerFeedSkillSyncService> logger,
-        [Microsoft.Extensions.DependencyInjection.FromKeyedServices("server-feeds")]
-        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
         IReadOnlyList<ResolvedExternalSource> externalSources)
     {
         _feedsConfig = feedsConfig;
@@ -46,7 +43,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         _timeProvider = timeProvider;
         _scanner = scanner;
         _logger = logger;
-        _serverFeedSources = serverFeedSources;
         _externalSources = externalSources;
     }
 

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -10,12 +10,13 @@ using Netclaw.SkillClient;
 namespace Netclaw.Daemon.Services;
 
 /// <summary>
-/// Syncs skills from private skill-server instances at daemon startup using
-/// the Cloudflare Agent Skills RFC discovery protocol. Each configured feed
-/// is synced independently — one failing server never blocks others.
-/// Never blocks startup on network failures; falls back to on-disk skills.
+/// Syncs skills from private skill-server instances at daemon startup and
+/// periodically thereafter using the Cloudflare Agent Skills RFC discovery
+/// protocol. Each configured feed is synced independently — one failing
+/// server never blocks others. Never blocks startup on network failures;
+/// falls back to on-disk skills.
 /// </summary>
-internal sealed class ServerFeedSkillSyncService : IHostedService
+internal sealed class ServerFeedSkillSyncService : BackgroundService
 {
     private readonly SkillFeedsConfig _feedsConfig;
     private readonly NetclawPaths _paths;
@@ -25,6 +26,9 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
     private readonly ISkillContentScanner _scanner;
     private readonly ILogger<ServerFeedSkillSyncService> _logger;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
+
+    // Random jitter (0–5 min) so multiple daemon instances don't all poll at once
+    private readonly TimeSpan _initialJitter;
 
     public ServerFeedSkillSyncService(
         SkillFeedsConfig feedsConfig,
@@ -44,18 +48,58 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         _scanner = scanner;
         _logger = logger;
         _externalSources = externalSources;
+        _initialJitter = TimeSpan.FromSeconds(Random.Shared.Next(0, 300));
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var anyChanged = false;
+        // Initial sync at startup — no jitter
+        await SyncAllFeedsAsync(stoppingToken);
 
+        var intervalMinutes = _feedsConfig.SyncIntervalMinutes;
+        if (intervalMinutes <= 0)
+        {
+            _logger.LogInformation("Periodic server feed sync disabled (SyncIntervalMinutes=0)");
+            return;
+        }
+
+        var interval = TimeSpan.FromMinutes(intervalMinutes);
+
+        // First periodic tick includes jitter to stagger across instances
+        var firstDelay = interval + _initialJitter;
+        _logger.LogInformation(
+            "Server feed periodic sync scheduled every {IntervalMinutes}m (first check in {FirstDelayMinutes:F1}m)",
+            intervalMinutes, firstDelay.TotalMinutes);
+
+        using var timer = new PeriodicTimer(interval, _timeProvider);
+
+        // Wait the jittered first interval
+        try
+        {
+            await Task.Delay(firstDelay, _timeProvider, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        // First periodic sync
+        await SyncAllFeedsAsync(stoppingToken);
+
+        // Subsequent syncs on the regular interval
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await SyncAllFeedsAsync(stoppingToken);
+        }
+    }
+
+    private async Task SyncAllFeedsAsync(CancellationToken cancellationToken)
+    {
         foreach (var feed in _feedsConfig.Feeds.Where(f => f.Enabled))
         {
             try
             {
-                var changed = await SyncFeedAsync(feed, cancellationToken);
-                anyChanged |= changed;
+                await SyncFeedAsync(feed, cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -68,9 +112,7 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         RescanAndUpdateIndex();
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-    private async Task<bool> SyncFeedAsync(SkillFeedSource feed, CancellationToken cancellationToken)
+    private async Task SyncFeedAsync(SkillFeedSource feed, CancellationToken cancellationToken)
     {
         var feedDir = _paths.ServerFeedDirectory(feed.Name);
         Directory.CreateDirectory(feedDir);
@@ -93,24 +135,24 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
                 _logger.LogWarning(
                     "Server feed '{FeedName}' RFC index fetch timed out — using on-disk skills",
                     feed.Name);
-                return false;
+                return;
             }
             catch (HttpRequestException ex)
             {
                 _logger.LogWarning(
                     "Server feed '{FeedName}' RFC index fetch failed: {Message} — using on-disk skills",
                     feed.Name, ex.Message);
-                return false;
+                return;
             }
         }
 
         if (index is null || index.Skills.Count == 0)
         {
-            _logger.LogInformation("Server feed '{FeedName}' returned empty index", feed.Name);
-            return false;
+            _logger.LogDebug("Server feed '{FeedName}' returned empty index", feed.Name);
+            return;
         }
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Fetched RFC index from server feed '{FeedName}' ({SkillCount} skills)",
             feed.Name, index.Skills.Count);
 
@@ -223,8 +265,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
             SkillSyncHelpers.WriteSyncState(
                 _paths.ServerFeedSyncStatePath(feed.Name), syncState);
         }
-
-        return updated;
     }
 
     private static HttpClient CreateHttpClientForFeed(SkillFeedSource feed)
@@ -274,7 +314,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
 
     private void RescanAndUpdateIndex()
     {
-        // Rebuild resolved server feed sources (directories may have been created during sync)
         var resolvedServerFeeds = new List<ResolvedExternalSource>();
         foreach (var feed in _feedsConfig.Feeds.Where(f => f.Enabled))
         {

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -1,0 +1,425 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Skills;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Feeds;
+using Netclaw.Security.Skills;
+using Netclaw.SkillClient;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Syncs skills from private skill-server instances at daemon startup using
+/// the Cloudflare Agent Skills RFC discovery protocol. Each configured feed
+/// is synced independently — one failing server never blocks others.
+/// Never blocks startup on network failures; falls back to on-disk skills.
+/// </summary>
+internal sealed class ServerFeedSkillSyncService : IHostedService
+{
+    private static readonly string[] AllowedResourcePrefixes = ["references", "scripts", "assets"];
+
+    private readonly SkillFeedsConfig _feedsConfig;
+    private readonly NetclawPaths _paths;
+    private readonly SkillRegistry _skillRegistry;
+    private readonly SkillIndexContextLayer _skillIndexLayer;
+    private readonly TimeProvider _timeProvider;
+    private readonly ISkillContentScanner _scanner;
+    private readonly ILogger<ServerFeedSkillSyncService> _logger;
+    private readonly IReadOnlyList<ResolvedExternalSource> _serverFeedSources;
+    private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
+
+    public ServerFeedSkillSyncService(
+        SkillFeedsConfig feedsConfig,
+        NetclawPaths paths,
+        SkillRegistry skillRegistry,
+        SkillIndexContextLayer skillIndexLayer,
+        TimeProvider timeProvider,
+        ISkillContentScanner scanner,
+        ILogger<ServerFeedSkillSyncService> logger,
+        [Microsoft.Extensions.DependencyInjection.FromKeyedServices("server-feeds")]
+        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
+        IReadOnlyList<ResolvedExternalSource> externalSources)
+    {
+        _feedsConfig = feedsConfig;
+        _paths = paths;
+        _skillRegistry = skillRegistry;
+        _skillIndexLayer = skillIndexLayer;
+        _timeProvider = timeProvider;
+        _scanner = scanner;
+        _logger = logger;
+        _serverFeedSources = serverFeedSources;
+        _externalSources = externalSources;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var anyChanged = false;
+
+        foreach (var feed in _feedsConfig.Feeds.Where(f => f.Enabled))
+        {
+            try
+            {
+                var changed = await SyncFeedAsync(feed, cancellationToken);
+                anyChanged |= changed;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Server feed sync failed for '{FeedName}' ({FeedUrl}) — using on-disk skills",
+                    feed.Name, feed.Url);
+            }
+        }
+
+        RescanAndUpdateIndex();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task<bool> SyncFeedAsync(SkillFeedSource feed, CancellationToken cancellationToken)
+    {
+        var feedDir = _paths.ServerFeedDirectory(feed.Name);
+        Directory.CreateDirectory(feedDir);
+
+        var syncState = ReadSyncState(feed.Name);
+        var now = _timeProvider.GetUtcNow();
+
+        RfcSkillIndex? index;
+        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        {
+            cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
+            try
+            {
+                using var client = new SkillServerClient(feed.Url, feed.ApiKey?.Value);
+                index = await client.GetRfcIndexAsync(cts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "Server feed '{FeedName}' RFC index fetch timed out — using on-disk skills",
+                    feed.Name);
+                return false;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(
+                    "Server feed '{FeedName}' RFC index fetch failed: {Message} — using on-disk skills",
+                    feed.Name, ex.Message);
+                return false;
+            }
+        }
+
+        if (index is null || index.Skills.Count == 0)
+        {
+            _logger.LogInformation("Server feed '{FeedName}' returned empty index", feed.Name);
+            return false;
+        }
+
+        _logger.LogInformation(
+            "Fetched RFC index from server feed '{FeedName}' ({SkillCount} skills)",
+            feed.Name, index.Skills.Count);
+
+        var updated = false;
+
+        foreach (var entry in index.Skills)
+        {
+            var digestHex = NormalizeDigest(entry.Digest);
+            var version = entry.Version ?? "unknown";
+
+            if (syncState.Skills.TryGetValue(entry.Name, out var existing)
+                && existing.Version == version
+                && string.Equals(existing.Sha256, digestHex, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            try
+            {
+                var mainContent = await DownloadAndVerifyAsync(
+                    entry.Url, digestHex, entry.Name, feed, cancellationToken);
+                if (mainContent is null)
+                    continue;
+
+                var mainScan = await _scanner.ScanAsync(entry.Name, mainContent, cancellationToken);
+                if (!mainScan.IsAllowed)
+                {
+                    _logger.LogWarning(
+                        "Rejected skill '{SkillName}' from feed '{FeedName}': {Reason}",
+                        entry.Name, feed.Name, mainScan.Reason);
+                    continue;
+                }
+
+                var downloadedFiles = new List<DownloadedSkillFile>
+                {
+                    new("SKILL.md", mainContent)
+                };
+
+                if (entry.Resources is { Count: > 0 })
+                {
+                    var allFilesOk = true;
+                    foreach (var resource in entry.Resources)
+                    {
+                        var normalizedPath = ValidateResourcePath(resource.Path);
+                        if (normalizedPath is null)
+                        {
+                            _logger.LogWarning(
+                                "Rejected resource path for '{SkillName}' from feed '{FeedName}': {Path}",
+                                entry.Name, feed.Name, resource.Path);
+                            allFilesOk = false;
+                            break;
+                        }
+
+                        var resourceDigest = NormalizeDigest(resource.Digest);
+                        var fileContent = await DownloadAndVerifyAsync(
+                            resource.Url, resourceDigest,
+                            $"{entry.Name}/{resource.Path}", feed, cancellationToken);
+                        if (fileContent is null)
+                        {
+                            allFilesOk = false;
+                            break;
+                        }
+
+                        var fileScan = await _scanner.ScanAsync(
+                            $"{entry.Name}:{normalizedPath}", fileContent, cancellationToken);
+                        if (!fileScan.IsAllowed)
+                        {
+                            _logger.LogWarning(
+                                "Rejected resource for '{SkillName}' from feed '{FeedName}' at {Path}: {Reason}",
+                                entry.Name, feed.Name, normalizedPath, fileScan.Reason);
+                            allFilesOk = false;
+                            break;
+                        }
+
+                        downloadedFiles.Add(new DownloadedSkillFile(normalizedPath, fileContent));
+                    }
+
+                    if (!allFilesOk)
+                        continue;
+                }
+
+                await ReplaceSkillDirectoryAsync(feed.Name, entry.Name, downloadedFiles, cancellationToken);
+
+                syncState.Skills[entry.Name] = new SyncedSkillState
+                {
+                    Version = version,
+                    Sha256 = digestHex,
+                    SyncedAtUtc = now
+                };
+
+                _logger.LogInformation(
+                    "Synced skill '{SkillName}' v{Version} from feed '{FeedName}'",
+                    entry.Name, version, feed.Name);
+                updated = true;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to sync skill '{SkillName}' from feed '{FeedName}' — keeping existing version",
+                    entry.Name, feed.Name);
+            }
+        }
+
+        if (updated)
+        {
+            syncState.LastSyncUtc = now;
+            WriteSyncState(feed.Name, syncState);
+        }
+
+        return updated;
+    }
+
+    private async Task<string?> DownloadAndVerifyAsync(
+        string url, string expectedSha256Hex, string label,
+        SkillFeedSource feed, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
+
+            using var httpClient = new HttpClient();
+            if (feed.ApiKey is { Value: { } apiKey } && !string.IsNullOrWhiteSpace(apiKey))
+            {
+                httpClient.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+            }
+
+            var content = await httpClient.GetStringAsync(url, cts.Token);
+
+            var hash = ComputeSha256(content);
+            if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
+                    label, expectedSha256Hex, hash);
+                return null;
+            }
+
+            return content;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("Download timed out for {Label}", label);
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
+            return null;
+        }
+    }
+
+    private SkillSyncState ReadSyncState(string feedName)
+    {
+        var path = _paths.ServerFeedSyncStatePath(feedName);
+        if (!File.Exists(path))
+            return new SkillSyncState();
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<SkillSyncState>(json) ?? new SkillSyncState();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to read sync state for feed '{FeedName}' — starting fresh", feedName);
+            return new SkillSyncState();
+        }
+    }
+
+    private void WriteSyncState(string feedName, SkillSyncState state)
+    {
+        var path = _paths.ServerFeedSyncStatePath(feedName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(path, json);
+    }
+
+    private void RescanAndUpdateIndex()
+    {
+        // Rebuild resolved server feed sources (directories may have been created during sync)
+        var resolvedServerFeeds = new List<ResolvedExternalSource>();
+        foreach (var feed in _feedsConfig.Feeds.Where(f => f.Enabled))
+        {
+            var feedDir = _paths.ServerFeedDirectory(feed.Name);
+            if (Directory.Exists(feedDir))
+                resolvedServerFeeds.Add(new ResolvedExternalSource(
+                    $"server-feed:{feed.Name}", [feedDir], AllowSymlinks: false));
+        }
+
+        var mergedResult = SkillScanner.ScanAndMerge(
+            _paths.SkillsDirectory, resolvedServerFeeds, _externalSources);
+        SkillRegistryUpdater.ApplyMergedScanResult(
+            _skillRegistry, _skillIndexLayer, mergedResult,
+            _paths.SkillsDirectory, _externalSources);
+
+        if (mergedResult.Issues.Count > 0)
+        {
+            _logger.LogWarning(
+                "Skill inventory is degraded after server feed sync: accepted={AcceptedSkillCount} rejected={RejectedIssueCount}",
+                mergedResult.AcceptedSkills.Count, mergedResult.Issues.Count);
+
+            foreach (var issue in mergedResult.Issues)
+            {
+                _logger.LogWarning(
+                    "Rejected skill item during server feed sync rebuild: kind={IssueKind} path={Path} message={Message}",
+                    issue.Kind, issue.Path, issue.Message);
+            }
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Skill index updated after server feed sync ({SkillCount} skills)",
+                mergedResult.AcceptedSkills.Count);
+        }
+    }
+
+    private async Task ReplaceSkillDirectoryAsync(
+        string feedName, string skillName,
+        IReadOnlyList<DownloadedSkillFile> files,
+        CancellationToken cancellationToken)
+    {
+        var feedDir = _paths.ServerFeedDirectory(feedName);
+        var skillDir = Path.Combine(feedDir, skillName);
+        var stagingRoot = Path.Combine(feedDir, ".staging");
+        Directory.CreateDirectory(stagingRoot);
+
+        var stagingDir = Path.Combine(stagingRoot, $"{skillName}-{Guid.NewGuid():N}");
+        var backupDir = Path.Combine(stagingRoot, $"{skillName}-backup-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(stagingDir);
+
+        try
+        {
+            foreach (var file in files)
+            {
+                var targetPath = Path.Combine(
+                    stagingDir, file.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                await File.WriteAllTextAsync(targetPath, file.Content, cancellationToken);
+            }
+
+            if (Directory.Exists(skillDir))
+                Directory.Move(skillDir, backupDir);
+
+            Directory.Move(stagingDir, skillDir);
+
+            if (Directory.Exists(backupDir))
+                Directory.Delete(backupDir, recursive: true);
+        }
+        catch
+        {
+            if (!Directory.Exists(skillDir) && Directory.Exists(backupDir))
+                Directory.Move(backupDir, skillDir);
+
+            throw;
+        }
+        finally
+        {
+            if (Directory.Exists(stagingDir))
+                Directory.Delete(stagingDir, recursive: true);
+
+            if (Directory.Exists(backupDir) && !Directory.Exists(skillDir))
+                Directory.Delete(backupDir, recursive: true);
+        }
+    }
+
+    internal static string ComputeSha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    /// <summary>
+    /// Strips the <c>sha256:</c> prefix from RFC digest values.
+    /// Returns the bare hex string for comparison with computed hashes.
+    /// </summary>
+    internal static string NormalizeDigest(string digest)
+    {
+        if (digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+            return digest[7..];
+        return digest;
+    }
+
+    private static string? ValidateResourcePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        if (Path.IsPathRooted(path) || path.Contains("..", StringComparison.Ordinal))
+            return null;
+
+        var normalized = path.Replace('\\', '/');
+        var firstSegment = normalized.Split('/')[0];
+        if (!AllowedResourcePrefixes.Contains(firstSegment, StringComparer.OrdinalIgnoreCase))
+            return null;
+
+        return normalized;
+    }
+
+    private sealed record DownloadedSkillFile(string RelativePath, string Content);
+}

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -1,6 +1,4 @@
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
+using System.Net.Http.Headers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Netclaw.Actors.Skills;
@@ -19,8 +17,6 @@ namespace Netclaw.Daemon.Services;
 /// </summary>
 internal sealed class ServerFeedSkillSyncService : IHostedService
 {
-    private static readonly string[] AllowedResourcePrefixes = ["references", "scripts", "assets"];
-
     private readonly SkillFeedsConfig _feedsConfig;
     private readonly NetclawPaths _paths;
     private readonly SkillRegistry _skillRegistry;
@@ -83,7 +79,8 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         var feedDir = _paths.ServerFeedDirectory(feed.Name);
         Directory.CreateDirectory(feedDir);
 
-        var syncState = ReadSyncState(feed.Name);
+        var syncState = SkillSyncHelpers.ReadSyncState(
+            _paths.ServerFeedSyncStatePath(feed.Name), _logger);
         var now = _timeProvider.GetUtcNow();
 
         RfcSkillIndex? index;
@@ -123,6 +120,8 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
 
         var updated = false;
 
+        using var httpClient = CreateHttpClientForFeed(feed);
+
         foreach (var entry in index.Skills)
         {
             var digestHex = NormalizeDigest(entry.Digest);
@@ -138,7 +137,7 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
             try
             {
                 var mainContent = await DownloadAndVerifyAsync(
-                    entry.Url, digestHex, entry.Name, feed, cancellationToken);
+                    httpClient, entry.Url, digestHex, entry.Name, feed.TimeoutSeconds, cancellationToken);
                 if (mainContent is null)
                     continue;
 
@@ -161,7 +160,7 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
                     var allFilesOk = true;
                     foreach (var resource in entry.Resources)
                     {
-                        var normalizedPath = ValidateResourcePath(resource.Path);
+                        var normalizedPath = SkillSyncHelpers.ValidateResourcePath(resource.Path);
                         if (normalizedPath is null)
                         {
                             _logger.LogWarning(
@@ -173,8 +172,8 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
 
                         var resourceDigest = NormalizeDigest(resource.Digest);
                         var fileContent = await DownloadAndVerifyAsync(
-                            resource.Url, resourceDigest,
-                            $"{entry.Name}/{resource.Path}", feed, cancellationToken);
+                            httpClient, resource.Url, resourceDigest,
+                            $"{entry.Name}/{resource.Path}", feed.TimeoutSeconds, cancellationToken);
                         if (fileContent is null)
                         {
                             allFilesOk = false;
@@ -199,7 +198,8 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
                         continue;
                 }
 
-                await ReplaceSkillDirectoryAsync(feed.Name, entry.Name, downloadedFiles, cancellationToken);
+                await SkillSyncHelpers.ReplaceSkillDirectoryAsync(
+                    feedDir, entry.Name, downloadedFiles, cancellationToken);
 
                 syncState.Skills[entry.Name] = new SyncedSkillState
                 {
@@ -224,31 +224,36 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         if (updated)
         {
             syncState.LastSyncUtc = now;
-            WriteSyncState(feed.Name, syncState);
+            SkillSyncHelpers.WriteSyncState(
+                _paths.ServerFeedSyncStatePath(feed.Name), syncState);
         }
 
         return updated;
     }
 
+    private static HttpClient CreateHttpClientForFeed(SkillFeedSource feed)
+    {
+        var client = new HttpClient();
+        if (feed.ApiKey is { Value: { } apiKey } && !string.IsNullOrWhiteSpace(apiKey))
+        {
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+        return client;
+    }
+
     private async Task<string?> DownloadAndVerifyAsync(
-        string url, string expectedSha256Hex, string label,
-        SkillFeedSource feed, CancellationToken cancellationToken)
+        HttpClient httpClient, string url, string expectedSha256Hex, string label,
+        int timeoutSeconds, CancellationToken cancellationToken)
     {
         try
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
-
-            using var httpClient = new HttpClient();
-            if (feed.ApiKey is { Value: { } apiKey } && !string.IsNullOrWhiteSpace(apiKey))
-            {
-                httpClient.DefaultRequestHeaders.Authorization =
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
-            }
+            cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
 
             var content = await httpClient.GetStringAsync(url, cts.Token);
 
-            var hash = ComputeSha256(content);
+            var hash = SkillSyncHelpers.ComputeSha256(content);
             if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning(
@@ -269,33 +274,6 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
             _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
             return null;
         }
-    }
-
-    private SkillSyncState ReadSyncState(string feedName)
-    {
-        var path = _paths.ServerFeedSyncStatePath(feedName);
-        if (!File.Exists(path))
-            return new SkillSyncState();
-
-        try
-        {
-            var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<SkillSyncState>(json) ?? new SkillSyncState();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to read sync state for feed '{FeedName}' — starting fresh", feedName);
-            return new SkillSyncState();
-        }
-    }
-
-    private void WriteSyncState(string feedName, SkillSyncState state)
-    {
-        var path = _paths.ServerFeedSyncStatePath(feedName);
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(path, json);
     }
 
     private void RescanAndUpdateIndex()
@@ -337,89 +315,10 @@ internal sealed class ServerFeedSkillSyncService : IHostedService
         }
     }
 
-    private async Task ReplaceSkillDirectoryAsync(
-        string feedName, string skillName,
-        IReadOnlyList<DownloadedSkillFile> files,
-        CancellationToken cancellationToken)
-    {
-        var feedDir = _paths.ServerFeedDirectory(feedName);
-        var skillDir = Path.Combine(feedDir, skillName);
-        var stagingRoot = Path.Combine(feedDir, ".staging");
-        Directory.CreateDirectory(stagingRoot);
-
-        var stagingDir = Path.Combine(stagingRoot, $"{skillName}-{Guid.NewGuid():N}");
-        var backupDir = Path.Combine(stagingRoot, $"{skillName}-backup-{Guid.NewGuid():N}");
-
-        Directory.CreateDirectory(stagingDir);
-
-        try
-        {
-            foreach (var file in files)
-            {
-                var targetPath = Path.Combine(
-                    stagingDir, file.RelativePath.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-                await File.WriteAllTextAsync(targetPath, file.Content, cancellationToken);
-            }
-
-            if (Directory.Exists(skillDir))
-                Directory.Move(skillDir, backupDir);
-
-            Directory.Move(stagingDir, skillDir);
-
-            if (Directory.Exists(backupDir))
-                Directory.Delete(backupDir, recursive: true);
-        }
-        catch
-        {
-            if (!Directory.Exists(skillDir) && Directory.Exists(backupDir))
-                Directory.Move(backupDir, skillDir);
-
-            throw;
-        }
-        finally
-        {
-            if (Directory.Exists(stagingDir))
-                Directory.Delete(stagingDir, recursive: true);
-
-            if (Directory.Exists(backupDir) && !Directory.Exists(skillDir))
-                Directory.Delete(backupDir, recursive: true);
-        }
-    }
-
-    internal static string ComputeSha256(string content)
-    {
-        var bytes = Encoding.UTF8.GetBytes(content);
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexStringLower(hash);
-    }
-
-    /// <summary>
-    /// Strips the <c>sha256:</c> prefix from RFC digest values.
-    /// Returns the bare hex string for comparison with computed hashes.
-    /// </summary>
     internal static string NormalizeDigest(string digest)
     {
         if (digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
             return digest[7..];
         return digest;
     }
-
-    private static string? ValidateResourcePath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-            return null;
-
-        if (Path.IsPathRooted(path) || path.Contains("..", StringComparison.Ordinal))
-            return null;
-
-        var normalized = path.Replace('\\', '/');
-        var firstSegment = normalized.Split('/')[0];
-        if (!AllowedResourcePrefixes.Contains(firstSegment, StringComparer.OrdinalIgnoreCase))
-            return null;
-
-        return normalized;
-    }
-
-    private sealed record DownloadedSkillFile(string RelativePath, string Content);
 }

--- a/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/SkillDirectoryWatcherService.cs
@@ -15,6 +15,7 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
     private static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly NetclawPaths _paths;
+    private readonly IReadOnlyList<ResolvedExternalSource> _serverFeedSources;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
     private readonly SkillRegistry _registry;
     private readonly SkillIndexContextLayer _indexLayer;
@@ -27,12 +28,15 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
 
     public SkillDirectoryWatcherService(
         NetclawPaths paths,
+        [Microsoft.Extensions.DependencyInjection.FromKeyedServices("server-feeds")]
+        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
         IReadOnlyList<ResolvedExternalSource> externalSources,
         SkillRegistry registry,
         SkillIndexContextLayer indexLayer,
         ILogger<SkillDirectoryWatcherService> logger)
     {
         _paths = paths;
+        _serverFeedSources = serverFeedSources;
         _externalSources = externalSources;
         _registry = registry;
         _indexLayer = indexLayer;
@@ -153,7 +157,8 @@ public sealed class SkillDirectoryWatcherService : BackgroundService
         {
             _logger.LogDebug("Debounce timer fired, starting skill rescan");
 
-            var result = SkillScanner.ScanAndMerge(_paths.SkillsDirectory, _externalSources);
+            var result = SkillScanner.ScanAndMerge(
+                _paths.SkillsDirectory, _serverFeedSources, _externalSources);
             SkillRegistryUpdater.ApplyMergedScanResult(
                 _registry, _indexLayer, result, _paths.SkillsDirectory, _externalSources);
 

--- a/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
+++ b/src/Netclaw.Daemon/Services/SkillSyncHelpers.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration.Feeds;
+
+namespace Netclaw.Daemon.Services;
+
+internal static class SkillSyncHelpers
+{
+    internal static readonly string[] AllowedResourcePrefixes = ["references", "scripts", "assets"];
+
+    private static readonly JsonSerializerOptions IndentedJsonOptions = new() { WriteIndented = true };
+
+    internal static string ComputeSha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    internal static string? ValidateResourcePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        if (Path.IsPathRooted(path) || path.Contains("..", StringComparison.Ordinal))
+            return null;
+
+        var normalized = path.Replace('\\', '/');
+        var firstSegment = normalized.Split('/')[0];
+        if (!AllowedResourcePrefixes.Contains(firstSegment, StringComparer.OrdinalIgnoreCase))
+            return null;
+
+        return normalized;
+    }
+
+    internal static SkillSyncState ReadSyncState(string path, ILogger logger)
+    {
+        if (!File.Exists(path))
+            return new SkillSyncState();
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<SkillSyncState>(json) ?? new SkillSyncState();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read sync state at {Path} — starting fresh", path);
+            return new SkillSyncState();
+        }
+    }
+
+    internal static void WriteSyncState(string path, SkillSyncState state)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonSerializer.Serialize(state, IndentedJsonOptions);
+        File.WriteAllText(path, json);
+    }
+
+    internal static async Task ReplaceSkillDirectoryAsync(
+        string parentDirectory,
+        string skillName,
+        IReadOnlyList<DownloadedSkillFile> files,
+        CancellationToken cancellationToken)
+    {
+        var skillDir = Path.Combine(parentDirectory, skillName);
+        var stagingRoot = Path.Combine(parentDirectory, ".staging");
+        Directory.CreateDirectory(stagingRoot);
+
+        var stagingDir = Path.Combine(stagingRoot, $"{skillName}-{Guid.NewGuid():N}");
+        var backupDir = Path.Combine(stagingRoot, $"{skillName}-backup-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(stagingDir);
+
+        try
+        {
+            foreach (var file in files)
+            {
+                var targetPath = Path.Combine(stagingDir, file.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                await File.WriteAllTextAsync(targetPath, file.Content, cancellationToken);
+            }
+
+            if (Directory.Exists(skillDir))
+                Directory.Move(skillDir, backupDir);
+
+            Directory.Move(stagingDir, skillDir);
+
+            if (Directory.Exists(backupDir))
+                Directory.Delete(backupDir, recursive: true);
+        }
+        catch
+        {
+            if (!Directory.Exists(skillDir) && Directory.Exists(backupDir))
+                Directory.Move(backupDir, skillDir);
+
+            throw;
+        }
+        finally
+        {
+            if (Directory.Exists(stagingDir))
+                Directory.Delete(stagingDir, recursive: true);
+
+            if (Directory.Exists(backupDir) && !Directory.Exists(skillDir))
+                Directory.Delete(backupDir, recursive: true);
+        }
+    }
+}
+
+internal sealed record DownloadedSkillFile(string RelativePath, string Content);

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -30,6 +30,7 @@ internal sealed class SystemSkillSyncService : IHostedService
     private readonly ILogger<SystemSkillSyncService> _logger;
     private readonly string _daemonVersion;
     private readonly ISkillContentScanner _scanner;
+    private readonly IReadOnlyList<ResolvedExternalSource> _serverFeedSources;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
 
     public SystemSkillSyncService(
@@ -41,10 +42,12 @@ internal sealed class SystemSkillSyncService : IHostedService
         TimeProvider timeProvider,
         ISkillContentScanner scanner,
         ILogger<SystemSkillSyncService> logger,
+        [Microsoft.Extensions.DependencyInjection.FromKeyedServices("server-feeds")]
+        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
         IReadOnlyList<ResolvedExternalSource> externalSources,
         IChatClientProvider? chatClientProvider = null)
         : this(httpClient, paths, skillSyncConfig, skillRegistry, skillIndexLayer,
-            timeProvider, scanner, logger, BuildInfo.Version, externalSources)
+            timeProvider, scanner, logger, BuildInfo.Version, serverFeedSources, externalSources)
     {
     }
 
@@ -59,6 +62,7 @@ internal sealed class SystemSkillSyncService : IHostedService
         ISkillContentScanner scanner,
         ILogger<SystemSkillSyncService> logger,
         string daemonVersion,
+        IReadOnlyList<ResolvedExternalSource>? serverFeedSources = null,
         IReadOnlyList<ResolvedExternalSource>? externalSources = null)
     {
         _httpClient = httpClient;
@@ -70,6 +74,7 @@ internal sealed class SystemSkillSyncService : IHostedService
         _scanner = scanner;
         _logger = logger;
         _daemonVersion = daemonVersion;
+        _serverFeedSources = serverFeedSources ?? [];
         _externalSources = externalSources ?? [];
     }
 
@@ -347,7 +352,8 @@ internal sealed class SystemSkillSyncService : IHostedService
     /// </summary>
     private void RescanAndUpdateIndex()
     {
-        var mergedResult = SkillScanner.ScanAndMerge(_paths.SkillsDirectory, _externalSources);
+        var mergedResult = SkillScanner.ScanAndMerge(
+            _paths.SkillsDirectory, _serverFeedSources, _externalSources);
         SkillRegistryUpdater.ApplyMergedScanResult(
             _skillRegistry, _skillIndexLayer, mergedResult, _paths.SkillsDirectory, _externalSources);
 

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -19,8 +17,6 @@ namespace Netclaw.Daemon.Services;
 /// </summary>
 internal sealed class SystemSkillSyncService : IHostedService
 {
-    private static readonly string[] AllowedResourcePrefixes = ["references", "scripts", "assets"];
-
     private readonly HttpClient _httpClient;
     private readonly NetclawPaths _paths;
     private readonly SkillSyncConfig _skillSyncConfig;
@@ -113,27 +109,10 @@ internal sealed class SystemSkillSyncService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     private SkillSyncState ReadSyncState()
-    {
-        if (!File.Exists(_paths.SkillSyncStatePath))
-            return new SkillSyncState();
-
-        try
-        {
-            var json = File.ReadAllText(_paths.SkillSyncStatePath);
-            return JsonSerializer.Deserialize<SkillSyncState>(json) ?? new SkillSyncState();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to read sync state — starting fresh");
-            return new SkillSyncState();
-        }
-    }
+        => SkillSyncHelpers.ReadSyncState(_paths.SkillSyncStatePath, _logger);
 
     private void WriteSyncState(SkillSyncState state)
-    {
-        var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(_paths.SkillSyncStatePath, json);
-    }
+        => SkillSyncHelpers.WriteSyncState(_paths.SkillSyncStatePath, state);
 
     private async Task<SkillFeedManifest?> FetchManifestAsync(CancellationToken cancellationToken)
     {
@@ -235,7 +214,7 @@ internal sealed class SystemSkillSyncService : IHostedService
                     var allFilesOk = true;
                     foreach (var file in entry.Files)
                     {
-                        var normalizedPath = ValidateFeedResourcePath(file.Path);
+                        var normalizedPath = SkillSyncHelpers.ValidateResourcePath(file.Path);
                         if (normalizedPath is null)
                         {
                             _logger.LogWarning(
@@ -277,7 +256,8 @@ internal sealed class SystemSkillSyncService : IHostedService
                         continue;
                 }
 
-                await ReplaceSkillDirectoryAsync(entry.Name, downloadedFiles, cancellationToken);
+                await SkillSyncHelpers.ReplaceSkillDirectoryAsync(
+                    _paths.SystemSkillsDirectory, entry.Name, downloadedFiles, cancellationToken);
 
                 syncState.Skills[entry.Name] = new SyncedSkillState
                 {
@@ -322,8 +302,7 @@ internal sealed class SystemSkillSyncService : IHostedService
 
             var content = await _httpClient.GetStringAsync(url, cts.Token);
 
-            // Verify SHA-256
-            var hash = ComputeSha256(content);
+            var hash = SkillSyncHelpers.ComputeSha256(content);
             if (!string.Equals(hash, expectedSha256, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning(
@@ -380,16 +359,8 @@ internal sealed class SystemSkillSyncService : IHostedService
     }
 
     internal static string ComputeSha256(string content)
-    {
-        var bytes = Encoding.UTF8.GetBytes(content);
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexStringLower(hash);
-    }
+        => SkillSyncHelpers.ComputeSha256(content);
 
-    /// <summary>
-    /// Returns true if <paramref name="current"/> >= <paramref name="minimum"/>.
-    /// Uses simple semver major.minor.patch comparison.
-    /// </summary>
     internal static bool IsVersionSatisfied(string current, string minimum)
     {
         if (Version.TryParse(current, out var currentVersion)
@@ -401,70 +372,4 @@ internal sealed class SystemSkillSyncService : IHostedService
         // If parsing fails, assume satisfied to avoid blocking skills unnecessarily
         return true;
     }
-
-    private static string? ValidateFeedResourcePath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-            return null;
-
-        if (Path.IsPathRooted(path) || path.Contains("..", StringComparison.Ordinal))
-            return null;
-
-        var normalized = path.Replace('\\', '/');
-        var firstSegment = normalized.Split('/')[0];
-        if (!AllowedResourcePrefixes.Contains(firstSegment, StringComparer.OrdinalIgnoreCase))
-            return null;
-
-        return normalized;
-    }
-
-    private async Task ReplaceSkillDirectoryAsync(
-        string skillName,
-        IReadOnlyList<DownloadedSkillFile> files,
-        CancellationToken cancellationToken)
-    {
-        var skillDir = Path.Combine(_paths.SystemSkillsDirectory, skillName);
-        var stagingRoot = Path.Combine(_paths.SystemSkillsDirectory, ".staging");
-        Directory.CreateDirectory(stagingRoot);
-
-        var stagingDir = Path.Combine(stagingRoot, $"{skillName}-{Guid.NewGuid():N}");
-        var backupDir = Path.Combine(stagingRoot, $"{skillName}-backup-{Guid.NewGuid():N}");
-
-        Directory.CreateDirectory(stagingDir);
-
-        try
-        {
-            foreach (var file in files)
-            {
-                var targetPath = Path.Combine(stagingDir, file.RelativePath.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-                await File.WriteAllTextAsync(targetPath, file.Content, cancellationToken);
-            }
-
-            if (Directory.Exists(skillDir))
-                Directory.Move(skillDir, backupDir);
-
-            Directory.Move(stagingDir, skillDir);
-
-            if (Directory.Exists(backupDir))
-                Directory.Delete(backupDir, recursive: true);
-        }
-        catch
-        {
-            if (!Directory.Exists(skillDir) && Directory.Exists(backupDir))
-                Directory.Move(backupDir, skillDir);
-
-            throw;
-        }
-        finally
-        {
-            if (Directory.Exists(stagingDir))
-                Directory.Delete(stagingDir, recursive: true);
-
-            if (Directory.Exists(backupDir) && !Directory.Exists(skillDir))
-                Directory.Delete(backupDir, recursive: true);
-        }
-    }
-
-    private sealed record DownloadedSkillFile(string RelativePath, string Content);
 }


### PR DESCRIPTION
## Summary

- Integrates the `Netclaw.SkillClient` NuGet package (v0.2.0) to enable organizations to configure private skill-server instances and have their Netclaw daemons automatically discover and sync skills at startup using the Cloudflare Agent Skills RFC discovery protocol
- Adds `ServerFeedSkillSyncService` as an `IHostedService` that syncs skills from configured feeds with per-feed error isolation, SHA-256 verification, and content security scanning
- Introduces three-tier skill precedence in `SkillScanner`: native > server-feed > external
- Adds a TUI init wizard step ("Skill Feeds") with live probe validation, spinner animation, and error recovery
- Extracts `SkillSyncHelpers` to deduplicate shared utilities between `SystemSkillSyncService` and `ServerFeedSkillSyncService`

Closes #532

## Changes

### Daemon
- **ServerFeedSkillSyncService** — syncs skills from configured feeds at startup using `SkillServerClient.GetRfcIndexAsync()`, writes to `.server-feeds/{feedName}/{skillName}/` with atomic directory replacement and per-feed sync state persistence
- **SkillSyncHelpers** — shared utilities: `ComputeSha256`, `ValidateResourcePath`, `ReadSyncState`/`WriteSyncState`, `ReplaceSkillDirectoryAsync`, `DownloadedSkillFile`
- **SkillScanner** — new 3-arg `ScanAndMerge` overload with `MergeSources` helper; `.server-feeds` added as allowed hidden directory
- **SystemSkillSyncService** / **SkillDirectoryWatcherService** — updated to accept keyed server-feed sources and use 3-arg `ScanAndMerge`
- **Program.cs** — DI wiring for `SkillFeedsConfig`, keyed `"server-feeds"` singleton, conditional `ServerFeedSkillSyncService` registration

### Configuration
- **SkillFeedsConfig** / **SkillFeedSource** — new config type (Name, Url, ApiKey?, Enabled, TimeoutSeconds)
- **NetclawPaths** — `ServerFeedsDirectory`, `ServerFeedDirectory(name)`, `ServerFeedSyncStatePath(name)`
- **netclaw-config.v1.schema.json** — `SkillFeeds` section with full schema

### TUI
- **SkillFeedsStepViewModel** — 5 sub-steps: connect prompt → URL input → probe → name input → add another loop
- **SkillFeedsStepView** — Termina view with `SelectionListNode`, `TextInputNode`, spinner, error recovery
- **WizardConfigBuilder** — `SkillFeedSources` property + config serialization
- **InitWizardViewModel** — step registered between external-skills and exposure-mode

## Test plan

- [ ] `dotnet build` — 0 warnings, 0 errors (verified)
- [ ] `dotnet test` — 2,969 tests pass (verified)
- [ ] `dotnet slopwatch analyze` — 0 issues (verified)
- [ ] Manual test: add `SkillFeeds.Feeds` entry pointing to a local skill-server, verify skills sync to `~/.netclaw/skills/.server-feeds/{name}/`
- [ ] Manual test: run `netclaw init` wizard, verify Skill Feeds step appears and probe works
- [ ] Verify duplicate skill names from lower-precedence feeds produce log warnings