### PR TITLE
fix(streams): drain output streams before stopping execution actors

### DIFF
--- a/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
+++ b/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
@@ -28,8 +28,11 @@ public sealed class SessionPipelineHandle
     private readonly ILoggingAdapter _log;
     private readonly string _materializerNamePrefix;
 
+    private static readonly TimeSpan StreamDrainTimeout = TimeSpan.FromSeconds(5);
+
     private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
+    private Task? _outputCompletion;
     private ChannelWriter<ChannelInput>? _inputQueue;
     private int _pipelineGeneration;
     private bool _isReinitializing;
@@ -97,13 +100,16 @@ public sealed class SessionPipelineHandle
             .Run(_materializer);
 
         var generation = ++_pipelineGeneration;
-        var outputCompletion = materialized.Output
+        var outputTerminated = materialized.Output
+            .WatchTermination((_, done) => done)
             .ToMaterialized(
                 Sink.ForEach<SessionOutput>(onOutput),
-                Keep.Right)
+                Keep.Left)
             .Run(_materializer);
 
-        _ = outputCompletion.ContinueWith(t =>
+        _outputCompletion = outputTerminated;
+
+        _ = outputTerminated.ContinueWith(t =>
             {
                 var cause = t.IsFaulted ? t.Exception?.GetBaseException() : null;
                 onStreamTerminated(generation, cause);
@@ -144,8 +150,11 @@ public sealed class SessionPipelineHandle
             .ToMaterialized(materialized.Input, Keep.Left)
             .Run(_materializer);
 
-        materialized.Output
-            .To(Sink.ForEach<SessionOutput>(onOutput))
+        _outputCompletion = materialized.Output
+            .WatchTermination((_, done) => done)
+            .ToMaterialized(
+                Sink.ForEach<SessionOutput>(onOutput),
+                Keep.Left)
             .Run(_materializer);
 
         _session = materialized;
@@ -186,6 +195,20 @@ public sealed class SessionPipelineHandle
                 _session = null;
             }
 
+            if (_outputCompletion is not null)
+            {
+                try
+                {
+                    await _outputCompletion.WaitAsync(StreamDrainTimeout);
+                }
+                catch
+                {
+                    // stream faulted or timed out — safe to proceed with materializer disposal
+                }
+
+                _outputCompletion = null;
+            }
+
             _materializer?.Dispose();
             _materializer = null;
 
@@ -205,27 +228,45 @@ public sealed class SessionPipelineHandle
     }
 
     /// <summary>
-    /// Synchronous cleanup for actor <c>PostStop</c>. Completes input queue,
-    /// disposes session and materializer.
+    /// Shuts down the kill switch and waits for the output stream to finish
+    /// draining. Must be called <b>before</b> <c>Context.Stop(Self)</c> so
+    /// that stream stage actors (children of the materializer's actor context)
+    /// complete gracefully rather than being abruptly terminated when the
+    /// parent actor stops.
     /// </summary>
-    public void Dispose()
+    public async Task DrainAsync()
     {
         _inputQueue?.TryComplete();
 
         if (_session is not null)
         {
+            await _session.DisposeAsync();
+            _session = null;
+        }
+
+        if (_outputCompletion is not null)
+        {
             try
             {
-                var vt = _session.DisposeAsync();
-                if (!vt.IsCompletedSuccessfully)
-                    vt.AsTask().GetAwaiter().GetResult();
+                await _outputCompletion.WaitAsync(StreamDrainTimeout);
             }
             catch (Exception ex)
             {
-                _log.Debug(ex, "Failed to dispose {0} session during cleanup", _materializerNamePrefix);
+                _log.Debug(ex, "{0} output stream faulted or timed out during drain", _materializerNamePrefix);
             }
-        }
 
+            _outputCompletion = null;
+        }
+    }
+
+    /// <summary>
+    /// Final cleanup for actor <c>PostStop</c>. Disposes the materializer.
+    /// Stream stages should already be drained via <see cref="DrainAsync"/>
+    /// before the actor stops.
+    /// </summary>
+    public void Dispose()
+    {
+        _inputQueue?.TryComplete();
         _materializer?.Dispose();
     }
 }

--- a/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
+++ b/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SessionPipelineHandle.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -21,6 +21,9 @@ namespace Netclaw.Actors.Channels;
 ///   <item>Long-lived (with reinitialization) for binding actors (Slack, SignalR)</item>
 ///   <item>Short-lived (fire-and-forget) for execution actors (Reminders, Webhooks)</item>
 /// </list>
+/// The handle does not own the <see cref="ActorMaterializer"/>. The owning actor
+/// creates the materializer from its context and passes it in; Akka disposes it
+/// automatically when the actor stops.
 /// </summary>
 public sealed class SessionPipelineHandle
 {
@@ -30,7 +33,6 @@ public sealed class SessionPipelineHandle
 
     private static readonly TimeSpan StreamDrainTimeout = TimeSpan.FromSeconds(5);
 
-    private ActorMaterializer? _materializer;
     private MaterializedSession? _session;
     private Task? _outputCompletion;
     private ChannelWriter<ChannelInput>? _inputQueue;
@@ -88,16 +90,16 @@ public sealed class SessionPipelineHandle
 
         _log.Info("Initializing {0} session pipeline", _materializerNamePrefix);
 
-        _materializer = context.Materializer(namePrefix: _materializerNamePrefix);
+        var materializer = context.Materializer(namePrefix: _materializerNamePrefix);
 
         var materialized = await _pipeline.CreateAsync(
             sessionId, options,
-            materializer: _materializer,
+            materializer: materializer,
             cancellationToken: cancellationToken);
 
         var inputQueue = Source.Channel<ChannelInput>(512, true)
             .ToMaterialized(materialized.Input, Keep.Left)
-            .Run(_materializer);
+            .Run(materializer);
 
         var generation = ++_pipelineGeneration;
         var outputTerminated = materialized.Output
@@ -105,18 +107,11 @@ public sealed class SessionPipelineHandle
             .ToMaterialized(
                 Sink.ForEach<SessionOutput>(onOutput),
                 Keep.Left)
-            .Run(_materializer);
+            .Run(materializer);
 
         _outputCompletion = outputTerminated;
 
-        _ = outputTerminated.ContinueWith(t =>
-            {
-                var cause = t.IsFaulted ? t.Exception?.GetBaseException() : null;
-                onStreamTerminated(generation, cause);
-            },
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        ObserveStreamTermination(outputTerminated, generation, onStreamTerminated);
 
         _session = materialized;
         _inputQueue = inputQueue;
@@ -139,23 +134,23 @@ public sealed class SessionPipelineHandle
     {
         _log.Info("Initializing {0} execution pipeline", _materializerNamePrefix);
 
-        _materializer = context.Materializer(namePrefix: _materializerNamePrefix);
+        var materializer = context.Materializer(namePrefix: _materializerNamePrefix);
 
         var materialized = await _pipeline.CreateAsync(
             sessionId, options,
-            materializer: _materializer,
+            materializer: materializer,
             cancellationToken: cancellationToken);
 
         var inputQueue = Source.Queue<ChannelInput>(8, OverflowStrategy.Backpressure)
             .ToMaterialized(materialized.Input, Keep.Left)
-            .Run(_materializer);
+            .Run(materializer);
 
         _outputCompletion = materialized.Output
             .WatchTermination((_, done) => done)
             .ToMaterialized(
                 Sink.ForEach<SessionOutput>(onOutput),
                 Keep.Left)
-            .Run(_materializer);
+            .Run(materializer);
 
         _session = materialized;
 
@@ -186,31 +181,7 @@ public sealed class SessionPipelineHandle
         {
             _log.Warning("Reinitializing {0} session pipeline: {1}", _materializerNamePrefix, reason);
 
-            _inputQueue?.TryComplete();
-            _inputQueue = null;
-
-            if (_session is not null)
-            {
-                await _session.DisposeAsync();
-                _session = null;
-            }
-
-            if (_outputCompletion is not null)
-            {
-                try
-                {
-                    await _outputCompletion.WaitAsync(StreamDrainTimeout);
-                }
-                catch
-                {
-                    // stream faulted or timed out — safe to proceed with materializer disposal
-                }
-
-                _outputCompletion = null;
-            }
-
-            _materializer?.Dispose();
-            _materializer = null;
+            await DrainAsync();
 
             await InitializeWithChannelAsync(
                 _storedContext, _storedSessionId.Value, _storedOptions,
@@ -237,6 +208,7 @@ public sealed class SessionPipelineHandle
     public async Task DrainAsync()
     {
         _inputQueue?.TryComplete();
+        _inputQueue = null;
 
         if (_session is not null)
         {
@@ -260,13 +232,28 @@ public sealed class SessionPipelineHandle
     }
 
     /// <summary>
-    /// Final cleanup for actor <c>PostStop</c>. Disposes the materializer.
-    /// Stream stages should already be drained via <see cref="DrainAsync"/>
-    /// before the actor stops.
+    /// Best-effort cleanup for actor <c>PostStop</c>. Completes the input
+    /// queue if it wasn't already drained. Does not dispose the materializer —
+    /// the actor's context owns that lifecycle.
     /// </summary>
     public void Dispose()
     {
         _inputQueue?.TryComplete();
-        _materializer?.Dispose();
+    }
+
+    private async void ObserveStreamTermination(
+        Task outputTerminated,
+        int generation,
+        Action<int, Exception?> onStreamTerminated)
+    {
+        try
+        {
+            await outputTerminated;
+            onStreamTerminated(generation, null);
+        }
+        catch (Exception ex)
+        {
+            onStreamTerminated(generation, ex);
+        }
     }
 }

--- a/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
+++ b/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
@@ -111,9 +111,22 @@ public sealed class SessionPipelineHandle
 
         _outputCompletion = outputTerminated;
 
-        ObserveStreamTermination(outputTerminated, generation, onStreamTerminated);
+        _ = ObserveTerminationAsync();
 
         _session = materialized;
+
+        async Task ObserveTerminationAsync()
+        {
+            try
+            {
+                await outputTerminated;
+                onStreamTerminated(generation, null);
+            }
+            catch (Exception ex)
+            {
+                onStreamTerminated(generation, ex);
+            }
+        }
         _inputQueue = inputQueue;
 
         _log.Info("{0} session pipeline initialized", _materializerNamePrefix);
@@ -241,19 +254,4 @@ public sealed class SessionPipelineHandle
         _inputQueue?.TryComplete();
     }
 
-    private async void ObserveStreamTermination(
-        Task outputTerminated,
-        int generation,
-        Action<int, Exception?> onStreamTerminated)
-    {
-        try
-        {
-            await outputTerminated;
-            onStreamTerminated(generation, null);
-        }
-        catch (Exception ex)
-        {
-            onStreamTerminated(generation, ex);
-        }
-    }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -443,7 +443,14 @@ internal sealed class ReminderExecutionActor : ReceiveActor
             new ReminderId(_definition.Id),
             success,
             errorMessage));
-        Context.Stop(Self);
+
+        // Drain stream stages before stopping so they complete gracefully
+        // rather than being abruptly terminated as actor children.
+        RunTask(async () =>
+        {
+            await _handle.DrainAsync();
+            Context.Stop(Self);
+        });
     }
 
     protected override void PostStop()

--- a/src/Netclaw.Daemon/Webhooks/WebhookExecutionActor.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookExecutionActor.cs
@@ -148,7 +148,11 @@ internal sealed class WebhookExecutionActor : ReceiveActor
                 errorMessage);
         }
 
-        Context.Stop(Self);
+        RunTask(async () =>
+        {
+            await _handle.DrainAsync();
+            Context.Stop(Self);
+        });
     }
 
     protected override void PostStop()


### PR DESCRIPTION
## Summary

- Fixes fatal crash log (`crash-20260429-035251.log`) caused by `AbruptTerminationException` from the `memory-monitor-4h` reminder execution
- Root cause: `Context.Stop(Self)` kills child actors (including stream stages under `StreamSupervisor`) before `PostStop()` runs, so the materializer disposal in `Dispose()` was too late — streams were already being abruptly terminated
- Adds `WatchTermination` stage to output streams in both `InitializeWithChannelAsync` and `InitializeWithQueueAsync` to track stream lifecycle
- Adds `DrainAsync()` to `SessionPipelineHandle` — shuts down kill switch and awaits `WatchTermination` task (bounded 5s) while the parent actor is still alive
- `ReminderExecutionActor` and `WebhookExecutionActor` now drain before stopping

## Open questions

- The long-lived channel actors (Slack, SignalR, Discord) also call `_handle.Dispose()` in PostStop and have the same theoretical race. They're less likely to hit it in practice (passivation vs explicit stop), but should they also drain before stopping?
- Is the 5s drain timeout appropriate, or should it be shorter/configurable?

## Test plan

- [ ] Deploy and verify no more `AbruptTerminationException` crash logs from reminder/webhook executions
- [ ] Verify reminder executions still complete and report results normally
- [ ] Verify webhook executions still complete normally
- [ ] Monitor for any new timeout-related issues from the drain step