### PR TITLE
perf: eliminate double LINQ enumeration and dictionary double-lookup

### DIFF
--- a/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
@@ -143,7 +143,7 @@ internal sealed class OpenAiCodexRequestPolicy(string? accountId) : PipelinePoli
             if (tool is not JsonObject toolObj)
                 continue;
 
-            if (toolObj.ContainsKey("strict") && toolObj["strict"] is null)
+            if (toolObj.TryGetPropertyValue("strict", out var strictValue) && strictValue is null)
                 toolObj.Remove("strict");
         }
     }

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -85,15 +85,20 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             foreach (var update in ParseStreamingUpdates(document.RootElement, pendingToolCalls))
             {
                 var suppressThisUpdate = false;
-                foreach (var tc in update.Contents.OfType<TextContent>())
+                foreach (var item in update.Contents)
                 {
-                    accumulatedText.Append(tc.Text);
-                    if (filter.ShouldSuppress(tc.Text))
-                        suppressThisUpdate = true;
+                    switch (item)
+                    {
+                        case TextContent tc:
+                            accumulatedText.Append(tc.Text);
+                            if (filter.ShouldSuppress(tc.Text))
+                                suppressThisUpdate = true;
+                            break;
+                        case FunctionCallContent:
+                            hadStructuredToolCalls = true;
+                            break;
+                    }
                 }
-
-                if (update.Contents.OfType<FunctionCallContent>().Any())
-                    hadStructuredToolCalls = true;
 
                 if (update.FinishReason is not null)
                     finalUpdate = update;


### PR DESCRIPTION
## Summary

- **Streaming path (`OpenAiCompatibleChatClient.cs`):** Replaced two separate `OfType<TextContent>()` and `OfType<FunctionCallContent>().Any()` calls — which each enumerate `update.Contents` independently — with a single `foreach` loop using a pattern-matching `switch` to handle both content types in one pass.
- **Dictionary lookup (`OpenAiCodexRequestPolicy.cs`):** Replaced `ContainsKey("strict")` followed by `toolObj["strict"]` (two hash lookups) with a single `TryGetPropertyValue("strict", out var strictValue)` call.

Closes #817

## Test plan

- [x] `dotnet build` — zero errors
- [x] `dotnet test` — all 3001 tests pass
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all copyright headers present