### PR TITLE
fix: embed config schema as assembly resource, fix Search.Backend enum casing

### DIFF
--- a/.claude/skills/local-binary-swap.md
+++ b/.claude/skills/local-binary-swap.md
@@ -68,21 +68,13 @@ dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj \
 (use `/p:` for clarity). The production pipeline uses these exact flags and any
 deviation produces subtly broken binaries that appear to work but fail at runtime.
 
-### 4. Copy schemas and system skills to install location
+### 4. Copy system skills and swap binaries
 
-The publish output includes a `Schemas/` directory with the JSON schema used by
-`netclaw doctor`. If you don't copy it, the doctor will validate against a
-**stale schema** from a previous install and report false failures.
+Schemas are embedded in the CLI binary, so no separate schema copy is needed.
 
 ```bash
-cp -r /tmp/netclaw-publish/Schemas/* ~/.netclaw/bin/Schemas/
-cp -r /tmp/netclawd-publish/Schemas/* ~/.netclaw/bin/Schemas/
 cp -r feeds/skills/.system/files/* ~/.netclaw/skills/.system/
 ```
-
-**CRITICAL**: Always copy Schemas. A stale schema at `~/.netclaw/bin/Schemas/`
-will cause `netclaw doctor` to fail with "Config does not match schema" even
-when the config is valid.
 
 ### 5. Swap binaries
 
@@ -124,6 +116,5 @@ cp ~/.netclaw/bin/netclawd.bak ~/.netclaw/bin/netclawd
 | Missing `IncludeNativeLibrariesForSelfExtract` | `TypeInitializationException` for `SqliteConnection`, memory health doctor check fails | Republish with all flags |
 | Missing `EnableCompressionInSingleFile` | Binary is 2-3x larger than expected | Republish with all flags |
 | Forgot to stop daemon before swap | Binary overwrite fails or daemon crashes | Always `netclaw daemon stop` first |
-| Forgot to copy Schemas directory | `netclaw doctor` reports "Config does not match schema" against stale schema | Copy `Schemas/` from publish output to `~/.netclaw/bin/Schemas/` |
 | Forgot to copy system skills | New/updated skills not available | Copy from `feeds/skills/.system/files/` |
 | Used `-p:` instead of `/p:` | May work but inconsistent with CI | Use `/p:` to match production |

--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -219,7 +219,6 @@ jobs:
         name: publish-output-${{ matrix.rid }}
         path: |
           ./publish/cli/netclaw
-          ./publish/cli/Schemas/
           ./publish/daemon/netclawd
         retention-days: 1
 
@@ -285,9 +284,6 @@ jobs:
         find_binary() {
           find "$1" -name "$2" -type f | head -1
         }
-        find_dir() {
-          find "$1" -name "$2" -type d | head -1
-        }
 
         for arch_pair in "linux-x64:amd64" "linux-arm64:arm64"; do
           SRC="${arch_pair%%:*}"
@@ -295,15 +291,11 @@ jobs:
 
           CLI=$(find_binary "./artifacts/${SRC}" "netclaw")
           DAEMON=$(find_binary "./artifacts/${SRC}" "netclawd")
-          SCHEMAS=$(find_dir "./artifacts/${SRC}" "Schemas")
 
-          echo "[$DST] CLI=$CLI DAEMON=$DAEMON SCHEMAS=$SCHEMAS"
+          echo "[$DST] CLI=$CLI DAEMON=$DAEMON"
 
           cp "$CLI" "publish/cli-${DST}/netclaw"
           cp "$DAEMON" "publish/daemon-${DST}/netclawd"
-          if [[ -n "$SCHEMAS" ]]; then
-            cp -r "$SCHEMAS" "publish/cli-${DST}/Schemas"
-          fi
         done
 
         chmod +x publish/cli-amd64/netclaw publish/daemon-amd64/netclawd

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,9 +65,8 @@ RUN apt-get update \
 WORKDIR /opt/netclaw
 
 # Self-contained single-file binaries. TARGETARCH selects the right
-# platform directory (amd64 or arm64).
+# platform directory (amd64 or arm64). Schemas are embedded in the CLI binary.
 COPY publish/cli-${TARGETARCH}/netclaw /opt/netclaw/cli/netclaw
-COPY publish/cli-${TARGETARCH}/Schemas/ /opt/netclaw/cli/Schemas/
 COPY publish/daemon-${TARGETARCH}/netclawd /opt/netclaw/daemon/netclawd
 COPY docker/entrypoint.sh /opt/netclaw/entrypoint.sh
 

--- a/src/Netclaw.Cli/Config/ConfigFileHelper.cs
+++ b/src/Netclaw.Cli/Config/ConfigFileHelper.cs
@@ -34,11 +34,11 @@ internal static class ConfigFileHelper
     internal static Dictionary<string, object> LoadJsonDict(string path)
     {
         if (!File.Exists(path))
-            return new Dictionary<string, object> { ["configVersion"] = 1 };
+            return new Dictionary<string, object> { ["configVersion"] = EmbeddedSchemaLoader.CurrentSchemaVersion };
 
         var text = File.ReadAllText(path);
         return JsonSerializer.Deserialize<Dictionary<string, object>>(text)
-            ?? new Dictionary<string, object> { ["configVersion"] = 1 };
+            ?? new Dictionary<string, object> { ["configVersion"] = EmbeddedSchemaLoader.CurrentSchemaVersion };
     }
 
     /// <summary>

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -63,25 +63,25 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
                 "Set `configVersion` to a supported integer value, e.g. 1."));
         }
 
-        var schemaPath = ResolveSchemaPath(version);
-        if (!File.Exists(schemaPath))
+        var schemaText = EmbeddedSchemaLoader.LoadConfigSchema(version);
+        if (schemaText is null)
         {
             return Task.FromResult(DoctorCheckResult.Error(
                 "Config Schema",
-                $"No schema found for configVersion {version}.",
-                $"Install/update Netclaw schema file: {schemaPath}"));
+                $"No embedded schema found for configVersion {version}.",
+                "This binary may be corrupted or built without embedded schemas. Reinstall Netclaw."));
         }
 
         JsonSchema schema;
         try
         {
-            schema = JsonSchema.FromText(File.ReadAllText(schemaPath));
+            schema = JsonSchema.FromText(schemaText);
         }
         catch (Exception ex)
         {
             return Task.FromResult(DoctorCheckResult.Error(
                 "Config Schema",
-                $"Failed loading schema {schemaPath}: {ex.Message}"));
+                $"Failed parsing embedded schema for v{version}: {ex.Message}"));
         }
 
         var evaluation = schema.Evaluate(obj, new EvaluationOptions
@@ -105,7 +105,7 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
 
             return Task.FromResult(DoctorCheckResult.Error(
                 "Config Schema",
-                $"Config does not match schema (loaded from: {schemaPath}).{errorDetails}",
+                $"Config does not match schema v{version}.{errorDetails}",
                 "Run `netclaw doctor --fix --dry-run` to preview auto-repairs, or check configVersion/schema fields in netclaw.json."));
         }
 
@@ -120,25 +120,5 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
         return Task.FromResult(DoctorCheckResult.Pass(
             "Config Schema",
             $"Config matches schema v{version}."));
-    }
-
-    internal static string ResolveSchemaPath(int version)
-    {
-        var fileName = $"netclaw-config.v{version}.schema.json";
-        var runtimePath = Path.Combine(AppContext.BaseDirectory, "Schemas", fileName);
-        if (File.Exists(runtimePath))
-            return runtimePath;
-
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            var candidate = Path.Combine(directory.FullName, "src", "Netclaw.Configuration", "Schemas", fileName);
-            if (File.Exists(candidate))
-                return candidate;
-
-            directory = directory.Parent;
-        }
-
-        return runtimePath;
     }
 }

--- a/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ConfigSchemaDoctorCheck.cs
@@ -51,7 +51,7 @@ public sealed class ConfigSchemaDoctorCheck(NetclawPaths paths) : IDoctorCheck
         }
         else if (obj["configVersion"] is null)
         {
-            version = 1;
+            version = EmbeddedSchemaLoader.CurrentSchemaVersion;
             obj["configVersion"] = version;
             syntheticVersion = true;
         }

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -41,7 +41,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
         if (obj["configVersion"] is null)
         {
-            obj["configVersion"] = 1;
+            obj["configVersion"] = EmbeddedSchemaLoader.CurrentSchemaVersion;
             appliedFixes.Add("configVersion");
         }
 
@@ -117,7 +117,7 @@ public sealed class DoctorFixService(NetclawPaths paths)
 
     private static void TryApplySchemaFixes(JsonObject config, List<string> appliedFixes)
     {
-        var version = 1;
+        var version = EmbeddedSchemaLoader.CurrentSchemaVersion;
         if (config["configVersion"] is JsonValue versionValue
             && versionValue.TryGetValue<int>(out var parsedVersion))
         {

--- a/src/Netclaw.Cli/Doctor/DoctorFixService.cs
+++ b/src/Netclaw.Cli/Doctor/DoctorFixService.cs
@@ -115,9 +115,8 @@ public sealed class DoctorFixService(NetclawPaths paths)
         return Task.FromResult(new DoctorFixPlan(fixes));
     }
 
-    private void TryApplySchemaFixes(JsonObject config, List<string> appliedFixes)
+    private static void TryApplySchemaFixes(JsonObject config, List<string> appliedFixes)
     {
-        // Resolve schema version (default to 1 if not present or invalid)
         var version = 1;
         if (config["configVersion"] is JsonValue versionValue
             && versionValue.TryGetValue<int>(out var parsedVersion))
@@ -125,15 +124,14 @@ public sealed class DoctorFixService(NetclawPaths paths)
             version = parsedVersion;
         }
 
-        var schemaPath = ConfigSchemaDoctorCheck.ResolveSchemaPath(version);
-        if (!File.Exists(schemaPath))
+        var schemaText = EmbeddedSchemaLoader.LoadConfigSchema(version);
+        if (schemaText is null)
             return;
 
         JsonSchema schema;
         JsonObject? schemaJson;
         try
         {
-            var schemaText = File.ReadAllText(schemaPath);
             schema = JsonSchema.FromText(schemaText);
             schemaJson = JsonNode.Parse(schemaText) as JsonObject;
         }

--- a/src/Netclaw.Configuration/EmbeddedSchemaLoader.cs
+++ b/src/Netclaw.Configuration/EmbeddedSchemaLoader.cs
@@ -10,6 +10,8 @@ namespace Netclaw.Configuration;
 /// </summary>
 public static class EmbeddedSchemaLoader
 {
+    public const int CurrentSchemaVersion = 1;
+
     private const string ResourcePrefix = "Netclaw.Configuration.Schemas.";
 
     /// <summary>

--- a/src/Netclaw.Configuration/EmbeddedSchemaLoader.cs
+++ b/src/Netclaw.Configuration/EmbeddedSchemaLoader.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmbeddedSchemaLoader.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Loads JSON schema files embedded in the Netclaw.Configuration assembly.
+/// </summary>
+public static class EmbeddedSchemaLoader
+{
+    private const string ResourcePrefix = "Netclaw.Configuration.Schemas.";
+
+    /// <summary>
+    /// Reads the embedded config schema for the given version. Returns null if not found.
+    /// </summary>
+    public static string? LoadConfigSchema(int version)
+    {
+        var resourceName = $"{ResourcePrefix}netclaw-config.v{version}.schema.json";
+        return ReadResource(resourceName);
+    }
+
+    private static string? ReadResource(string resourceName)
+    {
+        using var stream = typeof(EmbeddedSchemaLoader).Assembly
+            .GetManifestResourceStream(resourceName);
+        if (stream is null)
+            return null;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Netclaw.Configuration/Netclaw.Configuration.csproj
+++ b/src/Netclaw.Configuration/Netclaw.Configuration.csproj
@@ -26,10 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Schemas/**/*.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <EmbeddedResource Include="Schemas/**/*.json" />
     <EmbeddedResource Include="Resources/AGENTS.md" />
     <EmbeddedResource Include="Resources/AGENTS.public.md" />
   </ItemGroup>

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -339,8 +339,8 @@
         },
         "Backend": {
           "type": "string",
-          "enum": ["DuckDuckGo", "Brave", "SearXng"],
-          "default": "DuckDuckGo",
+          "enum": ["duckduckgo", "brave", "searxng"],
+          "default": "duckduckgo",
           "description": "Search backend identifier."
         },
         "BraveApiKey": {


### PR DESCRIPTION
## Summary

- **Fixed `netclaw doctor` schema validation failure** on Search.Backend: the schema used PascalCase enum values (`DuckDuckGo`, `Brave`, `SearXng`) but the wizard writes lowercase via `ToWireValue()`. Changed schema to match the wire format (`duckduckgo`, `brave`, `searxng`).
- **Converted config schema from loose content file to embedded assembly resource.** The tar.gz/zip CLI archives and install script only shipped the single-file binary — the `Schemas/` directory was silently dropped, meaning `netclaw doctor` only worked by accident (dev builds finding source tree via directory walk fallback). Schemas are now embedded in the `Netclaw.Configuration` assembly and always ship with the binary.
- **Cleaned up CI/CD and Docker:** removed `Schemas/` from artifact uploads, multi-arch Docker layout, and Dockerfile `COPY`. Updated local-binary-swap skill to remove the now-unnecessary schema copy step.

## Root cause

Introduced in `39c13ee9` (0.16.0) — the Search section was added to the schema with PascalCase enum values, but the wizard had been writing lowercase since `4eaeb416`. No one caught the mismatch because the schema file wasn't reliably shipped with CLI distributions.

## Test plan

- [x] Full solution builds clean (0 warnings, 0 errors)
- [x] All 127 doctor tests pass (`dotnet test --filter "FullyQualifiedName~Doctor"`)
- [x] `dotnet publish` with `PublishSingleFile=true` produces no `Schemas/` directory in output
- [x] Embedded resource names verified in built assembly: `Netclaw.Configuration.Schemas.netclaw-config.v1.schema.json`
- [ ] CI validates build and test suite