### PR TITLE
feat: relax exposure mode strictness for container/proxy deployments (#862)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.23.0"
+  version: "1.24.0"
 ---
 
 # Netclaw Operations
@@ -472,6 +472,17 @@ Doctor checks include `exposure-mode`, which validates that the `Daemon`
 config section (if present) specifies a supported exposure mode and that
 the corresponding tunnel integration is reachable.
 
+Exposure diagnostics are fail-closed:
+- `reverse-proxy` requires at least one remote authentication path and rejects
+  loopback final hops (`127.0.0.1`, `::1`, `localhost`) because loopback
+  auto-auth is reserved for true local operator traffic.
+- `Daemon.TrustedProxies` entries must be literal IPs or CIDR strings; malformed
+  values fail loudly in schema validation, `netclaw doctor`, and daemon startup.
+- Tunnel-backed modes (`tailscale-serve`, `tailscale-funnel`,
+  `cloudflare-tunnel`) require their local tunnel process by default.
+  `Daemon.SkipTunnelProcessCheck=true` is an explicit opt-in only for sidecar or
+  host-managed tunnel topologies; all other exposure requirements still apply.
+
 Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
 including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),
 `~/.netclaw/client/config.json` (local CLI endpoint state),
@@ -552,6 +563,10 @@ shell_execute: netclaw daemon pair
 
 This generates a single-use pairing code (8 chars, 5-minute TTL). The code
 generation endpoint is loopback-only.
+
+If `netclaw daemon pair` fails immediately after an exposure-mode change, run
+`netclaw doctor` and inspect `~/.netclaw/logs/crash-*.log` for the specific
+startup validation failure instead of assuming a generic readiness timeout.
 
 **Client side** (remote device):
 

--- a/openspec/changes/relax-exposure-strictness/.openspec.yaml
+++ b/openspec/changes/relax-exposure-strictness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/relax-exposure-strictness/.openspec.yaml
+++ b/openspec/changes/relax-exposure-strictness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/relax-exposure-strictness/design.md
+++ b/openspec/changes/relax-exposure-strictness/design.md
@@ -1,0 +1,257 @@
+## Context
+
+Netclaw already has the core pieces of a fail-closed exposure story in code:
+
+- `hub-auth` reserves auto-authentication for loopback connections only
+- `ExposureModeValidationService` already blocks non-local exposure when no remote
+  authentication path exists
+- `ExposureModeDoctorCheck` validates some exposure prerequisites offline
+- the init wizard writes config and then polls daemon readiness
+
+But the current planning artifacts do not protect one subtle but critical boundary:
+loopback trust is about the final TCP hop observed by Netclaw, not about where the
+original caller came from. In reverse-proxy mode, if the last hop into Netclaw is
+`127.0.0.1`, `::1`, or `localhost`, then any forwarded-header mistake would make
+remote traffic look identical to a trusted local operator connection. That violates
+PRD-002's fail-closed posture.
+
+The current doctor behavior also lags startup behavior. Startup already refuses
+non-local exposure when there is no remote auth path, but doctor can still report a
+pass in cases that startup will reject. Issue #862 also highlights an operator UX
+gap: startup validation errors currently surface poorly through setup and health
+check flows. The original issue scope also covered sidecar / host-managed tunnel
+topologies where tunnel process detection is too coarse because the tunnel runs
+outside the daemon's PID namespace or on a sibling host component.
+
+This change tightens the planning artifacts so all validation surfaces preserve the
+same trust boundary and fail-loud semantics, while preserving an explicit opt-in for
+tunnel modes that cannot satisfy local process detection.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve loopback auto-auth exclusively for true local operator traffic.
+- Forbid reverse-proxy mode configurations where the final hop into Netclaw is
+  loopback.
+- Allow same-host reverse-proxy deployments only when the final hop uses a
+  non-loopback internal IP.
+- Allow tunnel-sidecar / host-managed tunnel deployments to bypass local process
+  detection only when the operator explicitly opts in via
+  `Daemon.SkipTunnelProcessCheck`.
+- Ensure doctor and startup enforce the same remote-auth prerequisites for
+  reverse-proxy mode.
+- Ensure malformed `TrustedProxies` entries fail loudly and consistently across
+  config parsing, doctor, and startup.
+- Ensure setup/health-check flows surface startup validation failures as clean,
+  actionable operator messages.
+
+**Non-Goals:**
+
+- Implementing a new authentication scheme.
+- Auto-correcting proxy configs or synthesizing trusted-proxy defaults.
+- Auto-detecting or silently assuming tunnel health when process detection is
+  skipped.
+- Relaxing the existing loopback auth contract for convenience.
+- Managing nginx/Caddy/Traefik/HAProxy configuration directly.
+
+## Decisions
+
+### D1. Reverse-proxy trust is evaluated on the final hop, not the original client claim
+
+When Netclaw runs behind a reverse proxy, the security boundary is the address of the
+immediate peer connection into Netclaw plus the set of explicitly trusted proxies.
+Forwarded headers are only meaningful after the direct peer is validated as a trusted
+proxy.
+
+Rationale:
+
+- This preserves the existing loopback auth model from `hub-auth`.
+- It avoids blessing remote traffic just because a proxy can emit
+  `X-Forwarded-For` / `Forwarded` headers.
+- It matches PRD-002's default-deny posture: trust must be explicit at each hop.
+
+Alternative considered:
+
+- Allow loopback final hop when forwarded headers are present. Rejected because
+  missing, stripped, or misordered headers would collapse remote and local traffic
+  into the same auto-authenticated path.
+
+### D2. Reverse-proxy mode forbids loopback final hops
+
+If reverse-proxy mode is configured, Netclaw rejects configurations where the final
+hop from proxy to daemon uses `127.0.0.1`, `::1`, or `localhost`. This includes
+same-host proxies.
+
+Allowed same-host topology example:
+
+- proxy listens on public/tailnet interface
+- proxy forwards to daemon on a host-private non-loopback address such as
+  `192.168.x.x`, `10.x.x.x`, or another explicitly configured internal address
+- proxy source address or network is listed in `TrustedProxies`
+
+Rejected topology example:
+
+- nginx/Caddy/Traefik on the same host forwards to `http://127.0.0.1:5199`
+
+Rationale:
+
+- A loopback final hop is indistinguishable from a true local operator connection to
+  the loopback auth scheme when forwarded-header trust fails.
+- Same-host convenience is not a valid reason to blur the root-of-trust boundary.
+
+Alternative considered:
+
+- Allow same-host loopback forwarding with a warning. Rejected because that would
+  preserve a misconfiguration that can escalate remote traffic into local trust.
+
+### D3. `TrustedProxies` is fail-loud and all-or-nothing
+
+Every `TrustedProxies` entry must parse as a valid IP address or CIDR. If any entry
+is malformed, configuration validation, doctor, and startup all fail loudly with the
+specific bad value named. There is no partial acceptance of the valid subset.
+
+Examples that must fail:
+
+- `"not-an-ip"`
+- `"127.0.0.1/999"`
+- `"10.0.0.0/not-a-mask"`
+- malformed IPv6/CIDR strings
+
+Rationale:
+
+- Partial parsing silently changes the trust boundary.
+- Operators need deterministic feedback so they know the live trust graph matches
+  the declared config exactly.
+
+Alternative considered:
+
+- Ignore malformed entries and keep the valid ones. Rejected because it silently
+  narrows or broadens trust depending on operator intent and violates the repo's
+  no-silent-fallback rule.
+
+### D4. Tunnel process detection stays fail-closed by default, with explicit operator bypass
+
+For `tailscale-serve`, `tailscale-funnel`, and `cloudflare-tunnel`, Netclaw keeps
+the current hard-fail process prerequisite by default. If the required process is
+not visible locally, startup and doctor reject the configuration.
+
+Operators may explicitly set `Daemon.SkipTunnelProcessCheck=true` to bypass only the
+local process-liveness probe for those tunnel-backed modes. This supports sidecar,
+container sibling, or host-managed tunnel topologies where the tunnel is real but
+not discoverable from the Netclaw process.
+
+The bypass does not relax any other validation:
+
+- remote-auth remains required for non-local exposure
+- reverse-proxy final-hop loopback rejection remains unchanged
+- malformed `TrustedProxies` still fail loudly
+- doctor and startup must agree on whether the process check was skipped
+
+Rationale:
+
+- Process detection is a coarse heuristic, not the actual trust boundary.
+- Sidecar and host-managed deployments are legitimate operator-managed topologies.
+- Requiring an explicit config flag preserves fail-closed defaults and avoids silent
+  weakening of tunnel validation.
+
+Alternative considered:
+
+- Automatically skip process detection in containers or when a tunnel endpoint looks
+  externally reachable. Rejected because that introduces hidden heuristics on a
+  security-relevant startup gate.
+
+### D5. Doctor and startup share the same reverse-proxy and tunnel remote-auth rules
+
+Reverse-proxy mode requires the same remote-auth availability at doctor time that it
+requires at startup time: if Netclaw is reachable beyond pure local mode, doctor must
+reject configs that have no viable remote authentication path.
+
+At minimum, doctor must align with startup on:
+
+- required tunnel / proxy prerequisites for the selected exposure mode
+- explicit `SkipTunnelProcessCheck` handling for tunnel-backed modes
+- required remote-auth availability for non-local exposure
+- reverse-proxy final-hop loopback rejection
+- invalid `TrustedProxies` rejection
+
+Rationale:
+
+- `netclaw doctor` is supposed to be an operator preflight, not a weaker advisory
+  layer.
+- A green doctor result for a config that startup rejects is operationally misleading.
+
+Alternative considered:
+
+- Keep doctor advisory-only for remote-auth gaps. Rejected because startup already
+  treats these as hard failures.
+
+### D6. Setup and health-check flows surface startup validation failures as structured results
+
+When daemon startup fails because `ExposureModeValidationService` rejects the config,
+init and health-check flows must show a structured failure item containing the
+validation message and remediation text. They must not degrade to:
+
+- a raw crash/stack trace
+- a generic "daemon did not become ready" timeout when process startup already
+  failed synchronously
+
+The startup failure should be captured close to `DaemonManager.Start()` and surfaced
+in the wizard/health-check UI as a configuration failure.
+
+Rationale:
+
+- This satisfies issue #862's graceful setup requirement.
+- It preserves fail-closed behavior while making the failure understandable.
+
+Alternative considered:
+
+- Rely on daemon logs only. Rejected because setup and doctor are operator-facing
+  guidance surfaces and should not require log spelunking for expected validation
+  failures.
+
+## Risks / Trade-offs
+
+- [Risk] Some existing same-host reverse-proxy setups may rely on loopback upstreams.
+  -> Mitigation: fail loudly with explicit guidance to move the daemon bind/final hop
+  to a non-loopback internal IP.
+- [Risk] Doctor parity may require new probing or config-reading paths for remote-auth
+  availability. -> Mitigation: reuse the same validation helpers as startup where
+  possible instead of duplicating logic.
+- [Risk] Operators may set `SkipTunnelProcessCheck` and assume Netclaw is now
+  validating tunnel health some other way. -> Mitigation: document that the flag only
+  disables local process detection and shifts tunnel-liveness responsibility fully to
+  the operator.
+- [Risk] Strict all-or-nothing `TrustedProxies` parsing may break configs that were
+  previously tolerated. -> Mitigation: name the exact bad entry and provide valid
+  examples in remediation.
+- [Risk] Setup UI work may still miss some daemon crash paths unrelated to exposure
+  validation. -> Mitigation: scope this change specifically to validation failures from
+  `ExposureModeValidationService`, then generalize later if needed.
+
+## Migration Plan
+
+1. Add reverse-proxy trust-boundary requirements to `daemon-exposure` and align them
+   with `hub-auth`.
+2. Add or extend config/schema contracts for reverse-proxy mode,
+   `SkipTunnelProcessCheck`, and `TrustedProxies`.
+3. Centralize validation helpers so doctor and startup share the same decision rules,
+   including the explicit tunnel process-check bypass.
+4. Update init / health-check flows to surface startup validation messages directly.
+5. Add regression tests for loopback final-hop rejection, explicit process-check
+   bypass for tunnel-sidecar topologies, malformed trusted-proxy values,
+   doctor/startup parity, and graceful setup reporting.
+
+Rollback:
+
+- Revert the stricter reverse-proxy validation and onboarding surfacing together.
+- If rollback is required operationally, operators can return to `ExposureMode=local`
+  or a non-proxy tunnel mode until the stricter rules are restored.
+
+## Open Questions
+
+- What is the final wire name for reverse-proxy exposure mode and its config shape in
+  `DaemonConfig`?
+- Should doctor be able to infer remote-auth availability from bootstrap paired-device
+  files alone, or must it also validate additional scheme registrations indirectly via
+  config?

--- a/openspec/changes/relax-exposure-strictness/design.md
+++ b/openspec/changes/relax-exposure-strictness/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The daemon's `ExposureModeValidationService` enforces a hard process-detection check at startup: for non-local exposure modes it calls `Process.GetProcessesByName("tailscaled")` (or `"cloudflared"`) and throws `InvalidOperationException` if not found. This assumes the tunnel process shares a PID namespace with the daemon — true on bare metal, false in Docker/K8s with sidecar tunnels.
+
+The existing exposure mode enum (`Local`, `TailscaleServe`, `TailscaleFunnel`, `CloudflareTunnel`) does not accommodate operators who run their own reverse proxy infrastructure. There is no forwarded headers middleware anywhere in the pipeline, so IP-based security (rate limiter, `PairingExchangeGuard`, `LoopbackAuthenticationHandler`) operates on raw `Connection.RemoteIpAddress` — which is the proxy's IP when behind any intermediary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Allow daemon to start when tunnel process runs in a sidecar/host (different PID namespace)
+- Support operator-managed reverse proxy deployments without mandating a specific tunnel provider
+- Enable correct client IP resolution via standard `X-Forwarded-For` header processing
+- Preserve all existing security invariants (auth requirement, loopback trust boundary, fail-closed defaults)
+
+**Non-Goals:**
+
+- Implementing Tailscale identity header (`Tailscale-User-Login`) as an auth scheme (future work)
+- Cloudflare Access JWT validation as an auth scheme (future work)
+- Auto-detecting proxy topology or container networking
+- TLS termination at the daemon level (proxies handle TLS)
+
+## Decisions
+
+### Decision 1: `SkipTunnelProcessCheck` flag rather than soft-warning by default
+
+**Choice:** Add an opt-in boolean rather than changing the default behavior.
+
+**Rationale:** Bare-metal operators rely on the hard failure to detect when their tunnel crashes. Changing it to a warning globally would silently degrade safety for the majority of existing deployments. The flag is narrow: it only suppresses process detection, not the auth guard.
+
+**Alternatives considered:**
+- Always warn (never throw): Loses safety net for bare-metal users
+- Connectivity probe instead of process check: Requires the tunnel endpoint to be known at startup, adds network dependency to startup path, and doesn't work for all proxy types
+
+### Decision 2: `reverse-proxy` as a new enum value with no required process
+
+**Choice:** Add `ExposureMode.ReverseProxy` that returns `null` from `GetRequiredProcessName()`, skipping the process check entirely.
+
+**Rationale:** This mode declares intent ("I have my own proxy") without coupling to a specific technology. The auth guard still runs — the security posture is identical to `tailscale-funnel` minus the process check. The name `reverse-proxy` is industry-standard and self-documenting.
+
+**Alternatives considered:**
+- `network` mode: Too vague — implies raw network exposure without protection
+- Just use `local` + bind `0.0.0.0`: Skips the auth guard (local mode doesn't require paired devices), creating a security hole
+
+### Decision 3: Explicit `TrustedProxies` config with ASP.NET `ForwardedHeadersMiddleware`
+
+**Choice:** Add `Daemon.TrustedProxies` (string array of IPs/CIDRs) that configures `ForwardedHeadersOptions.KnownProxies`/`KnownNetworks`. Middleware only activates when the list is non-empty AND mode is non-local.
+
+**Rationale:** This is the standard ASP.NET Core pattern. The middleware rewrites `RemoteIpAddress` before any authentication handler runs, so all existing IP consumers benefit without code changes. The explicit list prevents header-spoofing attacks — untrusted sources cannot influence IP resolution.
+
+**Alternatives considered:**
+- Trust all `X-Forwarded-For` headers: Trivially spoofable, violates default-deny posture
+- Per-mode automatic trust (e.g., always trust Docker bridge): Too magical, breaks in non-standard networks
+
+### Decision 4: Middleware placement before authentication
+
+**Choice:** Insert `UseForwardedHeaders()` immediately after routing, before `UseAuthentication()`.
+
+**Rationale:** `LoopbackAuthenticationHandler` must see the resolved client IP, not the proxy IP. The rate limiter (configured as endpoint middleware) also needs the real IP. ASP.NET Core's middleware pipeline processes in registration order — forwarded headers must resolve before any security layer inspects `RemoteIpAddress`.
+
+**Failure modes:**
+- If middleware is placed AFTER auth: Loopback handler would see proxy IP, potentially granting operator claims to the proxy itself (if proxy is on localhost). This would be a privilege escalation.
+- If `TrustedProxies` is misconfigured (wrong IPs): Middleware ignores the header, `RemoteIpAddress` stays as connection IP. Degraded rate limiting but no security bypass since auth still requires bearer token.
+
+### Decision 5: `ForwardLimit = 1` default
+
+**Choice:** Only trust one hop of `X-Forwarded-For` by default.
+
+**Rationale:** Most deployments have exactly one proxy in front of the daemon. Multi-hop scenarios (CDN → load balancer → daemon) are uncommon in self-hosted agent deployments. Operators with multiple hops can increase this via future `Daemon.ForwardLimit` config.
+
+## Risks / Trade-offs
+
+- **[Risk] Operator forgets TrustedProxies when using reverse-proxy mode** → Doctor check warns "No trusted proxies configured; IP-based rate limiting will use proxy IP." Degraded but not insecure (auth still required).
+
+- **[Risk] Operator sets SkipTunnelProcessCheck but tunnel is genuinely down** → Warning log at startup; daemon starts but tunnel traffic won't reach it. No data loss or security issue — requests simply fail to arrive.
+
+- **[Risk] ForwardedHeaders middleware adds latency** → Negligible; it's a single header parse per request with O(1) lookup against KnownProxies set. No measurable impact.
+
+- **[Trade-off] No auto-detection of Docker/sidecar topology** → Operators must explicitly opt in. This is intentional: auto-detection would be fragile and violates "no silent fallbacks."

--- a/openspec/changes/relax-exposure-strictness/proposal.md
+++ b/openspec/changes/relax-exposure-strictness/proposal.md
@@ -1,0 +1,134 @@
+## Why
+
+Issue #862 exposed a gap between Netclaw's intended fail-closed gateway posture and
+the current exposure-mode artifacts. The current specs and implementation already
+preserve loopback auto-auth for true local operator traffic, and startup validation
+already blocks non-local exposure without remote auth. But the planning artifacts do
+not state several security-critical boundaries explicitly enough:
+
+- reverse-proxy mode must not treat a loopback final hop into Netclaw as safe,
+  because missing or broken forwarded-header trust would let remote traffic inherit
+  loopback operator trust
+- `netclaw doctor` must enforce the same remote-auth prerequisites as daemon startup,
+  so operators do not get a false green check for configs the daemon will refuse
+- issue #862 also covered tunnel-sidecar / host-managed topologies where Netclaw's
+  local process detector cannot see `tailscaled` or `cloudflared`, so operators
+  need an explicit opt-in escape hatch instead of being forced to disable the
+  tunnel mode entirely
+- malformed `TrustedProxies` entries must fail validation loudly instead of degrading
+  into a broader trust decision
+- setup and health-check flows must surface `ExposureModeValidationService` failures
+  cleanly instead of collapsing into a generic readiness timeout or raw crash trace
+
+This change tightens the existing exposure-mode planning to align with PRD-002's
+default-deny, fail-closed security posture and with the current loopback-auth model
+already defined in the hub-auth capability.
+
+## What Changes
+
+- Add reverse-proxy trust-boundary requirements that forbid configurations where the
+  final hop into Netclaw is loopback (`127.0.0.1`, `::1`, `localhost`) in reverse-proxy
+  mode, even when the proxy runs on the same host.
+- Require same-host reverse proxies to use a non-loopback internal IP for the final
+  hop if they want Netclaw to distinguish proxied remote traffic from true local
+  operator traffic.
+- Add an explicit `Daemon.SkipTunnelProcessCheck` opt-in for `tailscale-serve`,
+  `tailscale-funnel`, and `cloudflare-tunnel` so sidecar / host-managed tunnel
+  topologies can bypass local process detection when the operator knowingly manages
+  tunnel liveness outside the daemon.
+- Preserve default hard-fail behavior for tunnel modes: when
+  `SkipTunnelProcessCheck` is absent or `false`, startup and doctor still reject a
+  missing required tunnel process.
+- Tighten doctor requirements so reverse-proxy mode checks the same remote-auth
+  startup prerequisites as `ExposureModeValidationService`.
+- Require invalid `TrustedProxies` values to fail schema/config validation, doctor,
+  and startup loudly with actionable errors instead of silent fallback or partial
+  parsing.
+- Add onboarding/setup requirements so startup validation failures from
+  `ExposureModeValidationService` are presented as structured setup/health-check
+  failures with remediation guidance rather than raw crash output or opaque
+  readiness timeouts.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `daemon-exposure`: tighten reverse-proxy trust-boundary rules, doctor/startup
+  parity, opt-in tunnel process-check bypass for sidecar topologies,
+  `TrustedProxies` validation, and fail-closed error handling.
+- `netclaw-onboarding`: require clean surfacing of daemon startup validation
+  failures during init/health-check flows.
+- `hub-auth`: clarify that loopback auto-auth remains reserved for true local
+  connections and must not be inherited by reverse-proxied remote traffic.
+
+## Impact
+
+### Affected code and systems
+
+- `DaemonConfig` parsing/validation and JSON schema for reverse-proxy-related
+  exposure settings, including `TrustedProxies` and `SkipTunnelProcessCheck`.
+- `ExposureModeValidationService` and `ExposureModeDoctorCheck` so they share the
+  same remote-auth, tunnel-process, and proxy-trust validation rules.
+- Reverse-proxy / forwarded-header trust plumbing that determines whether a
+  connection can ever qualify for loopback auto-auth.
+- `netclaw init` health-check and daemon start polling so startup validation
+  failures are surfaced cleanly.
+
+### APIs and behavior
+
+- **BREAKING (validation hardening):** reverse-proxy configurations that forward
+  into Netclaw over loopback now fail validation instead of being considered a
+  potentially acceptable topology.
+- **BREAKING (validation hardening):** malformed `TrustedProxies` entries such as
+  `"abc"`, `"127.0.0.1/999"`, or invalid mixed CIDR/IP strings now fail every
+  validation surface explicitly.
+- **New opt-in behavior:** tunnel modes may explicitly set
+  `Daemon.SkipTunnelProcessCheck=true` to allow sidecar / host-managed tunnel
+  topologies where the required tunnel process is intentionally not visible from the
+  Netclaw process.
+- Doctor output becomes stricter for reverse-proxy mode by rejecting configs that
+  startup would reject.
+
+### Security and operational impact
+
+- Preserves Netclaw's loopback trust boundary so remote traffic cannot inherit the
+  `LocalProcess` / `Operator` path through proxy misconfiguration.
+- Removes false-positive operator feedback where doctor passes a remote-access
+  configuration that startup will fail.
+- Preserves fail-closed defaults for tunnel-backed modes while still supporting
+  explicit sidecar deployments that would otherwise fail a coarse process probe.
+- Eliminates silent degradation for malformed trusted-proxy lists.
+- Improves setup UX by turning fail-closed startup validation into actionable
+  operator guidance instead of stack traces or opaque daemon-not-ready results.
+
+### Dependencies and sequencing
+
+- Extends the existing exposure-mode and device-pairing behavior already present in
+  the codebase.
+- Must stay aligned with PRD-002 and the existing `hub-auth` loopback authentication
+  contract.
+
+### In scope for MVP
+
+- Reverse-proxy final-hop restriction, loud `TrustedProxies` validation, doctor /
+  startup parity, explicit `SkipTunnelProcessCheck` support for tunnel-sidecar
+  topologies, and clean setup/health-check surfacing for startup validation
+  failures.
+
+### Out of scope for MVP
+
+- Introducing a new fallback auth path for misconfigured reverse proxies.
+- Inferring tunnel health automatically when operators explicitly choose to bypass
+  local process detection.
+- Managing or auto-repairing reverse proxy configuration outside of Netclaw.
+- Broad redesign of hub authentication beyond preserving the existing loopback
+  boundary.
+
+### Source PRDs
+
+- `PRD-002` (gateway security envelope; fail-closed and default-deny)
+- `PRD-004` (CLI onboarding and operator diagnostics)

--- a/openspec/changes/relax-exposure-strictness/proposal.md
+++ b/openspec/changes/relax-exposure-strictness/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The daemon's startup validation crashes when `tailscaled`/`cloudflared` runs in a sidecar container or on the host (different PID namespace), blocking all Docker and Kubernetes deployments that use external tunnel infrastructure (GitHub Issue #862). Additionally, there is no exposure mode for operators who manage their own reverse proxy (nginx, Traefik, Caddy, K8s ingress) — they must either stay localhost-only or declare a specific tunnel provider they may not be using. Finally, all IP-based security (rate limiting, fail2ban lockout, loopback auth) uses raw `RemoteIpAddress` which shows the proxy's IP when behind any reverse proxy, degrading per-client protections.
+
+## What Changes
+
+- Add `Daemon.SkipTunnelProcessCheck` boolean config (default `false`) that downgrades the tunnel process detection from a hard startup crash to a warning log, enabling sidecar and host-level tunnel topologies
+- Add `reverse-proxy` exposure mode value — declares the daemon is behind an operator-managed reverse proxy with no specific tunnel process requirement; authentication is still enforced
+- Add `Daemon.TrustedProxies` config (string array of IPs/CIDRs) that enables ASP.NET `ForwardedHeaders` middleware to resolve real client IPs from `X-Forwarded-For` headers
+- Update doctor checks to handle new mode and skip-flag scenarios
+- Update setup wizard to offer `reverse-proxy` as an exposure mode choice
+
+## Capabilities
+
+### New Capabilities
+
+(none — all changes extend the existing `daemon-exposure` capability)
+
+### Modified Capabilities
+
+- `daemon-exposure`: Adding `reverse-proxy` mode, `SkipTunnelProcessCheck` flag, `TrustedProxies` config with forwarded headers middleware, and updated doctor check scenarios
+
+## Impact
+
+- **Configuration**: `DaemonConfig` gains three new properties; JSON schema gains corresponding entries with defaults (non-breaking for existing configs)
+- **Security pipeline**: `ForwardedHeaders` middleware inserted before authentication when `TrustedProxies` is non-empty; all existing `RemoteIpAddress` consumers benefit automatically
+- **Startup behavior**: `ExposureModeValidationService` gains two new code paths (skip-flag warning, null-process reverse-proxy); existing hard-fail behavior unchanged for operators who don't set the flag
+- **CLI**: Doctor check and wizard TUI gain new scenarios
+- **Source PRDs**: PRD-002 (gateway security envelope), PRD-004 (remote access)

--- a/openspec/changes/relax-exposure-strictness/specs/daemon-exposure/spec.md
+++ b/openspec/changes/relax-exposure-strictness/specs/daemon-exposure/spec.md
@@ -1,0 +1,155 @@
+## MODIFIED Requirements
+
+### Requirement: Startup prerequisite validation for tunnel modes
+
+The daemon SHALL validate that tunnel infrastructure and remote-auth prerequisites
+are met before completing startup. If prerequisites are not met, the daemon SHALL
+fail startup with a descriptive error. The daemon does NOT manage tunnel or proxy
+processes; it validates that the declared trust boundary is safe to honor.
+
+For `tailscale-serve`, `tailscale-funnel`, and `cloudflare-tunnel`, local tunnel
+process detection SHALL remain the default prerequisite check. Operators MAY set
+`Daemon.SkipTunnelProcessCheck` to `true` as an explicit opt-in to bypass only that
+process-liveness check for sidecar or host-managed tunnel topologies.
+
+When `Daemon.SkipTunnelProcessCheck` is `true`, the daemon SHALL still enforce every
+other exposure requirement for the selected mode, including remote-auth
+prerequisites.
+
+#### Scenario: Tunnel mode fails startup when required process is missing by default
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-funnel`
+- **AND** `Daemon.SkipTunnelProcessCheck` is absent or `false`
+- **AND** the required tunnel process is not running locally
+- **WHEN** the daemon starts
+- **THEN** startup fails with an error explaining that the selected tunnel mode
+  requires its tunnel process unless the operator explicitly opts out of the check
+
+#### Scenario: Tunnel sidecar topology may skip process detection when explicitly configured
+
+- **GIVEN** `Daemon.ExposureMode` is `cloudflare-tunnel`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **AND** the required tunnel process is not visible locally because the tunnel runs
+  in a sidecar or host-managed topology
+- **AND** at least one remote authentication path exists
+- **WHEN** the daemon starts
+- **THEN** startup does not fail solely because the local process probe did not find
+  the tunnel process
+
+#### Scenario: Reverse-proxy mode requires remote authentication
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** no paired devices exist
+- **AND** no alternative remote authentication scheme is configured
+- **WHEN** the daemon starts
+- **THEN** startup fails with an error explaining that reverse-proxy mode requires
+  at least one remote authentication path before remote traffic is accepted
+
+#### Scenario: Reverse-proxy mode rejects loopback final hop
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** the final hop from the reverse proxy into Netclaw uses `127.0.0.1`, `::1`,
+  or `localhost`
+- **WHEN** the daemon starts
+- **THEN** startup fails with an error explaining that loopback auto-auth is
+  reserved for true local operator traffic and cannot be inherited through a
+  reverse proxy
+
+#### Scenario: Same-host reverse proxy allowed with non-loopback final hop
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** the reverse proxy runs on the same machine as Netclaw
+- **AND** the final hop into Netclaw uses a non-loopback internal IP
+- **AND** the proxy source is covered by `TrustedProxies`
+- **AND** at least one remote authentication path exists
+- **WHEN** the daemon starts
+- **THEN** startup succeeds
+
+#### Scenario: Malformed TrustedProxies entry fails startup loudly
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** `Daemon.TrustedProxies` contains an invalid entry such as `"not-an-ip"`
+  or `"127.0.0.1/999"`
+- **WHEN** the daemon starts
+- **THEN** startup fails with a descriptive error naming the invalid entry
+- **AND** the daemon does not silently ignore or partially accept the remaining
+  entries
+
+### Requirement: Doctor checks for exposure health
+
+The `netclaw doctor` command SHALL include exposure mode health checks that validate
+ tunnel / proxy infrastructure status and SHALL reject the same remote-auth and
+proxy-trust configurations that daemon startup rejects.
+
+#### Scenario: Doctor errors when tunnel process is missing and process checks are not skipped
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** `Daemon.SkipTunnelProcessCheck` is absent or `false`
+- **AND** `tailscaled` is not running locally
+- **WHEN** `netclaw doctor` runs
+- **THEN** an error is reported explaining that the required tunnel process is not
+  running
+
+#### Scenario: Doctor honors explicit tunnel process-check bypass
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **AND** `tailscaled` is not running locally because the tunnel is managed outside
+  the Netclaw process namespace
+- **AND** at least one remote-auth path exists
+- **WHEN** `netclaw doctor` runs
+- **THEN** doctor does not report the missing local tunnel process as an error
+
+#### Scenario: Reverse-proxy mode without remote auth is an error
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** no paired devices exist or other remote-auth path is available
+- **WHEN** `netclaw doctor` runs
+- **THEN** an error is reported explaining that reverse-proxy mode would start
+  fail because no remote client can authenticate
+
+#### Scenario: Reverse-proxy mode with loopback final hop is an error
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** the final hop from proxy to daemon is configured as `127.0.0.1`, `::1`, or
+  `localhost`
+- **WHEN** `netclaw doctor` runs
+- **THEN** an error is reported explaining that loopback final-hop proxying would
+  let remote traffic inherit local operator trust if forwarded-header trust fails
+
+#### Scenario: Malformed TrustedProxies entry fails doctor loudly
+
+- **GIVEN** `Daemon.TrustedProxies` contains an invalid IP or CIDR string
+- **WHEN** `netclaw doctor` runs
+- **THEN** an error is reported naming the invalid entry
+- **AND** doctor does not continue as if the malformed entry were absent
+
+### Requirement: Daemon config section in JSON schema
+
+The `netclaw-config.v1.schema.json` SHALL validate reverse-proxy trust settings
+explicitly. Any `TrustedProxies` entry SHALL be a valid IP address or CIDR string.
+Malformed entries SHALL be rejected by validation instead of being ignored.
+
+The schema SHALL also support `Daemon.SkipTunnelProcessCheck` as a boolean flag.
+Its default behavior SHALL remain `false` when omitted.
+
+#### Scenario: Schema rejects malformed TrustedProxies entry
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "reverse-proxy",
+  "TrustedProxies": ["not-an-ip"] }`
+- **WHEN** schema validation runs
+- **THEN** validation fails citing the malformed `TrustedProxies` entry
+
+#### Scenario: Schema rejects invalid CIDR in TrustedProxies
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "reverse-proxy",
+  "TrustedProxies": ["127.0.0.1/999"] }`
+- **WHEN** schema validation runs
+- **THEN** validation fails citing the invalid CIDR value
+
+#### Scenario: Schema accepts explicit tunnel process-check bypass flag
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "tailscale-serve",
+  "SkipTunnelProcessCheck": true }`
+- **WHEN** schema validation runs
+- **THEN** validation passes for the flag shape

--- a/openspec/changes/relax-exposure-strictness/specs/daemon-exposure/spec.md
+++ b/openspec/changes/relax-exposure-strictness/specs/daemon-exposure/spec.md
@@ -1,0 +1,298 @@
+## ADDED Requirements
+
+### Requirement: Reverse proxy exposure mode
+
+The system SHALL support `ExposureMode` value `reverse-proxy` for deployments
+where the daemon is behind an operator-managed reverse proxy (nginx, Traefik,
+Caddy, Kubernetes ingress, or similar). This mode SHALL NOT require any specific
+tunnel process. The remote authentication guard (paired device or alternative
+auth scheme) SHALL still be enforced.
+
+#### Scenario: Reverse proxy mode starts without process check
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** the daemon starts
+- **THEN** no tunnel process check is performed
+- **AND** startup succeeds if at least one paired device or remote auth scheme exists
+
+#### Scenario: Reverse proxy mode without authentication fails startup
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** no paired devices exist
+- **AND** no alternative remote auth scheme is configured
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating remote authentication is required
+
+#### Scenario: Reverse proxy mode in JSON schema
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "reverse-proxy" }`
+- **WHEN** schema validation runs
+- **THEN** validation passes
+
+### Requirement: Skip tunnel process check for sidecar deployments
+
+The system SHALL support a `Daemon.SkipTunnelProcessCheck` boolean configuration
+property (default `false`). When `true` and the configured exposure mode requires
+a tunnel process that is not detected locally, the daemon SHALL log a warning and
+continue startup instead of aborting. The remote authentication guard SHALL still
+be enforced regardless of this flag.
+
+#### Scenario: Skip flag allows startup without local tunnel process
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-funnel`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **AND** the `tailscaled` process is not running locally
+- **AND** at least one paired device exists
+- **WHEN** the daemon starts
+- **THEN** a warning is logged indicating the tunnel process was not detected
+- **AND** startup succeeds
+
+#### Scenario: Skip flag does not bypass auth guard
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-funnel`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **AND** no paired devices exist
+- **AND** no alternative remote auth scheme is configured
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating remote authentication is required
+
+#### Scenario: Skip flag has no effect on local mode
+
+- **GIVEN** `Daemon.ExposureMode` is `local`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **WHEN** the daemon starts
+- **THEN** no tunnel validation is performed (same as without the flag)
+
+#### Scenario: Default behavior preserved without skip flag
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-funnel`
+- **AND** `Daemon.SkipTunnelProcessCheck` is `false` (or not configured)
+- **AND** the `tailscaled` process is not running locally
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating `tailscaled` is not running
+
+### Requirement: Trusted proxy forwarded headers
+
+The system SHALL support a `Daemon.TrustedProxies` configuration property
+(string array of IP addresses or CIDR ranges, default empty). When the array is
+non-empty AND the exposure mode is non-local, the daemon SHALL enable ASP.NET
+`ForwardedHeaders` middleware to resolve real client IPs from `X-Forwarded-For`
+and `X-Forwarded-Proto` headers. Only requests originating from listed proxy
+addresses SHALL have their forwarded headers honored.
+
+#### Scenario: Trusted proxy resolves real client IP
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"10.0.0.1"`
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives from connection IP `10.0.0.1` with header `X-Forwarded-For: 203.0.113.42`
+- **THEN** `RemoteIpAddress` is resolved to `203.0.113.42` for authentication and rate limiting
+
+#### Scenario: Untrusted source forwarded header ignored
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"10.0.0.1"`
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives from connection IP `192.168.1.50` with header `X-Forwarded-For: 203.0.113.42`
+- **THEN** `RemoteIpAddress` remains `192.168.1.50` (header ignored)
+
+#### Scenario: Empty trusted proxies disables header processing
+
+- **GIVEN** `Daemon.TrustedProxies` is empty (or not configured)
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives with `X-Forwarded-For` header
+- **THEN** `RemoteIpAddress` is the connection IP (header ignored)
+
+#### Scenario: CIDR range matching
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"172.17.0.0/16"`
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives from connection IP `172.17.0.5` with header `X-Forwarded-For: 203.0.113.42`
+- **THEN** `RemoteIpAddress` is resolved to `203.0.113.42`
+
+#### Scenario: Forwarded headers do not activate in local mode
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"10.0.0.1"`
+- **AND** `Daemon.ExposureMode` is `local`
+- **WHEN** a request arrives from connection IP `10.0.0.1` with header `X-Forwarded-For: 203.0.113.42`
+- **THEN** `RemoteIpAddress` remains `10.0.0.1` (middleware not active)
+
+#### Scenario: Forward limit restricts hop count
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"10.0.0.1"`
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives from `10.0.0.1` with header `X-Forwarded-For: 203.0.113.42, 198.51.100.1`
+- **THEN** `RemoteIpAddress` is resolved to `198.51.100.1` (rightmost untrusted hop, ForwardLimit=1)
+
+#### Scenario: Forwarded proto header honored
+
+- **GIVEN** `Daemon.TrustedProxies` contains `"10.0.0.1"`
+- **AND** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** a request arrives from `10.0.0.1` with header `X-Forwarded-Proto: https`
+- **THEN** `Request.Scheme` is set to `https`
+
+### Requirement: Trusted proxies in JSON schema
+
+The `netclaw-config.v1.schema.json` SHALL include `SkipTunnelProcessCheck`
+(boolean, default `false`), `TrustedProxies` (array of strings, default empty),
+in the `Daemon` object. The `ExposureMode` enum SHALL include `reverse-proxy`.
+
+#### Scenario: Schema validates new Daemon properties
+
+- **GIVEN** a config file with `"Daemon": { "SkipTunnelProcessCheck": true, "TrustedProxies": ["10.0.0.0/8"], "ExposureMode": "reverse-proxy" }`
+- **WHEN** schema validation runs
+- **THEN** validation passes
+
+#### Scenario: Schema rejects invalid TrustedProxies type
+
+- **GIVEN** a config file with `"Daemon": { "TrustedProxies": "10.0.0.1" }`
+- **WHEN** schema validation runs
+- **THEN** validation fails (expected array, got string)
+
+## MODIFIED Requirements
+
+### Requirement: Startup prerequisite validation for tunnel modes
+
+The daemon SHALL validate that tunnel infrastructure prerequisites are met
+before completing startup. If prerequisites are not met, the daemon SHALL
+fail startup with a descriptive error — unless `SkipTunnelProcessCheck` is
+`true`, in which case a warning SHALL be logged and startup continues.
+The daemon does NOT manage tunnel processes — it only validates their presence.
+For `reverse-proxy` mode, no process check is performed (no required process).
+
+#### Scenario: Tailscale Serve mode with tailscaled running
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** the `tailscaled` process is running
+- **WHEN** the daemon starts
+- **THEN** startup succeeds
+
+#### Scenario: Tailscale Serve mode without tailscaled
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** the `tailscaled` process is not running
+- **AND** `Daemon.SkipTunnelProcessCheck` is `false` (or not configured)
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating `tailscaled` is not running
+
+#### Scenario: Tailscale Funnel mode without tailscaled
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-funnel`
+- **AND** the `tailscaled` process is not running
+- **AND** `Daemon.SkipTunnelProcessCheck` is `false` (or not configured)
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating `tailscaled` is not running
+
+#### Scenario: Cloudflare Tunnel mode with cloudflared running
+
+- **GIVEN** `Daemon.ExposureMode` is `cloudflare-tunnel`
+- **AND** the `cloudflared` process is running
+- **WHEN** the daemon starts
+- **THEN** startup succeeds
+
+#### Scenario: Cloudflare Tunnel mode without cloudflared
+
+- **GIVEN** `Daemon.ExposureMode` is `cloudflare-tunnel`
+- **AND** the `cloudflared` process is not running
+- **AND** `Daemon.SkipTunnelProcessCheck` is `false` (or not configured)
+- **WHEN** the daemon starts
+- **THEN** startup fails with error indicating `cloudflared` is not running
+
+#### Scenario: Local mode requires no tunnel validation
+
+- **GIVEN** `Daemon.ExposureMode` is `local`
+- **WHEN** the daemon starts
+- **THEN** no tunnel prerequisite checks are performed
+
+#### Scenario: Reverse proxy mode requires no tunnel validation
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **WHEN** the daemon starts
+- **THEN** no tunnel prerequisite checks are performed
+
+### Requirement: Doctor checks for exposure health
+
+The `netclaw doctor` command SHALL include exposure mode health checks that
+validate tunnel infrastructure status, flag unsafe configurations, and account
+for the skip flag and reverse-proxy mode.
+
+#### Scenario: Non-loopback bind without exposure mode
+
+- **GIVEN** `Daemon.Host` is `"0.0.0.0"` or any non-loopback address
+- **AND** `Daemon.ExposureMode` is `local`
+- **WHEN** `netclaw doctor` runs
+- **THEN** a warning is reported: non-loopback bind address without a declared
+  exposure mode may make the daemon host-network reachable without the
+  required authenticated-user gate
+
+#### Scenario: Tailscale mode with healthy tunnel
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** `tailscaled` is running and serve is configured
+- **WHEN** `netclaw doctor` runs
+- **THEN** the exposure check passes
+
+#### Scenario: Tailscale mode with missing tunnel and skip flag
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** `tailscaled` is not running
+- **AND** `Daemon.SkipTunnelProcessCheck` is `true`
+- **WHEN** `netclaw doctor` runs
+- **THEN** a warning is reported: tunnel process not detected; operator asserts it is running externally
+
+#### Scenario: Tailscale mode with missing tunnel without skip flag
+
+- **GIVEN** `Daemon.ExposureMode` is `tailscale-serve`
+- **AND** `tailscaled` is not running
+- **AND** `Daemon.SkipTunnelProcessCheck` is `false` (or not configured)
+- **WHEN** `netclaw doctor` runs
+- **THEN** an error is reported: `tailscaled` is not running
+
+#### Scenario: Reverse proxy mode with loopback bind
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** `Daemon.Host` is `"127.0.0.1"`
+- **WHEN** `netclaw doctor` runs
+- **THEN** a warning is reported: mode is reverse-proxy but daemon is bound to loopback; reverse proxy may not be able to reach the daemon
+
+#### Scenario: Reverse proxy mode without trusted proxies
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** `Daemon.TrustedProxies` is empty or not configured
+- **WHEN** `netclaw doctor` runs
+- **THEN** a warning is reported: no trusted proxies configured; IP-based rate limiting will use proxy IP
+
+#### Scenario: Reverse proxy mode with valid configuration
+
+- **GIVEN** `Daemon.ExposureMode` is `reverse-proxy`
+- **AND** `Daemon.Host` is `"0.0.0.0"`
+- **AND** `Daemon.TrustedProxies` is non-empty
+- **WHEN** `netclaw doctor` runs
+- **THEN** the exposure check passes
+
+### Requirement: Daemon config section in JSON schema
+
+The `netclaw-config.v1.schema.json` SHALL include a `Daemon` object with
+`Host` (string, default `"127.0.0.1"`), `Port` (integer, default `5199`),
+`ExposureMode` (string enum: `local`, `tailscale-serve`, `tailscale-funnel`,
+`cloudflare-tunnel`, `reverse-proxy`, default `"local"`),
+`SkipTunnelProcessCheck` (boolean, default `false`),
+`TrustedProxies` (array of strings, default `[]`), and
+`DisableSelfUpdate` (boolean, default `false`).
+
+#### Scenario: Schema validates valid Daemon section with new properties
+
+- **GIVEN** a config file with `"Daemon": { "Host": "0.0.0.0", "Port": 5199, "ExposureMode": "reverse-proxy", "SkipTunnelProcessCheck": false, "TrustedProxies": ["172.17.0.0/16"] }`
+- **WHEN** schema validation runs
+- **THEN** validation passes
+
+#### Scenario: Schema rejects invalid ExposureMode
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "nginx-proxy" }`
+- **WHEN** schema validation runs
+- **THEN** validation fails citing the invalid enum value
+
+#### Scenario: Missing new properties use defaults
+
+- **GIVEN** a config file with `"Daemon": { "ExposureMode": "tailscale-funnel" }`
+- **WHEN** schema validation runs
+- **THEN** validation passes
+- **AND** defaults resolve to `SkipTunnelProcessCheck: false`, `TrustedProxies: []`

--- a/openspec/changes/relax-exposure-strictness/specs/netclaw-onboarding/spec.md
+++ b/openspec/changes/relax-exposure-strictness/specs/netclaw-onboarding/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Guided onboarding
+
+The CLI SHALL provide guided setup through `netclaw init`. On completion, the
+wizard SHALL run a health check to verify the baseline configuration is functional.
+If daemon startup fails because configuration validation rejects the selected
+exposure mode or remote-auth topology, the wizard SHALL surface that failure as a
+structured setup error with remediation guidance.
+
+#### Scenario: Exposure-mode startup validation failure shown cleanly
+
+- **GIVEN** the operator completes `netclaw init`
+- **AND** the written configuration causes `ExposureModeValidationService` to reject
+  daemon startup
+- **WHEN** the health-check step starts the daemon
+- **THEN** the wizard shows a failed health-check item containing the validation
+  message
+- **AND** the wizard includes remediation guidance for fixing the exposure/auth
+  configuration
+- **AND** the operator is not shown a raw stack trace
+
+#### Scenario: Startup validation failure does not degrade to generic readiness timeout
+
+- **GIVEN** daemon startup fails immediately because exposure validation rejects the
+  configuration
+- **WHEN** the health-check step polls daemon readiness
+- **THEN** the wizard reports the actual startup validation failure
+- **AND** it does NOT report only "Daemon did not become ready" unless the failure
+  reason is genuinely unavailable

--- a/openspec/changes/relax-exposure-strictness/tasks.md
+++ b/openspec/changes/relax-exposure-strictness/tasks.md
@@ -1,0 +1,91 @@
+## 1. Planning alignment and capability deltas
+
+- [x] 1.1 Update the `daemon-exposure` spec delta to define reverse-proxy final-hop
+  trust rules, doctor/startup parity, opt-in tunnel process-check bypass semantics,
+  and fail-loud `TrustedProxies` validation.
+- [x] 1.2 Update the `netclaw-onboarding` spec delta to require clean surfacing of
+  startup validation failures during init / health-check flows.
+- [x] 1.3 Cross-check the wording against `hub-auth` so loopback auto-auth remains
+  reserved for true local operator traffic.
+
+## 2. Reverse-proxy trust-boundary hardening
+
+- [x] 2.1 Add reverse-proxy mode validation that rejects configurations where the
+  final hop into Netclaw is `127.0.0.1`, `::1`, or `localhost`.
+- [x] 2.2 Allow same-host reverse-proxy topologies only when the final hop uses a
+  non-loopback internal IP and the proxy is explicitly trusted.
+- [x] 2.3 Update operator-facing diagnostics/remediation text to explain why loopback
+  final-hop proxying is rejected and how to move to a non-loopback internal address.
+
+## 3. `TrustedProxies` validation and config/schema updates
+
+- [x] 3.1 Update `DaemonConfig` / related config contracts to represent reverse-proxy
+  trust settings, including `TrustedProxies`.
+- [x] 3.2 Update `netclaw-config.v1.schema.json` so `TrustedProxies` entries are
+  validated as explicit IP/CIDR strings with no silent extra properties.
+- [x] 3.3 Ensure malformed `TrustedProxies` entries fail validation loudly in all
+  surfaces, including examples such as `not-an-ip` and invalid CIDR masks.
+
+## 4. Startup and doctor parity
+
+- [x] 4.1 Extend `ExposureModeValidationService` so reverse-proxy mode enforces the
+  same remote-auth prerequisites as other non-local exposure paths.
+- [x] 4.1a Extend tunnel-mode validation so local process detection remains the
+  default hard-fail gate, but `Daemon.SkipTunnelProcessCheck=true` explicitly skips
+  that check for sidecar / host-managed tunnel topologies.
+- [x] 4.2 Extend `ExposureModeDoctorCheck` so it rejects the same reverse-proxy and
+  remote-auth misconfigurations that startup rejects.
+- [x] 4.2a Extend `ExposureModeDoctorCheck` so it honors the same explicit
+  `SkipTunnelProcessCheck` bypass that startup uses for tunnel-backed modes.
+- [x] 4.3 Reuse shared validation logic or equivalent centralized rules so doctor and
+  startup cannot drift on proxy trust, remote-auth requirements, or malformed
+  `TrustedProxies` handling.
+
+## 5. Graceful setup and health-check reporting (#862)
+
+- [x] 5.1 Capture `ExposureModeValidationService` startup failures at daemon start so
+  init/health-check flows can distinguish config rejection from generic readiness
+  timeout.
+- [x] 5.2 Surface those failures in the wizard/health-check UI as structured failure
+  items with remediation guidance rather than raw stack traces or generic "did not
+  become ready" messages.
+- [x] 5.3 Ensure non-wizard startup/health-check surfaces report the same validation
+  failures cleanly for operators.
+
+## 6. Tests
+
+- [x] 6.1 Add validation tests for reverse-proxy mode rejecting loopback final hops.
+- [x] 6.2 Add validation tests for same-host reverse-proxy mode succeeding only with a
+  non-loopback internal final hop.
+- [x] 6.3 Add config/schema/doctor/startup tests for malformed `TrustedProxies`
+  entries failing loudly.
+- [x] 6.3a Add config/schema tests for `Daemon.SkipTunnelProcessCheck` with valid
+  boolean values and default-false behavior when omitted.
+- [x] 6.4 Add in-process ASP.NET reverse-proxy integration tests using `TestServer`
+  patterns, following existing tests like
+  `src/Netclaw.Daemon.Tests/Security/SessionHubAuthorizationTests.cs` and
+  `src/Netclaw.Daemon.Tests/Security/PairingExchangeEndpointTests.cs`.
+- [x] 6.5 Add a reverse-proxy integration test proving a trusted non-loopback proxy
+  plus `X-Forwarded-For` rewrites the effective client IP before auth evaluation,
+  so unauthenticated remote traffic does NOT inherit loopback auth.
+- [x] 6.6 Add a reverse-proxy integration test proving a trusted non-loopback proxy
+  plus a valid bearer token still succeeds through the normal remote-auth path
+  after forwarded-header rewriting.
+- [x] 6.7 Add a reverse-proxy integration test proving forwarded headers from an
+  untrusted proxy source are ignored and the direct peer IP remains authoritative.
+- [x] 6.8 Add reverse-proxy integration tests proving forwarded headers affect
+  IP-based protections such as pairing exchange and rate limiting using the
+  rewritten client IP for a supported trusted-proxy topology.
+- [x] 6.9 Add parity tests proving doctor rejects the same remote-auth/proxy-trust
+  configurations that startup rejects.
+- [x] 6.9a Add parity tests proving tunnel modes fail by default when the required
+  process is missing, but succeed past that gate when
+  `SkipTunnelProcessCheck=true` and the remaining prerequisites are satisfied.
+- [x] 6.10 Add onboarding / health-check tests proving startup validation failures are
+  surfaced as actionable setup failures.
+
+## 7. Verification
+
+- [x] 7.1 Run `openspec validate "relax-exposure-strictness"`.
+- [x] 7.2 Verify the change text still aligns with `PRD-002` fail-closed / default-deny
+  principles and the existing `hub-auth` loopback behavior.

--- a/openspec/changes/relax-exposure-strictness/tasks.md
+++ b/openspec/changes/relax-exposure-strictness/tasks.md
@@ -1,0 +1,39 @@
+## 1. Configuration Layer
+
+- [ ] 1.1 Add `ReverseProxy` value to `ExposureMode` enum with wire value `"reverse-proxy"`, update `ToWireValue()` and `GetRequiredProcessName()` (returns `null`)
+- [ ] 1.2 Add `SkipTunnelProcessCheck` (bool, default false) and `TrustedProxies` (IReadOnlyList<string>, default empty) properties to `DaemonConfig`
+- [ ] 1.3 Update `DaemonConfig.ParseExposureMode()` to accept `"reverse-proxy"` / `"reverseproxy"`
+- [ ] 1.4 Update `netclaw-config.v1.schema.json`: add `"reverse-proxy"` to ExposureMode enum, add `SkipTunnelProcessCheck` boolean with default, add `TrustedProxies` array of strings with default
+
+## 2. Startup Validation
+
+- [ ] 2.1 Modify `ExposureModeValidationService.StartAsync`: when `GetRequiredProcessName()` returns null (reverse-proxy mode), skip process check entirely but still run auth guard
+- [ ] 2.2 Modify `ExposureModeValidationService.StartAsync`: when `SkipTunnelProcessCheck` is true and process not found, log warning instead of throwing
+- [ ] 2.3 Add unit tests: reverse-proxy mode starts without process check, auth guard still enforced
+- [ ] 2.4 Add unit tests: SkipTunnelProcessCheck=true logs warning and continues; auth guard still enforced; flag has no effect on local mode
+
+## 3. Forwarded Headers Middleware
+
+- [ ] 3.1 Add `UseForwardedHeaders()` wiring in `Program.cs` before `UseAuthentication()` — activate only when `TrustedProxies` is non-empty AND mode is non-local
+- [ ] 3.2 Parse `TrustedProxies` entries as `IPAddress` or `IPNetwork` into `ForwardedHeadersOptions.KnownProxies`/`KnownNetworks`, set `ForwardLimit = 1`
+- [ ] 3.3 Add integration tests: trusted proxy resolves real client IP; untrusted proxy header ignored; empty TrustedProxies disables middleware; local mode disables middleware regardless
+
+## 4. Doctor Check Updates
+
+- [ ] 4.1 Update `ExposureModeDoctorCheck`: when mode is tunnel type + SkipTunnelProcessCheck=true + process missing → report Warning instead of Error
+- [ ] 4.2 Add doctor scenario: reverse-proxy mode + loopback bind → Warning
+- [ ] 4.3 Add doctor scenario: reverse-proxy mode + empty TrustedProxies → Warning
+- [ ] 4.4 Add doctor scenario: reverse-proxy mode + non-loopback + TrustedProxies configured → Pass
+- [ ] 4.5 Add unit tests for new doctor check scenarios
+
+## 5. Setup Wizard
+
+- [ ] 5.1 Add `reverse-proxy` option to `ExposureModeStepViewModel` mode selection with appropriate informational notice
+- [ ] 5.2 Ensure wizard still bootstraps a paired device token when reverse-proxy is selected (same as other non-local modes)
+
+## 6. Verification
+
+- [ ] 6.1 Run full test suite — ensure no regressions in existing exposure mode tests
+- [ ] 6.2 Run `dotnet slopwatch analyze` — no new violations
+- [ ] 6.3 Run `./scripts/Add-FileHeaders.ps1 -Verify` — copyright headers present
+- [ ] 6.4 Validate JSON schema accepts new config properties via `netclaw doctor`

--- a/src/Netclaw.Cli.Tests/Cli/RemotePairingSignalRIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/RemotePairingSignalRIntegrationTests.cs
@@ -101,7 +101,7 @@ public sealed class RemotePairingSignalRIntegrationTests : IDisposable
         builder.Services.AddSingleton(_deviceRegistry);
         builder.Services.AddSingleton(_pairingCodeService);
         builder.Services.AddSingleton(_exchangeGuard);
-        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddNetclawAuthSchemes(new DaemonConfig());
         builder.Services.AddAuthorization();
         builder.Services.AddSignalR();
 

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -52,6 +52,105 @@ public sealed class ConfigSchemaDoctorCheckTests
     }
 
     [Fact]
+    public async Task ReturnsPass_WhenReverseProxyTrustedProxiesLookValid()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "10.0.0.10",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["10.0.0.5", "10.0.0.0/24"]
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task ReturnsPass_WhenSkipTunnelProcessCheck_IsBoolean()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "ExposureMode": "tailscale-serve",
+                "SkipTunnelProcessCheck": true
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenTrustedProxyMalformed()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["not-an-ip"]
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("TrustedProxies", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenTrustedProxyCidrMalformed()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["127.0.0.1/999"]
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("TrustedProxies", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ReturnsPass_WhenMemoryAndSubAgentsSectionsValid()
     {
         var basePath = CreateTempBasePath();

--- a/src/Netclaw.Cli.Tests/Doctor/ExposureModeDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ExposureModeDoctorCheckTests.cs
@@ -66,6 +66,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
               "Daemon": { "ExposureMode": "tailscale-serve" }
             }
             """);
+        WritePairedDevice();
 
         var check = BuildCheck(name => name == "tailscaled");
 
@@ -73,6 +74,42 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
         Assert.Contains("tailscale-serve", result.Message);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithPairedDeviceAndTrustedProxy_Passes()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "10.0.0.10",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["10.0.0.5"]
+              }
+            }
+            """);
+
+        await File.WriteAllTextAsync(_paths.DevicesPath,
+            """
+            [
+              {
+                "Name": "laptop",
+                "TokenHash": "abc",
+                "Salt": "def",
+                "CreatedAt": "2026-01-01T00:00:00+00:00",
+                "LastUsedAt": "2026-01-01T00:00:00+00:00"
+              }
+            ]
+            """, TestContext.Current.CancellationToken);
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("reverse-proxy", result.Message);
     }
 
     [Fact]
@@ -84,6 +121,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
               "Daemon": { "ExposureMode": "tailscale-funnel" }
             }
             """);
+        WritePairedDevice();
 
         var check = BuildCheck(name => name == "tailscaled");
 
@@ -102,6 +140,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
               "Daemon": { "ExposureMode": "cloudflare-tunnel" }
             }
             """);
+        WritePairedDevice();
 
         var check = BuildCheck(name => name == "cloudflared");
 
@@ -170,6 +209,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
         Assert.Equal(DoctorSeverity.Error, result.Severity);
         Assert.Contains("tailscale-serve", result.Message);
         Assert.Contains("tailscaled", result.Message);
+        Assert.Contains("SkipTunnelProcessCheck", result.Message);
         Assert.NotNull(result.Remediation);
     }
 
@@ -190,6 +230,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
         Assert.Equal(DoctorSeverity.Error, result.Severity);
         Assert.Contains("tailscale-funnel", result.Message);
         Assert.Contains("tailscaled", result.Message);
+        Assert.Contains("SkipTunnelProcessCheck", result.Message);
     }
 
     [Fact]
@@ -209,6 +250,160 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
         Assert.Equal(DoctorSeverity.Error, result.Severity);
         Assert.Contains("cloudflare-tunnel", result.Message);
         Assert.Contains("cloudflared", result.Message);
+        Assert.Contains("SkipTunnelProcessCheck", result.Message);
+    }
+
+    [Theory]
+    [InlineData("tailscale-serve")]
+    [InlineData("tailscale-funnel")]
+    [InlineData("cloudflare-tunnel")]
+    public async Task TunnelMode_SkipTunnelProcessCheck_WithPairedDevice_Passes(string mode)
+    {
+        WriteConfig($$"""
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "ExposureMode": "{{mode}}",
+                "SkipTunnelProcessCheck": true
+              }
+            }
+            """);
+        WritePairedDevice();
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains(mode, result.Message);
+    }
+
+    [Theory]
+    [InlineData("tailscale-serve")]
+    [InlineData("tailscale-funnel")]
+    [InlineData("cloudflare-tunnel")]
+    public async Task TunnelMode_SkipTunnelProcessCheck_StillRequiresRemoteAuth(string mode)
+    {
+        WriteConfig($$"""
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "ExposureMode": "{{mode}}",
+                "SkipTunnelProcessCheck": true
+              }
+            }
+            """);
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("remote authentication", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithoutRemoteAuth_IsError()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "10.0.0.10",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["10.0.0.5"]
+              }
+            }
+            """);
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("remote authentication", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithLoopbackHost_IsError()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "127.0.0.1",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["10.0.0.5"]
+              }
+            }
+            """);
+
+        await File.WriteAllTextAsync(_paths.DevicesPath,
+            """
+            [{"Name":"laptop","TokenHash":"abc","Salt":"def","CreatedAt":"2026-01-01T00:00:00+00:00","LastUsedAt":"2026-01-01T00:00:00+00:00"}]
+            """, TestContext.Current.CancellationToken);
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("loopback", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithInvalidTrustedProxy_IsError()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "10.0.0.10",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["not-an-ip"]
+              }
+            }
+            """);
+
+        await File.WriteAllTextAsync(_paths.DevicesPath,
+            """
+            [{"Name":"laptop","TokenHash":"abc","Salt":"def","CreatedAt":"2026-01-01T00:00:00+00:00","LastUsedAt":"2026-01-01T00:00:00+00:00"}]
+            """, TestContext.Current.CancellationToken);
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("not-an-ip", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithInvalidTrustedProxyCidr_IsError()
+    {
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Daemon": {
+                "Host": "10.0.0.10",
+                "ExposureMode": "reverse-proxy",
+                "TrustedProxies": ["127.0.0.1/999"]
+              }
+            }
+            """);
+
+        WritePairedDevice();
+
+        var check = BuildCheck(_ => false);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("127.0.0.1/999", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -247,6 +442,20 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
 
     private ExposureModeDoctorCheck BuildCheck(Func<string, bool> processDetector)
         => new(_paths, processDetector);
+
+    private void WritePairedDevice(string name = "laptop")
+        => File.WriteAllText(_paths.DevicesPath,
+            $$"""
+            [
+              {
+                "Name": "{{name}}",
+                "TokenHash": "abc",
+                "Salt": "def",
+                "CreatedAt": "2026-01-01T00:00:00+00:00",
+                "LastUsedAt": "2026-01-01T00:00:00+00:00"
+              }
+            ]
+            """);
 
     private void WriteConfig(string configText)
         => File.WriteAllText(_paths.NetclawConfigPath, configText);

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="HealthCheckStepViewModelTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Tui;
+using Netclaw.Cli.Tui.Wizard;
+using Netclaw.Cli.Tui.Wizard.Steps;
+using Netclaw.Configuration;
+using Netclaw.Providers;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui.Wizard;
+
+public sealed class HealthCheckStepViewModelTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public HealthCheckStepViewModelTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("NETCLAW_DAEMON_PATH", null);
+        _dir.Dispose();
+    }
+
+    [Fact]
+    public async Task RunWithOrchestrator_PreservesSpecificStartupFailureMessage()
+    {
+        var fakeBinaryPath = Path.Combine(
+            _dir.Path,
+            OperatingSystem.IsWindows() ? "fake-netclawd.cmd" : "fake-netclawd.sh");
+        await File.WriteAllTextAsync(
+            fakeBinaryPath,
+            OperatingSystem.IsWindows()
+                ? "@echo off\r\nexit /b 1\r\n"
+                : "#!/usr/bin/env bash\nexit 1\n",
+            TestContext.Current.CancellationToken);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                fakeBinaryPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+        Environment.SetEnvironmentVariable("NETCLAW_DAEMON_PATH", fakeBinaryPath);
+
+        var expectedMessage =
+            "Daemon startup aborted: Invalid reverse-proxy topology: Daemon.Host '127.0.0.1' is loopback.";
+        var crashLogPath = Path.Combine(_paths.LogsDirectory, "crash-test.log");
+        await File.WriteAllTextAsync(
+            crashLogPath,
+            $"{expectedMessage}{Environment.NewLine}",
+            TestContext.Current.CancellationToken);
+        File.SetLastWriteTimeUtc(crashLogPath, DateTime.UtcNow.AddMinutes(1));
+
+        var daemonManager = new DaemonManager(_paths, TimeProvider.System);
+        using var step = new HealthCheckStepViewModel(
+            daemonManager,
+            daemonApi: null,
+            navigationState: new ChatNavigationState());
+        using var exposureStep = new ExposureModeStepViewModel
+        {
+            SelectedMode = ExposureMode.ReverseProxy
+        };
+
+        using var context = new WizardContext
+        {
+            Paths = _paths,
+            Registry = new ProviderDescriptorRegistry([]),
+            RequestRedraw = () => { }
+        };
+
+        step.OnEnter(context, NavigationDirection.Forward);
+        exposureStep.OnEnter(context, NavigationDirection.Forward);
+
+        using var orchestrator = new WizardOrchestrator([exposureStep, step], context);
+
+        await step.RunWithOrchestrator(orchestrator);
+
+        Assert.NotEmpty(step.Results);
+        var failure = Assert.Single(step.Results, result => result.Passed is false);
+        Assert.Contains(expectedMessage, failure.Label, StringComparison.Ordinal);
+        Assert.DoesNotContain("Daemon did not become ready", failure.Label, StringComparison.Ordinal);
+        Assert.Contains(crashLogPath, failure.Label, StringComparison.Ordinal);
+        Assert.Equal("Setup complete with warnings. Run `netclaw daemon start` to begin.", context.StatusMessage.Value);
+    }
+}

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -46,6 +46,9 @@ public sealed partial class DaemonManager
             FileName = binaryPath,
             UseShellExecute = false,
             CreateNoWindow = true,
+            // Don't redirect stdio — holding pipe handles prevents clean CLI exit
+            // and can cause the daemon to get SIGPIPE. The daemon handles its own
+            // logging via the ASP.NET Core logging infrastructure.
             RedirectStandardOutput = false,
             RedirectStandardError = false,
             RedirectStandardInput = false,

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -605,17 +605,14 @@ public sealed partial class DaemonManager
             if (!Directory.Exists(logsDirectory))
                 return null;
 
-            var latestCrashLog = new DirectoryInfo(logsDirectory)
-                .GetFiles("crash-*.log")
-                .Where(file => file.LastWriteTimeUtc >= startedAt.UtcDateTime.AddSeconds(-1))
-                .OrderByDescending(file => file.LastWriteTimeUtc)
+            var latestCrashLog = Doctor.CrashLogHelper
+                .FindCrashLogsSince(logsDirectory, startedAt.UtcDateTime.AddSeconds(-1))
                 .FirstOrDefault();
 
             if (latestCrashLog is null)
                 return null;
 
-            var crashLogText = File.ReadAllText(latestCrashLog.FullName);
-            foreach (var line in crashLogText.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            foreach (var line in File.ReadLines(latestCrashLog.FullName))
             {
                 if (line.Contains("Daemon startup aborted:", StringComparison.OrdinalIgnoreCase))
                 {
@@ -627,7 +624,7 @@ public sealed partial class DaemonManager
             crashLogPath = latestCrashLog.FullName;
             return null;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return null;
         }

--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -46,13 +46,12 @@ public sealed partial class DaemonManager
             FileName = binaryPath,
             UseShellExecute = false,
             CreateNoWindow = true,
-            // Don't redirect stdio — holding pipe handles prevents clean CLI exit
-            // and can cause the daemon to get SIGPIPE. The daemon handles its own
-            // logging via the ASP.NET Core logging infrastructure.
             RedirectStandardOutput = false,
             RedirectStandardError = false,
             RedirectStandardInput = false,
         };
+
+        var startedAt = _timeProvider.GetUtcNow();
 
         Process process;
         try
@@ -62,6 +61,12 @@ public sealed partial class DaemonManager
         catch (Exception ex)
         {
             return new DaemonResult(false, $"Failed to start daemon: {ex.Message}");
+        }
+
+        if (process.WaitForExit(1500))
+        {
+            var startupFailure = TryReadStartupFailureFromCrashLog(startedAt, out var crashLogPath);
+            return new DaemonResult(false, startupFailure ?? $"Failed to start daemon: process exited with code {process.ExitCode}.", crashLogPath);
         }
 
         // Preliminary PID file for immediate status checks. The daemon's PidFileService
@@ -589,8 +594,46 @@ public sealed partial class DaemonManager
             return false;
         }
     }
+
+    private string? TryReadStartupFailureFromCrashLog(DateTimeOffset startedAt, out string? crashLogPath)
+    {
+        crashLogPath = null;
+
+        try
+        {
+            var logsDirectory = _paths.LogsDirectory;
+            if (!Directory.Exists(logsDirectory))
+                return null;
+
+            var latestCrashLog = new DirectoryInfo(logsDirectory)
+                .GetFiles("crash-*.log")
+                .Where(file => file.LastWriteTimeUtc >= startedAt.UtcDateTime.AddSeconds(-1))
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .FirstOrDefault();
+
+            if (latestCrashLog is null)
+                return null;
+
+            var crashLogText = File.ReadAllText(latestCrashLog.FullName);
+            foreach (var line in crashLogText.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (line.Contains("Daemon startup aborted:", StringComparison.OrdinalIgnoreCase))
+                {
+                    crashLogPath = latestCrashLog.FullName;
+                    return line;
+                }
+            }
+
+            crashLogPath = latestCrashLog.FullName;
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }
 
-public sealed record DaemonResult(bool Success, string Message);
+public sealed record DaemonResult(bool Success, string Message, string? CrashLogPath = null);
 
 public sealed record DaemonStatus(bool IsRunning, int? Pid, string Message);

--- a/src/Netclaw.Cli/Doctor/CrashLogHelper.cs
+++ b/src/Netclaw.Cli/Doctor/CrashLogHelper.cs
@@ -24,6 +24,20 @@ internal static class CrashLogHelper
     }
 
     /// <summary>
+    /// Returns crash log files written at or after the given cutoff, ordered by most recent first.
+    /// </summary>
+    public static IEnumerable<FileInfo> FindCrashLogsSince(string logsDirectory, DateTime cutoffUtc)
+    {
+        if (!Directory.Exists(logsDirectory))
+            return [];
+
+        return new DirectoryInfo(logsDirectory)
+            .GetFiles("crash-*.log", SearchOption.TopDirectoryOnly)
+            .Where(f => f.LastWriteTimeUtc >= cutoffUtc)
+            .OrderByDescending(f => f.LastWriteTimeUtc);
+    }
+
+    /// <summary>
     /// Attempts to extract a UTC timestamp from a crash log filename with the format
     /// <c>crash-YYYYMMDD-HHMMSS.log</c> (with optional suffixes after the timestamp).
     /// Returns <c>null</c> if the filename does not match.

--- a/src/Netclaw.Cli/Doctor/DeviceRegistryInspector.cs
+++ b/src/Netclaw.Cli/Doctor/DeviceRegistryInspector.cs
@@ -17,7 +17,10 @@ internal static class DeviceRegistryInspector
 
         try
         {
-            return JsonSerializer.Deserialize<List<PairedDevice>>(File.ReadAllText(paths.DevicesPath))?.Count ?? 0;
+            using var doc = JsonDocument.Parse(File.ReadAllText(paths.DevicesPath));
+            return doc.RootElement.ValueKind == JsonValueKind.Array
+                ? doc.RootElement.GetArrayLength()
+                : 0;
         }
         catch (JsonException)
         {

--- a/src/Netclaw.Cli/Doctor/DeviceRegistryInspector.cs
+++ b/src/Netclaw.Cli/Doctor/DeviceRegistryInspector.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeviceRegistryInspector.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Doctor;
+
+internal static class DeviceRegistryInspector
+{
+    public static int CountPairedDevices(NetclawPaths paths)
+    {
+        if (!File.Exists(paths.DevicesPath))
+            return 0;
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<PairedDevice>>(File.ReadAllText(paths.DevicesPath))?.Count ?? 0;
+        }
+        catch (JsonException)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
@@ -104,7 +104,7 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
 
         var hasRemoteAuthenticationPath = DeviceRegistryInspector.CountPairedDevices(_paths) > 0;
         var validationIssues = DaemonExposureValidator.Validate(config, hasRemoteAuthenticationPath)
-            .Where(static issue => !issue.Message.Contains("trusted proxy", StringComparison.OrdinalIgnoreCase))
+            .Where(static issue => !issue.IsTrustedProxyIssue)
             .ToArray();
         if (validationIssues.Length > 0)
         {

--- a/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
@@ -49,6 +49,10 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
 
         var host = daemonNode?["Host"]?.GetValue<string>() ?? "127.0.0.1";
         var modeStr = daemonNode?["ExposureMode"]?.GetValue<string>() ?? "local";
+        var trustedProxies = daemonNode?["TrustedProxies"] is JsonArray trustedProxyArray
+            ? trustedProxyArray.Select(static node => node?.GetValue<string>() ?? string.Empty).ToArray()
+            : [];
+        var skipTunnelProcessCheck = daemonNode?["SkipTunnelProcessCheck"]?.GetValue<bool>() ?? false;
 
         ExposureMode mode;
         try
@@ -60,11 +64,27 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
             return Task.FromResult(DoctorCheckResult.Error(
                 CheckName,
                 $"Unknown ExposureMode value '{modeStr}' in Daemon section.",
-                "Valid values: local, tailscale-serve, tailscale-funnel, cloudflare-tunnel."));
+                "Valid values: local, reverse-proxy, tailscale-serve, tailscale-funnel, cloudflare-tunnel."));
+        }
+
+        var config = new DaemonConfig
+        {
+            Host = host,
+            ExposureMode = mode,
+            TrustedProxies = trustedProxies,
+            SkipTunnelProcessCheck = skipTunnelProcessCheck
+        };
+
+        if (DaemonExposureValidator.TryGetInvalidTrustedProxy(config.TrustedProxies, out var invalidTrustedProxyError))
+        {
+            return Task.FromResult(DoctorCheckResult.Error(
+                CheckName,
+                invalidTrustedProxyError!,
+                "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'."));
         }
 
         // Warning: local mode with non-loopback bind address — daemon exposed without tunnel.
-        if (mode == ExposureMode.Local && !IsLoopback(host))
+        if (mode == ExposureMode.Local && !DaemonExposureValidator.IsLoopbackHost(host))
         {
             return Task.FromResult(DoctorCheckResult.Warning(
                 CheckName,
@@ -74,20 +94,25 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
                 "cloudflare-tunnel) or bind to 127.0.0.1 in netclaw.json."));
         }
 
-        // Error: non-local mode but required tunnel process is not running.
-        if (mode != ExposureMode.Local)
+        if (DaemonExposureValidator.GetMissingRequiredProcessIssue(config, _processDetector) is { } processIssue)
         {
-            var requiredProcess = mode.GetRequiredProcessName();
+            return Task.FromResult(DoctorCheckResult.Error(
+                CheckName,
+                processIssue.Message,
+                processIssue.Remediation));
+        }
 
-            if (requiredProcess is not null && !_processDetector(requiredProcess))
-            {
-                var modeDisplay = mode.ToWireValue();
-                return Task.FromResult(DoctorCheckResult.Error(
-                    CheckName,
-                    $"ExposureMode is '{modeDisplay}' but '{requiredProcess}' is not running.",
-                    $"Start '{requiredProcess}' before starting Netclaw, " +
-                    "or set ExposureMode to 'local' in netclaw.json."));
-            }
+        var hasRemoteAuthenticationPath = DeviceRegistryInspector.CountPairedDevices(_paths) > 0;
+        var validationIssues = DaemonExposureValidator.Validate(config, hasRemoteAuthenticationPath)
+            .Where(static issue => !issue.Message.Contains("trusted proxy", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (validationIssues.Length > 0)
+        {
+            var issue = validationIssues[0];
+            return Task.FromResult(DoctorCheckResult.Error(
+                CheckName,
+                issue.Message,
+                issue.Remediation));
         }
 
         var modeDescription = mode == ExposureMode.Local
@@ -98,8 +123,5 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
             CheckName,
             $"ExposureMode: {modeDescription}."));
     }
-
-    private static bool IsLoopback(string host)
-        => host is "127.0.0.1" or "::1" or "localhost";
 
 }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -993,6 +993,8 @@ static void WriteCrashLog(Exception ex)
 static void WriteDaemonResult(DaemonResult result)
 {
     Console.WriteLine(result.Message);
+    if (!string.IsNullOrWhiteSpace(result.CrashLogPath))
+        Console.WriteLine($"Crash log: {result.CrashLogPath}");
     if (!result.Success)
         Environment.ExitCode = 1;
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
@@ -168,9 +168,14 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
         {
             runner.Add(new HealthCheckItem("Starting daemon", null));
             var daemonOk = await StartAndPollDaemonAsync(ct);
-            runner.UpdateLast(daemonOk
-                ? new HealthCheckItem("Daemon ready", true)
-                : new HealthCheckItem("Daemon did not become ready (personality setup skipped)", false));
+            if (daemonOk)
+            {
+                runner.UpdateLast(new HealthCheckItem("Daemon ready", true));
+            }
+            else if (Results.Count > 0 && Results[^1].Passed is null)
+            {
+                runner.UpdateLast(new HealthCheckItem("Daemon did not become ready (personality setup skipped)", false));
+            }
         }
 
         IsRunning.Value = false;
@@ -195,7 +200,14 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
 
         var result = _daemonManager.Start();
         if (!result.Success && !result.Message.Contains("already running", StringComparison.OrdinalIgnoreCase))
+        {
+            var failureText = result.CrashLogPath is null
+                ? result.Message
+                : $"{result.Message} See crash log: {result.CrashLogPath}";
+            Results[^1] = new HealthCheckItem(failureText, false);
+            NotifyChanged();
             return false;
+        }
 
         for (var i = 0; i < 30; i++)
         {

--- a/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
@@ -27,6 +27,7 @@ public sealed class DaemonConfigTests
         Assert.Equal(5199, result.Port);
         Assert.Equal(ExposureMode.Local, result.ExposureMode);
         Assert.False(result.DisableSelfUpdate);
+        Assert.False(result.SkipTunnelProcessCheck);
     }
 
     [Fact]
@@ -38,10 +39,12 @@ public sealed class DaemonConfigTests
         Assert.Equal(5199, result.Port);
         Assert.Equal(ExposureMode.Local, result.ExposureMode);
         Assert.False(result.DisableSelfUpdate);
+        Assert.False(result.SkipTunnelProcessCheck);
     }
 
     [Theory]
     [InlineData("local", ExposureMode.Local)]
+    [InlineData("reverse-proxy", ExposureMode.ReverseProxy)]
     [InlineData("tailscale-serve", ExposureMode.TailscaleServe)]
     [InlineData("tailscale-funnel", ExposureMode.TailscaleFunnel)]
     [InlineData("cloudflare-tunnel", ExposureMode.CloudflareTunnel)]
@@ -108,10 +111,26 @@ public sealed class DaemonConfigTests
         Assert.True(result.DisableSelfUpdate);
     }
 
+    [Fact]
+    public void BindFromConfiguration_reads_SkipTunnelProcessCheck_true()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Daemon:SkipTunnelProcessCheck"] = "true"
+            })
+            .Build();
+
+        var result = DaemonConfig.BindFromConfiguration(config.GetSection("Daemon"));
+
+        Assert.True(result.SkipTunnelProcessCheck);
+    }
+
     // ── System.Text.Json serialization path ──────────────────────────────────
 
     [Theory]
     [InlineData("local", ExposureMode.Local)]
+    [InlineData("reverse-proxy", ExposureMode.ReverseProxy)]
     [InlineData("tailscale-serve", ExposureMode.TailscaleServe)]
     [InlineData("tailscale-funnel", ExposureMode.TailscaleFunnel)]
     [InlineData("cloudflare-tunnel", ExposureMode.CloudflareTunnel)]
@@ -127,6 +146,7 @@ public sealed class DaemonConfigTests
 
     [Theory]
     [InlineData(ExposureMode.Local, "local")]
+    [InlineData(ExposureMode.ReverseProxy, "reverse-proxy")]
     [InlineData(ExposureMode.TailscaleServe, "tailscale-serve")]
     [InlineData(ExposureMode.TailscaleFunnel, "tailscale-funnel")]
     [InlineData(ExposureMode.CloudflareTunnel, "cloudflare-tunnel")]
@@ -137,5 +157,51 @@ public sealed class DaemonConfigTests
         var json = JsonSerializer.Serialize(config);
 
         Assert.Contains($"\"ExposureMode\":\"{expectedWire}\"", json);
+    }
+
+    [Fact]
+    public void BindFromConfiguration_reads_trusted_proxies()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Daemon:TrustedProxies:0"] = "10.0.0.5",
+                ["Daemon:TrustedProxies:1"] = "10.0.0.0/24"
+            })
+            .Build();
+
+        var result = DaemonConfig.BindFromConfiguration(config.GetSection("Daemon"));
+
+        Assert.Equal(["10.0.0.5", "10.0.0.0/24"], result.TrustedProxies);
+    }
+
+    [Fact]
+    public void Validator_rejects_loopback_reverse_proxy_topology()
+    {
+        var issues = DaemonExposureValidator.Validate(
+            new DaemonConfig
+            {
+                ExposureMode = ExposureMode.ReverseProxy,
+                Host = "127.0.0.1",
+                TrustedProxies = ["10.0.0.5"]
+            },
+            hasRemoteAuthenticationPath: true);
+
+        Assert.Contains(issues, issue => issue.Message.Contains("loopback", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validator_rejects_invalid_trusted_proxy_entry()
+    {
+        var issues = DaemonExposureValidator.Validate(
+            new DaemonConfig
+            {
+                ExposureMode = ExposureMode.ReverseProxy,
+                Host = "10.0.0.10",
+                TrustedProxies = ["not-an-ip"]
+            },
+            hasRemoteAuthenticationPath: true);
+
+        Assert.Contains(issues, issue => issue.Message.Contains("not-an-ip", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -120,7 +120,8 @@ public static class DaemonExposureValidator
         {
             issues.Add(new DaemonExposureValidationIssue(
                 invalidTrustedProxyError!,
-                "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'."));
+                "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'.",
+                IsTrustedProxyIssue: true));
         }
 
         if (!config.ExposureMode.RequiresRemoteAuthentication())
@@ -215,13 +216,19 @@ public static class DaemonExposureValidator
         return true;
     }
 
+    /// <summary>
+    /// Parses all trusted proxy entries. Throws on invalid entries — callers must validate
+    /// with <see cref="TryGetInvalidTrustedProxy"/> before calling this method.
+    /// </summary>
     public static IReadOnlyList<ParsedTrustedProxy> ParseTrustedProxies(IEnumerable<string> trustedProxies)
     {
         var parsed = new List<ParsedTrustedProxy>();
         foreach (var trustedProxy in trustedProxies)
         {
-            if (TryParseTrustedProxy(trustedProxy, out var entry, out _))
-                parsed.Add(entry!);
+            if (!TryParseTrustedProxy(trustedProxy, out var entry, out var error))
+                throw new InvalidOperationException(error);
+
+            parsed.Add(entry!);
         }
 
         return parsed;
@@ -255,6 +262,6 @@ public static class DaemonExposureValidator
     }
 }
 
-public sealed record DaemonExposureValidationIssue(string Message, string Remediation);
+public sealed record DaemonExposureValidationIssue(string Message, string Remediation, bool IsTrustedProxyIssue = false);
 
 public sealed record ParsedTrustedProxy(string RawValue, IPAddress Address, int? PrefixLength);

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Configuration;
+using System.Net;
 
 namespace Netclaw.Configuration;
 
@@ -39,6 +40,18 @@ public sealed record DaemonConfig
     public bool DisableSelfUpdate { get; init; }
 
     /// <summary>
+    /// Explicitly trusted reverse-proxy source addresses or CIDR ranges. Only used when
+    /// <see cref="ExposureMode"/> is <see cref="Netclaw.Configuration.ExposureMode.ReverseProxy"/>.
+    /// </summary>
+    public IReadOnlyList<string> TrustedProxies { get; init; } = [];
+
+    /// <summary>
+    /// When true, skips the default local tunnel-process prerequisite check for tunnel-backed
+    /// exposure modes. Intended only for sidecar or host-managed tunnel topologies.
+    /// </summary>
+    public bool SkipTunnelProcessCheck { get; init; }
+
+    /// <summary>
     /// Bind <see cref="DaemonConfig"/> from an <see cref="IConfigurationSection"/>.
     /// Handles kebab-case <c>ExposureMode</c> values (e.g., <c>tailscale-serve</c>).
     /// Returns defaults when the section is missing or empty.
@@ -53,8 +66,18 @@ public sealed record DaemonConfig
         var modeStr = section["ExposureMode"];
         var mode = ParseExposureMode(modeStr);
         var disableSelfUpdate = section.GetValue<bool?>("DisableSelfUpdate") ?? false;
+        var trustedProxies = section.GetSection("TrustedProxies").Get<string[]>() ?? [];
+        var skipTunnelProcessCheck = section.GetValue<bool?>("SkipTunnelProcessCheck") ?? false;
 
-        return new DaemonConfig { Host = host, Port = port, ExposureMode = mode, DisableSelfUpdate = disableSelfUpdate };
+        return new DaemonConfig
+        {
+            Host = host,
+            Port = port,
+            ExposureMode = mode,
+            DisableSelfUpdate = disableSelfUpdate,
+            TrustedProxies = trustedProxies,
+            SkipTunnelProcessCheck = skipTunnelProcessCheck
+        };
     }
 
     /// <summary>
@@ -70,12 +93,168 @@ public sealed record DaemonConfig
         return value.Trim().ToLowerInvariant() switch
         {
             "local" => ExposureMode.Local,
+            "reverse-proxy" or "reverseproxy" => ExposureMode.ReverseProxy,
             "tailscale-serve" or "tailscaleserve" => ExposureMode.TailscaleServe,
             "tailscale-funnel" or "tailscalefunnel" => ExposureMode.TailscaleFunnel,
             "cloudflare-tunnel" or "cloudflaretunnel" => ExposureMode.CloudflareTunnel,
             _ => throw new InvalidOperationException(
                 $"Unknown ExposureMode value: '{value.Trim()}'. " +
-                "Valid values: local, tailscale-serve, tailscale-funnel, cloudflare-tunnel.")
+                "Valid values: local, reverse-proxy, tailscale-serve, tailscale-funnel, cloudflare-tunnel.")
         };
     }
 }
+
+/// <summary>
+/// Shared daemon exposure validation and trusted-proxy parsing helpers used by startup,
+/// doctor, and reverse-proxy request handling.
+/// </summary>
+public static class DaemonExposureValidator
+{
+    public static IReadOnlyList<DaemonExposureValidationIssue> Validate(
+        DaemonConfig config,
+        bool hasRemoteAuthenticationPath)
+    {
+        var issues = new List<DaemonExposureValidationIssue>();
+
+        if (TryGetInvalidTrustedProxy(config.TrustedProxies, out var invalidTrustedProxyError))
+        {
+            issues.Add(new DaemonExposureValidationIssue(
+                invalidTrustedProxyError!,
+                "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'."));
+        }
+
+        if (!config.ExposureMode.RequiresRemoteAuthentication())
+            return issues;
+
+        if (!hasRemoteAuthenticationPath)
+        {
+            issues.Add(new DaemonExposureValidationIssue(
+                $"No remote authentication available: ExposureMode='{config.ExposureMode.ToWireValue()}' requires either at least one paired device or an alternative remote auth scheme.",
+                "Run 'netclaw daemon pair' to pair a device, or check your auth configuration before exposing the daemon remotely."));
+        }
+
+        if (config.ExposureMode == ExposureMode.ReverseProxy)
+        {
+            if (IsLoopbackHost(config.Host))
+            {
+                issues.Add(new DaemonExposureValidationIssue(
+                    $"Invalid reverse-proxy topology: Daemon.Host '{config.Host}' is loopback. Loopback auto-auth is reserved for true local operator traffic and cannot be inherited through a reverse proxy.",
+                    "Bind the daemon to a non-loopback internal IP, such as 10.x.x.x or 192.168.x.x, and have the proxy forward to that address instead of 127.0.0.1, ::1, or localhost."));
+            }
+
+            if (config.TrustedProxies.Count == 0)
+            {
+                issues.Add(new DaemonExposureValidationIssue(
+                    "Invalid reverse-proxy topology: Daemon.TrustedProxies must contain at least one explicitly trusted proxy address or CIDR.",
+                    "Add the reverse proxy's source IP or subnet to Daemon.TrustedProxies so forwarded headers are only honored from known peers."));
+            }
+        }
+
+        return issues;
+    }
+
+    public static bool IsLoopbackHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return false;
+
+        var trimmed = host.Trim();
+        if (string.Equals(trimmed, "localhost", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return IPAddress.TryParse(trimmed, out var address) && IPAddress.IsLoopback(address);
+    }
+
+    public static bool TryParseTrustedProxy(string rawValue, out ParsedTrustedProxy? parsedProxy, out string? error)
+    {
+        parsedProxy = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            error = "Invalid trusted proxy entry ''. Value cannot be empty.";
+            return false;
+        }
+
+        var trimmed = rawValue.Trim();
+        var slashIndex = trimmed.IndexOf('/', StringComparison.Ordinal);
+        if (slashIndex < 0)
+        {
+            if (!IPAddress.TryParse(trimmed, out var address))
+            {
+                error = $"Invalid trusted proxy entry '{trimmed}'. Value is not a valid IP address or CIDR.";
+                return false;
+            }
+
+            parsedProxy = new ParsedTrustedProxy(trimmed, address, PrefixLength: null);
+            return true;
+        }
+
+        var addressPart = trimmed[..slashIndex];
+        var prefixPart = trimmed[(slashIndex + 1)..];
+        if (!IPAddress.TryParse(addressPart, out var networkAddress))
+        {
+            error = $"Invalid trusted proxy entry '{trimmed}'. '{addressPart}' is not a valid IP address.";
+            return false;
+        }
+
+        if (!int.TryParse(prefixPart, out var prefixLength))
+        {
+            error = $"Invalid trusted proxy entry '{trimmed}'. '{prefixPart}' is not a valid CIDR prefix length.";
+            return false;
+        }
+
+        var maxPrefix = networkAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? 32 : 128;
+        if (prefixLength < 0 || prefixLength > maxPrefix)
+        {
+            error = $"Invalid trusted proxy entry '{trimmed}'. CIDR prefix length must be between 0 and {maxPrefix}.";
+            return false;
+        }
+
+        parsedProxy = new ParsedTrustedProxy(trimmed, networkAddress, prefixLength);
+        return true;
+    }
+
+    public static IReadOnlyList<ParsedTrustedProxy> ParseTrustedProxies(IEnumerable<string> trustedProxies)
+    {
+        var parsed = new List<ParsedTrustedProxy>();
+        foreach (var trustedProxy in trustedProxies)
+        {
+            if (TryParseTrustedProxy(trustedProxy, out var entry, out _))
+                parsed.Add(entry!);
+        }
+
+        return parsed;
+    }
+
+    public static bool TryGetInvalidTrustedProxy(IEnumerable<string> trustedProxies, out string? error)
+    {
+        foreach (var trustedProxy in trustedProxies)
+        {
+            if (!TryParseTrustedProxy(trustedProxy, out _, out error))
+                return true;
+        }
+
+        error = null;
+        return false;
+    }
+
+    public static DaemonExposureValidationIssue? GetMissingRequiredProcessIssue(
+        DaemonConfig config,
+        Func<string, bool> processDetector)
+    {
+        ArgumentNullException.ThrowIfNull(processDetector);
+
+        var requiredProcess = config.ExposureMode.GetRequiredProcessName();
+        if (requiredProcess is null || config.SkipTunnelProcessCheck || processDetector(requiredProcess))
+            return null;
+
+        return new DaemonExposureValidationIssue(
+            $"Tunnel prerequisite not met: ExposureMode='{config.ExposureMode.ToWireValue()}' requires '{requiredProcess}' to be running unless Daemon.SkipTunnelProcessCheck=true is explicitly set for a sidecar or host-managed tunnel topology.",
+            $"Start '{requiredProcess}' locally, or set Daemon.SkipTunnelProcessCheck=true only when the tunnel is intentionally managed outside the Netclaw process namespace.");
+    }
+}
+
+public sealed record DaemonExposureValidationIssue(string Message, string Remediation);
+
+public sealed record ParsedTrustedProxy(string RawValue, IPAddress Address, int? PrefixLength);

--- a/src/Netclaw.Configuration/ExposureMode.cs
+++ b/src/Netclaw.Configuration/ExposureMode.cs
@@ -18,6 +18,9 @@ public enum ExposureMode
     /// <summary>Daemon binds loopback only. No tunnel required.</summary>
     Local,
 
+    /// <summary>Daemon is reachable behind a trusted reverse proxy.</summary>
+    ReverseProxy,
+
     /// <summary>Daemon is reachable via Tailscale Serve (same tailnet only).</summary>
     TailscaleServe,
 
@@ -37,6 +40,7 @@ public static class ExposureModeExtensions
     public static string ToWireValue(this ExposureMode mode) => mode switch
     {
         ExposureMode.Local => "local",
+        ExposureMode.ReverseProxy => "reverse-proxy",
         ExposureMode.TailscaleServe => "tailscale-serve",
         ExposureMode.TailscaleFunnel => "tailscale-funnel",
         ExposureMode.CloudflareTunnel => "cloudflare-tunnel",
@@ -50,8 +54,20 @@ public static class ExposureModeExtensions
     public static string? GetRequiredProcessName(this ExposureMode mode) => mode switch
     {
         ExposureMode.Local => null,
+        ExposureMode.ReverseProxy => null,
         ExposureMode.TailscaleServe or ExposureMode.TailscaleFunnel => "tailscaled",
         ExposureMode.CloudflareTunnel => "cloudflared",
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, $"Unknown ExposureMode value: {mode}")
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when the mode accepts remote traffic and therefore requires
+    /// an explicit remote authentication path.
+    /// </summary>
+    public static bool RequiresRemoteAuthentication(this ExposureMode mode) => mode switch
+    {
+        ExposureMode.Local => false,
+        ExposureMode.ReverseProxy or ExposureMode.TailscaleServe or ExposureMode.TailscaleFunnel or ExposureMode.CloudflareTunnel => true,
         _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, $"Unknown ExposureMode value: {mode}")
     };
 }

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -593,9 +593,23 @@
         },
         "ExposureMode": {
           "type": "string",
-          "enum": ["local", "tailscale-serve", "tailscale-funnel", "cloudflare-tunnel"],
+          "enum": ["local", "reverse-proxy", "tailscale-serve", "tailscale-funnel", "cloudflare-tunnel"],
           "default": "local",
           "description": "Tunnel infrastructure in front of the daemon. Defaults to local (loopback only, no tunnel)."
+        },
+        "TrustedProxies": {
+          "type": "array",
+          "default": [],
+          "description": "Explicitly trusted reverse-proxy source IPs or CIDR ranges. Required for reverse-proxy mode.",
+          "items": {
+            "type": "string",
+            "pattern": "^(?:(?:\\d{1,3}\\.){3}\\d{1,3}(?:\\/(?:[0-9]|[12][0-9]|3[0-2]))?|(?:[0-9A-Fa-f:]+:+)+[0-9A-Fa-f]+(?:\\/(?:[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8]))?)$"
+          }
+        },
+        "SkipTunnelProcessCheck": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, skips the local tunnel-process prerequisite check for tunnel-backed exposure modes. Use only for sidecar or host-managed tunnel topologies."
         },
         "DisableSelfUpdate": {
           "type": "boolean",

--- a/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Reminder/ReminderEndpointAuthorizationTests.cs
@@ -58,7 +58,7 @@ public sealed class ReminderEndpointAuthorizationTests : IDisposable
             ShellExecutionMode.Off,
             UsedStrictFallback: false));
         builder.Services.AddSingleton<ClaimsPrincipalMapper>();
-        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddNetclawAuthSchemes(new DaemonConfig());
         builder.Services.AddAuthorization();
 
         var app = builder.Build();

--- a/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
@@ -20,10 +20,12 @@ namespace Netclaw.Daemon.Tests.Security;
 /// </summary>
 public sealed class LoopbackAuthenticationHandlerTests
 {
-    private static (IServiceProvider Sp, IAuthenticationService Auth) BuildAuthService()
+    private static (IServiceProvider Sp, IAuthenticationService Auth) BuildAuthService(
+        DaemonConfig? config = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton(config ?? new DaemonConfig());
         services
             .AddAuthentication(LoopbackAuthenticationHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, LoopbackAuthenticationHandler>(

--- a/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/LoopbackAuthenticationHandlerTests.cs
@@ -20,10 +20,11 @@ namespace Netclaw.Daemon.Tests.Security;
 /// </summary>
 public sealed class LoopbackAuthenticationHandlerTests
 {
-    private static (IServiceProvider Sp, IAuthenticationService Auth) BuildAuthService()
+    private static (IServiceProvider Sp, IAuthenticationService Auth) BuildAuthService(DaemonConfig? daemonConfig = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton(daemonConfig ?? new DaemonConfig());
         services
             .AddAuthentication(LoopbackAuthenticationHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, LoopbackAuthenticationHandler>(
@@ -86,6 +87,19 @@ public sealed class LoopbackAuthenticationHandlerTests
         var (sp, authService) = BuildAuthService();
         var ctx = BuildContext(IPAddress.None, sp);
         ctx.Connection.RemoteIpAddress = null;
+
+        var result = await authService.AuthenticateAsync(ctx, LoopbackAuthenticationHandler.SchemeName);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Failure);
+        Assert.Null(result.Principal);
+    }
+
+    [Fact]
+    public async Task Reverse_proxy_mode_returns_no_result_for_loopback_ip()
+    {
+        var (sp, authService) = BuildAuthService(new DaemonConfig { ExposureMode = ExposureMode.ReverseProxy });
+        var ctx = BuildContext(IPAddress.Loopback, sp);
 
         var result = await authService.AuthenticateAsync(ctx, LoopbackAuthenticationHandler.SchemeName);
 

--- a/src/Netclaw.Daemon.Tests/Security/PairingCodeEndpointTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/PairingCodeEndpointTests.cs
@@ -51,7 +51,7 @@ public sealed class PairingCodeEndpointTests : IDisposable
         builder.WebHost.UseTestServer();
 
         builder.Services.AddSingleton(_registry);
-        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddNetclawAuthSchemes(new DaemonConfig());
         builder.Services.AddAuthorization();
 
         var app = builder.Build();

--- a/src/Netclaw.Daemon.Tests/Security/PairingExchangeEndpointTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/PairingExchangeEndpointTests.cs
@@ -6,9 +6,12 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,8 +48,13 @@ public sealed class PairingExchangeEndpointTests : IDisposable
 
     public void Dispose() => _dir.Dispose();
 
-    private async Task<WebApplication> CreateAppAsync()
+    private async Task<WebApplication> CreateAppAsync(
+        DaemonConfig? daemonConfig = null,
+        IPAddress? directPeerIp = null,
+        bool enableRateLimiting = false)
     {
+        daemonConfig ??= new DaemonConfig();
+
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
 
@@ -54,17 +62,70 @@ public sealed class PairingExchangeEndpointTests : IDisposable
         builder.Services.AddSingleton(_pairingCodeService);
         builder.Services.AddSingleton(_exchangeGuard);
         builder.Services.AddSingleton<TimeProvider>(_time);
-        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddNetclawAuthSchemes(daemonConfig);
         builder.Services.AddAuthorization();
 
+        if (enableRateLimiting)
+        {
+            builder.Services.AddRateLimiter(options =>
+            {
+                options.AddPolicy("pairing-exchange", context =>
+                    RateLimitPartition.GetFixedWindowLimiter(
+                        context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                        _ => new FixedWindowRateLimiterOptions
+                        {
+                            PermitLimit = 5,
+                            Window = TimeSpan.FromMinutes(1),
+                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                            QueueLimit = 0,
+                        }));
+                options.RejectionStatusCode = 429;
+            });
+        }
+
         var app = builder.Build();
+
+        if (directPeerIp is not null)
+        {
+            var ip = directPeerIp;
+            app.Use(async (ctx, next) =>
+            {
+                ctx.Connection.RemoteIpAddress = ip;
+                await next(ctx);
+            });
+        }
+
+        if (daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
+        {
+            var forwardedHeadersOptions = new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+                ForwardLimit = 1
+            };
+
+            foreach (var trustedProxy in DaemonExposureValidator.ParseTrustedProxies(daemonConfig.TrustedProxies))
+            {
+                if (trustedProxy.PrefixLength is null)
+                {
+                    forwardedHeadersOptions.KnownProxies.Add(trustedProxy.Address);
+                }
+                else
+                {
+                    forwardedHeadersOptions.KnownIPNetworks.Add(
+                        new System.Net.IPNetwork(trustedProxy.Address, trustedProxy.PrefixLength.Value));
+                }
+            }
+
+            app.UseForwardedHeaders(forwardedHeadersOptions);
+        }
 
         app.UseAuthentication();
         app.UseAuthorization();
 
-        // Mirror the production exchange endpoint (from Program.cs) without rate limiting,
-        // since TestServer doesn't set RemoteIpAddress and rate limiting is orthogonal.
-        app.MapPost("/api/pair/exchange", async (
+        if (enableRateLimiting)
+            app.UseRateLimiter();
+
+        var exchangeEndpoint = app.MapPost("/api/pair/exchange", async (
             HttpContext httpContext,
             PairingCodeExchangeRequest request,
             PairingCodeService pairingCodeService,
@@ -125,7 +186,12 @@ public sealed class PairingExchangeEndpointTests : IDisposable
             }
 
             return Results.Ok(new { token = rawToken });
-        }).AllowAnonymous();
+        });
+
+        if (enableRateLimiting)
+            exchangeEndpoint.RequireRateLimiting("pairing-exchange");
+
+        exchangeEndpoint.AllowAnonymous();
 
         // Authenticated endpoint to verify returned tokens work
         app.MapGet("/api/pair/devices", async (DeviceRegistry deviceRegistry, CancellationToken ct) =>
@@ -300,5 +366,123 @@ public sealed class PairingExchangeEndpointTests : IDisposable
             new { code, deviceName = "Laptop" }, ct);
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_PairingGuard_UsesForwardedClientIp_FromTrustedProxy()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        _pairingCodeService.GenerateCode();
+
+        var daemonConfig = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+
+        await using var app = await CreateAppAsync(
+            daemonConfig: daemonConfig,
+            directPeerIp: IPAddress.Parse("10.0.0.5"));
+        var client = app.GetTestClient();
+
+        for (var i = 0; i < PairingExchangeGuard.FailureThreshold; i++)
+        {
+            var failedResponse = await PostExchangeAsync(
+                client,
+                code: "ZZZZ-ZZZZ",
+                deviceName: "laptop",
+                forwardedFor: "198.51.100.20",
+                ct);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, failedResponse.StatusCode);
+        }
+
+        var blockedResponse = await PostExchangeAsync(
+            client,
+            code: "ZZZZ-ZZZZ",
+            deviceName: "laptop",
+            forwardedFor: "198.51.100.20",
+            ct);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, blockedResponse.StatusCode);
+        Assert.True(blockedResponse.Headers.TryGetValues("Retry-After", out _));
+
+        var otherForwardedClientResponse = await PostExchangeAsync(
+            client,
+            code: "ZZZZ-ZZZZ",
+            deviceName: "laptop",
+            forwardedFor: "198.51.100.21",
+            ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, otherForwardedClientResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_RateLimiter_UsesForwardedClientIp_FromTrustedProxy()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        _pairingCodeService.GenerateCode();
+
+        var daemonConfig = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+
+        await using var app = await CreateAppAsync(
+            daemonConfig: daemonConfig,
+            directPeerIp: IPAddress.Parse("10.0.0.5"),
+            enableRateLimiting: true);
+        var client = app.GetTestClient();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var response = await PostExchangeAsync(
+                client,
+                code: "ZZZZ-ZZZZ",
+                deviceName: "laptop",
+                forwardedFor: "198.51.100.30",
+                ct);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        var limitedResponse = await PostExchangeAsync(
+            client,
+            code: "ZZZZ-ZZZZ",
+            deviceName: "laptop",
+            forwardedFor: "198.51.100.30",
+            ct);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
+
+        var otherForwardedClientResponse = await PostExchangeAsync(
+            client,
+            code: "ZZZZ-ZZZZ",
+            deviceName: "laptop",
+            forwardedFor: "198.51.100.31",
+            ct);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, otherForwardedClientResponse.StatusCode);
+    }
+
+    private static Task<HttpResponseMessage> PostExchangeAsync(
+        HttpClient client,
+        string code,
+        string deviceName,
+        string? forwardedFor,
+        CancellationToken ct)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/pair/exchange")
+        {
+            Content = JsonContent.Create(new { code, deviceName })
+        };
+
+        if (!string.IsNullOrWhiteSpace(forwardedFor))
+            request.Headers.TryAddWithoutValidation("X-Forwarded-For", forwardedFor);
+
+        return client.SendAsync(request, ct);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Security/SessionHubAuthorizationTests.cs
+++ b/src/Netclaw.Daemon.Tests/Security/SessionHubAuthorizationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,6 +34,8 @@ namespace Netclaw.Daemon.Tests.Security;
 /// </summary>
 public sealed class SessionHubAuthorizationTests : IDisposable
 {
+    private const string ObservedRemoteIpHeader = "X-Test-Observed-Remote-IP";
+
     private readonly DisposableTempDir _dir = new();
     private readonly FakeTimeProvider _time;
     private readonly DeviceRegistry _deviceRegistry;
@@ -62,13 +65,17 @@ public sealed class SessionHubAuthorizationTests : IDisposable
     /// simulating a connection from that IP. When null, the TestServer default of
     /// no remote IP is used, which the loopback handler treats as non-loopback.
     /// </summary>
-    private async Task<WebApplication> CreateAppAsync(IPAddress? spoofedRemoteIp = null)
+    private async Task<WebApplication> CreateAppAsync(
+        IPAddress? spoofedRemoteIp = null,
+        DaemonConfig? daemonConfig = null)
     {
+        daemonConfig ??= new DaemonConfig();
+
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
 
         builder.Services.AddSingleton(_deviceRegistry);
-        builder.Services.AddNetclawAuthSchemes();
+        builder.Services.AddNetclawAuthSchemes(daemonConfig);
         builder.Services.AddAuthorization();
         builder.Services.AddSignalR();
 
@@ -84,6 +91,44 @@ public sealed class SessionHubAuthorizationTests : IDisposable
                 await next(ctx);
             });
         }
+
+        if (daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
+        {
+            var forwardedHeadersOptions = new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+                ForwardLimit = 1
+            };
+
+            foreach (var trustedProxy in DaemonExposureValidator.ParseTrustedProxies(daemonConfig.TrustedProxies))
+            {
+                if (trustedProxy.PrefixLength is null)
+                {
+                    forwardedHeadersOptions.KnownProxies.Add(trustedProxy.Address);
+                }
+                else
+                {
+                    forwardedHeadersOptions.KnownIPNetworks.Add(
+                        new System.Net.IPNetwork(trustedProxy.Address, trustedProxy.PrefixLength.Value));
+                }
+            }
+
+            app.UseForwardedHeaders(forwardedHeadersOptions);
+        }
+
+        app.Use(async (ctx, next) =>
+        {
+            var observedRemoteIp = ctx.Connection.RemoteIpAddress?.ToString();
+            ctx.Response.OnStarting(() =>
+            {
+                if (!string.IsNullOrWhiteSpace(observedRemoteIp))
+                    ctx.Response.Headers[ObservedRemoteIpHeader] = observedRemoteIp;
+
+                return Task.CompletedTask;
+            });
+
+            await next(ctx);
+        });
 
         app.UseAuthentication();
         app.UseAuthorization();
@@ -170,5 +215,96 @@ public sealed class SessionHubAuthorizationTests : IDisposable
             ct);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Reverse_proxy_trusted_forwarded_client_ip_is_seen_before_auth_evaluation()
+    {
+        var daemonConfig = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+
+        await using var app = await CreateAppAsync(
+            spoofedRemoteIp: IPAddress.Parse("10.0.0.5"),
+            daemonConfig: daemonConfig);
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/hub/session/negotiate?negotiateVersion=1");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", "198.51.100.25");
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("198.51.100.25", GetObservedRemoteIp(response));
+    }
+
+    [Fact]
+    public async Task Reverse_proxy_trusted_forwarded_client_ip_allows_valid_bearer_auth()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (rawToken, device) = MakeDevice("proxy-laptop", _time.GetUtcNow());
+        await _deviceRegistry.AddAsync(device, ct);
+
+        var daemonConfig = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+
+        await using var app = await CreateAppAsync(
+            spoofedRemoteIp: IPAddress.Parse("10.0.0.5"),
+            daemonConfig: daemonConfig);
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", rawToken);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/hub/session/negotiate?negotiateVersion=1");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", "198.51.100.26");
+
+        var response = await client.SendAsync(request, ct);
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("198.51.100.26", GetObservedRemoteIp(response));
+    }
+
+    [Fact]
+    public async Task Reverse_proxy_ignores_forwarded_headers_from_untrusted_proxy_peer()
+    {
+        var daemonConfig = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+
+        await using var app = await CreateAppAsync(
+            spoofedRemoteIp: IPAddress.Parse("203.0.113.10"),
+            daemonConfig: daemonConfig);
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/hub/session/negotiate?negotiateVersion=1");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-For", "127.0.0.1");
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("203.0.113.10", GetObservedRemoteIp(response));
+    }
+
+    private static string GetObservedRemoteIp(HttpResponseMessage response)
+    {
+        Assert.True(response.Headers.TryGetValues(ObservedRemoteIpHeader, out var values));
+        return Assert.Single(values);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
@@ -31,7 +31,11 @@ public sealed class ExposureModeValidationServiceTests
     public async Task TailscaleServe_WithTailscaledRunning_StartSucceeds()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.TailscaleServe };
-        var sut = BuildService(config, name => name == "tailscaled");
+        var sut = BuildService(
+            config,
+            name => name == "tailscaled",
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
     }
@@ -47,6 +51,7 @@ public sealed class ExposureModeValidationServiceTests
 
         Assert.Contains("tailscale-serve", ex.Message);
         Assert.Contains("tailscaled", ex.Message);
+        Assert.Contains("SkipTunnelProcessCheck", ex.Message);
     }
 
     // ── TailscaleFunnel ──────────────────────────────────────────────────────
@@ -55,7 +60,11 @@ public sealed class ExposureModeValidationServiceTests
     public async Task TailscaleFunnel_WithTailscaledRunning_StartSucceeds()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.TailscaleFunnel };
-        var sut = BuildService(config, name => name == "tailscaled");
+        var sut = BuildService(
+            config,
+            name => name == "tailscaled",
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
     }
@@ -71,6 +80,7 @@ public sealed class ExposureModeValidationServiceTests
 
         Assert.Contains("tailscale-funnel", ex.Message);
         Assert.Contains("tailscaled", ex.Message);
+        Assert.Contains("SkipTunnelProcessCheck", ex.Message);
     }
 
     // ── CloudflareTunnel ─────────────────────────────────────────────────────
@@ -79,7 +89,11 @@ public sealed class ExposureModeValidationServiceTests
     public async Task CloudflareTunnel_WithCloudflaredRunning_StartSucceeds()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.CloudflareTunnel };
-        var sut = BuildService(config, name => name == "cloudflared");
+        var sut = BuildService(
+            config,
+            name => name == "cloudflared",
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
     }
@@ -95,6 +109,50 @@ public sealed class ExposureModeValidationServiceTests
 
         Assert.Contains("cloudflare-tunnel", ex.Message);
         Assert.Contains("cloudflared", ex.Message);
+        Assert.Contains("SkipTunnelProcessCheck", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(ExposureMode.TailscaleServe)]
+    [InlineData(ExposureMode.TailscaleFunnel)]
+    [InlineData(ExposureMode.CloudflareTunnel)]
+    public async Task TunnelModes_WithSkipTunnelProcessCheck_AndRemoteAuth_StartSucceeds(ExposureMode mode)
+    {
+        var config = new DaemonConfig
+        {
+            ExposureMode = mode,
+            SkipTunnelProcessCheck = true
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Theory]
+    [InlineData(ExposureMode.TailscaleServe)]
+    [InlineData(ExposureMode.TailscaleFunnel)]
+    [InlineData(ExposureMode.CloudflareTunnel)]
+    public async Task TunnelModes_WithSkipTunnelProcessCheck_StillRequireRemoteAuth(ExposureMode mode)
+    {
+        var config = new DaemonConfig
+        {
+            ExposureMode = mode,
+            SkipTunnelProcessCheck = true
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [],
+            deviceCount: 0);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("No remote authentication available", ex.Message);
     }
 
     // ── Cross-mode: wrong process running ────────────────────────────────────
@@ -170,6 +228,66 @@ public sealed class ExposureModeValidationServiceTests
             () => sut.StartAsync(TestContext.Current.CancellationToken));
 
         Assert.Contains("No remote authentication available", ex.Message);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithLoopbackHost_Throws()
+    {
+        var config = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "127.0.0.1",
+            TrustedProxies = ["10.0.0.5"]
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("loopback", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithInvalidTrustedProxy_Throws()
+    {
+        var config = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["127.0.0.1/999"]
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("127.0.0.1/999", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReverseProxy_WithNonLoopbackHostAndTrustedProxy_StartSucceeds()
+    {
+        var config = new DaemonConfig
+        {
+            ExposureMode = ExposureMode.ReverseProxy,
+            Host = "10.0.0.10",
+            TrustedProxies = ["10.0.0.5"]
+        };
+        var sut = BuildService(
+            config,
+            _ => false,
+            remoteAuthSchemes: [new FakeRemoteAuthScheme("TestScheme")],
+            deviceCount: 0);
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
     }
 
     // ── StopAsync is always a no-op ──────────────────────────────────────────

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -11,6 +11,7 @@ using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Sql.Hosting;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -127,7 +128,7 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
     builder.Services.AddSingleton<PairingCodeService>();
     builder.Services.AddSingleton<PairingExchangeGuard>();
     builder.Services.AddSingleton<IRemoteAuthSchemeRegistration, DevicePairingSchemeRegistration>();
-    builder.Services.AddNetclawAuthSchemes();
+    builder.Services.AddNetclawAuthSchemes(daemonConfig);
     builder.Services.AddAuthorization();
 
     // Rate limiting for the unauthenticated pairing exchange endpoint.
@@ -165,6 +166,30 @@ static async Task RunDaemonAsync(string[] args, DaemonRestartSignal restartSigna
 
     var app = builder.Build();
     crashMonitor.AttachServices(app.Services);
+
+    if (daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
+    {
+        var forwardedHeadersOptions = new ForwardedHeadersOptions
+        {
+            ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+            ForwardLimit = 1
+        };
+
+        foreach (var trustedProxy in DaemonExposureValidator.ParseTrustedProxies(daemonConfig.TrustedProxies))
+        {
+            if (trustedProxy.PrefixLength is null)
+            {
+                forwardedHeadersOptions.KnownProxies.Add(trustedProxy.Address);
+            }
+            else
+            {
+                forwardedHeadersOptions.KnownIPNetworks.Add(new System.Net.IPNetwork(trustedProxy.Address, trustedProxy.PrefixLength.Value));
+            }
+        }
+
+        // Forwarded headers are only meaningful after the direct peer is verified as a trusted proxy.
+        app.UseForwardedHeaders(forwardedHeadersOptions);
+    }
 
     // Eagerly resolve so StartedAt reflects daemon startup, not first request.
     app.Services.GetRequiredService<DaemonStartClock>();

--- a/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
+++ b/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
@@ -25,17 +25,23 @@ namespace Netclaw.Daemon.Security;
 public sealed class LoopbackAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     public const string SchemeName = "Loopback";
+    private readonly DaemonConfig _daemonConfig;
 
     public LoopbackAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
-        UrlEncoder encoder)
+        UrlEncoder encoder,
+        DaemonConfig daemonConfig)
         : base(options, logger, encoder)
     {
+        _daemonConfig = daemonConfig;
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        if (_daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
+            return Task.FromResult(AuthenticateResult.NoResult());
+
         var remoteIp = Context.Connection.RemoteIpAddress;
 
         if (remoteIp is null || !IsLoopback(remoteIp))

--- a/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
+++ b/src/Netclaw.Daemon/Security/LoopbackAuthenticationHandler.cs
@@ -39,6 +39,9 @@ public sealed class LoopbackAuthenticationHandler : AuthenticationHandler<Authen
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        // Reverse-proxy mode must never inherit loopback operator trust from the
+        // final hop. Even a same-host proxy forwarding over 127.0.0.1/::1 has to
+        // flow through a remote-authenticated scheme instead.
         if (_daemonConfig.ExposureMode == ExposureMode.ReverseProxy)
             return Task.FromResult(AuthenticateResult.NoResult());
 

--- a/src/Netclaw.Daemon/Security/NetclawAuthExtensions.cs
+++ b/src/Netclaw.Daemon/Security/NetclawAuthExtensions.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Security;
 
@@ -15,8 +16,9 @@ namespace Netclaw.Daemon.Security;
 /// </summary>
 internal static class NetclawAuthExtensions
 {
-    internal static IServiceCollection AddNetclawAuthSchemes(this IServiceCollection services)
+    internal static IServiceCollection AddNetclawAuthSchemes(this IServiceCollection services, DaemonConfig daemonConfig)
     {
+        services.AddSingleton(daemonConfig);
         services
             .AddAuthentication("AuthSelector")
             .AddPolicyScheme("AuthSelector", "Bearer or Loopback selector", options =>

--- a/src/Netclaw.Daemon/Security/NetclawAuthExtensions.cs
+++ b/src/Netclaw.Daemon/Security/NetclawAuthExtensions.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Netclaw.Configuration;
 
 namespace Netclaw.Daemon.Security;
@@ -18,7 +19,7 @@ internal static class NetclawAuthExtensions
 {
     internal static IServiceCollection AddNetclawAuthSchemes(this IServiceCollection services, DaemonConfig daemonConfig)
     {
-        services.AddSingleton(daemonConfig);
+        services.TryAddSingleton(daemonConfig);
         services
             .AddAuthentication("AuthSelector")
             .AddPolicyScheme("AuthSelector", "Bearer or Loopback selector", options =>

--- a/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
+++ b/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
@@ -65,29 +66,31 @@ internal sealed class ExposureModeValidationService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        if (DaemonExposureValidator.TryGetInvalidTrustedProxy(_config.TrustedProxies, out var invalidTrustedProxyError))
+        {
+            _logger.LogCritical(
+                "Daemon startup aborted: {Message} Remediation: {Remediation}",
+                invalidTrustedProxyError!,
+                "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'.");
+
+            throw new InvalidOperationException(
+                $"{invalidTrustedProxyError!} Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'.");
+        }
+
         if (_config.ExposureMode == ExposureMode.Local)
             return;
 
-        var requiredProcess = _config.ExposureMode.GetRequiredProcessName()
-            ?? throw new InvalidOperationException(
-                $"Unknown ExposureMode: {_config.ExposureMode}. " +
-                "Cannot determine tunnel prerequisite.");
-
-        if (!_processDetector(requiredProcess))
+        if (DaemonExposureValidator.GetMissingRequiredProcessIssue(_config, _processDetector) is { } processIssue)
         {
-            var modeWireValue = _config.ExposureMode.ToWireValue();
-
             _logger.LogCritical(
-                "Daemon startup aborted: ExposureMode is '{Mode}' but the required tunnel process " +
-                "'{Process}' is not running. Start '{Process}' before starting Netclaw, or set " +
-                "ExposureMode to 'local' in netclaw.json.",
-                modeWireValue, requiredProcess, requiredProcess);
+                "Daemon startup aborted: {Message} Remediation: {Remediation}",
+                processIssue.Message,
+                processIssue.Remediation);
 
-            throw new InvalidOperationException(
-                $"Tunnel prerequisite not met: ExposureMode='{modeWireValue}' requires " +
-                $"'{requiredProcess}' to be running. Start '{requiredProcess}' or set ExposureMode " +
-                "to 'local' in netclaw.json.");
+            throw new InvalidOperationException($"{processIssue.Message} {processIssue.Remediation}");
         }
+
+        var hasRemoteAuthenticationPath = false;
 
         // Remote auth guard: only applies when scheme registrations are explicitly provided
         // (i.e., the production DI path). Tests that don't inject this skip the check.
@@ -103,22 +106,18 @@ internal sealed class ExposureModeValidationService : IHostedService
                 ? await _deviceCounter(cancellationToken)
                 : 0;
 
-            if (!hasAlternativeRemoteAuthScheme && deviceCount == 0)
-            {
-                var modeWireValue = _config.ExposureMode.ToWireValue();
+            hasRemoteAuthenticationPath = hasAlternativeRemoteAuthScheme || deviceCount > 0;
+        }
 
-                _logger.LogCritical(
-                    "Daemon startup aborted: ExposureMode is '{Mode}' but no paired devices exist " +
-                    "and no alternative remote authentication scheme is configured. Pair a device " +
-                    "with 'netclaw daemon pair' or configure another remote auth scheme before " +
-                    "starting Netclaw.",
-                    modeWireValue);
+        foreach (var issue in DaemonExposureValidator.Validate(_config, hasRemoteAuthenticationPath)
+                     .Where(static issue => !issue.Message.Contains("trusted proxy", StringComparison.OrdinalIgnoreCase)))
+        {
+            _logger.LogCritical(
+                "Daemon startup aborted: {Message} Remediation: {Remediation}",
+                issue.Message,
+                issue.Remediation);
 
-                throw new InvalidOperationException(
-                    $"No remote authentication available: ExposureMode='{modeWireValue}' requires " +
-                    "either at least one paired device or an alternative remote auth scheme. " +
-                    "Run 'netclaw daemon pair' to pair a device, or check your auth configuration.");
-            }
+            throw new InvalidOperationException($"{issue.Message} {issue.Remediation}");
         }
     }
 

--- a/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
+++ b/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
@@ -110,7 +110,7 @@ internal sealed class ExposureModeValidationService : IHostedService
         }
 
         foreach (var issue in DaemonExposureValidator.Validate(_config, hasRemoteAuthenticationPath)
-                     .Where(static issue => !issue.Message.Contains("trusted proxy", StringComparison.OrdinalIgnoreCase)))
+                     .Where(static issue => !issue.IsTrustedProxyIssue))
         {
             _logger.LogCritical(
                 "Daemon startup aborted: {Message} Remediation: {Remediation}",


### PR DESCRIPTION
## Summary

- Hardens non-local exposure validation for sidecar and reverse-proxy deployments without weakening the fail-closed trust boundary
- Adds explicit support for sidecar or host-managed tunnel topologies via `Daemon.SkipTunnelProcessCheck`
- Adds `reverse-proxy` trust handling, loud `TrustedProxies` validation, and forwarded-header-aware integration coverage

Closes #862.

## What Changed

- Add `ExposureMode=reverse-proxy`
- Add `Daemon.SkipTunnelProcessCheck` for sidecar or host-managed tunnel topologies
- Add fail-loud `TrustedProxies` validation plus trusted forwarded-header handling
- Reject loopback final hops in `reverse-proxy` mode so remote traffic cannot inherit loopback auth
- Align schema validation, daemon startup checks, `netclaw doctor`, and onboarding health-check reporting
- Add reverse-proxy `TestServer` integration coverage for auth, forwarded headers, pairing guard, and rate limiting

## Verification

- `openspec validate "relax-exposure-strictness"`
- `"/home/aaronontheweb/.dotnet/dotnet" test src/Netclaw.Configuration.Tests/Netclaw.Configuration.Tests.csproj`
- `"/home/aaronontheweb/.dotnet/dotnet" test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj --filter "FullyQualifiedName~ExposureModeValidationServiceTests|FullyQualifiedName~SessionHubAuthorizationTests|FullyQualifiedName~PairingExchangeEndpointTests"`
- `"/home/aaronontheweb/.dotnet/dotnet" test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter "FullyQualifiedName~ExposureModeDoctorCheckTests|FullyQualifiedName~ConfigSchemaDoctorCheckTests|FullyQualifiedName~HealthCheckStepViewModelTests"`
- `"/home/aaronontheweb/.dotnet/dotnet" slopwatch analyze`
- `pwsh "./scripts/Add-FileHeaders.ps1" -Verify`

## Follow-Up

- Related follow-up issue: #866
- `#866` tracks the unresolved product and security design for daemon-host local CLI/operator access when secure `reverse-proxy` mode requires a non-loopback final hop
- This PR intentionally does not change `DaemonApi.ResolveEndpoint()`, daemon-host local operator auth semantics, or pairing flow behavior for that topology