### PR TITLE
refactor: consolidate channel registration duplication

### DIFF
--- a/src/Netclaw.Daemon/Configuration/ChannelRegistrationHelpers.cs
+++ b/src/Netclaw.Daemon/Configuration/ChannelRegistrationHelpers.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChannelRegistrationHelpers.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Channels;
+
+namespace Netclaw.Daemon.Configuration;
+
+/// <summary>
+/// Shared registration helpers for channel integrations. Each channel uses a
+/// keyed singleton so it can be resolved by name, then forwards the keyed
+/// registration to the non-keyed <see cref="IChannel"/> and
+/// <see cref="IHostedService"/> collections.
+/// </summary>
+internal static class ChannelRegistrationHelpers
+{
+    /// <summary>
+    /// Registers a channel implementation as a keyed singleton, forwards it to
+    /// the non-keyed <see cref="IChannel"/> collection, and registers it as an
+    /// <see cref="IHostedService"/> so the host starts/stops it automatically.
+    /// </summary>
+    internal static void AddChannelSingleton<TChannel>(
+        this IServiceCollection services, string channelKey)
+        where TChannel : class, IChannel
+    {
+        services.AddKeyedSingleton<IChannel, TChannel>(channelKey);
+        services.AddSingleton<IChannel>(sp =>
+            sp.GetRequiredKeyedService<IChannel>(channelKey));
+        services.AddSingleton<IHostedService>(sp =>
+            (IHostedService)sp.GetRequiredKeyedService<IChannel>(channelKey));
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/DiscordChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/DiscordChannelRegistrationExtensions.cs
@@ -64,11 +64,6 @@ public static class DiscordChannelRegistrationExtensions
         });
         services.AddSingleton<IReminderTargetResolver, DiscordReminderTargetResolver>();
 
-        services.AddKeyedSingleton<IChannel, DiscordChannel>(DiscordChannelKey);
-        services.AddSingleton<IChannel>(sp =>
-            sp.GetRequiredKeyedService<IChannel>(DiscordChannelKey));
-
-        services.AddSingleton<IHostedService>(sp =>
-            (IHostedService)sp.GetRequiredKeyedService<IChannel>(DiscordChannelKey));
+        services.AddChannelSingleton<DiscordChannel>(DiscordChannelKey);
     }
 }

--- a/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/SlackChannelRegistrationExtensions.cs
@@ -60,9 +60,7 @@ public static class SlackChannelRegistrationExtensions
         services.AddSingleton<ISlackTargetResolver, SlackTargetResolver>();
         services.AddSingleton<IReminderTargetResolver, SlackReminderTargetResolver>();
         services.AddSingleton<SlackApprovalHandler>();
-        services.AddKeyedSingleton<IChannel, SlackChannel>(SlackChannelKey);
-        services.AddSingleton<IChannel>(sp =>
-            sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
+        services.AddChannelSingleton<SlackChannel>(SlackChannelKey);
         services.AddSingleton<SlackChannel>(sp =>
             (SlackChannel)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
 
@@ -101,8 +99,5 @@ public static class SlackChannelRegistrationExtensions
             return new LookupSlackUserTool(slackApi.Users, slackOptions, timeProvider);
         });
         services.AddSingleton<IChannelTool>(sp => sp.GetRequiredService<LookupSlackUserTool>());
-
-        services.AddSingleton<IHostedService>(sp =>
-            (IHostedService)sp.GetRequiredKeyedService<IChannel>(SlackChannelKey));
     }
 }


### PR DESCRIPTION
## Summary
- Extracted `ChannelRegistrationHelpers.AddChannelSingleton<TChannel>()` to encapsulate the repeated keyed-singleton + forwarding-singleton + hosted-service registration pattern
- Replaced inline boilerplate in `SlackChannelRegistrationExtensions` (5 lines removed) and `DiscordChannelRegistrationExtensions` (6 lines removed) with single-line calls
- Channel-specific logic (validation, service registrations, tools) remains inline in each extension class

Closes #810

## Test plan
- [x] `dotnet build` -- zero errors, zero warnings
- [x] `dotnet test` -- all 3001 tests pass
- [x] `dotnet slopwatch analyze` -- no new violations
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` -- all copyright headers present