### PR TITLE
fix: path-aware shell approval patterns for high-risk verbs

### DIFF
--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -93,6 +93,13 @@ public sealed class ShellApprovalMatcherTests
     [InlineData("git pu", "git push", false)]    // Partial token no match (word boundary)
     [InlineData("gh pr", "gh pr create", true)]  // Multi-token prefix match
     [InlineData("gh pr", "gh issue list", false)] // Multi-token no match
+    // Path-aware patterns — exact path matches
+    [InlineData("cat /etc/passwd", "cat /etc/passwd", true)]
+    [InlineData("cat /etc/passwd", "cat /etc/shadow", false)]
+    [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /home/.netclaw/scripts/monitor.sh", true)]
+    [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /tmp/evil.sh", false)]
+    // Stale single-token approval no longer matches path-aware extractions
+    [InlineData("cat", "cat /etc/passwd", false)]
     public void IsApproved_pattern_matching(string pattern, string command, bool expected)
     {
         var approved = new[] { pattern };
@@ -106,6 +113,28 @@ public sealed class ShellApprovalMatcherTests
 
         Assert.True(_matcher.IsApproved(new ToolName("shell_execute"),
             Args("bash -c \"git push --force\""), approved));
+    }
+
+    [Fact]
+    public void ExtractPatterns_path_aware_verb_includes_path()
+    {
+        var patterns = _matcher.ExtractPatterns(
+            new ToolName("shell_execute"),
+            Args("cat /etc/hosts && git push origin main"));
+        Assert.Equal(2, patterns.Count);
+        Assert.Contains("cat /etc/hosts", patterns);
+        Assert.Contains("git push", patterns);
+    }
+
+    [Fact]
+    public void ExtractPatterns_pipe_with_path_aware_verbs()
+    {
+        var patterns = _matcher.ExtractPatterns(
+            new ToolName("shell_execute"),
+            Args("cat /var/log/syslog | grep error"));
+        Assert.Equal(2, patterns.Count);
+        Assert.Contains("cat /var/log/syslog", patterns);
+        Assert.Contains("grep error", patterns);
     }
 
     [Fact]

--- a/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
+++ b/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
@@ -111,13 +111,38 @@ public sealed class ShellTokenizerTests
 
     [Theory]
     [InlineData("git push origin main", "git push")]
-    [InlineData("ls -la /tmp", "ls")]
+    [InlineData("ls -la /tmp", "ls /tmp")]
     [InlineData("docker compose up -d", "docker compose")]
-    [InlineData("cat /etc/hosts", "cat")]
-    [InlineData("cat .gitignore", "cat")]
+    [InlineData("cat /etc/hosts", "cat /etc/hosts")]
+    [InlineData("cat .gitignore", "cat .gitignore")]
     [InlineData("kubectl delete pod my-pod", "kubectl delete")]
     [InlineData("", "")]
     public void ExtractVerbChain_extracts_expected_chain(string input, string expected)
+    {
+        Assert.Equal(expected, ShellTokenizer.ExtractVerbChain(input));
+    }
+
+    [Theory]
+    // Path-aware verbs include first non-flag argument
+    [InlineData("cat /etc/passwd", "cat /etc/passwd")]
+    [InlineData("grep secret /var/log/syslog", "grep secret")]
+    [InlineData("bash /home/user/.netclaw/scripts/monitor.sh", "bash /home/user/.netclaw/scripts/monitor.sh")]
+    [InlineData("python3 /opt/scripts/report.py --verbose", "python3 /opt/scripts/report.py")]
+    [InlineData("curl https://example.com/api", "curl https://example.com/api")]
+    [InlineData("find /var/log -name '*.log'", "find /var/log")]
+    [InlineData("sed -i 's/foo/bar/' /etc/config.txt", "sed s/foo/bar/")]
+    // Structured CLIs unchanged
+    [InlineData("git push origin main", "git push")]
+    [InlineData("docker compose up -d", "docker compose")]
+    [InlineData("kubectl delete pod my-pod", "kubectl delete")]
+    [InlineData("dotnet build --configuration Release", "dotnet build")]
+    // Edge: flag-only invocations of path-aware verbs
+    [InlineData("grep --version", "grep")]
+    [InlineData("cat --help", "cat")]
+    // Edge: home-relative and env-var paths
+    [InlineData("cat ~/.bashrc", "cat ~/.bashrc")]
+    [InlineData("bash ~/scripts/deploy.sh", "bash ~/scripts/deploy.sh")]
+    public void ExtractVerbChain_path_aware_verbs(string input, string expected)
     {
         Assert.Equal(expected, ShellTokenizer.ExtractVerbChain(input));
     }

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -17,6 +17,28 @@ public static class ShellTokenizer
     private static readonly string[] CompoundOperators = ["&&", "||"];
 
     /// <summary>
+    /// Verbs that can exfiltrate or mutate file contents when targeting protected paths.
+    /// Used by <see cref="ToolPathPolicy"/> for the protected-path heuristic.
+    /// </summary>
+    internal static readonly HashSet<string> HighRiskVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cat", "less", "more", "head", "tail", "grep", "rg", "find", "jq", "awk", "sed", "strings", "xxd", "hexdump",
+        "cp", "mv", "tar", "zip", "unzip", "scp", "rsync", "curl", "wget", "nc", "ncat",
+        "python", "python3", "node", "ruby", "perl", "php",
+        "bash", "sh", "zsh"
+    };
+
+    /// <summary>
+    /// Verbs whose first positional argument is security-relevant for approval
+    /// pattern extraction. Superset of <see cref="HighRiskVerbs"/> — includes
+    /// benign-but-path-consuming verbs like <c>ls</c>.
+    /// </summary>
+    internal static readonly HashSet<string> PathAwareVerbs = new(HighRiskVerbs, StringComparer.OrdinalIgnoreCase)
+    {
+        "ls"
+    };
+
+    /// <summary>
     /// Tokenizes a shell command string, respecting single and double quotes.
     /// Strips quote delimiters from tokens.
     /// </summary>
@@ -129,6 +151,8 @@ public static class ShellTokenizer
     /// command. Stops at the first token that looks like a flag (starts with -)
     /// or an argument (path, URL, etc.), and caps at <paramref name="maxDepth"/>
     /// tokens (default: 2) to avoid capturing positional arguments as subcommands.
+    /// For path-aware verbs (cat, grep, bash, etc.), appends the first non-flag
+    /// argument so the approval pattern captures what the command operates on.
     /// </summary>
     public static string ExtractVerbChain(string command, int maxDepth = 2)
     {
@@ -153,6 +177,22 @@ public static class ShellTokenizer
                 break;
 
             verbParts.Add(trimmed);
+        }
+
+        if (verbParts.Count == 1 && PathAwareVerbs.Contains(verbParts[0]))
+        {
+            for (var i = 1; i < tokens.Count; i++)
+            {
+                var trimmed = TrimShellPunctuation(tokens[i]);
+                if (trimmed.Length == 0)
+                    continue;
+
+                if (trimmed.StartsWith('-'))
+                    continue;
+
+                verbParts.Add(trimmed);
+                break;
+            }
         }
 
         return string.Join(' ', verbParts);

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -22,12 +22,6 @@ public sealed class ToolPathPolicy
     private readonly HashSet<string> _readDeniedPaths;
     private readonly HashSet<string> _shellDeniedPaths;
     private readonly HashSet<string> _commandIndicators;
-    private static readonly HashSet<string> HighRiskVerbs = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "cat", "less", "more", "head", "tail", "grep", "rg", "find", "jq", "awk", "sed", "strings", "xxd", "hexdump",
-        "cp", "mv", "tar", "zip", "unzip", "scp", "rsync", "curl", "wget", "nc", "ncat",
-        "python", "python3", "node", "ruby", "perl", "php"
-    };
 
     public ToolPathPolicy(IEnumerable<string> deniedPaths)
     {
@@ -161,7 +155,7 @@ public sealed class ToolPathPolicy
         foreach (var token in tokens)
         {
             var verb = ShellTokenizer.TrimShellPunctuation(token);
-            if (HighRiskVerbs.Contains(verb))
+            if (ShellTokenizer.HighRiskVerbs.Contains(verb))
                 return true;
         }
 


### PR DESCRIPTION
## Summary

- `ShellTokenizer.ExtractVerbChain` now captures the first positional argument for path-aware verbs (cat, grep, bash, curl, sed, etc.) so approval patterns reflect what the command targets — not just which verb it uses.
- Splits verb classification into `HighRiskVerbs` (for path-policy security heuristic) and `PathAwareVerbs` (superset, for approval pattern extraction) to keep concerns separated.
- Existing stale single-token approvals like `"cat"` become inert — `ApprovalPatternMatching` already refuses prefix-match on single-token patterns, so `"cat"` won't match the new `"cat /etc/passwd"` extraction.

Prerequisite for #842 (non-interactive approval checking in reminders).

## Test plan

- [x] Updated existing `ExtractVerbChain` theory expectations (`cat /etc/hosts` → `"cat /etc/hosts"`, `ls -la /tmp` → `"ls /tmp"`)
- [x] Added 16 new `InlineData` theory cases for path-aware verb extraction (runners, readers, structured CLIs unchanged, flag-only edge cases, home-relative paths)
- [x] Added 5 new `IsApproved_pattern_matching` cases validating that path-aware patterns work with prefix matching and that stale single-token approvals don't match
- [x] Added 2 new fact tests for compound/piped commands with path-aware verbs
- [x] Verified `ToolPathPolicy` regression test (`ls ~/.netclaw/config` still allowed) passes
- [x] All 104 Security tests + 33 Actor approval tests pass
- [x] `dotnet slopwatch analyze` clean, copyright headers verified