### PR TITLE
Migrate Akka persistence serialization from protobuf-net to Google Protobuf

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,8 @@
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>
-    <PackageVersion Include="protobuf-net" Version="3.2.56" />
+    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
+    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <!-- Test dependencies -->

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -369,6 +369,71 @@ public sealed class SerializationRoundTripTests : TestKit
     }
 
     [Fact]
+    public void AdoptedContextRecorded_round_trips()
+    {
+        var original = new AdoptedContextRecorded
+        {
+            SessionId = new SessionId("C99999/1708531200.000100"),
+            AuthorizedMessageId = "msg-42",
+            AuthorizerSenderId = "U12345",
+            LowerBound = "msg-40",
+            UpperBound = "msg-42",
+            Projection = "Alice said hello; Bob replied",
+            ProjectionPersisted = true,
+            RecordedAtMs = 1708531200000,
+            Messages =
+            [
+                new AdoptedContextRecorded.AdoptedMessageRecord
+                {
+                    MessageId = "msg-41",
+                    SenderId = "U67890",
+                    TimestampMs = 1708531190000,
+                    AuthorityAtInclusion = "verified"
+                }
+            ]
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal("msg-42", result.AuthorizedMessageId);
+        Assert.Equal("U12345", result.AuthorizerSenderId);
+        Assert.Equal("msg-40", result.LowerBound);
+        Assert.Equal("msg-42", result.UpperBound);
+        Assert.Equal("Alice said hello; Bob replied", result.Projection);
+        Assert.True(result.ProjectionPersisted);
+        Assert.Equal(1708531200000, result.RecordedAtMs);
+        var msg = Assert.Single(result.Messages);
+        Assert.Equal("msg-41", msg.MessageId);
+        Assert.Equal("U67890", msg.SenderId);
+        Assert.Equal(1708531190000, msg.TimestampMs);
+        Assert.Equal("verified", msg.AuthorityAtInclusion);
+    }
+
+    [Fact]
+    public void AdoptedContextRecorded_round_trips_with_null_optionals()
+    {
+        var original = new AdoptedContextRecorded
+        {
+            SessionId = new SessionId("C99999/1708531200.000100"),
+            AuthorizedMessageId = "msg-1",
+            AuthorizerSenderId = null,
+            LowerBound = null,
+            UpperBound = null,
+            Projection = "",
+            ProjectionPersisted = false,
+            RecordedAtMs = 1708531200000
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.Null(result.AuthorizerSenderId);
+        Assert.Null(result.LowerBound);
+        Assert.Null(result.UpperBound);
+        Assert.Empty(result.Messages);
+    }
+
+    [Fact]
     public void Unknown_manifest_throws_on_deserialize()
     {
         var serializer = new Serialization.NetclawProtobufSerializer((Akka.Actor.ExtendedActorSystem)Sys);

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -11,8 +11,8 @@ namespace Netclaw.Actors.Channels;
 /// <summary>
 /// Ephemeral metadata describing where a user message originated.
 /// Used for ACL checks and audit logging — NOT persisted with the session.
-/// <see cref="Protocol.SendUserMessage.Source"/> is marked
-/// <c>[ProtoIgnore]</c> so runtime-only fields such as
+/// <see cref="Protocol.SendUserMessage.Source"/> is excluded from the proto
+/// wire format so runtime-only fields such as
 /// <see cref="AckTarget"/> and <see cref="ReminderId"/> are safe to add.
 /// </summary>
 public sealed record MessageSource

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -183,6 +183,7 @@ public static class NetclawAkkaHostingExtensions
             typeof(ReminderDelivery),
             typeof(ReminderSchedule),
             typeof(ReminderPayload),
+            typeof(AdoptedContextRecorded),
         };
 
         return builder

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -158,8 +158,8 @@ public static class NetclawAkkaHostingExtensions
     }
 
     /// <summary>
-    /// Configures protobuf-net serialization for Netclaw protocol types.
-    /// Registered types use efficient protobuf encoding; our serializer throws
+    /// Configures Google Protobuf serialization for Netclaw protocol types.
+    /// Wire format defined in <c>netclaw_messages.proto</c>; our serializer throws
     /// for unregistered manifests to fail loudly on schema drift.
     /// </summary>
     public static AkkaConfigurationBuilder WithNetclawSerialization(

--- a/src/Netclaw.Actors/Jobs/ActiveJobInfo.cs
+++ b/src/Netclaw.Actors/Jobs/ActiveJobInfo.cs
@@ -1,10 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ActiveJobInfo.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Configuration;
-using ProtoBuf;
 
 namespace Netclaw.Actors.Jobs;
 
@@ -12,24 +11,17 @@ namespace Netclaw.Actors.Jobs;
 /// Lightweight record persisted in <c>SessionState.ActiveBackgroundJobs</c>
 /// so the LLM knows what it's waiting for after compaction or session resumption.
 /// </summary>
-[ProtoContract]
 public sealed record ActiveJobInfo
 {
-    [ProtoMember(1)]
     public required string JobId { get; init; }
 
-    [ProtoMember(2)]
     public required string Command { get; init; }
 
-    [ProtoMember(3)]
     public required string Rationale { get; init; }
 
-    [ProtoMember(4)]
     public required long StartedAtMs { get; init; }
 
-    [ProtoMember(5)]
     public TrustAudience Audience { get; init; } = TrustAudience.Personal;
 
-    [ProtoMember(6)]
     public string Boundary { get; init; } = SecurityPolicyDefaults.PersonalBoundary;
 }

--- a/src/Netclaw.Actors/Netclaw.Actors.csproj
+++ b/src/Netclaw.Actors/Netclaw.Actors.csproj
@@ -22,8 +22,13 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="ModelContextProtocol.Core" />
-    <PackageReference Include="protobuf-net" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Serialization\Protos\netclaw_messages.proto" GrpcServices="None" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Netclaw.Actors/Protocol/Broadcasts.cs
+++ b/src/Netclaw.Actors/Protocol/Broadcasts.cs
@@ -1,26 +1,20 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Broadcasts.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using ProtoBuf;
-
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Published via Akka pub/sub after a session completes a turn.
 /// Adapters subscribe to deliver replies through their respective channels.
 /// </summary>
-[ProtoContract]
 public sealed class TurnBroadcast
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public SerializableChatMessage AssistantReply { get; set; } = new();
 
-    [ProtoMember(3)]
     public long BroadcastAtMs { get; set; }
 
     public DateTimeOffset BroadcastAt => DateTimeOffset.FromUnixTimeMilliseconds(BroadcastAtMs);
@@ -29,16 +23,12 @@ public sealed class TurnBroadcast
 /// <summary>
 /// Published via Akka pub/sub after a session completes compaction.
 /// </summary>
-[ProtoContract]
 public sealed class CompactionBroadcast
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string Summary { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public long CompactedAtMs { get; set; }
 
     public DateTimeOffset CompactedAt => DateTimeOffset.FromUnixTimeMilliseconds(CompactedAtMs);

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -4,32 +4,26 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Channels;
-using ProtoBuf;
 
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Command delivering user input to a session actor.
 /// </summary>
-[ProtoContract]
 public sealed class SendUserMessage : IWithSessionId
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string Content { get; set; } = string.Empty;
 
     /// <summary>
     /// Media references (images, audio, etc.) attached to this message.
     /// </summary>
-    [ProtoMember(3)]
     public List<SerializableMediaReference> MediaReferences { get; set; } = [];
 
     /// <summary>
     /// Ephemeral channel metadata for ACL/audit. Not persisted.
     /// </summary>
-    [ProtoIgnore]
     public MessageSource? Source { get; set; }
 }
 

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -5,23 +5,6 @@
 // -----------------------------------------------------------------------
 namespace Netclaw.Actors.Protocol;
 
-// TODO: delete SystemPromptSet and its Recover<> handler once old journals have been migrated
-/// <summary>
-/// Retained for backward compatibility with pre-v0.9 journals.
-/// No longer persisted — the system prompt is now read fresh from identity files on every recovery.
-/// </summary>
-[Obsolete("No longer persisted. Retained so old journals can still deserialize during recovery.")]
-public sealed class SystemPromptSet
-{
-    public SessionId SessionId { get; set; }
-
-    public string Content { get; set; } = string.Empty;
-
-    public long SetAtMs { get; set; }
-
-    public DateTimeOffset SetAt => DateTimeOffset.FromUnixTimeMilliseconds(SetAtMs);
-}
-
 /// <summary>
 /// Persisted event recording a completed turn (user message + assistant reply).
 /// </summary>

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -1,10 +1,8 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Events.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using ProtoBuf;
-
 namespace Netclaw.Actors.Protocol;
 
 // TODO: delete SystemPromptSet and its Recover<> handler once old journals have been migrated
@@ -12,17 +10,13 @@ namespace Netclaw.Actors.Protocol;
 /// Retained for backward compatibility with pre-v0.9 journals.
 /// No longer persisted — the system prompt is now read fresh from identity files on every recovery.
 /// </summary>
-[ProtoContract]
 [Obsolete("No longer persisted. Retained so old journals can still deserialize during recovery.")]
 public sealed class SystemPromptSet
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string Content { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public long SetAtMs { get; set; }
 
     public DateTimeOffset SetAt => DateTimeOffset.FromUnixTimeMilliseconds(SetAtMs);
@@ -31,19 +25,14 @@ public sealed class SystemPromptSet
 /// <summary>
 /// Persisted event recording a completed turn (user message + assistant reply).
 /// </summary>
-[ProtoContract]
 public sealed class TurnRecorded
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public SerializableChatMessage UserMessage { get; set; } = new();
 
-    [ProtoMember(3)]
     public SerializableChatMessage AssistantReply { get; set; } = new();
 
-    [ProtoMember(4)]
     public long RecordedAtMs { get; set; }
 
     /// <summary>
@@ -55,7 +44,6 @@ public sealed class TurnRecorded
     /// (<see cref="Sessions.SessionState.ProcessedReminderIds"/>) from
     /// event replay.
     /// </summary>
-    [ProtoMember(5)]
     public string? SourceReminderId { get; set; }
 
     /// <summary>
@@ -64,56 +52,40 @@ public sealed class TurnRecorded
     /// <see cref="Channels.MessageSource.BackgroundJobId"/> by the
     /// background job manager. Null for regular user turns.
     /// </summary>
-    [ProtoMember(6)]
     public string? SourceBackgroundJobId { get; set; }
 
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
 }
 
-[ProtoContract]
 public sealed class AdoptedContextRecorded
 {
-    [ProtoContract]
     public sealed class AdoptedMessageRecord
     {
-        [ProtoMember(1)]
         public string MessageId { get; set; } = string.Empty;
 
-        [ProtoMember(2)]
         public string SenderId { get; set; } = string.Empty;
 
-        [ProtoMember(3)]
         public long TimestampMs { get; set; }
 
-        [ProtoMember(4)]
         public string AuthorityAtInclusion { get; set; } = string.Empty;
     }
 
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string AuthorizedMessageId { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public string? AuthorizerSenderId { get; set; }
 
-    [ProtoMember(4)]
     public string? LowerBound { get; set; }
 
-    [ProtoMember(5)]
     public string? UpperBound { get; set; }
 
-    [ProtoMember(6)]
     public string Projection { get; set; } = string.Empty;
 
-    [ProtoMember(7)]
     public List<AdoptedMessageRecord> Messages { get; set; } = [];
 
-    [ProtoMember(8)]
     public bool ProjectionPersisted { get; set; }
 
-    [ProtoMember(9)]
     public long RecordedAtMs { get; set; }
 
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
@@ -122,16 +94,12 @@ public sealed class AdoptedContextRecorded
 /// <summary>
 /// Persisted event recording that the session title was set or updated.
 /// </summary>
-[ProtoContract]
 public sealed class SessionTitleSet
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string Title { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public long SetAtMs { get; set; }
 
     public DateTimeOffset SetAt => DateTimeOffset.FromUnixTimeMilliseconds(SetAtMs);
@@ -141,29 +109,17 @@ public sealed class SessionTitleSet
 /// Persisted event recording that a session's conversation history was compacted.
 /// A snapshot is also taken after this event to avoid replaying the full journal.
 /// </summary>
-[ProtoContract]
 public sealed class SessionCompacted
 {
-    [ProtoMember(1)]
     public SessionId SessionId { get; set; }
 
-    [ProtoMember(2)]
     public string Summary { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public List<SerializableChatMessage> CompactedMessages { get; set; } = [];
 
-    [ProtoMember(4)]
     public int TurnCountBefore { get; set; }
 
-    [ProtoMember(5)]
     public long CompactedAtMs { get; set; }
-
-    // ProtoMember(6) reserved — formerly CompactionBoundaryIndex, removed
-    // before the compaction-rework change merged. Do not reuse this field
-    // number; local dev journals written during the rework development
-    // window may still contain an int at position 6, and re-binding it to
-    // a different type would fail deserialization silently.
 
     /// <summary>
     /// Updated working-context state carried on the event so
@@ -171,7 +127,6 @@ public sealed class SessionCompacted
     /// preserve it across compaction. Null means "no update — retain
     /// the existing <see cref="Sessions.WorkingContext"/> unchanged."
     /// </summary>
-    [ProtoMember(7)]
     public Sessions.WorkingContext? WorkingContext { get; set; }
 
     public DateTimeOffset CompactedAt => DateTimeOffset.FromUnixTimeMilliseconds(CompactedAtMs);

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -1,66 +1,53 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SerializableChatMessage.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using ProtoBuf;
-
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Persistence-safe representation of a chat message.
 /// Never persist Microsoft.Extensions.AI types directly — use this instead.
 /// </summary>
-[ProtoContract]
 public sealed class SerializableChatMessage
 {
-    [ProtoMember(1)]
     public ChatRole Role { get; set; }
 
-    [ProtoMember(2)]
     public string Content { get; set; } = string.Empty;
 
     /// <summary>Optional name (used for tool results: the tool function name).</summary>
-    [ProtoMember(3)]
     public string? Name { get; set; }
 
     /// <summary>
     /// Tool calls requested by the assistant. Present when role is Assistant
     /// and the LLM wants to invoke tools.
     /// </summary>
-    [ProtoMember(4)]
     public List<SerializableToolCall> ToolCalls { get; set; } = [];
 
     /// <summary>
     /// The tool call ID this message is a result for. Present when role is Tool.
     /// </summary>
-    [ProtoMember(5)]
     public string? ToolCallId { get; set; }
 
     /// <summary>
     /// Media references (images, audio, etc.) attached to this message.
     /// Stored as relative paths within the session media directory.
     /// </summary>
-    [ProtoMember(6)]
     public List<SerializableMediaReference> MediaReferences { get; set; } = [];
 }
 
 /// <summary>
 /// Persistence-safe reference to a media file stored in the session directory.
 /// </summary>
-[ProtoContract]
 public sealed class SerializableMediaReference
 {
     /// <summary>Relative path within the session media directory.</summary>
-    [ProtoMember(1)]
     public string RelativePath { get; set; } = string.Empty;
 
     /// <summary>MIME type of the media (e.g. "image/png").</summary>
-    [ProtoMember(2)]
     public string MimeType { get; set; } = string.Empty;
 
     /// <summary>Content modality as integer for wire safety (maps to <see cref="MediaModality"/>).</summary>
-    [ProtoMember(3)]
     public int Modality { get; set; }
 }
 
@@ -78,23 +65,18 @@ public enum MediaModality
 /// <summary>
 /// Persistence-safe representation of a single tool call from the assistant.
 /// </summary>
-[ProtoContract]
 public sealed class SerializableToolCall
 {
-    [ProtoMember(1)]
     public string CallId { get; set; } = string.Empty;
 
-    [ProtoMember(2)]
     public string Name { get; set; } = string.Empty;
 
-    [ProtoMember(3)]
     public string ArgumentsJson { get; set; } = string.Empty;
 
     /// <summary>
     /// Opaque JSON envelope for per-call metadata (rationale, timeout hint, background flag).
     /// Null for legacy tool calls persisted before metadata support was added.
     /// </summary>
-    [ProtoMember(4)]
     public string? MetaJson { get; set; }
 }
 

--- a/src/Netclaw.Actors/Protocol/SessionId.cs
+++ b/src/Netclaw.Actors/Protocol/SessionId.cs
@@ -3,17 +3,13 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using ProtoBuf;
-
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Strongly-typed session identity. Wraps the entity key string used for
 /// actor routing and persistence identity.
 /// </summary>
-[ProtoContract]
-public readonly record struct SessionId(
-    [property: ProtoMember(1)] string Value)
+public readonly record struct SessionId(string Value)
 {
     public static explicit operator SessionId(string value) => new(value);
 

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -1,11 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SessionSnapshot.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Jobs;
 using Netclaw.Actors.Sessions;
-using ProtoBuf;
 
 namespace Netclaw.Actors.Protocol;
 
@@ -13,57 +12,40 @@ namespace Netclaw.Actors.Protocol;
 /// Snapshot of session state for fast recovery. Persisted after compaction
 /// and periodically based on <see cref="Sessions.SessionConfig.SnapshotInterval"/>.
 /// </summary>
-[ProtoContract]
 public sealed class SessionSnapshot
 {
-    [ProtoContract]
     public sealed class AdoptedContextSnapshotRecord
     {
-        [ProtoContract]
         public sealed class AdoptedContextSnapshotMessage
         {
-            [ProtoMember(1)]
             public string MessageId { get; set; } = string.Empty;
 
-            [ProtoMember(2)]
             public string SenderId { get; set; } = string.Empty;
 
-            [ProtoMember(3)]
             public long TimestampMs { get; set; }
 
-            [ProtoMember(4)]
             public string AuthorityAtInclusion { get; set; } = string.Empty;
         }
 
-        [ProtoMember(1)]
         public string AuthorizedMessageId { get; set; } = string.Empty;
 
-        [ProtoMember(2)]
         public string? AuthorizerSenderId { get; set; }
 
-        [ProtoMember(3)]
         public string? LowerBound { get; set; }
 
-        [ProtoMember(4)]
         public string? UpperBound { get; set; }
 
-        [ProtoMember(5)]
         public string Projection { get; set; } = string.Empty;
 
-        [ProtoMember(6)]
         public bool ProjectionPersisted { get; set; }
 
-        [ProtoMember(7)]
         public List<AdoptedContextSnapshotMessage> Messages { get; set; } = [];
     }
 
-    [ProtoMember(1)]
     public List<SerializableChatMessage> History { get; set; } = [];
 
-    [ProtoMember(2)]
     public int TurnCount { get; set; }
 
-    [ProtoMember(3)]
     public string? Title { get; set; }
 
     /// <summary>
@@ -71,30 +53,20 @@ public sealed class SessionSnapshot
     /// <see cref="DeliveryFailed"/> feedback after passivation.
     /// Null when no turn is eligible (initial state or retries exhausted).
     /// </summary>
-    [ProtoMember(4)]
     public int? EligibleDeliveryTurnNumber { get; set; }
-
-    // ProtoMember(5) reserved — formerly CompactionBoundaryIndex, removed
-    // before the compaction-rework change merged. Do not reuse this field
-    // number; local dev snapshots written during the rework development
-    // window may still contain an int at position 5, and re-binding it to
-    // a different type would fail deserialization silently.
 
     /// <summary>
     /// Durable working-context state (recent files). Null when the session
     /// has never set a non-empty context — <see cref="Sessions.SessionState.FromSnapshot"/>
     /// defaults to <see cref="WorkingContext.Empty"/> in that case.
     /// </summary>
-    [ProtoMember(6)]
     public WorkingContext? WorkingContext { get; set; }
 
     /// <summary>
     /// Background jobs this session is waiting on. Persisted because jobs
     /// are long-lived and must survive recovery.
     /// </summary>
-    [ProtoMember(7)]
     public List<ActiveJobInfo> ActiveBackgroundJobs { get; set; } = [];
 
-    [ProtoMember(8)]
     public List<AdoptedContextSnapshotRecord> AdoptedContextRecords { get; set; } = [];
 }

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -1,10 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ReminderProtocol.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Serialization;
-using ProtoBuf;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Reminders;
@@ -12,9 +11,7 @@ namespace Netclaw.Actors.Reminders;
 /// <summary>
 /// Strongly-typed reminder identity.
 /// </summary>
-[ProtoContract]
-public readonly record struct ReminderId(
-    [property: ProtoMember(1)] string Value)
+public readonly record struct ReminderId(string Value)
 {
     public override string ToString() => Value;
 }
@@ -22,7 +19,6 @@ public readonly record struct ReminderId(
 /// <summary>
 /// How reminder results are delivered.
 /// </summary>
-[ProtoContract]
 public enum DeliveryKind
 {
     /// <summary>
@@ -48,33 +44,28 @@ public enum DeliveryKind
 /// <summary>
 /// Structured delivery target for a reminder.
 /// </summary>
-[ProtoContract]
 public sealed class ReminderDelivery
 {
     /// <summary>
     /// How results are delivered.
     /// </summary>
-    [ProtoMember(1)]
     public DeliveryKind Kind { get; set; }
 
     /// <summary>
     /// Transport identifier for Channel delivery (e.g., "slack").
     /// Null for CurrentSession and None.
     /// </summary>
-    [ProtoMember(2)]
     public string? Transport { get; set; }
 
     /// <summary>
     /// Canonical target address for Channel delivery (e.g., "C0123ABC").
     /// Resolved and validated at set time. Null for CurrentSession and None.
     /// </summary>
-    [ProtoMember(3)]
     public string? Address { get; set; }
 
     /// <summary>
     /// Session ID for CurrentSession delivery. Null for Channel and None.
     /// </summary>
-    [ProtoMember(4)]
     public string? SessionId { get; set; }
 
     /// <summary>
@@ -82,7 +73,6 @@ public sealed class ReminderDelivery
     /// Used to route DeliverTrustedSessionTurn to the correct gateway.
     /// Null for Channel and None.
     /// </summary>
-    [ProtoMember(5)]
     public Channels.ChannelType? OriginChannelType { get; set; }
 
     /// <summary>
@@ -102,7 +92,6 @@ public sealed class ReminderDelivery
 /// <summary>
 /// The type of schedule for a reminder.
 /// </summary>
-[ProtoContract]
 public enum ReminderScheduleType
 {
     OneShot = 0,
@@ -113,10 +102,8 @@ public enum ReminderScheduleType
 /// <summary>
 /// Describes when and how a reminder fires.
 /// </summary>
-[ProtoContract]
 public sealed class ReminderSchedule
 {
-    [ProtoMember(1)]
     public ReminderScheduleType Type { get; set; }
 
     /// <summary>
@@ -124,10 +111,8 @@ public sealed class ReminderSchedule
     /// For Interval: optional explicit first fire.
     /// For Cron: not used.
     /// </summary>
-    [ProtoMember(2)]
     public long? FireAtMs { get; set; }
 
-    [ProtoIgnore]
     public DateTimeOffset? FireAt
     {
         get => FireAtMs is not null ? DateTimeOffset.FromUnixTimeMilliseconds(FireAtMs.Value) : null;
@@ -137,10 +122,8 @@ public sealed class ReminderSchedule
     /// <summary>
     /// For Interval schedules: repeat interval.
     /// </summary>
-    [ProtoMember(3)]
     public long? IntervalTicks { get; set; }
 
-    [ProtoIgnore]
     public TimeSpan? Interval
     {
         get => IntervalTicks is not null ? TimeSpan.FromTicks(IntervalTicks.Value) : null;
@@ -150,13 +133,11 @@ public sealed class ReminderSchedule
     /// <summary>
     /// For Cron schedules: cron expression.
     /// </summary>
-    [ProtoMember(4)]
     public string? CronExpression { get; set; }
 
     /// <summary>
     /// Original expression as entered by user (e.g. "6h", "0 */6 * * *").
     /// </summary>
-    [ProtoMember(5)]
     public string? OriginalExpression { get; set; }
 }
 
@@ -250,10 +231,8 @@ public sealed record ReminderDefinition
 /// <summary>
 /// Message persisted inside Akka.Reminders. Intentionally lightweight: pointer to disk definition.
 /// </summary>
-[ProtoContract]
 public sealed class ReminderPayload
 {
-    [ProtoMember(1)]
     public ReminderId Id { get; set; }
 }
 

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -1,0 +1,525 @@
+// -----------------------------------------------------------------------
+// <copyright file="NetclawProtoMapper.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Immutable;
+using Google.Protobuf;
+using Netclaw.Actors.Channels;
+using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Reminders;
+using Netclaw.Actors.Sessions;
+using Proto = Netclaw.Actors.Serialization.Proto;
+
+namespace Netclaw.Actors.Serialization;
+
+#pragma warning disable CS0612, CS0618 // SystemPromptSet is obsolete but must remain serializable for journal recovery
+
+internal static class NetclawProtoMapper
+{
+    internal static IMessage ToProtoMessage(object obj) => obj switch
+    {
+        SessionId v => ToProto(v),
+        SendUserMessage v => ToProto(v),
+        SerializableChatMessage v => ToProto(v),
+        SerializableMediaReference v => ToProto(v),
+        SerializableToolCall v => ToProto(v),
+        TurnRecorded v => ToProto(v),
+        SystemPromptSet v => ToProto(v),
+        SessionTitleSet v => ToProto(v),
+        SessionCompacted v => ToProto(v),
+        SessionSnapshot v => ToProto(v),
+        TurnBroadcast v => ToProto(v),
+        CompactionBroadcast v => ToProto(v),
+        WorkingContext v => ToProto(v),
+        ReminderId v => ToProto(v),
+        ReminderDelivery v => ToProto(v),
+        ReminderSchedule v => ToProto(v),
+        ReminderPayload v => ToProto(v),
+        _ => throw new ArgumentException($"No proto mapping for {obj.GetType().FullName}")
+    };
+
+    // ── SessionId ──
+
+    internal static Proto.SessionIdProto ToProto(SessionId id) => new() { Value = id.Value };
+    internal static SessionId FromProto(Proto.SessionIdProto proto) => new(proto.Value);
+
+    // ── ReminderId ──
+
+    internal static Proto.ReminderIdProto ToProto(ReminderId id) => new() { Value = id.Value };
+    internal static ReminderId FromProto(Proto.ReminderIdProto proto) => new(proto.Value);
+
+    // ── SerializableMediaReference ──
+
+    internal static Proto.SerializableMediaReferenceProto ToProto(SerializableMediaReference r) => new()
+    {
+        RelativePath = r.RelativePath,
+        MimeType = r.MimeType,
+        Modality = r.Modality
+    };
+
+    internal static SerializableMediaReference FromProto(Proto.SerializableMediaReferenceProto proto) => new()
+    {
+        RelativePath = proto.RelativePath,
+        MimeType = proto.MimeType,
+        Modality = proto.Modality
+    };
+
+    // ── SerializableToolCall ──
+
+    internal static Proto.SerializableToolCallProto ToProto(SerializableToolCall tc)
+    {
+        var proto = new Proto.SerializableToolCallProto
+        {
+            CallId = tc.CallId,
+            Name = tc.Name,
+            ArgumentsJson = tc.ArgumentsJson
+        };
+        if (tc.MetaJson is not null)
+            proto.MetaJson = tc.MetaJson;
+        return proto;
+    }
+
+    internal static SerializableToolCall FromProto(Proto.SerializableToolCallProto proto) => new()
+    {
+        CallId = proto.CallId,
+        Name = proto.Name,
+        ArgumentsJson = proto.ArgumentsJson,
+        MetaJson = proto.HasMetaJson ? proto.MetaJson : null
+    };
+
+    // ── SerializableChatMessage ──
+
+    internal static Proto.SerializableChatMessageProto ToProto(SerializableChatMessage msg)
+    {
+        var proto = new Proto.SerializableChatMessageProto
+        {
+            Role = (Proto.ChatRole)(int)msg.Role,
+            Content = msg.Content
+        };
+        if (msg.Name is not null)
+            proto.Name = msg.Name;
+        if (msg.ToolCallId is not null)
+            proto.ToolCallId = msg.ToolCallId;
+        proto.ToolCalls.AddRange(msg.ToolCalls.Select(ToProto));
+        proto.MediaReferences.AddRange(msg.MediaReferences.Select(ToProto));
+        return proto;
+    }
+
+    internal static SerializableChatMessage FromProto(Proto.SerializableChatMessageProto proto)
+    {
+        var msg = new SerializableChatMessage
+        {
+            Role = (ChatRole)(int)proto.Role,
+            Content = proto.Content,
+            Name = proto.HasName ? proto.Name : null,
+            ToolCallId = proto.HasToolCallId ? proto.ToolCallId : null
+        };
+        msg.ToolCalls.AddRange(proto.ToolCalls.Select(FromProto));
+        msg.MediaReferences.AddRange(proto.MediaReferences.Select(FromProto));
+        return msg;
+    }
+
+    // ── SendUserMessage ──
+
+    internal static Proto.SendUserMessageProto ToProto(SendUserMessage cmd)
+    {
+        var proto = new Proto.SendUserMessageProto
+        {
+            SessionId = ToProto(cmd.SessionId),
+            Content = cmd.Content
+        };
+        proto.MediaReferences.AddRange(cmd.MediaReferences.Select(ToProto));
+        return proto;
+    }
+
+    internal static SendUserMessage FromProto(Proto.SendUserMessageProto proto)
+    {
+        var cmd = new SendUserMessage
+        {
+            SessionId = FromProto(proto.SessionId),
+            Content = proto.Content
+        };
+        cmd.MediaReferences.AddRange(proto.MediaReferences.Select(FromProto));
+        return cmd;
+    }
+
+    // ── SystemPromptSet ──
+
+    internal static Proto.SystemPromptSetProto ToProto(SystemPromptSet evt) => new()
+    {
+        SessionId = ToProto(evt.SessionId),
+        Content = evt.Content,
+        SetAtMs = evt.SetAtMs
+    };
+
+    internal static SystemPromptSet FromProto(Proto.SystemPromptSetProto proto) => new()
+    {
+        SessionId = FromProto(proto.SessionId),
+        Content = proto.Content,
+        SetAtMs = proto.SetAtMs
+    };
+
+    // ── TurnRecorded ──
+
+    internal static Proto.TurnRecordedProto ToProto(TurnRecorded evt)
+    {
+        var proto = new Proto.TurnRecordedProto
+        {
+            SessionId = ToProto(evt.SessionId),
+            UserMessage = ToProto(evt.UserMessage),
+            AssistantReply = ToProto(evt.AssistantReply),
+            RecordedAtMs = evt.RecordedAtMs
+        };
+        if (evt.SourceReminderId is not null)
+            proto.SourceReminderId = evt.SourceReminderId;
+        if (evt.SourceBackgroundJobId is not null)
+            proto.SourceBackgroundJobId = evt.SourceBackgroundJobId;
+        return proto;
+    }
+
+    internal static TurnRecorded FromProto(Proto.TurnRecordedProto proto) => new()
+    {
+        SessionId = FromProto(proto.SessionId),
+        UserMessage = FromProto(proto.UserMessage),
+        AssistantReply = FromProto(proto.AssistantReply),
+        RecordedAtMs = proto.RecordedAtMs,
+        SourceReminderId = proto.HasSourceReminderId ? proto.SourceReminderId : null,
+        SourceBackgroundJobId = proto.HasSourceBackgroundJobId ? proto.SourceBackgroundJobId : null
+    };
+
+    // ── AdoptedContextRecorded ──
+
+    internal static Proto.AdoptedContextRecordedProto ToProto(AdoptedContextRecorded evt)
+    {
+        var proto = new Proto.AdoptedContextRecordedProto
+        {
+            SessionId = ToProto(evt.SessionId),
+            AuthorizedMessageId = evt.AuthorizedMessageId,
+            Projection = evt.Projection,
+            ProjectionPersisted = evt.ProjectionPersisted,
+            RecordedAtMs = evt.RecordedAtMs
+        };
+        if (evt.AuthorizerSenderId is not null)
+            proto.AuthorizerSenderId = evt.AuthorizerSenderId;
+        if (evt.LowerBound is not null)
+            proto.LowerBound = evt.LowerBound;
+        if (evt.UpperBound is not null)
+            proto.UpperBound = evt.UpperBound;
+        proto.Messages.AddRange(evt.Messages.Select(ToAdoptedMessageRecord));
+        return proto;
+    }
+
+    internal static AdoptedContextRecorded FromProto(Proto.AdoptedContextRecordedProto proto)
+    {
+        var evt = new AdoptedContextRecorded
+        {
+            SessionId = FromProto(proto.SessionId),
+            AuthorizedMessageId = proto.AuthorizedMessageId,
+            AuthorizerSenderId = proto.HasAuthorizerSenderId ? proto.AuthorizerSenderId : null,
+            LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
+            UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
+            Projection = proto.Projection,
+            ProjectionPersisted = proto.ProjectionPersisted,
+            RecordedAtMs = proto.RecordedAtMs
+        };
+        evt.Messages.AddRange(proto.Messages.Select(FromAdoptedMessageRecord));
+        return evt;
+    }
+
+    private static Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecord ToAdoptedMessageRecord(
+        AdoptedContextRecorded.AdoptedMessageRecord r) => new()
+    {
+        MessageId = r.MessageId,
+        SenderId = r.SenderId,
+        TimestampMs = r.TimestampMs,
+        AuthorityAtInclusion = r.AuthorityAtInclusion
+    };
+
+    private static AdoptedContextRecorded.AdoptedMessageRecord FromAdoptedMessageRecord(
+        Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecord proto) => new()
+    {
+        MessageId = proto.MessageId,
+        SenderId = proto.SenderId,
+        TimestampMs = proto.TimestampMs,
+        AuthorityAtInclusion = proto.AuthorityAtInclusion
+    };
+
+    // ── SessionTitleSet ──
+
+    internal static Proto.SessionTitleSetProto ToProto(SessionTitleSet evt) => new()
+    {
+        SessionId = ToProto(evt.SessionId),
+        Title = evt.Title,
+        SetAtMs = evt.SetAtMs
+    };
+
+    internal static SessionTitleSet FromProto(Proto.SessionTitleSetProto proto) => new()
+    {
+        SessionId = FromProto(proto.SessionId),
+        Title = proto.Title,
+        SetAtMs = proto.SetAtMs
+    };
+
+    // ── SessionCompacted ──
+
+    internal static Proto.SessionCompactedProto ToProto(SessionCompacted evt)
+    {
+        var proto = new Proto.SessionCompactedProto
+        {
+            SessionId = ToProto(evt.SessionId),
+            Summary = evt.Summary,
+            TurnCountBefore = evt.TurnCountBefore,
+            CompactedAtMs = evt.CompactedAtMs
+        };
+        proto.CompactedMessages.AddRange(evt.CompactedMessages.Select(ToProto));
+        if (evt.WorkingContext is not null)
+            proto.WorkingContext = ToProto(evt.WorkingContext);
+        return proto;
+    }
+
+    internal static SessionCompacted FromProto(Proto.SessionCompactedProto proto)
+    {
+        var evt = new SessionCompacted
+        {
+            SessionId = FromProto(proto.SessionId),
+            Summary = proto.Summary,
+            TurnCountBefore = proto.TurnCountBefore,
+            CompactedAtMs = proto.CompactedAtMs,
+            WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null
+        };
+        evt.CompactedMessages.AddRange(proto.CompactedMessages.Select(FromProto));
+        return evt;
+    }
+
+    // ── SessionSnapshot ──
+
+    internal static Proto.SessionSnapshotProto ToProto(SessionSnapshot snap)
+    {
+        var proto = new Proto.SessionSnapshotProto
+        {
+            TurnCount = snap.TurnCount
+        };
+        if (snap.Title is not null)
+            proto.Title = snap.Title;
+        if (snap.EligibleDeliveryTurnNumber is not null)
+            proto.EligibleDeliveryTurnNumber = snap.EligibleDeliveryTurnNumber.Value;
+        if (snap.WorkingContext is not null)
+            proto.WorkingContext = ToProto(snap.WorkingContext);
+        proto.History.AddRange(snap.History.Select(ToProto));
+        proto.ActiveBackgroundJobs.AddRange(snap.ActiveBackgroundJobs.Select(ToProto));
+        proto.AdoptedContextRecords.AddRange(snap.AdoptedContextRecords.Select(ToAdoptedContextSnapshotRecord));
+        return proto;
+    }
+
+    internal static SessionSnapshot FromProto(Proto.SessionSnapshotProto proto)
+    {
+        var snap = new SessionSnapshot
+        {
+            TurnCount = proto.TurnCount,
+            Title = proto.HasTitle ? proto.Title : null,
+            EligibleDeliveryTurnNumber = proto.HasEligibleDeliveryTurnNumber ? proto.EligibleDeliveryTurnNumber : null,
+            WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null
+        };
+        snap.History.AddRange(proto.History.Select(FromProto));
+        snap.ActiveBackgroundJobs.AddRange(proto.ActiveBackgroundJobs.Select(FromProto));
+        snap.AdoptedContextRecords.AddRange(proto.AdoptedContextRecords.Select(FromAdoptedContextSnapshotRecord));
+        return snap;
+    }
+
+    private static Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord ToAdoptedContextSnapshotRecord(
+        SessionSnapshot.AdoptedContextSnapshotRecord r)
+    {
+        var proto = new Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord
+        {
+            AuthorizedMessageId = r.AuthorizedMessageId,
+            Projection = r.Projection,
+            ProjectionPersisted = r.ProjectionPersisted
+        };
+        if (r.AuthorizerSenderId is not null)
+            proto.AuthorizerSenderId = r.AuthorizerSenderId;
+        if (r.LowerBound is not null)
+            proto.LowerBound = r.LowerBound;
+        if (r.UpperBound is not null)
+            proto.UpperBound = r.UpperBound;
+        proto.Messages.AddRange(r.Messages.Select(ToAdoptedContextSnapshotMessage));
+        return proto;
+    }
+
+    private static SessionSnapshot.AdoptedContextSnapshotRecord FromAdoptedContextSnapshotRecord(
+        Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord proto)
+    {
+        var r = new SessionSnapshot.AdoptedContextSnapshotRecord
+        {
+            AuthorizedMessageId = proto.AuthorizedMessageId,
+            AuthorizerSenderId = proto.HasAuthorizerSenderId ? proto.AuthorizerSenderId : null,
+            LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
+            UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
+            Projection = proto.Projection,
+            ProjectionPersisted = proto.ProjectionPersisted
+        };
+        r.Messages.AddRange(proto.Messages.Select(FromAdoptedContextSnapshotMessage));
+        return r;
+    }
+
+    private static Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord.Types.AdoptedContextSnapshotMessage
+        ToAdoptedContextSnapshotMessage(SessionSnapshot.AdoptedContextSnapshotRecord.AdoptedContextSnapshotMessage m) => new()
+    {
+        MessageId = m.MessageId,
+        SenderId = m.SenderId,
+        TimestampMs = m.TimestampMs,
+        AuthorityAtInclusion = m.AuthorityAtInclusion
+    };
+
+    private static SessionSnapshot.AdoptedContextSnapshotRecord.AdoptedContextSnapshotMessage
+        FromAdoptedContextSnapshotMessage(
+            Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord.Types.AdoptedContextSnapshotMessage proto) => new()
+    {
+        MessageId = proto.MessageId,
+        SenderId = proto.SenderId,
+        TimestampMs = proto.TimestampMs,
+        AuthorityAtInclusion = proto.AuthorityAtInclusion
+    };
+
+    // ── TurnBroadcast ──
+
+    internal static Proto.TurnBroadcastProto ToProto(TurnBroadcast evt) => new()
+    {
+        SessionId = ToProto(evt.SessionId),
+        AssistantReply = ToProto(evt.AssistantReply),
+        BroadcastAtMs = evt.BroadcastAtMs
+    };
+
+    internal static TurnBroadcast FromProto(Proto.TurnBroadcastProto proto) => new()
+    {
+        SessionId = FromProto(proto.SessionId),
+        AssistantReply = FromProto(proto.AssistantReply),
+        BroadcastAtMs = proto.BroadcastAtMs
+    };
+
+    // ── CompactionBroadcast ──
+
+    internal static Proto.CompactionBroadcastProto ToProto(CompactionBroadcast evt) => new()
+    {
+        SessionId = ToProto(evt.SessionId),
+        Summary = evt.Summary,
+        CompactedAtMs = evt.CompactedAtMs
+    };
+
+    internal static CompactionBroadcast FromProto(Proto.CompactionBroadcastProto proto) => new()
+    {
+        SessionId = FromProto(proto.SessionId),
+        Summary = proto.Summary,
+        CompactedAtMs = proto.CompactedAtMs
+    };
+
+    // ── WorkingContext ──
+
+    internal static Proto.WorkingContextProto ToProto(WorkingContext wc)
+    {
+        var proto = new Proto.WorkingContextProto();
+        proto.RecentFiles.AddRange(wc.RecentFiles);
+        if (wc.ProjectDirectory is not null)
+            proto.ProjectDirectory = wc.ProjectDirectory;
+        return proto;
+    }
+
+    internal static WorkingContext FromProto(Proto.WorkingContextProto proto) => new()
+    {
+        RecentFiles = ImmutableList.CreateRange(proto.RecentFiles),
+        ProjectDirectory = proto.HasProjectDirectory ? proto.ProjectDirectory : null
+    };
+
+    // ── ReminderDelivery ──
+
+    internal static Proto.ReminderDeliveryProto ToProto(ReminderDelivery rd)
+    {
+        var proto = new Proto.ReminderDeliveryProto
+        {
+            Kind = (Proto.DeliveryKind)(int)rd.Kind
+        };
+        if (rd.Transport is not null)
+            proto.Transport = rd.Transport;
+        if (rd.Address is not null)
+            proto.Address = rd.Address;
+        if (rd.SessionId is not null)
+            proto.SessionId = rd.SessionId;
+        if (rd.OriginChannelType is not null)
+            proto.OriginChannelType = (Proto.ChannelType)(int)rd.OriginChannelType.Value;
+        return proto;
+    }
+
+    internal static ReminderDelivery FromProto(Proto.ReminderDeliveryProto proto) => new()
+    {
+        Kind = (Reminders.DeliveryKind)(int)proto.Kind,
+        Transport = proto.HasTransport ? proto.Transport : null,
+        Address = proto.HasAddress ? proto.Address : null,
+        SessionId = proto.HasSessionId ? proto.SessionId : null,
+        OriginChannelType = proto.HasOriginChannelType ? (ChannelType)(int)proto.OriginChannelType : null
+    };
+
+    // ── ReminderSchedule ──
+
+    internal static Proto.ReminderScheduleProto ToProto(ReminderSchedule rs)
+    {
+        var proto = new Proto.ReminderScheduleProto
+        {
+            Type = (Proto.ReminderScheduleType)(int)rs.Type
+        };
+        if (rs.FireAtMs is not null)
+            proto.FireAtMs = rs.FireAtMs.Value;
+        if (rs.IntervalTicks is not null)
+            proto.IntervalTicks = rs.IntervalTicks.Value;
+        if (rs.CronExpression is not null)
+            proto.CronExpression = rs.CronExpression;
+        if (rs.OriginalExpression is not null)
+            proto.OriginalExpression = rs.OriginalExpression;
+        return proto;
+    }
+
+    internal static ReminderSchedule FromProto(Proto.ReminderScheduleProto proto) => new()
+    {
+        Type = (Reminders.ReminderScheduleType)(int)proto.Type,
+        FireAtMs = proto.HasFireAtMs ? proto.FireAtMs : null,
+        IntervalTicks = proto.HasIntervalTicks ? proto.IntervalTicks : null,
+        CronExpression = proto.HasCronExpression ? proto.CronExpression : null,
+        OriginalExpression = proto.HasOriginalExpression ? proto.OriginalExpression : null
+    };
+
+    // ── ReminderPayload ──
+
+    internal static Proto.ReminderPayloadProto ToProto(ReminderPayload rp) => new()
+    {
+        Id = ToProto(rp.Id)
+    };
+
+    internal static ReminderPayload FromProto(Proto.ReminderPayloadProto proto) => new()
+    {
+        Id = FromProto(proto.Id)
+    };
+
+    // ── ActiveJobInfo ──
+
+    internal static Proto.ActiveJobInfoProto ToProto(ActiveJobInfo job) => new()
+    {
+        JobId = job.JobId,
+        Command = job.Command,
+        Rationale = job.Rationale,
+        StartedAtMs = job.StartedAtMs,
+        Audience = (Proto.TrustAudience)(int)job.Audience,
+        Boundary = job.Boundary
+    };
+
+    internal static ActiveJobInfo FromProto(Proto.ActiveJobInfoProto proto) => new()
+    {
+        JobId = proto.JobId,
+        Command = proto.Command,
+        Rationale = proto.Rationale,
+        StartedAtMs = proto.StartedAtMs,
+        Audience = (Configuration.TrustAudience)(int)proto.Audience,
+        Boundary = proto.Boundary
+    };
+}
+
+#pragma warning restore CS0612, CS0618

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -14,8 +14,6 @@ using Proto = Netclaw.Actors.Serialization.Proto;
 
 namespace Netclaw.Actors.Serialization;
 
-#pragma warning disable CS0612, CS0618 // SystemPromptSet is obsolete but must remain serializable for journal recovery
-
 internal static class NetclawProtoMapper
 {
     internal static IMessage ToProtoMessage(object obj) => obj switch
@@ -26,7 +24,9 @@ internal static class NetclawProtoMapper
         SerializableMediaReference v => ToProto(v),
         SerializableToolCall v => ToProto(v),
         TurnRecorded v => ToProto(v),
+#pragma warning disable CS0612, CS0618
         SystemPromptSet v => ToProto(v),
+#pragma warning restore CS0612, CS0618
         SessionTitleSet v => ToProto(v),
         SessionCompacted v => ToProto(v),
         SessionSnapshot v => ToProto(v),
@@ -145,8 +145,9 @@ internal static class NetclawProtoMapper
         return cmd;
     }
 
-    // ── SystemPromptSet ──
+    // ── SystemPromptSet (obsolete — retained for old journal recovery) ──
 
+#pragma warning disable CS0612, CS0618
     internal static Proto.SystemPromptSetProto ToProto(SystemPromptSet evt) => new()
     {
         SessionId = ToProto(evt.SessionId),
@@ -160,6 +161,7 @@ internal static class NetclawProtoMapper
         Content = proto.Content,
         SetAtMs = proto.SetAtMs
     };
+#pragma warning restore CS0612, CS0618
 
     // ── TurnRecorded ──
 
@@ -521,5 +523,3 @@ internal static class NetclawProtoMapper
         Boundary = proto.Boundary
     };
 }
-
-#pragma warning restore CS0612, CS0618

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -24,9 +24,6 @@ internal static class NetclawProtoMapper
         SerializableMediaReference v => ToProto(v),
         SerializableToolCall v => ToProto(v),
         TurnRecorded v => ToProto(v),
-#pragma warning disable CS0612, CS0618
-        SystemPromptSet v => ToProto(v),
-#pragma warning restore CS0612, CS0618
         SessionTitleSet v => ToProto(v),
         SessionCompacted v => ToProto(v),
         SessionSnapshot v => ToProto(v),
@@ -145,24 +142,6 @@ internal static class NetclawProtoMapper
         return cmd;
     }
 
-    // ── SystemPromptSet (obsolete — retained for old journal recovery) ──
-
-#pragma warning disable CS0612, CS0618
-    internal static Proto.SystemPromptSetProto ToProto(SystemPromptSet evt) => new()
-    {
-        SessionId = ToProto(evt.SessionId),
-        Content = evt.Content,
-        SetAtMs = evt.SetAtMs
-    };
-
-    internal static SystemPromptSet FromProto(Proto.SystemPromptSetProto proto) => new()
-    {
-        SessionId = FromProto(proto.SessionId),
-        Content = proto.Content,
-        SetAtMs = proto.SetAtMs
-    };
-#pragma warning restore CS0612, CS0618
-
     // ── TurnRecorded ──
 
     internal static Proto.TurnRecordedProto ToProto(TurnRecorded evt)
@@ -189,63 +168,6 @@ internal static class NetclawProtoMapper
         RecordedAtMs = proto.RecordedAtMs,
         SourceReminderId = proto.HasSourceReminderId ? proto.SourceReminderId : null,
         SourceBackgroundJobId = proto.HasSourceBackgroundJobId ? proto.SourceBackgroundJobId : null
-    };
-
-    // ── AdoptedContextRecorded ──
-
-    internal static Proto.AdoptedContextRecordedProto ToProto(AdoptedContextRecorded evt)
-    {
-        var proto = new Proto.AdoptedContextRecordedProto
-        {
-            SessionId = ToProto(evt.SessionId),
-            AuthorizedMessageId = evt.AuthorizedMessageId,
-            Projection = evt.Projection,
-            ProjectionPersisted = evt.ProjectionPersisted,
-            RecordedAtMs = evt.RecordedAtMs
-        };
-        if (evt.AuthorizerSenderId is not null)
-            proto.AuthorizerSenderId = evt.AuthorizerSenderId;
-        if (evt.LowerBound is not null)
-            proto.LowerBound = evt.LowerBound;
-        if (evt.UpperBound is not null)
-            proto.UpperBound = evt.UpperBound;
-        proto.Messages.AddRange(evt.Messages.Select(ToAdoptedMessageRecord));
-        return proto;
-    }
-
-    internal static AdoptedContextRecorded FromProto(Proto.AdoptedContextRecordedProto proto)
-    {
-        var evt = new AdoptedContextRecorded
-        {
-            SessionId = FromProto(proto.SessionId),
-            AuthorizedMessageId = proto.AuthorizedMessageId,
-            AuthorizerSenderId = proto.HasAuthorizerSenderId ? proto.AuthorizerSenderId : null,
-            LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
-            UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
-            Projection = proto.Projection,
-            ProjectionPersisted = proto.ProjectionPersisted,
-            RecordedAtMs = proto.RecordedAtMs
-        };
-        evt.Messages.AddRange(proto.Messages.Select(FromAdoptedMessageRecord));
-        return evt;
-    }
-
-    private static Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecord ToAdoptedMessageRecord(
-        AdoptedContextRecorded.AdoptedMessageRecord r) => new()
-    {
-        MessageId = r.MessageId,
-        SenderId = r.SenderId,
-        TimestampMs = r.TimestampMs,
-        AuthorityAtInclusion = r.AuthorityAtInclusion
-    };
-
-    private static AdoptedContextRecorded.AdoptedMessageRecord FromAdoptedMessageRecord(
-        Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecord proto) => new()
-    {
-        MessageId = proto.MessageId,
-        SenderId = proto.SenderId,
-        TimestampMs = proto.TimestampMs,
-        AuthorityAtInclusion = proto.AuthorityAtInclusion
     };
 
     // ── SessionTitleSet ──

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -34,6 +34,7 @@ internal static class NetclawProtoMapper
         ReminderDelivery v => ToProto(v),
         ReminderSchedule v => ToProto(v),
         ReminderPayload v => ToProto(v),
+        AdoptedContextRecorded v => ToProto(v),
         _ => throw new ArgumentException($"No proto mapping for {obj.GetType().FullName}")
     };
 
@@ -421,6 +422,63 @@ internal static class NetclawProtoMapper
     internal static ReminderPayload FromProto(Proto.ReminderPayloadProto proto) => new()
     {
         Id = FromProto(proto.Id)
+    };
+
+    // ── AdoptedContextRecorded ──
+
+    internal static Proto.AdoptedContextRecordedProto ToProto(AdoptedContextRecorded evt)
+    {
+        var proto = new Proto.AdoptedContextRecordedProto
+        {
+            SessionId = ToProto(evt.SessionId),
+            AuthorizedMessageId = evt.AuthorizedMessageId,
+            Projection = evt.Projection,
+            ProjectionPersisted = evt.ProjectionPersisted,
+            RecordedAtMs = evt.RecordedAtMs
+        };
+        if (evt.AuthorizerSenderId is not null)
+            proto.AuthorizerSenderId = evt.AuthorizerSenderId;
+        if (evt.LowerBound is not null)
+            proto.LowerBound = evt.LowerBound;
+        if (evt.UpperBound is not null)
+            proto.UpperBound = evt.UpperBound;
+        proto.Messages.AddRange(evt.Messages.Select(ToAdoptedMessageRecord));
+        return proto;
+    }
+
+    internal static AdoptedContextRecorded FromProto(Proto.AdoptedContextRecordedProto proto)
+    {
+        var evt = new AdoptedContextRecorded
+        {
+            SessionId = FromProto(proto.SessionId),
+            AuthorizedMessageId = proto.AuthorizedMessageId,
+            AuthorizerSenderId = proto.HasAuthorizerSenderId ? proto.AuthorizerSenderId : null,
+            LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
+            UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
+            Projection = proto.Projection,
+            ProjectionPersisted = proto.ProjectionPersisted,
+            RecordedAtMs = proto.RecordedAtMs
+        };
+        evt.Messages.AddRange(proto.Messages.Select(FromAdoptedMessageRecord));
+        return evt;
+    }
+
+    private static Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecordProto ToAdoptedMessageRecord(
+        AdoptedContextRecorded.AdoptedMessageRecord m) => new()
+    {
+        MessageId = m.MessageId,
+        SenderId = m.SenderId,
+        TimestampMs = m.TimestampMs,
+        AuthorityAtInclusion = m.AuthorityAtInclusion
+    };
+
+    private static AdoptedContextRecorded.AdoptedMessageRecord FromAdoptedMessageRecord(
+        Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecordProto proto) => new()
+    {
+        MessageId = proto.MessageId,
+        SenderId = proto.SenderId,
+        TimestampMs = proto.TimestampMs,
+        AuthorityAtInclusion = proto.AuthorityAtInclusion
     };
 
     // ── ActiveJobInfo ──

--- a/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
@@ -36,6 +36,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
     private const string ReminderDeliveryManifest = "rd-v1";
     private const string ReminderScheduleManifest = "rs-v1";
     private const string ReminderPayloadManifest = "rp-v1";
+    private const string AdoptedContextRecordedManifest = "acr-v1";
 
     private static readonly FrozenDictionary<Type, string> TypeToManifest = new Dictionary<Type, string>
     {
@@ -55,6 +56,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
         [typeof(ReminderDelivery)] = ReminderDeliveryManifest,
         [typeof(ReminderSchedule)] = ReminderScheduleManifest,
         [typeof(ReminderPayload)] = ReminderPayloadManifest,
+        [typeof(AdoptedContextRecorded)] = AdoptedContextRecordedManifest,
     }.ToFrozenDictionary();
 
     public override int Identifier => 150;
@@ -113,6 +115,8 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
                 Proto.ReminderScheduleProto.Parser.ParseFrom(bytes)),
             ReminderPayloadManifest => NetclawProtoMapper.FromProto(
                 Proto.ReminderPayloadProto.Parser.ParseFrom(bytes)),
+            AdoptedContextRecordedManifest => NetclawProtoMapper.FromProto(
+                Proto.AdoptedContextRecordedProto.Parser.ParseFrom(bytes)),
             _ => throw new ArgumentException(
                 $"Unknown manifest '{manifest}'. Add it to NetclawProtobufSerializer.")
         };

--- a/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
@@ -1,21 +1,20 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="NetclawProtobufSerializer.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using Akka.Actor;
 using Akka.Serialization;
+using Google.Protobuf;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
 using Netclaw.Actors.Sessions;
-using ProtoBuf;
 
 namespace Netclaw.Actors.Serialization;
 
 /// <summary>
-/// Akka.NET serializer using protobuf-net for Netclaw protocol types.
+/// Akka.NET serializer using Google Protobuf for Netclaw protocol types.
 /// Manifests are constant strings decoupled from type names for safe schema evolution.
 /// </summary>
 public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
@@ -58,26 +57,6 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
         [typeof(ReminderPayload)] = ReminderPayloadManifest,
     }.ToFrozenDictionary();
 
-    private static readonly FrozenDictionary<string, Type> ManifestToType = new Dictionary<string, Type>
-    {
-        [SessionIdManifest] = typeof(SessionId),
-        [SendUserMessageManifest] = typeof(SendUserMessage),
-        [SerializableChatMessageManifest] = typeof(SerializableChatMessage),
-        [SerializableMediaReferenceManifest] = typeof(SerializableMediaReference),
-        [SerializableToolCallManifest] = typeof(SerializableToolCall),
-        [TurnRecordedManifest] = typeof(TurnRecorded),
-        [SessionTitleSetManifest] = typeof(SessionTitleSet),
-        [SessionCompactedManifest] = typeof(SessionCompacted),
-        [SessionSnapshotManifest] = typeof(SessionSnapshot),
-        [TurnBroadcastManifest] = typeof(TurnBroadcast),
-        [CompactionBroadcastManifest] = typeof(CompactionBroadcast),
-        [WorkingContextManifest] = typeof(WorkingContext),
-        [ReminderIdManifest] = typeof(ReminderId),
-        [ReminderDeliveryManifest] = typeof(ReminderDelivery),
-        [ReminderScheduleManifest] = typeof(ReminderSchedule),
-        [ReminderPayloadManifest] = typeof(ReminderPayload),
-    }.ToFrozenDictionary();
-
     public override int Identifier => 150;
 
     public NetclawProtobufSerializer(ExtendedActorSystem system) : base(system)
@@ -95,18 +74,47 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
 
     public override byte[] ToBinary(object obj)
     {
-        using var stream = new MemoryStream();
-        ProtoBuf.Serializer.Serialize(stream, obj);
-        return stream.ToArray();
+        return NetclawProtoMapper.ToProtoMessage(obj).ToByteArray();
     }
 
     public override object FromBinary(byte[] bytes, string manifest)
     {
-        if (!ManifestToType.TryGetValue(manifest, out var type))
-            throw new ArgumentException($"Unknown manifest '{manifest}'. Add it to NetclawProtobufSerializer.");
-
-        using var stream = new MemoryStream(bytes);
-        return ProtoBuf.Serializer.Deserialize(type, stream)
-            ?? throw new InvalidOperationException($"Deserialization returned null for manifest '{manifest}'");
+        return manifest switch
+        {
+            SessionIdManifest => NetclawProtoMapper.FromProto(
+                Proto.SessionIdProto.Parser.ParseFrom(bytes)),
+            SendUserMessageManifest => NetclawProtoMapper.FromProto(
+                Proto.SendUserMessageProto.Parser.ParseFrom(bytes)),
+            SerializableChatMessageManifest => NetclawProtoMapper.FromProto(
+                Proto.SerializableChatMessageProto.Parser.ParseFrom(bytes)),
+            SerializableMediaReferenceManifest => NetclawProtoMapper.FromProto(
+                Proto.SerializableMediaReferenceProto.Parser.ParseFrom(bytes)),
+            SerializableToolCallManifest => NetclawProtoMapper.FromProto(
+                Proto.SerializableToolCallProto.Parser.ParseFrom(bytes)),
+            TurnRecordedManifest => NetclawProtoMapper.FromProto(
+                Proto.TurnRecordedProto.Parser.ParseFrom(bytes)),
+            SessionTitleSetManifest => NetclawProtoMapper.FromProto(
+                Proto.SessionTitleSetProto.Parser.ParseFrom(bytes)),
+            SessionCompactedManifest => NetclawProtoMapper.FromProto(
+                Proto.SessionCompactedProto.Parser.ParseFrom(bytes)),
+            SessionSnapshotManifest => NetclawProtoMapper.FromProto(
+                Proto.SessionSnapshotProto.Parser.ParseFrom(bytes)),
+            TurnBroadcastManifest => NetclawProtoMapper.FromProto(
+                Proto.TurnBroadcastProto.Parser.ParseFrom(bytes)),
+            CompactionBroadcastManifest => NetclawProtoMapper.FromProto(
+                Proto.CompactionBroadcastProto.Parser.ParseFrom(bytes)),
+            WorkingContextManifest => NetclawProtoMapper.FromProto(
+                Proto.WorkingContextProto.Parser.ParseFrom(bytes)),
+            ReminderIdManifest => NetclawProtoMapper.FromProto(
+                Proto.ReminderIdProto.Parser.ParseFrom(bytes)),
+            ReminderDeliveryManifest => NetclawProtoMapper.FromProto(
+                Proto.ReminderDeliveryProto.Parser.ParseFrom(bytes)),
+            ReminderScheduleManifest => NetclawProtoMapper.FromProto(
+                Proto.ReminderScheduleProto.Parser.ParseFrom(bytes)),
+            ReminderPayloadManifest => NetclawProtoMapper.FromProto(
+                Proto.ReminderPayloadProto.Parser.ParseFrom(bytes)),
+            _ => throw new ArgumentException(
+                $"Unknown manifest '{manifest}'. Add it to NetclawProtobufSerializer.")
+        };
     }
 }

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -83,12 +83,6 @@ message SendUserMessageProto {
 
 // ── Events ──
 
-message SystemPromptSetProto {
-  SessionIdProto session_id = 1;
-  string content = 2;
-  int64 set_at_ms = 3;
-}
-
 message TurnRecordedProto {
   SessionIdProto session_id = 1;
   SerializableChatMessageProto user_message = 2;
@@ -96,25 +90,6 @@ message TurnRecordedProto {
   int64 recorded_at_ms = 4;
   optional string source_reminder_id = 5;
   optional string source_background_job_id = 6;
-}
-
-message AdoptedContextRecordedProto {
-  message AdoptedMessageRecord {
-    string message_id = 1;
-    string sender_id = 2;
-    int64 timestamp_ms = 3;
-    string authority_at_inclusion = 4;
-  }
-
-  SessionIdProto session_id = 1;
-  string authorized_message_id = 2;
-  optional string authorizer_sender_id = 3;
-  optional string lower_bound = 4;
-  optional string upper_bound = 5;
-  string projection = 6;
-  repeated AdoptedMessageRecord messages = 7;
-  bool projection_persisted = 8;
-  int64 recorded_at_ms = 9;
 }
 
 message SessionTitleSetProto {

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -108,6 +108,27 @@ message SessionCompactedProto {
   WorkingContextProto working_context = 7;
 }
 
+// ── Adopted context ──
+
+message AdoptedContextRecordedProto {
+  message AdoptedMessageRecordProto {
+    string message_id = 1;
+    string sender_id = 2;
+    int64 timestamp_ms = 3;
+    string authority_at_inclusion = 4;
+  }
+
+  SessionIdProto session_id = 1;
+  string authorized_message_id = 2;
+  optional string authorizer_sender_id = 3;
+  optional string lower_bound = 4;
+  optional string upper_bound = 5;
+  string projection = 6;
+  repeated AdoptedMessageRecordProto messages = 7;
+  bool projection_persisted = 8;
+  int64 recorded_at_ms = 9;
+}
+
 // ── Snapshots ──
 
 message ActiveJobInfoProto {

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -1,0 +1,216 @@
+syntax = "proto3";
+
+option csharp_namespace = "Netclaw.Actors.Serialization.Proto";
+
+// ── Enums ──
+
+enum ChatRole {
+  CHAT_ROLE_USER = 0;
+  CHAT_ROLE_ASSISTANT = 1;
+  CHAT_ROLE_SYSTEM = 2;
+  CHAT_ROLE_TOOL = 3;
+}
+
+enum DeliveryKind {
+  DELIVERY_KIND_CURRENT_SESSION = 0;
+  DELIVERY_KIND_CHANNEL = 1;
+  DELIVERY_KIND_NONE = 2;
+}
+
+enum ReminderScheduleType {
+  REMINDER_SCHEDULE_TYPE_ONE_SHOT = 0;
+  REMINDER_SCHEDULE_TYPE_INTERVAL = 1;
+  REMINDER_SCHEDULE_TYPE_CRON = 2;
+}
+
+enum TrustAudience {
+  TRUST_AUDIENCE_PUBLIC = 0;
+  TRUST_AUDIENCE_TEAM = 1;
+  TRUST_AUDIENCE_PERSONAL = 2;
+}
+
+enum ChannelType {
+  CHANNEL_TYPE_SLACK = 0;
+  CHANNEL_TYPE_TUI = 1;
+  CHANNEL_TYPE_HEADLESS = 2;
+  CHANNEL_TYPE_SIGNALR = 3;
+  CHANNEL_TYPE_REMINDER = 4;
+  CHANNEL_TYPE_WEBHOOK = 5;
+  CHANNEL_TYPE_DISCORD = 6;
+}
+
+// ── Value types ──
+
+message SessionIdProto {
+  string value = 1;
+}
+
+message ReminderIdProto {
+  string value = 1;
+}
+
+// ── Chat messages ──
+
+message SerializableMediaReferenceProto {
+  string relative_path = 1;
+  string mime_type = 2;
+  int32 modality = 3;
+}
+
+message SerializableToolCallProto {
+  string call_id = 1;
+  string name = 2;
+  string arguments_json = 3;
+  optional string meta_json = 4;
+}
+
+message SerializableChatMessageProto {
+  ChatRole role = 1;
+  string content = 2;
+  optional string name = 3;
+  repeated SerializableToolCallProto tool_calls = 4;
+  optional string tool_call_id = 5;
+  repeated SerializableMediaReferenceProto media_references = 6;
+}
+
+// ── Commands ──
+
+message SendUserMessageProto {
+  SessionIdProto session_id = 1;
+  string content = 2;
+  repeated SerializableMediaReferenceProto media_references = 3;
+}
+
+// ── Events ──
+
+message SystemPromptSetProto {
+  SessionIdProto session_id = 1;
+  string content = 2;
+  int64 set_at_ms = 3;
+}
+
+message TurnRecordedProto {
+  SessionIdProto session_id = 1;
+  SerializableChatMessageProto user_message = 2;
+  SerializableChatMessageProto assistant_reply = 3;
+  int64 recorded_at_ms = 4;
+  optional string source_reminder_id = 5;
+  optional string source_background_job_id = 6;
+}
+
+message AdoptedContextRecordedProto {
+  message AdoptedMessageRecord {
+    string message_id = 1;
+    string sender_id = 2;
+    int64 timestamp_ms = 3;
+    string authority_at_inclusion = 4;
+  }
+
+  SessionIdProto session_id = 1;
+  string authorized_message_id = 2;
+  optional string authorizer_sender_id = 3;
+  optional string lower_bound = 4;
+  optional string upper_bound = 5;
+  string projection = 6;
+  repeated AdoptedMessageRecord messages = 7;
+  bool projection_persisted = 8;
+  int64 recorded_at_ms = 9;
+}
+
+message SessionTitleSetProto {
+  SessionIdProto session_id = 1;
+  string title = 2;
+  int64 set_at_ms = 3;
+}
+
+message SessionCompactedProto {
+  SessionIdProto session_id = 1;
+  string summary = 2;
+  repeated SerializableChatMessageProto compacted_messages = 3;
+  int32 turn_count_before = 4;
+  int64 compacted_at_ms = 5;
+  reserved 6;
+  WorkingContextProto working_context = 7;
+}
+
+// ── Snapshots ──
+
+message ActiveJobInfoProto {
+  string job_id = 1;
+  string command = 2;
+  string rationale = 3;
+  int64 started_at_ms = 4;
+  TrustAudience audience = 5;
+  string boundary = 6;
+}
+
+message SessionSnapshotProto {
+  message AdoptedContextSnapshotRecord {
+    message AdoptedContextSnapshotMessage {
+      string message_id = 1;
+      string sender_id = 2;
+      int64 timestamp_ms = 3;
+      string authority_at_inclusion = 4;
+    }
+
+    string authorized_message_id = 1;
+    optional string authorizer_sender_id = 2;
+    optional string lower_bound = 3;
+    optional string upper_bound = 4;
+    string projection = 5;
+    bool projection_persisted = 6;
+    repeated AdoptedContextSnapshotMessage messages = 7;
+  }
+
+  repeated SerializableChatMessageProto history = 1;
+  int32 turn_count = 2;
+  optional string title = 3;
+  optional int32 eligible_delivery_turn_number = 4;
+  reserved 5;
+  WorkingContextProto working_context = 6;
+  repeated ActiveJobInfoProto active_background_jobs = 7;
+  repeated AdoptedContextSnapshotRecord adopted_context_records = 8;
+}
+
+// ── Broadcasts ──
+
+message TurnBroadcastProto {
+  SessionIdProto session_id = 1;
+  SerializableChatMessageProto assistant_reply = 2;
+  int64 broadcast_at_ms = 3;
+}
+
+message CompactionBroadcastProto {
+  SessionIdProto session_id = 1;
+  string summary = 2;
+  int64 compacted_at_ms = 3;
+}
+
+// ── Session state ──
+
+message WorkingContextProto {
+  repeated string recent_files = 1;
+  optional string project_directory = 2;
+}
+
+// ── Reminders ──
+
+message ReminderDeliveryProto {
+  DeliveryKind kind = 1;
+  optional string transport = 2;
+  optional string address = 3;
+  optional string session_id = 4;
+  optional ChannelType origin_channel_type = 5;
+}
+
+message ReminderScheduleProto {
+  ReminderScheduleType type = 1;
+  optional int64 fire_at_ms = 2;
+  optional int64 interval_ticks = 3;
+  optional string cron_expression = 4;
+  optional string original_expression = 5;
+}
+
+message ReminderPayloadProto {
+  ReminderIdProto id = 1;
+}

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -225,11 +225,6 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _baseToolCount = _availableTools.Count;
 
         // ── Recovery handlers ──
-        // Backward compat: old journals contain SystemPromptSet events.
-        // Ignore the content — we always read fresh from disk in RecoveryCompleted.
-#pragma warning disable CS0618 // Obsolete type retained for journal deserialization
-        Recover<SystemPromptSet>(_ => { });
-#pragma warning restore CS0618
         Recover<TurnRecorded>(evt => _state = _state.Apply(evt));
         Recover<SessionTitleSet>(evt => _state = _state.Apply(evt));
         Recover<SessionCompacted>(evt => _state = _state.Apply(evt));

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Immutable;
-using ProtoBuf;
 
 namespace Netclaw.Actors.Sessions;
 
@@ -23,7 +22,6 @@ namespace Netclaw.Actors.Sessions;
 ///   root the session is working on. Set via <c>set_working_directory</c>
 ///   tool, persisted across crash/restart. Null means "no project selected."
 /// </summary>
-[ProtoContract]
 public sealed record WorkingContext
 {
     /// <summary>
@@ -34,11 +32,9 @@ public sealed record WorkingContext
 
     public static readonly WorkingContext Empty = new();
 
-    [ProtoMember(1)]
     public ImmutableList<string> RecentFiles { get; init; } =
         [];
 
-    [ProtoMember(2)]
     public string? ProjectDirectory { get; init; }
 
     /// <summary>

--- a/src/Netclaw.Channels/Netclaw.Channels.csproj
+++ b/src/Netclaw.Channels/Netclaw.Channels.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol.Core" />
-    <PackageReference Include="protobuf-net" />
     <ProjectReference Include="..\Netclaw.Actors\Netclaw.Actors.csproj" />
     <ProjectReference Include="..\Netclaw.Configuration\Netclaw.Configuration.csproj" />
     <ProjectReference Include="..\Netclaw.Security\Netclaw.Security.csproj" />

--- a/src/Netclaw.Configuration/ISystemPromptProvider.cs
+++ b/src/Netclaw.Configuration/ISystemPromptProvider.cs
@@ -41,9 +41,9 @@ public enum ContextLayerTiming
 
 /// <summary>
 /// Provides a dynamic context layer that is injected into LLM calls
-/// but NOT persisted as part of <c>SystemPromptSet</c>. This allows
-/// transient data (e.g. tool index) to be refreshed on every call
-/// without stale state in rehydrated sessions.
+/// but NOT persisted with the session. This allows transient data
+/// (e.g. tool index) to be refreshed on every call without stale
+/// state in rehydrated sessions.
 /// </summary>
 public interface IContextLayerProvider
 {


### PR DESCRIPTION
## Summary

Closes #808

- Replace protobuf-net (attribute-based) with Google Protobuf (.proto codegen) for Akka.NET persistence serialization
- Define wire format in `netclaw_messages.proto`; `Grpc.Tools` generates C# wire types at build time
- Add `NetclawProtoMapper` for bidirectional mapping between domain types and proto wire types
- Rewrite `NetclawProtobufSerializer` to use Google Protobuf via the mapper layer
- Remove all `[ProtoContract]`/`[ProtoMember]`/`[ProtoIgnore]` attributes from domain types
- Remove `protobuf-net` package from `Netclaw.Actors` and `Netclaw.Channels`
- Delete dead `SystemPromptSet` type and its `Recover<>` handler (never deployed, no old journals)
- Fix pre-existing bug: register `AdoptedContextRecorded` with the custom serializer (was missing, would crash with strict serialization)

Wire format is identical (protobuf-net and Google Protobuf produce the same bytes), so no journal migration needed. Serializer ID (150) and all manifest strings unchanged.

## Test plan

- [x] All 21 serialization round-trip tests pass (including 2 new ones for `AdoptedContextRecorded`)
- [x] All 1,446 tests in `Netclaw.Actors.Tests` pass
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `grep -r "protobuf-net\|using ProtoBuf\|ProtoContract\|ProtoMember\|ProtoIgnore" src/` returns no hits
- [x] Build succeeds with 0 warnings, 0 errors