### PR TITLE
fix(tui): unify MCP permissions navigation with context-sensitive arrows (#786)

### DIFF
--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
@@ -139,7 +139,7 @@ public sealed class McpToolPermissionsPageTests : IDisposable
     }
 
     [Fact]
-    public async Task ToolGrid_EnterOnServerEnabledRow_TogglesServerAccess()
+    public async Task ToolGrid_SpaceOnServerEnabledRow_TogglesServerAccess()
     {
         var (_, app, vm) = CreateHeadlessApp(out var input);
 
@@ -148,9 +148,9 @@ public sealed class McpToolPermissionsPageTests : IDisposable
 
         var wasBefore = vm.IsServerAllowedForSelectedAudience();
 
-        // Navigate to row 1 (Server enabled), Enter toggles.
+        // Navigate to row 1 (Server enabled), Space toggles.
         input.EnqueueKey(ConsoleKey.DownArrow);
-        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Spacebar);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -160,7 +160,7 @@ public sealed class McpToolPermissionsPageTests : IDisposable
     }
 
     [Fact]
-    public async Task ToolGrid_EnterOnToolRow_TogglesTool()
+    public async Task ToolGrid_SpaceOnToolRow_TogglesTool()
     {
         var (_, app, vm) = CreateHeadlessApp(out var input);
 
@@ -173,11 +173,11 @@ public sealed class McpToolPermissionsPageTests : IDisposable
 
         var wasBefore = vm.IsToolGranted(new ToolName("create-pages"));
 
-        // Navigate to row 3 (first tool), Enter toggles grant.
+        // Navigate to row 3 (first tool), Space toggles grant.
         input.EnqueueKey(ConsoleKey.DownArrow); // row 1
         input.EnqueueKey(ConsoleKey.DownArrow); // row 2
         input.EnqueueKey(ConsoleKey.DownArrow); // row 3 (first tool)
-        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Spacebar);
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -213,23 +213,69 @@ public sealed class McpToolPermissionsPageTests : IDisposable
     }
 
     [Fact]
-    public async Task ToolGrid_SaveClearsUnsavedState()
+    public async Task ToolGrid_EnterThenY_SavesAndGoesBack()
     {
         var (_, app, vm) = CreateHeadlessApp(out var input);
 
         vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
         vm.SetSelectedAudienceForTests(TrustAudience.Personal);
 
-        // Make a change (toggle server access) then save.
+        // Make a change (toggle server access via Space), then Enter → Y to save.
         input.EnqueueKey(ConsoleKey.DownArrow); // row 1 (server enabled)
-        input.EnqueueKey(ConsoleKey.Enter);     // toggle → creates unsaved state
-        input.EnqueueKey(ConsoleKey.S);         // save
+        input.EnqueueKey(ConsoleKey.Spacebar);  // toggle → creates unsaved state
+        input.EnqueueKey(ConsoleKey.Enter);     // triggers confirmation
+        input.EnqueueKey(ConsoleKey.Y);         // confirm save → goes back to server list
         input.EnqueueKey(ConsoleKey.Q, false, false, true);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await app.RunAsync(cts.Token);
 
         Assert.False(vm.HasUnsavedChanges);
+        Assert.Equal(ToolPermissionsState.ServerList, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public async Task ToolGrid_EnterThenN_DiscardsAndGoesBack()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Make a change, then Enter → N to discard.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Spacebar);  // toggle → unsaved
+        input.EnqueueKey(ConsoleKey.Enter);     // triggers confirmation
+        input.EnqueueKey(ConsoleKey.N);         // discard → goes back
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.False(vm.HasUnsavedChanges);
+        Assert.Equal(ToolPermissionsState.ServerList, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public async Task ToolGrid_EnterThenEsc_CancelsConfirmation()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Make a change, then Enter → Esc to cancel confirmation and stay.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Spacebar);  // toggle → unsaved
+        input.EnqueueKey(ConsoleKey.Enter);     // triggers confirmation
+        input.EnqueueKey(ConsoleKey.Escape);    // cancel → stays on tool grid
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(vm.HasUnsavedChanges);
+        Assert.Equal(ToolPermissionsState.ToolGrid, vm.CurrentState.Value);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
@@ -1,0 +1,304 @@
+using System.Net.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Mcp;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Mcp;
+
+public sealed class McpToolPermissionsPageTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly NetclawPaths _paths;
+
+    public McpToolPermissionsPageTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"netclaw-mcppage-test-{Guid.NewGuid():N}");
+        _paths = new NetclawPaths(_tempDir);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task ToolGrid_UpDown_NavigatesAllRows()
+    {
+        var (terminal, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages", "search"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Start at row 0 (Audience). Down 4 times → row 4 (second tool).
+        // Then Up twice → row 2 (Server default). Then Ctrl+Q.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.UpArrow);
+        input.EnqueueKey(ConsoleKey.UpArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("Audience"),
+            $"Expected 'Audience' in terminal. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("Server default"),
+            $"Expected 'Server default' in terminal. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("create-pages"),
+            $"Expected 'create-pages' in terminal. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("search"),
+            $"Expected 'search' in terminal. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task ToolGrid_RightArrowOnAudienceRow_CyclesAudience()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Cursor starts at row 0 (Audience). Right arrow cycles Personal → Team.
+        input.EnqueueKey(ConsoleKey.RightArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(TrustAudience.Team, vm.SelectedAudience);
+    }
+
+    [Fact]
+    public async Task ToolGrid_LeftArrowOnAudienceRow_CyclesAudienceBack()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Left arrow on audience row cycles Personal → Public (backward).
+        input.EnqueueKey(ConsoleKey.LeftArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(TrustAudience.Public, vm.SelectedAudience);
+    }
+
+    [Fact]
+    public async Task ToolGrid_RightArrowOnServerDefaultRow_CyclesServerDefault()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Navigate to row 2 (Server default), then Right to cycle Auto → Approval.
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 1
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 2 (Server default)
+        input.EnqueueKey(ConsoleKey.RightArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(ToolApprovalMode.Approval, vm.GetServerDefault());
+    }
+
+    [Fact]
+    public async Task ToolGrid_LeftArrowOnServerDefaultRow_CyclesServerDefaultBack()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Navigate to row 2, then Left to cycle Auto → Deny (backward).
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.LeftArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(ToolApprovalMode.Deny, vm.GetServerDefault());
+    }
+
+    [Fact]
+    public async Task ToolGrid_EnterOnServerEnabledRow_TogglesServerAccess()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        var wasBefore = vm.IsServerAllowedForSelectedAudience();
+
+        // Navigate to row 1 (Server enabled), Enter toggles.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.NotEqual(wasBefore, vm.IsServerAllowedForSelectedAudience());
+    }
+
+    [Fact]
+    public async Task ToolGrid_EnterOnToolRow_TogglesTool()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages", "search"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Enable server access first so tool toggling works
+        if (!vm.IsServerAllowedForSelectedAudience())
+            vm.ToggleServerAccess();
+
+        var wasBefore = vm.IsToolGranted(new ToolName("create-pages"));
+
+        // Navigate to row 3 (first tool), Enter toggles grant.
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 1
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 2
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 3 (first tool)
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.NotEqual(wasBefore, vm.IsToolGranted(new ToolName("create-pages")));
+    }
+
+    [Fact]
+    public async Task ToolGrid_RightArrowOnToolRow_CyclesToolOverride()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        if (!vm.IsServerAllowedForSelectedAudience())
+            vm.ToggleServerAccess();
+
+        // Navigate to row 3 (first tool), Right cycles inherit → Auto.
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.RightArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var (mode, inherited) = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.Equal(ToolApprovalMode.Auto, mode);
+        Assert.False(inherited);
+    }
+
+    [Fact]
+    public async Task ToolGrid_SaveClearsUnsavedState()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        // Make a change (toggle server access) then save.
+        input.EnqueueKey(ConsoleKey.DownArrow); // row 1 (server enabled)
+        input.EnqueueKey(ConsoleKey.Enter);     // toggle → creates unsaved state
+        input.EnqueueKey(ConsoleKey.S);         // save
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.False(vm.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public async Task ToolGrid_RightArrowOnServerEnabledRow_TogglesServerAccess()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.InitializeForTests(new McpServerName("notion"), ["create-pages"]);
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        var wasBefore = vm.IsServerAllowedForSelectedAudience();
+
+        // Navigate to row 1, Right arrow toggles (same as Enter on this row).
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.RightArrow);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.NotEqual(wasBefore, vm.IsServerAllowedForSelectedAudience());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private (VirtualTerminal Terminal, TerminaApplication App, McpToolPermissionsViewModel Vm)
+        CreateHeadlessApp(out VirtualInputSource input)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        McpToolPermissionsViewModel? capturedVm = null;
+
+        var configuration = new ConfigurationBuilder().Build();
+        var daemonPaths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-daemon-{Guid.NewGuid():N}"));
+        daemonPaths.EnsureDirectoriesExist();
+        var daemonApi = new DaemonApi(new FailingHttpClientFactory(), configuration, daemonPaths);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/mcp-tools", builder =>
+        {
+            builder.RegisterRoute<McpToolPermissionsPage, McpToolPermissionsViewModel>(
+                "/mcp-tools",
+                _ => new McpToolPermissionsPage(),
+                _ =>
+                {
+                    capturedVm = new McpToolPermissionsViewModel(_paths, daemonApi);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+
+    private sealed class FailingHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("Test: no daemon available");
+    }
+
+    private sealed class FailingHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new FailingHttpHandler());
+    }
+}

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsPageTests.cs
@@ -265,9 +265,7 @@ public sealed class McpToolPermissionsPageTests : IDisposable
         McpToolPermissionsViewModel? capturedVm = null;
 
         var configuration = new ConfigurationBuilder().Build();
-        var daemonPaths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-daemon-{Guid.NewGuid():N}"));
-        daemonPaths.EnsureDirectoriesExist();
-        var daemonApi = new DaemonApi(new FailingHttpClientFactory(), configuration, daemonPaths);
+        var daemonApi = new DaemonApi(new FailingHttpClientFactory(), configuration, _paths);
 
         var services = new ServiceCollection();
         services.AddSingleton<IAnsiTerminal>(terminal);

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -157,6 +157,70 @@ public sealed class McpToolPermissionsViewModelTests : IDisposable
         Assert.Equal(ToolApprovalMode.Approval, vm.GetServerDefault());
     }
 
+    [Fact]
+    public void CycleServerDefaultBack_StartingFromAuto_CyclesInReverse()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests(new McpServerName("notion"), new[] { "create-pages", "search" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        vm.CycleServerDefaultBack();
+        Assert.Equal(ToolApprovalMode.Deny, vm.GetServerDefault());
+
+        vm.CycleServerDefaultBack();
+        Assert.Equal(ToolApprovalMode.Approval, vm.GetServerDefault());
+
+        vm.CycleServerDefaultBack();
+        Assert.Equal(ToolApprovalMode.Auto, vm.GetServerDefault());
+    }
+
+    [Fact]
+    public void CycleToolOverrideBack_FromInherit_CyclesThroughAllModesInReverse()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests(new McpServerName("notion"), new[] { "create-pages" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        var (_, isInherited) = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.True(isInherited);
+
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+        var step1 = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.Equal(ToolApprovalMode.Deny, step1.Mode);
+        Assert.False(step1.IsInherited);
+
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+        var step2 = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.Equal(ToolApprovalMode.Approval, step2.Mode);
+        Assert.False(step2.IsInherited);
+
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+        var step3 = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.Equal(ToolApprovalMode.Auto, step3.Mode);
+        Assert.False(step3.IsInherited);
+
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+        var step4 = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.True(step4.IsInherited);
+    }
+
+    [Fact]
+    public void CycleToolOverride_ForwardThenBack_ReturnsToOriginalState()
+    {
+        var vm = CreateVm();
+        vm.InitializeForTests(new McpServerName("notion"), new[] { "create-pages" });
+        vm.SetSelectedAudienceForTests(TrustAudience.Personal);
+
+        vm.CycleToolOverride(new ToolName("create-pages"));
+        vm.CycleToolOverride(new ToolName("create-pages"));
+
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+        vm.CycleToolOverrideBack(new ToolName("create-pages"));
+
+        var (_, isInherited) = vm.GetEffectiveMode(new ToolName("create-pages"));
+        Assert.True(isInherited);
+    }
+
     private sealed class NoopHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -30,9 +30,7 @@ public sealed class McpToolPermissionsViewModelTests : IDisposable
     private McpToolPermissionsViewModel CreateVm()
     {
         var configuration = new ConfigurationBuilder().Build();
-        var daemonPaths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-vm-daemon-{Guid.NewGuid():N}"));
-        daemonPaths.EnsureDirectoriesExist();
-        var daemonApi = new DaemonApi(new NoopHttpClientFactory(), configuration, daemonPaths);
+        var daemonApi = new DaemonApi(new NoopHttpClientFactory(), configuration, _paths);
         return new McpToolPermissionsViewModel(_paths, daemonApi);
     }
 

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -43,10 +43,17 @@ internal static class ConfigFileHelper
     internal static Dictionary<string, object> GetOrCreateSection(
         Dictionary<string, object> dict, string key)
     {
-        if (dict.TryGetValue(key, out var existing))
+        if (dict.TryGetValue(key, out var existing) && existing is not null)
         {
             if (existing is JsonElement je)
             {
+                if (je.ValueKind == JsonValueKind.Null)
+                {
+                    var fresh = new Dictionary<string, object>();
+                    dict[key] = fresh;
+                    return fresh;
+                }
+
                 var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
                     ?? new Dictionary<string, object>();
                 dict[key] = parsed;

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -15,7 +15,14 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
     private SelectionListNode<string>? _serverList;
     private DynamicLayoutNode? _contentNode;
     private readonly CompositeDisposable _stepSubs = new();
-    private int _toolCursor;
+    private int _gridCursor;
+
+    private const int AudienceRow = 0;
+    private const int ServerEnabledRow = 1;
+    private const int ServerDefaultRow = 2;
+    private const int FirstToolRow = 3;
+
+    private int TotalRows => FirstToolRow + ViewModel.DiscoveredTools.Count;
 
     protected override void OnBound()
     {
@@ -106,34 +113,50 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             .WithChild(_serverList);
     }
 
-    /// <summary>
-    /// Manual cursor rendering — matches the channel wizard pattern.
-    /// Preserves cursor position across rebuilds (no SelectionListNode reset).
-    /// </summary>
     private ILayoutNode BuildToolGrid()
     {
         var server = ViewModel.SelectedServer ?? "?";
         var audienceLabel = ViewModel.SelectedAudience.ToWireValue();
-        var audienceSelector = $"[\u25c0 {audienceLabel,-8} \u25b6]";
-
-        var tools = ViewModel.DiscoveredTools;
-        if (_toolCursor >= tools.Count) _toolCursor = tools.Count - 1;
-        if (_toolCursor < 0) _toolCursor = 0;
-
         var serverAllowed = ViewModel.IsServerAllowedForSelectedAudience();
-        var accessMarker = serverAllowed ? "\u2713" : " ";
-
         var serverDefault = ViewModel.GetServerDefault();
-        var serverDefaultLabel = $"[{serverDefault}]";
+        var tools = ViewModel.DiscoveredTools;
+
+        var maxRow = TotalRows - 1;
+        if (_gridCursor > maxRow) _gridCursor = maxRow;
+        if (_gridCursor < 0) _gridCursor = 0;
 
         var layout = Layouts.Vertical()
-            .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold())
-            .WithChild(new TextNode($"  Audience: {audienceSelector}").WithForeground(Color.Cyan).Bold())
-            .WithSpacing(1)
-            .WithChild(new TextNode($"  [{accessMarker}] Server enabled for {audienceLabel}")
-                .WithForeground(serverAllowed ? Color.White : Color.Yellow))
-            .WithChild(new TextNode($"  [M] Server default: {serverDefaultLabel}")
-                .WithForeground(ColorForMode(serverDefault)));
+            .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold());
+
+        // Row 0: Audience selector
+        var audPrefix = _gridCursor == AudienceRow ? " ▶ " : "   ";
+        var audText = $"{audPrefix}Audience: [◀ {audienceLabel,-8} ▶]";
+        var audNode = new TextNode(audText);
+        audNode = _gridCursor == AudienceRow
+            ? audNode.WithForeground(Color.Cyan).Bold()
+            : audNode.WithForeground(Color.White);
+        layout = layout.WithChild(audNode);
+
+        layout = layout.WithSpacing(1);
+
+        // Row 1: Server enabled
+        var enPrefix = _gridCursor == ServerEnabledRow ? " ▶ " : "   ";
+        var accessMarker = serverAllowed ? "✓" : " ";
+        var enText = $"{enPrefix}[{accessMarker}] Server enabled for {audienceLabel}";
+        var enNode = new TextNode(enText);
+        enNode = _gridCursor == ServerEnabledRow
+            ? enNode.WithForeground(Color.Cyan).Bold()
+            : enNode.WithForeground(serverAllowed ? Color.White : Color.Yellow);
+        layout = layout.WithChild(enNode);
+
+        // Row 2: Server default
+        var sdPrefix = _gridCursor == ServerDefaultRow ? " ▶ " : "   ";
+        var sdText = $"{sdPrefix}Server default: [{serverDefault}]";
+        var sdNode = new TextNode(sdText);
+        sdNode = _gridCursor == ServerDefaultRow
+            ? sdNode.WithForeground(Color.Cyan).Bold()
+            : sdNode.WithForeground(ColorForMode(serverDefault));
+        layout = layout.WithChild(sdNode);
 
         if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
         {
@@ -143,17 +166,18 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         layout = layout.WithSpacing(1);
 
-        // Find the longest tool name for column alignment.
+        // Tool rows
         var maxToolNameLen = tools.Count > 0 ? tools.Max(t => t.Length) : 0;
 
         for (var i = 0; i < tools.Count; i++)
         {
+            var rowIndex = FirstToolRow + i;
+            var isFocused = _gridCursor == rowIndex;
             var tool = tools[i];
-            var isFocused = i == _toolCursor;
             var toolName = new ToolName(tool);
             var granted = serverAllowed && ViewModel.IsToolGranted(toolName);
-            var prefix = isFocused ? " \u25b6 " : "   ";
-            var marker = granted ? "\u2713" : " ";
+            var prefix = isFocused ? " ▶ " : "   ";
+            var marker = granted ? "✓" : " ";
             var paddedName = tool.PadRight(maxToolNameLen);
             var (effectiveMode, inherited) = ViewModel.GetEffectiveMode(toolName);
             var modeBadge = $"[{effectiveMode}]";
@@ -190,7 +214,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             {
                 ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    "[\u2190/\u2192] Audience  [\u2191/\u2193] Navigate  [Enter] Toggle  [A] All  [E] Enable/Disable  [M] Server default  [P] Tool mode  [S] Save  [Esc] Back",
+                    "[↑/↓] Navigate  [←/→] Change  [Enter] Toggle  [A] All  [S] Save  [Esc] Back",
                 _ => ""
             };
 
@@ -231,7 +255,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 return;
             }
 
-            _toolCursor = 0;
+            _gridCursor = 0;
             ViewModel.GoBack();
             return;
         }
@@ -241,31 +265,30 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             switch (keyInfo.Key)
             {
                 case ConsoleKey.UpArrow:
-                    if (_toolCursor > 0) _toolCursor--;
+                    if (_gridCursor > 0) _gridCursor--;
                     InvalidateAndRedraw();
                     return;
 
                 case ConsoleKey.DownArrow:
-                    if (_toolCursor < ViewModel.DiscoveredTools.Count - 1) _toolCursor++;
+                    if (_gridCursor < TotalRows - 1) _gridCursor++;
                     InvalidateAndRedraw();
                     return;
 
                 case ConsoleKey.RightArrow:
-                    ViewModel.CycleAudience();
+                    HandleRightArrow();
                     return;
 
                 case ConsoleKey.LeftArrow:
-                    ViewModel.CycleAudienceBack();
+                    HandleLeftArrow();
                     return;
 
                 case ConsoleKey.Enter:
-                    if (ViewModel.IsServerAllowedForSelectedAudience()
-                        && ViewModel.DiscoveredTools.Count > 0)
-                        ViewModel.ToggleTool(new ToolName(ViewModel.DiscoveredTools[_toolCursor]));
+                    HandleEnter();
                     return;
 
                 case ConsoleKey.S:
                     ViewModel.Save();
+                    InvalidateAndRedraw();
                     return;
 
                 case ConsoleKey.A:
@@ -283,41 +306,32 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
                 case ConsoleKey.P:
                     if (ViewModel.IsServerAllowedForSelectedAudience()
-                        && ViewModel.DiscoveredTools.Count > 0)
-                        ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[_toolCursor]));
+                        && ViewModel.DiscoveredTools.Count > 0
+                        && _gridCursor >= FirstToolRow)
+                        ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[_gridCursor - FirstToolRow]));
                     return;
             }
 
-            if (keyInfo.KeyChar == 's')
+            switch (keyInfo.KeyChar)
             {
-                ViewModel.Save();
-                return;
-            }
-
-            if (keyInfo.KeyChar == 'a' && ViewModel.IsServerAllowedForSelectedAudience())
-            {
-                ViewModel.ToggleAll();
-                return;
-            }
-
-            if (keyInfo.KeyChar == 'e')
-            {
-                ViewModel.ToggleServerAccess();
-                return;
-            }
-
-            if (keyInfo.KeyChar == 'm')
-            {
-                ViewModel.CycleServerDefault();
-                return;
-            }
-
-            if (keyInfo.KeyChar == 'p'
-                && ViewModel.IsServerAllowedForSelectedAudience()
-                && ViewModel.DiscoveredTools.Count > 0)
-            {
-                ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[_toolCursor]));
-                return;
+                case 's':
+                    ViewModel.Save();
+                    InvalidateAndRedraw();
+                    return;
+                case 'a' when ViewModel.IsServerAllowedForSelectedAudience():
+                    ViewModel.ToggleAll();
+                    return;
+                case 'e':
+                    ViewModel.ToggleServerAccess();
+                    return;
+                case 'm':
+                    ViewModel.CycleServerDefault();
+                    return;
+                case 'p' when ViewModel.IsServerAllowedForSelectedAudience()
+                    && ViewModel.DiscoveredTools.Count > 0
+                    && _gridCursor >= FirstToolRow:
+                    ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[_gridCursor - FirstToolRow]));
+                    return;
             }
 
             return;
@@ -328,6 +342,78 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         {
             _serverList.HandleInput(keyInfo);
             ViewModel.RequestRedraw();
+        }
+    }
+
+    private void HandleRightArrow()
+    {
+        switch (_gridCursor)
+        {
+            case AudienceRow:
+                ViewModel.CycleAudience();
+                break;
+            case ServerEnabledRow:
+                ViewModel.ToggleServerAccess();
+                break;
+            case ServerDefaultRow:
+                ViewModel.CycleServerDefault();
+                break;
+            default:
+                if (ViewModel.IsServerAllowedForSelectedAudience()
+                    && ViewModel.DiscoveredTools.Count > 0)
+                {
+                    var toolIdx = _gridCursor - FirstToolRow;
+                    ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
+                }
+                break;
+        }
+    }
+
+    private void HandleLeftArrow()
+    {
+        switch (_gridCursor)
+        {
+            case AudienceRow:
+                ViewModel.CycleAudienceBack();
+                break;
+            case ServerEnabledRow:
+                ViewModel.ToggleServerAccess();
+                break;
+            case ServerDefaultRow:
+                ViewModel.CycleServerDefaultBack();
+                break;
+            default:
+                if (ViewModel.IsServerAllowedForSelectedAudience()
+                    && ViewModel.DiscoveredTools.Count > 0)
+                {
+                    var toolIdx = _gridCursor - FirstToolRow;
+                    ViewModel.CycleToolOverrideBack(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
+                }
+                break;
+        }
+    }
+
+    private void HandleEnter()
+    {
+        switch (_gridCursor)
+        {
+            case AudienceRow:
+                ViewModel.CycleAudience();
+                break;
+            case ServerEnabledRow:
+                ViewModel.ToggleServerAccess();
+                break;
+            case ServerDefaultRow:
+                ViewModel.CycleServerDefault();
+                break;
+            default:
+                if (ViewModel.IsServerAllowedForSelectedAudience()
+                    && ViewModel.DiscoveredTools.Count > 0)
+                {
+                    var toolIdx = _gridCursor - FirstToolRow;
+                    ViewModel.ToggleTool(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
+                }
+                break;
         }
     }
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -14,8 +14,10 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 {
     private SelectionListNode<string>? _serverList;
     private DynamicLayoutNode? _contentNode;
+    private DynamicLayoutNode? _footerNode;
     private readonly CompositeDisposable _stepSubs = new();
     private int _gridCursor;
+    private bool _confirmingSave;
 
     private const int AudienceRow = 0;
     private const int ServerEnabledRow = 1;
@@ -158,12 +160,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             : sdNode.WithForeground(ColorForMode(serverDefault));
         layout = layout.WithChild(sdNode);
 
-        if (!string.IsNullOrEmpty(ViewModel.StatusMessage.Value))
-        {
-            layout = layout.WithSpacing(1)
-                .WithChild(new TextNode($"  {ViewModel.StatusMessage.Value}").WithForeground(Color.Green));
-        }
-
         layout = layout.WithSpacing(1);
 
         // Tool rows
@@ -208,32 +204,58 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
     private LayoutNode BuildFooter()
     {
-        var footerNode = new DynamicLayoutNode(() =>
+        _footerNode = new DynamicLayoutNode(() =>
         {
+            if (_confirmingSave)
+            {
+                return new TextNode("Save changes?  [Y] Yes  [N] No  [Esc] Cancel")
+                    .WithForeground(Color.Yellow).Bold();
+            }
+
             var hints = ViewModel.CurrentState.Value switch
             {
                 ToolPermissionsState.ServerList => "[Enter] Select  [Esc] Quit  [Ctrl+Q] Quit",
                 ToolPermissionsState.ToolGrid =>
-                    "[↑/↓] Navigate  [←/→] Change  [Enter] Toggle  [A] All  [S] Save  [Esc] Back",
+                    "[↑/↓] Navigate  [←/→] Change  [Space] Toggle  [A] All  [Enter] Done  [Esc] Back",
                 _ => ""
             };
 
-            if (ViewModel.CurrentState.Value == ToolPermissionsState.ToolGrid && ViewModel.HasUnsavedChanges)
+            if (ViewModel.CurrentState.Value == ToolPermissionsState.ToolGrid)
             {
-                return Layouts.Horizontal()
-                    .WithChild(new TextNode(hints).WithForeground(Color.BrightBlack))
-                    .WithChild(new TextNode("  *unsaved*").WithForeground(Color.Yellow));
+                var statusText = ViewModel.StatusMessage.Value;
+                var hasStatus = !string.IsNullOrEmpty(statusText);
+                var isError = hasStatus && statusText.StartsWith("Save failed", StringComparison.Ordinal);
+
+                if (isError)
+                {
+                    return Layouts.Horizontal()
+                        .WithChild(new TextNode(hints).WithForeground(Color.BrightBlack))
+                        .WithChild(new TextNode($"  {statusText}").WithForeground(Color.Red));
+                }
+
+                if (ViewModel.HasUnsavedChanges)
+                {
+                    return Layouts.Horizontal()
+                        .WithChild(new TextNode(hints).WithForeground(Color.BrightBlack))
+                        .WithChild(new TextNode("  *unsaved*").WithForeground(Color.Yellow));
+                }
+
+                if (hasStatus)
+                {
+                    return Layouts.Horizontal()
+                        .WithChild(new TextNode(hints).WithForeground(Color.BrightBlack))
+                        .WithChild(new TextNode($"  {statusText}").WithForeground(Color.Green));
+                }
             }
 
             return new TextNode(hints).WithForeground(Color.BrightBlack);
         });
 
-        // Footer must invalidate on state changes to show correct hints
         ViewModel.StateVersion
-            .Subscribe(_ => footerNode.Invalidate())
+            .Subscribe(_ => _footerNode.Invalidate())
             .DisposeWith(Subscriptions);
 
-        return footerNode;
+        return _footerNode;
     }
 
     private void HandleKeyPress(KeyPressed key)
@@ -244,6 +266,13 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
         {
             ViewModel.RequestQuit();
+            return;
+        }
+
+        // Handle save confirmation dialog
+        if (_confirmingSave)
+        {
+            HandleConfirmation(keyInfo);
             return;
         }
 
@@ -282,13 +311,12 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                     HandleLeftArrow();
                     return;
 
-                case ConsoleKey.Enter:
-                    HandleEnter();
+                case ConsoleKey.Spacebar:
+                    HandleToggle();
                     return;
 
-                case ConsoleKey.S:
-                    ViewModel.Save();
-                    InvalidateAndRedraw();
+                case ConsoleKey.Enter:
+                    HandleDone();
                     return;
 
                 case ConsoleKey.A:
@@ -314,10 +342,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
             switch (keyInfo.KeyChar)
             {
-                case 's':
-                    ViewModel.Save();
-                    InvalidateAndRedraw();
-                    return;
                 case 'a' when ViewModel.IsServerAllowedForSelectedAudience():
                     ViewModel.ToggleAll();
                     return;
@@ -395,7 +419,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         }
     }
 
-    private void HandleEnter()
+    private void HandleToggle()
     {
         switch (_gridCursor)
         {
@@ -420,9 +444,58 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         }
     }
 
+    private void HandleDone()
+    {
+        if (ViewModel.HasUnsavedChanges)
+        {
+            _confirmingSave = true;
+            InvalidateAndRedraw();
+        }
+        else
+        {
+            _gridCursor = 0;
+            ViewModel.GoBack();
+        }
+    }
+
+    private void HandleConfirmation(ConsoleKeyInfo keyInfo)
+    {
+        switch (keyInfo.Key)
+        {
+            case ConsoleKey.Y:
+                _confirmingSave = false;
+                try
+                {
+                    ViewModel.Save();
+                }
+                catch (Exception ex)
+                {
+                    ViewModel.StatusMessage.Value = $"Save failed: {ex.Message}";
+                    InvalidateAndRedraw();
+                    return;
+                }
+                _gridCursor = 0;
+                ViewModel.GoBack();
+                break;
+
+            case ConsoleKey.N:
+                _confirmingSave = false;
+                _gridCursor = 0;
+                ViewModel.DiscardChanges();
+                ViewModel.GoBack();
+                break;
+
+            case ConsoleKey.Escape:
+                _confirmingSave = false;
+                InvalidateAndRedraw();
+                break;
+        }
+    }
+
     private void InvalidateAndRedraw()
     {
         _contentNode?.Invalidate();
+        _footerNode?.Invalidate();
         ViewModel.RequestRedraw();
     }
 }

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -128,6 +128,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         var layout = Layouts.Vertical()
             .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold());
 
+        // Row 0: Audience selector
         var audPrefix = _gridCursor == AudienceRow ? " ▶ " : "   ";
         var audText = $"{audPrefix}Audience: [◀ {audienceLabel,-8} ▶]";
         var audNode = new TextNode(audText);
@@ -138,6 +139,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         layout = layout.WithSpacing(1);
 
+        // Row 1: Server enabled
         var enPrefix = _gridCursor == ServerEnabledRow ? " ▶ " : "   ";
         var accessMarker = serverAllowed ? "✓" : " ";
         var enText = $"{enPrefix}[{accessMarker}] Server enabled for {audienceLabel}";
@@ -147,6 +149,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             : enNode.WithForeground(serverAllowed ? Color.White : Color.Yellow);
         layout = layout.WithChild(enNode);
 
+        // Row 2: Server default
         var sdPrefix = _gridCursor == ServerDefaultRow ? " ▶ " : "   ";
         var sdText = $"{sdPrefix}Server default: [{serverDefault}]";
         var sdNode = new TextNode(sdText);
@@ -163,6 +166,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         layout = layout.WithSpacing(1);
 
+        // Tool rows
         var maxToolNameLen = tools.Count > 0 ? tools.Max(t => t.Length) : 0;
 
         for (var i = 0; i < tools.Count; i++)

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -128,7 +128,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         var layout = Layouts.Vertical()
             .WithChild(new TextNode($"  Server: {server}").WithForeground(Color.White).Bold());
 
-        // Row 0: Audience selector
         var audPrefix = _gridCursor == AudienceRow ? " ▶ " : "   ";
         var audText = $"{audPrefix}Audience: [◀ {audienceLabel,-8} ▶]";
         var audNode = new TextNode(audText);
@@ -139,7 +138,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         layout = layout.WithSpacing(1);
 
-        // Row 1: Server enabled
         var enPrefix = _gridCursor == ServerEnabledRow ? " ▶ " : "   ";
         var accessMarker = serverAllowed ? "✓" : " ";
         var enText = $"{enPrefix}[{accessMarker}] Server enabled for {audienceLabel}";
@@ -149,7 +147,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             : enNode.WithForeground(serverAllowed ? Color.White : Color.Yellow);
         layout = layout.WithChild(enNode);
 
-        // Row 2: Server default
         var sdPrefix = _gridCursor == ServerDefaultRow ? " ▶ " : "   ";
         var sdText = $"{sdPrefix}Server default: [{serverDefault}]";
         var sdNode = new TextNode(sdText);
@@ -166,7 +163,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
 
         layout = layout.WithSpacing(1);
 
-        // Tool rows
         var maxToolNameLen = tools.Count > 0 ? tools.Max(t => t.Length) : 0;
 
         for (var i = 0; i < tools.Count; i++)
@@ -359,7 +355,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 ViewModel.CycleServerDefault();
                 break;
             default:
-                if (ViewModel.IsServerAllowedForSelectedAudience()
+                if (_gridCursor >= FirstToolRow
+                    && ViewModel.IsServerAllowedForSelectedAudience()
                     && ViewModel.DiscoveredTools.Count > 0)
                 {
                     var toolIdx = _gridCursor - FirstToolRow;
@@ -383,7 +380,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 ViewModel.CycleServerDefaultBack();
                 break;
             default:
-                if (ViewModel.IsServerAllowedForSelectedAudience()
+                if (_gridCursor >= FirstToolRow
+                    && ViewModel.IsServerAllowedForSelectedAudience()
                     && ViewModel.DiscoveredTools.Count > 0)
                 {
                     var toolIdx = _gridCursor - FirstToolRow;
@@ -407,7 +405,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                 ViewModel.CycleServerDefault();
                 break;
             default:
-                if (ViewModel.IsServerAllowedForSelectedAudience()
+                if (_gridCursor >= FirstToolRow
+                    && ViewModel.IsServerAllowedForSelectedAudience()
                     && ViewModel.DiscoveredTools.Count > 0)
                 {
                     var toolIdx = _gridCursor - FirstToolRow;

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -224,9 +224,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
             {
                 var statusText = ViewModel.StatusMessage.Value;
                 var hasStatus = !string.IsNullOrEmpty(statusText);
-                var isError = hasStatus && statusText.StartsWith("Save failed", StringComparison.Ordinal);
 
-                if (isError)
+                if (ViewModel.HasSaveError)
                 {
                     return Layouts.Horizontal()
                         .WithChild(new TextNode(hints).WithForeground(Color.BrightBlack))
@@ -340,24 +339,6 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
                     return;
             }
 
-            switch (keyInfo.KeyChar)
-            {
-                case 'a' when ViewModel.IsServerAllowedForSelectedAudience():
-                    ViewModel.ToggleAll();
-                    return;
-                case 'e':
-                    ViewModel.ToggleServerAccess();
-                    return;
-                case 'm':
-                    ViewModel.CycleServerDefault();
-                    return;
-                case 'p' when ViewModel.IsServerAllowedForSelectedAudience()
-                    && ViewModel.DiscoveredTools.Count > 0
-                    && _gridCursor >= FirstToolRow:
-                    ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[_gridCursor - FirstToolRow]));
-                    return;
-            }
-
             return;
         }
 
@@ -369,76 +350,47 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         }
     }
 
-    private void HandleRightArrow()
-    {
-        switch (_gridCursor)
-        {
-            case AudienceRow:
-                ViewModel.CycleAudience();
-                break;
-            case ServerEnabledRow:
-                ViewModel.ToggleServerAccess();
-                break;
-            case ServerDefaultRow:
-                ViewModel.CycleServerDefault();
-                break;
-            default:
-                if (_gridCursor >= FirstToolRow
-                    && ViewModel.IsServerAllowedForSelectedAudience()
-                    && ViewModel.DiscoveredTools.Count > 0)
-                {
-                    var toolIdx = _gridCursor - FirstToolRow;
-                    ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
-                }
-                break;
-        }
-    }
+    private void HandleRightArrow() => DispatchGridAction(
+        ViewModel.CycleAudience,
+        ViewModel.ToggleServerAccess,
+        ViewModel.CycleServerDefault,
+        idx => ViewModel.CycleToolOverride(new ToolName(ViewModel.DiscoveredTools[idx])));
 
-    private void HandleLeftArrow()
-    {
-        switch (_gridCursor)
-        {
-            case AudienceRow:
-                ViewModel.CycleAudienceBack();
-                break;
-            case ServerEnabledRow:
-                ViewModel.ToggleServerAccess();
-                break;
-            case ServerDefaultRow:
-                ViewModel.CycleServerDefaultBack();
-                break;
-            default:
-                if (_gridCursor >= FirstToolRow
-                    && ViewModel.IsServerAllowedForSelectedAudience()
-                    && ViewModel.DiscoveredTools.Count > 0)
-                {
-                    var toolIdx = _gridCursor - FirstToolRow;
-                    ViewModel.CycleToolOverrideBack(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
-                }
-                break;
-        }
-    }
+    private void HandleLeftArrow() => DispatchGridAction(
+        ViewModel.CycleAudienceBack,
+        ViewModel.ToggleServerAccess,
+        ViewModel.CycleServerDefaultBack,
+        idx => ViewModel.CycleToolOverrideBack(new ToolName(ViewModel.DiscoveredTools[idx])));
 
-    private void HandleToggle()
+    private void HandleToggle() => DispatchGridAction(
+        ViewModel.CycleAudience,
+        ViewModel.ToggleServerAccess,
+        ViewModel.CycleServerDefault,
+        idx => ViewModel.ToggleTool(new ToolName(ViewModel.DiscoveredTools[idx])));
+
+    private void DispatchGridAction(
+        Action audienceAction,
+        Action serverEnabledAction,
+        Action serverDefaultAction,
+        Action<int> toolAction)
     {
         switch (_gridCursor)
         {
             case AudienceRow:
-                ViewModel.CycleAudience();
+                audienceAction();
                 break;
             case ServerEnabledRow:
-                ViewModel.ToggleServerAccess();
+                serverEnabledAction();
                 break;
             case ServerDefaultRow:
-                ViewModel.CycleServerDefault();
+                serverDefaultAction();
                 break;
             default:
                 if (_gridCursor >= FirstToolRow
                     && ViewModel.IsServerAllowedForSelectedAudience()
                     && ViewModel.DiscoveredTools.Count > 0)
                 {
-                    var toolIdx = _gridCursor - FirstToolRow;
-                    ViewModel.ToggleTool(new ToolName(ViewModel.DiscoveredTools[toolIdx]));
+                    toolAction(_gridCursor - FirstToolRow);
                 }
                 break;
         }
@@ -464,13 +416,8 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
         {
             case ConsoleKey.Y:
                 _confirmingSave = false;
-                try
+                if (!ViewModel.Save())
                 {
-                    ViewModel.Save();
-                }
-                catch (Exception ex)
-                {
-                    ViewModel.StatusMessage.Value = $"Save failed: {ex.Message}";
                     InvalidateAndRedraw();
                     return;
                 }

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -222,6 +222,27 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         NotifyStateChanged();
     }
 
+    public void CycleServerDefaultBack()
+    {
+        if (SelectedServer is null)
+            return;
+
+        var audience = AudienceName(SelectedAudience);
+        var key = (audience, SelectedServer);
+
+        var current = _pendingServerDefaults.TryGetValue(key, out var pending)
+            ? pending
+            : ResolveProfile(SelectedAudience).ApprovalPolicy?.McpServerDefaults.TryGetValue(SelectedServer, out var configMode) == true
+                ? configMode
+                : ToolApprovalMode.Auto;
+
+        var idx = Array.IndexOf(ServerDefaultCycle, current);
+        var next = ServerDefaultCycle[(idx - 1 + ServerDefaultCycle.Length) % ServerDefaultCycle.Length];
+        _pendingServerDefaults[key] = next;
+
+        NotifyStateChanged();
+    }
+
     /// <summary>
     /// Advances the per-tool approval override for <paramref name="toolName"/>
     /// under the current audience/server pair through
@@ -255,6 +276,41 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             ToolApprovalMode.Auto => ToolApprovalMode.Approval,
             ToolApprovalMode.Approval => ToolApprovalMode.Deny,
             ToolApprovalMode.Deny => null,
+            _ => null
+        };
+
+        _pendingToolOverrides[key] = next;
+
+        NotifyStateChanged();
+    }
+
+    public void CycleToolOverrideBack(ToolName toolName)
+    {
+        if (SelectedServer is null)
+            return;
+
+        var audience = AudienceName(SelectedAudience);
+        var key = (audience, SelectedServer, toolName.Value);
+
+        ToolApprovalMode? current;
+        if (_pendingToolOverrides.TryGetValue(key, out var pending))
+        {
+            current = pending;
+        }
+        else
+        {
+            var exactKey = $"{SelectedServer}/{toolName.Value}";
+            current = ResolveProfile(SelectedAudience).ApprovalPolicy?.ToolOverrides.TryGetValue(exactKey, out var configMode) == true
+                ? configMode
+                : null;
+        }
+
+        ToolApprovalMode? next = current switch
+        {
+            null => ToolApprovalMode.Deny,
+            ToolApprovalMode.Auto => null,
+            ToolApprovalMode.Approval => ToolApprovalMode.Auto,
+            ToolApprovalMode.Deny => ToolApprovalMode.Approval,
             _ => null
         };
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -420,13 +420,34 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     public void Save()
     {
         if (!HasUnsavedChanges)
+        {
+            StatusMessage.Value = "No unsaved changes.";
+            NotifyStateChanged();
             return;
+        }
 
         var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
         var toolsSection = ConfigFileHelper.GetOrCreateSection(config, "Tools");
         var profilesSection = ConfigFileHelper.GetOrCreateSection(toolsSection, "AudienceProfiles");
 
-        // Write server access changes (AllowedMcpServers)
+        SaveServerAccess(profilesSection);
+        SaveToolGrants(profilesSection);
+        SaveServerDefaults(profilesSection);
+        SaveToolOverrides(profilesSection);
+
+        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+        _pendingGrants.Clear();
+        _pendingServerAccess.Clear();
+        _pendingServerDefaults.Clear();
+        _pendingToolOverrides.Clear();
+
+        StatusMessage.Value = "✓ Saved to netclaw.json. Restart daemon to apply changes.";
+        CurrentState.Value = ToolPermissionsState.ToolGrid;
+        NotifyStateChanged();
+    }
+
+    private void SaveServerAccess(Dictionary<string, object> profilesSection)
+    {
         foreach (var ((audienceName, serverName), allowed) in _pendingServerAccess)
         {
             var audienceSection = ConfigFileHelper.GetOrCreateSection(profilesSection, audienceName);
@@ -460,8 +481,10 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             else if (!allowed)
                 profile.AllowedMcpServers.RemoveAll(s => s.Equals(serverName, StringComparison.OrdinalIgnoreCase));
         }
+    }
 
-        // Write tool grant changes (McpServerToolGrants)
+    private void SaveToolGrants(Dictionary<string, object> profilesSection)
+    {
         foreach (var (serverName, audienceGrants) in _pendingGrants)
         {
             foreach (var (audienceName, tools) in audienceGrants)
@@ -471,10 +494,10 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 grants[serverName] = tools.Order(StringComparer.Ordinal).ToList();
             }
         }
+    }
 
-        // Mirroring in-memory Profiles alongside the on-disk writes lets
-        // GetEffectiveMode / GetServerDefault reflect saved values without
-        // a full config reload.
+    private void SaveServerDefaults(Dictionary<string, object> profilesSection)
+    {
         foreach (var ((audienceName, serverName), mode) in _pendingServerDefaults)
         {
             var (approvalSection, inMemoryPolicy) = GetOrCreateApprovalPolicy(profilesSection, audienceName);
@@ -482,7 +505,10 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             serverDefaults[serverName] = mode.ToString();
             inMemoryPolicy.McpServerDefaults[serverName] = mode;
         }
+    }
 
+    private void SaveToolOverrides(Dictionary<string, object> profilesSection)
+    {
         foreach (var ((audienceName, serverName, toolName), mode) in _pendingToolOverrides)
         {
             var (approvalSection, inMemoryPolicy) = GetOrCreateApprovalPolicy(profilesSection, audienceName);
@@ -500,15 +526,15 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 inMemoryPolicy.ToolOverrides[exactKey] = mode.Value;
             }
         }
+    }
 
-        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+    public void DiscardChanges()
+    {
         _pendingGrants.Clear();
         _pendingServerAccess.Clear();
         _pendingServerDefaults.Clear();
         _pendingToolOverrides.Clear();
-
-        StatusMessage.Value = "Saved to netclaw.json. Restart daemon to apply changes.";
-        CurrentState.Value = ToolPermissionsState.ToolGrid;
+        StatusMessage.Value = "";
         NotifyStateChanged();
     }
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -31,6 +31,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     public ReactiveProperty<ToolPermissionsState> CurrentState { get; } = new(ToolPermissionsState.Loading);
     internal ReactiveProperty<int> StateVersion { get; } = new(0);
     public ReactiveProperty<string> StatusMessage { get; } = new("");
+    public bool HasSaveError { get; private set; }
 
     // Server list state
     public List<(string Name, string Status, int ToolCount)> Servers { get; } = [];
@@ -334,9 +335,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         // No pending grants = check config
         var profile = ResolveProfile(SelectedAudience);
 
-        // Check pending server access, then config
-        var audName = AudienceName(SelectedAudience);
-        if (_pendingServerAccess.TryGetValue((audName, SelectedServer), out var pendingAccess))
+        if (_pendingServerAccess.TryGetValue((audienceName, SelectedServer), out var pendingAccess))
         {
             if (!pendingAccess)
                 return false;
@@ -417,33 +416,46 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         NotifyStateChanged();
     }
 
-    public void Save()
+    public bool Save()
     {
+        HasSaveError = false;
+
         if (!HasUnsavedChanges)
         {
             StatusMessage.Value = "No unsaved changes.";
             NotifyStateChanged();
-            return;
+            return true;
         }
 
-        var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
-        var toolsSection = ConfigFileHelper.GetOrCreateSection(config, "Tools");
-        var profilesSection = ConfigFileHelper.GetOrCreateSection(toolsSection, "AudienceProfiles");
+        try
+        {
+            var (config, _) = ConfigFileHelper.LoadConfigFiles(_paths);
+            var toolsSection = ConfigFileHelper.GetOrCreateSection(config, "Tools");
+            var profilesSection = ConfigFileHelper.GetOrCreateSection(toolsSection, "AudienceProfiles");
 
-        SaveServerAccess(profilesSection);
-        SaveToolGrants(profilesSection);
-        SaveServerDefaults(profilesSection);
-        SaveToolOverrides(profilesSection);
+            SaveServerAccess(profilesSection);
+            SaveToolGrants(profilesSection);
+            SaveServerDefaults(profilesSection);
+            SaveToolOverrides(profilesSection);
 
-        ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
-        _pendingGrants.Clear();
-        _pendingServerAccess.Clear();
-        _pendingServerDefaults.Clear();
-        _pendingToolOverrides.Clear();
+            ConfigFileHelper.WriteConfigFile(_paths.NetclawConfigPath, config);
+            _pendingGrants.Clear();
+            _pendingServerAccess.Clear();
+            _pendingServerDefaults.Clear();
+            _pendingToolOverrides.Clear();
 
-        StatusMessage.Value = "✓ Saved to netclaw.json. Restart daemon to apply changes.";
-        CurrentState.Value = ToolPermissionsState.ToolGrid;
-        NotifyStateChanged();
+            StatusMessage.Value = "✓ Saved to netclaw.json. Restart daemon to apply changes.";
+            CurrentState.Value = ToolPermissionsState.ToolGrid;
+            NotifyStateChanged();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            HasSaveError = true;
+            StatusMessage.Value = $"Save failed: {ex.Message}";
+            NotifyStateChanged();
+            return false;
+        }
     }
 
     private void SaveServerAccess(Dictionary<string, object> profilesSection)

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -196,12 +196,11 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     private static readonly ToolApprovalMode[] ServerDefaultCycle =
         [ToolApprovalMode.Auto, ToolApprovalMode.Approval, ToolApprovalMode.Deny];
 
-    /// <summary>
-    /// Advances the server-default approval mode for the current audience/server
-    /// pair through Auto → Approval → Deny → Auto. The starting point is the
-    /// currently resolved effective default (pending or config).
-    /// </summary>
-    public void CycleServerDefault()
+    public void CycleServerDefault() => CycleServerDefaultCore(+1);
+
+    public void CycleServerDefaultBack() => CycleServerDefaultCore(-1);
+
+    private void CycleServerDefaultCore(int direction)
     {
         if (SelectedServer is null)
             return;
@@ -216,40 +215,19 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 : ToolApprovalMode.Auto;
 
         var idx = Array.IndexOf(ServerDefaultCycle, current);
-        var next = ServerDefaultCycle[(idx + 1) % ServerDefaultCycle.Length];
-        _pendingServerDefaults[key] = next;
+        _pendingServerDefaults[key] = ServerDefaultCycle[(idx + direction + ServerDefaultCycle.Length) % ServerDefaultCycle.Length];
 
         NotifyStateChanged();
     }
 
-    public void CycleServerDefaultBack()
-    {
-        if (SelectedServer is null)
-            return;
+    private static readonly ToolApprovalMode?[] ToolOverrideCycle =
+        [null, ToolApprovalMode.Auto, ToolApprovalMode.Approval, ToolApprovalMode.Deny];
 
-        var audience = AudienceName(SelectedAudience);
-        var key = (audience, SelectedServer);
+    public void CycleToolOverride(ToolName toolName) => CycleToolOverrideCore(toolName, +1);
 
-        var current = _pendingServerDefaults.TryGetValue(key, out var pending)
-            ? pending
-            : ResolveProfile(SelectedAudience).ApprovalPolicy?.McpServerDefaults.TryGetValue(SelectedServer, out var configMode) == true
-                ? configMode
-                : ToolApprovalMode.Auto;
+    public void CycleToolOverrideBack(ToolName toolName) => CycleToolOverrideCore(toolName, -1);
 
-        var idx = Array.IndexOf(ServerDefaultCycle, current);
-        var next = ServerDefaultCycle[(idx - 1 + ServerDefaultCycle.Length) % ServerDefaultCycle.Length];
-        _pendingServerDefaults[key] = next;
-
-        NotifyStateChanged();
-    }
-
-    /// <summary>
-    /// Advances the per-tool approval override for <paramref name="toolName"/>
-    /// under the current audience/server pair through
-    /// inherit (null) → Auto → Approval → Deny → inherit. The "inherit" state
-    /// removes any existing <c>ToolOverrides[{server}/{tool}]</c> entry on save.
-    /// </summary>
-    public void CycleToolOverride(ToolName toolName)
+    private void CycleToolOverrideCore(ToolName toolName, int direction)
     {
         if (SelectedServer is null)
             return;
@@ -270,51 +248,8 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
                 : null;
         }
 
-        ToolApprovalMode? next = current switch
-        {
-            null => ToolApprovalMode.Auto,
-            ToolApprovalMode.Auto => ToolApprovalMode.Approval,
-            ToolApprovalMode.Approval => ToolApprovalMode.Deny,
-            ToolApprovalMode.Deny => null,
-            _ => null
-        };
-
-        _pendingToolOverrides[key] = next;
-
-        NotifyStateChanged();
-    }
-
-    public void CycleToolOverrideBack(ToolName toolName)
-    {
-        if (SelectedServer is null)
-            return;
-
-        var audience = AudienceName(SelectedAudience);
-        var key = (audience, SelectedServer, toolName.Value);
-
-        ToolApprovalMode? current;
-        if (_pendingToolOverrides.TryGetValue(key, out var pending))
-        {
-            current = pending;
-        }
-        else
-        {
-            var exactKey = $"{SelectedServer}/{toolName.Value}";
-            current = ResolveProfile(SelectedAudience).ApprovalPolicy?.ToolOverrides.TryGetValue(exactKey, out var configMode) == true
-                ? configMode
-                : null;
-        }
-
-        ToolApprovalMode? next = current switch
-        {
-            null => ToolApprovalMode.Deny,
-            ToolApprovalMode.Auto => null,
-            ToolApprovalMode.Approval => ToolApprovalMode.Auto,
-            ToolApprovalMode.Deny => ToolApprovalMode.Approval,
-            _ => null
-        };
-
-        _pendingToolOverrides[key] = next;
+        var idx = Array.IndexOf(ToolOverrideCycle, current);
+        _pendingToolOverrides[key] = ToolOverrideCycle[(idx + direction + ToolOverrideCycle.Length) % ToolOverrideCycle.Length];
 
         NotifyStateChanged();
     }
@@ -387,12 +322,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         if (SelectedServer is null)
             return false;
 
-        var audienceName = SelectedAudience switch
-        {
-            TrustAudience.Public => "Public",
-            TrustAudience.Team => "Team",
-            _ => "Personal"
-        };
+        var audienceName = AudienceName(SelectedAudience);
 
         // Check pending grants first
         if (_pendingGrants.TryGetValue(SelectedServer, out var serverGrants)
@@ -402,12 +332,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         }
 
         // No pending grants = check config
-        var profile = SelectedAudience switch
-        {
-            TrustAudience.Public => Profiles.Public,
-            TrustAudience.Team => Profiles.Team,
-            _ => Profiles.Personal
-        };
+        var profile = ResolveProfile(SelectedAudience);
 
         // Check pending server access, then config
         var audName = AudienceName(SelectedAudience);
@@ -440,12 +365,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         // If any tool is granted, deselect all. Otherwise select all.
         var anyGranted = DiscoveredTools.Any(t => IsToolGranted(new ToolName(t)));
 
-        var audienceName = SelectedAudience switch
-        {
-            TrustAudience.Public => "Public",
-            TrustAudience.Team => "Team",
-            _ => "Personal"
-        };
+        var audienceName = AudienceName(SelectedAudience);
 
         if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
         {
@@ -465,12 +385,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
         if (SelectedServer is null)
             return;
 
-        var audienceName = SelectedAudience switch
-        {
-            TrustAudience.Public => "Public",
-            TrustAudience.Team => "Team",
-            _ => "Personal"
-        };
+        var audienceName = AudienceName(SelectedAudience);
 
         if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
         {
@@ -480,14 +395,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         if (!serverGrants.TryGetValue(audienceName, out var tools))
         {
-            // Initialize from config if grants exist for this server,
-            // otherwise start from all tools (matches IsToolGranted behavior)
-            var profile = SelectedAudience switch
-            {
-                TrustAudience.Public => Profiles.Public,
-                TrustAudience.Team => Profiles.Team,
-                _ => Profiles.Personal
-            };
+            var profile = ResolveProfile(SelectedAudience);
 
             if (profile.McpServerToolGrants is { } existing
                 && existing.TryGetValue(SelectedServer, out var configTools))


### PR DESCRIPTION
## Summary

- **Unified cursor model**: Replaced tools-only `_toolCursor` with `_gridCursor` spanning all configurable rows (Audience → Server Enabled → Server Default → Tools), so Up/Down navigates everything and Left/Right is context-sensitive per row
- **Simplified footer**: Reduced from 8+ key hints to `[↑/↓] Navigate  [←/→] Change  [Enter] Toggle  [A] All  [S] Save  [Esc] Back` — legacy shortcuts (E, M, P) still work but are hidden
- **Bidirectional cycling**: Added reverse-cycle methods (`CycleServerDefaultBack`, `CycleToolOverrideBack`) so Left arrow goes backward through options, then deduplicated forward/back into shared cores with modular arithmetic
- **Save feedback fix**: Added `InvalidateAndRedraw()` after `Save()` so `*unsaved*` indicator clears reliably
- **Cleanup**: Replaced 5 inline audience/profile switch expressions with `AudienceName()`/`ResolveProfile()` helpers, added defensive `_gridCursor >= FirstToolRow` bounds checks

Closes #786

## Test plan

- [x] 7 new ViewModel tests (reverse cycling, round-trip, config read-through)
- [x] 10 new headless Page tests using `VirtualTerminal` + `VirtualInputSource` (navigation, arrow cycling, enter toggling, save)
- [x] All 17 tests pass
- [ ] Binary swap: manual TUI testing against live daemon (deferred — instance busy)