### PR TITLE
feat: non-interactive approval, sub-agent approval chaining, and shell trust zone enforcement

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.22.0"
+  version: "1.23.0"
 ---
 
 # Netclaw Operations
@@ -144,11 +144,11 @@ the reminder fires.
 If the user has already approved the patterns in a previous session, no action is
 needed — grants persist across sessions.
 
-**Path restrictions:** Even with an approved verb, reminders are sandboxed to
+**Path restrictions:** Even with an approved command pattern, reminders are sandboxed to
 trust zone paths (session dir, workspaces, project directory, skills, identity).
-A reminder approved for `cat` can read files in workspaces but NOT arbitrary
-system paths like `/etc/shadow`. If a reminder needs access outside trust zones,
-the user must configure additional trusted roots.
+A reminder approved for `cat /srv/app/log.txt` can read that file inside trust
+zones but NOT arbitrary system paths like `/etc/shadow`. If a reminder needs
+access outside trust zones, the user must configure additional trusted roots.
 
 **If a reminder fails with `command_not_pre_approved`:** The command pattern was
 not in the approval store. Run the command interactively to trigger approval,
@@ -300,6 +300,23 @@ file edit, and approval should be scoped to the target.
 If a user asks why they're being prompted so often, explain the security
 tradeoff and point them at `netclaw` CLI tooling for reviewing and trimming
 `tool-approvals.json` if the grant list grows unmanageable.
+
+If approval matching seems stale after an upgrade, delete the approval file and
+rebuild grants interactively:
+
+macOS/Linux:
+
+```bash
+rm ~/.netclaw/config/tool-approvals.json
+```
+
+PowerShell:
+
+```powershell
+Remove-Item "$HOME/.netclaw/config/tool-approvals.json" -Force
+```
+
+Then restart the daemon so in-memory session approvals are cleared too.
 
 ## Skill Management
 

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.21.0"
+  version: "1.22.0"
 ---
 
 # Netclaw Operations
@@ -126,6 +126,37 @@ audience is always allowed.
 
 Other scheduling tools: `list_reminders`, `cancel_reminder`,
 `get_reminder_history`.
+
+### Approval Requirements for Reminders and Webhooks
+
+Reminders and webhooks execute without a human present — they CANNOT prompt for
+tool approval. If a reminder needs `shell_execute` or file tools, those command
+patterns must be pre-approved in `~/.netclaw/config/tool-approvals.json` BEFORE
+the reminder fires.
+
+**Before creating a reminder that uses shell commands:**
+1. Identify what commands the reminder will need (e.g. `git pull`, `curl`,
+   `cat /var/log/app.log`)
+2. Run those commands interactively in the current session — this triggers the
+   approval prompt and persists the grant
+3. Then create the reminder
+
+If the user has already approved the patterns in a previous session, no action is
+needed — grants persist across sessions.
+
+**Path restrictions:** Even with an approved verb, reminders are sandboxed to
+trust zone paths (session dir, workspaces, project directory, skills, identity).
+A reminder approved for `cat` can read files in workspaces but NOT arbitrary
+system paths like `/etc/shadow`. If a reminder needs access outside trust zones,
+the user must configure additional trusted roots.
+
+**If a reminder fails with `command_not_pre_approved`:** The command pattern was
+not in the approval store. Run the command interactively to trigger approval,
+then the next reminder firing will succeed.
+
+**If a reminder fails with `path_outside_trust_zone`:** The command targets a
+path outside the allowed roots. Either move the target into a workspace, or ask
+the user to add the path to trusted roots in config.
 
 ## Background Jobs
 
@@ -332,6 +363,11 @@ Verification kinds are generic:
 
 Route files hot-reload without restarting the daemon. If a route file becomes
 invalid, Netclaw removes that route immediately and emits an operational alert.
+
+**Approval gate:** Webhooks run without a human — they cannot prompt for
+approval. The same rules as reminders apply: commands must be pre-approved in
+`tool-approvals.json` and path arguments must be within trust zones. See
+"Approval Requirements for Reminders and Webhooks" in the Scheduling section.
 
 ### Webhook observability
 

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParentSessionApprovalBridgeTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+public sealed class ParentSessionApprovalBridgeTests
+{
+    [Fact]
+    public async Task Bridge_preserves_requester_identity_and_adopted_context()
+    {
+        var channel = new ApprovalChannel();
+        ToolInteractionRequest? emitted = null;
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            request =>
+            {
+                emitted = request;
+                channel.Complete(new ToolCallId(request.CallId), ApprovalDecision.ApprovedOnce);
+            },
+            new SessionId("signalr/thread-1"),
+            requesterSenderId: "user-123",
+            requesterPrincipal: PrincipalClassification.Operator,
+            hasAdoptedContext: true,
+            adoptedSpeakerIds: ["user-123", "user-456"]);
+
+        var decision = await bridge.RequestApprovalAsync(
+            new ToolCallId("call-1"),
+            "shell_execute",
+            "git push origin main",
+            ["git push"],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ParentApprovalDecision.ApprovedOnce, decision);
+        Assert.NotNull(emitted);
+        Assert.Equal("user-123", emitted!.RequesterSenderId);
+        Assert.Equal(PrincipalClassification.Operator, emitted.RequesterPrincipal);
+        Assert.True(emitted.HasAdoptedContext);
+        Assert.True(emitted.PersistedAdoptedContext);
+        Assert.Equal(["user-123", "user-456"], emitted.AdoptedSpeakerIds);
+    }
+}

--- a/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SubAgentActorTests.cs
@@ -124,6 +124,56 @@ public class SubAgentActorTests : TestKit
     }
 
     [Fact]
+    public async Task Approve_once_does_not_leak_between_subagent_tool_calls()
+    {
+        var fakeTool = new FakeNetclawTool("shell_execute", "ok");
+        var toolConfig = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        toolConfig.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Approval
+            }
+        };
+        var policy = new ToolAccessPolicy(
+            toolConfig,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy());
+        var fakeClient = new SequencedToolCallChatClient(
+            [
+                new FunctionCallContent(
+                    "call-approval-1",
+                    "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" }),
+                new FunctionCallContent(
+                    "call-approval-2",
+                    "shell_execute",
+                    new Dictionary<string, object?> { ["Command"] = "git push origin main" })
+            ]);
+        var approvalBridge = new RecordingParentApprovalBridge(ParentApprovalDecision.ApprovedOnce);
+
+        var definition = CreateDefinition([fakeTool]);
+        var agent = Sys.ActorOf(SubAgentActor.CreateProps(definition, fakeClient, policy, approvalService: null));
+
+        var result = await agent.Ask<SubAgentResult>(
+            new RunSubAgent
+            {
+                Task = "Run the same approval-gated tool twice",
+                Timeout = TimeSpan.FromSeconds(5),
+                ApprovalBridge = approvalBridge
+            },
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, approvalBridge.RequestCount);
+        Assert.Equal(["git push", "git push"], approvalBridge.RequestedPatterns);
+    }
+
+    [Fact]
     public async Task Max_iterations_forces_text_response()
     {
         var fakeTool = new FakeNetclawTool("looper", "loop result");
@@ -472,4 +522,69 @@ internal sealed class RecordingMcpToolInvoker(string result) : IMcpToolInvoker
         Audience = context?.Audience;
         return Task.FromResult(result);
     }
+}
+
+internal sealed class RecordingParentApprovalBridge(ParentApprovalDecision decisionToReturn) : IParentApprovalBridge
+{
+    public int RequestCount { get; private set; }
+    public List<string> RequestedPatterns { get; } = [];
+
+    public Task<ParentApprovalDecision> RequestApprovalAsync(
+        ToolCallId callId,
+        string toolName,
+        string displayText,
+        IReadOnlyList<string> unapprovedPatterns,
+        CancellationToken ct)
+    {
+        RequestCount++;
+        RequestedPatterns.AddRange(unapprovedPatterns);
+        return Task.FromResult(decisionToReturn);
+    }
+}
+
+internal sealed class SequencedToolCallChatClient(IReadOnlyList<FunctionCallContent> toolCalls) : IChatClient
+{
+    private int _callCount;
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Streaming path is used in subagent tests.");
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => CreateStreamingUpdatesAsync(cancellationToken);
+
+    private async IAsyncEnumerable<ChatResponseUpdate> CreateStreamingUpdatesAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        _callCount++;
+
+        ChatResponse response;
+        if (_callCount <= toolCalls.Count)
+        {
+            response = new ChatResponse(
+                new ChatMessage(ChatRole.Assistant, [toolCalls[_callCount - 1]]));
+        }
+        else
+        {
+            response = new ChatResponse(
+                new ChatMessage(ChatRole.Assistant, [new TextContent("[fake] finished") ]));
+        }
+
+        foreach (var update in response.ToChatResponseUpdates())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return update;
+            await Task.Yield();
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+    public void Dispose() { }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
@@ -175,6 +175,73 @@ public sealed class ToolApprovalActorTests : TestKit
         }
     }
 
+    [Fact]
+    public async Task SubAgent_inherits_parent_session_approval()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
+        var service = CreateService(actor);
+
+        // Parent session approves "git push"
+        await service.RecordApprovalAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], persistent: false, ct);
+
+        // Sub-agent queries with hierarchical scope ID — should inherit parent approval
+        var subAgentScope = "session-a/subagent/researcher/abc123";
+        var unapproved = await service.GetUnapprovedPatternsAsync(subAgentScope, TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], ct);
+
+        Assert.Empty(unapproved);
+    }
+
+    [Fact]
+    public async Task SubAgent_approval_does_not_leak_upward()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
+        var service = CreateService(actor);
+
+        // Sub-agent records its own approval
+        var subAgentScope = "session-a/subagent/researcher/abc123";
+        await service.RecordApprovalAsync(subAgentScope, TrustAudience.Personal, new ToolName("shell_execute"), ["curl"], persistent: false, ct);
+
+        // Parent session should NOT see sub-agent's approval
+        var unapproved = await service.GetUnapprovedPatternsAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["curl"], ct);
+        Assert.Equal(["curl"], unapproved);
+    }
+
+    [Fact]
+    public async Task Nested_subagent_inherits_through_chain()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
+        var service = CreateService(actor);
+
+        // Parent session approves "git status"
+        await service.RecordApprovalAsync("session-a", TrustAudience.Personal, new ToolName("shell_execute"), ["git status"], persistent: false, ct);
+
+        // Nested sub-agent (sub-agent spawned by sub-agent) should still inherit
+        var nestedScope = "session-a/subagent/orchestrator/def456/subagent/worker/ghi789";
+        var unapproved = await service.GetUnapprovedPatternsAsync(nestedScope, TrustAudience.Personal, new ToolName("shell_execute"), ["git status"], ct);
+
+        Assert.Empty(unapproved);
+    }
+
+    [Fact]
+    public async Task SubAgent_does_not_inherit_from_unrelated_session()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var actor = Sys.ActorOf(ToolApprovalActor.CreateProps());
+        var service = CreateService(actor);
+
+        // Session B approves "git push"
+        await service.RecordApprovalAsync("session-b", TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], persistent: false, ct);
+
+        // Sub-agent of session A should NOT inherit session B's approval
+        var subAgentScope = "session-a/subagent/researcher/abc123";
+        var unapproved = await service.GetUnapprovedPatternsAsync(subAgentScope, TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], ct);
+
+        Assert.Equal(["git push"], unapproved);
+    }
+
     private static AkkaToolApprovalService CreateService(IActorRef actor)
         => new(new StubRequiredActor(actor));
 

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -113,6 +113,8 @@ public sealed class ToolApprovalGateTests
 
         var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(supportsApproval: false), args);
 
+        // Non-interactive channels no longer auto-deny — they fall through to
+        // RequiresApproval so the executor can check the persistent approval store.
         Assert.True(decision.NeedsApproval);
         Assert.NotNull(decision.ApprovalContext);
         Assert.Contains("git push", decision.ApprovalContext!.UnapprovedPatterns);
@@ -536,6 +538,8 @@ public sealed class ToolApprovalGateTests
 
         var decision = policy.AuthorizeInvocation(tool, subagentCtx);
 
+        // Non-interactive channels now fall through to RequiresApproval so the
+        // executor can check the persistent approval store before denying.
         Assert.True(decision.NeedsApproval);
         Assert.NotNull(decision.ApprovalContext);
         Assert.Equal("store_memory", decision.ApprovalContext!.ToolName);

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -548,13 +548,17 @@ public sealed class ToolApprovalGateTests
     [Fact]
     public void Non_interactive_shell_with_path_outside_trust_zone_is_denied()
     {
-        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+        var outsidePath = Path.Combine(dir.Path, "outside", "secrets.txt");
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
         var policy = CreatePolicyWithTrustZone(trustZone);
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
         var decision = policy.AuthorizeInvocation(tool, ctx,
-            new Dictionary<string, object?> { ["command"] = "cat /etc/shadow" });
+            new Dictionary<string, object?> { ["command"] = $"cat {outsidePath}" });
 
         Assert.False(decision.Allowed);
         Assert.Equal("shell_path_outside_trust_zone", decision.DenyReason);
@@ -563,13 +567,17 @@ public sealed class ToolApprovalGateTests
     [Fact]
     public void Non_interactive_shell_with_path_inside_trust_zone_proceeds_to_approval()
     {
-        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+        var insidePath = Path.Combine(trustRoot, "project", "README.md");
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
         var policy = CreatePolicyWithTrustZone(trustZone);
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
 
         var decision = policy.AuthorizeInvocation(tool, ctx,
-            new Dictionary<string, object?> { ["command"] = "cat /home/user/.netclaw/workspaces/project/README.md" });
+            new Dictionary<string, object?> { ["command"] = $"cat {insidePath}" });
 
         // Path is within trust zone — proceeds to the approval gate (RequiresApproval)
         Assert.True(decision.NeedsApproval);
@@ -578,7 +586,10 @@ public sealed class ToolApprovalGateTests
     [Fact]
     public void Non_interactive_shell_without_path_args_proceeds_to_approval()
     {
-        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
         var policy = CreatePolicyWithTrustZone(trustZone);
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: false);
@@ -593,7 +604,10 @@ public sealed class ToolApprovalGateTests
     [Fact]
     public void Interactive_shell_skips_trust_zone_check()
     {
-        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
         var policy = CreatePolicyWithTrustZone(trustZone);
         var tool = ShellTool();
         var ctx = PersonalContext(supportsApproval: true);
@@ -601,6 +615,72 @@ public sealed class ToolApprovalGateTests
         // Interactive channels don't enforce trust zones — the human approves
         var decision = policy.AuthorizeInvocation(tool, ctx,
             new Dictionary<string, object?> { ["command"] = "cat /etc/passwd" });
+
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_nested_shell_path_outside_trust_zone_is_denied()
+    {
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+        var outsidePath = Path.Combine(dir.Path, "outside", "shadow.txt");
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = $"bash -c \"cat {outsidePath}\"" });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_path_outside_trust_zone", decision.DenyReason);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_working_directory_outside_trust_zone_is_denied()
+    {
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+        var outsideDir = Path.Combine(dir.Path, "outside");
+        Directory.CreateDirectory(outsideDir);
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?>
+            {
+                ["command"] = "cat README.md",
+                ["workingDirectory"] = outsideDir
+            });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_working_directory_outside_trust_zone", decision.DenyReason);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_in_zone_working_directory_and_relative_path_proceeds_to_approval()
+    {
+        using var dir = new DisposableTempDir();
+        var trustRoot = CreateTrustZoneRoot(dir.Path);
+        var workingDirectory = Path.Combine(trustRoot, "project");
+        Directory.CreateDirectory(workingDirectory);
+
+        var trustZone = new FakeShellTrustZonePolicy([trustRoot]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?>
+            {
+                ["command"] = "cat README.md",
+                ["workingDirectory"] = workingDirectory
+            });
 
         Assert.True(decision.NeedsApproval);
     }
@@ -618,6 +698,32 @@ public sealed class ToolApprovalGateTests
 
         Assert.False(decision.Allowed);
         Assert.Equal("shell_trust_zone_policy_not_configured", decision.DenyReason);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_working_directory_denied_when_no_trust_zone_configured()
+    {
+        using var dir = new DisposableTempDir();
+        var policy = CreatePolicy(ToolApprovalMode.Approval);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?>
+            {
+                ["command"] = "cat README.md",
+                ["workingDirectory"] = dir.Path
+            });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_trust_zone_policy_not_configured", decision.DenyReason);
+    }
+
+    private static string CreateTrustZoneRoot(string tempDir)
+    {
+        var root = Path.Combine(tempDir, ".netclaw", "workspaces");
+        Directory.CreateDirectory(Path.Combine(root, "project"));
+        return root;
     }
 
     private static ToolAccessPolicy CreatePolicyWithTrustZone(IShellTrustZonePolicy trustZone)

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -544,4 +544,109 @@ public sealed class ToolApprovalGateTests
         Assert.NotNull(decision.ApprovalContext);
         Assert.Equal("store_memory", decision.ApprovalContext!.ToolName);
     }
+
+    [Fact]
+    public void Non_interactive_shell_with_path_outside_trust_zone_is_denied()
+    {
+        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = "cat /etc/shadow" });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_path_outside_trust_zone", decision.DenyReason);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_path_inside_trust_zone_proceeds_to_approval()
+    {
+        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = "cat /home/user/.netclaw/workspaces/project/README.md" });
+
+        // Path is within trust zone — proceeds to the approval gate (RequiresApproval)
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_without_path_args_proceeds_to_approval()
+    {
+        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        // "git status" has no path-like arguments
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = "git status" });
+
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void Interactive_shell_skips_trust_zone_check()
+    {
+        var trustZone = new FakeShellTrustZonePolicy(["/home/user/.netclaw/workspaces"]);
+        var policy = CreatePolicyWithTrustZone(trustZone);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: true);
+
+        // Interactive channels don't enforce trust zones — the human approves
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = "cat /etc/passwd" });
+
+        Assert.True(decision.NeedsApproval);
+    }
+
+    [Fact]
+    public void Non_interactive_shell_with_path_denied_when_no_trust_zone_configured()
+    {
+        // No trust zone policy = fail-closed for non-interactive path commands
+        var policy = CreatePolicy(ToolApprovalMode.Approval);
+        var tool = ShellTool();
+        var ctx = PersonalContext(supportsApproval: false);
+
+        var decision = policy.AuthorizeInvocation(tool, ctx,
+            new Dictionary<string, object?> { ["command"] = "cat /etc/passwd" });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("shell_trust_zone_policy_not_configured", decision.DenyReason);
+    }
+
+    private static ToolAccessPolicy CreatePolicyWithTrustZone(IShellTrustZonePolicy trustZone)
+    {
+        var config = new ToolConfig { ShellMode = ShellExecutionMode.HostAllowed };
+        config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
+        {
+            ToolOverrides = new Dictionary<string, ToolApprovalMode>(StringComparer.Ordinal)
+            {
+                ["shell_execute"] = ToolApprovalMode.Approval
+            }
+        };
+
+        return new ToolAccessPolicy(
+            config,
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            shellTrustZonePolicy: trustZone);
+    }
+
+    private sealed class FakeShellTrustZonePolicy : IShellTrustZonePolicy
+    {
+        private readonly IReadOnlyList<string> _roots;
+
+        public FakeShellTrustZonePolicy(IReadOnlyList<string> roots) => _roots = roots;
+
+        public IReadOnlyList<string> GetTrustZoneRoots(ToolExecutionContext context) => _roots;
+    }
 }

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -113,8 +113,6 @@ public sealed class ToolApprovalGateTests
 
         var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(supportsApproval: false), args);
 
-        // Non-interactive channels no longer auto-deny — they fall through to
-        // RequiresApproval so the executor can check the persistent approval store.
         Assert.True(decision.NeedsApproval);
         Assert.NotNull(decision.ApprovalContext);
         Assert.Contains("git push", decision.ApprovalContext!.UnapprovedPatterns);
@@ -538,8 +536,6 @@ public sealed class ToolApprovalGateTests
 
         var decision = policy.AuthorizeInvocation(tool, subagentCtx);
 
-        // Non-interactive channels now fall through to RequiresApproval so the
-        // executor can check the persistent approval store before denying.
         Assert.True(decision.NeedsApproval);
         Assert.NotNull(decision.ApprovalContext);
         Assert.Equal("store_memory", decision.ApprovalContext!.ToolName);

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -106,15 +106,18 @@ public sealed class ToolApprovalGateTests
     }
 
     [Fact]
-    public void Unsupported_channel_auto_denies()
+    public void Unsupported_channel_returns_requires_approval_for_store_check()
     {
         var policy = CreatePolicy(ToolApprovalMode.Approval);
         var args = ToolInput.Create("Command", "git push");
 
         var decision = policy.AuthorizeInvocation(ShellTool(), PersonalContext(supportsApproval: false), args);
 
-        Assert.False(decision.Allowed);
-        Assert.Equal("channel_does_not_support_approval", decision.DenyReason);
+        // Non-interactive channels no longer auto-deny — they fall through to
+        // RequiresApproval so the executor can check the persistent approval store.
+        Assert.True(decision.NeedsApproval);
+        Assert.NotNull(decision.ApprovalContext);
+        Assert.Contains("git push", decision.ApprovalContext!.UnapprovedPatterns);
     }
 
     [Fact]
@@ -515,7 +518,7 @@ public sealed class ToolApprovalGateTests
     }
 
     [Fact]
-    public void Non_safe_list_tool_denied_when_interactive_approval_unsupported()
+    public void Non_safe_list_tool_returns_requires_approval_when_interactive_unsupported()
     {
         var config = new ToolConfig();
         config.AudienceProfiles.Personal.ApprovalPolicy = new ToolApprovalConfig
@@ -535,7 +538,10 @@ public sealed class ToolApprovalGateTests
 
         var decision = policy.AuthorizeInvocation(tool, subagentCtx);
 
-        Assert.False(decision.Allowed);
-        Assert.Equal("channel_does_not_support_approval", decision.DenyReason);
+        // Non-interactive channels now fall through to RequiresApproval so the
+        // executor can check the persistent approval store before denying.
+        Assert.True(decision.NeedsApproval);
+        Assert.NotNull(decision.ApprovalContext);
+        Assert.Equal("store_memory", decision.ApprovalContext!.ToolName);
     }
 }

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParentSessionApprovalBridge.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Sessions;
+
+/// <summary>
+/// Bridges a sub-agent's approval requests to the parent session's interactive channel.
+/// Wraps the session's <see cref="IApprovalChannel"/> and request emitter into the
+/// cross-layer <see cref="IParentApprovalBridge"/> contract.
+/// </summary>
+internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
+{
+    private readonly IApprovalChannel _channel;
+    private readonly Action<ToolInteractionRequest> _emitRequest;
+    private readonly SessionId _sessionId;
+
+    public ParentSessionApprovalBridge(
+        IApprovalChannel channel,
+        Action<ToolInteractionRequest> emitRequest,
+        SessionId sessionId)
+    {
+        _channel = channel;
+        _emitRequest = emitRequest;
+        _sessionId = sessionId;
+    }
+
+    public async Task<ParentApprovalDecision> RequestApprovalAsync(
+        ToolCallId callId,
+        string toolName,
+        string displayText,
+        IReadOnlyList<string> unapprovedPatterns,
+        CancellationToken ct)
+    {
+        var waitTask = _channel.WaitForApprovalAsync(callId, Timeout.InfiniteTimeSpan, ct);
+
+        _emitRequest(new ToolInteractionRequest
+        {
+            SessionId = _sessionId,
+            Kind = "approval",
+            CallId = callId.Value,
+            ToolName = toolName,
+            DisplayText = displayText,
+            Patterns = unapprovedPatterns,
+            Options =
+            [
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+            ]
+        });
+
+        var decision = await waitTask;
+
+        return decision switch
+        {
+            ApprovalDecision.ApprovedOnce => ParentApprovalDecision.ApprovedOnce,
+            ApprovalDecision.ApprovedSession => ParentApprovalDecision.ApprovedSession,
+            ApprovalDecision.ApprovedAlways => ParentApprovalDecision.ApprovedAlways,
+            ApprovalDecision.TimedOut => ParentApprovalDecision.TimedOut,
+            _ => ParentApprovalDecision.Denied
+        };
+    }
+}

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Sessions;
@@ -18,15 +19,27 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
     private readonly IApprovalChannel _channel;
     private readonly Action<ToolInteractionRequest> _emitRequest;
     private readonly SessionId _sessionId;
+    private readonly string? _requesterSenderId;
+    private readonly PrincipalClassification? _requesterPrincipal;
+    private readonly bool _hasAdoptedContext;
+    private readonly IReadOnlyList<string> _adoptedSpeakerIds;
 
     public ParentSessionApprovalBridge(
         IApprovalChannel channel,
         Action<ToolInteractionRequest> emitRequest,
-        SessionId sessionId)
+        SessionId sessionId,
+        string? requesterSenderId,
+        PrincipalClassification? requesterPrincipal,
+        bool hasAdoptedContext,
+        IReadOnlyList<string> adoptedSpeakerIds)
     {
         _channel = channel;
         _emitRequest = emitRequest;
         _sessionId = sessionId;
+        _requesterSenderId = requesterSenderId;
+        _requesterPrincipal = requesterPrincipal;
+        _hasAdoptedContext = hasAdoptedContext;
+        _adoptedSpeakerIds = adoptedSpeakerIds;
     }
 
     public async Task<ParentApprovalDecision> RequestApprovalAsync(
@@ -45,7 +58,12 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             CallId = callId.Value,
             ToolName = toolName,
             DisplayText = displayText,
+            RequesterSenderId = _requesterSenderId,
+            RequesterPrincipal = _requesterPrincipal,
             Patterns = unapprovedPatterns,
+            HasAdoptedContext = _hasAdoptedContext,
+            AdoptedSpeakerIds = _adoptedSpeakerIds,
+            PersistedAdoptedContext = _hasAdoptedContext,
             Options =
             [
                 new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -141,6 +141,8 @@ internal static class SessionToolExecutionPipeline
         string resultText;
         var context = BuildToolExecutionContext(sessionId, source, sessionDir, spawnChildActor);
         context.RequestedTimeoutSeconds = (int)timeout.TotalSeconds;
+        context.ParentApprovalChannel = approvalChannel;
+        context.EmitApprovalRequestCallback = emitApprovalRequest;
         var completedRuns = new List<CompletedSubAgentRun>();
         var acceptedFindings = new List<AcceptedSubAgentFinding>();
         context.OnSubAgentActivity = info =>

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -141,8 +141,11 @@ internal static class SessionToolExecutionPipeline
         string resultText;
         var context = BuildToolExecutionContext(sessionId, source, sessionDir, spawnChildActor);
         context.RequestedTimeoutSeconds = (int)timeout.TotalSeconds;
-        context.ParentApprovalChannel = approvalChannel;
-        context.EmitApprovalRequestCallback = emitApprovalRequest;
+        if (approvalChannel is not null && emitApprovalRequest is not null)
+        {
+            context.ApprovalBridge = new ParentSessionApprovalBridge(
+                approvalChannel, emitApprovalRequest, sessionId);
+        }
         var completedRuns = new List<CompletedSubAgentRun>();
         var acceptedFindings = new List<AcceptedSubAgentFinding>();
         context.OnSubAgentActivity = info =>

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -144,7 +144,13 @@ internal static class SessionToolExecutionPipeline
         if (approvalChannel is not null && emitApprovalRequest is not null)
         {
             context.ApprovalBridge = new ParentSessionApprovalBridge(
-                approvalChannel, emitApprovalRequest, sessionId);
+                approvalChannel,
+                emitApprovalRequest,
+                sessionId,
+                source?.SenderId,
+                source?.Principal,
+                source?.HasAdoptedContext ?? false,
+                source?.AdoptedSpeakerIds ?? []);
         }
         var completedRuns = new List<CompletedSubAgentRun>();
         var acceptedFindings = new List<AcceptedSubAgentFinding>();

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -399,9 +399,10 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             var tasks = toolCalls.Select(async tc =>
             {
+                var toolContext = CreatePerToolExecutionContext(executionContext);
                 try
                 {
-                    var result = await executor.ExecuteAsync(tc, executionContext, ct);
+                    var result = await executor.ExecuteAsync(tc, toolContext, ct);
                     return new SerializableChatMessage
                     {
                         Role = Protocol.ChatRole.Tool,
@@ -425,14 +426,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         or ParentApprovalDecision.ApprovedSession
                         or ParentApprovalDecision.ApprovedAlways)
                     {
-                        // Always set one-time bypass for the immediate retry — the
-                        // sub-agent's scope ID differs from the parent session ID, so
-                        // session/always grants recorded by the parent won't be visible
-                        // to the sub-agent's executor until the approval service propagates.
-                        executionContext.OneTimeApprovedToolName = tc.Name;
-                        executionContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
+                        // The immediate retry needs a transient grant even for session/always
+                        // approvals because the sub-agent's scope ID differs from the parent
+                        // session's scope. Keep that retry-local so approve-once cannot bleed
+                        // across parallel tool calls or later iterations.
+                        var retryContext = CreatePerToolExecutionContext(executionContext);
+                        retryContext.OneTimeApprovedToolName = tc.Name;
+                        retryContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
 
-                        var result = await executor.ExecuteAsync(tc, executionContext, ct);
+                        var result = await executor.ExecuteAsync(tc, retryContext, ct);
                         return new SerializableChatMessage
                         {
                             Role = Protocol.ChatRole.Tool,
@@ -476,6 +478,19 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             self.Tell(new ToolExecutionFailed { Cause = ex });
         }
     }
+
+    private static ToolExecutionContext CreatePerToolExecutionContext(ToolExecutionContext source)
+        => new(source.SessionId, source.SessionDirectory)
+        {
+            Audience = source.Audience,
+            Boundary = source.Boundary,
+            RequestedTimeoutSeconds = source.RequestedTimeoutSeconds,
+            ChannelType = source.ChannelType,
+            SupportsInteractiveApproval = source.SupportsInteractiveApproval,
+            OnSubAgentActivity = source.OnSubAgentActivity,
+            SpawnChildActor = source.SpawnChildActor,
+            ApprovalBridge = source.ApprovalBridge
+        };
 
     /// <summary>Singleton timeout marker message.</summary>
     private sealed class SubAgentTimeout

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -425,11 +425,12 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         or ParentApprovalDecision.ApprovedSession
                         or ParentApprovalDecision.ApprovedAlways)
                     {
-                        if (decision == ParentApprovalDecision.ApprovedOnce)
-                        {
-                            executionContext.OneTimeApprovedToolName = tc.Name;
-                            executionContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
-                        }
+                        // Always set one-time bypass for the immediate retry — the
+                        // sub-agent's scope ID differs from the parent session ID, so
+                        // session/always grants recorded by the parent won't be visible
+                        // to the sub-agent's executor until the approval service propagates.
+                        executionContext.OneTimeApprovedToolName = tc.Name;
+                        executionContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
 
                         var result = await executor.ExecuteAsync(tc, executionContext, ct);
                         return new SerializableChatMessage

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -47,8 +47,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private int _toolIterationCount;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
-    private IApprovalChannel? _parentApprovalChannel;
-    private Action<Protocol.ToolInteractionRequest>? _emitApprovalRequest;
+    private IParentApprovalBridge? _approvalBridge;
 
     public ITimerScheduler Timers { get; set; } = null!;
     private CancellationTokenRegistration _externalCancellationRegistration;
@@ -100,8 +99,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             _replyTo = Sender;
 
-            _parentApprovalChannel = msg.ParentApprovalChannel;
-            _emitApprovalRequest = msg.EmitApprovalRequest;
+            _approvalBridge = msg.ApprovalBridge;
 
             var scopeId = !string.IsNullOrWhiteSpace(msg.SessionScopeId)
                 ? msg.SessionScopeId!
@@ -110,8 +108,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext.Audience = msg.Audience ?? TrustAudience.Personal.ToWireValue();
             _toolExecutionContext.Boundary = msg.Boundary;
             _toolExecutionContext.ChannelType = msg.ChannelType;
-            _toolExecutionContext.SupportsInteractiveApproval =
-                _parentApprovalChannel is not null && _emitApprovalRequest is not null;
+            _toolExecutionContext.SupportsInteractiveApproval = _approvalBridge is not null;
             _executionCts = new CancellationTokenSource();
             var self = Self; // Capture before callback — Self requires active actor context
             _externalCancellationRegistration = msg.Cancellation.Register(() => self.Tell(SubAgentCancelled.Instance));
@@ -238,8 +235,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext,
             _executionCts?.Token ?? CancellationToken.None,
             self,
-            _parentApprovalChannel,
-            _emitApprovalRequest);
+            _approvalBridge);
     }
 
     private void FireLlmCall(bool forceNoTools = false)
@@ -397,8 +393,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         ToolExecutionContext executionContext,
         CancellationToken ct,
         IActorRef self,
-        IApprovalChannel? parentApprovalChannel = null,
-        Action<Protocol.ToolInteractionRequest>? emitApprovalRequest = null)
+        IParentApprovalBridge? approvalBridge = null)
     {
         try
         {
@@ -416,32 +411,21 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     };
                 }
                 catch (ToolApprovalRequiredException approvalEx)
-                    when (parentApprovalChannel is not null && emitApprovalRequest is not null)
+                    when (approvalBridge is not null)
                 {
                     var ctx = approvalEx.ApprovalContext;
-                    var waitTask = parentApprovalChannel.WaitForApprovalAsync(
+                    var decision = await approvalBridge.RequestApprovalAsync(
                         new ToolCallId(tc.CallId),
-                        TimeSpan.FromMinutes(5),
+                        ctx.ToolName,
+                        ctx.DisplayText,
+                        ctx.UnapprovedPatterns,
                         ct);
 
-                    emitApprovalRequest(new Protocol.ToolInteractionRequest
+                    if (decision is ParentApprovalDecision.ApprovedOnce
+                        or ParentApprovalDecision.ApprovedSession
+                        or ParentApprovalDecision.ApprovedAlways)
                     {
-                        SessionId = new Protocol.SessionId(executionContext.SessionId ?? "subagent"),
-                        Kind = "approval",
-                        CallId = tc.CallId,
-                        ToolName = ctx.ToolName,
-                        DisplayText = ctx.DisplayText,
-                        Patterns = ctx.UnapprovedPatterns,
-                        Options = ctx.Options
-                            .Select(o => new Protocol.ToolInteractionOption(o.Key, o.Label))
-                            .ToList()
-                    });
-
-                    var decision = await waitTask;
-
-                    if (decision is ApprovalDecision.ApprovedOnce or ApprovalDecision.ApprovedSession or ApprovalDecision.ApprovedAlways)
-                    {
-                        if (decision == ApprovalDecision.ApprovedOnce)
+                        if (decision == ParentApprovalDecision.ApprovedOnce)
                         {
                             executionContext.OneTimeApprovedToolName = tc.Name;
                             executionContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
@@ -457,7 +441,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                         };
                     }
 
-                    var reason = decision == ApprovalDecision.TimedOut
+                    var reason = decision == ParentApprovalDecision.TimedOut
                         ? "Tool access denied: approval_timed_out"
                         : "Tool access denied: approval_denied_by_user";
                     return new SerializableChatMessage

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -47,6 +47,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     private int _toolIterationCount;
     private IActorRef _replyTo = ActorRefs.Nobody;
     private CancellationTokenSource? _executionCts;
+    private IApprovalChannel? _parentApprovalChannel;
+    private Action<Protocol.ToolInteractionRequest>? _emitApprovalRequest;
 
     public ITimerScheduler Timers { get; set; } = null!;
     private CancellationTokenRegistration _externalCancellationRegistration;
@@ -98,6 +100,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         {
             _replyTo = Sender;
 
+            _parentApprovalChannel = msg.ParentApprovalChannel;
+            _emitApprovalRequest = msg.EmitApprovalRequest;
+
             var scopeId = !string.IsNullOrWhiteSpace(msg.SessionScopeId)
                 ? msg.SessionScopeId!
                 : $"subagent/{_definition.Name}/{Guid.NewGuid():N}";
@@ -105,7 +110,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             _toolExecutionContext.Audience = msg.Audience ?? TrustAudience.Personal.ToWireValue();
             _toolExecutionContext.Boundary = msg.Boundary;
             _toolExecutionContext.ChannelType = msg.ChannelType;
-            _toolExecutionContext.SupportsInteractiveApproval = false;
+            _toolExecutionContext.SupportsInteractiveApproval =
+                _parentApprovalChannel is not null && _emitApprovalRequest is not null;
             _executionCts = new CancellationTokenSource();
             var self = Self; // Capture before callback — Self requires active actor context
             _externalCancellationRegistration = msg.Cancellation.Register(() => self.Tell(SubAgentCancelled.Instance));
@@ -231,7 +237,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             toolCalls,
             _toolExecutionContext,
             _executionCts?.Token ?? CancellationToken.None,
-            self);
+            self,
+            _parentApprovalChannel,
+            _emitApprovalRequest);
     }
 
     private void FireLlmCall(bool forceNoTools = false)
@@ -388,7 +396,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
         List<FunctionCallContent> toolCalls,
         ToolExecutionContext executionContext,
         CancellationToken ct,
-        IActorRef self)
+        IActorRef self,
+        IApprovalChannel? parentApprovalChannel = null,
+        Action<Protocol.ToolInteractionRequest>? emitApprovalRequest = null)
     {
         try
         {
@@ -401,6 +411,59 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
                     {
                         Role = Protocol.ChatRole.Tool,
                         Content = result,
+                        ToolCallId = tc.CallId,
+                        Name = tc.Name
+                    };
+                }
+                catch (ToolApprovalRequiredException approvalEx)
+                    when (parentApprovalChannel is not null && emitApprovalRequest is not null)
+                {
+                    var ctx = approvalEx.ApprovalContext;
+                    var waitTask = parentApprovalChannel.WaitForApprovalAsync(
+                        new ToolCallId(tc.CallId),
+                        TimeSpan.FromMinutes(5),
+                        ct);
+
+                    emitApprovalRequest(new Protocol.ToolInteractionRequest
+                    {
+                        SessionId = new Protocol.SessionId(executionContext.SessionId ?? "subagent"),
+                        Kind = "approval",
+                        CallId = tc.CallId,
+                        ToolName = ctx.ToolName,
+                        DisplayText = ctx.DisplayText,
+                        Patterns = ctx.UnapprovedPatterns,
+                        Options = ctx.Options
+                            .Select(o => new Protocol.ToolInteractionOption(o.Key, o.Label))
+                            .ToList()
+                    });
+
+                    var decision = await waitTask;
+
+                    if (decision is ApprovalDecision.ApprovedOnce or ApprovalDecision.ApprovedSession or ApprovalDecision.ApprovedAlways)
+                    {
+                        if (decision == ApprovalDecision.ApprovedOnce)
+                        {
+                            executionContext.OneTimeApprovedToolName = tc.Name;
+                            executionContext.SetOneTimeApprovedPatterns(ctx.UnapprovedPatterns);
+                        }
+
+                        var result = await executor.ExecuteAsync(tc, executionContext, ct);
+                        return new SerializableChatMessage
+                        {
+                            Role = Protocol.ChatRole.Tool,
+                            Content = result,
+                            ToolCallId = tc.CallId,
+                            Name = tc.Name
+                        };
+                    }
+
+                    var reason = decision == ApprovalDecision.TimedOut
+                        ? "Tool access denied: approval_timed_out"
+                        : "Tool access denied: approval_denied_by_user";
+                    return new SerializableChatMessage
+                    {
+                        Role = Protocol.ChatRole.Tool,
+                        Content = reason,
                         ToolCallId = tc.CallId,
                         Name = tc.Name
                     };

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.AI;
-using Netclaw.Actors.Sessions;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.SubAgents;
@@ -73,16 +72,10 @@ public sealed record RunSubAgent
     public string? ChannelType { get; init; }
 
     /// <summary>
-    /// Parent session's approval channel. When provided, the sub-agent can route
+    /// Parent session's approval bridge. When provided, the sub-agent can route
     /// approval requests back to the interactive user instead of auto-denying.
     /// </summary>
-    internal IApprovalChannel? ParentApprovalChannel { get; init; }
-
-    /// <summary>
-    /// Callback to emit <see cref="Protocol.ToolInteractionRequest"/> to the parent session.
-    /// Required alongside <see cref="ParentApprovalChannel"/> for approval chaining to work.
-    /// </summary>
-    internal Action<Protocol.ToolInteractionRequest>? EmitApprovalRequest { get; init; }
+    public IParentApprovalBridge? ApprovalBridge { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Sessions;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.SubAgents;
@@ -70,6 +71,18 @@ public sealed record RunSubAgent
     public string? Boundary { get; init; }
 
     public string? ChannelType { get; init; }
+
+    /// <summary>
+    /// Parent session's approval channel. When provided, the sub-agent can route
+    /// approval requests back to the interactive user instead of auto-denying.
+    /// </summary>
+    internal IApprovalChannel? ParentApprovalChannel { get; init; }
+
+    /// <summary>
+    /// Callback to emit <see cref="Protocol.ToolInteractionRequest"/> to the parent session.
+    /// Required alongside <see cref="ParentApprovalChannel"/> for approval chaining to work.
+    /// </summary>
+    internal Action<Protocol.ToolInteractionRequest>? EmitApprovalRequest { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -6,8 +6,6 @@
 using System.Diagnostics;
 using Akka.Actor;
 using Microsoft.Extensions.Logging;
-using Netclaw.Actors.Protocol;
-using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -115,9 +113,6 @@ public sealed class SubAgentSpawner
         var sw = Stopwatch.StartNew();
         try
         {
-            var parentChannel = context.ParentApprovalChannel as IApprovalChannel;
-            var emitRequest = context.EmitApprovalRequestCallback as Action<ToolInteractionRequest>;
-
             var result = await subAgent.Ask<SubAgentResult>(
                 new RunSubAgent
                 {
@@ -129,8 +124,7 @@ public sealed class SubAgentSpawner
                     Boundary = context.Boundary,
                     ChannelType = context.ChannelType,
                     Cancellation = ct,
-                    ParentApprovalChannel = parentChannel,
-                    EmitApprovalRequest = emitRequest
+                    ApprovalBridge = context.ApprovalBridge
                 },
                 timeout: subAgentTimeout.Add(TimeSpan.FromSeconds(5)),
                 cancellationToken: ct);

--- a/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentSpawner.cs
@@ -6,6 +6,8 @@
 using System.Diagnostics;
 using Akka.Actor;
 using Microsoft.Extensions.Logging;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -113,6 +115,9 @@ public sealed class SubAgentSpawner
         var sw = Stopwatch.StartNew();
         try
         {
+            var parentChannel = context.ParentApprovalChannel as IApprovalChannel;
+            var emitRequest = context.EmitApprovalRequestCallback as Action<ToolInteractionRequest>;
+
             var result = await subAgent.Ask<SubAgentResult>(
                 new RunSubAgent
                 {
@@ -123,7 +128,9 @@ public sealed class SubAgentSpawner
                     Audience = context.Audience,
                     Boundary = context.Boundary,
                     ChannelType = context.ChannelType,
-                    Cancellation = ct
+                    Cancellation = ct,
+                    ParentApprovalChannel = parentChannel,
+                    EmitApprovalRequest = emitRequest
                 },
                 timeout: subAgentTimeout.Add(TimeSpan.FromSeconds(5)),
                 cancellationToken: ct);

--- a/src/Netclaw.Actors/Tools/ShellTrustZonePolicy.cs
+++ b/src/Netclaw.Actors/Tools/ShellTrustZonePolicy.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="ShellTrustZonePolicy.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Tools;
+
+namespace Netclaw.Actors.Tools;
+
+/// <summary>
+/// Implements <see cref="IShellTrustZonePolicy"/> by delegating to
+/// <see cref="ScopedFileAccessPolicy"/> for root resolution. Returns the
+/// write-access roots for the context — shell commands are treated as having
+/// write-equivalent privilege since they can modify files.
+/// </summary>
+public sealed class ShellTrustZonePolicy : IShellTrustZonePolicy
+{
+    private readonly ScopedFileAccessPolicy _fileAccessPolicy;
+
+    public ShellTrustZonePolicy(ToolConfig toolConfig, NetclawPaths? paths = null)
+    {
+        _fileAccessPolicy = new ScopedFileAccessPolicy(toolConfig, paths);
+    }
+
+    internal ShellTrustZonePolicy(ScopedFileAccessPolicy fileAccessPolicy)
+    {
+        _fileAccessPolicy = fileAccessPolicy;
+    }
+
+    public IReadOnlyList<string> GetTrustZoneRoots(ToolExecutionContext context)
+        => _fileAccessPolicy.GetRootsForContext(context, ScopedFileAccessPolicy.AccessKind.Write);
+}

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -20,6 +20,7 @@ public sealed class ToolAccessPolicy
     private readonly ToolAudienceProfileResolver _profileResolver;
     private readonly ShellCommandPolicy? _shellCommandPolicy;
     private readonly ToolPathPolicy? _toolPathPolicy;
+    private readonly IShellTrustZonePolicy? _shellTrustZonePolicy;
     private readonly IToolApprovalMatcher _fileApprovalMatcher;
     private readonly FeatureGates _featureGates;
 
@@ -29,13 +30,15 @@ public sealed class ToolAccessPolicy
         ShellCommandPolicy? shellCommandPolicy = null,
         IToolApprovalMatcher? fileApprovalMatcher = null,
         ToolPathPolicy? toolPathPolicy = null,
-        FeatureGates? featureGates = null)
+        FeatureGates? featureGates = null,
+        IShellTrustZonePolicy? shellTrustZonePolicy = null)
     {
         _toolConfig = toolConfig;
         _defaults = defaults;
         _profileResolver = new ToolAudienceProfileResolver(toolConfig);
         _shellCommandPolicy = shellCommandPolicy;
         _toolPathPolicy = toolPathPolicy;
+        _shellTrustZonePolicy = shellTrustZonePolicy;
         _fileApprovalMatcher = fileApprovalMatcher ?? DefaultApprovalMatcher.Instance;
         _featureGates = featureGates ?? FeatureGates.AllEnabled;
     }
@@ -142,7 +145,132 @@ public sealed class ToolAccessPolicy
             && _toolPathPolicy?.CommandReferencesDeniedPath(shellCommand, workingDirectory) == true)
             return ToolAccessDecision.Deny("shell_references_protected_path");
 
+        // Non-interactive channels: sandbox shell commands to trust zone paths.
+        // Even if the verb-chain is pre-approved, path arguments must fall within
+        // the channel's allowed filesystem roots. Fail-closed: if no trust zone
+        // policy is configured, deny any shell command with path arguments.
+        if (context?.SupportsInteractiveApproval == false && shellCommand is not null)
+        {
+            if (_shellTrustZonePolicy is null)
+            {
+                if (ShellCommandHasPathArguments(shellCommand))
+                    return ToolAccessDecision.Deny("shell_trust_zone_policy_not_configured");
+            }
+            else
+            {
+                var trustZoneDeny = EnforceShellTrustZones(shellCommand, workingDirectory, context);
+                if (trustZoneDeny is not null)
+                    return trustZoneDeny;
+            }
+        }
+
         return CheckApprovalGate(toolName, context, arguments, ShellApprovalMatcher.Instance);
+    }
+
+    /// <summary>
+    /// For non-interactive channels, validates that all path-like arguments in a shell
+    /// command fall within the trust zone roots for the channel's audience. Returns a
+    /// deny decision if any path escapes, or null if all paths are within bounds.
+    /// </summary>
+    private ToolAccessDecision? EnforceShellTrustZones(
+        string shellCommand,
+        string? workingDirectory,
+        ToolExecutionContext context)
+    {
+        var tokens = ShellTokenizer.Tokenize(shellCommand);
+        var pathTokens = new List<string>();
+
+        foreach (var token in tokens)
+        {
+            if (ShellTokenizer.LooksLikePath(token))
+                pathTokens.Add(token);
+        }
+
+        if (pathTokens.Count == 0)
+            return null;
+
+        var roots = _shellTrustZonePolicy!.GetTrustZoneRoots(context);
+        if (roots.Count == 0)
+            return ToolAccessDecision.Deny("shell_no_trust_zone_roots");
+
+        foreach (var pathToken in pathTokens)
+        {
+            var expanded = ExpandShellPath(pathToken, workingDirectory);
+            if (expanded is null)
+                continue;
+
+            if (!IsPathWithinAnyRoot(expanded, roots))
+                return ToolAccessDecision.Deny("shell_path_outside_trust_zone");
+        }
+
+        return null;
+    }
+
+    private static string? ExpandShellPath(string token, string? workingDirectory)
+    {
+        var expanded = token;
+
+        if (expanded.StartsWith('~'))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (string.IsNullOrWhiteSpace(home))
+                return null;
+            expanded = expanded.Length == 1
+                ? home
+                : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
+        }
+
+        var homeEnv = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(homeEnv))
+        {
+            expanded = expanded.Replace("$HOME", homeEnv, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("${HOME}", homeEnv, StringComparison.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
+                ? workingDirectory
+                : Environment.CurrentDirectory;
+
+            return Path.IsPathRooted(expanded)
+                ? Path.GetFullPath(expanded)
+                : Path.GetFullPath(Path.Combine(baseDir, expanded));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsPathWithinAnyRoot(string fullPath, IReadOnlyList<string> roots)
+    {
+        var normalized = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        foreach (var root in roots)
+        {
+            var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (!normalized.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (normalized.Length == normalizedRoot.Length)
+                return true;
+            var boundary = normalized[normalizedRoot.Length];
+            if (boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ShellCommandHasPathArguments(string shellCommand)
+    {
+        foreach (var token in ShellTokenizer.Tokenize(shellCommand))
+        {
+            if (ShellTokenizer.LooksLikePath(token))
+                return true;
+        }
+
+        return false;
     }
 
     private static string? ExtractShellCommand(IDictionary<string, object?>? arguments)

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -209,10 +209,10 @@ public sealed class ToolAccessPolicy
     private static string? ExpandShellPath(string token, string? workingDirectory)
     {
         var expanded = token;
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
         if (expanded.StartsWith('~'))
         {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             if (string.IsNullOrWhiteSpace(home))
                 return null;
             expanded = expanded.Length == 1
@@ -220,11 +220,10 @@ public sealed class ToolAccessPolicy
                 : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
         }
 
-        var homeEnv = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrWhiteSpace(homeEnv))
+        if (!string.IsNullOrWhiteSpace(home))
         {
-            expanded = expanded.Replace("$HOME", homeEnv, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("${HOME}", homeEnv, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
         }
 
         try

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -153,7 +153,7 @@ public sealed class ToolAccessPolicy
         {
             if (_shellTrustZonePolicy is null)
             {
-                if (ShellCommandHasPathArguments(shellCommand))
+                if (ShellCommandHasTrustZoneSensitiveInputs(shellCommand, workingDirectory))
                     return ToolAccessDecision.Deny("shell_trust_zone_policy_not_configured");
             }
             else
@@ -177,21 +177,23 @@ public sealed class ToolAccessPolicy
         string? workingDirectory,
         ToolExecutionContext context)
     {
-        var tokens = ShellTokenizer.Tokenize(shellCommand);
-        var pathTokens = new List<string>();
-
-        foreach (var token in tokens)
-        {
-            if (ShellTokenizer.LooksLikePath(token))
-                pathTokens.Add(token);
-        }
-
-        if (pathTokens.Count == 0)
-            return null;
-
         var roots = _shellTrustZonePolicy!.GetTrustZoneRoots(context);
         if (roots.Count == 0)
             return ToolAccessDecision.Deny("shell_no_trust_zone_roots");
+
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var expandedWorkingDirectory = ExpandShellPath(workingDirectory, workingDirectory: null);
+            if (expandedWorkingDirectory is null)
+                return ToolAccessDecision.Deny("shell_invalid_working_directory");
+
+            if (!IsPathWithinAnyRoot(expandedWorkingDirectory, roots))
+                return ToolAccessDecision.Deny("shell_working_directory_outside_trust_zone");
+        }
+
+        var pathTokens = ExtractShellPathTokens(shellCommand);
+        if (pathTokens.Count == 0)
+            return null;
 
         foreach (var pathToken in pathTokens)
         {
@@ -204,6 +206,22 @@ public sealed class ToolAccessPolicy
         }
 
         return null;
+    }
+
+    private static IReadOnlyList<string> ExtractShellPathTokens(string shellCommand)
+    {
+        var pathTokens = new List<string>();
+        foreach (var segment in ShellTokenizer.GetAllCommandSegments(shellCommand))
+        {
+            foreach (var token in ShellTokenizer.Tokenize(segment))
+            {
+                var trimmed = TrimShellTokenPunctuation(token);
+                if (ShellTokenizer.LooksLikePath(trimmed))
+                    pathTokens.Add(trimmed);
+            }
+        }
+
+        return pathTokens;
     }
 
     private static string? ExpandShellPath(string token, string? workingDirectory)
@@ -244,12 +262,15 @@ public sealed class ToolAccessPolicy
 
     private static bool IsPathWithinAnyRoot(string fullPath, IReadOnlyList<string> roots)
     {
-        var normalized = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalized = NormalizeDirectoryComparisonPath(fullPath);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 
         foreach (var root in roots)
         {
-            var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            if (!normalized.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            var normalizedRoot = NormalizeDirectoryComparisonPath(root);
+            if (!normalized.StartsWith(normalizedRoot, comparison))
                 continue;
             if (normalized.Length == normalizedRoot.Length)
                 return true;
@@ -261,11 +282,20 @@ public sealed class ToolAccessPolicy
         return false;
     }
 
+    private static string NormalizeDirectoryComparisonPath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    private static bool ShellCommandHasTrustZoneSensitiveInputs(string shellCommand, string? workingDirectory)
+        => !string.IsNullOrWhiteSpace(workingDirectory) || ShellCommandHasPathArguments(shellCommand);
+
+    private static string TrimShellTokenPunctuation(string token)
+        => token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');
+
     private static bool ShellCommandHasPathArguments(string shellCommand)
     {
-        foreach (var token in ShellTokenizer.Tokenize(shellCommand))
+        foreach (var token in ExtractShellPathTokens(shellCommand))
         {
-            if (ShellTokenizer.LooksLikePath(token))
+            if (!string.IsNullOrWhiteSpace(token))
                 return true;
         }
 

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -191,13 +191,14 @@ public sealed class ToolAccessPolicy
         if (mode == ToolApprovalMode.Auto)
             return ToolAccessDecision.Allow();
 
-        // Subagents can't prompt for approval. Tools on the SubAgentToolPolicy
-        // safe list are auto-granted; everything else is denied.
-        if (context?.SupportsInteractiveApproval == false)
+        // Non-interactive channels (reminders, webhooks, sub-agents without parent
+        // approval channel): tools on the safe list are auto-granted. Everything else
+        // falls through to the normal approval extraction path — the executor will
+        // check the persistent approval store and allow if all patterns are pre-approved.
+        if (context?.SupportsInteractiveApproval == false
+            && SubAgentToolPolicy.IsAllowedForUserFacing(toolName.Value))
         {
-            return SubAgentToolPolicy.IsAllowedForUserFacing(toolName.Value)
-                ? ToolAccessDecision.Allow()
-                : ToolAccessDecision.Deny("channel_does_not_support_approval");
+            return ToolAccessDecision.Allow();
         }
 
         var allPatterns = matcher.ExtractPatterns(toolName, arguments);

--- a/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
@@ -52,18 +52,38 @@ internal sealed class ToolApprovalActor : ReceiveActor
 
     private bool IsApproved(SessionId? sessionId, TrustAudience audience, ToolName toolName, string pattern)
     {
-        if (sessionId.HasValue
-            && _sessionApprovals.TryGetValue(BuildSessionKey(sessionId.Value, audience), out var toolMap)
-            && toolMap.TryGetValue(toolName.Value, out var patterns)
-            && ApprovalPatternMatching.MatchesAny(pattern, patterns))
-        {
+        if (sessionId.HasValue && IsSessionApproved(sessionId.Value, audience, toolName, pattern))
             return true;
-        }
 
         if (_persistentStore is null)
             return false;
 
         return ApprovalPatternMatching.MatchesAny(pattern, _persistentStore.GetApprovedPatterns(audience, toolName.Value));
+    }
+
+    private bool IsSessionApproved(SessionId sessionId, TrustAudience audience, ToolName toolName, string pattern)
+    {
+        // Walk up the scope chain: sub-agent scopes inherit parent session approvals.
+        // Scope format: "{parentSessionId}/subagent/{name}/{runId}" — parent is the prefix before "/subagent/".
+        var scopeId = sessionId.Value;
+        while (true)
+        {
+            var sessionKey = BuildSessionKey((SessionId)scopeId, audience);
+            if (_sessionApprovals.TryGetValue(sessionKey, out var toolMap)
+                && toolMap.TryGetValue(toolName.Value, out var patterns)
+                && ApprovalPatternMatching.MatchesAny(pattern, patterns))
+            {
+                return true;
+            }
+
+            var subagentMarker = scopeId.IndexOf("/subagent/", StringComparison.Ordinal);
+            if (subagentMarker <= 0)
+                break;
+
+            scopeId = scopeId[..subagentMarker];
+        }
+
+        return false;
     }
 
     private void AddSessionApproval(SessionId sessionId, TrustAudience audience, ToolName toolName, string pattern)

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -446,6 +446,53 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
         Assert.Contains("approval default on Personal", result.Message);
     }
 
+    [Fact]
+    public async Task StalePathAwareShellApprovals_WarnWithResetInstructions()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "ShellMode": "HostAllowed",
+                "AudienceProfiles": {
+                  "Personal": {
+                    "ToolsMode": "All",
+                    "McpServersMode": "All",
+                    "ApprovalPolicy": {
+                      "ToolOverrides": { "shell_execute": "Approval" }
+                    },
+                    "ReadFiles": { "Mode": "All" },
+                    "WriteFiles": { "Mode": "All" },
+                    "AttachFiles": { "Mode": "All" }
+                  }
+                }
+              }
+            }
+            """);
+
+        File.WriteAllText(
+            _paths.ToolApprovalsPath,
+            """
+            {
+              "audiences": {
+                "personal": {
+                  "shell_execute": ["cat", "git push"]
+                }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("bare path-aware command patterns", result.Message);
+        Assert.Contains("cat", result.Message);
+        Assert.Contains("Delete", result.Message);
+        Assert.Contains(_paths.ToolApprovalsPath, result.Message);
+    }
+
     private void WriteConfig(object config)
     {
         File.WriteAllText(

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -9,6 +9,7 @@ using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tools;
 using Netclaw.Cli.Json;
 using Netclaw.Configuration;
+using Netclaw.Security;
 
 namespace Netclaw.Cli.Doctor;
 
@@ -307,9 +308,6 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
         if (!File.Exists(approvalsPath))
             return;
 
-        if (toolConfig.ShellMode != ShellExecutionMode.Off)
-            return;
-
         try
         {
             var store = new ToolApprovalStore(approvalsPath);
@@ -317,12 +315,29 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
 
             foreach (var (audienceKey, tools) in data.Audiences)
             {
-                if (tools.ContainsKey(ShellTool.ToolName))
+                if (!tools.TryGetValue(ShellTool.ToolName, out var patterns))
+                    continue;
+
+                if (toolConfig.ShellMode == ShellExecutionMode.Off)
                 {
                     warnings.Add(
                         $"Persistent approvals exist for {audienceKey}.{ShellTool.ToolName} " +
                         "but shell is disabled.");
                 }
+
+                var stalePathAwarePatterns = patterns
+                    .Where(ShellTokenizer.IsSingleTokenPathAwarePattern)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Order(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                if (stalePathAwarePatterns.Length == 0)
+                    continue;
+
+                warnings.Add(
+                    $"Persistent shell approvals for audience '{audienceKey}' contain bare path-aware command patterns " +
+                    $"({string.Join(", ", stalePathAwarePatterns)}). These no longer pre-approve path-targeting shell commands. " +
+                    $"Delete '{approvalsPath}' and restart the daemon to rebuild approvals under the stricter matcher.");
             }
         }
         catch (Exception ex)

--- a/src/Netclaw.Configuration/Resources/AGENTS.md
+++ b/src/Netclaw.Configuration/Resources/AGENTS.md
@@ -60,6 +60,11 @@ When the user says "remind me", "every day at", "check this weekly", "schedule",
 or any time-based instruction: use set_reminder immediately. Do not explain how
 reminders work — create the reminder.
 
+**Approval gate:** Reminders run without a human — they cannot prompt for
+approval. Before creating a reminder that will use shell_execute, run the needed
+commands in the current session first to trigger and persist approval. If unsure
+what commands the reminder will need, execute a dry-run now.
+
 **Full scheduling parameters, CLI commands, and Netclaw operations:**
 `file_read("{{SYSTEM_SKILLS_DIR}}/netclaw-operations/SKILL.md")`
 

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -637,13 +637,15 @@ static void ConfigureDaemonServices(
         SubAgentsEnabled: subAgentConfig.Enabled,
         SchedulingEnabled: schedulingConfig.Enabled);
     var fileApprovalMatcher = new FilePathApprovalMatcher(paths.ConfigDirectory);
+    var shellTrustZonePolicy = new ShellTrustZonePolicy(toolConfig, paths);
     var toolAccessPolicy = new ToolAccessPolicy(
         toolConfig,
         effectivePolicyDefaults,
         shellCommandPolicy,
         fileApprovalMatcher,
         toolPathPolicy,
-        featureGates);
+        featureGates,
+        shellTrustZonePolicy);
     services.AddSingleton(toolAccessPolicy);
 
     var toolApprovalStore = new ToolApprovalStore(paths.ToolApprovalsPath);

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -98,8 +98,14 @@ public sealed class ShellApprovalMatcherTests
     [InlineData("cat /etc/passwd", "cat /etc/shadow", false)]
     [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /home/.netclaw/scripts/monitor.sh", true)]
     [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /tmp/evil.sh", false)]
-    // Stale single-token approval no longer matches path-aware extractions
-    [InlineData("cat", "cat /etc/passwd", false)]
+    // Single-token path-aware verbs wildcard-match (Claude Code model)
+    [InlineData("cat", "cat /etc/passwd", true)]
+    [InlineData("grep", "grep TODO", true)]
+    [InlineData("bash", "bash /tmp/script.sh", true)]
+    [InlineData("find", "find /var/log", true)]
+    // Non-path-aware single tokens still require exact match
+    [InlineData("echo", "echo hello", false)]
+    [InlineData("docker", "docker compose", false)]
     public void IsApproved_pattern_matching(string pattern, string command, bool expected)
     {
         var approved = new[] { pattern };

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -98,11 +98,11 @@ public sealed class ShellApprovalMatcherTests
     [InlineData("cat /etc/passwd", "cat /etc/shadow", false)]
     [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /home/.netclaw/scripts/monitor.sh", true)]
     [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /tmp/evil.sh", false)]
-    // Single-token path-aware verbs wildcard-match (Claude Code model)
-    [InlineData("cat", "cat /etc/passwd", true)]
-    [InlineData("grep", "grep TODO", true)]
-    [InlineData("bash", "bash /tmp/script.sh", true)]
-    [InlineData("find", "find /var/log", true)]
+    // Single-token path-aware verbs stay exact-only
+    [InlineData("cat", "cat /etc/passwd", false)]
+    [InlineData("grep", "grep TODO", false)]
+    [InlineData("bash", "bash /tmp/script.sh", false)]
+    [InlineData("find", "find /var/log", false)]
     // Non-path-aware single tokens still require exact match
     [InlineData("echo", "echo hello", false)]
     [InlineData("docker", "docker compose", false)]

--- a/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
+++ b/src/Netclaw.Security.Tests/ShellApprovalMatcherTests.cs
@@ -93,6 +93,13 @@ public sealed class ShellApprovalMatcherTests
     [InlineData("git pu", "git push", false)]    // Partial token no match (word boundary)
     [InlineData("gh pr", "gh pr create", true)]  // Multi-token prefix match
     [InlineData("gh pr", "gh issue list", false)] // Multi-token no match
+    // Path-aware patterns — exact path matches
+    [InlineData("cat /etc/passwd", "cat /etc/passwd", true)]
+    [InlineData("cat /etc/passwd", "cat /etc/shadow", false)]
+    [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /home/.netclaw/scripts/monitor.sh", true)]
+    [InlineData("bash /home/.netclaw/scripts/monitor.sh", "bash /tmp/evil.sh", false)]
+    // Stale single-token approval no longer matches path-aware extractions
+    [InlineData("cat", "cat /etc/passwd", false)]
     public void IsApproved_pattern_matching(string pattern, string command, bool expected)
     {
         var approved = new[] { pattern };
@@ -106,6 +113,28 @@ public sealed class ShellApprovalMatcherTests
 
         Assert.True(_matcher.IsApproved(new ToolName("shell_execute"),
             Args("bash -c \"git push --force\""), approved));
+    }
+
+    [Fact]
+    public void ExtractPatterns_path_aware_verb_includes_path()
+    {
+        var patterns = _matcher.ExtractPatterns(
+            new ToolName("shell_execute"),
+            Args("cat /etc/hosts && git push origin main"));
+        Assert.Equal(2, patterns.Count);
+        Assert.Contains("cat /etc/hosts", patterns);
+        Assert.Contains("git push", patterns);
+    }
+
+    [Fact]
+    public void ExtractPatterns_pipe_with_path_aware_verbs()
+    {
+        var patterns = _matcher.ExtractPatterns(
+            new ToolName("shell_execute"),
+            Args("cat /var/log/syslog | grep error"));
+        Assert.Equal(2, patterns.Count);
+        Assert.Contains("cat /var/log/syslog", patterns);
+        Assert.Contains("grep error", patterns);
     }
 
     [Fact]

--- a/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
+++ b/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
@@ -111,13 +111,38 @@ public sealed class ShellTokenizerTests
 
     [Theory]
     [InlineData("git push origin main", "git push")]
-    [InlineData("ls -la /tmp", "ls")]
+    [InlineData("ls -la /tmp", "ls /tmp")]
     [InlineData("docker compose up -d", "docker compose")]
-    [InlineData("cat /etc/hosts", "cat")]
-    [InlineData("cat .gitignore", "cat")]
+    [InlineData("cat /etc/hosts", "cat /etc/hosts")]
+    [InlineData("cat .gitignore", "cat .gitignore")]
     [InlineData("kubectl delete pod my-pod", "kubectl delete")]
     [InlineData("", "")]
     public void ExtractVerbChain_extracts_expected_chain(string input, string expected)
+    {
+        Assert.Equal(expected, ShellTokenizer.ExtractVerbChain(input));
+    }
+
+    [Theory]
+    // Path-aware verbs include first non-flag argument
+    [InlineData("cat /etc/passwd", "cat /etc/passwd")]
+    [InlineData("grep secret /var/log/syslog", "grep secret")]
+    [InlineData("bash /home/user/.netclaw/scripts/monitor.sh", "bash /home/user/.netclaw/scripts/monitor.sh")]
+    [InlineData("python3 /opt/scripts/report.py --verbose", "python3 /opt/scripts/report.py")]
+    [InlineData("curl https://example.com/api", "curl https://example.com/api")]
+    [InlineData("find /var/log -name '*.log'", "find /var/log")]
+    [InlineData("sed -i 's/foo/bar/' /etc/config.txt", "sed s/foo/bar/")]
+    // Structured CLIs unchanged
+    [InlineData("git push origin main", "git push")]
+    [InlineData("docker compose up -d", "docker compose")]
+    [InlineData("kubectl delete pod my-pod", "kubectl delete")]
+    [InlineData("dotnet build --configuration Release", "dotnet build")]
+    // Edge: flag-only invocations of path-aware verbs
+    [InlineData("grep --version", "grep")]
+    [InlineData("cat --help", "cat")]
+    // Edge: home-relative and env-var paths
+    [InlineData("cat ~/.bashrc", "cat ~/.bashrc")]
+    [InlineData("bash ~/scripts/deploy.sh", "bash ~/scripts/deploy.sh")]
+    public void ExtractVerbChain_path_aware_verbs(string input, string expected)
     {
         Assert.Equal(expected, ShellTokenizer.ExtractVerbChain(input));
     }

--- a/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
+++ b/src/Netclaw.Security.Tests/ShellTokenizerTests.cs
@@ -193,4 +193,81 @@ public sealed class ShellTokenizerTests
         Assert.Single(segments);
         Assert.Equal("git status", segments[0]);
     }
+
+    // ── LooksLikePath ──
+
+    // Anchored paths — always true
+    [Theory]
+    [InlineData("/etc/passwd")]
+    [InlineData("/home/user/.netclaw/workspaces/project/file.txt")]
+    [InlineData("./script.sh")]
+    [InlineData("../parent/config.json")]
+    [InlineData("~/Documents/notes.md")]
+    [InlineData("~")]
+    [InlineData("$HOME/.config/app.toml")]
+    [InlineData("${HOME}/workspace")]
+    [InlineData("C:\\Users\\file.txt")]
+    [InlineData("c:\\users\\documents")]
+    [InlineData("D:/Projects/src")]
+    [InlineData("C:/Windows/System32")]
+    [InlineData("\\\\server\\share\\file.txt")]
+    [InlineData("\\\\nas\\backups")]
+    public void LooksLikePath_anchored_paths(string token)
+    {
+        Assert.True(ShellTokenizer.LooksLikePath(token));
+    }
+
+    // Non-paths — always false
+    [Theory]
+    [InlineData("https://api.github.com/repos/foo")]
+    [InlineData("ftp://mirror.example.com/file")]
+    [InlineData("--output=/tmp/foo")]
+    [InlineData("-v")]
+    [InlineData("origin/main")]
+    [InlineData("feature/fix-bug")]
+    [InlineData("nginx:latest")]
+    [InlineData("ghcr.io/org/image:tag")]
+    [InlineData("redis:6379")]
+    [InlineData("@scope/package")]
+    [InlineData("s/foo/bar/g")]
+    [InlineData("y/abc/xyz/")]
+    [InlineData("application/json")]
+    [InlineData("git")]
+    [InlineData("status")]
+    [InlineData("TODO")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void LooksLikePath_non_paths(string token)
+    {
+        Assert.False(ShellTokenizer.LooksLikePath(token));
+    }
+
+    // Bare relative with file extension — treated as path
+    [Theory]
+    [InlineData("src/main.rs")]
+    [InlineData("config/app.json")]
+    [InlineData("logs/output.log")]
+    [InlineData("scripts/deploy.sh")]
+    public void LooksLikePath_relative_with_extension(string token)
+    {
+        Assert.True(ShellTokenizer.LooksLikePath(token));
+    }
+
+    // Path traversal in unanchored token — treated as path
+    [Theory]
+    [InlineData("foo/../bar")]
+    [InlineData("workspace/project/../other/file.txt")]
+    public void LooksLikePath_traversal_component(string token)
+    {
+        Assert.True(ShellTokenizer.LooksLikePath(token));
+    }
+
+    // Backslash always indicates Windows path
+    [Theory]
+    [InlineData("src\\main.cs")]
+    [InlineData("folder\\subfolder")]
+    public void LooksLikePath_backslash(string token)
+    {
+        Assert.True(ShellTokenizer.LooksLikePath(token));
+    }
 }

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -8,7 +8,8 @@ namespace Netclaw.Security;
 /// <summary>
 /// Shared verb-chain prefix matcher used for tool approval grants. An approved
 /// pattern matches a candidate exactly or as a verb-chain prefix on a space
-/// boundary — so "git" approves "git push" but never "github-cli".
+/// boundary — so "git push" approves "git push origin main" but never
+/// "github-cli".
 /// </summary>
 public static class ApprovalPatternMatching
 {
@@ -25,14 +26,10 @@ public static class ApprovalPatternMatching
             if (!candidate.StartsWith(approved, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            // Multi-token patterns always prefix-match on space boundary.
+            // Multi-token patterns prefix-match on a space boundary. Single-token
+            // patterns remain exact-only so grants do not silently widen from
+            // "cat" to every path-bearing cat invocation.
             if (approved.Contains(' ', StringComparison.Ordinal))
-                return true;
-
-            // Single-token path-aware verbs (cat, grep, bash, etc.) wildcard-match
-            // so "cat" covers "cat /etc/hosts". Non-path-aware single tokens (gh, echo)
-            // require exact match only.
-            if (ShellTokenizer.PathAwareVerbs.Contains(approved))
                 return true;
         }
 

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -19,15 +19,21 @@ public static class ApprovalPatternMatching
             if (string.Equals(candidate, approved, StringComparison.OrdinalIgnoreCase))
                 return true;
 
-            // Only do prefix matching for multi-token patterns (contains space).
-            // Single-token patterns like "gh" should not match "gh pr".
-            if (approved.Contains(" ", StringComparison.Ordinal)
-                && candidate.StartsWith(approved, StringComparison.OrdinalIgnoreCase)
-                && candidate.Length > approved.Length
-                && candidate[approved.Length] == ' ')
-            {
+            if (candidate.Length <= approved.Length || candidate[approved.Length] != ' ')
+                continue;
+
+            if (!candidate.StartsWith(approved, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Multi-token patterns always prefix-match on space boundary.
+            if (approved.Contains(' ', StringComparison.Ordinal))
                 return true;
-            }
+
+            // Single-token path-aware verbs (cat, grep, bash, etc.) wildcard-match
+            // so "cat" covers "cat /etc/hosts". Non-path-aware single tokens (gh, echo)
+            // require exact match only.
+            if (ShellTokenizer.PathAwareVerbs.Contains(approved))
+                return true;
         }
 
         return false;

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -278,6 +278,85 @@ public static class ShellTokenizer
             || token.Contains('*', StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Returns true if a token is identifiable as a local filesystem path.
+    /// Uses positive identification (anchored prefixes + extension heuristic)
+    /// rather than broad "contains a slash" matching to avoid false positives
+    /// on URIs, git refs, docker images, sed expressions, and MIME types.
+    /// </summary>
+    public static bool LooksLikePath(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return false;
+
+        if (token.StartsWith('-'))
+            return false;
+
+        // URIs
+        if (token.Contains("://", StringComparison.Ordinal))
+            return false;
+
+        // Anchored paths — definitively filesystem references
+        if (token.StartsWith('/'))
+            return true;
+        if (token.StartsWith("./", StringComparison.Ordinal) || token.StartsWith("../", StringComparison.Ordinal))
+            return true;
+        if (token.StartsWith('~'))
+            return true;
+        if (token.StartsWith("$HOME", StringComparison.Ordinal) || token.StartsWith("${HOME}", StringComparison.Ordinal))
+            return true;
+        // Windows drive letter: C:\ or C:/ (case-insensitive)
+        if (token.Length >= 3 && char.IsAsciiLetter(token[0]) && token[1] == ':'
+            && (token[2] == '/' || token[2] == '\\'))
+            return true;
+        // UNC path: \\server\share
+        if (token.StartsWith("\\\\", StringComparison.Ordinal))
+            return true;
+
+        // Backslash always indicates a Windows-style path
+        if (token.Contains('\\', StringComparison.Ordinal))
+            return true;
+
+        // Unanchored tokens with forward slashes — disambiguate using exclusions
+        // and the file-extension heuristic
+        if (token.Contains('/', StringComparison.Ordinal))
+        {
+            // Colon before first slash = docker image, port, or key:value
+            var firstSlash = token.IndexOf('/', StringComparison.Ordinal);
+            if (token.IndexOf(':', StringComparison.Ordinal) is var colonIdx && colonIdx >= 0 && colonIdx < firstSlash)
+                return false;
+
+            // npm scoped package: @scope/name
+            if (token.StartsWith('@') && token.IndexOf('/', 1) == token.LastIndexOf('/'))
+                return false;
+
+            // sed/tr expression: s/pattern/replacement/ or y/abc/xyz/
+            if ((token.StartsWith("s/", StringComparison.Ordinal) || token.StartsWith("y/", StringComparison.Ordinal))
+                && token.Count(c => c == '/') >= 3)
+                return false;
+
+            // Path traversal component is always a path signal
+            if (token.Contains("/../", StringComparison.Ordinal) || token.EndsWith("/..", StringComparison.Ordinal))
+                return true;
+
+            // File extension in the last component → treat as relative path
+            // (src/main.rs, config/app.json). Git refs and docker images don't
+            // have extensions.
+            var lastSlash = token.LastIndexOf('/');
+            if (lastSlash >= 0 && lastSlash < token.Length - 1)
+            {
+                var lastComponent = token.AsSpan(lastSlash + 1);
+                var dotIdx = lastComponent.LastIndexOf('.');
+                if (dotIdx > 0 && dotIdx < lastComponent.Length - 1)
+                    return true;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
     internal static string TrimShellPunctuation(string token)
     {
         return token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -332,7 +332,7 @@ public static class ShellTokenizer
 
             // sed/tr expression: s/pattern/replacement/ or y/abc/xyz/
             if ((token.StartsWith("s/", StringComparison.Ordinal) || token.StartsWith("y/", StringComparison.Ordinal))
-                && token.Count(c => c == '/') >= 3)
+                && CountChar(token, '/') >= 3)
                 return false;
 
             // Path traversal component is always a path signal
@@ -360,6 +360,18 @@ public static class ShellTokenizer
     internal static string TrimShellPunctuation(string token)
     {
         return token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');
+    }
+
+    private static int CountChar(string value, char target)
+    {
+        var count = 0;
+        foreach (var c in value)
+        {
+            if (c == target)
+                count++;
+        }
+
+        return count;
     }
 
     private static void FlushSegment(StringBuilder current, List<string> segments)

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -17,6 +17,28 @@ public static class ShellTokenizer
     private static readonly string[] CompoundOperators = ["&&", "||"];
 
     /// <summary>
+    /// Verbs that can exfiltrate or mutate file contents when targeting protected paths.
+    /// Used by <see cref="ToolPathPolicy"/> for the protected-path heuristic.
+    /// </summary>
+    internal static readonly HashSet<string> HighRiskVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cat", "less", "more", "head", "tail", "grep", "rg", "find", "jq", "awk", "sed", "strings", "xxd", "hexdump",
+        "cp", "mv", "tar", "zip", "unzip", "scp", "rsync", "curl", "wget", "nc", "ncat",
+        "python", "python3", "node", "ruby", "perl", "php",
+        "bash", "sh", "zsh"
+    };
+
+    /// <summary>
+    /// Verbs whose first positional argument is security-relevant for approval
+    /// pattern extraction. Superset of <see cref="HighRiskVerbs"/> — includes
+    /// benign-but-path-consuming verbs like <c>ls</c>.
+    /// </summary>
+    internal static readonly HashSet<string> PathAwareVerbs = new(HighRiskVerbs, StringComparer.OrdinalIgnoreCase)
+    {
+        "ls"
+    };
+
+    /// <summary>
     /// Tokenizes a shell command string, respecting single and double quotes.
     /// Strips quote delimiters from tokens.
     /// </summary>
@@ -129,6 +151,8 @@ public static class ShellTokenizer
     /// command. Stops at the first token that looks like a flag (starts with -)
     /// or an argument (path, URL, etc.), and caps at <paramref name="maxDepth"/>
     /// tokens (default: 2) to avoid capturing positional arguments as subcommands.
+    /// For path-aware verbs (cat, grep, bash, etc.), appends the first non-flag
+    /// argument so the approval pattern captures what the command operates on.
     /// </summary>
     public static string ExtractVerbChain(string command, int maxDepth = 2)
     {
@@ -153,6 +177,22 @@ public static class ShellTokenizer
                 break;
 
             verbParts.Add(trimmed);
+        }
+
+        if (verbParts.Count == 1 && PathAwareVerbs.Contains(verbParts[0]))
+        {
+            for (var i = 1; i < tokens.Count; i++)
+            {
+                var trimmed = TrimShellPunctuation(tokens[i]);
+                if (trimmed.Length == 0)
+                    continue;
+
+                if (trimmed.StartsWith('-'))
+                    continue;
+
+                verbParts.Add(trimmed);
+                break;
+            }
         }
 
         return string.Join(' ', verbParts);

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -357,6 +357,24 @@ public static class ShellTokenizer
         return false;
     }
 
+    /// <summary>
+    /// Returns true when the pattern is a single-token shell approval for a
+    /// path-aware verb such as <c>cat</c> or <c>bash</c>.
+    /// </summary>
+    public static bool IsSingleTokenPathAwarePattern(string pattern)
+    {
+        var trimmed = TrimShellPunctuation(pattern).Trim();
+        if (trimmed.Length == 0)
+            return false;
+
+        if (trimmed.IndexOfAny([' ', '\t', '\n', '\r']) >= 0)
+        {
+            return false;
+        }
+
+        return PathAwareVerbs.Contains(trimmed);
+    }
+
     internal static string TrimShellPunctuation(string token)
     {
         return token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -22,12 +22,6 @@ public sealed class ToolPathPolicy
     private readonly HashSet<string> _readDeniedPaths;
     private readonly HashSet<string> _shellDeniedPaths;
     private readonly HashSet<string> _commandIndicators;
-    private static readonly HashSet<string> HighRiskVerbs = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "cat", "less", "more", "head", "tail", "grep", "rg", "find", "jq", "awk", "sed", "strings", "xxd", "hexdump",
-        "cp", "mv", "tar", "zip", "unzip", "scp", "rsync", "curl", "wget", "nc", "ncat",
-        "python", "python3", "node", "ruby", "perl", "php"
-    };
 
     public ToolPathPolicy(IEnumerable<string> deniedPaths)
     {
@@ -161,7 +155,7 @@ public sealed class ToolPathPolicy
         foreach (var token in tokens)
         {
             var verb = ShellTokenizer.TrimShellPunctuation(token);
-            if (HighRiskVerbs.Contains(verb))
+            if (ShellTokenizer.HighRiskVerbs.Contains(verb))
                 return true;
         }
 

--- a/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
+++ b/src/Netclaw.Tools.Abstractions/IParentApprovalBridge.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="IParentApprovalBridge.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Decision returned by a parent session's approval channel in response to a
+/// tool approval request from a sub-agent.
+/// </summary>
+public enum ParentApprovalDecision
+{
+    ApprovedOnce,
+    ApprovedSession,
+    ApprovedAlways,
+    Denied,
+    TimedOut
+}
+
+/// <summary>
+/// Bridge that allows sub-agents to route approval requests back to their parent
+/// interactive session. Defined in the tools abstraction layer so
+/// <see cref="ToolExecutionContext"/> can reference it without depending on actor types.
+/// </summary>
+public interface IParentApprovalBridge
+{
+    /// <summary>
+    /// Emits an approval request to the parent session and waits for the user's decision.
+    /// </summary>
+    Task<ParentApprovalDecision> RequestApprovalAsync(
+        ToolCallId callId,
+        string toolName,
+        string displayText,
+        IReadOnlyList<string> unapprovedPatterns,
+        CancellationToken ct);
+}

--- a/src/Netclaw.Tools.Abstractions/IShellTrustZonePolicy.cs
+++ b/src/Netclaw.Tools.Abstractions/IShellTrustZonePolicy.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="IShellTrustZonePolicy.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Tools;
+
+/// <summary>
+/// Provides trust zone roots for shell command path validation.
+/// Non-interactive channels (reminders, webhooks) use this to sandbox
+/// shell commands to allowed filesystem paths.
+/// </summary>
+public interface IShellTrustZonePolicy
+{
+    /// <summary>
+    /// Returns the set of allowed filesystem root directories for the given
+    /// execution context. Shell commands with path arguments outside these
+    /// roots are denied for non-interactive channels.
+    /// </summary>
+    IReadOnlyList<string> GetTrustZoneRoots(ToolExecutionContext context);
+}

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -102,18 +102,10 @@ public sealed class ToolExecutionContext
     public Func<object, string, CancellationToken, Task<object>>? SpawnChildActor { get; set; }
 
     /// <summary>
-    /// Opaque reference to the parent session's approval channel. Typed as <c>object</c>
-    /// to avoid coupling the tools abstraction layer to the actor-level approval types.
-    /// Cast to <c>IApprovalChannel</c> in <c>Netclaw.Actors</c>.
+    /// Parent session's approval bridge for sub-agent approval chaining. When set,
+    /// the sub-agent can route approval requests back to the interactive user.
     /// </summary>
-    public object? ParentApprovalChannel { get; set; }
-
-    /// <summary>
-    /// Opaque callback for emitting approval requests to the parent session. Typed as
-    /// <c>object</c> to avoid coupling. Cast to <c>Action&lt;ToolInteractionRequest&gt;</c>
-    /// in <c>Netclaw.Actors</c>.
-    /// </summary>
-    public object? EmitApprovalRequestCallback { get; set; }
+    public IParentApprovalBridge? ApprovalBridge { get; set; }
 
     /// <summary>
     /// Tool name granted a one-shot approval for the current execution retry.

--- a/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolExecutionContext.cs
@@ -102,6 +102,20 @@ public sealed class ToolExecutionContext
     public Func<object, string, CancellationToken, Task<object>>? SpawnChildActor { get; set; }
 
     /// <summary>
+    /// Opaque reference to the parent session's approval channel. Typed as <c>object</c>
+    /// to avoid coupling the tools abstraction layer to the actor-level approval types.
+    /// Cast to <c>IApprovalChannel</c> in <c>Netclaw.Actors</c>.
+    /// </summary>
+    public object? ParentApprovalChannel { get; set; }
+
+    /// <summary>
+    /// Opaque callback for emitting approval requests to the parent session. Typed as
+    /// <c>object</c> to avoid coupling. Cast to <c>Action&lt;ToolInteractionRequest&gt;</c>
+    /// in <c>Netclaw.Actors</c>.
+    /// </summary>
+    public object? EmitApprovalRequestCallback { get; set; }
+
+    /// <summary>
     /// Tool name granted a one-shot approval for the current execution retry.
     /// This is not persisted and only applies to the current in-memory context.
     /// </summary>


### PR DESCRIPTION
## Goal

Closes #842.
Supersedes #849.

Make reminders, webhooks, and sub-agents functional with approval-gated tools instead of silently auto-denying everything.

## What was accomplished

### 1. Non-interactive approval store check
Reminders and webhooks no longer blanket auto-deny approval-gated tools. They fall through to the persistent approval store (`tool-approvals.json`). Pre-approved command patterns execute; unapproved ones fail with a clear error the agent can act on.

### 2. Sub-agent approval chaining via `IParentApprovalBridge`
Sub-agents spawned from interactive sessions inherit the parent's approval channel, requester identity, and adopted-context metadata. When a sub-agent needs an unapproved tool, the request routes back to the parent session's user through a typed contract.

### 3. Hierarchical scope approval lookup
Sub-agents inherit parent session approvals via scope ID chain walking. Scope format: `"parent-session/subagent/name/runId"` and the approval actor walks up `/subagent/` boundaries to find parent grants.

### 4. Shell trust zone enforcement (fail-closed)
Non-interactive channels are sandboxed: shell commands with path arguments or explicit working directories must fall within trust zone roots. Nested shell wrappers such as `bash -c` are inspected recursively. If no `IShellTrustZonePolicy` is configured, trust-zone-sensitive shell commands are denied. Interactive channels are unaffected.

### 5. Path-aware shell approval matching
Path-aware verbs (`cat`, `grep`, `bash`, `find`, etc.) extract approval patterns that include the targeted path when present, so approvals reflect what the command operates on. Single-token path-aware approvals now stay exact-only instead of widening to arbitrary path-bearing invocations. Existing stale single-token shell approvals become inert by design, and `doctor` now warns users to reset the approval file.

### 6. Approve-once isolation for sub-agents
Sub-agent retries apply transient one-time approvals to a retry-local execution context so `Approve Once` cannot bleed across parallel tool calls or later iterations.

### 7. Agent guidance
Updated `netclaw-operations` with stricter reminder approval guidance, trust-zone behavior, and approval reset instructions for stale shell grants.

## Security model

- Hard-deny paths (secrets, key material, disallowed config paths) and hard-deny verbs remain unchanged and still block regardless of approval store contents
- Trust zones are fail-closed: no policy configured means deny
- Path-aware single-token shell approvals do not wildcard-match later path-bearing invocations
- Approvals flow downward only (parent to sub-agent), never upward
- Sub-agent prompts retain original requester identity so unrelated users in a shared channel cannot approve them

## Validation

- [x] `dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj -c Release`
- [x] `dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj -c Release`
- [x] `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj -c Release`
- [x] `dotnet slopwatch analyze`
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- [x] Regression tests for requester propagation, trust-zone enforcement, nested shell wrappers, stale approval warnings, and sub-agent approve-once isolation
- [ ] Manual: create reminder with pre-approved shell command and verify it fires successfully
- [ ] Manual: trigger an approval-gated tool from a sub-agent and verify the parent session prompts the original requester
- [ ] Manual: reminder attempts a path outside the trust zone and fails with the expected denial reason

## Related

- #852 — tech debt: consolidate duplicated path utilities
