### PR TITLE
fix: consolidate duplicated path utilities into PathUtility

### DIFF
--- a/src/Netclaw.Actors/Skills/SkillScanner.cs
+++ b/src/Netclaw.Actors/Skills/SkillScanner.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Text.RegularExpressions;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -267,7 +268,7 @@ public static partial class SkillScanner
 
     private static SkillEntry? ParseSkillFile(string filePath, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false, bool strictNameMatch = true)
     {
-        var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
+        var canonicalRoot = PathUtility.Normalize(rootDirectory);
         var canonicalSkillFilePath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "skill file", allowSymlinks);
         if (canonicalSkillFilePath is null)
             return null;
@@ -321,7 +322,7 @@ public static partial class SkillScanner
         bool strictNameMatch = true,
         bool allowFrontmatterlessFlatFiles = false)
     {
-        var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
+        var canonicalRoot = PathUtility.Normalize(rootDirectory);
         var canonicalPath = ValidateCanonicalPath(filePath, canonicalRoot, issues, "flat skill file", allowSymlinks);
         if (canonicalPath is null)
             return null;
@@ -576,7 +577,7 @@ public static partial class SkillScanner
     private static IReadOnlyList<string>? EnumerateResources(string skillDirectory, string rootDirectory, List<SkillScanIssue> issues, bool allowSymlinks = false)
     {
         List<string>? resources = null;
-        var canonicalRoot = NormalizeDirectoryPath(rootDirectory);
+        var canonicalRoot = PathUtility.Normalize(rootDirectory);
 
         foreach (var subDirName in ResourceSubdirectories)
         {
@@ -702,7 +703,7 @@ public static partial class SkillScanner
 
     private static bool IsClaudeCommandsDirectory(string path)
     {
-        var normalized = NormalizeDirectoryPath(path);
+        var normalized = PathUtility.Normalize(path);
         var directoryName = Path.GetFileName(normalized);
         if (!string.Equals(directoryName, "commands", StringComparison.OrdinalIgnoreCase))
             return false;
@@ -717,9 +718,6 @@ public static partial class SkillScanner
     internal static string NormalizeSkillName(string value)
         => value.Trim().ToLowerInvariant();
 
-    internal static string NormalizeDirectoryPath(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
     private static string? ValidateCanonicalPath(
         string path,
         string canonicalRoot,
@@ -728,9 +726,8 @@ public static partial class SkillScanner
         bool allowSymlinks = false)
     {
         var normalizedPath = Path.GetFullPath(path);
-        var normalizedDirectoryPath = NormalizeDirectoryPath(normalizedPath);
 
-        if (!IsUnderRoot(normalizedDirectoryPath, canonicalRoot))
+        if (!PathUtility.IsWithinRoot(normalizedPath, canonicalRoot))
         {
             issues.Add(new SkillScanIssue(
                 Path: normalizedPath,
@@ -751,15 +748,10 @@ public static partial class SkillScanner
         return normalizedPath;
     }
 
-    internal static bool IsUnderRoot(string path, string canonicalRoot)
-        => path.Equals(canonicalRoot, StringComparison.Ordinal)
-            || path.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-            || path.StartsWith(canonicalRoot + Path.AltDirectorySeparatorChar, StringComparison.Ordinal);
-
     private static bool ContainsSymlink(string path, string canonicalRoot)
     {
         string? current = path;
-        while (!string.IsNullOrEmpty(current) && IsUnderRoot(NormalizeDirectoryPath(current), canonicalRoot))
+        while (!string.IsNullOrEmpty(current) && PathUtility.IsWithinRoot(current, canonicalRoot))
         {
             if (File.Exists(current) && new FileInfo(current).LinkTarget is not null)
                 return true;

--- a/src/Netclaw.Actors/Tools/AttachFileTool.cs
+++ b/src/Netclaw.Actors/Tools/AttachFileTool.cs
@@ -51,11 +51,11 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         if (!_fileAccessPolicy.TryResolveAttachPath(args.Path, context, out var requestedPath, out var accessError))
             return Task.FromResult(accessError);
 
-        var sessionDir = NormalizeDirectoryPath(context.SessionDirectory);
+        var sessionDir = PathUtility.Normalize(context.SessionDirectory);
         var sessionRoot = TryGetSessionRootDirectory(sessionDir);
 
-        var requestedInCurrentSession = IsPathWithinDirectory(requestedPath, sessionDir);
-        var requestedInSessionRoot = sessionRoot is not null && IsPathWithinDirectory(requestedPath, sessionRoot);
+        var requestedInCurrentSession = PathUtility.IsWithinRoot(requestedPath, sessionDir);
+        var requestedInSessionRoot = sessionRoot is not null && PathUtility.IsWithinRoot(requestedPath, sessionRoot);
 
         if (!requestedInCurrentSession && !requestedInSessionRoot)
         {
@@ -67,8 +67,8 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             return Task.FromResult($"Error: File not found: {requestedPath}");
 
         var resolvedPath = ResolveFinalPath(requestedPath);
-        var resolvedInCurrentSession = IsPathWithinDirectory(resolvedPath, sessionDir);
-        var resolvedInSessionRoot = sessionRoot is not null && IsPathWithinDirectory(resolvedPath, sessionRoot);
+        var resolvedInCurrentSession = PathUtility.IsWithinRoot(resolvedPath, sessionDir);
+        var resolvedInSessionRoot = sessionRoot is not null && PathUtility.IsWithinRoot(resolvedPath, sessionRoot);
 
         if (!resolvedInCurrentSession && !resolvedInSessionRoot)
         {
@@ -80,7 +80,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             ? resolvedPath
             : CopyIntoCurrentSession(resolvedPath, sessionDir);
 
-        if (!IsPathWithinDirectory(attachPath, sessionDir))
+        if (!PathUtility.IsWithinRoot(attachPath, sessionDir))
             return Task.FromResult($"Error: Attach path escaped the session directory ({sessionDir}).");
 
         var rawFilename = args.DisplayName ?? Path.GetFileName(attachPath);
@@ -93,27 +93,6 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
             : " (copied into current session)";
 
         return Task.FromResult($"File attached: {sanitizedFilename} ({mimeType}) at {attachPath}{copiedText}");
-    }
-
-    private static string NormalizeDirectoryPath(string directoryPath)
-    {
-        return Path.GetFullPath(directoryPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-    }
-
-    private static bool IsPathWithinDirectory(string path, string directory)
-    {
-        var fullPath = Path.GetFullPath(path)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (!fullPath.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (fullPath.Length == directory.Length)
-            return true;
-
-        var boundary = fullPath[directory.Length];
-        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
     }
 
     private static string ResolveFinalPath(string path)
@@ -133,7 +112,7 @@ public sealed partial class AttachFileTool : NetclawTool<AttachFileTool.Params>
         if (name.Equals("sessions", StringComparison.OrdinalIgnoreCase)
             || name.Equals("netclaw-sessions", StringComparison.OrdinalIgnoreCase))
         {
-            return NormalizeDirectoryPath(parent.FullName);
+            return PathUtility.Normalize(parent.FullName);
         }
 
         return null;

--- a/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
+++ b/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
@@ -22,7 +22,7 @@ public sealed class FilePathApprovalMatcher : IToolApprovalMatcher
 
     public FilePathApprovalMatcher(string controlPlaneRoot)
     {
-        _controlPlaneRoot = NormalizePath(controlPlaneRoot);
+        _controlPlaneRoot = PathUtility.Normalize(controlPlaneRoot);
     }
 
     public string GetApprovalModeKey(ToolName toolName, IDictionary<string, object?>? arguments)
@@ -82,10 +82,10 @@ public sealed class FilePathApprovalMatcher : IToolApprovalMatcher
         if (!TryGetPath(arguments, out var rawPath))
             return false;
 
-        if (!TryNormalizePath(rawPath, out var normalized))
+        if (!PathUtility.TryNormalize(rawPath, out var normalized))
             return false;
 
-        if (!IsUnderRoot(normalized, _controlPlaneRoot))
+        if (!PathUtility.IsWithinRoot(normalized, _controlPlaneRoot))
             return false;
 
         relativePath = Path.GetRelativePath(_controlPlaneRoot, normalized)
@@ -111,36 +111,4 @@ public sealed class FilePathApprovalMatcher : IToolApprovalMatcher
         return false;
     }
 
-    private static bool TryNormalizePath(string rawPath, out string normalized)
-    {
-        normalized = string.Empty;
-        try
-        {
-            var baseDir = Environment.CurrentDirectory;
-            var combined = Path.IsPathRooted(rawPath)
-                ? rawPath
-                : Path.Combine(baseDir, rawPath);
-            normalized = NormalizePath(combined);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static string NormalizePath(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-    private static bool IsUnderRoot(string candidate, string root)
-    {
-        if (!candidate.StartsWith(root, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (candidate.Length == root.Length)
-            return true;
-
-        var boundary = candidate[root.Length];
-        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
-    }
 }

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
@@ -18,7 +19,7 @@ internal sealed class ScopedFileAccessPolicy
         _profileResolver = new ToolAudienceProfileResolver(toolConfig, paths);
         _cachedGlobalReadRoots = new Lazy<IReadOnlyList<string>>(() =>
             _profileResolver.ResolveGlobalReadRoots()
-                .Select(NormalizeDirectoryPath)
+                .Select(PathUtility.Normalize)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray());
     }
@@ -85,7 +86,7 @@ internal sealed class ScopedFileAccessPolicy
 
         foreach (var root in roots)
         {
-            if (!IsPathWithinDirectory(fullPath, root))
+            if (!PathUtility.IsWithinRoot(fullPath, root))
                 continue;
 
             if (ContainsSymlinkSegment(root, fullPath))
@@ -127,7 +128,7 @@ internal sealed class ScopedFileAccessPolicy
         AccessKind accessKind)
     {
         var roots = _profileResolver.ResolveRoots(access, context)
-            .Select(NormalizeDirectoryPath)
+            .Select(PathUtility.Normalize)
             .ToList();
 
         if (accessKind == AccessKind.Read && audience != TrustAudience.Public)
@@ -151,27 +152,6 @@ internal sealed class ScopedFileAccessPolicy
         TrustAudience.Personal => "Personal",
         _ => "Public"
     };
-
-    private static string NormalizeDirectoryPath(string directoryPath)
-    {
-        return Path.GetFullPath(directoryPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-    }
-
-    private static bool IsPathWithinDirectory(string path, string directory)
-    {
-        var fullPath = Path.GetFullPath(path)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (!fullPath.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (fullPath.Length == directory.Length)
-            return true;
-
-        var boundary = fullPath[directory.Length];
-        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
-    }
 
     private static bool ContainsSymlinkSegment(string allowedRoot, string fullPath)
     {

--- a/src/Netclaw.Actors/Tools/SkillManageTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillManageTool.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Netclaw.Actors.Skills;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Security.Skills;
 using Netclaw.Tools;
 
@@ -334,7 +335,7 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (fileError is not null) return fileError;
 
         var fullPath = Path.GetFullPath(Path.Combine(skill.SkillDirectory, args.FilePath));
-        if (!fullPath.StartsWith(Path.GetFullPath(skill.SkillDirectory), StringComparison.Ordinal))
+        if (!PathUtility.IsWithinRoot(fullPath, skill.SkillDirectory))
             return "Resolved path is outside the skill directory.";
 
         var scanResult = await _scanner.ScanAsync(
@@ -379,7 +380,7 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
         if (fileError is not null) return fileError;
 
         var fullPath = Path.GetFullPath(Path.Combine(skill.SkillDirectory, args.FilePath));
-        if (!fullPath.StartsWith(Path.GetFullPath(skill.SkillDirectory), StringComparison.Ordinal))
+        if (!PathUtility.IsWithinRoot(fullPath, skill.SkillDirectory))
             return "Resolved path is outside the skill directory.";
 
         if (!File.Exists(fullPath))
@@ -479,9 +480,9 @@ public sealed partial class SkillManageTool : NetclawTool<SkillManageTool.Params
 
     private bool IsExternalSkill(SkillEntry skill)
     {
-        var nativeRoot = SkillScanner.NormalizeDirectoryPath(_paths.SkillsDirectory);
-        var skillPath = SkillScanner.NormalizeDirectoryPath(Path.GetDirectoryName(skill.FilePath)!);
-        return !SkillScanner.IsUnderRoot(skillPath, nativeRoot);
+        var nativeRoot = PathUtility.Normalize(_paths.SkillsDirectory);
+        var skillPath = PathUtility.Normalize(Path.GetDirectoryName(skill.FilePath)!);
+        return !PathUtility.IsWithinRoot(skillPath, nativeRoot);
     }
 
     private static void AtomicWrite(string path, string content)

--- a/src/Netclaw.Actors/Tools/SkillReadResourceTool.cs
+++ b/src/Netclaw.Actors/Tools/SkillReadResourceTool.cs
@@ -6,6 +6,7 @@
 using System.ComponentModel;
 using Netclaw.Actors.Skills;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Security.Skills;
 using Netclaw.Tools;
 
@@ -84,7 +85,7 @@ public sealed partial class SkillReadResourceTool : NetclawTool<SkillReadResourc
         var fullPath = Path.GetFullPath(Path.Combine(skill.SkillDirectory, resourcePath));
         var skillDirFull = Path.GetFullPath(skill.SkillDirectory);
 
-        if (!fullPath.StartsWith(skillDirFull, StringComparison.Ordinal))
+        if (!PathUtility.IsWithinRoot(fullPath, skillDirFull))
             return "Resolved path is outside the skill directory.";
 
         // Check for symlinks in the path

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -183,11 +183,11 @@ public sealed class ToolAccessPolicy
 
         if (!string.IsNullOrWhiteSpace(workingDirectory))
         {
-            var expandedWorkingDirectory = ExpandShellPath(workingDirectory, workingDirectory: null);
+            var expandedWorkingDirectory = PathUtility.ExpandAndNormalize(workingDirectory, workingDirectory: null);
             if (expandedWorkingDirectory is null)
                 return ToolAccessDecision.Deny("shell_invalid_working_directory");
 
-            if (!IsPathWithinAnyRoot(expandedWorkingDirectory, roots))
+            if (!PathUtility.IsWithinAnyRoot(expandedWorkingDirectory, roots))
                 return ToolAccessDecision.Deny("shell_working_directory_outside_trust_zone");
         }
 
@@ -197,11 +197,11 @@ public sealed class ToolAccessPolicy
 
         foreach (var pathToken in pathTokens)
         {
-            var expanded = ExpandShellPath(pathToken, workingDirectory);
+            var expanded = PathUtility.ExpandAndNormalize(pathToken, workingDirectory);
             if (expanded is null)
                 continue;
 
-            if (!IsPathWithinAnyRoot(expanded, roots))
+            if (!PathUtility.IsWithinAnyRoot(expanded, roots))
                 return ToolAccessDecision.Deny("shell_path_outside_trust_zone");
         }
 
@@ -223,67 +223,6 @@ public sealed class ToolAccessPolicy
 
         return pathTokens;
     }
-
-    private static string? ExpandShellPath(string token, string? workingDirectory)
-    {
-        var expanded = token;
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-        if (expanded.StartsWith('~'))
-        {
-            if (string.IsNullOrWhiteSpace(home))
-                return null;
-            expanded = expanded.Length == 1
-                ? home
-                : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
-        }
-
-        if (!string.IsNullOrWhiteSpace(home))
-        {
-            expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
-        }
-
-        try
-        {
-            var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
-                ? workingDirectory
-                : Environment.CurrentDirectory;
-
-            return Path.IsPathRooted(expanded)
-                ? Path.GetFullPath(expanded)
-                : Path.GetFullPath(Path.Combine(baseDir, expanded));
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static bool IsPathWithinAnyRoot(string fullPath, IReadOnlyList<string> roots)
-    {
-        var normalized = NormalizeDirectoryComparisonPath(fullPath);
-        var comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-
-        foreach (var root in roots)
-        {
-            var normalizedRoot = NormalizeDirectoryComparisonPath(root);
-            if (!normalized.StartsWith(normalizedRoot, comparison))
-                continue;
-            if (normalized.Length == normalizedRoot.Length)
-                return true;
-            var boundary = normalized[normalizedRoot.Length];
-            if (boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar)
-                return true;
-        }
-
-        return false;
-    }
-
-    private static string NormalizeDirectoryComparisonPath(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     private static bool ShellCommandHasTrustZoneSensitiveInputs(string shellCommand, string? workingDirectory)
         => !string.IsNullOrWhiteSpace(workingDirectory) || ShellCommandHasPathArguments(shellCommand);

--- a/src/Netclaw.Security.Tests/PathUtilityTests.cs
+++ b/src/Netclaw.Security.Tests/PathUtilityTests.cs
@@ -1,0 +1,196 @@
+// -----------------------------------------------------------------------
+// <copyright file="PathUtilityTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+public sealed class PathUtilityTests
+{
+    [Fact]
+    public void Normalize_removes_trailing_separator()
+    {
+        var result = PathUtility.Normalize("/home/user/");
+        Assert.False(result.EndsWith('/'));
+        Assert.False(result.EndsWith('\\'));
+    }
+
+    [Fact]
+    public void Normalize_resolves_dot_sequences()
+    {
+        var result = PathUtility.Normalize("/home/user/../user/docs");
+        Assert.DoesNotContain("..", result);
+    }
+
+    [Fact]
+    public void TryNormalize_returns_true_for_valid_path()
+    {
+        var success = PathUtility.TryNormalize("/home/user", out var normalized);
+        Assert.True(success);
+        Assert.False(string.IsNullOrEmpty(normalized));
+    }
+
+    [Fact]
+    public void TryNormalize_returns_false_for_invalid_path()
+    {
+        var success = PathUtility.TryNormalize("path\0with\0nulls", out var normalized);
+        Assert.False(success);
+        Assert.Empty(normalized);
+    }
+
+    [Fact]
+    public void TryNormalize_respects_working_directory()
+    {
+        var workingDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var success = PathUtility.TryNormalize("relative/path", workingDir, out var normalized);
+        Assert.True(success);
+        Assert.StartsWith(workingDir, normalized);
+    }
+
+    [Fact]
+    public void IsWithinRoot_returns_true_for_exact_match()
+    {
+        Assert.True(PathUtility.IsWithinRoot("/home/user", "/home/user"));
+    }
+
+    [Fact]
+    public void IsWithinRoot_returns_true_for_child_path()
+    {
+        Assert.True(PathUtility.IsWithinRoot("/home/user/docs/file.txt", "/home/user"));
+    }
+
+    [Fact]
+    public void IsWithinRoot_returns_false_for_prefix_without_boundary()
+    {
+        Assert.False(PathUtility.IsWithinRoot("/home/usersecret/file.txt", "/home/user"));
+    }
+
+    [Fact]
+    public void IsWithinRoot_returns_false_for_unrelated_path()
+    {
+        Assert.False(PathUtility.IsWithinRoot("/var/log/app.log", "/home/user"));
+    }
+
+    [Fact]
+    public void IsWithinRoot_handles_trailing_separators()
+    {
+        Assert.True(PathUtility.IsWithinRoot("/home/user/docs/", "/home/user/"));
+        Assert.True(PathUtility.IsWithinRoot("/home/user/docs", "/home/user/"));
+        Assert.True(PathUtility.IsWithinRoot("/home/user/docs/", "/home/user"));
+    }
+
+    [Fact]
+    public void IsWithinAnyRoot_returns_false_for_empty_roots()
+    {
+        Assert.False(PathUtility.IsWithinAnyRoot("/home/user", Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void IsWithinAnyRoot_returns_true_when_in_first_root()
+    {
+        var roots = new[] { "/home/user", "/var/data" };
+        Assert.True(PathUtility.IsWithinAnyRoot("/home/user/file.txt", roots));
+    }
+
+    [Fact]
+    public void IsWithinAnyRoot_returns_true_when_in_last_root()
+    {
+        var roots = new[] { "/home/user", "/var/data" };
+        Assert.True(PathUtility.IsWithinAnyRoot("/var/data/file.txt", roots));
+    }
+
+    [Fact]
+    public void IsWithinAnyRoot_returns_false_when_in_no_root()
+    {
+        var roots = new[] { "/home/user", "/var/data" };
+        Assert.False(PathUtility.IsWithinAnyRoot("/etc/passwd", roots));
+    }
+
+    [Fact]
+    public void ExpandHome_expands_tilde()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandHome("~/docs");
+        Assert.StartsWith(home, result);
+        Assert.DoesNotContain("~", result);
+    }
+
+    [Fact]
+    public void ExpandHome_expands_tilde_alone()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandHome("~");
+        Assert.Equal(home, result);
+    }
+
+    [Fact]
+    public void ExpandHome_expands_dollar_home()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandHome("$HOME/docs");
+        Assert.StartsWith(home, result);
+        Assert.DoesNotContain("$HOME", result);
+    }
+
+    [Fact]
+    public void ExpandHome_expands_braced_home()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandHome("${HOME}/docs");
+        Assert.StartsWith(home, result);
+        Assert.DoesNotContain("${HOME}", result);
+    }
+
+    [Fact]
+    public void ExpandHome_expands_userprofile()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandHome("%USERPROFILE%/docs");
+        Assert.StartsWith(home, result);
+        Assert.DoesNotContain("%USERPROFILE%", result);
+    }
+
+    [Fact]
+    public void ExpandHome_returns_unchanged_for_absolute_path()
+    {
+        var result = PathUtility.ExpandHome("/absolute/path");
+        Assert.Equal("/absolute/path", result);
+    }
+
+    [Fact]
+    public void ExpandAndNormalize_combines_expansion_and_normalization()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return;
+
+        var result = PathUtility.ExpandAndNormalize("~/docs/../docs");
+        Assert.NotNull(result);
+        Assert.StartsWith(home, result);
+        Assert.DoesNotContain("..", result);
+    }
+
+    [Fact]
+    public void ExpandAndNormalize_returns_null_for_invalid_path()
+    {
+        var result = PathUtility.ExpandAndNormalize("path\0with\0nulls");
+        Assert.Null(result);
+    }
+}

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------
+// <copyright file="PathUtility.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Netclaw.Security;
+
+/// <summary>
+/// Centralized path utilities for security-sensitive path operations.
+/// </summary>
+public static class PathUtility
+{
+    /// <summary>
+    /// Normalizes a path by resolving to full path and removing trailing separators.
+    /// </summary>
+    public static string Normalize(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    /// <summary>
+    /// Attempts to normalize a path, returning false if the path is invalid.
+    /// </summary>
+    public static bool TryNormalize(string path, out string normalized)
+        => TryNormalize(path, workingDirectory: null, out normalized);
+
+    /// <summary>
+    /// Attempts to normalize a path relative to a working directory.
+    /// </summary>
+    public static bool TryNormalize(string path, string? workingDirectory, out string normalized)
+    {
+        normalized = string.Empty;
+        try
+        {
+            var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
+                ? workingDirectory
+                : Environment.CurrentDirectory;
+
+            normalized = Path.IsPathRooted(path)
+                ? Normalize(path)
+                : Normalize(Path.Combine(baseDir, path));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a candidate path is within or equal to a root directory.
+    /// Uses platform-appropriate case sensitivity.
+    /// </summary>
+    public static bool IsWithinRoot(string candidate, string root)
+    {
+        var normalizedCandidate = Normalize(candidate);
+        var normalizedRoot = Normalize(root);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (!normalizedCandidate.StartsWith(normalizedRoot, comparison))
+            return false;
+
+        if (normalizedCandidate.Length == normalizedRoot.Length)
+            return true;
+
+        var boundary = normalizedCandidate[normalizedRoot.Length];
+        return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
+    }
+
+    /// <summary>
+    /// Checks if a candidate path is within or equal to any of the root directories.
+    /// Uses platform-appropriate case sensitivity.
+    /// </summary>
+    public static bool IsWithinAnyRoot(string candidate, IReadOnlyList<string> roots)
+    {
+        foreach (var root in roots)
+        {
+            if (IsWithinRoot(candidate, root))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Expands shell path tokens: ~, $HOME, ${HOME}, %USERPROFILE%.
+    /// Does not normalize the path.
+    /// </summary>
+    public static string ExpandHome(string path)
+    {
+        var expanded = path;
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        if (expanded.StartsWith('~'))
+        {
+            if (!string.IsNullOrWhiteSpace(home))
+            {
+                expanded = expanded.Length == 1
+                    ? home
+                    : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
+            expanded = expanded.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return expanded;
+    }
+
+    /// <summary>
+    /// Expands shell path tokens and normalizes relative to working directory.
+    /// Returns null if expansion or normalization fails.
+    /// </summary>
+    public static string? ExpandAndNormalize(string path, string? workingDirectory = null)
+    {
+        var expanded = ExpandHome(path);
+        return TryNormalize(expanded, workingDirectory, out var normalized) ? normalized : null;
+    }
+}

--- a/src/Netclaw.Security/ToolPathPolicy.cs
+++ b/src/Netclaw.Security/ToolPathPolicy.cs
@@ -46,14 +46,14 @@ public sealed class ToolPathPolicy
 
     private static HashSet<string> BuildNormalizedSet(IEnumerable<string> paths)
     {
-        var normalized = paths.Select(NormalizePath);
+        var normalized = paths.Select(PathUtility.Normalize);
         return new HashSet<string>(normalized, StringComparer.OrdinalIgnoreCase);
     }
 
     private static HashSet<string> BuildCommandIndicators(IEnumerable<string> paths)
     {
         var materialized = paths.ToList();
-        var normalizedPaths = materialized.Select(NormalizePath).ToList();
+        var normalizedPaths = materialized.Select(PathUtility.Normalize).ToList();
         var indicators = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var path in materialized.Concat(normalizedPaths))
@@ -92,7 +92,7 @@ public sealed class ToolPathPolicy
         if (string.IsNullOrWhiteSpace(path))
             return false;
 
-        if (TryNormalizePath(path, null, out var normalized) && IsDeniedNormalized(normalized, deniedSet))
+        if (PathUtility.TryNormalize(path, null, out var normalized) && IsDeniedNormalized(normalized, deniedSet))
             return true;
 
         return TryResolveSymlinkTarget(path, out var resolvedTarget)
@@ -122,8 +122,8 @@ public sealed class ToolPathPolicy
             if (!LooksLikePath(token))
                 continue;
 
-            var expanded = ExpandHomeAndEnv(token);
-            if (TryNormalizePath(expanded, workingDirectory, out var normalized)
+            var expanded = PathUtility.ExpandHome(token);
+            if (PathUtility.TryNormalize(expanded, workingDirectory, out var normalized)
                 && IsDeniedNormalized(normalized, _shellDeniedPaths))
             {
                 return true;
@@ -185,28 +185,6 @@ public sealed class ToolPathPolicy
         return boundary == Path.DirectorySeparatorChar || boundary == Path.AltDirectorySeparatorChar;
     }
 
-    private static bool TryNormalizePath(string rawPath, string? workingDirectory, out string normalized)
-    {
-        normalized = string.Empty;
-
-        try
-        {
-            var baseDir = !string.IsNullOrWhiteSpace(workingDirectory)
-                ? workingDirectory
-                : Environment.CurrentDirectory;
-
-            normalized = Path.IsPathRooted(rawPath)
-                ? NormalizePath(rawPath)
-                : NormalizePath(Path.Combine(baseDir, rawPath));
-
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
     private static bool TryResolveSymlinkTarget(string path, out string normalizedTarget)
     {
         normalizedTarget = string.Empty;
@@ -219,7 +197,7 @@ public sealed class ToolPathPolicy
                 if (target is null)
                     return false;
 
-                normalizedTarget = NormalizePath(target.FullName);
+                normalizedTarget = PathUtility.Normalize(target.FullName);
                 return true;
             }
 
@@ -229,7 +207,7 @@ public sealed class ToolPathPolicy
                 if (target is null)
                     return false;
 
-                normalizedTarget = NormalizePath(target.FullName);
+                normalizedTarget = PathUtility.Normalize(target.FullName);
                 return true;
             }
 
@@ -257,34 +235,4 @@ public sealed class ToolPathPolicy
             || token.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string ExpandHomeAndEnv(string token)
-    {
-        var expanded = token;
-
-        if (expanded.StartsWith("~", StringComparison.Ordinal))
-        {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            if (!string.IsNullOrWhiteSpace(home))
-            {
-                expanded = expanded.Length == 1
-                    ? home
-                    : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
-            }
-        }
-
-        var homeEnv = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrWhiteSpace(homeEnv))
-        {
-            expanded = expanded.Replace("$HOME", homeEnv, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("${HOME}", homeEnv, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("%USERPROFILE%", homeEnv, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return expanded;
-    }
-
-    private static string NormalizePath(string path)
-    {
-        return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-    }
 }


### PR DESCRIPTION
## Summary

Closes #852

- Extract shared path utilities into `Netclaw.Security.PathUtility` with 6 methods: `Normalize`, `TryNormalize`, `IsWithinRoot`, `IsWithinAnyRoot`, `ExpandHome`, `ExpandAndNormalize`
- Migrate 8 consumer files and remove 232 lines of duplicated code
- Fix security vulnerability in `SkillReadResourceTool` and `SkillManageTool` where bare `StartsWith` checks lacked boundary validation (prefix-without-boundary attack)

## Test plan

- [x] All 22 new `PathUtilityTests` pass
- [x] All 393 `Netclaw.Security.Tests` pass
- [x] All 1463 `Netclaw.Actors.Tests` pass
- [x] Slopwatch: 0 violations
- [x] Copyright headers verified