### PR TITLE
refactor(tests): consolidate LlmSession integration test boilerplate

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -35,6 +35,8 @@ public class CompactionIntegrationTests : LlmSessionTestBase
     protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
+        // Small context window so 0.75 threshold (750 tokens) is easy to exceed.
+        // KeepRecentMessages=0 so single-turn tests actually reduce message count.
         services.AddSingleton(new ModelCapabilities
         {
             ModelId = "fake-model",

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -5,11 +5,8 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
@@ -25,17 +22,17 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Verifies: threshold trigger, tool result clearing, structured summarization,
 /// session recovery after compaction, and buffer drain post-compaction.
 /// </summary>
-public class CompactionIntegrationTests : TestKit
+public class CompactionIntegrationTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeMemoryExtractor _fakeMemoryExtractor = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
 
-    public CompactionIntegrationTests(ITestOutputHelper output) : base(output: output)
+    public CompactionIntegrationTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
@@ -43,15 +40,13 @@ public class CompactionIntegrationTests : TestKit
             ModelId = "fake-model",
             ContextWindowTokens = 1000,
         });
-        // Small context window for easy threshold triggering in tests.
-        // KeepRecentMessages=0 so minimal-history tests (1 turn) actually reduce message count.
         services.AddSingleton(new SessionConfig
         {
             TurnLlmTimeout = TimeSpan.FromSeconds(1),
             SidecarLlmTimeout = TimeSpan.FromSeconds(1),
             Tuning = new SessionTuning
             {
-                CompactionThreshold = 0.75, // 750 tokens triggers compaction
+                CompactionThreshold = 0.75,
                 SnapshotInterval = 5,
                 KeepRecentToolResults = 1,
                 KeepRecentMessages = 0,
@@ -61,48 +56,13 @@ public class CompactionIntegrationTests : TestKit
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
         services.AddSingleton<IMemoryExtractor>(_fakeMemoryExtractor);
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
 
-        // Tool registry + fake executor so tool-execution tests can exercise
-        // the WorkingContext-through-compaction path. Other tests in this
-        // class don't drive tool calls and are unaffected.
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
         var registry = new ToolRegistry();
         registry.Register(
             AIFunctionFactory.Create((string path) => $"contents of {path}", "file_read"),
             "file_read");
         services.AddSingleton(registry);
-
-        services.AddTestNetclawPaths();
-
-        // Composite records for LlmSessionActor constructor
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ErrorCorrelationTests.cs
@@ -5,13 +5,9 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Hosting;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
@@ -24,11 +20,11 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// carries a non-empty <see cref="ErrorOutput.CorrelationId"/> and a correctly
 /// classified <see cref="ErrorOutput.Category"/>.
 /// </summary>
-public sealed class ErrorCorrelationTests(ITestOutputHelper output) : TestKit(output: output)
+public sealed class ErrorCorrelationTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
     private readonly FailingChatClient _chatClient = new();
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
         services.AddSingleton(new ModelCapabilities
@@ -48,29 +44,6 @@ public sealed class ErrorCorrelationTests(ITestOutputHelper output) : TestKit(ou
             }
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -5,13 +5,10 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Akka.Streams;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
@@ -30,18 +27,18 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Subscribers join sessions directly via <see cref="JoinSession"/> and receive
 /// <see cref="SessionOutput"/> events filtered by <see cref="OutputFilter"/>.
 /// </summary>
-public class LlmSessionIntegrationTests : TestKit
+public class LlmSessionIntegrationTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.Parse("2026-03-21T12:00:00Z"));
     private readonly RecordingSessionLifecycleObserver _lifecycleObserver = new();
 
-    public LlmSessionIntegrationTests(ITestOutputHelper output) : base(output: output)
+    public LlmSessionIntegrationTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
@@ -79,41 +76,9 @@ public class LlmSessionIntegrationTests : TestKit
 
         services.AddSingleton(registry);
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
         services.AddSingleton<TimeProvider>(_timeProvider);
         services.AddSingleton<ISessionLifecycleObserver>(_lifecycleObserver);
         services.AddSingleton<ISessionPipeline>(new UnusedSessionPipeline());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(sp => new SessionObservability(
-            sp.GetService<Telemetry.ISessionMetrics>(),
-            sp.GetService<ISessionLifecycleObserver>()));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionStreamingTimeoutTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionStreamingTimeoutTests.cs
@@ -6,13 +6,9 @@
 using System.Runtime.CompilerServices;
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Hosting;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
@@ -21,11 +17,11 @@ using AiChatRole = Microsoft.Extensions.AI.ChatRole;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
-public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : TestKit(output: output)
+public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
     private readonly StreamingTimeoutTestChatClient _chatClient = new();
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
         services.AddSingleton(new ModelCapabilities
@@ -45,29 +41,6 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             }
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]
@@ -179,19 +152,11 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
         {
             return Mode switch
             {
-                StreamMode.HangForever => NeverCompletesAsync(CancellationToken.None),
+                StreamMode.HangForever => TestStreamingHelpers.NeverCompletesAsync(CancellationToken.None),
                 StreamMode.EmitThenHang => EmitThenHangAsync(cancellationToken),
-                StreamMode.SucceedImmediately => ReturnTextAsync("success response", cancellationToken),
+                StreamMode.SucceedImmediately => TestStreamingHelpers.ReturnTextAsync("success response", cancellationToken),
                 _ => throw new InvalidOperationException()
             };
-        }
-
-        private static async IAsyncEnumerable<ChatResponseUpdate> NeverCompletesAsync(
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            await gate.Task;
-            yield break;
         }
 
         private static async IAsyncEnumerable<ChatResponseUpdate> EmitThenHangAsync(
@@ -220,22 +185,6 @@ public sealed class LlmSessionStreamingTimeoutTests(ITestOutputHelper output) : 
             var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await gate.Task;
             yield break;
-        }
-
-        private static async IAsyncEnumerable<ChatResponseUpdate> ReturnTextAsync(
-            string text,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            var response = new ChatResponse(new ChatMessage(
-                AiChatRole.Assistant,
-                [new TextContent(text)]));
-
-            foreach (var update in response.ToChatResponseUpdates())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return update;
-                await Task.Yield();
-            }
         }
 
         public object? GetService(Type serviceType, object? serviceKey = null) => null;

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmSessionTestBase.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Persistence.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Hosting;
+using Netclaw.Configuration;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public abstract class LlmSessionTestBase : TestKit
+{
+    protected LlmSessionTestBase(ITestOutputHelper output) : base(output: output) { }
+
+    protected sealed override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithInMemoryJournal()
+            .WithInMemorySnapshotStore()
+            .WithNetclawActors();
+    }
+
+    protected sealed override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
+        services.AddTestNetclawPaths();
+        ConfigureSessionServices(services);
+        services.AddLlmSessionCompositeRecords();
+    }
+
+    protected virtual void ConfigureSessionServices(IServiceCollection services) { }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestExtensions.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlmSessionTestExtensions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Memory;
+using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Skills;
+using Netclaw.Actors.SubAgents;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+internal static class LlmSessionTestExtensions
+{
+    public static IServiceCollection AddLlmSessionCompositeRecords(this IServiceCollection services)
+    {
+        services.TryAddSingleton(sp => new SessionServices(
+            sp.GetRequiredService<IChatClientProvider>(),
+            sp.GetRequiredService<ISystemPromptProvider>(),
+            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
+            sp.GetService<TimeProvider>() ?? TimeProvider.System,
+            sp.GetRequiredService<NetclawPaths>()));
+
+        services.TryAddSingleton(sp => new SessionMemoryServices(
+            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
+            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
+            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
+            sp.GetService<SQLiteMemoryStore>()));
+
+        services.TryAddSingleton(sp => new SessionObservability(
+            sp.GetService<Telemetry.ISessionMetrics>(),
+            sp.GetService<ISessionLifecycleObserver>()));
+
+        if (services.Any(d => d.ServiceType == typeof(IToolExecutor)))
+        {
+            services.TryAddSingleton(sp => new SessionToolServices(
+                sp.GetRequiredService<IToolExecutor>(),
+                sp.GetService<IToolAuditLogger>(),
+                sp.GetRequiredService<ToolRegistry>(),
+                sp.GetService<ToolAccessPolicy>(),
+                sp.GetService<TrustContextDeriver>(),
+                sp.GetService<SkillRegistry>(),
+                sp.GetService<IToolApprovalService>(),
+                sp.GetService<SubAgentDefinitionRegistry>(),
+                sp.GetService<SubAgentSpawner>()));
+        }
+
+        return services;
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionWatchdogTests.cs
@@ -3,16 +3,11 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Runtime.CompilerServices;
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Hosting;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
@@ -20,11 +15,11 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
-public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(output: output)
+public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : LlmSessionTestBase(output)
 {
     private readonly HangingStreamingChatClient _chatClient = new();
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_chatClient));
         services.AddSingleton(new ModelCapabilities
@@ -44,29 +39,6 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
             }
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider("You are a test assistant."));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]
@@ -168,33 +140,9 @@ public sealed class LlmSessionWatchdogTests(ITestOutputHelper output) : TestKit(
             var callNumber = Interlocked.Increment(ref _callCount);
 
             if (SucceedAfterFirstTimeout && callNumber > 1)
-                return ReturnTextAsync($"recovered after timeout on call {callNumber}", cancellationToken);
+                return TestStreamingHelpers.ReturnTextAsync($"recovered after timeout on call {callNumber}", cancellationToken);
 
-            return NeverCompletesAsync(CancellationToken.None);
-        }
-
-        private static async IAsyncEnumerable<ChatResponseUpdate> NeverCompletesAsync(
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            await gate.Task;
-            yield break;
-        }
-
-        private static async IAsyncEnumerable<ChatResponseUpdate> ReturnTextAsync(
-            string text,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            var response = new ChatResponse(new ChatMessage(
-                Microsoft.Extensions.AI.ChatRole.Assistant,
-                [new TextContent(text)]));
-
-            foreach (var update in response.ToChatResponseUpdates())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return update;
-                await Task.Yield();
-            }
+            return TestStreamingHelpers.NeverCompletesAsync(CancellationToken.None);
         }
 
         public object? GetService(Type serviceType, object? serviceKey = null) => null;

--- a/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MaxToolIterationTests.cs
@@ -5,15 +5,11 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
@@ -24,17 +20,17 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Integration tests for the max tool iterations safety circuit breaker.
 /// Verifies that unbounded agentic tool loops are terminated after the configured limit.
 /// </summary>
-public class MaxToolIterationTests : TestKit
+public class MaxToolIterationTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeToolAuditLogger _fakeAuditLogger = new();
 
-    public MaxToolIterationTests(ITestOutputHelper output) : base(output: output)
+    public MaxToolIterationTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
@@ -44,7 +40,7 @@ public class MaxToolIterationTests : TestKit
         });
         services.AddSingleton(new SessionConfig
         {
-            MaxToolCallsPerTurn = 3, // Low limit for testing
+            MaxToolCallsPerTurn = 3,
             Tuning = new SessionTuning
             {
                 SnapshotInterval = 5,
@@ -61,36 +57,6 @@ public class MaxToolIterationTests : TestKit
             AIFunctionFactory.Create(() => "search result", "web_search"),
             "web_search");
         services.AddSingleton(registry);
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -5,15 +5,10 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
-using Netclaw.Actors.Memory;
+using Netclaw.Configuration;
 using Netclaw.Actors.Sessions;
 using Xunit;
 
@@ -23,20 +18,20 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Tests the modality gate in <see cref="LlmSessionActor"/>:
 /// images sent to a text-only model are stripped; images sent to a vision model pass through.
 /// </summary>
-public class ModalityGateTextOnlyTests : TestKit
+public class ModalityGateTextOnlyTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
 
-    public ModalityGateTextOnlyTests(ITestOutputHelper output) : base(output: output) { }
+    public ModalityGateTextOnlyTests(ITestOutputHelper output) : base(output) { }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
         {
             ModelId = "text-only-model",
             ContextWindowTokens = 128_000,
-            InputModalities = ModelModality.Text, // no Image flag
+            InputModalities = ModelModality.Text,
         });
         services.AddSingleton(new SessionConfig
         {
@@ -47,29 +42,6 @@ public class ModalityGateTextOnlyTests : TestKit
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]
@@ -176,20 +148,20 @@ public class ModalityGateTextOnlyTests : TestKit
 /// <summary>
 /// Tests that a vision-capable model accepts image references without stripping them.
 /// </summary>
-public class ModalityGateVisionTests : TestKit
+public class ModalityGateVisionTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
 
-    public ModalityGateVisionTests(ITestOutputHelper output) : base(output: output) { }
+    public ModalityGateVisionTests(ITestOutputHelper output) : base(output) { }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
         {
             ModelId = "vision-model",
             ContextWindowTokens = 128_000,
-            InputModalities = ModelModality.Text | ModelModality.Image, // supports vision
+            InputModalities = ModelModality.Text | ModelModality.Image,
         });
         services.AddSingleton(new SessionConfig
         {
@@ -200,29 +172,6 @@ public class ModalityGateVisionTests : TestKit
         });
         services.AddSingleton<ISystemPromptProvider>(new StaticSystemPromptProvider(
             "You are a test assistant."));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentSpawnIntegrationTests.cs
@@ -5,21 +5,16 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Skills;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
-using Netclaw.Actors.Memory;
-using Netclaw.Actors.Tests.Memory;
 using Netclaw.Actors.Tests.SubAgents;
-using Netclaw.Actors.Channels;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -27,7 +22,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Sessions;
 
-public class SubAgentSpawnIntegrationTests : TestKit
+public class SubAgentSpawnIntegrationTests : LlmSessionTestBase
 {
     private const string MainIdentityMarker = "You are a test assistant with subagent support.";
     private const string AgentsLayerMarker = "[agents] This marker should never appear in routed subagent calls.";
@@ -35,11 +30,11 @@ public class SubAgentSpawnIntegrationTests : TestKit
     private readonly RecordingRoleChatClientProvider _clientProvider = new();
     private RecordingContextTool? _recordingFileReadTool;
 
-    public SubAgentSpawnIntegrationTests(ITestOutputHelper output) : base(output: output)
+    public SubAgentSpawnIntegrationTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(_clientProvider);
         services.AddSingleton(new ModelCapabilities
@@ -171,39 +166,6 @@ public class SubAgentSpawnIntegrationTests : TestKit
         services.AddSingleton<IToolExecutor>(new DispatchingToolExecutor(
             registry,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<DispatchingToolExecutor>.Instance));
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>(),
-            sp.GetService<IToolApprovalService>(),
-            sp.GetService<SubAgentDefinitionRegistry>(),
-            sp.GetService<SubAgentSpawner>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/TestStreamingHelpers.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/TestStreamingHelpers.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestStreamingHelpers.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+internal static class TestStreamingHelpers
+{
+    public static async IAsyncEnumerable<ChatResponseUpdate> NeverCompletesAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await gate.Task;
+        yield break;
+    }
+
+    public static async IAsyncEnumerable<ChatResponseUpdate> ReturnTextAsync(
+        string text,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = new ChatResponse(new ChatMessage(
+            ChatRole.Assistant,
+            [new TextContent(text)]));
+
+        foreach (var update in response.ToChatResponseUpdates())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return update;
+            await Task.Yield();
+        }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -5,15 +5,11 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
@@ -24,17 +20,17 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Integration tests for the tool execution loop:
 /// LLM returns tool call → actor executes tool → feeds result back → LLM completes.
 /// </summary>
-public class ToolExecutionIntegrationTests : TestKit
+public class ToolExecutionIntegrationTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeToolAuditLogger _fakeAuditLogger = new();
 
-    public ToolExecutionIntegrationTests(ITestOutputHelper output) : base(output: output)
+    public ToolExecutionIntegrationTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
@@ -56,7 +52,6 @@ public class ToolExecutionIntegrationTests : TestKit
         services.AddSingleton<IToolExecutor>(_fakeToolExecutor);
         services.AddSingleton<IToolAuditLogger>(_fakeAuditLogger);
 
-        // Register a tool in the registry
         var registry = new ToolRegistry();
         registry.Register(
             AIFunctionFactory.Create(() => "search result", "web_search"),
@@ -65,36 +60,6 @@ public class ToolExecutionIntegrationTests : TestKit
             AIFunctionFactory.Create((string path) => $"contents of {path}", "file_read"),
             "file_read");
         services.AddSingleton(registry);
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolLoopCompactionTests.cs
@@ -5,15 +5,11 @@
 // -----------------------------------------------------------------------
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.Hosting.TestKit;
-using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Netclaw.Configuration;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
-using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Xunit;
@@ -25,17 +21,17 @@ namespace Netclaw.Actors.Tests.Sessions;
 /// Verifies that _lastInputTokenCount is updated from tool-call responses and that
 /// ShouldCompact() is checked before firing follow-up LLM calls in the tool loop.
 /// </summary>
-public class ToolLoopCompactionTests : TestKit
+public class ToolLoopCompactionTests : LlmSessionTestBase
 {
     private readonly FakeChatClient _fakeChatClient = new();
     private readonly FakeToolExecutor _fakeToolExecutor = new();
     private readonly FakeToolAuditLogger _fakeAuditLogger = new();
 
-    public ToolLoopCompactionTests(ITestOutputHelper output) : base(output: output)
+    public ToolLoopCompactionTests(ITestOutputHelper output) : base(output)
     {
     }
 
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    protected override void ConfigureSessionServices(IServiceCollection services)
     {
         services.AddSingleton<IChatClientProvider>(new SingleClientProvider(_fakeChatClient));
         services.AddSingleton(new ModelCapabilities
@@ -45,10 +41,10 @@ public class ToolLoopCompactionTests : TestKit
         });
         services.AddSingleton(new SessionConfig
         {
-            MaxToolCallsPerTurn = 10, // High enough that budget doesn't interfere
+            MaxToolCallsPerTurn = 10,
             Tuning = new SessionTuning
             {
-                CompactionThreshold = 0.75, // 750 tokens triggers compaction
+                CompactionThreshold = 0.75,
                 SnapshotInterval = 5,
                 KeepRecentToolResults = 1,
                 KeepRecentMessages = 0,
@@ -65,36 +61,6 @@ public class ToolLoopCompactionTests : TestKit
             AIFunctionFactory.Create(() => "search result", "web_search"),
             "web_search");
         services.AddSingleton(registry);
-        services.AddSingleton<IModelCapabilityResolver>(new FakeCapabilityResolver());
-
-        services.AddTestNetclawPaths();
-        services.AddSingleton(sp => new SessionServices(
-            sp.GetRequiredService<IChatClientProvider>(),
-            sp.GetRequiredService<ISystemPromptProvider>(),
-            sp.GetService<IReadOnlyList<IContextLayerProvider>>() ?? Array.Empty<IContextLayerProvider>(),
-            sp.GetService<TimeProvider>() ?? TimeProvider.System,
-            sp.GetRequiredService<NetclawPaths>()));
-        services.AddSingleton(sp => new SessionToolServices(
-            sp.GetRequiredService<IToolExecutor>(),
-            sp.GetService<IToolAuditLogger>(),
-            sp.GetRequiredService<ToolRegistry>(),
-            sp.GetService<ToolAccessPolicy>(),
-            sp.GetService<Netclaw.Actors.Channels.TrustContextDeriver>(),
-            sp.GetService<Netclaw.Actors.Skills.SkillRegistry>()));
-        services.AddSingleton(sp => new SessionMemoryServices(
-            sp.GetService<IMemoryExtractor>() ?? NullMemoryExtractor.Instance,
-            sp.GetService<IMemoryRecallCoordinator>() ?? NullMemoryRecallCoordinator.Instance,
-            sp.GetService<IMemoryCheckpointSink>() ?? NullMemoryCheckpointSink.Instance,
-            sp.GetService<SQLiteMemoryStore>()));
-        services.AddSingleton(new SessionObservability(null, null));
-    }
-
-    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-    {
-        builder
-            .WithInMemoryJournal()
-            .WithInMemorySnapshotStore()
-            .WithNetclawActors();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Extracts shared DI wiring from 10 LlmSession integration test files into `LlmSessionTestBase` (abstract base class) and `LlmSessionTestExtensions` (composite record registration)
- Extracts duplicated `NeverCompletesAsync` / `ReturnTextAsync` streaming helpers from 2 test files into `TestStreamingHelpers`
- Net reduction: ~265 lines of duplicated boilerplate removed across 10 test files, ~130 lines added in 3 new shared files

## Motivation

Every test file repeated 20-40 lines of identical DI wiring for `SessionServices`, `SessionMemoryServices`, `SessionToolServices`, `SessionObservability`, `ConfigureAkka`, `FakeCapabilityResolver`, and `AddTestNetclawPaths`. Any constructor change to a dependency record required updating all 10 files.

## New shared infrastructure

| File | Purpose |
|------|---------|
| `LlmSessionTestBase.cs` | Abstract TestKit base: sealed `ConfigureAkka` + `ConfigureServices` with `ConfigureSessionServices` hook |
| `LlmSessionTestExtensions.cs` | `AddLlmSessionCompositeRecords()` — registers all 4 composite records via `TryAddSingleton`, conditionally wires `SessionToolServices` when `IToolExecutor` is present |
| `TestStreamingHelpers.cs` | `NeverCompletesAsync()` + `ReturnTextAsync()` for streaming test fakes |

## Test plan

- [x] `dotnet build src/Netclaw.Actors.Tests/` — 0 warnings, 0 errors
- [x] `dotnet test src/Netclaw.Actors.Tests/ --filter "FullyQualifiedName~Sessions"` — all 332 session tests pass
- [x] `dotnet slopwatch analyze` — 0 new violations
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all new files have copyright headers