### PR TITLE
fix: background reconnection for unreachable MCP servers

### DIFF
--- a/src/Netclaw.Configuration/OperationalAlert.cs
+++ b/src/Netclaw.Configuration/OperationalAlert.cs
@@ -22,6 +22,7 @@ public enum AlertType
 {
     McpAuthExpired,
     McpServerDisconnected,
+    McpServerReconnected,
     ChannelDisconnected,
     ProviderAuthExpired,
     ProviderFailover,

--- a/src/Netclaw.Daemon.Tests/Mcp/McpReconnectionServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpReconnectionServiceTests.cs
@@ -1,0 +1,213 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpReconnectionServiceTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Netclaw.Configuration;
+using Netclaw.Daemon.Mcp;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+public sealed class McpReconnectionServiceTests
+{
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+    private readonly FakeNotificationSink _sink = new();
+    private readonly FakeMcpReconnectable _reconnectable = new();
+
+    private McpReconnectionService CreateService() =>
+        new(_reconnectable, _sink, _time, NullLogger<McpReconnectionService>.Instance);
+
+    [Fact]
+    public async Task SkipsNonUnreachableServers()
+    {
+        _reconnectable.SetStatus("connected-server", McpConnectionState.Connected, 5);
+        _reconnectable.SetStatus("auth-server", McpConnectionState.AwaitingAuth);
+        _reconnectable.SetStatus("failed-auth", McpConnectionState.AuthFailed);
+        _reconnectable.SetStatus("disabled-server", McpConnectionState.Disabled);
+
+        var service = CreateService();
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+
+        Assert.Equal(0, _reconnectable.ReconnectCallCount);
+    }
+
+    [Fact]
+    public async Task RetriesUnreachableServerOnFirstTick()
+    {
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) =>
+        {
+            _reconnectable.SetStatus("memorizer", McpConnectionState.Connected, 10);
+            return Task.FromResult(true);
+        };
+
+        var service = CreateService();
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+
+        Assert.Equal(1, _reconnectable.ReconnectCallCount);
+        Assert.Single(_sink.Alerts);
+        Assert.Equal(AlertType.McpServerReconnected, _sink.Alerts[0].Category);
+        Assert.Contains("memorizer", _sink.Alerts[0].Summary);
+    }
+
+    [Fact]
+    public async Task BacksOffAfterFailedReconnect()
+    {
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) => Task.FromResult(false);
+
+        var service = CreateService();
+
+        // First tick: attempt 1 (immediate, failureCount=0)
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(1, _reconnectable.ReconnectCallCount);
+
+        // Advance 15s — still within 30s backoff window
+        _time.Advance(TimeSpan.FromSeconds(15));
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(1, _reconnectable.ReconnectCallCount);
+
+        // Advance to 31s total — past the 30s backoff
+        _time.Advance(TimeSpan.FromSeconds(16));
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(2, _reconnectable.ReconnectCallCount);
+    }
+
+    [Fact]
+    public async Task BackoffResetsOnSuccess()
+    {
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+
+        var callCount = 0;
+        _reconnectable.OnReconnect = (_, _) =>
+        {
+            callCount++;
+            if (callCount >= 3)
+            {
+                _reconnectable.SetStatus("memorizer", McpConnectionState.Connected, 10);
+                return Task.FromResult(true);
+            }
+            return Task.FromResult(false);
+        };
+
+        var service = CreateService();
+
+        // Fail twice to build up backoff
+        await service.CheckAndReconnectAsync(CancellationToken.None); // attempt 1
+        _time.Advance(TimeSpan.FromSeconds(31));
+        await service.CheckAndReconnectAsync(CancellationToken.None); // attempt 2
+
+        // Third attempt succeeds
+        _time.Advance(TimeSpan.FromSeconds(61));
+        await service.CheckAndReconnectAsync(CancellationToken.None); // attempt 3
+
+        Assert.Single(_sink.Alerts);
+        Assert.Equal(AlertType.McpServerReconnected, _sink.Alerts[0].Category);
+
+        // Simulate server going unreachable again — backoff should be reset
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) => Task.FromResult(false);
+
+        // Should retry immediately (no stale backoff)
+        _time.Advance(TimeSpan.FromSeconds(1));
+        var countBefore = _reconnectable.ReconnectCallCount;
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(countBefore + 1, _reconnectable.ReconnectCallCount);
+    }
+
+    [Fact]
+    public async Task HandlesExceptionsWithoutCrashing()
+    {
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) => throw new HttpRequestException("Connection refused");
+
+        var service = CreateService();
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+
+        Assert.Equal(1, _reconnectable.ReconnectCallCount);
+        Assert.Empty(_sink.Alerts);
+
+        // Should still back off after exception
+        _time.Advance(TimeSpan.FromSeconds(15));
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(1, _reconnectable.ReconnectCallCount);
+    }
+
+    [Fact]
+    public async Task CleansUpBackoffWhenServerRecoveredExternally()
+    {
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) => Task.FromResult(false);
+
+        var service = CreateService();
+
+        // Build up some backoff
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        _time.Advance(TimeSpan.FromSeconds(31));
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+
+        // External code reconnected the server
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Connected, 10);
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+
+        // Now it goes unreachable again — should retry immediately (backoff was cleaned)
+        _reconnectable.SetStatus("memorizer", McpConnectionState.Unreachable);
+        _reconnectable.OnReconnect = (_, _) => Task.FromResult(false);
+
+        _time.Advance(TimeSpan.FromSeconds(1));
+        var countBefore = _reconnectable.ReconnectCallCount;
+        await service.CheckAndReconnectAsync(CancellationToken.None);
+        Assert.Equal(countBefore + 1, _reconnectable.ReconnectCallCount);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 30_000)]
+    [InlineData(2, 60_000)]
+    [InlineData(3, 120_000)]
+    [InlineData(4, 240_000)]
+    [InlineData(5, 300_000)]
+    [InlineData(10, 300_000)]
+    public void ComputeBackoffMs_ReturnsExpectedValues(int failureCount, long expectedMs)
+    {
+        Assert.Equal(expectedMs, McpReconnectionService.ComputeBackoffMs(failureCount));
+    }
+
+    private sealed class FakeMcpReconnectable : IMcpReconnectable
+    {
+        private readonly Dictionary<McpServerName, McpServerStatus> _statuses = new();
+        private int _reconnectCallCount;
+
+        public int ReconnectCallCount => Volatile.Read(ref _reconnectCallCount);
+
+        public Func<McpServerName, CancellationToken, Task<bool>>? OnReconnect { get; set; }
+
+        public void SetStatus(string name, McpConnectionState state, int toolCount = 0)
+        {
+            var serverName = new McpServerName(name);
+            _statuses[serverName] = new McpServerStatus(
+                serverName, state, toolCount,
+                state == McpConnectionState.Unreachable ? "test error" : null);
+        }
+
+        public IReadOnlyDictionary<McpServerName, McpServerStatus> GetServerStatuses() => _statuses;
+
+        public async Task<bool> TryReconnectAsync(McpServerName serverName, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _reconnectCallCount);
+            if (OnReconnect is not null)
+                return await OnReconnect(serverName, ct);
+            return false;
+        }
+    }
+
+    private sealed class FakeNotificationSink : IOperationalNotificationSink
+    {
+        public List<OperationalAlert> Alerts { get; } = [];
+        public void Emit(OperationalAlert alert) => Alerts.Add(alert);
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/IMcpReconnectable.cs
+++ b/src/Netclaw.Daemon/Mcp/IMcpReconnectable.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="IMcpReconnectable.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Tools;
+
+namespace Netclaw.Daemon.Mcp;
+
+internal interface IMcpReconnectable
+{
+    IReadOnlyDictionary<McpServerName, McpServerStatus> GetServerStatuses();
+
+    Task<bool> TryReconnectAsync(McpServerName serverName, CancellationToken ct = default);
+}

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -15,7 +15,7 @@ using Netclaw.Tools;
 
 namespace Netclaw.Daemon.Mcp;
 
-internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolInvoker
+internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolInvoker, IMcpReconnectable
 {
     private const string PlaywrightServerName = "browser_playwright";
 

--- a/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
@@ -22,8 +22,7 @@ internal sealed class McpReconnectionService : BackgroundService
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<McpReconnectionService> _logger;
 
-    private readonly ConcurrentDictionary<McpServerName, int> _failureCounts = new();
-    private readonly ConcurrentDictionary<McpServerName, long> _lastAttemptTimestamps = new();
+    private readonly ConcurrentDictionary<McpServerName, BackoffState> _backoff = new();
 
     public McpReconnectionService(
         IMcpReconnectable mcpReconnectable,
@@ -58,19 +57,18 @@ internal sealed class McpReconnectionService : BackgroundService
         {
             if (status.State is not McpConnectionState.Unreachable)
             {
-                _failureCounts.TryRemove(serverName, out _);
-                _lastAttemptTimestamps.TryRemove(serverName, out _);
+                _backoff.TryRemove(serverName, out _);
                 continue;
             }
 
-            var failureCount = _failureCounts.GetValueOrDefault(serverName, 0);
+            var state = _backoff.GetValueOrDefault(serverName);
+            var failureCount = state.FailureCount;
             var backoffMs = ComputeBackoffMs(failureCount);
-            var lastAttemptMs = _lastAttemptTimestamps.GetValueOrDefault(serverName, 0L);
 
-            if (nowMs - lastAttemptMs < backoffMs)
+            if (nowMs - state.LastAttemptMs < backoffMs)
                 continue;
 
-            _lastAttemptTimestamps[serverName] = nowMs;
+            _backoff[serverName] = state with { LastAttemptMs = nowMs };
 
             _logger.LogDebug(
                 "Attempting reconnection to MCP server '{Name}' (attempt {Attempt})",
@@ -81,8 +79,7 @@ internal sealed class McpReconnectionService : BackgroundService
                 var success = await _mcpReconnectable.TryReconnectAsync(serverName, ct);
                 if (success)
                 {
-                    _failureCounts.TryRemove(serverName, out _);
-                    _lastAttemptTimestamps.TryRemove(serverName, out _);
+                    _backoff.TryRemove(serverName, out _);
 
                     _logger.LogInformation(
                         "MCP server '{Name}' reconnected successfully after {Attempts} attempt(s)",
@@ -92,7 +89,7 @@ internal sealed class McpReconnectionService : BackgroundService
                 }
                 else
                 {
-                    _failureCounts[serverName] = failureCount + 1;
+                    _backoff[serverName] = new BackoffState(failureCount + 1, nowMs);
                     _logger.LogDebug(
                         "MCP server '{Name}' reconnection failed (next retry in ~{BackoffSeconds}s)",
                         serverName.Value, ComputeBackoffMs(failureCount + 1) / 1000);
@@ -104,7 +101,7 @@ internal sealed class McpReconnectionService : BackgroundService
             }
             catch (Exception ex)
             {
-                _failureCounts[serverName] = failureCount + 1;
+                _backoff[serverName] = new BackoffState(failureCount + 1, nowMs);
                 _logger.LogDebug(ex,
                     "MCP server '{Name}' reconnection threw an exception",
                     serverName.Value);
@@ -137,4 +134,6 @@ internal sealed class McpReconnectionService : BackgroundService
                 ["serverName"] = serverName.Value,
             }));
     }
+
+    internal readonly record struct BackoffState(int FailureCount, long LastAttemptMs);
 }

--- a/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
+++ b/src/Netclaw.Daemon/Mcp/McpReconnectionService.cs
@@ -1,0 +1,140 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpReconnectionService.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Netclaw.Configuration;
+using Netclaw.Tools;
+
+namespace Netclaw.Daemon.Mcp;
+
+internal sealed class McpReconnectionService : BackgroundService
+{
+    internal static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(30);
+    internal const int BaseBackoffSeconds = 30;
+    internal const int MaxBackoffSeconds = 300;
+
+    private readonly IMcpReconnectable _mcpReconnectable;
+    private readonly IOperationalNotificationSink _notificationSink;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<McpReconnectionService> _logger;
+
+    private readonly ConcurrentDictionary<McpServerName, int> _failureCounts = new();
+    private readonly ConcurrentDictionary<McpServerName, long> _lastAttemptTimestamps = new();
+
+    public McpReconnectionService(
+        IMcpReconnectable mcpReconnectable,
+        IOperationalNotificationSink notificationSink,
+        TimeProvider timeProvider,
+        ILogger<McpReconnectionService> logger)
+    {
+        _mcpReconnectable = mcpReconnectable;
+        _notificationSink = notificationSink;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Let McpClientManager.StartAsync complete before polling.
+        await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, stoppingToken);
+
+        using var timer = new PeriodicTimer(TickInterval, _timeProvider);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await CheckAndReconnectAsync(stoppingToken);
+        }
+    }
+
+    internal async Task CheckAndReconnectAsync(CancellationToken ct)
+    {
+        var statuses = _mcpReconnectable.GetServerStatuses();
+        var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+
+        foreach (var (serverName, status) in statuses)
+        {
+            if (status.State is not McpConnectionState.Unreachable)
+            {
+                _failureCounts.TryRemove(serverName, out _);
+                _lastAttemptTimestamps.TryRemove(serverName, out _);
+                continue;
+            }
+
+            var failureCount = _failureCounts.GetValueOrDefault(serverName, 0);
+            var backoffMs = ComputeBackoffMs(failureCount);
+            var lastAttemptMs = _lastAttemptTimestamps.GetValueOrDefault(serverName, 0L);
+
+            if (nowMs - lastAttemptMs < backoffMs)
+                continue;
+
+            _lastAttemptTimestamps[serverName] = nowMs;
+
+            _logger.LogDebug(
+                "Attempting reconnection to MCP server '{Name}' (attempt {Attempt})",
+                serverName.Value, failureCount + 1);
+
+            try
+            {
+                var success = await _mcpReconnectable.TryReconnectAsync(serverName, ct);
+                if (success)
+                {
+                    _failureCounts.TryRemove(serverName, out _);
+                    _lastAttemptTimestamps.TryRemove(serverName, out _);
+
+                    _logger.LogInformation(
+                        "MCP server '{Name}' reconnected successfully after {Attempts} attempt(s)",
+                        serverName.Value, failureCount + 1);
+
+                    EmitReconnectedAlert(serverName);
+                }
+                else
+                {
+                    _failureCounts[serverName] = failureCount + 1;
+                    _logger.LogDebug(
+                        "MCP server '{Name}' reconnection failed (next retry in ~{BackoffSeconds}s)",
+                        serverName.Value, ComputeBackoffMs(failureCount + 1) / 1000);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _failureCounts[serverName] = failureCount + 1;
+                _logger.LogDebug(ex,
+                    "MCP server '{Name}' reconnection threw an exception",
+                    serverName.Value);
+            }
+        }
+    }
+
+    internal static long ComputeBackoffMs(int failureCount)
+    {
+        if (failureCount <= 0)
+            return 0;
+
+        var seconds = Math.Min(
+            BaseBackoffSeconds * (1 << Math.Min(failureCount - 1, 10)),
+            MaxBackoffSeconds);
+        return seconds * 1000L;
+    }
+
+    private void EmitReconnectedAlert(McpServerName serverName)
+    {
+        _notificationSink.Emit(OperationalAlert.Create(
+            _timeProvider,
+            "mcp.server.reconnected",
+            AlertType.McpServerReconnected,
+            $"MCP server '{serverName.Value}' reconnected successfully.",
+            AlertSeverity.Info,
+            source: serverName.Value,
+            context: new Dictionary<string, string>
+            {
+                ["serverName"] = serverName.Value,
+            }));
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -808,6 +808,8 @@ static void ConfigureDaemonServices(
         sp.GetService<ISecretsProtector>()));
     services.AddSingleton<McpClientManager>();
     services.AddHostedService(sp => sp.GetRequiredService<McpClientManager>());
+    services.AddSingleton<IMcpReconnectable>(sp => sp.GetRequiredService<McpClientManager>());
+    services.AddHostedService<McpReconnectionService>();
 
     // Dynamic tool index context layer — NOT part of the persisted system prompt.
     // The prompt-facing layer is computed from the live registry with audience


### PR DESCRIPTION
## Summary

Closes #883

- Adds `McpReconnectionService` (`BackgroundService`) that polls every 30s for MCP servers in `Unreachable` state and retries connection with per-server exponential backoff (30s → 60s → 120s → 240s → 300s cap)
- Emits `McpServerReconnected` operational alert on successful recovery
- Skips `AwaitingAuth`, `AuthFailed`, `Disabled`, and `Connected` servers — only retries `Unreachable`
- Extracts `IMcpReconnectable` interface from `McpClientManager` for testability

**Root cause:** `McpClientManager` only reconnects reactively (on tool invocation failure, OAuth completion, or config change). A transient DNS outage that resolves itself leaves the MCP server permanently dead.

## Test plan

- [x] 13 unit tests covering: skip non-unreachable, retry on first tick, exponential backoff timing, backoff reset on success, alert emission, exception handling, external recovery cleanup
- [x] `dotnet slopwatch analyze` — 0 violations
- [x] Copyright headers verified
- [ ] Manual: stop memorizer server → daemon shows Unreachable → restart server → verify auto-reconnect within ~30s