### PR TITLE
docs: normalize example hostnames and expand OAuth skill notes

### DIFF
--- a/.claude/skills/update-openai-models.md
+++ b/.claude/skills/update-openai-models.md
@@ -38,16 +38,35 @@ model list for OAuth-authenticated users.
 
 4. **Build and verify**: `dotnet build` to confirm no compilation errors.
 
-5. **Update the memorizer memory** (ID: `e3c8ac2b-0fa2-47d3-b9ff-50a78f2d2863`)
-   if the limitation status has changed.
-
 ## Why This Exists
 
-See the detailed memorizer memory for full context:
-https://memory.testlab.petabridge.net/view/e3c8ac2b-0fa2-47d3-b9ff-50a78f2d2863
+OAuth tokens obtained via the Codex CLI client ID (`app_EMoamEEZ73f0CkXaXp7hrann`)
+**cannot call `/v1/models`** — the endpoint returns HTTP 403 "Missing scopes:
+api.model.read". This is NOT fixable by requesting additional OAuth scopes:
 
-The Codex CLI public client ID (`app_EMoamEEZ73f0CkXaXp7hrann`) only grants
-identity OAuth scopes. API scope names like `model.request` and `api.model.read`
-are not valid OAuth scope values — the authorization endpoint rejects them.
-All third-party tools (OpenCode, OpenClaw) use curated/hardcoded model lists
-instead of live discovery for OAuth tokens.
+- `model.request` and `api.model.read` are **not valid OAuth scope names** — the
+  authorization endpoint rejects them as "invalid scope"
+- The only valid scopes are identity scopes: `openid profile email offline_access`
+- The client ID grants API access (chat completions) implicitly, but model listing
+  is blocked
+
+All third-party tools (OpenCode, OpenClaw, Codex CLI) use curated/hardcoded model
+lists instead of live discovery for OAuth tokens.
+
+### Responses API requirement
+
+Codex OAuth tokens MUST use the Responses API (`/v1/responses`), NOT Chat
+Completions (`/v1/chat/completions`). Chat Completions is deprecated for Codex
+and returns `insufficient_quota` even when the user has quota remaining.
+
+| Endpoint | OAuth Token | API Key |
+|----------|-------------|---------|
+| `/v1/models` | **BLOCKED** (403) | Works |
+| `/v1/chat/completions` | **BLOCKED** (429 insufficient_quota) | Works |
+| `/v1/responses` | Works | Works |
+
+### References
+
+- OpenCode implementation: https://github.com/anomalyco/opencode/issues/3281
+- OpenClaw scope fix: https://github.com/openclaw/openclaw/issues/24720
+- Codex models docs: https://developers.openai.com/codex/models

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -41,7 +41,7 @@
 - SQLite for Akka.Persistence journal and snapshots (in-memory for tests)
 - MCP servers for external tool integration (MVP requirement)
 - local Ollama endpoint can be used for optional smoke tests
-  - local dev host: `big-gpu` on Tailscale (`http://big-gpu:11434`)
+  - local dev host: `my-gpu-server` on Tailscale (`http://my-gpu-server:11434`)
   - preferred model: `qwen3:30b` (fallback `qwen3:14b`)
 
 ## Security-Relevant Surfaces
@@ -64,4 +64,4 @@
 - operator-controlled host and credentials
 - default-deny policy with explicit per-channel and per-sender allow rules
 - required CI tests do not depend on live model providers
-- `big-gpu` Ollama access is local-dev only and not available in CI/CD
+- `my-gpu-server` Ollama access is local-dev only and not available in CI/CD

--- a/docs/prd/PRD-005-model-provider-strategy.md
+++ b/docs/prd/PRD-005-model-provider-strategy.md
@@ -100,7 +100,7 @@ model provider credentials or network access to external inference services.
 ### MP-008 Local Dev Ollama Profile
 
 The default local smoke profile SHALL target the Tailscale-reachable Ollama
-server `big-gpu` (`http://big-gpu:11434`) and use `qwen3:30b` (fallback
+server `my-gpu-server` (`http://my-gpu-server:11434`) and use `qwen3:30b` (fallback
 `qwen3:14b`).
 
 ### MP-009 Primary + Fallback Configuration

--- a/docs/spec/SPEC-008-model-provider-abstraction.md
+++ b/docs/spec/SPEC-008-model-provider-abstraction.md
@@ -41,11 +41,11 @@ Session actors depend on provider-neutral chat client behavior.
 
 ## Local Dev Defaults (Non-CI)
 
-- preferred smoke endpoint: `http://big-gpu:11434`
+- preferred smoke endpoint: `http://my-gpu-server:11434`
 - preferred smoke model: `qwen3:30b`
 - fallback smoke model: `qwen3:14b`
 
-Rationale: `big-gpu` is available on Tailscale for local development and has
+Rationale: `my-gpu-server` is available on Tailscale for local development and has
 enough VRAM for a stronger coding-oriented model profile.
 
 ## Testing Constraints

--- a/docs/spec/SPEC-010-testing-and-smoke-strategy.md
+++ b/docs/spec/SPEC-010-testing-and-smoke-strategy.md
@@ -44,7 +44,7 @@ tests can validate real provider integrations.
 ## Local Smoke Profile (Developer Default)
 
 - provider: `ollama`
-- endpoint: `http://big-gpu:11434` (Tailscale network)
+- endpoint: `http://my-gpu-server:11434` (Tailscale network)
 - model: `qwen3:30b`
 - fallback model: `qwen3:14b`
 

--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -84,7 +84,7 @@ keys used by model references.
     },
     "remote-gpu": {
       "Type": "ollama",
-      "Endpoint": "http://big-gpu:11434"
+      "Endpoint": "http://my-gpu-server:11434"
     },
     "openrouter": {
       "Type": "openrouter",

--- a/evals/README.md
+++ b/evals/README.md
@@ -13,7 +13,7 @@ netclaw init
 
 # Run the full suite against your preferred LLM endpoint.
 NETCLAW_EVAL_PROVIDER_TYPE=ollama \
-NETCLAW_EVAL_PROVIDER_ENDPOINT=http://big-gpu.tailnet.ts.net:11434 \
+NETCLAW_EVAL_PROVIDER_ENDPOINT=http://my-gpu-server.tailnet.ts.net:11434 \
 NETCLAW_EVAL_MODEL_ID=qwen3:30b \
   ./evals/run-evals.sh
 ```
@@ -48,7 +48,7 @@ default provider.
    handles files the daemon wrote as UID 0.
 
 `--network host` is the default because operators often host their LLM on
-a Tailscale node — MagicDNS hostnames like `big-gpu.tailnet.ts.net` only
+a Tailscale node — MagicDNS hostnames like `my-gpu-server.tailnet.ts.net` only
 resolve when the container shares the host's DNS resolver. macOS/Windows
 operators need a different endpoint resolution strategy (Docker Desktop
 reduces `--network host` to bridge mode).
@@ -125,7 +125,7 @@ the missing values. In non-interactive contexts it fails loudly.
 ```bash
 # Quick smoke test (1 run, lower threshold)
 NETCLAW_EVAL_PROVIDER_TYPE=ollama \
-NETCLAW_EVAL_PROVIDER_ENDPOINT=http://big-gpu:11434 \
+NETCLAW_EVAL_PROVIDER_ENDPOINT=http://my-gpu-server:11434 \
 NETCLAW_EVAL_MODEL_ID=qwen3:30b \
 NETCLAW_EVAL_RUNS=1 NETCLAW_EVAL_THRESHOLD=0.50 \
   ./evals/run-evals.sh

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   NETCLAW_EVAL_PROVIDER_TYPE=ollama \
-#   NETCLAW_EVAL_PROVIDER_ENDPOINT=http://big-gpu.tailnet.ts.net:11434 \
+#   NETCLAW_EVAL_PROVIDER_ENDPOINT=http://my-gpu-server.tailnet.ts.net:11434 \
 #   NETCLAW_EVAL_MODEL_ID=qwen3:30b \
 #     ./evals/run-evals.sh
 #

--- a/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/design.md
+++ b/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/design.md
@@ -30,7 +30,7 @@ Live provider checks run only through explicit command invocation.
 
 Ollama is treated as an OpenAI-compatible provider profile for smoke checks.
 
-### Decision 4: Local smoke defaults target big-gpu
+### Decision 4: Local smoke defaults target my-gpu-server
 
-Default local smoke profile points at `http://big-gpu:11434` with
+Default local smoke profile points at `http://my-gpu-server:11434` with
 `qwen3:30b` as preferred model and `qwen3:14b` as fallback.

--- a/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/proposal.md
+++ b/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/proposal.md
@@ -16,7 +16,7 @@ the OSS-friendly CI pipeline must not require live provider credentials.
 1. Add requirements for optional live smoke tests against local providers.
 2. Add requirements that CI-required tests remain provider-independent.
 3. Add CLI and capability-level contracts for smoke command semantics.
-4. Capture local-dev defaults for the Tailscale Ollama host `big-gpu`.
+4. Capture local-dev defaults for the Tailscale Ollama host `my-gpu-server`.
 
 ## Scope
 

--- a/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/specs/netclaw-model-providers/spec.md
+++ b/openspec/changes/archive/2026-02-25-add-provider-smoke-and-ci-independence/specs/netclaw-model-providers/spec.md
@@ -27,5 +27,5 @@ OpenAI-compatible endpoint such as Ollama.
 
 - **GIVEN** local smoke profile is used
 - **WHEN** endpoint defaults are applied
-- **THEN** provider targets `http://big-gpu:11434`
+- **THEN** provider targets `http://my-gpu-server:11434`
 - **AND** model defaults to `qwen3:30b` with fallback `qwen3:14b`

--- a/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/design.md
+++ b/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/design.md
@@ -248,7 +248,7 @@ container completely decoupled from in-place host mutation.
 **Alternatives considered:**
 
 1. Default bridged network with `-p 5299:5199`. Rejected: Tailscale
-   MagicDNS hostnames (e.g. `big-gpu.tailnet.ts.net`) don't resolve
+   MagicDNS hostnames (e.g. `my-gpu-server.tailnet.ts.net`) don't resolve
    inside bridged containers on Linux because MagicDNS is exposed via
    the host's `systemd-resolved` entries, not propagated into container
    DNS. `--network host` shares the host's resolver and loopback,

--- a/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/proposal.md
+++ b/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/proposal.md
@@ -39,7 +39,7 @@ contamination disappears, and the daemon gains a first-class
   container per suite run, forward provider/model config via `NETCLAW_`
   env vars, bind-mount the host's `~/.netclaw/identity` read-only, capture
   daemon logs from `docker logs`, run the container with `--network host`
-  so Tailscale MagicDNS hostnames (e.g. a local `big-gpu.tail...ts.net`
+  so Tailscale MagicDNS hostnames (e.g. a local `my-gpu-server.tail...ts.net`
   inference endpoint) resolve inside the container, and tear down the
   container on exit. Case definitions, assertion helpers, and the run-loop
   are untouched.
@@ -145,7 +145,7 @@ run locally against a host-provided LLM endpoint (self-hosted or cloud).
     running; in fact, the host daemon is irrelevant to the eval run.
   - `--network host` is the default container network mode for evals. This
     inherits the host's DNS resolver (so Tailscale MagicDNS entries like
-    `big-gpu.tail...ts.net` resolve automatically) and loopback namespace
+    `my-gpu-server.tail...ts.net` resolve automatically) and loopback namespace
     (so `http://127.0.0.1:1234/v1`-style LLM endpoints work without port
     mapping). It also means the container binds `$NETCLAW_EVAL_PORT`
     directly on the host — the script fails loudly if the port is already

--- a/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/specs/daemon-container/spec.md
+++ b/openspec/changes/archive/2026-04-29-containerize-daemon-and-evals/specs/daemon-container/spec.md
@@ -238,7 +238,7 @@ torn down on script exit (success, failure, or SIGINT). Eval state
 
 `evals/run-evals.sh` SHALL start the eval container with `--network host`
 by default. This inherits the host's DNS resolver so Tailscale MagicDNS
-hostnames (e.g. `big-gpu.tail...ts.net`) resolve inside the container, and
+hostnames (e.g. `my-gpu-server.tail...ts.net`) resolve inside the container, and
 it inherits the loopback namespace so `http://127.0.0.1:<port>`-style LLM
 endpoints are reachable without port mapping. The script SHALL fail loudly
 if `$NETCLAW_EVAL_PORT` is already bound on the host, rather than silently
@@ -246,7 +246,7 @@ falling through to a different port.
 
 #### Scenario: Tailscale-only endpoint resolves inside container
 
-- **GIVEN** the operator's LLM endpoint is `http://big-gpu.tailnet.ts.net:1234/v1`
+- **GIVEN** the operator's LLM endpoint is `http://my-gpu-server.tailnet.ts.net:1234/v1`
 - **AND** the host has a working Tailscale connection with MagicDNS enabled
 - **WHEN** the eval script starts the container and routes prompts through
   the eval daemon

--- a/openspec/specs/daemon-container/spec.md
+++ b/openspec/specs/daemon-container/spec.md
@@ -238,7 +238,7 @@ torn down on script exit (success, failure, or SIGINT). Eval state
 
 `evals/run-evals.sh` SHALL start the eval container with `--network host`
 by default. This inherits the host's DNS resolver so Tailscale MagicDNS
-hostnames (e.g. `big-gpu.tail...ts.net`) resolve inside the container, and
+hostnames (e.g. `my-gpu-server.tail...ts.net`) resolve inside the container, and
 it inherits the loopback namespace so `http://127.0.0.1:<port>`-style LLM
 endpoints are reachable without port mapping. The script SHALL fail loudly
 if `$NETCLAW_EVAL_PORT` is already bound on the host, rather than silently
@@ -246,7 +246,7 @@ falling through to a different port.
 
 #### Scenario: Tailscale-only endpoint resolves inside container
 
-- **GIVEN** the operator's LLM endpoint is `http://big-gpu.tailnet.ts.net:1234/v1`
+- **GIVEN** the operator's LLM endpoint is `http://my-gpu-server.tailnet.ts.net:1234/v1`
 - **AND** the host has a working Tailscale connection with MagicDNS enabled
 - **WHEN** the eval script starts the container and routes prompts through
   the eval daemon

--- a/openspec/specs/netclaw-model-providers/spec.md
+++ b/openspec/specs/netclaw-model-providers/spec.md
@@ -71,7 +71,7 @@ OpenAI-compatible endpoint such as Ollama.
 
 - **GIVEN** local smoke profile is used
 - **WHEN** endpoint defaults are applied
-- **THEN** provider targets `http://big-gpu:11434`
+- **THEN** provider targets `http://my-gpu-server:11434`
 - **AND** model defaults to `qwen3:30b` with fallback `qwen3:14b`
 
 ### Requirement: CI provider independence

--- a/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Provider/ProviderCommandTests.cs
@@ -51,7 +51,7 @@ public sealed class ProviderCommandTests : IDisposable
                 ["my-ollama"] = new Dictionary<string, object>
                 {
                     ["Type"] = "ollama",
-                    ["Endpoint"] = "http://big-gpu:11434",
+                    ["Endpoint"] = "http://my-gpu-server:11434",
                     ["AuthMethod"] = "None"
                 }
             }
@@ -62,14 +62,14 @@ public sealed class ProviderCommandTests : IDisposable
 
         Assert.Contains("my-ollama", output);
         Assert.Contains("ollama", output);
-        Assert.Contains("http://big-gpu:11434", output);
+        Assert.Contains("http://my-gpu-server:11434", output);
     }
 
     [Fact]
     public async Task Add_OllamaProvider_WritesConfig()
     {
         var exitCode = await ProviderCommand.RunAsync(
-            ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://big-gpu:11434"],
+            ["provider", "add", "my-ollama", "ollama", "--endpoint", "http://my-gpu-server:11434"],
             _paths, output: _output);
 
         Assert.Equal(0, exitCode);
@@ -78,7 +78,7 @@ public sealed class ProviderCommandTests : IDisposable
         Assert.True(config.RootElement.TryGetProperty("Providers", out var providers));
         Assert.True(providers.TryGetProperty("my-ollama", out var entry));
         Assert.Equal("ollama", entry.GetProperty("Type").GetString());
-        Assert.Equal("http://big-gpu:11434", entry.GetProperty("Endpoint").GetString());
+        Assert.Equal("http://my-gpu-server:11434", entry.GetProperty("Endpoint").GetString());
     }
 
     [Fact]

--- a/src/Netclaw.Cli/Provider/ProviderCommand.cs
+++ b/src/Netclaw.Cli/Provider/ProviderCommand.cs
@@ -445,7 +445,7 @@ internal static class ProviderCommand
         writer.WriteLine("Provider types: " + string.Join(", ", registry.KnownTypeKeys));
         writer.WriteLine();
         writer.WriteLine("Examples:");
-        writer.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://big-gpu:11434");
+        writer.WriteLine("  netclaw provider add my-ollama ollama --endpoint http://my-gpu-server:11434");
         writer.WriteLine("  netclaw provider add my-anthropic anthropic --api-key sk-ant-...");
         writer.WriteLine("  netclaw provider add my-openai openai --auth oauth-device");
         writer.WriteLine("  netclaw provider remove my-ollama");


### PR DESCRIPTION
## Summary
- Replace dev-specific hostnames in examples, specs, and tests with generic placeholder names
- Inline OAuth limitation details into the update-openai-models skill file

## Test plan
- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] Verified no remaining references to old hostname via grep