### PR TITLE
docs: add netclaw.dev website links and positioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to Netclaw
 
 This guide covers development workflows, planning tooling, and contributor
-conventions. For end-user setup and usage, see [`README.md`](README.md).
+conventions. For end-user setup and usage, see [`README.md`](README.md) or
+visit [netclaw.dev](https://netclaw.dev).
 
 ## Build and Test
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <Copyright>Copyright © 2026-$([System.DateTime]::Now.Year) Petabridge, LLC</Copyright>
     <Authors>Petabridge, LLC</Authors>
     <Company>Petabridge, LLC</Company>
+    <PackageProjectUrl>https://netclaw.dev</PackageProjectUrl>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,5 +1,9 @@
 # Project Context - Netclaw
 
+**Website:** [netclaw.dev](https://netclaw.dev)
+**Slogan:** "Run your own agent."
+**Positioning:** Simple, secure, reliable agents.
+
 ## What Netclaw Is
 
 Netclaw is an **always-on autonomous operations agent** that runs anywhere —
@@ -10,6 +14,24 @@ react, investigate, delegate work, and manage its own schedule.
 
 Netclaw is open source and designed for hobbyists, small teams, and businesses
 who want a self-hosted AI operations agent with strong safety defaults.
+
+## Competitive Positioning
+
+Netclaw's differentiator is **simplicity as a deliberate design choice, not a
+limitation.** Competitors compete on scale and velocity (ecosystem breadth,
+GitHub stars, feature count, PR volume). Netclaw counter-positions on three
+pillars:
+
+1. **Simplicity** — As few moving parts as possible. Readable codebase, small
+   configuration footprint, no feature bloat.
+2. **Security** — Audience disposition system and approval gates built in from
+   day one. Default-deny, fail-closed. The human stays in the loop.
+3. **Reliability** — Curated skill feeds managed by your organization (not an
+   unaudited public marketplace), persistent memory, background tasks, works
+   with small models (Qwen 3.5 9B and up).
+
+Key principle: when competitors' complexity is the source of their security
+vulnerabilities, our simplicity IS our security story.
 
 ## Primary Users
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,32 @@
   <img src="https://raw.githubusercontent.com/netclaw-dev/netclaw-brand/dev/logo/netclaw-horizontal-purple.png" alt="Netclaw" width="400" />
 </p>
 
+<p align="center">
+  <strong>Run your own agent.</strong><br />
+  Simple, secure, reliable agents.
+</p>
+
+<p align="center">
+  <a href="https://netclaw.dev">Website</a> &middot;
+  <a href="https://netclaw.dev/docs">Documentation</a> &middot;
+  <a href="https://github.com/netclaw-dev/netclaw/releases">Releases</a>
+</p>
+
 # Netclaw
 
-Netclaw is an open-source, self-hosted autonomous operations agent built on top
-of a minimal actor-driven session framework called Akka.Agents.
+Netclaw is an open-source, self-hosted autonomous operations agent that runs
+anywhere — from a Raspberry Pi to a cloud VM. Built on top of a minimal
+actor-driven session framework called Akka.Agents, Netclaw is designed for
+hobbyists, small teams, and businesses who want an AI operations agent with
+strong safety defaults and as few moving parts as possible.
+
+Where other agents compete on ecosystem breadth and feature velocity, Netclaw
+takes the opposite approach: **simplicity** (a readable codebase with a small
+configuration footprint), **security** (audience dispositions and approval gates
+from day one, not bolted on after incidents), and **reliability** (curated skill
+feeds managed by your organization, not an unaudited public marketplace).
+
+Learn more at **[netclaw.dev](https://netclaw.dev)**.
 
 ## Architecture
 
@@ -470,4 +492,6 @@ See `LICENSE` for the full text.
 
 ---
 
-Built with care by [Petabridge](https://petabridge.com).
+Built with care by [Petabridge](https://petabridge.com). Visit
+[netclaw.dev](https://netclaw.dev) for documentation, guides, and community
+resources.

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -1032,6 +1032,8 @@ static void WriteGeneralHelp()
     Console.WriteLine("  config                   Configuration management (planned)");
     Console.WriteLine();
     Console.WriteLine("Run `netclaw <command> --help` for details on any command.");
+    Console.WriteLine();
+    Console.WriteLine("Docs & guides: https://netclaw.dev/docs");
 }
 
 static void WriteDaemonHelp()


### PR DESCRIPTION
## Summary

- Adds [netclaw.dev](https://netclaw.dev) links and "simple, secure, reliable" competitive positioning across public-facing surfaces
- README gets a hero block (slogan + tagline + nav links), an expanded intro paragraph with three-pillar positioning, and a footer website link
- PROJECT_CONTEXT gets the website/slogan/positioning header and a new Competitive Positioning section
- CONTRIBUTING gets a website link alongside the existing README reference
- `Directory.Build.props` gets `PackageProjectUrl` for assembly/NuGet metadata
- CLI `--help` output gets a docs URL footer

## Test plan

- [ ] `dotnet build Netclaw.slnx` passes (verified locally, no errors)
- [ ] README renders correctly on GitHub (hero block, links, positioning paragraph, footer)
- [ ] `netclaw --help` shows `Docs & guides: https://netclaw.dev/docs` at the bottom