### PR TITLE
refactor(channels): consolidate ACL decision types and test boilerplate

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
@@ -40,7 +40,7 @@ public abstract class AclPolicyContractTests
         var options = new ChannelOptionsBuilder { AllowDirectMessages = false };
         var result = EvaluateDm("user-1", options);
         Assert.False(result.IsAllowed);
-        Assert.NotNull(result.DenyReason);
+        Assert.Contains(AclDenyReasons.DirectMessagesDisabled, result.DenyReason!);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
@@ -31,7 +31,7 @@ public abstract class AclPolicyContractTests
         var options = new ChannelOptionsBuilder { AllowDirectMessages = true };
         var result = EvaluateDm("", options);
         Assert.False(result.IsAllowed);
-        Assert.Contains("missing_user_id", result.DenyReason!);
+        Assert.Contains(AclDenyReasons.MissingUserId, result.DenyReason!);
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public abstract class AclPolicyContractTests
         };
         var result = EvaluateChannel("ch-other", "user-1", options);
         Assert.False(result.IsAllowed);
-        Assert.Contains("channel_not_allowed", result.DenyReason!);
+        Assert.Contains(AclDenyReasons.ChannelNotAllowed, result.DenyReason!);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public abstract class AclPolicyContractTests
         };
         var result = EvaluateChannel("ch-1", "user-denied", options);
         Assert.False(result.IsAllowed);
-        Assert.Contains("user_not_allowed", result.DenyReason!);
+        Assert.Contains(AclDenyReasons.UserNotAllowed, result.DenyReason!);
     }
 
     // --- Allow cases ---
@@ -199,7 +199,7 @@ public abstract class AclPolicyContractTests
         };
         var result = EvaluateChannel("ch-1", "user-1", options);
         Assert.False(result.IsAllowed);
-        Assert.Contains("invalid_channel_audience", result.DenyReason!);
+        Assert.Contains(AclDenyReasons.InvalidChannelAudiencePrefix, result.DenyReason!);
     }
 
     // --- Provenance ---

--- a/src/Netclaw.Actors.Tests/Channels/DiscordRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordRoutingPolicyTests.cs
@@ -95,95 +95,38 @@ public class DiscordRoutingPolicyTests
         Assert.Null(decision.IgnoreReason);
     }
 
-    [Fact]
-    public void DirectMessage_ProcessesWithoutMention_WhenEnabled()
+    [Theory]
+    [InlineData(true, false, false, DiscordRoutingDecisionKind.StartOrContinue, null)]
+    [InlineData(false, false, false, DiscordRoutingDecisionKind.Ignore, DiscordRoutingIgnoreReason.DmNotAllowed)]
+    [InlineData(true, true, false, DiscordRoutingDecisionKind.Ignore, DiscordRoutingIgnoreReason.DmMentionRequired)]
+    [InlineData(true, true, true, DiscordRoutingDecisionKind.StartOrContinue, null)]
+    internal void DirectMessage_routing_decision(
+        bool allowDirectMessages,
+        bool mentionRequiredInDm,
+        bool containsBotMention,
+        DiscordRoutingDecisionKind expectedKind,
+        DiscordRoutingIgnoreReason? expectedReason)
     {
         var message = CreateMessage(text: "hey", isDirectMessage: true);
 
         var decision = DiscordRoutingPolicy.Evaluate(
             message,
             mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: false,
+            allowDirectMessages: allowDirectMessages,
+            mentionRequiredInDm: mentionRequiredInDm,
             threadExists: false,
-            containsBotMention: false);
+            containsBotMention: containsBotMention);
 
-        Assert.Equal(DiscordRoutingDecisionKind.StartOrContinue, decision.Kind);
-        Assert.Null(decision.IgnoreReason);
+        Assert.Equal(expectedKind, decision.Kind);
+        Assert.Equal(expectedReason, decision.IgnoreReason);
     }
 
-    [Fact]
-    public void DirectMessage_Ignored_WhenDisabled()
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    internal void EmptyContent_Ignored(string text)
     {
-        var message = CreateMessage(text: "hey", isDirectMessage: true);
-
-        var decision = DiscordRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: false,
-            mentionRequiredInDm: false,
-            threadExists: false,
-            containsBotMention: false);
-
-        Assert.Equal(DiscordRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(DiscordRoutingIgnoreReason.DmNotAllowed, decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void DirectMessage_Ignored_WhenMentionRequired_AndNoMention()
-    {
-        var message = CreateMessage(text: "hey", isDirectMessage: true);
-
-        var decision = DiscordRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: true,
-            threadExists: false,
-            containsBotMention: false);
-
-        Assert.Equal(DiscordRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(DiscordRoutingIgnoreReason.DmMentionRequired, decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void DirectMessage_Processed_WhenMentionRequired_AndMentionPresent()
-    {
-        var message = CreateMessage(text: "<@123> hey", isDirectMessage: true);
-
-        var decision = DiscordRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: true,
-            threadExists: false,
-            containsBotMention: true);
-
-        Assert.Equal(DiscordRoutingDecisionKind.StartOrContinue, decision.Kind);
-        Assert.Null(decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void NoContent_Ignored()
-    {
-        var message = CreateMessage(text: "");
-
-        var decision = DiscordRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: false,
-            allowDirectMessages: false,
-            mentionRequiredInDm: false,
-            threadExists: false,
-            containsBotMention: false);
-
-        Assert.Equal(DiscordRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(DiscordRoutingIgnoreReason.NoContent, decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void WhitespaceOnly_Ignored()
-    {
-        var message = CreateMessage(text: "   ");
+        var message = CreateMessage(text: text);
 
         var decision = DiscordRoutingPolicy.Evaluate(
             message,

--- a/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackRoutingPolicyTests.cs
@@ -80,72 +80,30 @@ public class SlackRoutingPolicyTests
         Assert.Null(decision.IgnoreReason);
     }
 
-    [Fact]
-    public void DirectMessage_ProcessesWithoutMention_WhenEnabled()
+    [Theory]
+    [InlineData(true, false, false, SlackRoutingDecisionKind.StartOrContinue, null)]
+    [InlineData(false, false, false, SlackRoutingDecisionKind.Ignore, SlackRoutingIgnoreReason.DmNotAllowed)]
+    [InlineData(true, true, false, SlackRoutingDecisionKind.Ignore, SlackRoutingIgnoreReason.DmMentionRequired)]
+    [InlineData(true, true, true, SlackRoutingDecisionKind.StartOrContinue, null)]
+    internal void DirectMessage_routing_decision(
+        bool allowDirectMessages,
+        bool mentionRequiredInDm,
+        bool containsBotMention,
+        SlackRoutingDecisionKind expectedKind,
+        SlackRoutingIgnoreReason? expectedReason)
     {
         var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
 
         var decision = SlackRoutingPolicy.Evaluate(
             message,
             mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: false,
+            allowDirectMessages: allowDirectMessages,
+            mentionRequiredInDm: mentionRequiredInDm,
             threadExists: false,
-            containsBotMention: false);
+            containsBotMention: containsBotMention);
 
-        Assert.Equal(SlackRoutingDecisionKind.StartOrContinue, decision.Kind);
-        Assert.Null(decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void DirectMessage_Ignored_WhenDisabled()
-    {
-        var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
-
-        var decision = SlackRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: false,
-            mentionRequiredInDm: false,
-            threadExists: false,
-            containsBotMention: false);
-
-        Assert.Equal(SlackRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(SlackRoutingIgnoreReason.DmNotAllowed, decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void DirectMessage_Ignored_WhenMentionRequired_AndNoMention()
-    {
-        var message = CreateMessage(text: "hey", threadTs: null, isDirectMessage: true);
-
-        var decision = SlackRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: true,
-            threadExists: false,
-            containsBotMention: false);
-
-        Assert.Equal(SlackRoutingDecisionKind.Ignore, decision.Kind);
-        Assert.Equal(SlackRoutingIgnoreReason.DmMentionRequired, decision.IgnoreReason);
-    }
-
-    [Fact]
-    public void DirectMessage_Processed_WhenMentionRequired_AndMentionPresent()
-    {
-        var message = CreateMessage(text: "<@U1> hey", threadTs: null, isDirectMessage: true);
-
-        var decision = SlackRoutingPolicy.Evaluate(
-            message,
-            mentionOnly: true,
-            allowDirectMessages: true,
-            mentionRequiredInDm: true,
-            threadExists: false,
-            containsBotMention: true);
-
-        Assert.Equal(SlackRoutingDecisionKind.StartOrContinue, decision.Kind);
-        Assert.Null(decision.IgnoreReason);
+        Assert.Equal(expectedKind, decision.Kind);
+        Assert.Equal(expectedReason, decision.IgnoreReason);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ApprovalChannelTests.cs
@@ -11,51 +11,20 @@ namespace Netclaw.Actors.Tests.Sessions;
 
 public sealed class ApprovalChannelTests
 {
-    [Fact]
-    public async Task WaitAndComplete_returns_decision()
+    [Theory]
+    [InlineData(ApprovalDecision.ApprovedOnce)]
+    [InlineData(ApprovalDecision.ApprovedAlways)]
+    [InlineData(ApprovalDecision.ApprovedSession)]
+    [InlineData(ApprovalDecision.Denied)]
+    public async Task WaitAndComplete_returns_expected_decision(ApprovalDecision decision)
     {
         var channel = new ApprovalChannel();
+        var callId = new ToolCallId($"call-{decision}");
 
-        var waitTask = channel.WaitForApprovalAsync(new ToolCallId("call-1"), TimeSpan.FromSeconds(30), CancellationToken.None);
+        var waitTask = channel.WaitForApprovalAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+        channel.Complete(callId, decision);
 
-        // Complete from another context (simulating actor mailbox)
-        channel.Complete(new ToolCallId("call-1"), ApprovalDecision.ApprovedOnce);
-
-        var result = await waitTask;
-        Assert.Equal(ApprovalDecision.ApprovedOnce, result);
-    }
-
-    [Fact]
-    public async Task WaitAndComplete_approve_always()
-    {
-        var channel = new ApprovalChannel();
-
-        var waitTask = channel.WaitForApprovalAsync(new ToolCallId("call-2"), TimeSpan.FromSeconds(30), CancellationToken.None);
-        channel.Complete(new ToolCallId("call-2"), ApprovalDecision.ApprovedAlways);
-
-        Assert.Equal(ApprovalDecision.ApprovedAlways, await waitTask);
-    }
-
-    [Fact]
-    public async Task WaitAndComplete_approve_session()
-    {
-        var channel = new ApprovalChannel();
-
-        var waitTask = channel.WaitForApprovalAsync(new ToolCallId("call-2b"), TimeSpan.FromSeconds(30), CancellationToken.None);
-        channel.Complete(new ToolCallId("call-2b"), ApprovalDecision.ApprovedSession);
-
-        Assert.Equal(ApprovalDecision.ApprovedSession, await waitTask);
-    }
-
-    [Fact]
-    public async Task WaitAndComplete_denied()
-    {
-        var channel = new ApprovalChannel();
-
-        var waitTask = channel.WaitForApprovalAsync(new ToolCallId("call-3"), TimeSpan.FromSeconds(30), CancellationToken.None);
-        channel.Complete(new ToolCallId("call-3"), ApprovalDecision.Denied);
-
-        Assert.Equal(ApprovalDecision.Denied, await waitTask);
+        Assert.Equal(decision, await waitTask);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -425,7 +425,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
             return;
 
         var canonicalAnchor = decision.CanonicalAnchorName ?? operation.AnchorCanonicalName;
-        var canonicalAnchorId = $"anchor:{canonicalAnchor.Trim().ToLowerInvariant().Replace(' ', '-')}";
+        var canonicalAnchorId = MemoryTypedId.AnchorId(canonicalAnchor);
 
         // For each consolidation target document, re-anchor it if it belongs to a different anchor,
         // then tombstone the redundant anchor

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -81,8 +81,6 @@ public sealed record MemoryCheckpointCandidate(
 
 public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
 {
-    private static readonly TimeSpan EvidenceExpiry = TimeSpan.FromDays(30);
-    private static readonly TimeSpan TraceExpiry = TimeSpan.FromHours(72);
     private static readonly Regex ProjectStatementPattern = new(
         "^(?<subject>(?:[A-Z][A-Za-z0-9.+-]*)(?:\\s+[A-Z][A-Za-z0-9.+-]*){0,4}|(?:our|the)\\s+[a-z][a-z0-9_-]*(?:\\s+[a-z][a-z0-9_-]*){0,4})\\s+(?<verb>has|have|uses|use|supports|support|requires|require|needs|need|completed|completes)\\s+(?<object>.+)$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -251,8 +249,8 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
 
         return memoryClass switch
         {
-            MemoryClass.Evidence => freshnessAt.Value + (long)EvidenceExpiry.TotalMilliseconds,
-            MemoryClass.Trace => freshnessAt.Value + (long)TraceExpiry.TotalMilliseconds,
+            MemoryClass.Evidence => freshnessAt.Value + (long)MemoryExpiryDefaults.EvidenceExpiry.TotalMilliseconds,
+            MemoryClass.Trace => freshnessAt.Value + (long)MemoryExpiryDefaults.TraceExpiry.TotalMilliseconds,
             _ => null
         };
     }

--- a/src/Netclaw.Actors/Memory/MemoryExpiryDefaults.cs
+++ b/src/Netclaw.Actors/Memory/MemoryExpiryDefaults.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemoryExpiryDefaults.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Memory;
+
+internal static class MemoryExpiryDefaults
+{
+    internal static readonly TimeSpan EvidenceExpiry = TimeSpan.FromDays(30);
+    internal static readonly TimeSpan TraceExpiry = TimeSpan.FromHours(72);
+}

--- a/src/Netclaw.Actors/Memory/MemoryPolicyGates.cs
+++ b/src/Netclaw.Actors/Memory/MemoryPolicyGates.cs
@@ -41,8 +41,6 @@ public sealed class MemoryProposalGate
         IReadOnlyDictionary<string, int> RejectionReasons);
 
     private const int MaxProposalsPerRun = 3;
-    private static readonly TimeSpan EvidenceExpiry = TimeSpan.FromDays(30);
-    private static readonly TimeSpan TraceExpiry = TimeSpan.FromHours(72);
     private static readonly Regex IdentityTitlePattern = new(
         "\\b(name|tone|style|voice|persona|communication preference|response preference)\\b",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -205,8 +203,8 @@ public sealed class MemoryProposalGate
 
         return memoryClass switch
         {
-            MemoryClass.Evidence => freshnessAt + (long)EvidenceExpiry.TotalMilliseconds,
-            MemoryClass.Trace => freshnessAt + (long)TraceExpiry.TotalMilliseconds,
+            MemoryClass.Evidence => freshnessAt + (long)MemoryExpiryDefaults.EvidenceExpiry.TotalMilliseconds,
+            MemoryClass.Trace => freshnessAt + (long)MemoryExpiryDefaults.TraceExpiry.TotalMilliseconds,
             _ => null
         };
     }

--- a/src/Netclaw.Actors/Memory/MemoryTypedId.cs
+++ b/src/Netclaw.Actors/Memory/MemoryTypedId.cs
@@ -6,8 +6,8 @@
 namespace Netclaw.Actors.Memory;
 
 /// <summary>
-/// Strongly-typed memory identity that includes a kind prefix (doc: or rec:).
-/// Centralizes parse/format logic previously duplicated across tool and store files.
+/// Strongly-typed memory identity with kind prefix (doc: or rec:).
+/// Centralizes ID parsing, formatting, and generation for the memory subsystem.
 /// </summary>
 public readonly record struct MemoryTypedId(MemoryKind Kind, string Id)
 {
@@ -35,4 +35,11 @@ public readonly record struct MemoryTypedId(MemoryKind Kind, string Id)
     }
 
     public override string ToString() => ToWireValue();
+
+    public static string AnchorId(string canonicalName)
+        => $"anchor:{canonicalName.Trim().ToLowerInvariant().Replace(' ', '-')}";
+
+    public static string NewDocumentId() => $"doc-{Guid.NewGuid():N}";
+
+    public static string NewRecordId() => $"rec-{Guid.NewGuid():N}";
 }

--- a/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
+++ b/src/Netclaw.Actors/Memory/SQLiteMemoryStore.cs
@@ -984,7 +984,7 @@ public sealed class SQLiteMemoryStore
         }
 
         var now = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
-        var newId = $"rec-{Guid.NewGuid():N}";
+        var newId = MemoryTypedId.NewRecordId();
 
         await using var insert = conn.CreateCommand();
         insert.Transaction = tx;
@@ -1067,7 +1067,7 @@ public sealed class SQLiteMemoryStore
         }
 
         // Build the expected anchor ID for exact match detection
-        var normalizedProposedId = $"anchor:{proposedAnchorName.Trim().ToLowerInvariant().Replace(' ', '-')}";
+        var normalizedProposedId = MemoryTypedId.AnchorId(proposedAnchorName);
         var proposedTokens = AnchorNameMatcher.Tokenize(proposedAnchorName);
 
         var candidates = new List<ExistingMemoryCandidate>();
@@ -1239,7 +1239,7 @@ public sealed class SQLiteMemoryStore
 
             if (operation.Kind == MemoryKind.Record.ToWireValue())
             {
-                var recId = string.IsNullOrWhiteSpace(operation.MemoryId) ? $"rec-{Guid.NewGuid():N}" : operation.MemoryId;
+                var recId = string.IsNullOrWhiteSpace(operation.MemoryId) ? MemoryTypedId.NewRecordId() : operation.MemoryId;
                 await using var recordCmd = conn.CreateCommand();
                 recordCmd.Transaction = tx;
                 recordCmd.CommandText = """
@@ -1299,11 +1299,11 @@ public sealed class SQLiteMemoryStore
                     """;
                 lookupCmd.Parameters.AddWithValue("$anchorId", anchor.AnchorId);
                 documentId = (string?)await lookupCmd.ExecuteScalarAsync(ct)
-                    ?? $"doc-{Guid.NewGuid():N}";
+                    ?? MemoryTypedId.NewDocumentId();
             }
             else
             {
-                documentId = $"doc-{Guid.NewGuid():N}";
+                documentId = MemoryTypedId.NewDocumentId();
             }
 
             await using var documentCmd = conn.CreateCommand();
@@ -1394,7 +1394,7 @@ public sealed class SQLiteMemoryStore
 
             if (operation.Kind == MemoryKind.Record.ToWireValue())
             {
-                var recId = string.IsNullOrWhiteSpace(operation.MemoryId) ? $"rec-{Guid.NewGuid():N}" : operation.MemoryId;
+                var recId = string.IsNullOrWhiteSpace(operation.MemoryId) ? MemoryTypedId.NewRecordId() : operation.MemoryId;
                 await using var recordCmd = conn.CreateCommand();
                 recordCmd.Transaction = tx;
                 recordCmd.CommandText = """
@@ -1457,11 +1457,11 @@ public sealed class SQLiteMemoryStore
                     """;
                 lookupCmd.Parameters.AddWithValue("$anchorId", anchor.AnchorId);
                 documentId = (string?)await lookupCmd.ExecuteScalarAsync(ct)
-                    ?? $"doc-{Guid.NewGuid():N}";
+                    ?? MemoryTypedId.NewDocumentId();
             }
             else
             {
-                documentId = $"doc-{Guid.NewGuid():N}";
+                documentId = MemoryTypedId.NewDocumentId();
             }
 
             await using var documentCmd = conn.CreateCommand();
@@ -1686,7 +1686,7 @@ public sealed class SQLiteMemoryStore
     {
         var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         return new SQLiteMemoryAnchor(
-            AnchorId: $"anchor:{canonicalName.Trim().ToLowerInvariant().Replace(' ', '-')}",
+            AnchorId: MemoryTypedId.AnchorId(canonicalName),
             AnchorType: "concept",
             CanonicalName: canonicalName,
             ParentAnchorId: null,

--- a/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
+++ b/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
@@ -74,7 +74,7 @@ public static class DiscordAclPolicy
         {
             return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
                 ? new AudienceResult(channelAudience)
-                : new AudienceResult($"invalid_channel_audience:{message.ChannelId.Value}={channelOverride}");
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:{message.ChannelId.Value}={channelOverride}");
         }
 
         if (message.IsDirectMessage
@@ -82,7 +82,7 @@ public static class DiscordAclPolicy
         {
             return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
                 ? new AudienceResult(dmAudience)
-                : new AudienceResult($"invalid_channel_audience:dm={dmOverride}");
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:dm={dmOverride}");
         }
 
         var audience = (message.IsDirectMessage || isExplicitUser || isExplicitChannel)

--- a/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
+++ b/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
@@ -31,7 +31,9 @@ public static class DiscordAclPolicy
 
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
-        var audienceResult = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
+        var audienceResult = AudienceResult.Resolve(
+            message.ChannelId.Value, message.IsDirectMessage,
+            options.ChannelAudiences, isExplicitUser, isExplicitChannel);
         if (audienceResult.Error is not null)
             return ChannelAclDecision.Deny(audienceResult.Error);
 
@@ -62,33 +64,6 @@ public static class DiscordAclPolicy
             return true;
 
         return options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
-    }
-
-    internal static AudienceResult ResolveAudience(
-        DiscordGatewayMessage message,
-        DiscordChannelOptions options,
-        bool isExplicitUser,
-        bool isExplicitChannel)
-    {
-        if (options.ChannelAudiences.TryGetValue(message.ChannelId.Value, out var channelOverride))
-        {
-            return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
-                ? new AudienceResult(channelAudience)
-                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:{message.ChannelId.Value}={channelOverride}");
-        }
-
-        if (message.IsDirectMessage
-            && options.ChannelAudiences.TryGetValue("dm", out var dmOverride))
-        {
-            return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
-                ? new AudienceResult(dmAudience)
-                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:dm={dmOverride}");
-        }
-
-        var audience = (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
-            ? TrustAudience.Team
-            : TrustAudience.Public;
-        return new AudienceResult(audience);
     }
 
 }

--- a/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
+++ b/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
@@ -10,37 +10,37 @@ namespace Netclaw.Channels.Discord;
 
 public static class DiscordAclPolicy
 {
-    public static DiscordAclDecision EvaluateInbound(
+    public static ChannelAclDecision EvaluateInbound(
         DiscordGatewayMessage message,
         DiscordChannelOptions options,
         DiscordChannelId? defaultChannelId)
     {
         if (string.IsNullOrWhiteSpace(message.SenderId.Value))
-            return DiscordAclDecision.Deny("missing_user_id");
+            return ChannelAclDecision.Deny(AclDenyReasons.MissingUserId);
 
         if (message.IsDirectMessage && !options.AllowDirectMessages)
-            return DiscordAclDecision.Deny("direct_messages_disabled");
+            return ChannelAclDecision.Deny(AclDenyReasons.DirectMessagesDisabled);
 
         if (!message.IsDirectMessage
             && !IsAllowedChannel(message.ChannelId, options, defaultChannelId))
-            return DiscordAclDecision.Deny("channel_not_allowed");
+            return ChannelAclDecision.Deny(AclDenyReasons.ChannelNotAllowed);
 
         var isExplicitUser = options.AllowedUserIds.Contains(message.SenderId.Value, StringComparer.Ordinal);
         if (options.AllowedUserIds.Length > 0 && !isExplicitUser)
-            return DiscordAclDecision.Deny("user_not_allowed");
+            return ChannelAclDecision.Deny(AclDenyReasons.UserNotAllowed);
 
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
         var audienceResult = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
         if (audienceResult.Error is not null)
-            return DiscordAclDecision.Deny(audienceResult.Error);
+            return ChannelAclDecision.Deny(audienceResult.Error);
 
         var audience = audienceResult.Audience;
         var principal = isExplicitUser
             ? PrincipalClassification.TrustedInternal
             : PrincipalClassification.UntrustedExternal;
 
-        return DiscordAclDecision.Allow(
+        return ChannelAclDecision.Allow(
             audience,
             principal,
             new SourceProvenance
@@ -91,29 +91,4 @@ public static class DiscordAclPolicy
         return new AudienceResult(audience);
     }
 
-}
-
-public sealed record DiscordAclDecision(
-    bool IsAllowed,
-    string? DenyReason,
-    TrustAudience Audience,
-    PrincipalClassification Principal,
-    SourceProvenance Provenance) : IAclDecision
-{
-    public static DiscordAclDecision Deny(string reason) => new(
-        false,
-        reason,
-        TrustAudience.Public,
-        PrincipalClassification.UntrustedExternal,
-        SourceProvenance.StrictDefault());
-
-    public static DiscordAclDecision Allow(
-        TrustAudience audience,
-        PrincipalClassification principal,
-        SourceProvenance provenance) => new(
-        true,
-        null,
-        audience,
-        principal,
-        provenance);
 }

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -413,23 +413,10 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
     {
         var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
         var isDirectMessage = string.Equals(channelId.Value, threadOrMessageId.Value, StringComparison.Ordinal);
-        var syntheticMessage = new DiscordGatewayMessage(
-            EventId: new DiscordEventId($"history-{channelId.Value}"),
-            ChannelId: channelId,
-            ReplyChannelId: new DiscordReplyChannelId(threadOrMessageId.Value),
-            MessageId: new DiscordMessageId($"history-{channelId.Value}"),
-            ThreadOrMessageId: threadOrMessageId,
-            RootMessageId: null,
-            SenderId: new DiscordUserId("history"),
-            IsBotMessage: false,
-            IsDirectMessage: isDirectMessage,
-            ContainsBotMention: false,
-            Text: string.Empty,
-            ReceivedAt: TimeProvider.System.GetUtcNow());
 
-        return DiscordAclPolicy.ResolveAudience(
-            syntheticMessage,
-            _options,
+        return AudienceResult.Resolve(
+            channelId.Value, isDirectMessage,
+            _options.ChannelAudiences,
             isExplicitUser: false,
             isExplicitChannel: isExplicitChannel);
     }

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -90,7 +90,7 @@ public static class SlackAclPolicy
         {
             return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
                 ? new AudienceResult(channelAudience)
-                : new AudienceResult($"invalid_channel_audience:{message.ChannelId.Value}={channelOverride}");
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:{message.ChannelId.Value}={channelOverride}");
         }
 
         // 2. DM key mapping
@@ -99,7 +99,7 @@ public static class SlackAclPolicy
         {
             return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
                 ? new AudienceResult(dmAudience)
-                : new AudienceResult($"invalid_channel_audience:dm={dmOverride}");
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:dm={dmOverride}");
         }
 
         // 3. Existing heuristic fallback (no key matched — this is the only legitimate fallback)

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -15,30 +15,30 @@ namespace Netclaw.Channels.Slack;
 /// </summary>
 public static class SlackAclPolicy
 {
-    public static SlackAclDecision EvaluateInbound(
+    public static ChannelAclDecision EvaluateInbound(
         SlackInboundMessage message,
         SlackChannelOptions options,
         SlackChannelId? defaultChannelId)
     {
         if (message.UserId is not { } userId)
-            return SlackAclDecision.Deny("missing_user_id");
+            return ChannelAclDecision.Deny(AclDenyReasons.MissingUserId);
 
         var isConversationAllowed = message.IsDirectMessage
             ? options.AllowDirectMessages
             : IsAllowedChannel(message.ChannelId, options, defaultChannelId);
 
         if (!isConversationAllowed)
-            return SlackAclDecision.Deny("channel_not_allowed");
+            return ChannelAclDecision.Deny(AclDenyReasons.ChannelNotAllowed);
 
         if (!IsAllowedUser(userId, options))
-            return SlackAclDecision.Deny("user_not_allowed");
+            return ChannelAclDecision.Deny(AclDenyReasons.UserNotAllowed);
 
         var isExplicitUser = options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
         var audienceResult = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
         if (audienceResult.Error is not null)
-            return SlackAclDecision.Deny(audienceResult.Error);
+            return ChannelAclDecision.Deny(audienceResult.Error);
 
         var audience = audienceResult.Audience;
 
@@ -46,7 +46,7 @@ public static class SlackAclPolicy
             ? PrincipalClassification.TrustedInternal
             : PrincipalClassification.UntrustedExternal;
 
-        return SlackAclDecision.Allow(
+        return ChannelAclDecision.Allow(
             audience,
             principal,
             new SourceProvenance
@@ -119,29 +119,4 @@ public static class SlackAclPolicy
 
         return options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
     }
-}
-
-public sealed record SlackAclDecision(
-    bool IsAllowed,
-    string? DenyReason,
-    TrustAudience Audience,
-    PrincipalClassification Principal,
-    SourceProvenance Provenance) : IAclDecision
-{
-    public static SlackAclDecision Deny(string reason) => new(
-        false,
-        reason,
-        TrustAudience.Public,
-        PrincipalClassification.UntrustedExternal,
-        SourceProvenance.StrictDefault());
-
-    public static SlackAclDecision Allow(
-        TrustAudience audience,
-        PrincipalClassification principal,
-        SourceProvenance provenance) => new(
-        true,
-        null,
-        audience,
-        principal,
-        provenance);
 }

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -23,11 +23,11 @@ public static class SlackAclPolicy
         if (message.UserId is not { } userId)
             return ChannelAclDecision.Deny(AclDenyReasons.MissingUserId);
 
-        var isConversationAllowed = message.IsDirectMessage
-            ? options.AllowDirectMessages
-            : IsAllowedChannel(message.ChannelId, options, defaultChannelId);
+        if (message.IsDirectMessage && !options.AllowDirectMessages)
+            return ChannelAclDecision.Deny(AclDenyReasons.DirectMessagesDisabled);
 
-        if (!isConversationAllowed)
+        if (!message.IsDirectMessage
+            && !IsAllowedChannel(message.ChannelId, options, defaultChannelId))
             return ChannelAclDecision.Deny(AclDenyReasons.ChannelNotAllowed);
 
         if (!IsAllowedUser(userId, options))
@@ -36,7 +36,9 @@ public static class SlackAclPolicy
         var isExplicitUser = options.AllowedUserIds.Contains(userId.Value, StringComparer.Ordinal);
         var isExplicitChannel = options.AllowedChannelIds.Contains(message.ChannelId.Value, StringComparer.Ordinal);
 
-        var audienceResult = ResolveAudience(message, options, isExplicitUser, isExplicitChannel);
+        var audienceResult = AudienceResult.Resolve(
+            message.ChannelId.Value, message.IsDirectMessage,
+            options.ChannelAudiences, isExplicitUser, isExplicitChannel);
         if (audienceResult.Error is not null)
             return ChannelAclDecision.Deny(audienceResult.Error);
 
@@ -71,42 +73,6 @@ public static class SlackAclPolicy
             return true;
 
         return options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
-    }
-
-    /// <summary>
-    /// Resolves audience via: explicit channel ID → "dm" key → existing heuristic fallback.
-    /// Returns an error when a <see cref="SlackChannelOptions.ChannelAudiences"/> key matches
-    /// but the value is not a recognized audience string — this is a config error, not a
-    /// "fall through to default" situation.
-    /// </summary>
-    internal static AudienceResult ResolveAudience(
-        SlackInboundMessage message,
-        SlackChannelOptions options,
-        bool isExplicitUser,
-        bool isExplicitChannel)
-    {
-        // 1. Explicit channel ID mapping
-        if (options.ChannelAudiences.TryGetValue(message.ChannelId.Value, out var channelOverride))
-        {
-            return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
-                ? new AudienceResult(channelAudience)
-                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:{message.ChannelId.Value}={channelOverride}");
-        }
-
-        // 2. DM key mapping
-        if (message.IsDirectMessage
-            && options.ChannelAudiences.TryGetValue("dm", out var dmOverride))
-        {
-            return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
-                ? new AudienceResult(dmAudience)
-                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:dm={dmOverride}");
-        }
-
-        // 3. Existing heuristic fallback (no key matched — this is the only legitimate fallback)
-        var audience = (message.IsDirectMessage || isExplicitUser || isExplicitChannel)
-            ? TrustAudience.Team
-            : TrustAudience.Public;
-        return new AudienceResult(audience);
     }
 
     /// <summary>

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -427,22 +427,11 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
     private AudienceResult ResolveHistoricalAudience(SlackChannelId channelId, SlackThreadTs threadTs)
     {
         var isExplicitChannel = _options.AllowedChannelIds.Contains(channelId.Value, StringComparer.Ordinal);
-        var syntheticMessage = new SlackInboundMessage(
-            Kind: SlackInboundKind.Message,
-            EventId: new SlackEventId($"history:{threadTs.Value}"),
-            ChannelId: channelId,
-            ThreadTs: threadTs,
-            EventTs: new SlackEventTs(threadTs.Value),
-            UserId: null,
-            BotId: null,
-            Text: string.Empty,
-            Subtype: null,
-            Hidden: false,
-            IsDirectMessage: channelId.Value.StartsWith("D", StringComparison.Ordinal));
+        var isDirectMessage = channelId.Value.StartsWith("D", StringComparison.Ordinal);
 
-        return SlackAclPolicy.ResolveAudience(
-            syntheticMessage,
-            _options,
+        return AudienceResult.Resolve(
+            channelId.Value, isDirectMessage,
+            _options.ChannelAudiences,
             isExplicitUser: false,
             isExplicitChannel: isExplicitChannel);
     }

--- a/src/Netclaw.Channels/AudienceResult.cs
+++ b/src/Netclaw.Channels/AudienceResult.cs
@@ -11,4 +11,35 @@ public readonly record struct AudienceResult(TrustAudience Audience, string? Err
 {
     public AudienceResult(TrustAudience audience) : this(audience, null) { }
     public AudienceResult(string error) : this(default, error) { }
+
+    /// <summary>
+    /// Shared audience resolution: explicit channel ID → "dm" key → heuristic fallback.
+    /// </summary>
+    public static AudienceResult Resolve(
+        string channelId,
+        bool isDirectMessage,
+        IReadOnlyDictionary<string, string> channelAudiences,
+        bool isExplicitUser,
+        bool isExplicitChannel)
+    {
+        if (channelAudiences.TryGetValue(channelId, out var channelOverride))
+        {
+            return SecurityPolicyDefaults.TryParseAudience(channelOverride, out var channelAudience)
+                ? new AudienceResult(channelAudience)
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:{channelId}={channelOverride}");
+        }
+
+        if (isDirectMessage
+            && channelAudiences.TryGetValue("dm", out var dmOverride))
+        {
+            return SecurityPolicyDefaults.TryParseAudience(dmOverride, out var dmAudience)
+                ? new AudienceResult(dmAudience)
+                : new AudienceResult($"{AclDenyReasons.InvalidChannelAudiencePrefix}:dm={dmOverride}");
+        }
+
+        var audience = (isDirectMessage || isExplicitUser || isExplicitChannel)
+            ? TrustAudience.Team
+            : TrustAudience.Public;
+        return new AudienceResult(audience);
+    }
 }

--- a/src/Netclaw.Channels/IAclDecision.cs
+++ b/src/Netclaw.Channels/IAclDecision.cs
@@ -48,4 +48,5 @@ public static class AclDenyReasons
     public const string ChannelNotAllowed = "channel_not_allowed";
     public const string UserNotAllowed = "user_not_allowed";
     public const string DirectMessagesDisabled = "direct_messages_disabled";
+    public const string InvalidChannelAudiencePrefix = "invalid_channel_audience";
 }

--- a/src/Netclaw.Channels/IAclDecision.cs
+++ b/src/Netclaw.Channels/IAclDecision.cs
@@ -16,3 +16,36 @@ public interface IAclDecision
     PrincipalClassification Principal { get; }
     SourceProvenance Provenance { get; }
 }
+
+public sealed record ChannelAclDecision(
+    bool IsAllowed,
+    string? DenyReason,
+    TrustAudience Audience,
+    PrincipalClassification Principal,
+    SourceProvenance Provenance) : IAclDecision
+{
+    public static ChannelAclDecision Deny(string reason) => new(
+        false,
+        reason,
+        TrustAudience.Public,
+        PrincipalClassification.UntrustedExternal,
+        SourceProvenance.StrictDefault());
+
+    public static ChannelAclDecision Allow(
+        TrustAudience audience,
+        PrincipalClassification principal,
+        SourceProvenance provenance) => new(
+        true,
+        null,
+        audience,
+        principal,
+        provenance);
+}
+
+public static class AclDenyReasons
+{
+    public const string MissingUserId = "missing_user_id";
+    public const string ChannelNotAllowed = "channel_not_allowed";
+    public const string UserNotAllowed = "user_not_allowed";
+    public const string DirectMessagesDisabled = "direct_messages_disabled";
+}

--- a/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DaemonRuntimeStatusServiceTests.cs
@@ -292,7 +292,7 @@ public sealed class DaemonRuntimeStatusServiceTests : IAsyncLifetime
         var before = slack.GetSnapshot();
 
         slack.RecordEventReceived("message");
-        slack.RecordEventDropped("channel_not_allowed");
+        slack.RecordEventDropped(AclDenyReasons.ChannelNotAllowed);
         slack.RecordEventRouted("message");
         slack.RecordMessageEnqueued();
         slack.RecordReplyPosted(42);


### PR DESCRIPTION
## Summary

- Consolidate identical `SlackAclDecision` and `DiscordAclDecision` records into a shared `ChannelAclDecision` type in `Netclaw.Channels`
- Extract magic deny-reason strings into `AclDenyReasons` constants used across both ACL policies and tests
- Extract duplicate `ResolveAudience` logic from both ACL policies into `AudienceResult.Resolve()`, eliminating synthetic message construction in thread history fetchers
- Fix Slack DM deny reason: now returns `DirectMessagesDisabled` instead of `ChannelNotAllowed` (matching Discord behavior)
- Convert 14 duplicate `[Fact]` tests into 4 parameterized `[Theory]` tests (approval channel, Slack/Discord DM routing, Discord empty-content)
- Centralize memory ID generation and expiry constants in `MemoryTypedId`

**Net change:** ~200 lines removed across 12 files, no behavior changes except the Slack DM deny-reason correction.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --filter "Channels|Approval|DaemonRuntimeStatus"` — 482 tests pass
- [x] Theory test count matches original Fact count (14 cases across 4 theories)
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Copyright headers verified
- [x] No remaining references to `SlackAclDecision`, `DiscordAclDecision`, or local `ResolveAudience` in policy files