### PR TITLE
fix(tui): clear channel picker subscriptions on sub-step transitions (#792)

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ChannelPickerStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ChannelPickerStepViewModelTests.cs
@@ -8,6 +8,7 @@ using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Cli.Tui.Wizard.Steps;
 using Netclaw.Configuration;
+using R3;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui.Wizard;
@@ -276,5 +277,62 @@ public sealed class ChannelPickerStepViewModelTests : WizardStepTestBase
         Assert.True(picker.IsInPickerMode);
         // Should still be enabled because it was previously configured
         Assert.True(picker.IsAdapterEnabled(0));
+    }
+
+    // ── Regression tests for subscription accumulation (#792) ──
+
+    private StepViewCallbacks CreateTestCallbacks(CompositeDisposable subs) => new()
+    {
+        Subscriptions = subs,
+        InvalidateContent = () => { },
+        InvalidateHelp = () => { },
+        AdvanceStep = () => { },
+        RequestRedraw = () => { },
+    };
+
+    [Fact]
+    public void SubFlow_BuildContent_ClearsSubscriptionsOnReRender()
+    {
+        using var picker = new ChannelPickerStepViewModel(_fakeProbe, _fakeDiscordProbe);
+        var view = new ChannelPickerStepView();
+        using var subs = new CompositeDisposable();
+        var callbacks = CreateTestCallbacks(subs);
+
+        picker.OnEnter(Context, NavigationDirection.Forward);
+        picker.ToggleAdapter(0); // Slack sub-flow at bot token sub-step
+
+        // First render — adds subscriptions from SlackStepView.BuildBotTokenSubStep
+        view.BuildContent(picker, callbacks);
+        var countAfterFirst = subs.Count;
+        Assert.True(countAfterFirst > 0, "SlackStepView should add at least one subscription");
+
+        // Simulate a cursor-blink-timer re-render of the same sub-step
+        view.BuildContent(picker, callbacks);
+        Assert.Equal(countAfterFirst, subs.Count);
+    }
+
+    [Fact]
+    public void SubFlow_BuildContent_ClearsSubscriptionsAcrossSubStepTransitions()
+    {
+        using var picker = new ChannelPickerStepViewModel(_fakeProbe, _fakeDiscordProbe);
+        var view = new ChannelPickerStepView();
+        using var subs = new CompositeDisposable();
+        var callbacks = CreateTestCallbacks(subs);
+
+        picker.OnEnter(Context, NavigationDirection.Forward);
+        picker.ToggleAdapter(0); // Slack sub-flow
+
+        // Render bot token sub-step
+        view.BuildContent(picker, callbacks);
+        var countAtBotToken = subs.Count;
+
+        // Advance to app token sub-step
+        picker.TryAdvance();
+        view.BuildContent(picker, callbacks);
+
+        // Subscription count should not grow — old subs cleared before new ones added
+        Assert.True(subs.Count <= countAtBotToken,
+            $"Subscriptions should not accumulate across sub-steps: " +
+            $"bot token had {countAtBotToken}, app token has {subs.Count}");
     }
 }

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -191,6 +191,9 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
             if (step is null) return Layouts.Empty();
 
             var currentView = ViewModel.StepViews[step.StepId];
+            // Views with ManagesOwnFocusState = true must clear
+            // callbacks.Subscriptions themselves to prevent subscription
+            // accumulation on cursor-blink-timer re-renders (#792).
             if (!currentView.ManagesOwnFocusState)
             {
                 _stepSubs.Clear();

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelPickerStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelPickerStepView.cs
@@ -31,8 +31,16 @@ public sealed class ChannelPickerStepView : IWizardStepView
         _vm = (ChannelPickerStepViewModel)stepVm;
         _callbacks = callbacks;
 
+        // ManagesOwnFocusState = true prevents InitWizardPage from clearing
+        // step-scoped subscriptions. Clear here to prevent accumulation across
+        // sub-step transitions and cursor-blink-timer re-renders (#792).
+        callbacks.Subscriptions.Clear();
+
         if (_vm.IsInSubFlow && _vm.ActiveAdapterVm is not null && _vm.ActiveAdapterView is not null)
+        {
+            _vm.ActiveAdapterView.ClearFocusState();
             return _vm.ActiveAdapterView.BuildContent(_vm.ActiveAdapterVm, callbacks);
+        }
 
         return BuildPickerChecklist();
     }


### PR DESCRIPTION
## Summary

- Fix subscription accumulation race in `ChannelPickerStepView` that caused Slack/Discord bot token sub-step to loop instead of advancing (#792)
- `ManagesOwnFocusState = true` prevented `InitWizardPage` from clearing step-scoped subscriptions; now `ChannelPickerStepView.BuildContent()` clears them itself before delegating to adapter views
- Add `ClearFocusState()` call on adapter view before delegation to prevent stale `TextInputNode` instances from intercepting keys
- Add 2 deterministic regression tests verifying subscription count stays bounded across re-renders and sub-step transitions

## Test plan

- [x] All 544 existing tests pass (`dotnet test src/Netclaw.Cli.Tests/`)
- [x] New regression tests pass: `SubFlow_BuildContent_ClearsSubscriptionsOnReRender`, `SubFlow_BuildContent_ClearsSubscriptionsAcrossSubStepTransitions`
- [x] `dotnet slopwatch analyze` — no new violations
- [x] Copyright headers verified
- [ ] Manual: `netclaw init` → Channel Picker → Slack → enter `xoxb-...` → press Enter → should advance to App Token

Closes #792