### PR TITLE
refactor: consolidate HTTP timeout pattern into shared HttpTimeoutHelper

### DIFF
--- a/src/Netclaw.Configuration/HttpTimeoutHelper.cs
+++ b/src/Netclaw.Configuration/HttpTimeoutHelper.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="HttpTimeoutHelper.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Outcome of an HTTP operation executed with a timeout via
+/// <see cref="HttpTimeoutHelper.ExecuteWithTimeoutAsync{T}"/>.
+/// </summary>
+public enum HttpTimeoutOutcome
+{
+    /// <summary>The operation completed successfully within the timeout.</summary>
+    Success,
+
+    /// <summary>The operation was cancelled because the timeout elapsed.</summary>
+    TimedOut,
+
+    /// <summary>The operation failed with an <see cref="HttpRequestException"/>.</summary>
+    HttpError,
+}
+
+/// <summary>
+/// Result of an HTTP operation executed with a timeout. Wraps the value
+/// (on success) or the exception (on HTTP failure) alongside the outcome.
+/// </summary>
+public readonly record struct HttpTimeoutResult<T>(
+    HttpTimeoutOutcome Outcome,
+    T? Value,
+    HttpRequestException? Exception)
+{
+    public bool IsSuccess => Outcome == HttpTimeoutOutcome.Success;
+}
+
+/// <summary>
+/// Encapsulates the repeated pattern of creating a linked
+/// <see cref="CancellationTokenSource"/> with a timeout, executing an async
+/// HTTP operation, and distinguishing timeout cancellation from caller
+/// cancellation. Keeps the <c>OperationCanceledException</c> semantics
+/// correct: if the <em>caller's</em> token is cancelled the exception
+/// propagates; if only the timeout fires the result is
+/// <see cref="HttpTimeoutOutcome.TimedOut"/>.
+/// </summary>
+public static class HttpTimeoutHelper
+{
+    /// <summary>
+    /// Executes <paramref name="operation"/> with a linked cancellation token
+    /// that will auto-cancel after <paramref name="timeout"/>.
+    /// </summary>
+    /// <returns>
+    /// A result indicating success (with value), timeout, or HTTP error.
+    /// If the caller's <paramref name="cancellationToken"/> is cancelled,
+    /// the <see cref="OperationCanceledException"/> propagates unhandled.
+    /// </returns>
+    public static async Task<HttpTimeoutResult<T>> ExecuteWithTimeoutAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        try
+        {
+            var result = await operation(cts.Token);
+            return new HttpTimeoutResult<T>(HttpTimeoutOutcome.Success, result, null);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new HttpTimeoutResult<T>(HttpTimeoutOutcome.TimedOut, default, null);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new HttpTimeoutResult<T>(HttpTimeoutOutcome.HttpError, default, ex);
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
@@ -35,22 +35,32 @@ public sealed class CompositeCapabilityResolver : IModelCapabilityResolver
         {
             try
             {
-                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                timeoutCts.CancelAfter(ResolverTimeout);
+                var result = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+                    innerCt => resolver.ResolveAsync(modelId, innerCt),
+                    ResolverTimeout,
+                    ct);
 
-                var result = await resolver.ResolveAsync(modelId, timeoutCts.Token);
-                if (result is not null)
+                if (result.Outcome == HttpTimeoutOutcome.TimedOut)
+                {
+                    _logger.LogDebug("{Resolver} timed out for model {ModelId}, trying next",
+                        resolver.GetType().Name, modelId);
+                    continue;
+                }
+
+                if (result.Outcome == HttpTimeoutOutcome.HttpError)
+                {
+                    _logger.LogDebug(result.Exception!, "{Resolver} failed for model {ModelId}, trying next",
+                        resolver.GetType().Name, modelId);
+                    continue;
+                }
+
+                if (result.Value is not null)
                 {
                     _logger.LogDebug(
                         "Resolved capabilities for {ModelId} via {Resolver}: input={Input}, output={Output}",
-                        modelId, resolver.GetType().Name, result.InputModalities, result.OutputModalities);
-                    return result;
+                        modelId, resolver.GetType().Name, result.Value.InputModalities, result.Value.OutputModalities);
+                    return result.Value;
                 }
-            }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-            {
-                _logger.LogDebug("{Resolver} timed out for model {ModelId}, trying next",
-                    resolver.GetType().Name, modelId);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/ServerFeedSkillSyncService.cs
@@ -126,30 +126,30 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
             _paths.ServerFeedSyncStatePath(feed.Name), _logger);
         var now = _timeProvider.GetUtcNow();
 
-        RfcSkillIndex? index;
-        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-        {
-            cts.CancelAfter(TimeSpan.FromSeconds(feed.TimeoutSeconds));
-            try
+        var indexResult = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+            async ct =>
             {
                 using var client = new SkillServerClient(feed.Url, feed.ApiKey?.Value);
-                index = await client.GetRfcIndexAsync(cts.Token);
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
+                return await client.GetRfcIndexAsync(ct);
+            },
+            TimeSpan.FromSeconds(feed.TimeoutSeconds),
+            cancellationToken);
+
+        switch (indexResult.Outcome)
+        {
+            case HttpTimeoutOutcome.TimedOut:
                 _logger.LogWarning(
                     "Server feed '{FeedName}' RFC index fetch timed out — using on-disk skills",
                     feed.Name);
                 return;
-            }
-            catch (HttpRequestException ex)
-            {
+            case HttpTimeoutOutcome.HttpError:
                 _logger.LogWarning(
                     "Server feed '{FeedName}' RFC index fetch failed: {Message} — using on-disk skills",
-                    feed.Name, ex.Message);
+                    feed.Name, indexResult.Exception!.Message);
                 return;
-            }
         }
+
+        var index = indexResult.Value;
 
         if (index is null || index.Skills.Count == 0)
         {
@@ -287,34 +287,32 @@ internal sealed class ServerFeedSkillSyncService : BackgroundService
         HttpClient httpClient, string url, string expectedSha256Hex, string label,
         int timeoutSeconds, CancellationToken cancellationToken)
     {
-        try
+        var result = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+            ct => httpClient.GetStringAsync(url, ct),
+            TimeSpan.FromSeconds(timeoutSeconds),
+            cancellationToken);
+
+        switch (result.Outcome)
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
-
-            var content = await httpClient.GetStringAsync(url, cts.Token);
-
-            var hash = SkillSyncHelpers.ComputeSha256(content);
-            if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning(
-                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
-                    label, expectedSha256Hex, hash);
+            case HttpTimeoutOutcome.TimedOut:
+                _logger.LogWarning("Download timed out for {Label}", label);
                 return null;
-            }
+            case HttpTimeoutOutcome.HttpError:
+                _logger.LogWarning("Download failed for {Label}: {Message}", label, result.Exception!.Message);
+                return null;
+        }
 
-            return content;
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        var content = result.Value!;
+        var hash = SkillSyncHelpers.ComputeSha256(content);
+        if (!string.Equals(hash, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogWarning("Download timed out for {Label}", label);
+            _logger.LogWarning(
+                "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
+                label, expectedSha256Hex, hash);
             return null;
         }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
-            return null;
-        }
+
+        return content;
     }
 
     private void RescanAndUpdateIndex()

--- a/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
+++ b/src/Netclaw.Daemon/Services/SystemSkillSyncService.cs
@@ -121,45 +121,48 @@ internal sealed class SystemSkillSyncService : IHostedService
 
     private async Task<SkillFeedManifest?> FetchManifestAsync(CancellationToken cancellationToken)
     {
-        try
+        var result = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+            async ct =>
+            {
+                var response = await _httpClient.GetAsync(
+                    FeedConstants.SystemSkillsManifestUrl, ct);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync(ct);
+                return JsonSerializer.Deserialize<SkillFeedManifest>(json);
+            },
+            FeedConstants.FeedHttpTimeout,
+            cancellationToken);
+
+        switch (result.Outcome)
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(FeedConstants.FeedHttpTimeout);
-
-            var response = await _httpClient.GetAsync(
-                FeedConstants.SystemSkillsManifestUrl, cts.Token);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync(cts.Token);
-            var manifest = JsonSerializer.Deserialize<SkillFeedManifest>(json);
-
-            if (manifest is null)
-            {
-                _logger.LogWarning("Feed manifest deserialized to null");
+            case HttpTimeoutOutcome.TimedOut:
+                _logger.LogWarning("Feed manifest fetch timed out — using on-disk skills");
                 return null;
-            }
-
-            if (manifest.SchemaVersion != 1)
-            {
-                _logger.LogWarning("Unsupported feed schema version {Version} — skipping sync",
-                    manifest.SchemaVersion);
+            case HttpTimeoutOutcome.HttpError:
+                _logger.LogWarning("Feed manifest fetch failed: {Message} — using on-disk skills",
+                    result.Exception!.Message);
                 return null;
-            }
-
-            _logger.LogInformation("Fetched skill feed manifest ({SkillCount} skills, updated {UpdatedAt})",
-                manifest.Skills.Count, manifest.UpdatedAt);
-            return manifest;
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+
+        var manifest = result.Value;
+
+        if (manifest is null)
         {
-            _logger.LogWarning("Feed manifest fetch timed out — using on-disk skills");
+            _logger.LogWarning("Feed manifest deserialized to null");
             return null;
         }
-        catch (HttpRequestException ex)
+
+        if (manifest.SchemaVersion != 1)
         {
-            _logger.LogWarning("Feed manifest fetch failed: {Message} — using on-disk skills", ex.Message);
+            _logger.LogWarning("Unsupported feed schema version {Version} — skipping sync",
+                manifest.SchemaVersion);
             return null;
         }
+
+        _logger.LogInformation("Fetched skill feed manifest ({SkillCount} skills, updated {UpdatedAt})",
+            manifest.Skills.Count, manifest.UpdatedAt);
+        return manifest;
     }
 
     private async Task SyncSkillsAsync(
@@ -300,34 +303,32 @@ internal sealed class SystemSkillSyncService : IHostedService
     private async Task<string?> DownloadAndVerifyAsync(
         string url, string expectedSha256, string label, CancellationToken cancellationToken)
     {
-        try
+        var result = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+            ct => _httpClient.GetStringAsync(url, ct),
+            FeedConstants.FeedHttpTimeout,
+            cancellationToken);
+
+        switch (result.Outcome)
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(FeedConstants.FeedHttpTimeout);
-
-            var content = await _httpClient.GetStringAsync(url, cts.Token);
-
-            var hash = SkillSyncHelpers.ComputeSha256(content);
-            if (!string.Equals(hash, expectedSha256, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning(
-                    "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
-                    label, expectedSha256, hash);
+            case HttpTimeoutOutcome.TimedOut:
+                _logger.LogWarning("Download timed out for {Label}", label);
                 return null;
-            }
+            case HttpTimeoutOutcome.HttpError:
+                _logger.LogWarning("Download failed for {Label}: {Message}", label, result.Exception!.Message);
+                return null;
+        }
 
-            return content;
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        var content = result.Value!;
+        var hash = SkillSyncHelpers.ComputeSha256(content);
+        if (!string.Equals(hash, expectedSha256, StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogWarning("Download timed out for {Label}", label);
+            _logger.LogWarning(
+                "SHA-256 mismatch for {Label}: expected {Expected}, got {Actual}",
+                label, expectedSha256, hash);
             return null;
         }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning("Download failed for {Label}: {Message}", label, ex.Message);
-            return null;
-        }
+
+        return content;
     }
 
     /// <summary>

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -53,43 +53,47 @@ internal static class ProbeHelpers
         Func<string, ProviderProbeResult> parseResponse,
         CancellationToken ct)
     {
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(ProbeTimeout);
-
+        HttpTimeoutResult<ProviderProbeResult> result;
         try
         {
-            var baseUrl = string.IsNullOrWhiteSpace(entryEndpoint)
-                ? defaultEndpoint
-                : entryEndpoint.TrimEnd('/');
-            var url = $"{baseUrl}{modelListingPath}";
+            result = await HttpTimeoutHelper.ExecuteWithTimeoutAsync(
+                async timeoutCt =>
+                {
+                    var baseUrl = string.IsNullOrWhiteSpace(entryEndpoint)
+                        ? defaultEndpoint
+                        : entryEndpoint.TrimEnd('/');
+                    var url = $"{baseUrl}{modelListingPath}";
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            configureRequest(request);
+                    using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    configureRequest(request);
 
-            using var response = await httpClient.SendAsync(request, timeoutCts.Token);
+                    using var response = await httpClient.SendAsync(request, timeoutCt);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                var apiErrorDetail = await ExtractApiErrorDetailAsync(response, timeoutCts.Token);
-                return FailForStatus(response.StatusCode, providerName, apiErrorDetail);
-            }
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var apiErrorDetail = await ExtractApiErrorDetailAsync(response, timeoutCt);
+                        return FailForStatus(response.StatusCode, providerName, apiErrorDetail);
+                    }
 
-            var json = await response.Content.ReadAsStringAsync(timeoutCts.Token);
-            return parseResponse(json);
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return new ProviderProbeResult(false,
-                "Connection timed out after 10 seconds. Check that the endpoint is reachable.", []);
+                    var json = await response.Content.ReadAsStringAsync(timeoutCt);
+                    return parseResponse(json);
+                },
+                ProbeTimeout,
+                ct);
         }
         catch (OperationCanceledException)
         {
             return new ProviderProbeResult(false, "Validation cancelled.", []);
         }
-        catch (HttpRequestException ex)
+
+        return result.Outcome switch
         {
-            return new ProviderProbeResult(false, $"Connection failed: {ex.Message}", []);
-        }
+            HttpTimeoutOutcome.TimedOut => new ProviderProbeResult(false,
+                "Connection timed out after 10 seconds. Check that the endpoint is reachable.", []),
+            HttpTimeoutOutcome.HttpError => new ProviderProbeResult(false,
+                $"Connection failed: {result.Exception!.Message}", []),
+            _ => result.Value!,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Introduces `HttpTimeoutHelper.ExecuteWithTimeoutAsync<T>` in `Netclaw.Configuration` that encapsulates the `CreateLinkedTokenSource` + `CancelAfter` + timeout-vs-caller cancellation discrimination pattern
- Returns a discriminated `HttpTimeoutResult<T>` (Success/TimedOut/HttpError) so callers handle outcomes via pattern matching instead of catch blocks
- Replaces 5 instances of the pattern across 4 files: `SystemSkillSyncService`, `ServerFeedSkillSyncService`, `CompositeCapabilityResolver`, and `ProbeHelpers`

Closes #815

## Test plan

- [ ] `dotnet build` passes with zero errors
- [ ] All 3001 tests pass (`dotnet test`)
- [ ] `dotnet slopwatch analyze` reports no new violations
- [ ] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` confirms all headers present
- [ ] Verify existing skill sync tests still exercise timeout and HTTP error paths through the updated code
- [ ] Verify provider probe tests still exercise timeout and cancellation paths