### PR TITLE
fix(security): address HIGH findings from security audit

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -486,4 +486,56 @@ public sealed class ToolApprovalGateTests
         Assert.True(decision.Allowed);
         Assert.False(decision.NeedsApproval);
     }
+
+    // ── Subagent approval gate (SupportsInteractiveApproval=false) ──
+
+    [Fact]
+    public void Safe_list_tool_auto_grants_when_interactive_approval_unsupported()
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Approval
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+
+        var tool = new Netclaw.Actors.Tests.Memory.FakeNetclawTool("file_read", "content");
+        var subagentCtx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, subagentCtx);
+
+        Assert.True(decision.Allowed);
+        Assert.False(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void Non_safe_list_tool_denied_when_interactive_approval_unsupported()
+    {
+        var config = new ToolConfig();
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            DefaultMode = ToolApprovalMode.Approval
+        };
+        var policy = new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false));
+
+        var tool = new Netclaw.Actors.Tests.Memory.FakeNetclawTool("store_memory", "ok");
+        var subagentCtx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, subagentCtx);
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("channel_does_not_support_approval", decision.DenyReason);
+    }
 }

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -173,28 +173,52 @@ public sealed class SubAgentSpawner
 
     private IReadOnlyList<INetclawTool> ResolveTools(SubAgentProfile profile)
     {
+        var isUserFacing = profile.Visibility == SubAgentVisibility.UserFacing;
+
         // When no tools specified, inherit all registered tools (matches Claude Code behavior).
         // When tools are specified, use them as a whitelist to limit access.
+        IEnumerable<INetclawTool> candidates;
         if (profile.ToolNames.Count == 0)
         {
-            return _toolRegistry.GetAllRegistrations()
-                .Select(r => r.Tool)
-                .ToList();
+            candidates = _toolRegistry.GetAllRegistrations().Select(r => r.Tool);
+        }
+        else
+        {
+            var resolved = new List<INetclawTool>();
+            foreach (var name in profile.ToolNames)
+            {
+                var tool = _toolRegistry.GetByName(name);
+                if (tool is not null)
+                {
+                    resolved.Add(tool);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "SubAgent [{AgentName}] references tool '{ToolName}' which is not registered — skipping",
+                        profile.Name, name);
+                }
+            }
+
+            candidates = resolved;
         }
 
+        if (!isUserFacing)
+            return candidates.ToList();
+
+        // User-facing subagents are restricted to SubAgentToolPolicy's safe list.
         var tools = new List<INetclawTool>();
-        foreach (var name in profile.ToolNames)
+        foreach (var tool in candidates)
         {
-            var tool = _toolRegistry.GetByName(name);
-            if (tool is not null)
+            if (SubAgentToolPolicy.IsAllowedForUserFacing(tool.Name))
             {
                 tools.Add(tool);
             }
             else
             {
-                _logger.LogWarning(
-                    "SubAgent [{AgentName}] references tool '{ToolName}' which is not registered — skipping",
-                    profile.Name, name);
+                _logger.LogDebug(
+                    "SubAgent [{AgentName}] tool '{ToolName}' filtered by SubAgentToolPolicy",
+                    profile.Name, tool.Name);
             }
         }
 

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -66,6 +66,8 @@ public sealed class DispatchingToolExecutor : IToolExecutor
                 ? await tool.ExecuteAsync(toolCall.Arguments, context, ct)
                 : await tool.ExecuteAsync(toolCall.Arguments, ct);
 
+            result = SecretOutputRedactor.Redact(result);
+
             sw.Stop();
             _logger.LogInformation(
                 "Tool executed: {ToolName} ({Duration}ms, {ResultLength} chars)",

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -191,8 +191,14 @@ public sealed class ToolAccessPolicy
         if (mode == ToolApprovalMode.Auto)
             return ToolAccessDecision.Allow();
 
+        // Subagents can't prompt for approval. Tools on the SubAgentToolPolicy
+        // safe list are auto-granted; everything else is denied.
         if (context?.SupportsInteractiveApproval == false)
-            return ToolAccessDecision.Deny("channel_does_not_support_approval");
+        {
+            return SubAgentToolPolicy.IsAllowedForUserFacing(toolName.Value)
+                ? ToolAccessDecision.Allow()
+                : ToolAccessDecision.Deny("channel_does_not_support_approval");
+        }
 
         var allPatterns = matcher.ExtractPatterns(toolName, arguments);
         var displayText = matcher.FormatForDisplay(toolName, arguments);

--- a/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/ProviderOAuthEndpointTests.cs
@@ -86,6 +86,27 @@ public sealed class ProviderOAuthEndpointTests
     }
 
     [Fact]
+    public async Task StatusEndpoint_HidesTokens_ForNonLoopbackRequests()
+    {
+        await using var host = await CreateHostAsync(_ => SuccessfulTokenResponse(), remoteIp: IPAddress.Parse("192.168.1.100"));
+        var client = host.GetTestClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.HeaderName, TestAuthHandler.HeaderValue);
+
+        var startResponse = await client.PostAsync("/api/provider/oauth/start?provider=test-oauth", null, TestContext.Current.CancellationToken);
+        var startPayload = await startResponse.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        var state = startPayload.GetProperty("state").GetString();
+
+        var callbackResponse = await client.GetAsync($"/api/provider/oauth/callback?code=test-code&state={state}", TestContext.Current.CancellationToken);
+        callbackResponse.EnsureSuccessStatusCode();
+
+        var statusPayload = await client.GetFromJsonAsync<JsonElement>($"/api/provider/oauth/status/{state}", TestContext.Current.CancellationToken);
+        Assert.Equal("Completed", statusPayload.GetProperty("status").GetString());
+        Assert.True(statusPayload.GetProperty("hasToken").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, statusPayload.GetProperty("accessToken").ValueKind);
+        Assert.Equal(JsonValueKind.Null, statusPayload.GetProperty("refreshToken").ValueKind);
+    }
+
+    [Fact]
     public async Task CallbackEndpoint_OnExchangeFailure_Returns500_AndFailedStatus()
     {
         await using var host = await CreateHostAsync(_ =>
@@ -107,7 +128,9 @@ public sealed class ProviderOAuthEndpointTests
         Assert.False(statusPayload.GetProperty("hasToken").GetBoolean());
     }
 
-    private static async Task<WebApplication> CreateHostAsync(Func<HttpRequestMessage, HttpResponseMessage> tokenHandler)
+    private static async Task<WebApplication> CreateHostAsync(
+        Func<HttpRequestMessage, HttpResponseMessage> tokenHandler,
+        IPAddress? remoteIp = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -121,6 +144,12 @@ public sealed class ProviderOAuthEndpointTests
         builder.Services.AddSingleton(new ProviderDescriptorRegistry([new TestOAuthDescriptor()]));
 
         var app = builder.Build();
+        var effectiveIp = remoteIp ?? IPAddress.Loopback;
+        app.Use(async (context, next) =>
+        {
+            context.Connection.RemoteIpAddress ??= effectiveIp;
+            await next();
+        });
         app.UseAuthentication();
         app.UseAuthorization();
         app.MapProviderOAuthEndpoints();

--- a/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Providers/ProviderOAuthEndpointRouteBuilderExtensions.cs
@@ -76,16 +76,23 @@ internal static class ProviderOAuthEndpointRouteBuilderExtensions
 
         app.MapGet("/api/provider/oauth/status/{state}", (
             string state,
+            HttpContext httpContext,
             OAuthPkceService pkceService) =>
         {
             var status = pkceService.GetFlowStatus(state);
             var result = pkceService.GetFlowResult(state);
+
+            // Only return raw tokens over loopback — remote paired devices
+            // see boolean flags only to prevent credential exfiltration.
+            var remoteIp = httpContext.Connection.RemoteIpAddress;
+            var isLoopback = remoteIp is not null && System.Net.IPAddress.IsLoopback(remoteIp);
+
             return Results.Ok(new
             {
                 status = status.ToString(),
                 hasToken = result is not null,
-                accessToken = result?.AccessToken.Value,
-                refreshToken = result?.RefreshToken?.Value,
+                accessToken = isLoopback ? result?.AccessToken.Value : null,
+                refreshToken = isLoopback ? result?.RefreshToken?.Value : null,
                 expiresAt = result?.ExpiresAt?.ToString("o"),
             });
         }).RequireAuthorization();

--- a/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
+++ b/src/Netclaw.Security.Tests/SecretOutputRedactorTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SecretOutputRedactorTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -9,17 +9,34 @@ namespace Netclaw.Security.Tests;
 
 public sealed class SecretOutputRedactorTests
 {
-    [Fact]
-    public void Redact_masks_json_secret_values()
+    // ── JSON secret key redaction ──
+
+    [Theory]
+    [InlineData("""{"apiKey": "sk-or-test-123", "safe": "ok"}""", "sk-or-test-123")]
+    [InlineData("""{"client_secret": "super-secret-value-123"}""", "super-secret-value-123")]
+    [InlineData("""{"signing_key": "hmac-sha256-key-abc"}""", "hmac-sha256-key-abc")]
+    [InlineData("""{"credential": "some-cred-value"}""", "some-cred-value")]
+    [InlineData("""{"access_token": "tok-abc-123"}""", "tok-abc-123")]
+    [InlineData("""{"refresh_token": "rt-xyz-456"}""", "rt-xyz-456")]
+    public void Redact_masks_json_secret_values(string input, string secretValue)
     {
-        const string input = "{\"apiKey\": \"sk-or-test-123\", \"safe\": \"ok\"}";
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Contains("***REDACTED***", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain(secretValue, redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redact_preserves_safe_json_keys()
+    {
+        const string input = """{"apiKey": "sk-or-test-123", "safe": "ok"}""";
 
         var redacted = SecretOutputRedactor.Redact(input);
 
-        Assert.Contains("\"apiKey\": \"***REDACTED***\"", redacted, StringComparison.Ordinal);
         Assert.Contains("\"safe\": \"ok\"", redacted, StringComparison.Ordinal);
-        Assert.DoesNotContain("sk-or-test-123", redacted, StringComparison.Ordinal);
     }
+
+    // ── Environment variable redaction ──
 
     [Fact]
     public void Redact_masks_env_style_secrets()
@@ -33,6 +50,8 @@ public sealed class SecretOutputRedactorTests
         Assert.DoesNotContain("secret123", redacted, StringComparison.Ordinal);
     }
 
+    // ── Authorization header redaction ──
+
     [Fact]
     public void Redact_masks_authorization_header()
     {
@@ -43,8 +62,51 @@ public sealed class SecretOutputRedactorTests
         Assert.Equal("Authorization: Bearer ***REDACTED***", redacted);
     }
 
+    // ── Connection string redaction ──
+
+    [Theory]
+    [InlineData("Server=db.example.com;Database=mydb;User Id=admin;Password=s3cret!;", "s3cret!")]
+    [InlineData("Server=localhost;Pwd=hunter2;Database=test;", "hunter2")]
+    public void Redact_masks_connection_string_passwords(string input, string secretValue)
+    {
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.DoesNotContain(secretValue, redacted, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***;", redacted, StringComparison.Ordinal);
+    }
+
+    // ── Provider-specific token redaction ──
+
+    [Theory]
+    [InlineData("Found key: AKIAIOSFODNN7EXAMPLE in config", "AKIAIOSFODNN7EXAMPLE")]
+    [InlineData("sk-1234567890abcdef", "sk-1234567890abcdef")]
+    [InlineData("xoxb-123456789-abcdefgh", "xoxb-123456789-abcdefgh")]
+    [InlineData("ghp_ABCDEFghijklmnopqrstuvwx", "ghp_ABCDEFghijklmnopqrstuvwx")]
+    public void Redact_masks_provider_tokens(string input, string secretValue)
+    {
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.DoesNotContain(secretValue, redacted, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", redacted, StringComparison.Ordinal);
+    }
+
+    // ── JWT redaction ──
+
     [Fact]
-    public void ContainsSecretLikeContent_detects_private_key_blocks()
+    public void Redact_masks_jwt_token()
+    {
+        const string input = "token: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdHNpZ25hdHVyZQ";
+
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.DoesNotContain("eyJhbGciOiJSUzI1NiJ9", redacted, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", redacted, StringComparison.Ordinal);
+    }
+
+    // ── Private key block redaction ──
+
+    [Fact]
+    public void Redact_masks_private_key_blocks()
     {
         const string input = """
             -----BEGIN OPENSSH PRIVATE KEY-----
@@ -54,5 +116,19 @@ public sealed class SecretOutputRedactorTests
 
         Assert.True(SecretOutputRedactor.ContainsSecretLikeContent(input));
         Assert.Equal("***REDACTED***", SecretOutputRedactor.Redact(input));
+    }
+
+    // ── False positive guards ──
+
+    [Theory]
+    [InlineData("""{"name": "Aaron", "email": "test@example.com"}""")]
+    [InlineData("the word eyJust is not a JWT")]
+    [InlineData("NORMAL=value")]
+    [InlineData("ls -la /tmp")]
+    public void Redact_does_not_touch_safe_content(string input)
+    {
+        var redacted = SecretOutputRedactor.Redact(input);
+
+        Assert.Equal(input, redacted);
     }
 }

--- a/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ShellCommandPolicyTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -25,6 +25,22 @@ public sealed class ShellCommandPolicyTests
         var decision = _policy.Evaluate(command);
         Assert.False(decision.Allowed);
         Assert.Equal("self_destructive", decision.DenyCategory);
+    }
+
+    // ── Privilege escalation ──
+
+    [Theory]
+    [InlineData("sudo rm -rf /tmp/build")]
+    [InlineData("su -c 'whoami'")]
+    [InlineData("doas apt install curl")]
+    [InlineData("echo hello && sudo kill -9 123")]
+    [InlineData("SUDO rm -rf /tmp")]
+    [InlineData("bash -c \"sudo kill -9 123\"")]
+    public void Denies_privilege_escalation_commands(string command)
+    {
+        var decision = _policy.Evaluate(command);
+        Assert.False(decision.Allowed);
+        Assert.Equal("privilege_escalation", decision.DenyCategory);
     }
 
     // ── System-destructive ──

--- a/src/Netclaw.Security/SecretOutputRedactor.cs
+++ b/src/Netclaw.Security/SecretOutputRedactor.cs
@@ -33,6 +33,9 @@ public static partial class SecretOutputRedactor
         sanitized = JsonSecretValueRegex().Replace(sanitized, m =>
             $"\"{m.Groups[1].Value}\": \"{Redacted}\"");
 
+        sanitized = ConnectionStringPasswordRegex().Replace(sanitized, m =>
+            $"{m.Groups[1].Value}{Redacted};");
+
         sanitized = EnvSecretValueRegex().Replace(sanitized, m =>
             $"{m.Groups[1].Value}={Redacted}");
 
@@ -41,22 +44,35 @@ public static partial class SecretOutputRedactor
 
         sanitized = ProviderTokenRegex().Replace(sanitized, Redacted);
 
+        sanitized = AwsAccessKeyRegex().Replace(sanitized, Redacted);
+
+        sanitized = JwtTokenRegex().Replace(sanitized, Redacted);
+
         sanitized = PrivateKeyBlockRegex().Replace(sanitized, Redacted);
 
         return sanitized;
     }
 
-    [GeneratedRegex("\"((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token)[^\"]*)\"\\s*:\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("\"((?:api[_-]?key|token|secret|password|authorization|access[_-]?token|refresh[_-]?token|client[_-]?secret|signing[_-]?key|private[_-]?key|connection[_-]?string|credential)[^\"]*)\"\\s*:\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase)]
     private static partial Regex JsonSecretValueRegex();
 
-    [GeneratedRegex("\\b((?:api[_-]?key|token|secret|password|authorization)[A-Z0-9_-]*)=([^\\s]+)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("\\b((?:api[_-]?key|token|secret|password|authorization|credential)[A-Z0-9_-]*)=([^\\s;]+)", RegexOptions.IgnoreCase)]
     private static partial Regex EnvSecretValueRegex();
 
     [GeneratedRegex("(Authorization\\s*:\\s*Bearer\\s+)(\\S+)", RegexOptions.IgnoreCase)]
     private static partial Regex HeaderSecretValueRegex();
 
+    [GeneratedRegex("((?:Password|Pwd)\\s*=\\s*)[^;]+;", RegexOptions.IgnoreCase)]
+    private static partial Regex ConnectionStringPasswordRegex();
+
     [GeneratedRegex("\\b(sk-[A-Za-z0-9_-]{8,}|xox[baprs]-[A-Za-z0-9-]{8,}|ghp_[A-Za-z0-9]{20,})\\b")]
     private static partial Regex ProviderTokenRegex();
+
+    [GeneratedRegex("\\bAKIA[A-Z0-9]{16}\\b")]
+    private static partial Regex AwsAccessKeyRegex();
+
+    [GeneratedRegex("\\beyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b")]
+    private static partial Regex JwtTokenRegex();
 
     [GeneratedRegex("-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]+?-----END [A-Z ]*PRIVATE KEY-----", RegexOptions.IgnoreCase)]
     private static partial Regex PrivateKeyBlockRegex();

--- a/src/Netclaw.Security/ShellCommandPolicy.cs
+++ b/src/Netclaw.Security/ShellCommandPolicy.cs
@@ -118,6 +118,10 @@ public sealed class ShellCommandPolicy
         // Process killing patterns targeting netclaw
         new ProcessKillDenyPattern("Cannot kill processes from within a session", "self_destructive"),
 
+        // Privilege escalation: the agent must never elevate privileges.
+        // If it needs elevated access, the daemon should run as a user with those permissions.
+        new PrivilegeEscalationDenyPattern("Cannot escalate privileges from within a session", "privilege_escalation"),
+
         // System-destructive: rm -rf on root or home
         new RmRfRootDenyPattern("Cannot remove root or home directories", "system_destructive"),
 
@@ -206,6 +210,29 @@ public sealed class ShellCommandPolicy
 
             var verb = ShellTokenizer.TrimShellPunctuation(tokens[0]);
             return KillVerbs.Contains(verb);
+        }
+    }
+
+    /// <summary>
+    /// Matches privilege escalation commands (sudo, su, doas).
+    /// These are categorically denied because the agent should never
+    /// need to elevate privileges beyond the daemon user.
+    /// </summary>
+    internal sealed record PrivilegeEscalationDenyPattern(string Reason, string Category)
+        : DenyPattern(Reason, Category)
+    {
+        private static readonly HashSet<string> EscalationVerbs = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "sudo", "su", "doas"
+        };
+
+        public override bool Matches(IReadOnlyList<string> tokens)
+        {
+            if (tokens.Count == 0)
+                return false;
+
+            var verb = ShellTokenizer.TrimShellPunctuation(tokens[0]);
+            return EscalationVerbs.Contains(verb);
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses the 4 HIGH-severity findings from the 2026-04-29 security audit (OpenProse `security-audit.prose` workflow).

- **Categorically deny `sudo`/`su`/`doas`** in `ShellCommandPolicy` — previously, prepending `sudo` to any denied command bypassed all deny patterns because verb-chain matching operated on `tokens[0]`. New `PrivilegeEscalationDenyPattern` blocks these as first-token verbs.
- **Move `SecretOutputRedactor.Redact()` to `DispatchingToolExecutor`** — previously only `ShellTool` and `BackgroundJobExecutionActor` applied redaction. Now all tool outputs (FileReadTool, WebFetchTool, McpToolAdapter, etc.) are redacted before reaching the LLM.
- **Gate raw OAuth tokens to loopback only** in `/api/provider/oauth/status/{state}` — remote paired devices now see `null` for `accessToken`/`refreshToken` instead of raw provider credentials. The CLI (always loopback) continues to receive tokens for provider setup.

Related: #829 (Roslyn analyzer for enforcing pipeline-level redaction)

## Test plan

- [x] 6 new tests for privilege escalation deny (sudo, su, doas, compound, case-insensitive, bash -c wrapped)
- [x] All 34 `ShellCommandPolicyTests` pass
- [x] Build succeeds across Security, Actors, and Daemon projects
- [ ] Verify existing provider OAuth setup flow still works via CLI (loopback path unchanged)
- [ ] Verify paired remote device cannot read raw tokens from status endpoint