### PR TITLE
fix: include schema files in Docker image for netclaw doctor

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,7 @@ WORKDIR /opt/netclaw
 # Self-contained single-file binaries. TARGETARCH selects the right
 # platform directory (amd64 or arm64).
 COPY publish/cli-${TARGETARCH}/netclaw /opt/netclaw/cli/netclaw
+COPY publish/cli-${TARGETARCH}/Schemas/ /opt/netclaw/cli/Schemas/
 COPY publish/daemon-${TARGETARCH}/netclawd /opt/netclaw/daemon/netclawd
 COPY docker/entrypoint.sh /opt/netclaw/entrypoint.sh
 

--- a/scripts/docker/build-image.sh
+++ b/scripts/docker/build-image.sh
@@ -89,10 +89,12 @@ case "$RID" in
     *) echo "ERROR: unsupported RID '$RID' for Docker build" >&2; exit 1 ;;
 esac
 
-# Symlink the single-arch publish output to the arch-suffixed paths the
-# Dockerfile expects (publish/cli-{arch}/, publish/daemon-{arch}/).
-ln -sfn cli "publish/cli-${DOCKER_ARCH}"
-ln -sfn daemon "publish/daemon-${DOCKER_ARCH}"
+# Hard-link copy the single-arch publish output to the arch-suffixed paths
+# the Dockerfile expects (publish/cli-{arch}/, publish/daemon-{arch}/).
+# Symlinks don't survive Docker Buildx context transfer reliably.
+rm -rf "publish/cli-${DOCKER_ARCH}" "publish/daemon-${DOCKER_ARCH}" 2>/dev/null || true
+cp -rl publish/cli "publish/cli-${DOCKER_ARCH}"
+cp -rl publish/daemon "publish/daemon-${DOCKER_ARCH}"
 
 echo "→ Building image $IMAGE_TAG..."
 docker build \


### PR DESCRIPTION
## Summary

- Copies the `Schemas/` directory alongside the CLI binary in the Docker image so `netclaw doctor` can find the config schema at runtime

Fixes #860

## Root Cause

`dotnet publish /p:PublishSingleFile=true` places content files (like the JSON schema) next to the single-file binary in the output directory. The Dockerfile copied only the binary itself, leaving the `Schemas/` directory behind.

## Test plan

- [ ] `validate_docker_image` CI workflow passes (builds image from scratch)
- [ ] `docker run --rm <image> ls /opt/netclaw/cli/Schemas/` shows `netclaw-config.v1.schema.json`
- [ ] `docker run --rm <image> netclaw doctor` no longer reports Config Schema as FAIL