### PR TITLE
refactor: consolidate SkillSyncService duplication via base class

### DIFF
--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ServerFeedSkillSyncService.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -25,12 +25,10 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
 {
     private readonly SkillFeedsConfig _feedsConfig;
     private readonly NetclawPaths _paths;
-    private readonly SkillRegistry _skillRegistry;
-    private readonly SkillIndexContextLayer _skillIndexLayer;
     private readonly TimeProvider _timeProvider;
-    private readonly ISkillContentScanner _scanner;
     private readonly ILogger<ServerFeedSkillSyncService> _logger;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
+    private readonly ServerFeedSyncHelper _syncHelper;
 
     // Random jitter (0–5 min) so multiple daemon instances don't all poll at once
     private readonly TimeSpan _initialJitter;
@@ -47,13 +45,11 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
     {
         _feedsConfig = feedsConfig;
         _paths = paths;
-        _skillRegistry = skillRegistry;
-        _skillIndexLayer = skillIndexLayer;
         _timeProvider = timeProvider;
-        _scanner = scanner;
         _logger = logger;
         _externalSources = externalSources;
         _initialJitter = TimeSpan.FromSeconds(Random.Shared.Next(0, 300));
+        _syncHelper = new ServerFeedSyncHelper(scanner, skillRegistry, skillIndexLayer, logger);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -104,7 +100,7 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
         {
             try
             {
-                await SyncFeedAsync(feed, cancellationToken);
+                await _syncHelper.SyncFeedAsync(feed, _paths, _timeProvider, cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -114,211 +110,6 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
             }
         }
 
-        RescanAndUpdateIndex();
-    }
-
-    private async Task SyncFeedAsync(SkillFeedSource feed, CancellationToken cancellationToken)
-    {
-        var feedDir = _paths.ServerFeedDirectory(feed.Name);
-        Directory.CreateDirectory(feedDir);
-
-        var syncState = SkillSyncHelpers.ReadSyncState(
-            _paths.ServerFeedSyncStatePath(feed.Name), _logger);
-        var now = _timeProvider.GetUtcNow();
-
-        RfcSkillIndex? index;
-        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-        {
-            cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
-            try
-            {
-                using var client = new SkillServerClient(feed.Url, feed.ApiKey?.Value);
-                index = await client.GetRfcIndexAsync(cts.Token);
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                _logger.LogWarning(
-                    "Server feed '{FeedName}' RFC index fetch timed out — using on-disk skills",
-                    feed.Name);
-                return;
-            }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogWarning(
-                    "Server feed '{FeedName}' RFC index fetch failed: {Message} — using on-disk skills",
-                    feed.Name, ex.Message);
-                return;
-            }
-        }
-
-        if (index is null || index.Skills.Count == 0)
-        {
-            _logger.LogDebug("Server feed '{FeedName}' returned empty index", feed.Name);
-            return;
-        }
-
-        _logger.LogDebug(
-            "Fetched RFC index from server feed '{FeedName}' ({SkillCount} skills)",
-            feed.Name, index.Skills.Count);
-
-        var updated = false;
-
-        using var httpClient = CreateHttpClientForFeed(feed);
-
-        foreach (var entry in index.Skills)
-        {
-            var digestHex = NormalizeDigest(entry.Digest);
-            var version = entry.Version ?? "unknown";
-
-            if (syncState.Skills.TryGetValue(entry.Name, out var existing)
-                && existing.Version == version
-                && string.Equals(existing.Sha256, digestHex, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            try
-            {
-                var mainContent = await DownloadAndVerifyAsync(
-                    httpClient, entry.Url, digestHex, entry.Name, feed.TimeoutSeconds, cancellationToken);
-                if (mainContent is null)
-                    continue;
-
-                var mainScan = await _scanner.ScanAsync(entry.Name, mainContent, cancellationToken);
-                if (!mainScan.IsAllowed)
-                {
-                    _logger.LogWarning(
-                        "Rejected skill '{SkillName}' from feed '{FeedName}': {Reason}",
-                        entry.Name, feed.Name, mainScan.Reason);
-                    continue;
-                }
-
-                var downloadedFiles = new List<DownloadedSkillFile>
-                {
-                    new("SKILL.md", mainContent)
-                };
-
-                if (entry.Resources is { Count: > 0 })
-                {
-                    var allFilesOk = true;
-                    foreach (var resource in entry.Resources)
-                    {
-                        var normalizedPath = SkillSyncHelpers.ValidateResourcePath(resource.Path);
-                        if (normalizedPath is null)
-                        {
-                            _logger.LogWarning(
-                                "Rejected resource path for '{SkillName}' from feed '{FeedName}': {Path}",
-                                entry.Name, feed.Name, resource.Path);
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        var resourceDigest = NormalizeDigest(resource.Digest);
-                        var fileContent = await DownloadAndVerifyAsync(
-                            httpClient, resource.Url, resourceDigest,
-                            $"{entry.Name}/{resource.Path}", feed.TimeoutSeconds, cancellationToken);
-                        if (fileContent is null)
-                        {
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        var fileScan = await _scanner.ScanAsync(
-                            $"{entry.Name}:{normalizedPath}", fileContent, cancellationToken);
-                        if (!fileScan.IsAllowed)
-                        {
-                            _logger.LogWarning(
-                                "Rejected resource for '{SkillName}' from feed '{FeedName}' at {Path}: {Reason}",
-                                entry.Name, feed.Name, normalizedPath, fileScan.Reason);
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        downloadedFiles.Add(new DownloadedSkillFile(normalizedPath, fileContent));
-                    }
-
-                    if (!allFilesOk)
-                        continue;
-                }
-
-                await SkillSyncHelpers.ReplaceSkillDirectoryAsync(
-                    feedDir, entry.Name, downloadedFiles, cancellationToken);
-
-                syncState.Skills[entry.Name] = new SyncedSkillState
-                {
-                    Version = version,
-                    Sha256 = digestHex,
-                    SyncedAtUtc = now
-                };
-
-                _logger.LogInformation(
-                    "Synced skill '{SkillName}' v{Version} from feed '{FeedName}'",
-                    entry.Name, version, feed.Name);
-                updated = true;
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogWarning(ex,
-                    "Failed to sync skill '{SkillName}' from feed '{FeedName}' — keeping existing version",
-                    entry.Name, feed.Name);
-            }
-        }
-
-        if (updated)
-        {
-            syncState.LastSyncUtc = now;
-            SkillSyncHelpers.WriteSyncState(
-                _paths.ServerFeedSyncStatePath(feed.Name), syncState);
-        }
-    }
-
-    private static HttpClient CreateHttpClientForFeed(SkillFeedSource feed)
-    {
-        var client = new HttpClient();
-        if (feed.ApiKey is { Value: { } apiKey } && !string.IsNullOrWhiteSpace(apiKey))
-        {
-            client.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", apiKey);
-        }
-        return client;
-    }
-
-    private async Task<string?> DownloadAndVerifyAsync(
-        HttpClient httpClient, string url, string expectedSha256Hex, string label,
-        int timeoutSeconds, CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
-
-            var content = await httpClient.GetStringAsync(url, cts.Token);
-
-            var hash = SkillSyncHelpers.ComputeSha256(content);
-            if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning(
-                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
-                    label, expectedSha256Hex, hash);
-                return null;
-            }
-
-            return content;
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            _logger.LogWarning("Download timed out for {Label}", label);
-            return null;
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
-            return null;
-        }
-    }
-
-    private void RescanAndUpdateIndex()
-    {
         var resolvedServerFeeds = new List<ResolvedExternalSource>();
         foreach (var feed in _feedsConfig.Feeds.Where(f => f.Enabled))
         {
@@ -328,31 +119,8 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
                     $"server-feed:{feed.Name}", [feedDir], AllowSymlinks: false));
         }
 
-        var mergedResult = SkillScanner.ScanAndMerge(
-            _paths.SkillsDirectory, resolvedServerFeeds, _externalSources);
-        SkillRegistryUpdater.ApplyMergedScanResult(
-            _skillRegistry, _skillIndexLayer, mergedResult,
-            _paths.SkillsDirectory, _externalSources);
-
-        if (mergedResult.Issues.Count > 0)
-        {
-            _logger.LogWarning(
-                "Skill inventory is degraded after server feed sync: accepted={AcceptedSkillCount} rejected={RejectedIssueCount}",
-                mergedResult.AcceptedSkills.Count, mergedResult.Issues.Count);
-
-            foreach (var issue in mergedResult.Issues)
-            {
-                _logger.LogWarning(
-                    "Rejected skill item during server feed sync rebuild: kind={IssueKind} path={Path} message={Message}",
-                    issue.Kind, issue.Path, issue.Message);
-            }
-        }
-        else
-        {
-            _logger.LogInformation(
-                "Skill index updated after server feed sync ({SkillCount} skills)",
-                mergedResult.AcceptedSkills.Count);
-        }
+        _syncHelper.RescanAndUpdateIndex(
+            _paths.SkillsDirectory, resolvedServerFeeds, _externalSources, "server feed sync");
     }
 
     internal static string NormalizeDigest(string digest)
@@ -360,5 +128,147 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
         if (digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
             return digest[7..];
         return digest;
+    }
+
+    /// <summary>
+    /// Inner helper that extends <see cref="SkillSyncServiceBase"/> to reuse
+    /// download-and-verify and per-skill sync logic. Separated from the
+    /// <see cref="BackgroundService"/> hosting so the base class stays
+    /// hosting-agnostic.
+    /// </summary>
+    private sealed class ServerFeedSyncHelper : SkillSyncServiceBase
+    {
+        private readonly ILogger _logger;
+
+        internal ServerFeedSyncHelper(
+            ISkillContentScanner scanner,
+            SkillRegistry skillRegistry,
+            SkillIndexContextLayer skillIndexLayer,
+            ILogger logger)
+            : base(scanner, skillRegistry, skillIndexLayer)
+        {
+            _logger = logger;
+        }
+
+        protected override ILogger Logger => _logger;
+
+        internal new void RescanAndUpdateIndex(
+            string skillsDirectory,
+            IReadOnlyList<ResolvedExternalSource> serverFeedSources,
+            IReadOnlyList<ResolvedExternalSource> externalSources,
+            string logLabel)
+            => base.RescanAndUpdateIndex(skillsDirectory, serverFeedSources, externalSources, logLabel);
+
+        internal async Task SyncFeedAsync(
+            SkillFeedSource feed, NetclawPaths paths, TimeProvider timeProvider,
+            CancellationToken cancellationToken)
+        {
+            var feedDir = paths.ServerFeedDirectory(feed.Name);
+            Directory.CreateDirectory(feedDir);
+
+            var syncState = SkillSyncHelpers.ReadSyncState(
+                paths.ServerFeedSyncStatePath(feed.Name), _logger);
+            var now = timeProvider.GetUtcNow();
+
+            RfcSkillIndex? index;
+            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
+                try
+                {
+                    using var client = new SkillServerClient(feed.Url, feed.ApiKey?.Value);
+                    index = await client.GetRfcIndexAsync(cts.Token);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(
+                        "Server feed '{FeedName}' RFC index fetch timed out — using on-disk skills",
+                        feed.Name);
+                    return;
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogWarning(
+                        "Server feed '{FeedName}' RFC index fetch failed: {Message} — using on-disk skills",
+                        feed.Name, ex.Message);
+                    return;
+                }
+            }
+
+            if (index is null || index.Skills.Count == 0)
+            {
+                _logger.LogDebug("Server feed '{FeedName}' returned empty index", feed.Name);
+                return;
+            }
+
+            _logger.LogDebug(
+                "Fetched RFC index from server feed '{FeedName}' ({SkillCount} skills)",
+                feed.Name, index.Skills.Count);
+
+            var updated = false;
+            var feedTimeout = TimeSpan.FromSeconds(feed.TimeoutSeconds);
+
+            using var httpClient = CreateHttpClientForFeed(feed);
+
+            foreach (var entry in index.Skills)
+            {
+                var digestHex = NormalizeDigest(entry.Digest);
+                var version = entry.Version ?? "unknown";
+
+                if (syncState.Skills.TryGetValue(entry.Name, out var existing)
+                    && existing.Version == version
+                    && string.Equals(existing.Sha256, digestHex, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var resources = entry.Resources?.Select(
+                        r => new SkillResourceDescriptor(r.Path, r.Url, NormalizeDigest(r.Digest))).ToList();
+
+                    var synced = await SyncSingleSkillAsync(
+                        httpClient,
+                        entry.Name,
+                        version,
+                        entry.Url,
+                        digestHex,
+                        resources,
+                        feedDir,
+                        syncState,
+                        now,
+                        feedTimeout,
+                        logContext: $" from feed '{feed.Name}'",
+                        cancellationToken);
+
+                    if (synced)
+                        updated = true;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to sync skill '{SkillName}' from feed '{FeedName}' — keeping existing version",
+                        entry.Name, feed.Name);
+                }
+            }
+
+            if (updated)
+            {
+                syncState.LastSyncUtc = now;
+                SkillSyncHelpers.WriteSyncState(
+                    paths.ServerFeedSyncStatePath(feed.Name), syncState);
+            }
+        }
+
+        private static HttpClient CreateHttpClientForFeed(SkillFeedSource feed)
+        {
+            var client = new HttpClient();
+            if (feed.ApiKey is { Value: { } apiKey } && !string.IsNullOrWhiteSpace(apiKey))
+            {
+                client.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", apiKey);
+            }
+            return client;
+        }
     }
 }

--- a/src/Netclaw.Daemon/Services/SkillSyncServiceBase.cs
+++ b/src/Netclaw.Daemon/Services/SkillSyncServiceBase.cs
@@ -1,0 +1,211 @@
+// -----------------------------------------------------------------------
+// <copyright file="SkillSyncServiceBase.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Skills;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Feeds;
+using Netclaw.Security.Skills;
+
+namespace Netclaw.Daemon.Services;
+
+/// <summary>
+/// Shared orchestration logic for skill sync services. Provides the
+/// download-and-verify pipeline, per-skill sync loop, and rescan/index
+/// rebuild. Subclasses supply their own hosting model (IHostedService,
+/// BackgroundService) and manifest/index fetch logic.
+/// </summary>
+internal abstract class SkillSyncServiceBase
+{
+    private readonly ISkillContentScanner _scanner;
+    private readonly SkillRegistry _skillRegistry;
+    private readonly SkillIndexContextLayer _skillIndexLayer;
+
+    protected SkillSyncServiceBase(
+        ISkillContentScanner scanner,
+        SkillRegistry skillRegistry,
+        SkillIndexContextLayer skillIndexLayer)
+    {
+        _scanner = scanner;
+        _skillRegistry = skillRegistry;
+        _skillIndexLayer = skillIndexLayer;
+    }
+
+    protected abstract ILogger Logger { get; }
+
+    /// <summary>
+    /// Downloads content from <paramref name="url"/>, verifies its SHA-256
+    /// against <paramref name="expectedSha256Hex"/>, and returns the content
+    /// on success. Returns <c>null</c> on timeout, HTTP error, or hash
+    /// mismatch — never throws for those conditions.
+    /// </summary>
+    protected async Task<string?> DownloadAndVerifyAsync(
+        HttpClient httpClient, string url, string expectedSha256Hex, string label,
+        TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+
+            var content = await httpClient.GetStringAsync(url, cts.Token);
+
+            var hash = SkillSyncHelpers.ComputeSha256(content);
+            if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.LogWarning(
+                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
+                    label, expectedSha256Hex, hash);
+                return null;
+            }
+
+            return content;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            Logger.LogWarning("Download timed out for {Label}", label);
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            Logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Synchronizes a single skill entry: downloads the main content and any
+    /// resource files, runs content scanning on each, and atomically replaces
+    /// the skill directory on disk. Returns <c>true</c> if the skill was
+    /// updated and the sync state should be persisted.
+    /// </summary>
+    protected async Task<bool> SyncSingleSkillAsync(
+        HttpClient httpClient,
+        string skillName,
+        string version,
+        string mainUrl,
+        string expectedSha256Hex,
+        IReadOnlyList<SkillResourceDescriptor>? resources,
+        string targetDirectory,
+        SkillSyncState syncState,
+        DateTimeOffset now,
+        TimeSpan downloadTimeout,
+        string logContext,
+        CancellationToken cancellationToken)
+    {
+        var mainContent = await DownloadAndVerifyAsync(
+            httpClient, mainUrl, expectedSha256Hex, skillName, downloadTimeout, cancellationToken);
+        if (mainContent is null)
+            return false;
+
+        var mainScan = await _scanner.ScanAsync(skillName, mainContent, cancellationToken);
+        if (!mainScan.IsAllowed)
+        {
+            Logger.LogWarning(
+                "Rejected skill {SkillName} v{Version}{Context}: {Reason}",
+                skillName, version, logContext, mainScan.Reason);
+            return false;
+        }
+
+        var downloadedFiles = new List<DownloadedSkillFile>
+        {
+            new("SKILL.md", mainContent)
+        };
+
+        if (resources is { Count: > 0 })
+        {
+            foreach (var resource in resources)
+            {
+                var normalizedPath = SkillSyncHelpers.ValidateResourcePath(resource.Path);
+                if (normalizedPath is null)
+                {
+                    Logger.LogWarning(
+                        "Rejected resource path for {SkillName} v{Version}{Context}: {Path}",
+                        skillName, version, logContext, resource.Path);
+                    return false;
+                }
+
+                var fileContent = await DownloadAndVerifyAsync(
+                    httpClient, resource.Url, resource.Sha256, $"{skillName}/{resource.Path}",
+                    downloadTimeout, cancellationToken);
+                if (fileContent is null)
+                    return false;
+
+                var fileScan = await _scanner.ScanAsync(
+                    $"{skillName}:{normalizedPath}", fileContent, cancellationToken);
+                if (!fileScan.IsAllowed)
+                {
+                    Logger.LogWarning(
+                        "Rejected resource for {SkillName} v{Version}{Context} at {Path}: {Reason}",
+                        skillName, version, logContext, normalizedPath, fileScan.Reason);
+                    return false;
+                }
+
+                downloadedFiles.Add(new DownloadedSkillFile(normalizedPath, fileContent));
+            }
+        }
+
+        await SkillSyncHelpers.ReplaceSkillDirectoryAsync(
+            targetDirectory, skillName, downloadedFiles, cancellationToken);
+
+        syncState.Skills[skillName] = new SyncedSkillState
+        {
+            Version = version,
+            Sha256 = expectedSha256Hex,
+            SyncedAtUtc = now
+        };
+
+        Logger.LogInformation("Synced skill {SkillName} v{Version}{Context}", skillName, version, logContext);
+        return true;
+    }
+
+    /// <summary>
+    /// Re-scans the skills directory tree, rebuilds the registry and context
+    /// layer, and logs any rejected items.
+    /// </summary>
+    protected void RescanAndUpdateIndex(
+        string skillsDirectory,
+        IReadOnlyList<ResolvedExternalSource> serverFeedSources,
+        IReadOnlyList<ResolvedExternalSource> externalSources,
+        string logLabel)
+    {
+        var mergedResult = SkillScanner.ScanAndMerge(
+            skillsDirectory, serverFeedSources, externalSources);
+        SkillRegistryUpdater.ApplyMergedScanResult(
+            _skillRegistry, _skillIndexLayer, mergedResult, skillsDirectory, externalSources);
+
+        if (mergedResult.Issues.Count > 0)
+        {
+            Logger.LogWarning(
+                "Skill inventory is degraded after {Label}: accepted={AcceptedSkillCount} rejected={RejectedIssueCount}",
+                logLabel,
+                mergedResult.AcceptedSkills.Count,
+                mergedResult.Issues.Count);
+
+            foreach (var issue in mergedResult.Issues)
+            {
+                Logger.LogWarning(
+                    "Rejected skill item during {Label}: kind={IssueKind} path={Path} message={Message}",
+                    logLabel,
+                    issue.Kind,
+                    issue.Path,
+                    issue.Message);
+            }
+        }
+        else
+        {
+            Logger.LogInformation(
+                "Skill index updated after {Label} ({SkillCount} skills)",
+                logLabel,
+                mergedResult.AcceptedSkills.Count);
+        }
+    }
+}
+
+/// <summary>
+/// Uniform descriptor for a skill resource file, abstracting over the
+/// different wire types used by system feed manifests and server feed indexes.
+/// </summary>
+internal sealed record SkillResourceDescriptor(string Path, string Url, string Sha256);

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SystemSkillSyncService.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -20,17 +20,14 @@ namespace Netclaw.Daemon.Services;
 /// Never blocks startup on network — if the feed is unreachable, the daemon
 /// starts with whatever skills are already on disk.
 /// </summary>
-internal sealed class SystemSkillSyncService : IHostedService
+internal sealed class SystemSkillSyncService : SkillSyncServiceBase, IHostedService
 {
     private readonly HttpClient _httpClient;
     private readonly NetclawPaths _paths;
     private readonly SkillSyncConfig _skillSyncConfig;
-    private readonly SkillRegistry _skillRegistry;
-    private readonly SkillIndexContextLayer _skillIndexLayer;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<SystemSkillSyncService> _logger;
     private readonly string _daemonVersion;
-    private readonly ISkillContentScanner _scanner;
     private readonly IReadOnlyList<ResolvedExternalSource> _serverFeedSources;
     private readonly IReadOnlyList<ResolvedExternalSource> _externalSources;
 
@@ -65,19 +62,19 @@ internal sealed class SystemSkillSyncService : IHostedService
         string daemonVersion,
         IReadOnlyList<ResolvedExternalSource>? serverFeedSources = null,
         IReadOnlyList<ResolvedExternalSource>? externalSources = null)
+        : base(scanner, skillRegistry, skillIndexLayer)
     {
         _httpClient = httpClient;
         _paths = paths;
         _skillSyncConfig = skillSyncConfig;
-        _skillRegistry = skillRegistry;
-        _skillIndexLayer = skillIndexLayer;
         _timeProvider = timeProvider;
-        _scanner = scanner;
         _logger = logger;
         _daemonVersion = daemonVersion;
         _serverFeedSources = serverFeedSources ?? [];
         _externalSources = externalSources ?? [];
     }
+
+    protected override ILogger Logger => _logger;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -85,7 +82,8 @@ internal sealed class SystemSkillSyncService : IHostedService
         {
             _logger.LogInformation(
                 "System skill sync disabled via SkillSync.DisableSystemSkillSync; using on-disk built-in skills only");
-            RescanAndUpdateIndex();
+            RescanAndUpdateIndex(
+                _paths.SkillsDirectory, _serverFeedSources, _externalSources, "sync rebuild");
             return;
         }
 
@@ -101,13 +99,15 @@ internal sealed class SystemSkillSyncService : IHostedService
                 await SyncSkillsAsync(manifest, syncState, cancellationToken);
             }
 
-            RescanAndUpdateIndex();
+            RescanAndUpdateIndex(
+                _paths.SkillsDirectory, _serverFeedSources, _externalSources, "sync rebuild");
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "System skill sync failed — continuing with on-disk skills");
             // Still re-scan on-disk skills even if sync failed
-            RescanAndUpdateIndex();
+            RescanAndUpdateIndex(
+                _paths.SkillsDirectory, _serverFeedSources, _externalSources, "sync rebuild");
         }
     }
 
@@ -188,91 +188,27 @@ internal sealed class SystemSkillSyncService : IHostedService
                 continue;
             }
 
-            // Download skill into its directory (skill-name/SKILL.md)
             try
             {
-                var mainContent = await DownloadAndVerifyAsync(entry.Url, entry.Sha256, entry.Name, cancellationToken);
-                if (mainContent is null)
-                    continue;
+                var resources = entry.Files?.Select(
+                    f => new SkillResourceDescriptor(f.Path, f.Url, f.Sha256)).ToList();
 
-                var mainScan = await _scanner.ScanAsync(
+                var synced = await SyncSingleSkillAsync(
+                    _httpClient,
                     entry.Name,
-                    mainContent,
+                    entry.Version,
+                    entry.Url,
+                    entry.Sha256,
+                    resources,
+                    _paths.SystemSkillsDirectory,
+                    syncState,
+                    now,
+                    FeedConstants.FeedHttpTimeout,
+                    logContext: "",
                     cancellationToken);
-                if (!mainScan.IsAllowed)
-                {
-                    _logger.LogWarning(
-                        "Rejected synced skill {SkillName} v{Version}: {Reason}",
-                        entry.Name,
-                        entry.Version,
-                        mainScan.Reason);
-                    continue;
-                }
 
-                var downloadedFiles = new List<DownloadedSkillFile>
-                {
-                    new("SKILL.md", mainContent)
-                };
-
-                if (entry.Files is { Count: > 0 })
-                {
-                    var allFilesOk = true;
-                    foreach (var file in entry.Files)
-                    {
-                        var normalizedPath = SkillSyncHelpers.ValidateResourcePath(file.Path);
-                        if (normalizedPath is null)
-                        {
-                            _logger.LogWarning(
-                                "Rejected synced resource path for {SkillName} v{Version}: {Path}",
-                                entry.Name,
-                                entry.Version,
-                                file.Path);
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        var fileContent = await DownloadAndVerifyAsync(file.Url, file.Sha256, $"{entry.Name}/{file.Path}", cancellationToken);
-                        if (fileContent is null)
-                        {
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        var fileScan = await _scanner.ScanAsync(
-                            $"{entry.Name}:{normalizedPath}",
-                            fileContent,
-                            cancellationToken);
-                        if (!fileScan.IsAllowed)
-                        {
-                            _logger.LogWarning(
-                                "Rejected synced resource for {SkillName} v{Version} at {Path}: {Reason}",
-                                entry.Name,
-                                entry.Version,
-                                normalizedPath,
-                                fileScan.Reason);
-                            allFilesOk = false;
-                            break;
-                        }
-
-                        downloadedFiles.Add(new DownloadedSkillFile(normalizedPath, fileContent));
-                    }
-
-                    if (!allFilesOk)
-                        continue;
-                }
-
-                await SkillSyncHelpers.ReplaceSkillDirectoryAsync(
-                    _paths.SystemSkillsDirectory, entry.Name, downloadedFiles, cancellationToken);
-
-                syncState.Skills[entry.Name] = new SyncedSkillState
-                {
-                    Version = entry.Version,
-                    Sha256 = entry.Sha256,
-                    SyncedAtUtc = now
-                };
-
-                _logger.LogInformation("Synced skill {SkillName} v{Version}", entry.Name, entry.Version);
-                updated = true;
+                if (synced)
+                    updated = true;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -294,72 +230,6 @@ internal sealed class SystemSkillSyncService : IHostedService
         {
             syncState.LastSyncUtc = now;
             WriteSyncState(syncState);
-        }
-    }
-
-    private async Task<string?> DownloadAndVerifyAsync(
-        string url, string expectedSha256, string label, CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(FeedConstants.FeedHttpTimeout);
-
-            var content = await _httpClient.GetStringAsync(url, cts.Token);
-
-            var hash = SkillSyncHelpers.ComputeSha256(content);
-            if (!string.Equals(hash, expectedSha256, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning(
-                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
-                    label, expectedSha256, hash);
-                return null;
-            }
-
-            return content;
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            _logger.LogWarning("Download timed out for {Label}", label);
-            return null;
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Re-scans the entire skills directory and rebuilds the registry + context layer.
-    /// Called after sync completes (or fails) to ensure the agent sees current skills.
-    /// </summary>
-    private void RescanAndUpdateIndex()
-    {
-        var mergedResult = SkillScanner.ScanAndMerge(
-            _paths.SkillsDirectory, _serverFeedSources, _externalSources);
-        SkillRegistryUpdater.ApplyMergedScanResult(
-            _skillRegistry, _skillIndexLayer, mergedResult, _paths.SkillsDirectory, _externalSources);
-
-        if (mergedResult.Issues.Count > 0)
-        {
-            _logger.LogWarning(
-                "Skill inventory is degraded after sync rebuild: accepted={AcceptedSkillCount} rejected={RejectedIssueCount}",
-                mergedResult.AcceptedSkills.Count,
-                mergedResult.Issues.Count);
-
-            foreach (var issue in mergedResult.Issues)
-            {
-                _logger.LogWarning(
-                    "Rejected skill item during sync rebuild: kind={IssueKind} path={Path} message={Message}",
-                    issue.Kind,
-                    issue.Path,
-                    issue.Message);
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Skill description menu updated ({SkillCount} skills)", mergedResult.AcceptedSkills.Count);
         }
     }
 


### PR DESCRIPTION
## Summary
- Extracts `SkillSyncServiceBase` abstract class from `SystemSkillSyncService` and `ServerFeedSkillSyncService`, consolidating three duplicated concerns:
  - **`DownloadAndVerifyAsync`** — HTTP download with linked CTS + timeout, SHA-256 verification, and `OperationCanceledException` handling (timeout vs caller cancellation)
  - **`SyncSingleSkillAsync`** — full per-entry sync pipeline: download main content + resource files, content scanning, atomic directory replacement, sync state update
  - **`RescanAndUpdateIndex`** — skill directory re-scan with registry and context layer rebuild, degraded-inventory logging
- `SystemSkillSyncService` (381 → 250 lines) now inherits `SkillSyncServiceBase` directly alongside `IHostedService`
- `ServerFeedSkillSyncService` (364 → 274 lines) composes with a private `ServerFeedSyncHelper` nested class that inherits `SkillSyncServiceBase`, keeping the `BackgroundService` hosting model intact

Closes #809

## Test plan
- [x] `dotnet build` — zero errors
- [x] `dotnet test` — all 458 daemon tests pass (including all 17 SystemSkillSyncServiceTests)
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all copyright headers present
- [ ] Review log message format consistency (parameterized `logLabel` in base produces same structured log output as before)