### PR TITLE
fix: cancel_reminder disables instead of deleting config files

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.20.0"
+  version: "1.21.0"
 ---
 
 # Netclaw Operations
@@ -99,6 +99,25 @@ Rules:
 - For recurring reminders that are permanently complete (PR merged, deploy done,
   incident resolved), call `cancel_reminder` with that reminder's ID so it does
   not keep firing indefinitely.
+
+`cancel_reminder` **disables** the reminder — it stops future executions but
+preserves the definition file on disk for diagnosis and re-enablement. To
+permanently delete a reminder and its history, use the CLI:
+
+```
+netclaw reminder delete <id>
+```
+
+The `cancel` CLI subcommand mirrors the tool behavior (disable only):
+
+```
+netclaw reminder cancel <id>     # disable, keep definition
+netclaw reminder delete <id>     # permanent delete + history
+```
+
+Reminders that hit 5 consecutive execution failures are auto-disabled with a
+`ReminderAutoDisabled` critical alert. The definition stays on disk so the
+operator can diagnose and re-enable after fixing the root cause.
 
 If `audience` is omitted during conversational scheduling, the reminder inherits
 the audience of the channel/session that created it. A reminder cannot be
@@ -464,6 +483,7 @@ file. If it should be recalled when relevant → SQLite memory.
 | List/manage skills | `netclaw skill list` |
 | List past sessions | `netclaw sessions --once` |
 | Inspect reminder history | `netclaw reminder history <id> --last 5` |
+| Permanently delete a reminder | `netclaw reminder delete <id>` |
 
 ## Device Pairing
 

--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -350,7 +350,7 @@ fi
 
 # ── Reminder lifecycle smoke tests ──
 # Schedule a one-shot reminder, wait for it to execute and record history,
-# then cancel it and verify it is fully removed.
+# then permanently delete it and verify it is fully removed.
 
 REMINDER_ID="smoke-lifecycle-$$"
 
@@ -384,14 +384,14 @@ if [[ "$history_found" != "true" ]]; then
   exit 1
 fi
 
-echo "Cancelling reminder $REMINDER_ID..."
-run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw reminder cancel "$REMINDER_ID"
+echo "Deleting reminder $REMINDER_ID..."
+run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw reminder delete "$REMINDER_ID"
 
-echo "Verifying reminder is absent from list after cancel..."
-after_cancel_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw reminder list)"
-echo "$after_cancel_list"
-if [[ "$after_cancel_list" == *"$REMINDER_ID"* ]]; then
-  echo "Expected $REMINDER_ID to be absent from reminder list after cancel."
+echo "Verifying reminder is absent from list after delete..."
+after_delete_list="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw reminder list)"
+echo "$after_delete_list"
+if [[ "$after_delete_list" == *"$REMINDER_ID"* ]]; then
+  echo "Expected $REMINDER_ID to be absent from reminder list after delete."
   exit 1
 fi
 

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -105,7 +105,7 @@ public class ReminderManagerActorTests : TestKit
     }
 
     [Fact]
-    public async Task Cancel_existing_reminder_returns_found()
+    public async Task Cancel_existing_reminder_disables_and_preserves_definition()
     {
         var manager = await GetManagerAsync();
 
@@ -119,6 +119,10 @@ public class ReminderManagerActorTests : TestKit
             new CancelReminderCommand(new ReminderId(definition.Id)), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(cancelled.Found);
+
+        var preserved = _definitionStore.Get(new ReminderId(definition.Id));
+        Assert.NotNull(preserved);
+        Assert.False(preserved!.Enabled);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
+++ b/src/Netclaw.Actors/Reminders/CancelReminderTool.cs
@@ -11,10 +11,10 @@ using Netclaw.Tools;
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
-/// LLM tool for deleting a reminder by ID.
+/// LLM tool for cancelling (disabling) a reminder by ID.
 /// </summary>
 [NetclawTool("cancel_reminder",
-    "Delete a reminder by its ID. Use list_reminders to find reminder IDs.",
+    "Cancel a reminder by its ID — disables it and stops future executions. The reminder definition is preserved for diagnosis. Use list_reminders to find reminder IDs.",
     Grant = "scheduling")]
 public sealed partial class CancelReminderTool : NetclawTool<CancelReminderTool.Params>
 {
@@ -44,7 +44,7 @@ public sealed partial class CancelReminderTool : NetclawTool<CancelReminderTool.
             new CancelReminderCommand(id), TimeSpan.FromSeconds(10), ct);
 
         return response.Found
-            ? $"Reminder '{args.ReminderId}' deleted."
+            ? $"Reminder '{args.ReminderId}' cancelled (disabled). The definition is preserved on disk."
             : $"Reminder '{args.ReminderId}' not found.";
     }
 }

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -71,6 +71,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         ReceiveAsync<SaveReminderCommand>(HandleSaveAsync);
         ReceiveAsync<CancelReminderCommand>(HandleCancelAsync);
+        ReceiveAsync<DeleteReminderCommand>(HandlePermanentDeleteAsync);
         ReceiveAsync<DisableReminderCommand>(HandleDisableAsync);
         ReceiveAsync<EnableReminderCommand>(HandleEnableAsync);
         ReceiveAsync<ListRemindersCommand>(HandleListAsync);
@@ -313,27 +314,20 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     private async Task HandleCancelAsync(CancelReminderCommand cmd)
     {
         var replyTo = Sender;
-        var deleted = _definitionStore.Delete(cmd.Id);
-        var scheduleCancelled = await CancelScheduleOnlyAsync(cmd.Id);
+        var response = await DisableReminderInternalAsync(cmd.Id);
 
-        _failureCounts.Remove(cmd.Id);
-        RemoveFromDeferredQueue(cmd.Id);
+        _log.Info("Cancel reminder '{0}': {1}", cmd.Id.Value, response.Found ? "disabled" : "not found");
+        replyTo.Tell(new ReminderCancelledResponse(cmd.Id, response.Found));
+    }
 
-        if (deleted)
-        {
-            try
-            {
-                _historyStore.DeleteHistory(cmd.Id);
-            }
-            catch (Exception ex)
-            {
-                _log.Warning(ex, "Failed to delete history file for reminder '{0}'", cmd.Id.Value);
-            }
-        }
+    private async Task HandlePermanentDeleteAsync(DeleteReminderCommand cmd)
+    {
+        var replyTo = Sender;
+        var found = _definitionStore.Exists(cmd.Id);
+        await DeleteReminderInternalAsync(cmd.Id);
 
-        var found = deleted || scheduleCancelled;
-        _log.Info("Delete reminder '{0}': {1}", cmd.Id.Value, found ? "deleted" : "not found");
-        replyTo.Tell(new ReminderCancelledResponse(cmd.Id, found));
+        _log.Info("Permanently delete reminder '{0}': {1}", cmd.Id.Value, found ? "deleted" : "not found");
+        replyTo.Tell(new ReminderDeletedResponse(cmd.Id, found));
     }
 
     private async Task HandleDisableAsync(DisableReminderCommand cmd)

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -264,9 +264,16 @@ public sealed record ReminderAudienceAuthorizationContext(
     string? SourceDescription = null);
 
 /// <summary>
-/// Permanently deletes a reminder definition and cancels any active schedule.
+/// Disables a reminder and cancels any active schedule. The definition file
+/// is preserved on disk so history and configuration remain available for diagnosis.
 /// </summary>
 public sealed record CancelReminderCommand(ReminderId Id);
+
+/// <summary>
+/// Permanently deletes a reminder definition, its schedule, and history from disk.
+/// Not exposed as an LLM tool — use via CLI (<c>netclaw reminder delete</c>) or HTTP API.
+/// </summary>
+public sealed record DeleteReminderCommand(ReminderId Id);
 public sealed record DisableReminderCommand(ReminderId Id);
 public sealed record EnableReminderCommand(ReminderId Id);
 public sealed record ListRemindersCommand(bool IncludeDisabled = true);
@@ -283,6 +290,7 @@ public sealed record ReminderSavedResponse(
     string? ErrorMessage = null);
 
 public sealed record ReminderCancelledResponse(ReminderId Id, bool Found);
+public sealed record ReminderDeletedResponse(ReminderId Id, bool Found);
 
 public sealed record ReminderStateResponse(
     ReminderId Id,

--- a/src/Netclaw.Cli/Daemon/DaemonApi.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonApi.cs
@@ -133,11 +133,12 @@ public sealed class DaemonApi
         return await client.PostAsJsonAsync($"{_endpoint}/api/reminders", request, cts.Token);
     }
 
-    public async Task<HttpResponseMessage> DeleteReminderAsync(string id, CancellationToken ct = default)
+    public async Task<HttpResponseMessage> DeleteReminderAsync(string id, bool permanent = false, CancellationToken ct = default)
     {
         using var cts = CreateTimeoutCts(DefaultTimeout, ct);
         var client = CreateHttpClient();
-        return await client.DeleteAsync($"{_endpoint}/api/reminders/{id}", cts.Token);
+        var query = permanent ? "?permanent=true" : "";
+        return await client.DeleteAsync($"{_endpoint}/api/reminders/{id}{query}", cts.Token);
     }
 
     public async Task<HttpResponseMessage> GetReminderAsync(string id, CancellationToken ct = default)

--- a/src/Netclaw.Cli/Reminder/ReminderCommand.cs
+++ b/src/Netclaw.Cli/Reminder/ReminderCommand.cs
@@ -52,7 +52,8 @@ internal static class ReminderCommand
         {
             "list" => await RunListAsync(daemonApi),
             "create" => await RunCreateAsync(daemonApi, args),
-            "cancel" or "delete" => await RunDeleteAsync(daemonApi, args),
+            "cancel" => await RunCancelAsync(daemonApi, args),
+            "delete" => await RunDeleteAsync(daemonApi, args),
             "disable" => await RunDisableAsync(daemonApi, args),
             "enable" => await RunEnableAsync(daemonApi, args),
             "import" => await RunImportAsync(daemonApi, args),
@@ -192,6 +193,17 @@ internal static class ReminderCommand
         }
     }
 
+    private static async Task<int> RunCancelAsync(DaemonApi api, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: netclaw reminder cancel <id>");
+            return 1;
+        }
+
+        return await RunRemoveAsync(api, args[2], permanent: false);
+    }
+
     private static async Task<int> RunDeleteAsync(DaemonApi api, string[] args)
     {
         if (args.Length < 3)
@@ -200,10 +212,14 @@ internal static class ReminderCommand
             return 1;
         }
 
-        var id = args[2];
+        return await RunRemoveAsync(api, args[2], permanent: true);
+    }
+
+    private static async Task<int> RunRemoveAsync(DaemonApi api, string id, bool permanent)
+    {
         try
         {
-            using var response = await api.DeleteReminderAsync(id);
+            using var response = await api.DeleteReminderAsync(id, permanent);
             var json = await response.Content.ReadAsStringAsync();
             var result = JsonSerializer.Deserialize<JsonElement>(json);
 
@@ -543,7 +559,8 @@ internal static class ReminderCommand
         Console.WriteLine("Subcommands:");
         Console.WriteLine("  list                                          List all active reminders");
         Console.WriteLine("  create <id> <type> <schedule> \"<prompt>\"      Create or update a reminder");
-        Console.WriteLine("  delete <id>                                   Delete a reminder");
+        Console.WriteLine("  cancel <id>                                   Cancel a reminder (disables, keeps definition)");
+        Console.WriteLine("  delete <id>                                   Permanently delete a reminder and its history");
         Console.WriteLine("  disable <id>                                  Disable a reminder");
         Console.WriteLine("  enable <id>                                   Enable a reminder");
         Console.WriteLine("  import <file> [--replace|--upsert]            Import one reminder file");

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -1391,16 +1391,30 @@ static void MapReminderEndpoints(WebApplication app)
 
     reminders.MapDelete("/{id}", async (
         string id,
+        bool? permanent,
         Akka.Hosting.IRequiredActor<Netclaw.Actors.Hosting.ReminderManagerActorKey> actor,
         CancellationToken ct) =>
     {
         var manager = await actor.GetAsync(ct);
+        var reminderId = new Netclaw.Actors.Reminders.ReminderId(id);
+
+        if (permanent == true)
+        {
+            var deleted = await manager.Ask<Netclaw.Actors.Reminders.ReminderDeletedResponse>(
+                new Netclaw.Actors.Reminders.DeleteReminderCommand(reminderId),
+                TimeSpan.FromSeconds(10), ct);
+
+            return deleted.Found
+                ? Results.Ok(new { message = $"Reminder '{id}' permanently deleted." })
+                : Results.NotFound(new { error = $"Reminder '{id}' not found." });
+        }
+
         var response = await manager.Ask<Netclaw.Actors.Reminders.ReminderCancelledResponse>(
-            new Netclaw.Actors.Reminders.CancelReminderCommand(new Netclaw.Actors.Reminders.ReminderId(id)),
+            new Netclaw.Actors.Reminders.CancelReminderCommand(reminderId),
             TimeSpan.FromSeconds(10), ct);
 
         return response.Found
-            ? Results.Ok(new { message = $"Reminder '{id}' cancelled." })
+            ? Results.Ok(new { message = $"Reminder '{id}' cancelled (disabled)." })
             : Results.NotFound(new { error = $"Reminder '{id}' not found." });
     });
 


### PR DESCRIPTION
## Summary

Closes #841.

- **`cancel_reminder` (LLM tool) now disables** instead of hard-deleting ��� sets `Enabled=false` and preserves the definition file on disk for diagnosis and re-enablement
- **New `DeleteReminderCommand`** for permanent deletion, exposed via CLI and HTTP API only (not as an LLM tool)
- **CLI distinction:** `netclaw reminder cancel <id>` disables; `netclaw reminder delete <id>` permanently removes definition + history
- **HTTP API:** `DELETE /api/reminders/{id}` defaults to disable; pass `?permanent=true` for hard delete
- Updated `netclaw-operations` skill docs to v1.21.0 documenting the cancel vs delete distinction

## Test plan

- [x] Existing `Cancel_existing_reminder_disables_and_preserves_definition` test updated — verifies definition stays on disk with `Enabled=false` after cancel
- [x] All 21 `ReminderManagerActorTests` pass
- [x] `Reconcile_deletes_zombie_oneshot_reminders` still passes — stale one-shot cleanup via reconciliation is unchanged
- [x] `dotnet slopwatch analyze` clean
- [x] Copyright headers verified