### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -12,6 +12,9 @@ on:
       - dev
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test-${{matrix.os}}

--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -18,6 +18,9 @@ concurrency:
   group: smoke-sandbox-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Smoke Sandbox

--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -35,6 +35,9 @@ on:
       - 'Directory.Packages.props'
       - '.github/workflows/validate_docker_image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-docker-build:
     name: Validate Docker Build


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to `pr_validation.yml`, `validate_docker_image.yml`, and `smoke_sandbox.yml` to restrict GITHUB_TOKEN scope per least-privilege (resolves CodeQL alerts #1–5)
- Dismissed 10 CodeQL false positive alerts (#6–15) with explanatory comments:
  - `cs/log-forging` (6 alerts): all use structured logging with named parameters — safe from injection
  - `cs/cleartext-storage-of-sensitive-information` (2 alerts): logged data is validation error messages, not the proxy IPs themselves
  - `cs/user-controlled-bypass` (2 alerts): route segment is validated against a registered catalog, not used to bypass auth

## Test plan

- [ ] CI passes on this PR (the permission changes are additive restrictions, not breaking)
- [ ] Verify dismissed alerts remain dismissed: `gh api repos/netclaw-dev/netclaw/code-scanning/alerts --jq '[.[] | select(.state=="dismissed")] | length'` returns 10