### PR TITLE
ci: cache Docker build layers for smoke sandbox to prevent timeout

### DIFF
--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -41,9 +41,15 @@ jobs:
         with:
           global-json-file: ./global.json
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build smoke sandbox image
-        timeout-minutes: 10
+        timeout-minutes: 15
         shell: bash
+        env:
+          DOCKER_CACHE_FROM: type=gha
+          DOCKER_CACHE_TO: type=gha,mode=max
         run: |
           chmod +x scripts/docker/build-image.sh
           IMAGE_REPO=netclaw-smoke \

--- a/scripts/docker/build-image.sh
+++ b/scripts/docker/build-image.sh
@@ -97,10 +97,31 @@ cp -rl publish/cli "publish/cli-${DOCKER_ARCH}"
 cp -rl publish/daemon "publish/daemon-${DOCKER_ARCH}"
 
 echo "→ Building image $IMAGE_TAG..."
-docker build \
-    -f docker/Dockerfile \
-    -t "$IMAGE_TAG" \
-    --build-arg "NETCLAW_VERSION=$VERSION" \
-    .
+# When DOCKER_CACHE_FROM/DOCKER_CACHE_TO are set (e.g. in CI via GHA cache backend),
+# use `docker buildx build --load` so the image lands in the local daemon.
+# Without cache env vars, fall back to plain `docker build` which works without buildx.
+CACHE_ARGS=()
+if [[ -n "${DOCKER_CACHE_FROM:-}" ]]; then
+    CACHE_ARGS+=(--cache-from "$DOCKER_CACHE_FROM")
+fi
+if [[ -n "${DOCKER_CACHE_TO:-}" ]]; then
+    CACHE_ARGS+=(--cache-to "$DOCKER_CACHE_TO")
+fi
+
+if [[ ${#CACHE_ARGS[@]} -gt 0 ]]; then
+    docker buildx build \
+        -f docker/Dockerfile \
+        -t "$IMAGE_TAG" \
+        --build-arg "NETCLAW_VERSION=$VERSION" \
+        --load \
+        "${CACHE_ARGS[@]}" \
+        .
+else
+    docker build \
+        -f docker/Dockerfile \
+        -t "$IMAGE_TAG" \
+        --build-arg "NETCLAW_VERSION=$VERSION" \
+        .
+fi
 
 echo "✓ Built $IMAGE_TAG"


### PR DESCRIPTION
## Summary

- Add `docker/setup-buildx-action@v4` before the Docker build step so `buildx` is available as the builder
- Pass `DOCKER_CACHE_FROM=type=gha` / `DOCKER_CACHE_TO=type=gha,mode=max` env vars to `build-image.sh`; the script now uses `docker buildx build --load --cache-from/--cache-to` when those vars are set, and falls back to plain `docker build` for local use
- Bump `timeout-minutes` on the build step from 10 → 15 as a safety net for uncached first runs on slow runner mirrors

## Test plan

- [ ] PR CI run should show a "Set up Docker Buildx" step completing cleanly
- [ ] First run populates the GHA cache; second run skips the apt-get layer download
- [ ] `build-image.sh` still works locally without `DOCKER_CACHE_FROM`/`DOCKER_CACHE_TO` set (falls back to plain `docker build`)
- [ ] Smoke sandbox checks still pass end-to-end

Fixes #869