### PR TITLE
ci: enable Docker image publishing to GHCR on release

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -228,8 +228,6 @@ jobs:
   publish-docker:
     name: Publish Docker Image (multi-arch)
     needs: publish-binaries
-    # Disabled until GHCR image path is updated for the new org
-    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Removes the `if: false` guard that disabled the `publish-docker` job in `publish_release_binaries.yml`
- The job was blocked pending the org migration to `netclaw-dev`; the repo is now at `netclaw-dev/netclaw` so the GHCR image path (`ghcr.io/netclaw-dev/netclaw`) is already correct

## Test plan

- [ ] Verify workflow file parses cleanly (no YAML errors) via CI
- [ ] On next release tag push, confirm `publish-docker` job runs and image lands at `ghcr.io/netclaw-dev/netclaw:<tag>`
- [ ] After first publish, set GHCR package visibility to Public