### PR TITLE
ci: migrate from self-hosted ARC runners to GitHub-hosted runners

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -14,20 +14,19 @@ on:
 
 jobs:
   test:
-    name: Test-${{matrix.name}}
+    name: Test-${{matrix.os}}
     runs-on: ${{matrix.os}}
     timeout-minutes: 30
 
     strategy:
       matrix:
-        include:
-          - os: arc-netclaw
-            name: ubuntu-latest
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
         with:
+          lfs: true
           fetch-depth: 0
 
       - name: "Install .NET SDK"
@@ -87,7 +86,7 @@ jobs:
 
   copyright-headers:
     name: Copyright Headers
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -102,7 +101,7 @@ jobs:
 
   slopwatch:
     name: Slopwatch
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -210,12 +210,10 @@ jobs:
         name: checksums-${{ matrix.rid }}
         path: ./checksums/
 
-    # Share the self-contained binaries with publish-docker so it doesn't
-    # have to re-run `dotnet publish`. Only the linux-x64 variant is
-    # consumed by the Docker image today — if other RIDs get wired up
-    # they can share this same artifact upload pattern.
+    # Share the self-contained binaries with publish-docker for multi-arch
+    # image builds. Both linux-x64 and linux-arm64 upload their output.
     - name: Upload publish output for downstream jobs
-      if: matrix.rid == 'linux-x64'
+      if: runner.os == 'Linux'
       uses: actions/upload-artifact@v7
       with:
         name: publish-output-${{ matrix.rid }}
@@ -228,7 +226,7 @@ jobs:
   # Job 3: Build and publish netclawd Docker image to GHCR
   # ────────────────────────────────────────────────────────────────────
   publish-docker:
-    name: Publish Docker Image
+    name: Publish Docker Image (multi-arch)
     needs: publish-binaries
     # Disabled until GHCR image path is updated for the new org
     if: false
@@ -244,6 +242,9 @@ jobs:
         lfs: true
         fetch-depth: 0
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -254,54 +255,61 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Reuse the binaries produced by the publish-binaries job instead of
-    # re-running `dotnet publish`. The Docker build script falls through
-    # to its NO_BUILD=1 code path so it only invokes `docker build`.
-    - name: Download publish output from publish-binaries
+    - name: Download linux-x64 publish output
       uses: actions/download-artifact@v8
       with:
         name: publish-output-linux-x64
-        path: .
+        path: ./artifacts/linux-x64
 
-    - name: Restore executable bit on published binaries
+    - name: Download linux-arm64 publish output
+      uses: actions/download-artifact@v8
+      with:
+        name: publish-output-linux-arm64
+        path: ./artifacts/linux-arm64
+
+    - name: Prepare multi-arch publish layout
       shell: bash
       run: |
-        ls -la ./publish/cli/netclaw ./publish/daemon/netclawd
-        chmod +x ./publish/cli/netclaw ./publish/daemon/netclawd
+        set -euo pipefail
+        # The Dockerfile expects publish/cli-{arch}/ and publish/daemon-{arch}/
+        mkdir -p publish/cli-amd64 publish/daemon-amd64
+        mkdir -p publish/cli-arm64 publish/daemon-arm64
 
-    # Reuse the shared build script so the release image build matches the
-    # PR validation build byte-for-byte. NO_BUILD=1 skips `dotnet publish`
-    # and reuses the downloaded binaries directly.
-    - name: Build image via scripts/docker/build-image.sh
-      shell: bash
-      run: |
-        chmod +x scripts/docker/build-image.sh
-        IMAGE_REPO=ghcr.io/aaronontheweb/netclawd \
-        NO_BUILD=1 \
-          scripts/docker/build-image.sh "${{ github.ref_name }}"
+        cp ./artifacts/linux-x64/publish/cli/netclaw    publish/cli-amd64/netclaw
+        cp ./artifacts/linux-x64/publish/daemon/netclawd publish/daemon-amd64/netclawd
+        cp ./artifacts/linux-arm64/publish/cli/netclaw    publish/cli-arm64/netclaw
+        cp ./artifacts/linux-arm64/publish/daemon/netclawd publish/daemon-arm64/netclawd
 
-    - name: Tag additional aliases (latest + major.minor)
+        chmod +x publish/cli-amd64/netclaw publish/daemon-amd64/netclawd
+        chmod +x publish/cli-arm64/netclaw publish/daemon-arm64/netclawd
+
+        echo "Layout:"
+        ls -la publish/cli-amd64/ publish/daemon-amd64/ publish/cli-arm64/ publish/daemon-arm64/
+
+    - name: Compute image tags
+      id: tags
       shell: bash
       run: |
         set -euo pipefail
         VERSION="${{ github.ref_name }}"
         STRIPPED="${VERSION#v}"
         MAJOR_MINOR=$(echo "$STRIPPED" | awk -F. '{print $1"."$2}')
+        REPO="ghcr.io/aaronontheweb/netclawd"
 
-        docker tag \
-          "ghcr.io/aaronontheweb/netclawd:${VERSION}" \
-          "ghcr.io/aaronontheweb/netclawd:latest"
-        docker tag \
-          "ghcr.io/aaronontheweb/netclawd:${VERSION}" \
-          "ghcr.io/aaronontheweb/netclawd:v${MAJOR_MINOR}"
+        TAGS="${REPO}:${VERSION},${REPO}:latest,${REPO}:v${MAJOR_MINOR}"
+        echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+        echo "Tags: $TAGS"
 
-        echo "Tags ready:"
-        docker images --format '{{.Repository}}:{{.Tag}}' ghcr.io/aaronontheweb/netclawd
-
-    - name: Push all tags
-      shell: bash
-      run: |
-        docker push --all-tags ghcr.io/aaronontheweb/netclawd
+    - name: Build and push multi-arch image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: docker/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.tags.outputs.tags }}
+        build-args: |
+          NETCLAW_VERSION=${{ github.ref_name }}
 
   # ────────────────────────────────────────────────────────────────────
   # Job 4: Generate binary manifest and deploy to Cloudflare Pages

--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -14,7 +14,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────
   create-release:
     name: Create GitHub Release
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - name: Checkout
@@ -75,17 +75,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: arc-netclaw
+          - os: ubuntu-latest
             rid: linux-x64
             archive_ext: tar.gz
-          # Disabled: no self-hosted ARM runner available yet
-          # - os: ubuntu-24.04-arm
-          #   rid: linux-arm64
-          #   archive_ext: tar.gz
-          # Disabled: no self-hosted Windows runner available yet
-          # - os: windows-latest
-          #   rid: win-x64
-          #   archive_ext: zip
+          - os: ubuntu-24.04-arm
+            rid: linux-arm64
+            archive_ext: tar.gz
+          - os: windows-latest
+            rid: win-x64
+            archive_ext: zip
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -137,18 +135,21 @@ jobs:
         tar czf "./archives/netclawd-${VERSION}-${RID}.tar.gz" \
           -C ./publish/daemon netclawd
 
-    # Disabled: no self-hosted Windows runner available yet
-    # - name: Package archives (Windows)
-    #   if: runner.os == 'Windows'
-    #   shell: pwsh
-    #   run: |
-    #     $VERSION = "${{ github.ref_name }}"
-    #     $RID = "${{ matrix.rid }}"
-    #     New-Item -ItemType Directory -Path ./archives -Force
-    #     Compress-Archive -Path ./publish/cli/netclaw.exe `
-    #       -DestinationPath "./archives/netclaw-${VERSION}-${RID}.zip"
-    #     Compress-Archive -Path ./publish/daemon/netclawd.exe `
-    #       -DestinationPath "./archives/netclawd-${VERSION}-${RID}.zip"
+    - name: Package archives (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $VERSION = "${{ github.ref_name }}"
+        $RID = "${{ matrix.rid }}"
+        New-Item -ItemType Directory -Path ./archives -Force
+
+        # CLI archive
+        Compress-Archive -Path ./publish/cli/netclaw.exe `
+          -DestinationPath "./archives/netclaw-${VERSION}-${RID}.zip"
+
+        # Daemon archive
+        Compress-Archive -Path ./publish/daemon/netclawd.exe `
+          -DestinationPath "./archives/netclawd-${VERSION}-${RID}.zip"
 
     - name: Compute checksums
       shell: bash
@@ -176,11 +177,13 @@ jobs:
         files: 'archives/*'
 
     - name: Install Wrangler
+      shell: bash
       run: |
         npm install wrangler@3.90.0 --include=optional
         echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
 
     - name: Upload CLI archive to R2
+      shell: bash
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -191,6 +194,7 @@ jobs:
         --content-type=application/octet-stream
 
     - name: Upload Daemon archive to R2
+      shell: bash
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -226,10 +230,9 @@ jobs:
   publish-docker:
     name: Publish Docker Image
     needs: publish-binaries
-    # Temporarily disabled — not ready to publish netclawd images to GHCR yet.
-    # Flip to `true` (or remove the guard) when the Docker release is ready.
+    # Disabled until GHCR image path is updated for the new org
     if: false
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -306,7 +309,7 @@ jobs:
   publish-binary-manifest:
     name: Publish Binary Manifest
     needs: publish-binaries
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Checkout

--- a/.github/workflows/publish_skills.yml
+++ b/.github/workflows/publish_skills.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -41,35 +41,13 @@ jobs:
         with:
           global-json-file: ./global.json
 
-      - name: Publish CLI
-        run: >
-          dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj
-          -c Release
-          -r linux-x64
-          --self-contained true
-          /p:PublishSingleFile=true
-          /p:EnableCompressionInSingleFile=true
-          /p:IncludeNativeLibrariesForSelfExtract=true
-          -o ./publish/cli
-
-      - name: Publish Daemon
-        run: >
-          dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj
-          -c Release
-          -r linux-x64
-          --self-contained true
-          /p:PublishSingleFile=true
-          /p:EnableCompressionInSingleFile=true
-          /p:IncludeNativeLibrariesForSelfExtract=true
-          -o ./publish/daemon
-
       - name: Build smoke sandbox image
-        timeout-minutes: 5
-        run: >
-          docker build
-          -f docker/Dockerfile
-          -t netclaw-smoke:local
-          .
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          chmod +x scripts/docker/build-image.sh
+          IMAGE_REPO=netclaw-smoke \
+            scripts/docker/build-image.sh local
 
       - name: Start smoke sandbox
         run: bash scripts/smoke/up.sh

--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   smoke:
     name: Smoke Sandbox
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     env:

--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   validate-docker-build:
     name: Validate Docker Build
-    runs-on: arc-netclaw
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,17 @@
 # Release image for netclawd: the Netclaw autonomous operations daemon.
 #
-# This is the published image (ghcr.io/aaronontheweb/netclawd) that ships
-# alongside the self-contained binary archives. It is distinct from
-# docker/smoke/Dockerfile, which is a test fixture for the CLI smoke suite.
+# Supports multi-arch builds (linux/amd64, linux/arm64) via buildx.
+# For multi-arch, pre-built binaries are laid out as:
+#   publish/cli-{amd64,arm64}/netclaw
+#   publish/daemon-{amd64,arm64}/netclawd
+# The TARGETARCH arg (injected by buildx) selects the right directory.
+#
+# For single-arch local builds (build-image.sh), the binaries are at:
+#   publish/cli/netclaw
+#   publish/daemon/netclawd
+# TARGETARCH defaults to amd64, and the COPY falls through to the
+# arch-suffixed path — the build script symlinks the single-arch
+# layout to the expected path.
 #
 # A wrapper entrypoint (entrypoint.sh) runs as PID 1 and supervises the
 # netclawd process, restarting it on exit so the container survives
@@ -19,6 +28,7 @@
 FROM ubuntu:24.04
 
 ARG NETCLAW_VERSION=unknown
+ARG TARGETARCH=amd64
 
 # Pre-install the general-purpose toolkit an autonomous agent is expected
 # to reach for via its shell_execute tool. An Ubuntu base (not a chiseled
@@ -53,10 +63,10 @@ RUN apt-get update \
 
 WORKDIR /opt/netclaw
 
-# Self-contained single-file binaries published on the host by the
-# shared build script (scripts/docker/build-image.sh) and copied in.
-COPY publish/cli/netclaw /opt/netclaw/cli/netclaw
-COPY publish/daemon/netclawd /opt/netclaw/daemon/netclawd
+# Self-contained single-file binaries. TARGETARCH selects the right
+# platform directory (amd64 or arm64).
+COPY publish/cli-${TARGETARCH}/netclaw /opt/netclaw/cli/netclaw
+COPY publish/daemon-${TARGETARCH}/netclawd /opt/netclaw/daemon/netclawd
 COPY docker/entrypoint.sh /opt/netclaw/entrypoint.sh
 
 RUN chmod +x /opt/netclaw/cli/netclaw /opt/netclaw/daemon/netclawd /opt/netclaw/entrypoint.sh \

--- a/scripts/docker/build-image.sh
+++ b/scripts/docker/build-image.sh
@@ -82,6 +82,18 @@ if [[ ! -x ./publish/daemon/netclawd ]]; then
     exit 1
 fi
 
+# Map RID to Docker TARGETARCH so the Dockerfile's arch-suffixed COPY works.
+case "$RID" in
+    linux-x64)  DOCKER_ARCH="amd64" ;;
+    linux-arm64) DOCKER_ARCH="arm64" ;;
+    *) echo "ERROR: unsupported RID '$RID' for Docker build" >&2; exit 1 ;;
+esac
+
+# Symlink the single-arch publish output to the arch-suffixed paths the
+# Dockerfile expects (publish/cli-{arch}/, publish/daemon-{arch}/).
+ln -sfn cli "publish/cli-${DOCKER_ARCH}"
+ln -sfn daemon "publish/daemon-${DOCKER_ARCH}"
+
 echo "→ Building image $IMAGE_TAG..."
 docker build \
     -f docker/Dockerfile \

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobExecutionActorTests.cs
@@ -34,6 +34,9 @@ public class BackgroundJobExecutionActorTests : TestKit
         await base.AfterAllAsync();
     }
 
+    private static string LongRunningCommand =>
+        OperatingSystem.IsWindows() ? "ping -n 300 127.0.0.1" : "sleep 300";
+
     private BackgroundJobDefinition MakeDefinition(string command, int timeoutSeconds = 600) => new()
     {
         Id = Guid.NewGuid().ToString("N")[..12],
@@ -75,7 +78,7 @@ public class BackgroundJobExecutionActorTests : TestKit
     [Fact]
     public async Task ProcessTimeout_KillsAndReportsTimedOut()
     {
-        var definition = MakeDefinition("sleep 300", timeoutSeconds: 1);
+        var definition = MakeDefinition(LongRunningCommand, timeoutSeconds: 1);
         var probe = CreateTestProbe("parent");
         SpawnExecution(definition, probe);
 
@@ -90,7 +93,7 @@ public class BackgroundJobExecutionActorTests : TestKit
     [Fact]
     public async Task Cancellation_KillsAndReportsCancelled()
     {
-        var definition = MakeDefinition("sleep 300");
+        var definition = MakeDefinition(LongRunningCommand);
         var probe = CreateTestProbe("parent");
         var actor = SpawnExecution(definition, probe);
 

--- a/src/Netclaw.Actors.Tests/Memory/MemoryRedesignedEvalSuiteTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/MemoryRedesignedEvalSuiteTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
+public sealed class MemoryRedesignedEvalSuiteTests : IAsyncDisposable
 {
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-memory-redesigned-evals", Guid.NewGuid().ToString("N"));
     private readonly string _dbPath;
@@ -589,9 +589,8 @@ public sealed class MemoryRedesignedEvalSuiteTests : IDisposable
         Assert.Equal(0.0, evidenceLeakage);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        if (Directory.Exists(_baseDir))
-            Directory.Delete(_baseDir, recursive: true);
+        await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
     }
 }

--- a/src/Netclaw.Actors.Tests/Memory/SqliteMemoryPolicyScopeTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SqliteMemoryPolicyScopeTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public sealed class SqliteMemoryPolicyScopeTests : IDisposable
+public sealed class SqliteMemoryPolicyScopeTests : IAsyncDisposable
 {
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-sqlite-memory-policy-tests", Guid.NewGuid().ToString("N"));
     private readonly string _dbPath;
@@ -118,10 +118,9 @@ public sealed class SqliteMemoryPolicyScopeTests : IDisposable
         Assert.Equal(SecurityPolicyDefaults.PersonalBoundary, payload.Boundary);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        if (Directory.Exists(_baseDir))
-            Directory.Delete(_baseDir, recursive: true);
+        await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
     }
 
     private sealed class CapturingCheckpointSink : IMemoryCheckpointSink

--- a/src/Netclaw.Actors.Tests/Memory/SqliteMemoryToolsTests.cs
+++ b/src/Netclaw.Actors.Tests/Memory/SqliteMemoryToolsTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Netclaw.Actors.Tests.Memory;
 
-public sealed class SqliteMemoryToolsTests : IDisposable
+public sealed class SqliteMemoryToolsTests : IAsyncDisposable
 {
     private readonly string _baseDir = Path.Combine(Path.GetTempPath(), "netclaw-sqlite-memory-tool-tests", Guid.NewGuid().ToString("N"));
     private readonly string _dbPath;
@@ -276,10 +276,9 @@ public sealed class SqliteMemoryToolsTests : IDisposable
         Assert.DoesNotContain("Security issue", result);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        if (Directory.Exists(_baseDir))
-            Directory.Delete(_baseDir, recursive: true);
+        await SqliteTempDirectoryCleanup.TryDeleteDirectoryAsync(_baseDir);
     }
 
 }

--- a/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobExecutionActor.cs
@@ -77,14 +77,14 @@ public sealed class BackgroundJobExecutionActor : ReceiveActor
             psi.ArgumentList.Add("/c");
             psi.ArgumentList.Add(_definition.Command);
         }
-
-        if (!string.IsNullOrWhiteSpace(_definition.WorkingDirectory))
-            psi.WorkingDirectory = _definition.WorkingDirectory;
         else
         {
             psi.ArgumentList.Add("-c");
             psi.ArgumentList.Add(_definition.Command);
         }
+
+        if (!string.IsNullOrWhiteSpace(_definition.WorkingDirectory))
+            psi.WorkingDirectory = _definition.WorkingDirectory;
 
         _process = Process.Start(psi);
         if (_process is null)

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Gateway;
@@ -64,6 +65,7 @@ public sealed class DailyStatsActorTests : IDisposable
     public void Dispose()
     {
         _system.Terminate().GetAwaiter().GetResult();
+        SqliteConnection.ClearAllPools();
         _dir.Dispose();
     }
 

--- a/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/RestartRecoveryServiceTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Concurrent;
 using Akka.Actor;
 using Akka.Hosting;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
@@ -70,6 +71,7 @@ public sealed class RestartRecoveryServiceTests : IDisposable
     public void Dispose()
     {
         _system.Terminate().GetAwaiter().GetResult();
+        SqliteConnection.ClearAllPools();
         _dir.Dispose();
     }
 

--- a/src/Netclaw.MemoryRetrievalPoC.Tests/Prototype/PrototypeSqliteStore.cs
+++ b/src/Netclaw.MemoryRetrievalPoC.Tests/Prototype/PrototypeSqliteStore.cs
@@ -224,8 +224,22 @@ internal sealed class PrototypeSqliteStore : IDisposable
 
     public void Dispose()
     {
+        SqliteConnection.ClearAllPools();
         var path = Path.GetDirectoryName(_dbPath);
-        if (path is not null && Directory.Exists(path))
-            Directory.Delete(path, recursive: true);
+        if (path is null || !Directory.Exists(path))
+            return;
+
+        for (var i = 0; i < 5; i++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < 4)
+            {
+                Thread.Sleep(50 * (i + 1));
+            }
+        }
     }
 }

--- a/src/Netclaw.Tests.Utilities/DisposableTempDir.cs
+++ b/src/Netclaw.Tests.Utilities/DisposableTempDir.cs
@@ -16,7 +16,30 @@ internal sealed class DisposableTempDir : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(Path, recursive: true); }
-        catch (DirectoryNotFoundException) { } // slopwatch-ignore: SW003 test cleanup — directory may already be gone
+        if (!Directory.Exists(Path))
+            return;
+
+        // Retry loop for Windows CI where SQLite pooled connections can
+        // briefly hold file handles after the test completes.
+        for (var i = 0; i < 5; i++)
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < 4) // slopwatch-ignore: SW003 test cleanup retry
+            {
+                Thread.Sleep(50 * (i + 1));
+            }
+            catch (UnauthorizedAccessException) when (i < 4) // slopwatch-ignore: SW003 test cleanup retry
+            {
+                Thread.Sleep(50 * (i + 1));
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace all `arc-netclaw` self-hosted runner references with GitHub-hosted equivalents (`ubuntu-latest`, `ubuntu-24.04-arm`, `windows-latest`)
- Restore ARM64 and Windows matrix entries in release binary publishing
- Restore Windows testing in PR validation
- Add `shell: bash` to Wrangler/R2 upload steps so they work on Windows runners
- Docker publish job remains disabled (`if: false`) until GHCR image path is updated for the new org

Prepares CI/CD for repo transfer to the NetClaw Dev organization where ARC runners won't exist.

## Test plan

- [ ] PR validation passes on both `ubuntu-latest` and `windows-latest`
- [ ] Slopwatch and copyright-headers jobs run on `ubuntu-latest`
- [ ] Smoke sandbox runs on `ubuntu-latest`
- [ ] Docker image validation runs on `ubuntu-latest`