### PR TITLE
fix: add CursorAdvanced serialization bindings (#887)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tests.Channels.TestHelpers;
@@ -23,7 +24,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        builder.WithInMemoryJournal().WithInMemorySnapshotStore();
+        builder.WithInMemoryJournal().WithInMemorySnapshotStore().WithNetclawSerialization();
     }
 
     protected override IActorRef CreateBindingActor(

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -8,6 +8,7 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tests.Channels.TestHelpers;
@@ -26,7 +27,7 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        builder.WithInMemoryJournal().WithInMemorySnapshotStore();
+        builder.WithInMemoryJournal().WithInMemorySnapshotStore().WithNetclawSerialization();
     }
 
     protected override IActorRef CreateBindingActor(

--- a/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordFileFlowIntegrationTests.cs
@@ -90,6 +90,7 @@ public sealed class DiscordFileFlowIntegrationTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
+            .WithNetclawSerialization()
             .WithNetclawActors();
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackAttachmentIngressTests.cs
@@ -103,6 +103,7 @@ public sealed class SlackAttachmentIngressVisionTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
+            .WithNetclawSerialization()
             .WithNetclawActors();
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -99,6 +99,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
+            .WithNetclawSerialization()
             .WithNetclawActors();
     }
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -93,6 +93,7 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
+            .WithNetclawSerialization()
             .WithNetclawActors();
     }
 

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -6,6 +6,7 @@
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Serialization;
+using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
@@ -431,6 +432,15 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.Null(result.LowerBound);
         Assert.Null(result.UpperBound);
         Assert.Empty(result.Messages);
+    }
+
+    [Fact]
+    public void CursorAdvanced_round_trips()
+    {
+        var original = new CursorAdvanced("1778082564.879599");
+        var result = RoundTrip(original);
+        Assert.Equal(original, result);
+        Assert.Equal("1778082564.879599", result.Cursor);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -30,7 +30,8 @@ public class ReminderManagerActorTests : TestKit
     {
         builder
             .WithInMemoryJournal()
-            .WithInMemorySnapshotStore();
+            .WithInMemorySnapshotStore()
+            .WithNetclawSerialization();
 
         var paths = new NetclawPaths(_basePath);
         paths.EnsureDirectoriesExist();

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -8,6 +8,7 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
 using Microsoft.Extensions.Time.Testing;
+using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Reminders;
 using Netclaw.Configuration;
@@ -27,7 +28,8 @@ public class SetReminderToolTests : TestKit
     {
         builder
             .WithInMemoryJournal()
-            .WithInMemorySnapshotStore();
+            .WithInMemorySnapshotStore()
+            .WithNetclawSerialization();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -22,6 +22,7 @@ public abstract class LlmSessionTestBase : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
+            .WithNetclawSerialization()
             .WithNetclawActors();
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -8,6 +8,7 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
@@ -28,7 +29,8 @@ public sealed class SessionMemoryObserverActorTests : TestKit
     {
         builder
             .WithInMemoryJournal()
-            .WithInMemorySnapshotStore();
+            .WithInMemorySnapshotStore()
+            .WithNetclawSerialization();
     }
 
     /// <summary>

--- a/src/Netclaw.Actors/Channels/CursorAdvanced.cs
+++ b/src/Netclaw.Actors/Channels/CursorAdvanced.cs
@@ -1,0 +1,13 @@
+// -----------------------------------------------------------------------
+// <copyright file="CursorAdvanced.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Persistence event indicating a channel binding actor's inbound cursor moved forward.
+/// The cursor value is channel-specific (e.g. Slack timestamp, Discord snowflake)
+/// but serialized as an opaque string — only the owning actor interprets it.
+/// </summary>
+public readonly record struct CursorAdvanced(string Cursor);

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -184,6 +184,7 @@ public static class NetclawAkkaHostingExtensions
             typeof(ReminderSchedule),
             typeof(ReminderPayload),
             typeof(AdoptedContextRecorded),
+            typeof(Channels.CursorAdvanced),
         };
 
         return builder

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -35,6 +35,7 @@ internal static class NetclawProtoMapper
         ReminderSchedule v => ToProto(v),
         ReminderPayload v => ToProto(v),
         AdoptedContextRecorded v => ToProto(v),
+        CursorAdvanced v => ToProto(v),
         _ => throw new ArgumentException($"No proto mapping for {obj.GetType().FullName}")
     };
 
@@ -480,6 +481,11 @@ internal static class NetclawProtoMapper
         TimestampMs = proto.TimestampMs,
         AuthorityAtInclusion = proto.AuthorityAtInclusion
     };
+
+    // ── CursorAdvanced ──
+
+    internal static Proto.CursorAdvancedProto ToProto(CursorAdvanced ca) => new() { Cursor = ca.Cursor };
+    internal static CursorAdvanced FromProto(Proto.CursorAdvancedProto proto) => new(proto.Cursor);
 
     // ── ActiveJobInfo ──
 

--- a/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
@@ -37,6 +37,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
     private const string ReminderScheduleManifest = "rs-v1";
     private const string ReminderPayloadManifest = "rp-v1";
     private const string AdoptedContextRecordedManifest = "acr-v1";
+    private const string CursorAdvancedManifest = "ca-v1";
 
     private static readonly FrozenDictionary<Type, string> TypeToManifest = new Dictionary<Type, string>
     {
@@ -57,6 +58,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
         [typeof(ReminderSchedule)] = ReminderScheduleManifest,
         [typeof(ReminderPayload)] = ReminderPayloadManifest,
         [typeof(AdoptedContextRecorded)] = AdoptedContextRecordedManifest,
+        [typeof(Channels.CursorAdvanced)] = CursorAdvancedManifest,
     }.ToFrozenDictionary();
 
     public override int Identifier => 150;
@@ -117,6 +119,8 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
                 Proto.ReminderPayloadProto.Parser.ParseFrom(bytes)),
             AdoptedContextRecordedManifest => NetclawProtoMapper.FromProto(
                 Proto.AdoptedContextRecordedProto.Parser.ParseFrom(bytes)),
+            CursorAdvancedManifest => NetclawProtoMapper.FromProto(
+                Proto.CursorAdvancedProto.Parser.ParseFrom(bytes)),
             _ => throw new ArgumentException(
                 $"Unknown manifest '{manifest}'. Add it to NetclawProtobufSerializer.")
         };

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -210,3 +210,9 @@ message ReminderScheduleProto {
 message ReminderPayloadProto {
   ReminderIdProto id = 1;
 }
+
+// ── Channel cursor ──
+
+message CursorAdvancedProto {
+  string cursor = 1;
+}

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -1144,12 +1144,18 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return;
         }
 
-        Persist(new CursorAdvanced(candidateSnowflake), ApplyCursorAdvanced);
+        Persist(new CursorAdvanced(candidateSnowflake.ToString()), ApplyCursorAdvanced);
     }
 
     private void ApplyCursorAdvanced(CursorAdvanced advanced)
     {
-        _cursorSnowflake = advanced.CursorSnowflake;
+        if (!ulong.TryParse(advanced.Cursor, out var snowflake))
+        {
+            _log.Warning("Corrupt cursor value during recovery, skipping: {Cursor}", advanced.Cursor);
+            return;
+        }
+
+        _cursorSnowflake = snowflake;
 
         if (!IsRecovering && LastSequenceNr > 1 && LastSequenceNr % 10 == 0)
             DeleteMessages(LastSequenceNr - 1);
@@ -1157,8 +1163,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
     private static ulong? TryParseSnowflake(string value)
         => ulong.TryParse(value, out var id) ? id : null;
-
-    private readonly record struct CursorAdvanced(ulong CursorSnowflake);
 
     private sealed record InitializePipeline
     {

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -839,7 +839,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private void ApplyCursorAdvanced(CursorAdvanced advanced)
     {
-        _cursorTs = new SlackEventTs(advanced.CursorTs);
+        _cursorTs = new SlackEventTs(advanced.Cursor);
 
         // Skip journal truncation during recovery replay — we only need to run
         // it when new events are being persisted.
@@ -848,8 +848,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     }
 
     private readonly record struct InboundBuildResult(ChannelInput Input, bool BackfillDetectorUnavailable);
-
-    private readonly record struct CursorAdvanced(string CursorTs);
 
     private static AdoptedContextMergeResult MergeGapWithLiveContents(
         IReadOnlyList<AdoptedContextMessage> gap,


### PR DESCRIPTION
## Summary

- Replaces private nested `CursorAdvanced` types in `SlackThreadBindingActor` and `DiscordSessionBindingActor` with a shared `CursorAdvanced(string Cursor)` in `Netclaw.Actors.Channels`
- Adds protobuf message definition (`CursorAdvancedProto`), serializer manifest (`"ca-v1"`), mapper methods, hosting type registration, and round-trip test
- Discord converts snowflake `ulong` to/from string with `TryParse` for corruption resilience during recovery

Closes #887

## Test plan

- [x] `dotnet build` — zero warnings, proto codegen succeeds
- [x] `dotnet test --filter SerializationRoundTripTests` — all 22 tests pass (including new `CursorAdvanced_round_trips`)
- [x] Copyright header verification passes
- [ ] CI checks pass