### PR TITLE
fix: correct user-invocable → invocable in archived OpenSpec docs

### DIFF
--- a/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/design.md
+++ b/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/design.md
@@ -18,7 +18,7 @@ load the right skill.
 - `SkillEntry.ResourcePaths` — already enumerates resource files
 - `SkillRegistry.Search()` — basic name/description search
 - `LlmSessionActor.FireLlmCall()` — turn assembly with context layers
-- Claude Code frontmatter spec: `disable-model-invocation`, `user-invocable`,
+- Claude Code frontmatter spec: `disable-model-invocation`, `invocable`,
   `argument-hint` fields
 
 ## Goals / Non-Goals
@@ -65,7 +65,7 @@ command (`/name`). No separate `invoke` or `command` field needed. Two flags
 control visibility:
 - `disable-model-invocation: true` — LLM cannot auto-trigger (excluded from
   index), but users can type `/name`
-- `user-invocable: false` — Users cannot type `/name`, but LLM can auto-load
+- `invocable: false` — Users cannot type `/name`, but LLM can auto-load
 
 **Why:** This matches the Claude Code ecosystem standard. It's simpler than
 a separate invocation field and provides fine-grained control over who can

--- a/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/proposal.md
+++ b/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/proposal.md
@@ -25,8 +25,8 @@ Ref: PRD-001 FR-006 (Layered System Prompt), PRD-002 (Gateway Security).
   frontmatter validation and atomic writes
 - Add slash-command dispatch — adopt Claude Code invocation model where every
   skill `name` becomes `/name`. Two flags control invocation:
-  `disable-model-invocation` and `user-invocable`
-- Extend `SkillFrontmatter` with `disable-model-invocation`, `user-invocable`,
+  `disable-model-invocation` and `invocable`
+- Extend `SkillFrontmatter` with `disable-model-invocation`, `invocable`,
   and `argument-hint` fields
 - Add deterministic error response for unrecognized slash commands
 

--- a/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/specs/slash-command-dispatch/spec.md
+++ b/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/specs/slash-command-dispatch/spec.md
@@ -16,13 +16,13 @@ SHALL be rebuilt when the skill registry is re-populated.
 
 #### Scenario: Skill registered as slash command
 
-- **GIVEN** a skill with `name: netclaw-operations` and `user-invocable` not set (default true)
+- **GIVEN** a skill with `name: netclaw-operations` and `invocable` not set (default true)
 - **WHEN** the slash-command registry is built
 - **THEN** `/netclaw-operations` maps to that skill entry
 
 #### Scenario: Non-user-invocable skill excluded
 
-- **GIVEN** a skill with `user-invocable: false`
+- **GIVEN** a skill with `invocable: false`
 - **WHEN** the slash-command registry is built
 - **THEN** the skill does not appear in the slash-command registry
 
@@ -55,7 +55,7 @@ as a transient system message and the remainder passed as user content.
 
 ### Requirement: Frontmatter invocation control fields
 
-The system SHALL parse `disable-model-invocation`, `user-invocable`, and
+The system SHALL parse `disable-model-invocation`, `invocable`, and
 `argument-hint` from YAML frontmatter.
 
 #### Scenario: disable-model-invocation parsed
@@ -68,7 +68,7 @@ The system SHALL parse `disable-model-invocation`, `user-invocable`, and
 
 #### Scenario: user-invocable false parsed
 
-- **GIVEN** a skill with `user-invocable: false` in frontmatter
+- **GIVEN** a skill with `invocable: false` in frontmatter
 - **WHEN** the skill is scanned
 - **THEN** `SkillEntry.UserInvocable` is `false`
 - **AND** the skill is excluded from the slash-command registry

--- a/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/tasks.md
+++ b/openspec/changes/archive/2026-03-24-skill-tools-and-slash-commands/tasks.md
@@ -2,7 +2,7 @@
 
 ### 1. Extend SkillFrontmatter and SkillEntry with invocation fields
 
-- [x] Add `disable-model-invocation`, `user-invocable`, `argument-hint` to
+- [x] Add `disable-model-invocation`, `invocable`, `argument-hint` to
       `SkillFrontmatter` in `SkillScanner.cs` with `[YamlMember]` aliases
 - [x] Add `bool DisableModelInvocation` (default false), `bool UserInvocable`
       (default true), `string? ArgumentHint` to `SkillEntry.cs`

--- a/openspec/changes/archive/2026-03-24-trust-tiers-security-stub/design.md
+++ b/openspec/changes/archive/2026-03-24-trust-tiers-security-stub/design.md
@@ -63,7 +63,7 @@ implementation changes.
 - `netclaw-diagnostics` → `disable-model-invocation: true` (same reasoning)
 - `netclaw-memory` → keep model-invocable (agent should auto-load for memory queries)
 - `search-citation` → keep model-invocable (agent should auto-load for web searches)
-- `netclaw-manual` → `user-invocable: false` (reference material, not a workflow)
+- `netclaw-manual` → `invocable: false` (reference material, not a workflow)
 
 **Why:** Operations and diagnostics are side-effect workflows where timing
 matters. The user should explicitly request them. Memory and search-citation

--- a/openspec/changes/archive/2026-03-24-trust-tiers-security-stub/tasks.md
+++ b/openspec/changes/archive/2026-03-24-trust-tiers-security-stub/tasks.md
@@ -52,7 +52,7 @@ hidden directories are scanned.
   - AgentSkills.io directory layout (`skill-name/SKILL.md`)
   - Required frontmatter: `name`, `description`
   - Optional frontmatter: `license`, `compatibility`, `allowed-tools`,
-    `metadata`, `disable-model-invocation`, `user-invocable`, `argument-hint`
+    `metadata`, `disable-model-invocation`, `invocable`, `argument-hint`
   - Progressive disclosure: `references/`, `scripts/`, `assets/`
   - Invocation model: name = slash command, control flags explained
   - When to create a skill vs memory vs identity file

--- a/openspec/changes/archive/2026-04-15-skill-subagent-overlays/specs/slash-command-dispatch/spec.md
+++ b/openspec/changes/archive/2026-04-15-skill-subagent-overlays/specs/slash-command-dispatch/spec.md
@@ -54,7 +54,7 @@ session prompt stack for that turn.
 
 ### Requirement: Frontmatter invocation control fields
 
-The system SHALL parse `disable-model-invocation`, `user-invocable`,
+The system SHALL parse `disable-model-invocation`, `invocable`,
 `argument-hint`, and `metadata.subagent` from YAML frontmatter.
 
 `metadata.subagent` SHALL be treated as an optional string field naming a
@@ -69,9 +69,9 @@ deterministic configuration errors.
 - **AND** the skill is excluded from the compressed index
 - **AND** the skill remains in the slash-command registry
 
-#### Scenario: user-invocable false parsed
+#### Scenario: invocable false parsed
 
-- **GIVEN** a skill with `user-invocable: false` in frontmatter
+- **GIVEN** a skill with `invocable: false` in frontmatter
 - **WHEN** the skill is scanned
 - **THEN** `SkillEntry.UserInvocable` is `false`
 - **AND** the skill is excluded from the slash-command registry


### PR DESCRIPTION
## Summary

- Fixes incorrect `user-invocable` field name references in archived OpenSpec specs to `invocable` (the actual YAML field recognized by `SkillScanner`)
- This stale terminology was the source of confusion that led to #857 being filed
- Closes #857 (issue was invalid — code already uses `invocable` correctly)

## Test plan

- No behavioral change — only archived documentation corrected
- `grep -r "user-invocable" openspec/` confirms only prose adjective uses remain (not YAML field references)