### PR TITLE
fix: reset health check state on re-entry so go-back-and-retry works

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/HealthCheckStepViewModelTests.cs
@@ -91,4 +91,45 @@ public sealed class HealthCheckStepViewModelTests : IDisposable
         Assert.Contains(crashLogPath, failure.Label, StringComparison.Ordinal);
         Assert.Equal("Setup complete with warnings. Run `netclaw daemon start` to begin.", context.StatusMessage.Value);
     }
+
+    [Fact]
+    public async Task OnEnter_Forward_AfterFailedRun_ResetsStateForRetry()
+    {
+        using var step = new HealthCheckStepViewModel(
+            daemonManager: null,
+            daemonApi: null,
+            navigationState: new ChatNavigationState());
+        using var exposureStep = new ExposureModeStepViewModel
+        {
+            SelectedMode = ExposureMode.Local
+        };
+
+        using var context = new WizardContext
+        {
+            Paths = _paths,
+            Registry = new ProviderDescriptorRegistry([]),
+            RequestRedraw = () => { }
+        };
+
+        step.OnEnter(context, NavigationDirection.Forward);
+        exposureStep.OnEnter(context, NavigationDirection.Forward);
+
+        using var orchestrator = new WizardOrchestrator([exposureStep, step], context);
+
+        // First run — daemon start fails because DaemonManager is null
+        await step.RunWithOrchestrator(orchestrator);
+        Assert.True(step.IsComplete.Value);
+        Assert.False(step.IsRunning.Value);
+
+        // Simulate going back and re-entering
+        step.OnEnter(context, NavigationDirection.Forward);
+
+        Assert.False(step.IsComplete.Value);
+        Assert.False(step.IsRunning.Value);
+        Assert.Empty(step.Results);
+
+        // Second run should execute (not blocked by stale IsComplete)
+        await step.RunWithOrchestrator(orchestrator);
+        Assert.True(step.IsComplete.Value);
+    }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
@@ -66,6 +66,14 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
         _context = context;
+
+        if (direction == NavigationDirection.Forward)
+        {
+            IsRunning.Value = false;
+            IsComplete.Value = false;
+            Results.Clear();
+            NotifyChanged();
+        }
     }
 
     public void OnLeave() { }


### PR DESCRIPTION
## Summary

- Fixes #859: `netclaw init` health check now re-attempts daemon launch after the user navigates back and corrects config
- Resets `IsComplete`, `IsRunning`, and `Results` in `HealthCheckStepViewModel.OnEnter()` when entering with `NavigationDirection.Forward`, clearing stale state from a previous failed run

## Test plan

- [x] New test `OnEnter_Forward_AfterFailedRun_ResetsStateForRetry` verifies the reset-and-retry flow
- [x] Existing test `RunWithOrchestrator_PreservesSpecificStartupFailureMessage` still passes
- [x] `dotnet slopwatch analyze` — no new violations
- [x] `Add-FileHeaders.ps1 -Verify` — all headers present