### PR TITLE
refactor: replace raw string SessionId params with SessionId value object

### DIFF
--- a/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryEvalSeedSuiteTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
@@ -51,7 +52,7 @@ public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
 
         var coordinator = new SQLiteMemoryRecallCoordinator(_store, NullLogger<SQLiteMemoryRecallCoordinator>.Instance, sessionTuning: new SessionTuning());
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "ops/thread-1",
+            SessionId: (SessionId)"ops/thread-1",
             Query: "router failover",
             RecentUserMessages: ["what was our vrrp delay"],
             MaxItems: 3), TestContext.Current.CancellationToken);
@@ -88,7 +89,7 @@ public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
 
         var coordinator = new SQLiteMemoryRecallCoordinator(_store, NullLogger<SQLiteMemoryRecallCoordinator>.Instance, sessionTuning: new SessionTuning());
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "ops/thread-1",
+            SessionId: (SessionId)"ops/thread-1",
             Query: "token",
             RecentUserMessages: ["what is token"],
             MaxItems: 3), TestContext.Current.CancellationToken);
@@ -312,7 +313,7 @@ public sealed class MemoryEvalSeedSuiteTests : IAsyncLifetime
         var coordinator = new SQLiteMemoryRecallCoordinator(_store, NullLogger<SQLiteMemoryRecallCoordinator>.Instance, sessionTuning: new SessionTuning());
         var start = TimeProvider.System.GetTimestamp();
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "latency/thread-1",
+            SessionId: (SessionId)"latency/thread-1",
             Query: "latency",
             RecentUserMessages: ["latency"],
             MaxItems: 3), TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Memory/MemoryRedesignedEvalSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRedesignedEvalSuiteTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Netclaw.Tools;
@@ -68,7 +69,7 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
             sessionTuning: new SessionTuning());
 
         var result = await recall.RecallAsync(new AutomaticRecallRequest(
-            "slack/thread-1",
+            (SessionId)"slack/thread-1",
             "what airline do I usually use",
             ["I usually fly United"],
             3), TestContext.Current.CancellationToken);
@@ -129,7 +130,7 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await recall.RecallAsync(new AutomaticRecallRequest(
-            "signalr/thread-iah",
+            (SessionId)"signalr/thread-iah",
             "What airport do I usually fly out of?",
             ["What airport do I usually fly out of?"],
             3,
@@ -190,7 +191,7 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await recall.RecallAsync(new AutomaticRecallRequest(
-            "signalr/thread-united",
+            (SessionId)"signalr/thread-united",
             "What airline do I usually take?",
             ["What airline do I usually take?"],
             3,
@@ -258,7 +259,7 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
             sessionTuning: new SessionTuning());
 
         var auto = await recall.RecallAsync(new AutomaticRecallRequest(
-            "slack/thread-2",
+            (SessionId)"slack/thread-2",
             "where should I stay",
             ["where should I stay near Stir Trek"],
             3), TestContext.Current.CancellationToken);
@@ -550,7 +551,7 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
             CancellationToken.None);
 
         var auto = await recall.RecallAsync(new AutomaticRecallRequest(
-            "slack/thread-report",
+            (SessionId)"slack/thread-report",
             "what airline do I use and where should I stay",
             ["what airline do I use and where should I stay near Stir Trek"],
             3), TestContext.Current.CancellationToken);

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionIntegrationTests.cs
@@ -980,9 +980,9 @@ internal sealed class FakeMemoryExtractor : IMemoryExtractor
 
     public int CallCount => _callCount;
 
-    public List<(string SessionId, string Memories)> Entries { get; } = new();
+    public List<(SessionId SessionId, string Memories)> Entries { get; } = new();
 
-    public Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default)
+    public Task PersistAsync(SessionId sessionId, string extractedMemories, CancellationToken ct = default)
     {
         Interlocked.Increment(ref _callCount);
         lock (Entries)

--- a/src/Netclaw.Actors.Tests/Sessions/DeterministicRetrievalPlanningTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/DeterministicRetrievalPlanningTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,7 +19,7 @@ public sealed class DeterministicRetrievalPlanningTests
     {
         var planner = new DeterministicRetrievalRequestPlanner();
         var plan = planner.Plan(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-1",
+            SessionId: (SessionId)"signalr/thread-1",
             Query: "I'm speaking at Stir Trek 2026 - I fly out of IAH. What's the best flight / hotel combination for me?",
             RecentUserMessages: ["I'm speaking at Stir Trek 2026 - I fly out of IAH. What's the best flight / hotel combination for me?"],
             MaxItems: 3,
@@ -35,7 +36,7 @@ public sealed class DeterministicRetrievalPlanningTests
     {
         var planner = new DeterministicRetrievalRequestPlanner();
         var plan = planner.Plan(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-2",
+            SessionId: (SessionId)"signalr/thread-2",
             Query: "What's the pricing model for TextForge?",
             RecentUserMessages: ["What's the pricing model for TextForge?"],
             MaxItems: 3,
@@ -60,7 +61,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-3",
+            SessionId: (SessionId)"signalr/thread-3",
             Query: "What's the pricing model for TextForge?",
             RecentUserMessages: ["What's the pricing model for TextForge?"],
             MaxItems: 3,
@@ -105,7 +106,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-4",
+            SessionId: (SessionId)"signalr/thread-4",
             Query: "What's the pricing model for TextForge?",
             RecentUserMessages: ["What's the pricing model for TextForge?"],
             MaxItems: 3,
@@ -150,7 +151,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-score",
+            SessionId: (SessionId)"signalr/thread-score",
             Query: "What's the pricing model for TextForge?",
             RecentUserMessages: ["What's the pricing model for TextForge?"],
             MaxItems: 3,
@@ -170,7 +171,7 @@ public sealed class DeterministicRetrievalPlanningTests
             "because we are planning a group outing after the keynote sessions conclude";
 
         var plan = planner.Plan(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-long",
+            SessionId: (SessionId)"signalr/thread-long",
             Query: longMessage,
             RecentUserMessages: [longMessage],
             MaxItems: 3));
@@ -184,7 +185,7 @@ public sealed class DeterministicRetrievalPlanningTests
     {
         var planner = new DeterministicRetrievalRequestPlanner();
         var plan = planner.Plan(new AutomaticRecallRequest(
-            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            SessionId: (SessionId)"D0AC6CKBK5K/1774371415.126439",
             Query: "what did we find about Reel.Farm?",
             RecentUserMessages: ["what did we find about Reel.Farm?"],
             MaxItems: 3));
@@ -228,7 +229,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            SessionId: (SessionId)"D0AC6CKBK5K/1774371415.126439",
             Query: "what did we find about Reel.Farm?",
             RecentUserMessages: ["what did we find about Reel.Farm?"],
             MaxItems: 3), TestContext.Current.CancellationToken);
@@ -272,7 +273,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "D0AC6CKBK5K/1774371415.126439",
+            SessionId: (SessionId)"D0AC6CKBK5K/1774371415.126439",
             Query: "what company does Aaron work at",
             RecentUserMessages: ["what company does Aaron work at"],
             MaxItems: 3), TestContext.Current.CancellationToken);
@@ -316,7 +317,7 @@ public sealed class DeterministicRetrievalPlanningTests
             sessionTuning: new SessionTuning { DeterministicRetrievalEnabled = true });
 
         var result = await coordinator.RecallAsync(new AutomaticRecallRequest(
-            SessionId: "signalr/thread-5",
+            SessionId: (SessionId)"signalr/thread-5",
             Query: "what is TextForge",
             RecentUserMessages: ["what is TextForge"],
             MaxItems: 3,

--- a/src/Netclaw.Actors.Tests/Sessions/MemoryRecallScenarioTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/MemoryRecallScenarioTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Xunit;
@@ -176,7 +177,7 @@ public sealed class MemoryRecallScenarioTests : IAsyncLifetime
             sessionTuning: new SessionTuning());
 
         var request = new AutomaticRecallRequest(
-            SessionId: TestSessionId,
+            SessionId: (SessionId)TestSessionId,
             Query: prompt,
             RecentUserMessages: string.IsNullOrEmpty(prompt) ? [] : [prompt],
             MaxItems: 3,

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -505,7 +505,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     public void BuildDistillationUserPrompt_includes_existing_proposals_for_legacy_anchor_context()
     {
         var prompt = SessionMemoryObserverActor.BuildDistillationUserPrompt(
-            "test-channel/legacy-recovery",
+            (SessionId)"test-channel/legacy-recovery",
             1,
             "check legacy skip context",
             [new ProposedMemoryContext("legacy-anchor", "legacy-anchor", string.Empty)]);
@@ -583,7 +583,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     public Task DistillationUserPromptTemplate_matches_approved_snapshot()
     {
         var prompt = SessionMemoryObserverActor.BuildDistillationUserPrompt(
-            sessionId: "synthetic/snapshot",
+            sessionId: (SessionId)"synthetic/snapshot",
             turnCount: 3,
             transcript: "user: synthetic transcript line one\nassistant: synthetic response line one",
             existingProposals: [new ProposedMemoryContext("synthetic-anchor", "Synthetic Anchor", "snippet")]);

--- a/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SubAgentFindingReviewTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
 using Netclaw.Configuration;
@@ -18,7 +19,7 @@ public class SubAgentFindingReviewTests
     {
         var finding = CreateFinding();
 
-        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, "project-a/thread-1");
+        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, (SessionId)"project-a/thread-1");
 
         Assert.Equal(SubAgentFindingReviewDecision.Accepted, result.Decision);
         Assert.Null(result.Reason);
@@ -29,7 +30,7 @@ public class SubAgentFindingReviewTests
     {
         var finding = CreateFinding() with { Durability = (SubAgentFindingDurability)999 };
 
-        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, "project-a/thread-1");
+        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, (SessionId)"project-a/thread-1");
 
         Assert.Equal(SubAgentFindingReviewDecision.Deferred, result.Decision);
         Assert.Equal("missing durability", result.Reason);
@@ -40,7 +41,7 @@ public class SubAgentFindingReviewTests
     {
         var finding = CreateFinding() with { Reusability = SubAgentFindingReusability.TaskLocal };
 
-        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, "project-a/thread-1");
+        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, (SessionId)"project-a/thread-1");
 
         Assert.Equal(SubAgentFindingReviewDecision.Deferred, result.Decision);
         Assert.Equal("insufficient reusability", result.Reason);
@@ -55,7 +56,7 @@ public class SubAgentFindingReviewTests
             Content = "Step 1: I called file_read. Step 2: I inspected stdout: done."
         };
 
-        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, "project-a/thread-1");
+        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, (SessionId)"project-a/thread-1");
 
         Assert.Equal(SubAgentFindingReviewDecision.Rejected, result.Decision);
         Assert.Equal("unsupported shape", result.Reason);
@@ -70,7 +71,7 @@ public class SubAgentFindingReviewTests
             RecallMode = SubAgentFindingRecallMode.Auto
         };
 
-        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, "project-a/thread-1");
+        var result = SessionToolExecutionPipeline.ReviewSubAgentFinding(finding, (SessionId)"project-a/thread-1");
 
         Assert.Equal(SubAgentFindingReviewDecision.Rejected, result.Decision);
         Assert.Equal("secret cannot auto-recall", result.Reason);

--- a/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationPipeline.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 
@@ -142,7 +143,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
         var kind = ResolveKind(payload);
         var title = ResolveTitle(payload, kind, content);
         var updateSemantics = ResolveUpdateSemantics(payload, kind, memoryClass);
-        var anchor = ResolveAnchor(content, payload.SessionId);
+        var anchor = ResolveAnchor(content, (SessionId)payload.SessionId);
         var anchorType = kind == MemoryKind.Record ? "event" : "concept";
         var fingerprint = BuildFingerprint(kind.ToWireValue(), title, content);
         if (fingerprintSet.Contains(fingerprint))
@@ -266,7 +267,7 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
         return content.Length <= 72 ? content : content[..72];
     }
 
-    private static string ResolveAnchor(string content, string sessionId)
+    private static string ResolveAnchor(string content, SessionId sessionId)
     {
         var firstWord = content
             .Split(' ', StringSplitOptions.RemoveEmptyEntries)
@@ -274,8 +275,9 @@ public sealed class MemoryRulesFirstExtractor(MemoryPolicyEvaluator policy)
         if (!string.IsNullOrWhiteSpace(firstWord))
             return firstWord.ToLowerInvariant();
 
-        var slash = sessionId.IndexOf('/', StringComparison.Ordinal);
-        return slash > 0 ? sessionId[..slash].ToLowerInvariant() : "session";
+        var value = sessionId.Value;
+        var slash = value.IndexOf('/', StringComparison.Ordinal);
+        return slash > 0 ? value[..slash].ToLowerInvariant() : "session";
     }
 
     public static string BuildFingerprint(string kind, string title, string content)

--- a/src/Netclaw.Actors/Memory/SqliteFindMemoriesTool.cs
+++ b/src/Netclaw.Actors/Memory/SqliteFindMemoriesTool.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
 using Netclaw.Configuration;
 using Netclaw.Tools;
@@ -44,10 +45,11 @@ public sealed partial class SqliteFindMemoriesTool : NetclawTool<SqliteFindMemor
     {
         var limit = args.Limit is > 0 ? args.Limit.Value : 5;
         var includeStale = args.IncludeStale ?? false;
-        var sessionId = string.IsNullOrWhiteSpace(context.SessionId)
+        var sessionIdRaw = string.IsNullOrWhiteSpace(context.SessionId)
             ? "manual/tool"
             : context.SessionId!;
-        var audience = MemoryPolicyScopeResolver.ResolveAudience(context.Audience, sessionId);
+        var sessionId = (SessionId)sessionIdRaw;
+        var audience = MemoryPolicyScopeResolver.ResolveAudience(context.Audience, sessionIdRaw);
 
         var request = _planner.BuildRequest(
             sessionId,

--- a/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionDirectoryHelper.cs
@@ -36,7 +36,7 @@ public static class SessionDirectoryHelper
     /// </summary>
     public static string GetSessionDirectory(SessionId sessionId, string basePath)
     {
-        var sanitized = SanitizeSessionId(sessionId.Value);
+        var sanitized = SanitizeSessionId(sessionId);
         return Path.Combine(basePath, sanitized);
     }
 
@@ -63,7 +63,7 @@ public static class SessionDirectoryHelper
     public static string GetOrCreateAttachmentStagingDirectory(SessionId sessionId, string basePath)
     {
         var stagingRoot = Path.Combine(basePath, AttachmentStagingRootSubdirectory);
-        var stagingDir = Path.Combine(stagingRoot, SanitizeSessionId(sessionId.Value));
+        var stagingDir = Path.Combine(stagingRoot, SanitizeSessionId(sessionId));
         Directory.CreateDirectory(stagingDir);
         return stagingDir;
     }
@@ -98,11 +98,12 @@ public static class SessionDirectoryHelper
     /// Replaces non-alphanumeric characters (except hyphens) with underscores.
     /// Session IDs may contain slashes (e.g. "C123/1234567890.123456").
     /// </summary>
-    public static string SanitizeSessionId(string sessionId)
+    public static string SanitizeSessionId(SessionId sessionId)
     {
-        Span<char> buf = stackalloc char[sessionId.Length];
-        for (var i = 0; i < sessionId.Length; i++)
-            buf[i] = char.IsLetterOrDigit(sessionId[i]) || sessionId[i] == '-' ? sessionId[i] : '_';
+        var value = sessionId.Value;
+        Span<char> buf = stackalloc char[value.Length];
+        for (var i = 0; i < value.Length; i++)
+            buf[i] = char.IsLetterOrDigit(value[i]) || value[i] == '-' ? value[i] : '_';
         return new string(buf);
     }
 }

--- a/src/Netclaw.Actors/Sessions/IMemoryExtractor.cs
+++ b/src/Netclaw.Actors/Sessions/IMemoryExtractor.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+
 namespace Netclaw.Actors.Sessions;
 
 /// <summary>
@@ -20,7 +22,7 @@ public interface IMemoryExtractor
     /// <param name="sessionId">The session that is being compacted.</param>
     /// <param name="extractedMemories">Structured memory text from the extraction LLM call.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default);
+    Task PersistAsync(SessionId sessionId, string extractedMemories, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -31,7 +33,7 @@ public sealed class NullMemoryExtractor : IMemoryExtractor
 {
     public static readonly NullMemoryExtractor Instance = new();
 
-    public Task PersistAsync(string sessionId, string extractedMemories, CancellationToken ct = default)
+    public Task PersistAsync(SessionId sessionId, string extractedMemories, CancellationToken ct = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Netclaw.Actors/Sessions/IMemoryRecallCoordinator.cs
+++ b/src/Netclaw.Actors/Sessions/IMemoryRecallCoordinator.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Sessions;
@@ -19,7 +20,7 @@ public interface IMemoryRecallCoordinator
 /// Request for automatic pre-turn memory recall.
 /// </summary>
 public sealed record AutomaticRecallRequest(
-    string SessionId,
+    SessionId SessionId,
     string Query,
     IReadOnlyList<string> RecentUserMessages,
     int MaxItems,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1219,8 +1219,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         {
             // Persist extracted memories externally (fire-and-forget)
             var self = Self;
-            var sessionId = _sessionId.Value;
-            _ = PersistMemoriesAsync(_memoryExtractor, sessionId, msg.ExtractedMemories, self);
+            _ = PersistMemoriesAsync(_memoryExtractor, _sessionId, msg.ExtractedMemories, self);
 
             DrainBufferOrReady();
         });
@@ -1494,7 +1493,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     }
 
     private static async Task PersistMemoriesAsync(
-        IMemoryExtractor extractor, string sessionId, string memories, IActorRef self)
+        IMemoryExtractor extractor, SessionId sessionId, string memories, IActorRef self)
     {
         try
         {
@@ -1503,7 +1502,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         catch (Exception ex)
         {
             // Memory persistence is best-effort — log and continue compaction
-            Trace.TraceWarning("Memory persistence failed for session {0}: {1}", sessionId, ex.Message);
+            Trace.TraceWarning("Memory persistence failed for session {0}: {1}", sessionId.Value, ex.Message);
         }
     }
 
@@ -2417,7 +2416,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             forceNoTools,
             _activeCallId);
 
-        _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _sessionId.Value, _activeLlmCts!.Token);
+        _ = SessionLlmInvoker.InvokeAsync(client, messages, options, self, _activeCallId, _sessionId, _activeLlmCts!.Token);
     }
 
 

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionLlmInvoker.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using Akka.Actor;
 using Microsoft.Extensions.AI;
+using SessionId = Netclaw.Actors.Protocol.SessionId;
 using Netclaw.Configuration;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
@@ -24,7 +25,7 @@ internal static class SessionLlmInvoker
         ChatOptions? options,
         IActorRef self,
         long callId,
-        string sessionId,
+        SessionId sessionId,
         CancellationToken cancellationToken)
     {
         // Set session affinity so the HTTP-layer DelegatingHandler adds an
@@ -32,7 +33,7 @@ internal static class SessionLlmInvoker
         // the same backend for KV cache reuse. Set here (not in the actor)
         // so sidecar calls (compaction, title gen) that bypass this invoker
         // naturally omit the header and round-robin across backends.
-        SessionAffinityContext.SessionId = sessionId;
+        SessionAffinityContext.SessionId = sessionId.Value;
         try
         {
             var response = await StreamAsync(client, messages, options, self, callId, cancellationToken);

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionRecallManager.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionRecallManager.cs
@@ -60,7 +60,7 @@ internal sealed class SessionRecallManager
             .ToArray();
 
         var request = new AutomaticRecallRequest(
-            sessionId.Value,
+            sessionId,
             query,
             recentUser,
             3,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -170,7 +170,7 @@ internal static class SessionToolExecutionPipeline
 
                 if (info.Success && info.Findings.Count == 1)
                 {
-                    var singleDecision = ReviewSubAgentFinding(info.Findings[0], sessionId.Value);
+                    var singleDecision = ReviewSubAgentFinding(info.Findings[0], sessionId);
                     decision = singleDecision.Decision.ToWireValue();
                     reason = singleDecision.Reason;
                 }
@@ -191,7 +191,7 @@ internal static class SessionToolExecutionPipeline
             {
                 foreach (var finding in info.Findings)
                 {
-                    var findingDecision = ReviewSubAgentFinding(finding, sessionId.Value);
+                    var findingDecision = ReviewSubAgentFinding(finding, sessionId);
                     acceptedFindings.Add(new AcceptedSubAgentFinding
                     {
                         RunId = info.RunId,
@@ -460,7 +460,7 @@ internal static class SessionToolExecutionPipeline
     /// </summary>
     internal static SubAgentFindingReviewResult ReviewSubAgentFinding(
         SubAgentFinding finding,
-        string sessionId)
+        SessionId sessionId)
     {
         if (string.IsNullOrWhiteSpace(finding.Title))
             return new(SubAgentFindingReviewDecision.Deferred, "missing title");
@@ -614,7 +614,7 @@ internal static class SessionToolExecutionPipeline
         TimeSpan duration,
         ToolCallMeta? meta) => new()
     {
-        SessionId = sessionId.Value,
+        SessionId = sessionId,
         ToolName = tc.Name,
         CallId = tc.CallId,
         Timestamp = timeProvider.GetUtcNow(),

--- a/src/Netclaw.Actors/Sessions/SessionLogActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionLogActor.cs
@@ -49,7 +49,7 @@ public sealed class SessionLogActor : ReceiveActor
     /// </summary>
     public static string GetSessionLogsDirectory(SessionId sessionId, string sessionLogsBasePath)
     {
-        var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId.Value);
+        var sanitized = SessionDirectoryHelper.SanitizeSessionId(sessionId);
         return Path.Combine(sessionLogsBasePath, sanitized);
     }
 

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -203,7 +203,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 
         _ = RunDistillationAsync(
             _client,
-            _sessionId.Value,
+            _sessionId,
             _turnCount,
             transcriptText,
             _proposedMemories.ToArray(),
@@ -340,7 +340,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 
     private async Task RunDistillationAsync(
         IChatClient client,
-        string sessionId,
+        SessionId sessionId,
         int turnCount,
         string transcript,
         IReadOnlyList<ProposedMemoryContext> existingProposals,
@@ -732,12 +732,12 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         """;
 
     internal static string BuildDistillationUserPrompt(
-        string sessionId,
+        SessionId sessionId,
         int turnCount,
         string transcript,
         IReadOnlyList<ProposedMemoryContext> existingProposals) => JsonSerializer.Serialize(new
     {
-        sessionId,
+        sessionId = sessionId.Value,
         turnCount,
         existingProposals = existingProposals.Select(p => new
         {

--- a/src/Netclaw.Actors/Sessions/SidecarRecallPlanner.cs
+++ b/src/Netclaw.Actors/Sessions/SidecarRecallPlanner.cs
@@ -3,12 +3,14 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+
 namespace Netclaw.Actors.Sessions;
 
 public sealed class SidecarRecallPlanner
 {
     public RecallPlanningRequest BuildRequest(
-        string sessionId,
+        SessionId sessionId,
         string userText,
         IReadOnlyList<string> recentUserTurns,
         IReadOnlyList<string> recentAssistantTurns,
@@ -18,7 +20,7 @@ public sealed class SidecarRecallPlanner
         int maxResults)
     {
         return new RecallPlanningRequest(
-            sessionId,
+            sessionId.Value,
             mode,
             userText,
             recentUserTurns,

--- a/src/Netclaw.Actors/Tools/AkkaToolApprovalService.cs
+++ b/src/Netclaw.Actors/Tools/AkkaToolApprovalService.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Netclaw.Actors.Hosting;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -30,7 +31,7 @@ public sealed class AkkaToolApprovalService : IToolApprovalService
     {
         var actor = await _actorProvider.GetAsync(ct);
         var response = await actor.Ask<UnapprovedPatternsResponse>(
-            new GetUnapprovedPatterns(sessionId, audience, toolName, patterns),
+            new GetUnapprovedPatterns(sessionId is not null ? (SessionId)sessionId : null, audience, toolName, patterns),
             TimeSpan.FromSeconds(5),
             ct);
 
@@ -47,7 +48,7 @@ public sealed class AkkaToolApprovalService : IToolApprovalService
     {
         var actor = await _actorProvider.GetAsync(ct);
         await actor.Ask<ToolApprovalRecorded>(
-            new RecordToolApproval(sessionId, audience, toolName, patterns, persistent),
+            new RecordToolApproval((SessionId)sessionId, audience, toolName, patterns, persistent),
             TimeSpan.FromSeconds(5),
             ct);
     }

--- a/src/Netclaw.Actors/Tools/IToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/IToolExecutor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Protocol;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
@@ -24,7 +25,7 @@ public interface IToolExecutor
 /// </summary>
 public sealed record ToolAuditEntry
 {
-    public required string SessionId { get; init; }
+    public required SessionId SessionId { get; init; }
     public required string ToolName { get; init; }
     public required string CallId { get; init; }
     public required DateTimeOffset Timestamp { get; init; }

--- a/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
 using Netclaw.Tools;
@@ -49,10 +50,10 @@ internal sealed class ToolApprovalActor : ReceiveActor
     public static Props CreateProps(ToolApprovalStore? persistentStore = null)
         => Props.Create(() => new ToolApprovalActor(persistentStore));
 
-    private bool IsApproved(string? sessionId, TrustAudience audience, ToolName toolName, string pattern)
+    private bool IsApproved(SessionId? sessionId, TrustAudience audience, ToolName toolName, string pattern)
     {
-        if (!string.IsNullOrWhiteSpace(sessionId)
-            && _sessionApprovals.TryGetValue(BuildSessionKey(sessionId, audience), out var toolMap)
+        if (sessionId.HasValue
+            && _sessionApprovals.TryGetValue(BuildSessionKey(sessionId.Value, audience), out var toolMap)
             && toolMap.TryGetValue(toolName.Value, out var patterns)
             && ApprovalPatternMatching.MatchesAny(pattern, patterns))
         {
@@ -65,7 +66,7 @@ internal sealed class ToolApprovalActor : ReceiveActor
         return ApprovalPatternMatching.MatchesAny(pattern, _persistentStore.GetApprovedPatterns(audience, toolName.Value));
     }
 
-    private void AddSessionApproval(string sessionId, TrustAudience audience, ToolName toolName, string pattern)
+    private void AddSessionApproval(SessionId sessionId, TrustAudience audience, ToolName toolName, string pattern)
     {
         var sessionKey = BuildSessionKey(sessionId, audience);
         if (!_sessionApprovals.TryGetValue(sessionKey, out var toolMap))
@@ -83,8 +84,8 @@ internal sealed class ToolApprovalActor : ReceiveActor
         patterns.Add(pattern);
     }
 
-    private static string BuildSessionKey(string sessionId, TrustAudience audience)
-        => $"{sessionId}|{audience.ToWireValue()}";
+    private static string BuildSessionKey(SessionId sessionId, TrustAudience audience)
+        => $"{sessionId.Value}|{audience.ToWireValue()}";
 }
 
 internal sealed record ToolApprovalRecorded

--- a/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
@@ -3,13 +3,14 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
 
 internal sealed record GetUnapprovedPatterns(
-    string? SessionId,
+    SessionId? SessionId,
     TrustAudience Audience,
     ToolName ToolName,
     IReadOnlyList<string> Patterns);
@@ -17,7 +18,7 @@ internal sealed record GetUnapprovedPatterns(
 internal sealed record UnapprovedPatternsResponse(IReadOnlyList<string> Patterns);
 
 internal sealed record RecordToolApproval(
-    string SessionId,
+    SessionId SessionId,
     TrustAudience Audience,
     ToolName ToolName,
     IReadOnlyList<string> Patterns,


### PR DESCRIPTION
## Summary

- Replaces internal method parameters and record properties that carried session identity as plain `string` with the existing `SessionId` readonly record struct across `Netclaw.Actors`
- Covers `IMemoryRecallCoordinator`, `IMemoryExtractor`, `ToolApprovalActor`, `SessionToolExecutionPipeline`, `SessionLlmInvoker`, `SessionMemoryObserverActor`, `SidecarRecallPlanner`, `MemoryCurationPipeline`, `SessionDirectoryHelper`, `SqliteFindMemoriesTool`, and 7 test files
- Wire formats are unchanged: protobuf-serialized types, JSON-persisted records, and SignalR API boundaries remain `string` — only internal call signatures are tightened
- Types in lower-level projects (`Netclaw.Configuration`, `Netclaw.Tools.Abstractions`, `Netclaw.Security`) are left as `string` because they cannot reference `Netclaw.Actors.Protocol` without creating a circular dependency

Closes #811

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test` — all 2,997 tests pass
- [x] `dotnet slopwatch analyze` — zero issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all headers present
- [ ] CI green on PR