### PR TITLE
refactor: modernize collection initializers to C# 12 collection expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.cs]
+# Prefer collection expressions and modern initializers.
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = true:suggestion
+
 # Start with one high-signal reliability rule as warning.
 dotnet_diagnostic.CA2016.severity = warning
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -680,7 +680,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
     private sealed class RecordingChatClient : IChatClient
     {
         private readonly object _gate = new();
-        private readonly List<IList<AIContent>> _messages = new();
+        private readonly List<IList<AIContent>> _messages = [];
 
         public IReadOnlyList<IList<AIContent>> ReceivedMessages
         {

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -714,7 +714,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             CancellationToken cancellationToken = default)
         {
             Interlocked.Increment(ref _callCount);
-            LastMessages = messages.ToList();
+            LastMessages = [.. messages];
             Calls.Add(LastMessages);
 
             var response = new ChatResponse(new ChatMessage(

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -364,7 +364,7 @@ public sealed class SlackThreadHistoryFetcherTests
 
     private sealed class FakeReplies
     {
-        private readonly Dictionary<string, ConversationMessagesResponse> _responses = new();
+        private readonly Dictionary<string, ConversationMessagesResponse> _responses = [];
         public SlackException? ThrowOnFetch { get; set; }
 
         public void Set(string channel, string threadTs, string? cursor, ConversationMessagesResponse response)

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/ChannelOptionsBuilder.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/ChannelOptionsBuilder.cs
@@ -10,6 +10,6 @@ public sealed record ChannelOptionsBuilder
     public bool AllowDirectMessages { get; init; }
     public string[] AllowedChannelIds { get; init; } = [];
     public string[] AllowedUserIds { get; init; } = [];
-    public Dictionary<string, string> ChannelAudiences { get; init; } = new();
+    public Dictionary<string, string> ChannelAudiences { get; init; } = [];
     public string? DefaultChannelId { get; init; }
 }

--- a/src/Netclaw.Actors.Tests/Memory/AnchorNameMatcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/AnchorNameMatcherTests.cs
@@ -115,8 +115,8 @@ public sealed class AnchorNameMatcherTests
     public void IsFuzzyMatch_returns_false_for_empty_tokens()
     {
         Assert.False(AnchorNameMatcher.IsFuzzyMatch([], []));
-        Assert.False(AnchorNameMatcher.IsFuzzyMatch([], new[] { "a" }));
-        Assert.False(AnchorNameMatcher.IsFuzzyMatch(new[] { "a" }, []));
+        Assert.False(AnchorNameMatcher.IsFuzzyMatch([], ["a"]));
+        Assert.False(AnchorNameMatcher.IsFuzzyMatch(["a"], []));
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public sealed class AnchorNameMatcherTests
     [Fact]
     public void ComputeAnchorJaccard_returns_0_for_empty_tokens()
     {
-        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard([], new[] { "a" }));
-        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard(new[] { "a" }, []));
+        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard([], ["a"]));
+        Assert.Equal(0.0, AnchorNameMatcher.ComputeAnchorJaccard(["a"], []));
     }
 }

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -281,11 +281,11 @@ public class ChatMessageConverterTests
         var imageBytes = new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }; // GIF89a header
 
         // Step 1: AI message with DataContent → SerializableChatMessage
-        var originalAi = new AiChatMessage(AiChatRole.User, new List<AIContent>
-        {
+        var originalAi = new AiChatMessage(AiChatRole.User,
+        [
             new TextContent("Here is a gif"),
             new DataContent(imageBytes, "image/gif")
-        });
+        ]);
         var serializable = ChatMessageConverter.FromAiMessage(originalAi, sessionDir: tempDir.Path);
         Assert.Single(serializable.MediaReferences);
 

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -127,10 +127,10 @@ public sealed class SerializationRoundTripTests : TestKit
         {
             SessionId = new SessionId("C99999/1708531200.000100"),
             Summary = "The user asked about system status; all services healthy.",
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.System, Content = "Summary: all services healthy." }
-            },
+            ],
             TurnCountBefore = 42,
             CompactedAtMs = ts.ToUnixTimeMilliseconds()
         };

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -980,7 +980,7 @@ internal sealed class FakeMemoryExtractor : IMemoryExtractor
 
     public int CallCount => _callCount;
 
-    public List<(string SessionId, string Memories)> Entries { get; } = new();
+    public List<(string SessionId, string Memories)> Entries { get; } = [];
 
     public Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default)
     {

--- a/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
@@ -89,8 +89,8 @@ public class ModelCapabilityActorTests : TestKit
     /// </summary>
     private sealed class ControllableResolver : IModelCapabilityResolver
     {
-        private readonly Dictionary<string, ResolvedModelCapabilities> _results = new();
-        private readonly Dictionary<string, Exception> _errors = new();
+        private readonly Dictionary<string, ResolvedModelCapabilities> _results = [];
+        private readonly Dictionary<string, Exception> _errors = [];
         private int _callCount;
 
         public int CallCount => _callCount;

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateCompactionTests.cs
@@ -120,14 +120,14 @@ public class SessionStateCompactionTests
         {
             SessionId = new SessionId("test"),
             Summary = "Summary of conversation",
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new()
                 {
                     Role = ChatRole.Assistant,
                     Content = "Summary of conversation"
                 }
-            },
+            ],
             TurnCountBefore = 1,
             CompactedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         };
@@ -157,14 +157,14 @@ public class SessionStateCompactionTests
         {
             SessionId = new SessionId("test"),
             Summary = "Summary",
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new()
                 {
                     Role = ChatRole.Assistant,
                     Content = "Summary"
                 }
-            },
+            ],
             TurnCountBefore = 1,
             CompactedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         };

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -107,10 +107,10 @@ public class SessionStateTests
         {
             SessionId = TestSessionId,
             Summary = "Conversation summary",
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.Assistant, Content = "Summary of prior conversation." }
-            }
+            ]
         });
 
         // System prompt preserved + compacted message
@@ -135,10 +135,10 @@ public class SessionStateTests
         var compacted = state.Apply(new SessionCompacted
         {
             SessionId = TestSessionId,
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.Assistant, Content = "Compacted" }
-            }
+            ]
         });
 
         Assert.Single(compacted.History);
@@ -262,10 +262,10 @@ public class SessionStateTests
         var compacted = state.Apply(new SessionCompacted
         {
             SessionId = TestSessionId,
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.User, Content = "[session-summary session:test/session]\nsummary" }
-            },
+            ],
             WorkingContext = null  // event does not carry an update
         });
 
@@ -291,10 +291,10 @@ public class SessionStateTests
         var compacted = state.Apply(new SessionCompacted
         {
             SessionId = TestSessionId,
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.User, Content = "[session-summary session:test/session]\nsummary" }
-            },
+            ],
             WorkingContext = newContext
         });
 
@@ -333,7 +333,7 @@ public class SessionStateTests
         // WorkingContext.Empty, not null.
         var snapshot = new SessionSnapshot
         {
-            History = new List<SerializableChatMessage>(),
+            History = [],
             TurnCount = 0,
             Title = null,
             WorkingContext = null
@@ -481,10 +481,10 @@ public class SessionStateTests
         var compacted = state.Apply(new SessionCompacted
         {
             SessionId = TestSessionId,
-            CompactedMessages = new List<SerializableChatMessage>
-            {
+            CompactedMessages =
+            [
                 new() { Role = ChatRole.User, Content = "[session-summary session:test/session]\nsummary" }
-            }
+            ]
         });
 
         Assert.Contains("preserved:1", compacted.ProcessedReminderIds);

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -342,10 +342,10 @@ internal sealed class FakeToolExecutor : IToolExecutor
     public int CallCount => _callCount;
 
     /// <summary>Tool name → result string.</summary>
-    public Dictionary<string, string> Results { get; } = new();
+    public Dictionary<string, string> Results { get; } = [];
 
     /// <summary>Tool names that should throw on execution.</summary>
-    public HashSet<string> FailForTools { get; } = new();
+    public HashSet<string> FailForTools { get; } = [];
 
     public Task AuthorizeAsync(FunctionCallContent toolCall, Netclaw.Tools.ToolExecutionContext? context = null, CancellationToken ct = default)
     {
@@ -374,7 +374,7 @@ internal sealed class FakeToolExecutor : IToolExecutor
 /// </summary>
 internal sealed class FakeToolAuditLogger : IToolAuditLogger
 {
-    public List<ToolAuditEntry> Entries { get; } = new();
+    public List<ToolAuditEntry> Entries { get; } = [];
 
     public void Log(ToolAuditEntry entry)
     {

--- a/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/AttachFileToolTests.cs
@@ -25,7 +25,7 @@ public class AttachFileToolTests : IDisposable
     public async Task Valid_file_within_session_directory_succeeds()
     {
         var filePath = Path.Combine(_dir.Path, "report.png");
-        await File.WriteAllBytesAsync(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }, TestContext.Current.CancellationToken);
+        await File.WriteAllBytesAsync(filePath, [0x89, 0x50, 0x4E, 0x47], TestContext.Current.CancellationToken);
 
         var context = new ToolExecutionContext("test-session", _dir.Path);
         var args = new Dictionary<string, object?>
@@ -130,7 +130,7 @@ public class AttachFileToolTests : IDisposable
     public async Task Display_name_is_used_when_provided()
     {
         var filePath = Path.Combine(_dir.Path, "abc123.png");
-        await File.WriteAllBytesAsync(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }, TestContext.Current.CancellationToken);
+        await File.WriteAllBytesAsync(filePath, [0x89, 0x50, 0x4E, 0x47], TestContext.Current.CancellationToken);
 
         var context = new ToolExecutionContext("test-session", _dir.Path);
         var args = new Dictionary<string, object?>
@@ -150,7 +150,7 @@ public class AttachFileToolTests : IDisposable
     public async Task Successful_attach_populates_file_attachments_on_context()
     {
         var filePath = Path.Combine(_dir.Path, "chart.png");
-        await File.WriteAllBytesAsync(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }, TestContext.Current.CancellationToken);
+        await File.WriteAllBytesAsync(filePath, [0x89, 0x50, 0x4E, 0x47], TestContext.Current.CancellationToken);
 
         var context = new ToolExecutionContext("test-session", _dir.Path);
         var args = new Dictionary<string, object?>

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -33,7 +33,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
 
     private readonly HashSet<string> _activeJobIds = [];
     private readonly Queue<string> _deferredQueue = new();
-    private readonly Dictionary<string, BackgroundJobDefinition> _definitions = new();
+    private readonly Dictionary<string, BackgroundJobDefinition> _definitions = [];
 
     public BackgroundJobManagerActor(
         BackgroundJobDefinitionStore store,

--- a/src/Netclaw.Actors/Memory/MemoryPolicyGates.cs
+++ b/src/Netclaw.Actors/Memory/MemoryPolicyGates.cs
@@ -146,11 +146,10 @@ public sealed class MemoryProposalGate
         if (accepted.Count > MaxProposalsPerRun)
         {
             var trimmed = accepted.Count - MaxProposalsPerRun;
-            accepted = accepted
+            accepted = [.. accepted
                 .OrderByDescending(a => a.Proposal.Confidence)
                 .ThenBy(a => a.OriginalIndex)
-                .Take(MaxProposalsPerRun)
-                .ToList();
+                .Take(MaxProposalsPerRun)];
             rejectionReasons["max-proposals-exceeded"] = trimmed;
         }
 

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -92,7 +92,7 @@ public static class ChatMessageConverter
         string? sessionDir = null,
         ILogger? logger = null)
     {
-        return messages.Select(m => ToAiMessage(m, sessionDir, logger)).ToList();
+        return [.. messages.Select(m => ToAiMessage(m, sessionDir, logger))];
     }
 
     public static SerializableChatMessage FromAiMessage(AiChatMessage msg, string? sessionDir = null)

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -24,7 +24,7 @@ public sealed class SendUserMessage : IWithSessionId
     /// Media references (images, audio, etc.) attached to this message.
     /// </summary>
     [ProtoMember(3)]
-    public List<SerializableMediaReference> MediaReferences { get; set; } = new();
+    public List<SerializableMediaReference> MediaReferences { get; set; } = [];
 
     /// <summary>
     /// Ephemeral channel metadata for ACL/audit. Not persisted.

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -151,7 +151,7 @@ public sealed class SessionCompacted
     public string Summary { get; set; } = string.Empty;
 
     [ProtoMember(3)]
-    public List<SerializableChatMessage> CompactedMessages { get; set; } = new();
+    public List<SerializableChatMessage> CompactedMessages { get; set; } = [];
 
     [ProtoMember(4)]
     public int TurnCountBefore { get; set; }

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -29,7 +29,7 @@ public sealed class SerializableChatMessage
     /// and the LLM wants to invoke tools.
     /// </summary>
     [ProtoMember(4)]
-    public List<SerializableToolCall> ToolCalls { get; set; } = new();
+    public List<SerializableToolCall> ToolCalls { get; set; } = [];
 
     /// <summary>
     /// The tool call ID this message is a result for. Present when role is Tool.
@@ -42,7 +42,7 @@ public sealed class SerializableChatMessage
     /// Stored as relative paths within the session media directory.
     /// </summary>
     [ProtoMember(6)]
-    public List<SerializableMediaReference> MediaReferences { get; set; } = new();
+    public List<SerializableMediaReference> MediaReferences { get; set; } = [];
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -178,10 +178,10 @@ public static class SessionOutputDtoMapper
             ToolName = msg.ToolName,
             InteractionDisplayText = msg.DisplayText,
             RequesterSenderId = msg.RequesterSenderId,
-            InteractionPatterns = msg.Patterns.ToList(),
-            InteractionOptions = msg.Options.ToList(),
+            InteractionPatterns = [.. msg.Patterns],
+            InteractionOptions = [.. msg.Options],
             InteractionHasAdoptedContext = msg.HasAdoptedContext,
-            InteractionAdoptedSpeakerIds = msg.AdoptedSpeakerIds.ToList()
+            InteractionAdoptedSpeakerIds = [.. msg.AdoptedSpeakerIds]
         },
 
         _ => new SessionOutputDto

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -54,11 +54,11 @@ public sealed class SessionSnapshot
         public bool ProjectionPersisted { get; set; }
 
         [ProtoMember(7)]
-        public List<AdoptedContextSnapshotMessage> Messages { get; set; } = new();
+        public List<AdoptedContextSnapshotMessage> Messages { get; set; } = [];
     }
 
     [ProtoMember(1)]
-    public List<SerializableChatMessage> History { get; set; } = new();
+    public List<SerializableChatMessage> History { get; set; } = [];
 
     [ProtoMember(2)]
     public int TurnCount { get; set; }
@@ -93,8 +93,8 @@ public sealed class SessionSnapshot
     /// are long-lived and must survive recovery.
     /// </summary>
     [ProtoMember(7)]
-    public List<ActiveJobInfo> ActiveBackgroundJobs { get; set; } = new();
+    public List<ActiveJobInfo> ActiveBackgroundJobs { get; set; } = [];
 
     [ProtoMember(8)]
-    public List<AdoptedContextSnapshotRecord> AdoptedContextRecords { get; set; } = new();
+    public List<AdoptedContextSnapshotRecord> AdoptedContextRecords { get; set; } = [];
 }

--- a/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
+++ b/src/Netclaw.Actors/Sessions/ExtractiveSessionReducer.cs
@@ -44,7 +44,7 @@ public sealed class ExtractiveSessionReducer : IChatReducer
         IEnumerable<ChatMessage> messages,
         CancellationToken cancellationToken)
     {
-        var list = messages as IList<ChatMessage> ?? messages.ToList();
+        var list = messages as IList<ChatMessage> ?? [.. messages];
 
         var hasSystemPrompt = list.Count > 0 && list[0].Role == ChatRole.System;
         var systemOffset = hasSystemPrompt ? 1 : 0;

--- a/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DiscoveredToolCache.cs
@@ -15,7 +15,7 @@ namespace Netclaw.Actors.Sessions.Handlers;
 /// </summary>
 internal sealed class DiscoveredToolCache
 {
-    private readonly List<string> _order = new();
+    private readonly List<string> _order = [];
     private readonly Dictionary<string, int> _leases = new(StringComparer.Ordinal);
 
     /// <summary>

--- a/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
@@ -16,7 +16,7 @@ internal sealed class TurnStateTracker
     private const int DuplicateToolThreshold = 3;
     private const double BudgetNudgeRatio = 0.75;
 
-    private readonly Dictionary<ToolCallFingerprint, int> _toolCallCounts = new();
+    private readonly Dictionary<ToolCallFingerprint, int> _toolCallCounts = [];
 
     public int ToolCallCount { get; private set; }
     public int ToolIterationCount { get; private set; }

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -71,11 +71,11 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private readonly ILoggingAdapter _log;
 
     // Transient state (not persisted)
-    private readonly List<SendUserMessage> _buffer = new();
+    private readonly List<SendUserMessage> _buffer = [];
     private readonly HashSet<string> _inFlightReminderIds = new(StringComparer.Ordinal);
     private readonly HashSet<string> _inFlightBackgroundJobIds = new(StringComparer.Ordinal);
-    private readonly Dictionary<IActorRef, OutputFilter> _subscribers = new();
-    private readonly List<AITool> _availableTools = new();
+    private readonly Dictionary<IActorRef, OutputFilter> _subscribers = [];
+    private readonly List<AITool> _availableTools = [];
     private readonly Dictionary<string, PendingToolInteraction> _pendingToolInteractions = new(StringComparer.Ordinal);
     private MessageSource? _currentTurnSource;
     private readonly ToolRegistry? _fullRegistry;
@@ -1887,7 +1887,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     "ingress_bug model={ModelId} modalities={Modalities} offending={Offending}",
                     _model.ModelId, _model.InputModalities, offendingDesc);
 
-                mediaRefs = mediaRefs.Where(r => r.Modality != (int)MediaModality.Image).ToList();
+                mediaRefs = [.. mediaRefs.Where(r => r.Modality != (int)MediaModality.Image)];
 
                 const string ingressBugNotice =
                     "[system] An attachment was received but could not be delivered to the model due to an ingress bug. " +
@@ -2405,7 +2405,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             options = new ChatOptions
             {
-                Tools = exposedTools.ToList()
+                Tools = [.. exposedTools]
             };
         }
 
@@ -3056,15 +3056,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             Projection = source.AdoptedContextProjection ?? string.Empty,
             ProjectionPersisted = true,
             RecordedAtMs = NowMs(),
-            Messages = source.AdoptedContextEntries
+            Messages = [.. source.AdoptedContextEntries
                 .Select(entry => new AdoptedContextRecorded.AdoptedMessageRecord
                 {
                     MessageId = entry.MessageId,
                     SenderId = entry.SenderId,
                     TimestampMs = entry.Timestamp.ToUnixTimeMilliseconds(),
                     AuthorityAtInclusion = entry.AuthorityAtInclusion
-                })
-                .ToList()
+                })]
         };
 
         // Persist the adopted-context audit record before continuing the turn so the

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
@@ -63,7 +63,7 @@ internal static class SessionCompactionPipeline
                 var meaiMessages = ChatMessageConverter.ToAiMessages(history);
                 var reduced = await reducer.ReduceAsync(meaiMessages, cts.Token);
 
-                var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage> ?? reduced.ToList();
+                var reducedList = reduced as IList<Microsoft.Extensions.AI.ChatMessage> ?? [.. reduced];
                 var keptNonSystemCount = reducedList.Count(m => m.Role != Microsoft.Extensions.AI.ChatRole.System);
 
                 var startIndex = history.Count - keptNonSystemCount;

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -82,14 +82,10 @@ internal static class SessionToolExecutionPipeline
             var fileAttachments = results.SelectMany(r => r.FileAttachments).ToList();
             self.Tell(new ToolExecutionCompleted
             {
-                ToolResults = results.Select(r => r.Message).ToList(),
+                ToolResults = [.. results.Select(r => r.Message)],
                 FileAttachments = fileAttachments,
-                CompletedSubAgentRuns = results
-                    .SelectMany(r => r.CompletedSubAgentRuns)
-                    .ToList(),
-                AcceptedSubAgentFindings = results
-                    .SelectMany(r => r.AcceptedSubAgentFindings)
-                    .ToList()
+                CompletedSubAgentRuns = [.. results.SelectMany(r => r.CompletedSubAgentRuns)],
+                AcceptedSubAgentFindings = [.. results.SelectMany(r => r.AcceptedSubAgentFindings)]
             });
         }
         catch (TimeoutException ex)

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -48,7 +48,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     // V1 recovery so those anchors are not lost. New sessions use V2 events
     // and populate _proposedMemories instead.
     private readonly HashSet<string> _proposedAnchors = new(StringComparer.OrdinalIgnoreCase);
-    private readonly List<ProposedMemoryContext> _proposedMemories = new();
+    private readonly List<ProposedMemoryContext> _proposedMemories = [];
     private bool _hasNewContent;
     private bool _draining;
     private long _contentVersion;

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -39,7 +39,7 @@ public sealed record SessionState
     internal const string SystemNudgePrefix = "[system:";
 
     public ImmutableList<SerializableChatMessage> History { get; init; } =
-        ImmutableList<SerializableChatMessage>.Empty;
+        [];
 
     public int TurnCount { get; init; }
 
@@ -74,10 +74,10 @@ public sealed record SessionState
     /// because jobs are long-lived and must survive recovery.
     /// </summary>
     public ImmutableDictionary<string, ActiveJobInfo> ActiveBackgroundJobs { get; init; } =
-        ImmutableDictionary<string, ActiveJobInfo>.Empty;
+        [];
 
     public ImmutableDictionary<string, AdoptedContextAuditRecord> AdoptedContextRecords { get; init; } =
-        ImmutableDictionary<string, AdoptedContextAuditRecord>.Empty;
+        [];
 
     /// <summary>
     /// In-memory best-effort dedup ledger for background-job-originated turns.
@@ -127,13 +127,12 @@ public sealed record SessionState
             evt.UpperBound,
             evt.Projection,
             evt.ProjectionPersisted,
-            evt.Messages
+            [.. evt.Messages
                 .Select(message => new AdoptedContextAuditMessage(
                     message.MessageId,
                     message.SenderId,
                     DateTimeOffset.FromUnixTimeMilliseconds(message.TimestampMs),
-                    message.AuthorityAtInclusion))
-                .ToImmutableList());
+                    message.AuthorityAtInclusion))]);
 
         return this with
         {
@@ -315,8 +314,8 @@ public sealed record SessionState
             TurnCount = TurnCount,
             Title = Title,
             WorkingContext = WorkingContext.IsEmpty ? null : WorkingContext,
-            ActiveBackgroundJobs = ActiveBackgroundJobs.Values.ToList(),
-            AdoptedContextRecords = AdoptedContextRecords.Values
+            ActiveBackgroundJobs = [.. ActiveBackgroundJobs.Values],
+            AdoptedContextRecords = [.. AdoptedContextRecords.Values
                 .OrderBy(record => record.AuthorizedMessageId, StringComparer.Ordinal)
                 .Select(record => new SessionSnapshot.AdoptedContextSnapshotRecord
                 {
@@ -326,17 +325,15 @@ public sealed record SessionState
                     UpperBound = record.UpperBound,
                     Projection = record.Projection,
                     ProjectionPersisted = record.ProjectionPersisted,
-                    Messages = record.Messages
+                    Messages = [.. record.Messages
                         .Select(message => new SessionSnapshot.AdoptedContextSnapshotRecord.AdoptedContextSnapshotMessage
                         {
                             MessageId = message.MessageId,
                             SenderId = message.SenderId,
                             TimestampMs = message.Timestamp.ToUnixTimeMilliseconds(),
                             AuthorityAtInclusion = message.AuthorityAtInclusion
-                        })
-                        .ToList()
-                })
-                .ToList()
+                        })]
+                })]
         };
     }
 
@@ -345,7 +342,7 @@ public sealed record SessionState
         var activeJobs = snapshot.ActiveBackgroundJobs.Count > 0
             ? snapshot.ActiveBackgroundJobs.ToImmutableDictionary(
                 j => $"{Jobs.BackgroundJobManagerActor.JobDeliveryKeyPrefix}{j.JobId}", j => j)
-            : ImmutableDictionary<string, ActiveJobInfo>.Empty;
+            : [];
 
         var adoptedContextRecords = snapshot.AdoptedContextRecords.Count > 0
             ? snapshot.AdoptedContextRecords.ToImmutableDictionary(
@@ -357,14 +354,13 @@ public sealed record SessionState
                     record.UpperBound,
                     record.Projection,
                     record.ProjectionPersisted,
-                    record.Messages
+                    [.. record.Messages
                         .Select(message => new AdoptedContextAuditMessage(
                             message.MessageId,
                             message.SenderId,
                             DateTimeOffset.FromUnixTimeMilliseconds(message.TimestampMs),
-                            message.AuthorityAtInclusion))
-                        .ToImmutableList()))
-            : ImmutableDictionary<string, AdoptedContextAuditRecord>.Empty;
+                            message.AuthorityAtInclusion))]))
+            : [];
 
         return new SessionState
         {

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -36,7 +36,7 @@ public sealed record WorkingContext
 
     [ProtoMember(1)]
     public ImmutableList<string> RecentFiles { get; init; } =
-        ImmutableList<string>.Empty;
+        [];
 
     [ProtoMember(2)]
     public string? ProjectDirectory { get; init; }

--- a/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContextUpdater.cs
@@ -29,7 +29,7 @@ internal static class WorkingContextUpdater
     // keyed as `{"Path": "..."}`. MCP tools and other conventions use the
     // camelCase/snake_case variants. Probe all common forms.
     private static readonly string[] PathFieldNames =
-    {
+    [
         "Path",
         "path",
         "FilePath",
@@ -40,7 +40,7 @@ internal static class WorkingContextUpdater
         "FileName",
         "filename",
         "fileName",
-    };
+    ];
 
     /// <summary>
     /// Process a batch of tool results that just completed, find each

--- a/src/Netclaw.Actors/Skills/SkillRegistry.cs
+++ b/src/Netclaw.Actors/Skills/SkillRegistry.cs
@@ -14,7 +14,7 @@ namespace Netclaw.Actors.Skills;
 /// </summary>
 public sealed class SkillRegistry
 {
-    private readonly List<SkillEntry> _skills = new();
+    private readonly List<SkillEntry> _skills = [];
     private volatile IReadOnlyList<SkillScanIssue> _scanIssues = [];
 
     /// <summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -43,7 +43,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private readonly MemoryPolicyEvaluator _policyEvaluator = new();
 
     // Conversation state (not persisted — ephemeral)
-    private readonly List<AiChatMessage> _history = new();
+    private readonly List<AiChatMessage> _history = [];
     private int _toolIterationCount;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
@@ -245,7 +245,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             options = new ChatOptions
             {
-                Tools = _aiTools.ToList()
+                Tools = [.. _aiTools]
             };
         }
 
@@ -420,7 +420,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             var results = await Task.WhenAll(tasks);
             self.Tell(new ToolExecutionCompleted
             {
-                ToolResults = results.ToList()
+                ToolResults = [.. results]
             });
         }
         catch (Exception ex)

--- a/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
+++ b/src/Netclaw.Actors/Tools/McpSchemaSanitizer.cs
@@ -314,7 +314,7 @@ public static class McpSchemaSanitizer
         // Get or create properties object
         if (!dict.TryGetValue("properties", out var propsObj) || propsObj is not Dictionary<string, object?> props)
         {
-            props = new Dictionary<string, object?>();
+            props = [];
             dict["properties"] = props;
         }
 

--- a/src/Netclaw.Actors/Tools/SetWebhookTool.cs
+++ b/src/Netclaw.Actors/Tools/SetWebhookTool.cs
@@ -133,8 +133,6 @@ public sealed partial class SetWebhookTool : NetclawTool<SetWebhookTool.Params>
         if (string.IsNullOrWhiteSpace(value))
             return [];
 
-        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .ToList();
+        return [.. value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Where(x => !string.IsNullOrWhiteSpace(x))];
     }
 }

--- a/src/Netclaw.Actors/Tools/ToolRegistry.cs
+++ b/src/Netclaw.Actors/Tools/ToolRegistry.cs
@@ -27,7 +27,7 @@ public sealed record McpServerSummary(string ServerName, string Description, int
 /// </summary>
 public sealed class ToolRegistry
 {
-    private readonly List<ToolRegistration> _tools = new();
+    private readonly List<ToolRegistration> _tools = [];
 
     public void Register(INetclawTool tool)
     {

--- a/src/Netclaw.Channels.Discord/DiscordGatewayActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordGatewayActor.cs
@@ -19,7 +19,7 @@ public sealed class DiscordGatewayActor : ReceiveActor
 
     private readonly DiscordGatewayDependencies _dependencies;
     private readonly ILoggingAdapter _log;
-    private readonly Dictionary<DiscordEventId, byte> _processedEventIds = new();
+    private readonly Dictionary<DiscordEventId, byte> _processedEventIds = [];
     private readonly Queue<DiscordEventId> _processedEventOrder = new();
 
     public DiscordGatewayActor(DiscordGatewayDependencies dependencies)

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -80,7 +80,7 @@ internal static class SlackApprovalBlockBuilder
 
         blocks.Add(new ActionsBlock
         {
-            Elements = request.Options
+            Elements = [.. request.Options
                 .Select(option => (IActionElement)new Button
                 {
                     ActionId = BuildActionId(option.Key),
@@ -88,8 +88,7 @@ internal static class SlackApprovalBlockBuilder
                     Value = BuildButtonValue(request, option),
                     Style = GetButtonStyle(option.Key),
                     AccessibilityLabel = option.Label
-                })
-                .ToList()
+                })]
         });
 
         blocks.Add(new SectionBlock

--- a/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackGatewayActor.cs
@@ -19,7 +19,7 @@ public sealed class SlackGatewayActor : ReceiveActor
 
     private readonly SlackGatewayDependencies _dependencies;
     private readonly ILoggingAdapter _log;
-    private readonly Dictionary<SlackEventId, byte> _processedEventIds = new();
+    private readonly Dictionary<SlackEventId, byte> _processedEventIds = [];
     private readonly Queue<SlackEventId> _processedEventOrder = new();
 
     public SlackGatewayActor(SlackGatewayDependencies dependencies)

--- a/src/Netclaw.Channels.Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackReplyClient.cs
@@ -20,7 +20,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
         try
         {
             var blocks = message.Blocks?.Count > 0
-                ? message.Blocks.ToList()
+                ? [.. message.Blocks]
                 : SlackBlockConverter.Convert(message.Text);
 
             var response = await slackApiClient.Chat.PostMessage(new Message

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
@@ -112,7 +112,7 @@ public sealed class DaemonClientSessionTests
     {
         private readonly object _gate = new();
         private readonly HashSet<string> _sessions = [];
-        private readonly Dictionary<string, string> _connectionSessions = new();
+        private readonly Dictionary<string, string> _connectionSessions = [];
         public (string CallId, string SelectedKey)? LastInteractionResponse { get; private set; }
 
         public SessionEnsureResultDto Ensure(string connectionId, string? sessionId)

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -264,7 +264,7 @@ public sealed class McpCommandTests : IDisposable
     [Fact]
     public async Task List_NoServers_ShowsEmptyMessage()
     {
-        await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: _output);
+        await McpCommand.RunAsync(["mcp", "list"], _paths, output: _output);
 
         Assert.Contains("No MCP servers configured", _output.ToString());
     }
@@ -273,7 +273,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task List_ShowsConfiguredServersWithDaemonReportedStatus()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
 
         var daemonApi = CreateDaemonApi(request => request.RequestUri!.AbsolutePath switch
@@ -291,7 +291,7 @@ public sealed class McpCommandTests : IDisposable
         });
 
         var listOutput = new StringWriter();
-        var exitCode = await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, daemonApi, listOutput);
+        var exitCode = await McpCommand.RunAsync(["mcp", "list"], _paths, daemonApi, listOutput);
         var output = listOutput.ToString();
 
         Assert.Equal(0, exitCode);
@@ -304,11 +304,11 @@ public sealed class McpCommandTests : IDisposable
     public async Task List_WithoutDaemon_ShowsExplicitUnavailableStatus()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
 
         var listOutput = new StringWriter();
-        var exitCode = await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: listOutput);
+        var exitCode = await McpCommand.RunAsync(["mcp", "list"], _paths, output: listOutput);
         var output = listOutput.ToString();
 
         Assert.Equal(1, exitCode);
@@ -321,7 +321,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task List_WhenDaemonDoesNotTrackServer_ShowsRestartHint()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "http", "textforge", "https://textforge.net/mcp" },
+            ["mcp", "add", "--transport", "http", "textforge", "https://textforge.net/mcp"],
             _paths, output: _output);
 
         var daemonApi = CreateDaemonApi(request => request.RequestUri!.AbsolutePath switch
@@ -331,7 +331,7 @@ public sealed class McpCommandTests : IDisposable
         });
 
         var listOutput = new StringWriter();
-        var exitCode = await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, daemonApi, listOutput);
+        var exitCode = await McpCommand.RunAsync(["mcp", "list"], _paths, daemonApi, listOutput);
         var output = listOutput.ToString();
 
         Assert.Equal(0, exitCode);
@@ -343,13 +343,13 @@ public sealed class McpCommandTests : IDisposable
     public async Task List_DisabledServer_ShowsDisabledStatus()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
         await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
+            ["mcp", "disable", "memorizer"], _paths, output: _output);
 
         var listOutput = new StringWriter();
-        await McpCommand.RunAsync(new[] { "mcp", "list" }, _paths, output: listOutput);
+        await McpCommand.RunAsync(["mcp", "list"], _paths, output: listOutput);
         var output = listOutput.ToString();
 
         Assert.Contains("memorizer", output);
@@ -360,11 +360,11 @@ public sealed class McpCommandTests : IDisposable
     public async Task Get_ShowsServerDetails()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
 
         var getOutput = new StringWriter();
-        await McpCommand.RunAsync(new[] { "mcp", "get", "memorizer" }, _paths, output: getOutput);
+        await McpCommand.RunAsync(["mcp", "get", "memorizer"], _paths, output: getOutput);
         var output = getOutput.ToString();
 
         Assert.Contains("Name:", output);
@@ -377,7 +377,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Get_NotFound_ReturnsError()
     {
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "get", "nonexistent" }, _paths, output: _output);
+            ["mcp", "get", "nonexistent"], _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -386,11 +386,11 @@ public sealed class McpCommandTests : IDisposable
     public async Task Remove_DeletesFromConfig()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "remove", "memorizer" }, _paths, output: _output);
+            ["mcp", "remove", "memorizer"], _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -403,7 +403,7 @@ public sealed class McpCommandTests : IDisposable
     public async Task Remove_NotFound_ReturnsError()
     {
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "remove", "nonexistent" }, _paths, output: _output);
+            ["mcp", "remove", "nonexistent"], _paths, output: _output);
 
         Assert.Equal(1, exitCode);
     }
@@ -412,11 +412,11 @@ public sealed class McpCommandTests : IDisposable
     public async Task Disable_TogglesEnabled()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
+            ["mcp", "disable", "memorizer"], _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 
@@ -428,13 +428,13 @@ public sealed class McpCommandTests : IDisposable
     public async Task Enable_TogglesEnabled()
     {
         await McpCommand.RunAsync(
-            new[] { "mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp" },
+            ["mcp", "add", "--transport", "stdio", "memorizer", "--", "npx", "-y", "@memorizer/mcp"],
             _paths, output: _output);
         await McpCommand.RunAsync(
-            new[] { "mcp", "disable", "memorizer" }, _paths, output: _output);
+            ["mcp", "disable", "memorizer"], _paths, output: _output);
 
         var exitCode = await McpCommand.RunAsync(
-            new[] { "mcp", "enable", "memorizer" }, _paths, output: _output);
+            ["mcp", "enable", "memorizer"], _paths, output: _output);
 
         Assert.Equal(0, exitCode);
 

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardOrchestratorTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardOrchestratorTests.cs
@@ -295,7 +295,7 @@ public sealed class WizardOrchestratorTests : WizardStepTestBase
     // ── Helpers ──
 
     private static List<IWizardStepViewModel> CreateSteps(params string[] ids)
-        => ids.Select(id => (IWizardStepViewModel)new FakeStep(id)).ToList();
+        => [.. ids.Select(id => (IWizardStepViewModel)new FakeStep(id))];
 
     /// <summary>
     /// Minimal fake step for testing the orchestrator.

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -60,7 +60,7 @@ internal static class ConfigFileHelper
                 }
 
                 var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
-                    ?? new Dictionary<string, object>();
+                    ?? [];
                 dict[key] = parsed;
                 return parsed;
             }
@@ -85,7 +85,7 @@ internal static class ConfigFileHelper
         if (existing is JsonElement je)
         {
             var parsed = JsonSerializer.Deserialize<Dictionary<string, object>>(je.GetRawText())
-                ?? new Dictionary<string, object>();
+                ?? [];
             dict[key] = parsed;
             return parsed;
         }

--- a/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorJsonConfigReader.cs
@@ -26,10 +26,9 @@ internal static class DoctorJsonConfigReader
         if (obj[property] is not JsonArray arr)
             return [];
 
-        return arr.Select(v => v?.GetValue<string>())
+        return [.. arr.Select(v => v?.GetValue<string>())
             .Where(s => !string.IsNullOrWhiteSpace(s))
-            .Cast<string>()
-            .ToList();
+            .Cast<string>()];
     }
 
     public static (JsonObject? Root, DoctorCheckResult? Error) TryReadConfig(NetclawPaths paths)

--- a/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/McpServersDoctorCheck.cs
@@ -35,7 +35,7 @@ public sealed class McpServersDoctorCheck(NetclawPaths paths, DaemonApi daemonAp
                     "No MCP servers configured (use `netclaw mcp add` to add one)");
 
             servers = JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpSection.GetRawText())
-                ?? new();
+                ?? [];
         }
         catch (Exception ex)
         {

--- a/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
+++ b/src/Netclaw.Cli/Doctor/SchemaFixResolver.cs
@@ -177,7 +177,7 @@ public static class SchemaFixResolver
 
             var instancePath = detail.InstanceLocation.ToString();
             var parentSegments = string.IsNullOrEmpty(instancePath)
-                ? Array.Empty<string>()
+                ? []
                 : ParseJsonPointer(instancePath);
 
             var parentSchema = parentSegments.Length == 0

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -64,8 +64,8 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         }
 
         var mcpServers = root["McpServers"] is JsonObject mcpObj
-            ? JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpObj, JsonDefaults.ConfigRead) ?? new()
-            : new();
+            ? JsonSerializer.Deserialize<Dictionary<string, McpServerEntry>>(mcpObj, JsonDefaults.ConfigRead) ?? []
+            : [];
 
         var errors = new List<string>();
         ValidateNonPersonalProfile("public", toolConfig.AudienceProfiles.Public, errors);
@@ -205,7 +205,7 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
             }
         }
 
-        return allowedServers.Except(grantedServers, StringComparer.OrdinalIgnoreCase).Order().ToList();
+        return [.. allowedServers.Except(grantedServers, StringComparer.OrdinalIgnoreCase).Order()];
     }
 
     /// <summary>
@@ -248,7 +248,7 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
             result.Add(serverName);
         }
 
-        return result.Order(StringComparer.OrdinalIgnoreCase).ToList();
+        return [.. result.Order(StringComparer.OrdinalIgnoreCase)];
     }
 
     private static void CheckApprovalMismatch(ToolConfig toolConfig, List<string> warnings)

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
@@ -208,7 +208,7 @@ internal static class BrowserAutomationRuntimeDetector
 
         var edgePaths = OperatingSystem.IsMacOS()
             ? new[] { "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" }
-            : new[] { "/usr/bin/microsoft-edge", "/usr/bin/msedge" };
+            : ["/usr/bin/microsoft-edge", "/usr/bin/msedge"];
 
         return edgePaths.Any(File.Exists);
     }

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -150,13 +150,13 @@ internal static class McpCommand
             {
                 // netclaw mcp add --transport stdio memorizer -- npx -y @memorizer/mcp-server
                 commandOrUrl = dashArgs[0];
-                commandArgs = dashArgs.Skip(1).ToArray();
+                commandArgs = [.. dashArgs.Skip(1)];
             }
             else if (positional.Count >= 2)
             {
                 // netclaw mcp add --transport stdio memorizer npx
                 commandOrUrl = positional[1];
-                commandArgs = positional.Skip(2).ToArray();
+                commandArgs = [.. positional.Skip(2)];
             }
 
             if (string.IsNullOrWhiteSpace(commandOrUrl))
@@ -873,7 +873,7 @@ internal static class McpCommand
 
                 if (prop.Value.TryGetProperty("EnvironmentVariables", out var envVars))
                 {
-                    entry.EnvironmentVariables ??= new Dictionary<string, string>();
+                    entry.EnvironmentVariables ??= [];
                     foreach (var ev in envVars.EnumerateObject())
                     {
                         var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, ev.Value.GetString());
@@ -883,7 +883,7 @@ internal static class McpCommand
 
                 if (prop.Value.TryGetProperty("Headers", out var hdrs))
                 {
-                    entry.Headers ??= new Dictionary<string, string>();
+                    entry.Headers ??= [];
                     foreach (var h in hdrs.EnumerateObject())
                     {
                         var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, h.Value.GetString());
@@ -923,10 +923,10 @@ internal static class McpCommand
                     audienceFilter = args[++i];
                     break;
                 case "--grant" when i + 1 < args.Length:
-                    grantTools = args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList();
+                    grantTools = [.. args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0)];
                     break;
                 case "--revoke" when i + 1 < args.Length:
-                    revokeTools = args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToList();
+                    revokeTools = [.. args[++i].Split(',').Select(t => t.Trim()).Where(t => t.Length > 0)];
                     break;
                 case "--help" or "-h":
                     WriteToolsHelp(writer);
@@ -1110,9 +1110,9 @@ internal static class McpCommand
         var audienceNames = targetAudience switch
         {
             TrustAudience.Public => new[] { "Public" },
-            TrustAudience.Team => new[] { "Team" },
-            TrustAudience.Personal => new[] { "Personal" },
-            _ => new[] { "Public", "Team", "Personal" }
+            TrustAudience.Team => ["Team"],
+            TrustAudience.Personal => ["Personal"],
+            _ => ["Public", "Team", "Personal"]
         };
 
         var updated = 0;
@@ -1143,7 +1143,7 @@ internal static class McpCommand
             var grants = audienceSection.TryGetValue("McpServerToolGrants", out var existing)
                 && existing is Dictionary<string, object> dict
                     ? dict
-                    : new Dictionary<string, object>();
+                    : [];
 
             grants[serverName.Value] = discoveredTools;
             audienceSection["McpServerToolGrants"] = grants;
@@ -1217,7 +1217,7 @@ internal static class McpCommand
         var grants = audienceSection.TryGetValue("McpServerToolGrants", out var ex)
             && ex is Dictionary<string, object> dict
                 ? dict
-                : new Dictionary<string, object>();
+                : [];
 
         grants[serverName.Value] = currentTools.Order(StringComparer.Ordinal).ToList();
         audienceSection["McpServerToolGrants"] = grants;

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsPage.cs
@@ -20,7 +20,7 @@ public sealed class McpToolPermissionsPage : ReactivePage<McpToolPermissionsView
     private SelectionListNode<string>? _serverList;
     private DynamicLayoutNode? _contentNode;
     private DynamicLayoutNode? _footerNode;
-    private readonly CompositeDisposable _stepSubs = new();
+    private readonly CompositeDisposable _stepSubs = [];
     private int _gridCursor;
     private bool _confirmingSave;
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -48,16 +48,16 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
     public ToolAudienceProfiles Profiles { get; private set; } = ToolAudienceProfileDefaults.CreateProfiles();
 
     // Track pending changes
-    private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _pendingGrants = new();
+    private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _pendingGrants = [];
     // Track pending server access changes: (audience, server) → allowed
-    private readonly Dictionary<(string Audience, string Server), bool> _pendingServerAccess = new();
+    private readonly Dictionary<(string Audience, string Server), bool> _pendingServerAccess = [];
     // Track pending server-level approval defaults: (audience, server) → mode
-    private readonly Dictionary<(string Audience, string Server), ToolApprovalMode> _pendingServerDefaults = new();
+    private readonly Dictionary<(string Audience, string Server), ToolApprovalMode> _pendingServerDefaults = [];
     // Track pending per-tool approval overrides: (audience, server, tool) → mode.
     // A null value is the "inherit" sentinel: the entry is removed from
     // ToolOverrides on save so the effective mode falls through to the
     // server default / global default.
-    private readonly Dictionary<(string Audience, string Server, string Tool), ToolApprovalMode?> _pendingToolOverrides = new();
+    private readonly Dictionary<(string Audience, string Server, string Tool), ToolApprovalMode?> _pendingToolOverrides = [];
     public bool HasUnsavedChanges =>
         _pendingGrants.Count > 0
         || _pendingServerAccess.Count > 0
@@ -373,7 +373,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
         {
-            serverGrants = new Dictionary<string, HashSet<string>>();
+            serverGrants = [];
             _pendingGrants[SelectedServer] = serverGrants;
         }
 
@@ -393,7 +393,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
         {
-            serverGrants = new Dictionary<string, HashSet<string>>();
+            serverGrants = [];
             _pendingGrants[SelectedServer] = serverGrants;
         }
 
@@ -585,7 +585,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             // so the operator explicitly selects which tools to expose
             if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
             {
-                serverGrants = new Dictionary<string, HashSet<string>>();
+                serverGrants = [];
                 _pendingGrants[SelectedServer] = serverGrants;
             }
 

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1278,7 +1278,7 @@ static async Task<int> RunStatusAsync(IServiceProvider services, bool jsonOutput
         if (jsonOutput)
         {
             var node = JsonSerializer.SerializeToNode(status, JsonDefaults.Api)!;
-            var updateNode = (node["update"] as JsonObject) ?? new JsonObject();
+            var updateNode = (node["update"] as JsonObject) ?? [];
             var updateAvailable = string.Equals(cliUpdate.State, "update-available", StringComparison.Ordinal);
             updateNode["available"] = updateAvailable;
             updateNode["state"] = cliUpdate.State;

--- a/src/Netclaw.Cli/Secrets/SecretsCommand.cs
+++ b/src/Netclaw.Cli/Secrets/SecretsCommand.cs
@@ -56,11 +56,11 @@ internal static class SecretsCommand
         if (File.Exists(paths.SecretsPath))
         {
             var existing = File.ReadAllText(paths.SecretsPath);
-            root = JsonNode.Parse(existing)?.AsObject() ?? new JsonObject();
+            root = JsonNode.Parse(existing)?.AsObject() ?? [];
         }
         else
         {
-            root = new JsonObject();
+            root = [];
         }
 
         // Navigate/create the dotted key path and set the value

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -26,7 +26,7 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
     private TextAreaNode _promptInput = null!;
     private SelectionListNode<string>? _approvalList;
     private DynamicLayoutNode? _inputContentNode;
-    private readonly CompositeDisposable _inputSubs = new();
+    private readonly CompositeDisposable _inputSubs = [];
 
     private int _nextSegmentId = 1;
 

--- a/src/Netclaw.Cli/Tui/InitWizardPage.cs
+++ b/src/Netclaw.Cli/Tui/InitWizardPage.cs
@@ -36,7 +36,7 @@ public sealed class InitWizardPage : ReactivePage<InitWizardViewModel>
     private DynamicLayoutNode? _helpTextNode;
 
     // Step-specific subscriptions — cleared when step content is rebuilt.
-    private readonly CompositeDisposable _stepSubs = new();
+    private readonly CompositeDisposable _stepSubs = [];
 
     protected override void OnBound()
     {

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -31,7 +31,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
     private DynamicLayoutNode? _contentNode;
-    private readonly CompositeDisposable _stepSubs = new();
+    private readonly CompositeDisposable _stepSubs = [];
 
     protected override void OnBound()
     {

--- a/src/Netclaw.Cli/Tui/OAuthFlowViews.cs
+++ b/src/Netclaw.Cli/Tui/OAuthFlowViews.cs
@@ -27,7 +27,7 @@ internal static class OAuthFlowViews
     public static List<string> BuildAuthMethodLabels(IProviderAuth auth)
     {
         var customLabels = (auth as MultiAuth)?.AuthMethodLabels;
-        return auth.SupportedAuthMethods
+        return [.. auth.SupportedAuthMethods
             .Where(m => m != AuthMethod.None)
             .Select(m => customLabels?.TryGetValue(m, out var label) == true
                 ? label
@@ -37,8 +37,7 @@ internal static class OAuthFlowViews
                     AuthMethod.OAuthPkce => "OAuth Login (recommended)",
                     AuthMethod.OAuthDevice => "OAuth Device Flow",
                     _ => m.ToString()
-                })
-            .ToList();
+                })];
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ProviderManagerPage.cs
@@ -41,7 +41,7 @@ public sealed class ProviderManagerPage : ReactivePage<ProviderManagerViewModel>
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
     private DynamicLayoutNode? _contentNode;
-    private readonly CompositeDisposable _stepSubs = new();
+    private readonly CompositeDisposable _stepSubs = [];
 
     protected override void OnBound()
     {

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelPickerStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelPickerStepViewModel.cs
@@ -29,8 +29,8 @@ public sealed class ChannelPickerStepViewModel : IWizardStepViewModel
     private WizardContext? _context;
 
     private readonly List<ChannelAdapterEntry> _adapters;
-    private readonly Dictionary<ChannelType, bool> _enabled = new();
-    private readonly Dictionary<ChannelType, string> _summaries = new();
+    private readonly Dictionary<ChannelType, bool> _enabled = [];
+    private readonly Dictionary<ChannelType, string> _summaries = [];
 
     public ChannelPickerStepViewModel(ISlackProbe slackProbe, IDiscordProbe discordProbe)
     {

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/DiscordStepViewModel.cs
@@ -383,11 +383,10 @@ public sealed class DiscordStepViewModel : IWizardStepViewModel, IChannelAdapter
     internal static List<string> ParseChannelIds(string? input)
         => string.IsNullOrWhiteSpace(input)
             ? []
-            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : [.. input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(x => x.Trim().TrimStart('#'))
                 .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
+                .Distinct(StringComparer.Ordinal)];
 
     private static List<string> ParseUserIds(string? input)
         => WizardStepHelpers.ParseUserIds(input);

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SkillFeedsStepViewModel.cs
@@ -187,14 +187,13 @@ public sealed class SkillFeedsStepViewModel : IWizardStepViewModel, IDisposable
         if (_feeds.Count == 0)
             return;
 
-        builder.SkillFeedSources = _feeds
+        builder.SkillFeedSources = [.. _feeds
             .Select(f => new SkillFeedSource
             {
                 Name = f.Name,
                 Url = f.Url,
                 Enabled = true
-            })
-            .ToList();
+            })];
     }
 
     public void ContributeSecrets(WizardSecretsBuilder builder) { }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/SlackStepViewModel.cs
@@ -202,7 +202,7 @@ public sealed class SlackStepViewModel : IWizardStepViewModel, IChannelAdapterVi
         {
             Enabled = true,
             AllowedChannelIds = LastChannelResolution is { Resolved.Count: > 0 }
-                ? LastChannelResolution.Resolved.Select(r => r.Id).ToList()
+                ? [.. LastChannelResolution.Resolved.Select(r => r.Id)]
                 : null,
             AllowDirectMessages = AllowDirectMessages,
             AllowedUserIds = userIds.Count > 0 ? userIds : null,

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/WizardStepHelpers.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/WizardStepHelpers.cs
@@ -56,11 +56,10 @@ internal static class WizardStepHelpers
     internal static List<string> ParseUserIds(string? input)
         => string.IsNullOrWhiteSpace(input)
             ? []
-            : input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : [.. input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(x => x.Trim())
                 .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
+                .Distinct(StringComparer.Ordinal)];
 }
 
 internal sealed record SelectionOption<T>(T Value, string Label)

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -340,7 +340,7 @@ public sealed class WizardConfigBuilder
 public sealed class WizardSecretsBuilder
 {
     private readonly NetclawPaths _paths;
-    private readonly Dictionary<string, object> _secrets = new();
+    private readonly Dictionary<string, object> _secrets = [];
 
     public WizardSecretsBuilder(NetclawPaths paths)
     {

--- a/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
@@ -195,7 +195,7 @@ public sealed class WizardOrchestrator : IDisposable
     private List<IWizardStepViewModel> BuildInitialActiveSteps()
     {
         _currentIndex = 0;
-        return _allSteps.Where(s => s.IsApplicable(_context)).ToList();
+        return [.. _allSteps.Where(s => s.IsApplicable(_context))];
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
+++ b/src/Netclaw.Cli/Webhooks/WebhooksCommand.cs
@@ -370,7 +370,7 @@ internal static class WebhooksCommand
 
         if (hasEvents)
         {
-            route.Events = events.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+            route.Events = [.. events.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
         }
 
         // Parse audience

--- a/src/Netclaw.Configuration/ExternalSkillsConfig.cs
+++ b/src/Netclaw.Configuration/ExternalSkillsConfig.cs
@@ -85,7 +85,7 @@ public sealed class ExternalSkillsConfig
 
             IReadOnlyList<string> candidatePaths = source.WellKnown is not null
                 ? ResolveWellKnownPaths(source.WellKnown, homeDirectory)
-                : source.Path is not null ? new[] { source.Path } : Array.Empty<string>();
+                : source.Path is not null ? new[] { source.Path } : [];
 
             if (string.Equals(source.WellKnown, ClaudeCodeAlias, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Netclaw.Configuration/Feeds/SkillSyncState.cs
+++ b/src/Netclaw.Configuration/Feeds/SkillSyncState.cs
@@ -17,7 +17,7 @@ public sealed class SkillSyncState
     public DateTimeOffset LastSyncUtc { get; set; }
 
     [JsonPropertyName("skills")]
-    public Dictionary<string, SyncedSkillState> Skills { get; set; } = new();
+    public Dictionary<string, SyncedSkillState> Skills { get; set; } = [];
 }
 
 /// <summary>

--- a/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
+++ b/src/Netclaw.Daemon/Gateway/DaemonStatsService.cs
@@ -97,7 +97,7 @@ internal sealed class DaemonStatsService(
             {
                 Date = group.Key,
                 TotalLoads = group.Sum(x => x.Count),
-                Methods = group
+                Methods = [.. group
                     .GroupBy(x => x.Method)
                     .Select(methodGroup => new SkillUsageStats.MethodCount
                     {
@@ -105,15 +105,14 @@ internal sealed class DaemonStatsService(
                         Count = methodGroup.Sum(x => x.Count)
                     })
                     .OrderByDescending(x => x.Count)
-                    .ThenBy(x => x.Method, StringComparer.Ordinal)
-                    .ToList(),
-                Skills = group
+                    .ThenBy(x => x.Method, StringComparer.Ordinal)],
+                Skills = [.. group
                     .GroupBy(x => x.SkillName, StringComparer.OrdinalIgnoreCase)
                     .Select(skillGroup => new SkillUsageStats.SkillCount
                     {
                         SkillName = skillGroup.Key,
                         TotalLoads = skillGroup.Sum(x => x.Count),
-                        Methods = skillGroup
+                        Methods = [.. skillGroup
                             .GroupBy(x => x.Method)
                             .Select(methodGroup => new SkillUsageStats.MethodCount
                             {
@@ -121,12 +120,10 @@ internal sealed class DaemonStatsService(
                                 Count = methodGroup.Sum(x => x.Count)
                             })
                             .OrderByDescending(x => x.Count)
-                            .ThenBy(x => x.Method, StringComparer.Ordinal)
-                            .ToList()
+                            .ThenBy(x => x.Method, StringComparer.Ordinal)]
                     })
                     .OrderByDescending(x => x.TotalLoads)
-                    .ThenBy(x => x.SkillName, StringComparer.OrdinalIgnoreCase)
-                    .ToList()
+                    .ThenBy(x => x.SkillName, StringComparer.OrdinalIgnoreCase)]
             })
             .ToList();
 
@@ -142,10 +139,9 @@ internal sealed class DaemonStatsService(
         if (slackOptions.Enabled) enabledChannelTypes.Add(ChannelType.Slack);
         if (discordOptions.Enabled) enabledChannelTypes.Add(ChannelType.Discord);
 
-        return ChannelTelemetry.GetAllSnapshots()
+        return [.. ChannelTelemetry.GetAllSnapshots()
             .Where(s => enabledChannelTypes.Contains(s.ChannelType))
-            .Select(s => s.ToWireActivity())
-            .ToList();
+            .Select(s => s.ToWireActivity())];
     }
 
     private static async Task<List<DaemonStats.DailyRow>> QueryDailyStatsAsync(IActorRef actorRef, int days, CancellationToken ct)
@@ -154,7 +150,7 @@ internal sealed class DaemonStatsService(
         {
             var result = await actorRef.Ask<DailyStatsActor.QueryDailyStatsResult>(
                 new DailyStatsActor.QueryDailyStats(days), TimeSpan.FromSeconds(5), ct);
-            return result.Rows
+            return [.. result.Rows
                 .Select(r => new DaemonStats.DailyRow
                 {
                     Date = r.DateKey,
@@ -165,8 +161,7 @@ internal sealed class DaemonStatsService(
                     MemoriesFormed = r.MemoriesFormed,
                     MemoriesRecalled = r.MemoriesRecalled,
                     SkillsLoaded = r.SkillsLoaded
-                })
-                .ToList();
+                })];
         }
         catch
         {

--- a/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
+++ b/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
@@ -22,8 +22,8 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
     private readonly string _connectionString;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<DailyStatsActor> _logger;
-    private readonly Dictionary<string, Accumulator> _pending = new();
-    private readonly Dictionary<(string DateKey, string SkillName, SkillLoadMethod Method), long> _pendingSkillUsage = new();
+    private readonly Dictionary<string, Accumulator> _pending = [];
+    private readonly Dictionary<(string DateKey, string SkillName, SkillLoadMethod Method), long> _pendingSkillUsage = [];
 
     // Process-lifetime totals (never reset, never persisted — lost on restart)
     private long _totalInputTokens;

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -38,7 +38,7 @@ public sealed class SessionRegistry
     private readonly ILogger<SessionRegistry> _logger;
 
     // session ID → channel type (retained for re-create on re-materialization)
-    private readonly Dictionary<SessionId, Actors.Channels.ChannelType> _knownSessions = new();
+    private readonly Dictionary<SessionId, Actors.Channels.ChannelType> _knownSessions = [];
     private readonly SemaphoreSlim _sessionMutationGate = new(1, 1);
 
     private readonly SessionConnectionMap _connections = new();

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -693,7 +693,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             args.Add("--isolated");
         }
 
-        return args.ToArray();
+        return [.. args];
     }
 
     private static Dictionary<string, AIFunction> CreateFunctionMap(IList<McpClientTool> tools)

--- a/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpOAuthService.cs
@@ -610,11 +610,11 @@ internal sealed class McpOAuthService
             {
                 var existing = File.ReadAllText(_paths.SecretsPath);
                 secrets = JsonSerializer.Deserialize<Dictionary<string, object>>(existing, JsonOptions)
-                    ?? new Dictionary<string, object>();
+                    ?? [];
             }
             else
             {
-                secrets = new Dictionary<string, object>();
+                secrets = [];
             }
 
             secrets[TokensSectionKey] = JsonSerializer.SerializeToElement(

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -758,7 +758,7 @@ static void ConfigureDaemonServices(
 
     // MCP server lifecycle management
     var mcpServers = configuration.GetSection("McpServers")
-        .Get<Dictionary<string, McpServerEntry>>() ?? new();
+        .Get<Dictionary<string, McpServerEntry>>() ?? [];
     services.AddSingleton(mcpServers);
     services.AddHttpClient("ProviderOAuth");
     services.AddSingleton(sp =>
@@ -910,8 +910,10 @@ static void ConfigureDaemonServices(
     }
     services.AddSingleton<IModelCapabilityResolver>(sp =>
     {
-        var resolvers = new List<IModelCapabilityResolver>();
-        resolvers.Add(sp.GetRequiredService<OpenAiCodexCapabilityResolver>());
+        var resolvers = new List<IModelCapabilityResolver>
+        {
+            sp.GetRequiredService<OpenAiCodexCapabilityResolver>()
+        };
         if (ollamaEndpoint is not null)
             resolvers.Add(sp.GetRequiredService<OllamaCapabilityResolver>());
         if (openAiCompatibleEndpoint is not null)

--- a/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
+++ b/src/Netclaw.Daemon/Services/DaemonCrashMonitor.cs
@@ -46,7 +46,7 @@ internal sealed class DaemonCrashMonitor : IDisposable
         => new(
             paths.LogsDirectory,
             timeProvider,
-            benignUnobservedFilters is null ? [] : benignUnobservedFilters.ToArray());
+            benignUnobservedFilters is null ? [] : [.. benignUnobservedFilters]);
 
     public void AttachServices(IServiceProvider services)
     {

--- a/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
+++ b/src/Netclaw.Daemon/Services/DaemonRestartCoordinator.cs
@@ -80,8 +80,8 @@ public sealed class DaemonRestartCoordinator : IDaemonRestartCoordinator
             {
                 Reason = "config-reload",
                 RequestedAt = _timeProvider.GetUtcNow(),
-                SessionIds = drainResult.AllSessionIds.Select(static id => id.Value).ToList(),
-                TimedOutSessionIds = drainResult.TimedOutSessionIds.Select(static id => id.Value).ToList()
+                SessionIds = [.. drainResult.AllSessionIds.Select(static id => id.Value)],
+                TimedOutSessionIds = [.. drainResult.TimedOutSessionIds.Select(static id => id.Value)]
             };
 
             if (manifest.SessionIds.Count == 0)

--- a/src/Netclaw.Daemon/Services/SchemaMigrator.cs
+++ b/src/Netclaw.Daemon/Services/SchemaMigrator.cs
@@ -224,7 +224,7 @@ public sealed class SchemaMigrator
         var migrationRoot = Path.Combine(AppContext.BaseDirectory, "migrations", "sqlite");
         if (Directory.Exists(migrationRoot))
         {
-            return Directory.GetFiles(migrationRoot, "*.sql", SearchOption.TopDirectoryOnly)
+            return [.. Directory.GetFiles(migrationRoot, "*.sql", SearchOption.TopDirectoryOnly)
                 .Select(path => new
                 {
                     Path = path,
@@ -233,14 +233,13 @@ public sealed class SchemaMigrator
                 })
                 .Where(x => x.Version is not null)
                 .OrderBy(x => x.Version)
-                .Select(x => new SqlMigration(x.Version!.Value, x.Name, File.ReadAllText(x.Path)))
-                .ToList();
+                .Select(x => new SqlMigration(x.Version!.Value, x.Name, File.ReadAllText(x.Path)))];
         }
 
         var marker = ".migrations.sqlite.";
         var assembly = typeof(SchemaMigrator).Assembly;
 
-        return assembly.GetManifestResourceNames()
+        return [.. assembly.GetManifestResourceNames()
             .Where(name => name.EndsWith(".sql", StringComparison.OrdinalIgnoreCase)
                            && name.Contains(marker, StringComparison.OrdinalIgnoreCase))
             .Select(path => new
@@ -260,8 +259,7 @@ public sealed class SchemaMigrator
             .Select(x => new SqlMigration(
                 x.Version!.Value,
                 x.Name,
-                ReadEmbeddedResourceText(assembly, x.ResourceName)))
-            .ToList();
+                ReadEmbeddedResourceText(assembly, x.ResourceName)))];
     }
 
     private static async Task<HashSet<string>> ReadTableColumnsAsync(

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -201,8 +201,8 @@ public static class WebhookEndpointRouteBuilderExtensions
 
     internal static string SanitizeWebhookId(string value)
     {
-        var sanitized = new string(value.Select(ch =>
-            char.IsLetterOrDigit(ch) || ch is '-' or '_' or '.' ? ch : '-').ToArray());
+        var sanitized = new string([.. value.Select(ch =>
+            char.IsLetterOrDigit(ch) || ch is '-' or '_' or '.' ? ch : '-')]);
 
         return string.IsNullOrWhiteSpace(sanitized)
             ? Guid.NewGuid().ToString("N")

--- a/src/Netclaw.Daemon/Webhooks/WebhookExecutionService.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookExecutionService.cs
@@ -52,5 +52,5 @@ public sealed class WebhookExecutionService : IWebhookExecutionService
     }
 
     private static string Sanitize(string value)
-        => new string(value.Select(ch => char.IsLetterOrDigit(ch) ? ch : '-').ToArray()).Trim('-');
+        => new string([.. value.Select(ch => char.IsLetterOrDigit(ch) ? ch : '-')]).Trim('-');
 }

--- a/src/Netclaw.MemoryRetrievalPoC.Tests/Prototype/DeterministicRecallEngine.cs
+++ b/src/Netclaw.MemoryRetrievalPoC.Tests/Prototype/DeterministicRecallEngine.cs
@@ -318,7 +318,7 @@ internal sealed class DeterministicRecallEngine
             x => x.DocumentId,
             x => (IReadOnlyList<string>)(_inferredNeighborsByAnchor.TryGetValue(_documents.First(d => d.DocumentId == x.DocumentId).AnchorId, out var list)
                 ? list.Select(n => $"{n.ToAnchorId} ({n.Reason}, {n.Weight:F2})").ToArray()
-                : Array.Empty<string>()),
+                : []),
             StringComparer.OrdinalIgnoreCase);
 
         return new RetrievalExplanation(

--- a/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
+++ b/src/Netclaw.Providers/OAuth/OAuthTokenPersistence.cs
@@ -34,11 +34,11 @@ public static class OAuthTokenPersistence
             ? File.ReadAllText(paths.SecretsPath)
             : "{}";
 
-        var root = JsonNode.Parse(existingJson)?.AsObject() ?? new JsonObject();
-        var providers = root["Providers"]?.AsObject() ?? new JsonObject();
+        var root = JsonNode.Parse(existingJson)?.AsObject() ?? [];
+        var providers = root["Providers"]?.AsObject() ?? [];
         root["Providers"] = providers;
 
-        var providerNode = providers[providerName]?.AsObject() ?? new JsonObject();
+        var providerNode = providers[providerName]?.AsObject() ?? [];
         providers[providerName] = providerNode;
 
         providerNode["OAuthAccessToken"] = result.AccessToken.Value;
@@ -57,10 +57,10 @@ public static class OAuthTokenPersistence
         {
             var configJson = File.Exists(paths.NetclawConfigPath)
                 ? File.ReadAllText(paths.NetclawConfigPath) : "{}";
-            var configRoot = JsonNode.Parse(configJson)?.AsObject() ?? new JsonObject();
-            var configProviders = configRoot["Providers"]?.AsObject() ?? new JsonObject();
+            var configRoot = JsonNode.Parse(configJson)?.AsObject() ?? [];
+            var configProviders = configRoot["Providers"]?.AsObject() ?? [];
             configRoot["Providers"] = configProviders;
-            var configProvider = configProviders[providerName]?.AsObject() ?? new JsonObject();
+            var configProvider = configProviders[providerName]?.AsObject() ?? [];
             configProviders[providerName] = configProvider;
             configProvider["OAuthTokenExpiry"] = result.ExpiresAt.Value.ToString("o");
             File.WriteAllText(paths.NetclawConfigPath,

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -127,7 +127,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                     yield return new ChatResponseUpdate(ChatRole.Assistant, [new TextContent(cleaned)]);
                 }
 
-                yield return new ChatResponseUpdate(ChatRole.Assistant, textToolCalls.Cast<AIContent>().ToList())
+                yield return new ChatResponseUpdate(ChatRole.Assistant, [.. textToolCalls.Cast<AIContent>()])
                 {
                     FinishReason = ChatFinishReason.ToolCalls
                 };
@@ -142,7 +142,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             var textToolCalls = TextToolCallParser.ExtractFromText(accumulatedText.ToString());
             if (textToolCalls.Count > 0)
             {
-                yield return new ChatResponseUpdate(ChatRole.Assistant, textToolCalls.Cast<AIContent>().ToList())
+                yield return new ChatResponseUpdate(ChatRole.Assistant, [.. textToolCalls.Cast<AIContent>()])
                 {
                     FinishReason = ChatFinishReason.ToolCalls
                 };
@@ -670,7 +670,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             Additional(details)[PredictedTokPerSecX100Key] = (long)(predictedPerSec * 100);
 
         static AdditionalPropertiesDictionary<long> Additional(UsageDetails d)
-            => d.AdditionalCounts ??= new AdditionalPropertiesDictionary<long>();
+            => d.AdditionalCounts ??= [];
     }
 
     private static bool TryGetLong(JsonElement obj, string name, out long value)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleModelsClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleModelsClient.cs
@@ -34,10 +34,9 @@ public sealed class OpenAiCompatibleModelsClient
             || data.ValueKind != JsonValueKind.Array)
             return [];
 
-        return data.EnumerateArray()
+        return [.. data.EnumerateArray()
             .Where(x => x.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.String)
-            .Select(x => x.GetProperty("id").GetString()!)
-            .ToArray();
+            .Select(x => x.GetProperty("id").GetString()!)];
     }
 
     private void ApplyAuth(HttpRequestMessage request)

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -230,7 +230,7 @@ public class BraveSearchBackendTests
     {
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(new byte[] { 0x1F, 0x8B, 0x00, 0x01 })
+            Content = new ByteArrayContent([0x1F, 0x8B, 0x00, 0x01])
         };
         response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
         return response;

--- a/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
+++ b/src/Netclaw.Security.Tests/MagicByteValidatorTests.cs
@@ -477,7 +477,7 @@ public sealed class MagicByteValidatorTests
     [Fact]
     public void Validate_EmptyContent_Rejected()
     {
-        var result = MagicByteValidator.Validate(ReadOnlySpan<byte>.Empty, "image/png", "empty.png");
+        var result = MagicByteValidator.Validate([], "image/png", "empty.png");
 
         Assert.False(result.IsAllowed);
         Assert.Equal(ContentScanError.EmptyContent, result.Error);
@@ -813,8 +813,8 @@ public sealed class MagicByteValidatorTests
     [Fact]
     public void DetectMimeType_returns_null_for_empty_or_short_content()
     {
-        Assert.Null(MagicByteValidator.DetectMimeType(ReadOnlySpan<byte>.Empty));
-        Assert.Null(MagicByteValidator.DetectMimeType(new byte[] { 0xFF }));
-        Assert.Null(MagicByteValidator.DetectMimeType(new byte[] { 0xFF, 0xD8 }));
+        Assert.Null(MagicByteValidator.DetectMimeType([]));
+        Assert.Null(MagicByteValidator.DetectMimeType([0xFF]));
+        Assert.Null(MagicByteValidator.DetectMimeType([0xFF, 0xD8]));
     }
 }

--- a/src/Netclaw.Security/MagicByteValidator.cs
+++ b/src/Netclaw.Security/MagicByteValidator.cs
@@ -223,73 +223,74 @@ public static class MagicByteValidator
 
     private static Dictionary<string, SignatureRule> BuildRules()
     {
-        var rules = new Dictionary<string, SignatureRule>(StringComparer.OrdinalIgnoreCase);
+        var rules = new Dictionary<string, SignatureRule>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Images
+            ["image/png"] = new(Exts(".png"), IsPng),
+            ["image/jpeg"] = new(Exts(".jpg", ".jpeg"), IsJpeg),
+            ["image/gif"] = new(Exts(".gif"), IsGif),
+            ["image/webp"] = new(Exts(".webp"), IsWebp),
 
-        // Images
-        rules["image/png"] = new(Exts(".png"), IsPng);
-        rules["image/jpeg"] = new(Exts(".jpg", ".jpeg"), IsJpeg);
-        rules["image/gif"] = new(Exts(".gif"), IsGif);
-        rules["image/webp"] = new(Exts(".webp"), IsWebp);
+            // PDF
+            ["application/pdf"] = new(Exts(".pdf"), IsPdf),
 
-        // PDF
-        rules["application/pdf"] = new(Exts(".pdf"), IsPdf);
+            // OOXML (ZIP-based) — docx/xlsx/pptx
+            ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"] =
+            new(Exts(".docx"), IsZip),
+            ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] =
+            new(Exts(".xlsx"), IsZip),
+            ["application/vnd.openxmlformats-officedocument.presentationml.presentation"] =
+            new(Exts(".pptx"), IsZip),
 
-        // OOXML (ZIP-based) — docx/xlsx/pptx
-        rules["application/vnd.openxmlformats-officedocument.wordprocessingml.document"] =
-            new(Exts(".docx"), IsZip);
-        rules["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] =
-            new(Exts(".xlsx"), IsZip);
-        rules["application/vnd.openxmlformats-officedocument.presentationml.presentation"] =
-            new(Exts(".pptx"), IsZip);
+            // OpenDocument (also ZIP-based)
+            ["application/vnd.oasis.opendocument.text"] = new(Exts(".odt"), IsZip),
+            ["application/vnd.oasis.opendocument.spreadsheet"] = new(Exts(".ods"), IsZip),
+            ["application/vnd.oasis.opendocument.presentation"] = new(Exts(".odp"), IsZip),
 
-        // OpenDocument (also ZIP-based)
-        rules["application/vnd.oasis.opendocument.text"] = new(Exts(".odt"), IsZip);
-        rules["application/vnd.oasis.opendocument.spreadsheet"] = new(Exts(".ods"), IsZip);
-        rules["application/vnd.oasis.opendocument.presentation"] = new(Exts(".odp"), IsZip);
+            // Legacy OLE Compound Document Office formats
+            ["application/msword"] = new(Exts(".doc"), IsOle),
+            ["application/vnd.ms-excel"] = new(Exts(".xls"), IsOle),
+            ["application/vnd.ms-powerpoint"] = new(Exts(".ppt"), IsOle),
 
-        // Legacy OLE Compound Document Office formats
-        rules["application/msword"] = new(Exts(".doc"), IsOle);
-        rules["application/vnd.ms-excel"] = new(Exts(".xls"), IsOle);
-        rules["application/vnd.ms-powerpoint"] = new(Exts(".ppt"), IsOle);
+            // Plain/structured text — no signature, but executable pre-check
+            // still blocks MZ / ELF / shebang payloads.
+            ["text/plain"] = new(Exts(".txt", ".log"), AnyContent),
+            ["text/markdown"] = new(Exts(".md", ".markdown"), AnyContent),
+            ["text/csv"] = new(Exts(".csv"), AnyContent),
+            ["text/xml"] = new(Exts(".xml"), AnyContent),
+            ["application/json"] = new(Exts(".json"), AnyContent),
+            ["application/xml"] = new(Exts(".xml"), AnyContent),
+            ["application/yaml"] = new(Exts(".yml", ".yaml"), AnyContent),
+            ["application/x-yaml"] = new(Exts(".yml", ".yaml"), AnyContent),
 
-        // Plain/structured text — no signature, but executable pre-check
-        // still blocks MZ / ELF / shebang payloads.
-        rules["text/plain"] = new(Exts(".txt", ".log"), AnyContent);
-        rules["text/markdown"] = new(Exts(".md", ".markdown"), AnyContent);
-        rules["text/csv"] = new(Exts(".csv"), AnyContent);
-        rules["text/xml"] = new(Exts(".xml"), AnyContent);
-        rules["application/json"] = new(Exts(".json"), AnyContent);
-        rules["application/xml"] = new(Exts(".xml"), AnyContent);
-        rules["application/yaml"] = new(Exts(".yml", ".yaml"), AnyContent);
-        rules["application/x-yaml"] = new(Exts(".yml", ".yaml"), AnyContent);
+            // Rich text
+            ["application/rtf"] = new(Exts(".rtf"), IsRtf),
+            ["text/rtf"] = new(Exts(".rtf"), IsRtf),
 
-        // Rich text
-        rules["application/rtf"] = new(Exts(".rtf"), IsRtf);
-        rules["text/rtf"] = new(Exts(".rtf"), IsRtf);
+            // Archives
+            ["application/zip"] = new(Exts(".zip"), IsZip),
+            ["application/x-zip-compressed"] = new(Exts(".zip"), IsZip),
+            ["application/x-7z-compressed"] = new(Exts(".7z"), Is7z),
+            ["application/gzip"] = new(Exts(".gz", ".tgz"), IsGzip),
+            ["application/x-gzip"] = new(Exts(".gz", ".tgz"), IsGzip),
+            ["application/x-bzip2"] = new(Exts(".bz2"), IsBzip2),
+            ["application/x-xz"] = new(Exts(".xz"), IsXz),
 
-        // Archives
-        rules["application/zip"] = new(Exts(".zip"), IsZip);
-        rules["application/x-zip-compressed"] = new(Exts(".zip"), IsZip);
-        rules["application/x-7z-compressed"] = new(Exts(".7z"), Is7z);
-        rules["application/gzip"] = new(Exts(".gz", ".tgz"), IsGzip);
-        rules["application/x-gzip"] = new(Exts(".gz", ".tgz"), IsGzip);
-        rules["application/x-bzip2"] = new(Exts(".bz2"), IsBzip2);
-        rules["application/x-xz"] = new(Exts(".xz"), IsXz);
+            // Audio
+            ["audio/mpeg"] = new(Exts(".mp3"), IsMp3FrameOrId3),
+            ["audio/mp4"] = new(Exts(".m4a", ".mp4"), IsFtyp),
+            ["audio/x-m4a"] = new(Exts(".m4a"), IsFtyp),
+            ["audio/wav"] = new(Exts(".wav"), IsWav),
+            ["audio/x-wav"] = new(Exts(".wav"), IsWav),
+            ["audio/ogg"] = new(Exts(".ogg", ".oga"), IsOgg),
 
-        // Audio
-        rules["audio/mpeg"] = new(Exts(".mp3"), IsMp3FrameOrId3);
-        rules["audio/mp4"] = new(Exts(".m4a", ".mp4"), IsFtyp);
-        rules["audio/x-m4a"] = new(Exts(".m4a"), IsFtyp);
-        rules["audio/wav"] = new(Exts(".wav"), IsWav);
-        rules["audio/x-wav"] = new(Exts(".wav"), IsWav);
-        rules["audio/ogg"] = new(Exts(".ogg", ".oga"), IsOgg);
-
-        // Video
-        rules["video/mp4"] = new(Exts(".mp4", ".m4v"), IsFtyp);
-        rules["video/quicktime"] = new(Exts(".mov"), IsFtyp);
-        rules["video/webm"] = new(Exts(".webm"), IsEbml);
-        rules["video/x-matroska"] = new(Exts(".mkv"), IsEbml);
-        rules["video/x-msvideo"] = new(Exts(".avi"), IsAvi);
+            // Video
+            ["video/mp4"] = new(Exts(".mp4", ".m4v"), IsFtyp),
+            ["video/quicktime"] = new(Exts(".mov"), IsFtyp),
+            ["video/webm"] = new(Exts(".webm"), IsEbml),
+            ["video/x-matroska"] = new(Exts(".mkv"), IsEbml),
+            ["video/x-msvideo"] = new(Exts(".avi"), IsAvi)
+        };
 
         return rules;
     }
@@ -299,18 +300,19 @@ public static class MagicByteValidator
 
     private static Dictionary<(string Extension, string DeclaredMime), string> BuildMimeNormalizationRules()
     {
-        var rules = new Dictionary<(string, string), string>(new ExtensionMimePairComparer());
+        var rules = new Dictionary<(string, string), string>(new ExtensionMimePairComparer())
+        {
+            // Slack reports .md files as text/plain instead of text/markdown
+            [(".md", "text/plain")] = "text/markdown",
+            [(".markdown", "text/plain")] = "text/markdown",
 
-        // Slack reports .md files as text/plain instead of text/markdown
-        rules[(".md", "text/plain")] = "text/markdown";
-        rules[(".markdown", "text/plain")] = "text/markdown";
-
-        // JSON/YAML/CSV/XML sometimes reported as text/plain by various providers
-        rules[(".json", "text/plain")] = "application/json";
-        rules[(".yaml", "text/plain")] = "application/yaml";
-        rules[(".yml", "text/plain")] = "application/yaml";
-        rules[(".csv", "text/plain")] = "text/csv";
-        rules[(".xml", "text/plain")] = "text/xml";
+            // JSON/YAML/CSV/XML sometimes reported as text/plain by various providers
+            [(".json", "text/plain")] = "application/json",
+            [(".yaml", "text/plain")] = "application/yaml",
+            [(".yml", "text/plain")] = "application/yaml",
+            [(".csv", "text/plain")] = "text/csv",
+            [(".xml", "text/plain")] = "text/xml"
+        };
 
         return rules;
     }

--- a/src/Netclaw.Tests.Utilities/FakeHttpMessageHandler.cs
+++ b/src/Netclaw.Tests.Utilities/FakeHttpMessageHandler.cs
@@ -13,7 +13,7 @@ internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
     private const string JsonMediaType = "application/json";
 
-    private readonly Dictionary<string, Func<HttpRequestMessage, HttpResponseMessage>> _routes = new();
+    private readonly Dictionary<string, Func<HttpRequestMessage, HttpResponseMessage>> _routes = [];
     private readonly Func<HttpRequestMessage, HttpResponseMessage>? _catchAll;
 
     public FakeHttpMessageHandler() { }

--- a/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
+++ b/src/Netclaw.Tools.Generators/NetclawToolGenerator.cs
@@ -120,7 +120,7 @@ public sealed class NetclawToolGenerator : IIncrementalGenerator
             description,
             grant,
             paramsType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-            parameters.ToImmutableArray());
+            [.. parameters]);
     }
 
     private static string GetJsonType(ITypeSymbol type)


### PR DESCRIPTION
## Summary

- Apply C# 12 collection expressions across the codebase via `dotnet format`, replacing verbose `new List<T>()`, `new List<T> { ... }`, and `Array.Empty<T>()` with `[]` syntax
- Add `.editorconfig` rules (`dotnet_style_collection_initializer`, `dotnet_style_prefer_collection_expression`) to enforce the style going forward
- 90 files changed, net -18 lines — pure syntax modernization with zero behavioral change

Closes #813

## Test plan

- [x] `dotnet build` — zero warnings, zero errors
- [x] `dotnet test` — all 3,001 tests pass
- [x] `dotnet slopwatch analyze` — no new violations
- [ ] CI passes