### PR TITLE
fix: use provider-reported context window instead of hardcoded 32k default

### DIFF
--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -237,16 +237,50 @@ if [[ "$cleared_list" == *"$ALT_MODEL"* ]]; then
   exit 1
 fi
 
-# ── Session browsing smoke tests ──
-# These tests verify the session catalog API and help text for session
-# resume functionality. Requires daemon + provider + model to be configured
-# (done by the provider/model tests above).
+# ── Context window auto-detection smoke test ──
+# Verifies that netclaw doctor and netclaw status report the provider-detected
+# context window (not the 32k hardcoded default) when no explicit ContextWindow
+# is configured. Requires daemon + provider + model configured (done above).
 
-echo "Restarting daemon for session tests..."
+echo "Restarting daemon for context window and session tests..."
 start_daemon_with_timeout
 
 echo "Waiting for daemon health endpoint..."
 wait_for_health
+
+echo "Verifying context window auto-detection via status API..."
+ctx_json="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" curl -fsS http://127.0.0.1:5199/api/health/status)"
+ctx_window="$(echo "$ctx_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('model',{}).get('contextWindow',0))")"
+echo "Daemon reports context window: $ctx_window tokens"
+if [[ "$ctx_window" -le 32768 ]]; then
+  # qwen2:0.5b has a context window > 32k that Ollama reports via /api/show.
+  # If we get exactly 32768 or less, auto-detection failed and we hit the
+  # hardcoded default — which is the bug this test guards against.
+  echo "WARNING: Context window is $ctx_window (≤ 32768). Auto-detection may not have worked."
+  echo "This is acceptable for models with native 32k context, but unexpected for most models."
+fi
+
+echo "Verifying netclaw doctor reports auto-detected context window..."
+doctor_output="$(run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw doctor 2>&1 || true)"
+echo "$doctor_output"
+if [[ "$doctor_output" == *"Using default 32,768 tokens"* ]]; then
+  echo "FAIL: netclaw doctor still reports the hardcoded 32k default."
+  echo "Expected 'Auto-detected' message from running daemon."
+  exit 1
+fi
+if [[ "$doctor_output" == *"Auto-detected"* ]]; then
+  echo "PASS: netclaw doctor shows auto-detected context window."
+elif [[ "$doctor_output" == *"Context window explicitly set"* ]]; then
+  echo "PASS: context window explicitly configured (no auto-detection needed)."
+else
+  echo "FAIL: unexpected doctor output for context window check."
+  exit 1
+fi
+
+# ── Session browsing smoke tests ──
+# These tests verify the session catalog API and help text for session
+# resume functionality. Requires daemon + provider + model to be configured
+# (done by the provider/model tests above).
 
 echo "Sending a headless prompt to create a session..."
 run_sandbox_timed "$STEP_TIMEOUT_SECONDS" netclaw chat -p "Say hello in one word" || true

--- a/scripts/smoke/check.sh
+++ b/scripts/smoke/check.sh
@@ -267,8 +267,7 @@ if [[ "$doctor_output" == *"Using default 32,768 tokens"* ]]; then
   echo "FAIL: netclaw doctor still reports the hardcoded 32k default."
   echo "Expected 'Auto-detected' message from running daemon."
   exit 1
-fi
-if [[ "$doctor_output" == *"Auto-detected"* ]]; then
+elif [[ "$doctor_output" == *"Auto-detected"* ]]; then
   echo "PASS: netclaw doctor shows auto-detected context window."
 elif [[ "$doctor_output" == *"Context window explicitly set"* ]]; then
   echo "PASS: context window explicitly configured (no auto-detection needed)."

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -168,7 +168,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         int? probeResult = null,
         Exception? probeException = null)
     {
-        Task<int?> FakeProbe(NetclawPaths _, string __, string ___, CancellationToken ____)
+        Task<int?> FakeProbe(string _, string __, CancellationToken ___)
         {
             if (probeException is not null) throw probeException;
             return Task.FromResult(probeResult);

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -1,0 +1,175 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWindowDoctorCheckTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Cli.Daemon;
+using Netclaw.Cli.Doctor;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Doctor;
+
+public sealed class ContextWindowDoctorCheckTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+
+    public ContextWindowDoctorCheckTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task NoConfigFile_ReturnsWarning()
+    {
+        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        // TryReadConfig returns a Warning when the config file doesn't exist
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("Config file not found", result.Message);
+    }
+
+    [Fact]
+    public async Task NoModelsMainSection_ReturnsWarning()
+    {
+        WriteConfig(new { configVersion = 1 });
+        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("No Models.Main section", result.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitContextWindow_Passes()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = 131072 } }
+        });
+        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("131,072", result.Message);
+    }
+
+    [Fact]
+    public async Task InvalidContextWindow_ReturnsError()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = -1 } }
+        });
+        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+    }
+
+    [Fact]
+    public async Task NoExplicitContextWindow_DaemonReportsValue_Passes()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
+        });
+
+        var daemonApi = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(262144)));
+
+        var check = new ContextWindowDoctorCheck(_paths, daemonApi);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("262,144", result.Message);
+        Assert.Contains("from running daemon", result.Message);
+    }
+
+    [Fact]
+    public async Task NoExplicitContextWindow_DaemonOffline_ProviderUnreachable_PassesWithInfoMessage()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
+        });
+
+        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("auto-detects from the provider", result.Message);
+    }
+
+    private void WriteConfig(object config)
+    {
+        File.WriteAllText(_paths.NetclawConfigPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static DaemonApi CreateOfflineDaemonApi()
+        => CreateDaemonApi(_ => throw new HttpRequestException("daemon offline"));
+
+    private static DaemonApi CreateDaemonApi(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-ctx-test-{Guid.NewGuid():N}"));
+        paths.EnsureDirectoriesExist();
+        return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
+    }
+
+    private static object BuildStatusResponse(int contextWindow) => new
+    {
+        Overall = "healthy",
+        Build = new { Version = "1.0.0", CommitHash = "abc123", BuildTimestamp = "2026-01-01T00:00:00Z" },
+        Process = new { Pid = 1234, StartedAtUtc = "2026-01-01T00:00:00Z", UptimeSeconds = 3600 },
+        Connectors = Array.Empty<object>(),
+        Persistence = new { Provider = "sqlite" },
+        Telemetry = new { Enabled = false },
+        Model = new
+        {
+            ModelId = "qwen3:30b",
+            Provider = "openai-compatible",
+            ContextWindow = contextWindow,
+            InputModalities = "Text",
+            OutputModalities = "Text"
+        }
+    };
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+
+    private sealed class StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+            => new(new StubHttpMessageHandler(handler));
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -31,10 +31,9 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     [Fact]
     public async Task NoConfigFile_ReturnsWarning()
     {
-        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var check = CreateCheck(CreateOfflineDaemonApi());
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        // TryReadConfig returns a Warning when the config file doesn't exist
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("Config file not found", result.Message);
     }
@@ -43,7 +42,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     public async Task NoModelsMainSection_ReturnsWarning()
     {
         WriteConfig(new { configVersion = 1 });
-        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var check = CreateCheck(CreateOfflineDaemonApi());
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
@@ -59,7 +58,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             configVersion = 1,
             Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = 131072 } }
         });
-        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var check = CreateCheck(CreateOfflineDaemonApi());
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
@@ -75,7 +74,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             configVersion = 1,
             Models = new { Main = new { ModelId = "test-model", Provider = "local-ollama", ContextWindow = -1 } }
         });
-        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var check = CreateCheck(CreateOfflineDaemonApi());
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
@@ -92,8 +91,8 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         });
 
         var daemonApi = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(262144)));
+        var check = CreateCheck(daemonApi);
 
-        var check = new ContextWindowDoctorCheck(_paths, daemonApi);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
@@ -102,7 +101,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task NoExplicitContextWindow_DaemonOffline_ProviderUnreachable_ReturnsWarning()
+    public async Task NoExplicitContextWindow_DaemonOffline_ProviderProbeSucceeds_Passes()
     {
         WriteConfig(new
         {
@@ -110,12 +109,72 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
-        var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
+        var check = CreateCheck(
+            CreateOfflineDaemonApi(),
+            probeResult: 131072);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("131,072", result.Message);
+        Assert.Contains("from provider", result.Message);
+    }
+
+    [Fact]
+    public async Task NoExplicitContextWindow_DaemonOffline_ProviderProbeThrows_ReturnsWarning()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
+        });
+
+        var check = CreateCheck(
+            CreateOfflineDaemonApi(),
+            probeException: new HttpRequestException("connection refused"));
+
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
         Assert.Contains("Could not detect context window", result.Message);
         Assert.Contains("daemon:", result.Message);
+        Assert.Contains("provider probe failed: HttpRequestException", result.Message);
+    }
+
+    [Fact]
+    public async Task NoExplicitContextWindow_DaemonOffline_ProviderReturnsNull_ReturnsWarning()
+    {
+        WriteConfig(new
+        {
+            configVersion = 1,
+            Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
+        });
+
+        var check = CreateCheck(
+            CreateOfflineDaemonApi(),
+            probeResult: null);
+
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("Could not detect context window", result.Message);
+        Assert.Contains("provider returned no context window", result.Message);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private ContextWindowDoctorCheck CreateCheck(
+        DaemonApi daemonApi,
+        int? probeResult = null,
+        Exception? probeException = null)
+    {
+        Task<int?> FakeProbe(NetclawPaths _, string __, string ___, CancellationToken ____)
+        {
+            if (probeException is not null) throw probeException;
+            return Task.FromResult(probeResult);
+        }
+
+        return new ContextWindowDoctorCheck(_paths, daemonApi, FakeProbe);
     }
 
     private void WriteConfig(object config)

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -102,7 +102,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task NoExplicitContextWindow_DaemonOffline_ProviderUnreachable_PassesWithInfoMessage()
+    public async Task NoExplicitContextWindow_DaemonOffline_ProviderUnreachable_ReturnsWarning()
     {
         WriteConfig(new
         {
@@ -113,8 +113,9 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         var check = new ContextWindowDoctorCheck(_paths, CreateOfflineDaemonApi());
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Pass, result.Severity);
-        Assert.Contains("auto-detects from the provider", result.Message);
+        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Contains("Could not detect context window", result.Message);
+        Assert.Contains("daemon:", result.Message);
     }
 
     private void WriteConfig(object config)

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -9,11 +9,30 @@ using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
 
-public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi) : IDoctorCheck
+public sealed class ContextWindowDoctorCheck : IDoctorCheck
 {
+    private readonly NetclawPaths _paths;
+    private readonly DaemonApi _daemonApi;
+    private readonly Func<NetclawPaths, string, string, CancellationToken, Task<int?>> _probeProvider;
+
+    public ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi)
+        : this(paths, daemonApi, ContextWindowDoctorProbe.ProbeAsync)
+    {
+    }
+
+    internal ContextWindowDoctorCheck(
+        NetclawPaths paths,
+        DaemonApi daemonApi,
+        Func<NetclawPaths, string, string, CancellationToken, Task<int?>> probeProvider)
+    {
+        _paths = paths;
+        _daemonApi = daemonApi;
+        _probeProvider = probeProvider;
+    }
+
     public async Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
     {
-        var (root, error) = DoctorJsonConfigReader.TryReadConfig(paths);
+        var (root, error) = DoctorJsonConfigReader.TryReadConfig(_paths);
         if (error is not null)
             return error;
 
@@ -58,7 +77,7 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
         string? daemonError = null;
         try
         {
-            var status = await daemonApi.GetStatusAsync(ct);
+            var status = await _daemonApi.GetStatusAsync(ct);
             if (status?.Model?.ContextWindow is > 0 and var daemonCw)
             {
                 return DoctorCheckResult.Pass(
@@ -74,7 +93,7 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
         string? probeError = null;
         try
         {
-            var probed = await ContextWindowDoctorProbe.ProbeAsync(paths, modelId, providerName, ct);
+            var probed = await _probeProvider(_paths, modelId, providerName, ct);
             if (probed is > 0 and var probedCw)
             {
                 return DoctorCheckResult.Pass(

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -13,17 +13,17 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
 {
     private readonly NetclawPaths _paths;
     private readonly DaemonApi _daemonApi;
-    private readonly Func<NetclawPaths, string, string, CancellationToken, Task<int?>> _probeProvider;
+    private readonly Func<string, string, CancellationToken, Task<int?>> _probeProvider;
 
     public ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi)
-        : this(paths, daemonApi, ContextWindowDoctorProbe.ProbeAsync)
+        : this(paths, daemonApi, (modelId, provider, ct) => ContextWindowDoctorProbe.ProbeAsync(paths, modelId, provider, ct))
     {
     }
 
     internal ContextWindowDoctorCheck(
         NetclawPaths paths,
         DaemonApi daemonApi,
-        Func<NetclawPaths, string, string, CancellationToken, Task<int?>> probeProvider)
+        Func<string, string, CancellationToken, Task<int?>> probeProvider)
     {
         _paths = paths;
         _daemonApi = daemonApi;
@@ -93,7 +93,7 @@ public sealed class ContextWindowDoctorCheck : IDoctorCheck
         string? probeError = null;
         try
         {
-            var probed = await _probeProvider(_paths, modelId, providerName, ct);
+            var probed = await _probeProvider(modelId, providerName, ct);
             if (probed is > 0 and var probedCw)
             {
                 return DoctorCheckResult.Pass(

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -1,55 +1,89 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ContextWindowDoctorCheck.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Nodes;
+using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Doctor;
 
-public sealed class ContextWindowDoctorCheck(NetclawPaths paths) : IDoctorCheck
+public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemonApi) : IDoctorCheck
 {
-    public Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
+    public async Task<DoctorCheckResult> RunAsync(CancellationToken cancellationToken = default)
     {
         var (root, error) = DoctorJsonConfigReader.TryReadConfig(paths);
         if (error is not null)
-            return Task.FromResult(error);
+            return error;
 
         if (root is null)
-            return Task.FromResult(DoctorCheckResult.Pass("Context Window", "No config file to check."));
+            return DoctorCheckResult.Pass("Context Window", "No config file to check.");
 
         var models = root["Models"] as JsonObject;
         var main = models?["Main"] as JsonObject;
 
         if (main is null)
         {
-            return Task.FromResult(DoctorCheckResult.Warning(
+            return DoctorCheckResult.Warning(
                 "Context Window",
                 "No Models.Main section in config. Using default context window (32,768 tokens).",
-                "Add a Models.Main section with ContextWindow to netclaw.json."));
+                "Add a Models.Main section with ContextWindow to netclaw.json.");
         }
 
         var contextWindow = main["ContextWindow"];
         if (contextWindow is null)
         {
             var modelId = main["ModelId"]?.GetValue<string>() ?? "unknown";
-            return Task.FromResult(DoctorCheckResult.Warning(
-                "Context Window",
-                $"No explicit context window configured for {modelId}. Using default 32,768 tokens.",
-                "Set Models.Main.ContextWindow in netclaw.json to clamp the effective runtime context window if needed."));
+            var providerName = main["Provider"]?.GetValue<string>() ?? "local-ollama";
+            return await ResolveEffectiveContextWindowAsync(modelId, providerName, cancellationToken);
         }
 
         if (contextWindow.GetValue<int>() is var cw and > 0)
         {
-            return Task.FromResult(DoctorCheckResult.Pass(
+            return DoctorCheckResult.Pass(
                 "Context Window",
-                $"Context window explicitly set to {cw:N0} tokens."));
+                $"Context window explicitly set to {cw:N0} tokens.");
         }
 
-        return Task.FromResult(DoctorCheckResult.Error(
+        return DoctorCheckResult.Error(
             "Context Window",
             "Models.Main.ContextWindow must be a positive integer.",
-            "Set Models.Main.ContextWindow to the effective runtime context window size in tokens."));
+            "Set Models.Main.ContextWindow to the effective runtime context window size in tokens.");
+    }
+
+    private async Task<DoctorCheckResult> ResolveEffectiveContextWindowAsync(
+        string modelId, string providerName, CancellationToken ct)
+    {
+        // Tier 1: query running daemon for authoritative resolved value
+        try
+        {
+            var status = await daemonApi.GetStatusAsync(ct);
+            if (status?.Model?.ContextWindow is > 0 and var daemonCw)
+            {
+                return DoctorCheckResult.Pass(
+                    "Context Window",
+                    $"Auto-detected {daemonCw:N0} tokens for {modelId} (from running daemon).");
+            }
+        }
+        catch
+        {
+            // Daemon unreachable — fall through to provider probe
+        }
+
+        // Tier 2: probe provider directly
+        var probed = await ContextWindowDoctorProbe.ProbeAsync(paths, modelId, providerName, ct);
+        if (probed is > 0 and var probedCw)
+        {
+            return DoctorCheckResult.Pass(
+                "Context Window",
+                $"Auto-detected {probedCw:N0} tokens for {modelId} (from provider).");
+        }
+
+        // Tier 3: neither available — informational pass with accurate messaging
+        return DoctorCheckResult.Pass(
+            "Context Window",
+            $"No explicit context window configured for {modelId}. " +
+            "At runtime, the daemon auto-detects from the provider (fallback if detection fails: 32,768 tokens).");
     }
 }

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -55,6 +55,7 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
     private async Task<DoctorCheckResult> ResolveEffectiveContextWindowAsync(
         string modelId, string providerName, CancellationToken ct)
     {
+        string? daemonError = null;
         try
         {
             var status = await daemonApi.GetStatusAsync(ct);
@@ -65,21 +66,37 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
                     $"Auto-detected {daemonCw:N0} tokens for {modelId} (from running daemon).");
             }
         }
-        catch
+        catch (Exception ex)
         {
+            daemonError = ex.GetType().Name;
         }
 
-        var probed = await ContextWindowDoctorProbe.ProbeAsync(paths, modelId, providerName, ct);
-        if (probed is > 0 and var probedCw)
+        string? probeError = null;
+        try
         {
-            return DoctorCheckResult.Pass(
-                "Context Window",
-                $"Auto-detected {probedCw:N0} tokens for {modelId} (from provider).");
+            var probed = await ContextWindowDoctorProbe.ProbeAsync(paths, modelId, providerName, ct);
+            if (probed is > 0 and var probedCw)
+            {
+                return DoctorCheckResult.Pass(
+                    "Context Window",
+                    $"Auto-detected {probedCw:N0} tokens for {modelId} (from provider).");
+            }
+
+            probeError = "provider returned no context window";
+        }
+        catch (Exception ex)
+        {
+            probeError = $"provider probe failed: {ex.GetType().Name}";
         }
 
-        return DoctorCheckResult.Pass(
+        var reasons = new List<string>(2);
+        if (daemonError is not null) reasons.Add($"daemon: {daemonError}");
+        if (probeError is not null) reasons.Add(probeError);
+
+        return DoctorCheckResult.Warning(
             "Context Window",
-            $"No explicit context window configured for {modelId}. " +
-            "At runtime, the daemon auto-detects from the provider (fallback if detection fails: 32,768 tokens).");
+            $"Could not detect context window for {modelId} ({string.Join("; ", reasons)}). " +
+            "At runtime, the daemon will attempt auto-detection from the provider.",
+            "Set Models.Main.ContextWindow in netclaw.json to pin a specific value.");
     }
 }

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs
@@ -55,7 +55,6 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
     private async Task<DoctorCheckResult> ResolveEffectiveContextWindowAsync(
         string modelId, string providerName, CancellationToken ct)
     {
-        // Tier 1: query running daemon for authoritative resolved value
         try
         {
             var status = await daemonApi.GetStatusAsync(ct);
@@ -68,10 +67,8 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
         }
         catch
         {
-            // Daemon unreachable — fall through to provider probe
         }
 
-        // Tier 2: probe provider directly
         var probed = await ContextWindowDoctorProbe.ProbeAsync(paths, modelId, providerName, ct);
         if (probed is > 0 and var probedCw)
         {
@@ -80,7 +77,6 @@ public sealed class ContextWindowDoctorCheck(NetclawPaths paths, DaemonApi daemo
                 $"Auto-detected {probedCw:N0} tokens for {modelId} (from provider).");
         }
 
-        // Tier 3: neither available — informational pass with accurate messaging
         return DoctorCheckResult.Pass(
             "Context Window",
             $"No explicit context window configured for {modelId}. " +

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWindowDoctorProbe.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Cli.Provider;
+using Netclaw.Configuration;
+using Netclaw.Providers.SelfHosted;
+
+namespace Netclaw.Cli.Doctor;
+
+/// <summary>
+/// Probes the configured provider to detect the effective context window
+/// without requiring a running daemon.
+/// </summary>
+internal static class ContextWindowDoctorProbe
+{
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+    public static async Task<int?> ProbeAsync(
+        NetclawPaths paths, string modelId, string providerName, CancellationToken ct)
+    {
+        var providers = ProviderCommand.LoadProviders(paths);
+        if (!providers.TryGetValue(providerName, out var entry))
+            return null;
+
+        using var httpClient = new HttpClient { Timeout = ProbeTimeout };
+
+        IModelCapabilityResolver? resolver = entry.Type.ToLowerInvariant() switch
+        {
+            "ollama" => new OllamaCapabilityResolver(
+                httpClient,
+                NullLogger<OllamaCapabilityResolver>.Instance,
+                entry.Endpoint),
+            "openai-compatible" => new OpenAiCompatibleCapabilityResolver(
+                httpClient,
+                NullLogger<OpenAiCompatibleCapabilityResolver>.Instance,
+                entry.Endpoint,
+                entry.ApiKey?.Value),
+            _ => null
+        };
+
+        if (resolver is null)
+            return null;
+
+        try
+        {
+            var result = await resolver.ResolveAsync(modelId, ct);
+            return result?.ContextWindowTokens;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
@@ -40,14 +40,7 @@ internal static class ContextWindowDoctorProbe
         if (resolver is null)
             return null;
 
-        try
-        {
-            var result = await resolver.ResolveAsync(modelId, ct);
-            return result?.ContextWindowTokens;
-        }
-        catch
-        {
-            return null;
-        }
+        var result = await resolver.ResolveAsync(modelId, ct);
+        return result?.ContextWindowTokens;
     }
 }

--- a/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
+++ b/src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs
@@ -10,10 +10,6 @@ using Netclaw.Providers.SelfHosted;
 
 namespace Netclaw.Cli.Doctor;
 
-/// <summary>
-/// Probes the configured provider to detect the effective context window
-/// without requiring a running daemon.
-/// </summary>
 internal static class ContextWindowDoctorProbe
 {
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1741,22 +1741,22 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
         var contextWindow = models.Main.ContextWindow;
         if (contextWindow is null)
         {
-            try
-            {
-                var daemon = sp.GetRequiredService<DaemonApi>();
-                var status = daemon.GetStatusAsync().GetAwaiter().GetResult();
-                if (status?.Model?.ContextWindow is > 0 and var daemonCw)
-                    contextWindow = daemonCw;
-            }
-            catch
-            {
-            }
+            var daemon = sp.GetRequiredService<DaemonApi>();
+            var status = daemon.GetStatusAsync().GetAwaiter().GetResult()
+                ?? throw new InvalidOperationException(
+                    "Daemon returned empty status. Cannot resolve effective context window. " +
+                    "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
+            contextWindow = status.Model?.ContextWindow is > 0 and var daemonCw
+                ? daemonCw
+                : throw new InvalidOperationException(
+                    $"Daemon reported no context window for model '{models.Main.ModelId}'. " +
+                    "Set Models.Main.ContextWindow in netclaw.json.");
         }
 
         return new ModelCapabilities
         {
             ModelId = models.Main.ModelId,
-            ContextWindowTokens = contextWindow ?? 32_768,
+            ContextWindowTokens = contextWindow.Value,
             CompactionModelId = models.Compaction?.ModelId,
         };
     });

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1741,7 +1741,6 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
         var contextWindow = models.Main.ContextWindow;
         if (contextWindow is null)
         {
-            // Query the running daemon for its resolved context window
             try
             {
                 var daemon = sp.GetRequiredService<DaemonApi>();
@@ -1751,7 +1750,6 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
             }
             catch
             {
-                // Daemon unreachable — fall through to default
             }
         }
 

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1736,11 +1736,31 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
     // Session config: bind operator-facing settings
     var sessionConfig = SessionConfig.BindFromConfiguration(configuration.GetSection("Session"));
     services.AddSingleton(sessionConfig);
-    services.AddSingleton(new ModelCapabilities
+    services.AddSingleton(sp =>
     {
-        ModelId = models.Main.ModelId,
-        ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
-        CompactionModelId = models.Compaction?.ModelId,
+        var contextWindow = models.Main.ContextWindow;
+        if (contextWindow is null)
+        {
+            // Query the running daemon for its resolved context window
+            try
+            {
+                var daemon = sp.GetRequiredService<DaemonApi>();
+                var status = daemon.GetStatusAsync().GetAwaiter().GetResult();
+                if (status?.Model?.ContextWindow is > 0 and var daemonCw)
+                    contextWindow = daemonCw;
+            }
+            catch
+            {
+                // Daemon unreachable — fall through to default
+            }
+        }
+
+        return new ModelCapabilities
+        {
+            ModelId = models.Main.ModelId,
+            ContextWindowTokens = contextWindow ?? 32_768,
+            CompactionModelId = models.Compaction?.ModelId,
+        };
     });
 
     // DaemonClient uses the endpoint from DaemonApi. For non-loopback (remote) endpoints,


### PR DESCRIPTION
## Summary

Closes #861. When `Models.Main.ContextWindow` is not explicitly configured:

- **`netclaw chat`** (daemon-backed CLI) now queries the running daemon for its resolved context window instead of silently falling back to 32,768 tokens. Throws `InvalidOperationException` if the daemon can't report a value (fail-fast, not silent degradation).
- **`netclaw doctor`** resolves the effective context window via daemon status API (tier 1) or direct provider probe (tier 2), and reports a Warning with error details if neither succeeds. No more misleading "Using default 32,768 tokens" message when the daemon correctly auto-detects from the provider.

## Changes

- `src/Netclaw.Cli/Program.cs` — CLI chat singleton factory queries daemon for resolved context window
- `src/Netclaw.Cli/Doctor/ContextWindowDoctorCheck.cs` — Two-tier resolution (daemon → provider probe) with injectable probe for testing
- `src/Netclaw.Cli/Doctor/ContextWindowDoctorProbe.cs` — New helper that probes Ollama/OpenAI-compatible providers directly
- `scripts/smoke/check.sh` — Smoke test assertion verifying auto-detected context window in doctor output

## Test plan

- [x] 8 unit tests covering all resolution tiers (daemon success, provider probe success, probe throws, probe returns null, explicit config, invalid config)
- [x] All 109 existing doctor tests pass
- [x] Smoke test assertion in `check.sh` guards against regression (fails if "Using default 32,768 tokens" appears in doctor output)
- [ ] Run full smoke sandbox (`scripts/smoke/up.sh` + `scripts/smoke/check.sh`) to verify end-to-end with live Ollama