### PR TITLE
fix: drain binding actors, fix thinking-only empty response, fix dropped tool calls

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -461,10 +461,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            // Guard: empty response (no text, no thinking, no tool calls) — delegate decision to tracker
-            var hasText = lastMessage.Contents.OfType<TextContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
-            var hasThinking = lastMessage.Contents.OfType<TextReasoningContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
-            if (!hasText && !hasThinking)
+            var hasContent = lastMessage.Contents.Any(c =>
+                (c is TextContent tc && !string.IsNullOrWhiteSpace(tc.Text)) ||
+                (c is TextReasoningContent rc && !string.IsNullOrWhiteSpace(rc.Text)));
+            if (!hasContent)
             {
                 switch (_turnState.EvaluateEmptyResponse())
                 {

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -461,6 +461,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
+            // Guard: empty response (no text, no thinking, no tool calls) — delegate decision to tracker
             var hasContent = lastMessage.Contents.Any(c =>
                 (c is TextContent tc && !string.IsNullOrWhiteSpace(tc.Text)) ||
                 (c is TextReasoningContent rc && !string.IsNullOrWhiteSpace(rc.Text)));

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -461,9 +461,10 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            // Guard: empty response (no text, no tool calls) — delegate decision to tracker
+            // Guard: empty response (no text, no thinking, no tool calls) — delegate decision to tracker
             var hasText = lastMessage.Contents.OfType<TextContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
-            if (!hasText)
+            var hasThinking = lastMessage.Contents.OfType<TextReasoningContent>().Any(t => !string.IsNullOrWhiteSpace(t.Text));
+            if (!hasText && !hasThinking)
             {
                 switch (_turnState.EvaluateEmptyResponse())
                 {
@@ -963,7 +964,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 SessionId = _sessionId,
                 InputTokens = msg.InputTokens,
                 OutputTokens = msg.OutputTokens,
-                TotalTokens = (msg.InputTokens ?? 0) + (msg.OutputTokens ?? 0)
+                TotalTokens = (msg.InputTokens ?? 0) + (msg.OutputTokens ?? 0),
+                ContextWindowTokens = _model.ContextWindowTokens
             }, OutputFilter.Usage);
         }
 

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -196,7 +196,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             }
 
             _log.Info("Discord session idle for 1 hour, passivating");
-            Context.Stop(Self);
+            RunTask(async () =>
+            {
+                await _handle.DrainAsync();
+                Context.Stop(Self);
+            });
         });
 
         Context.SetReceiveTimeout(IdlePassivationTimeout);

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -148,7 +148,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             }
 
             _log.Info("Slack thread idle for 1 hour, passivating");
-            Context.Stop(Self);
+            RunTask(async () =>
+            {
+                await _handle.DrainAsync();
+                Context.Stop(Self);
+            });
         });
     }
 

--- a/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
+++ b/src/Netclaw.Daemon/Gateway/SignalRSessionActor.cs
@@ -171,7 +171,11 @@ internal sealed class SignalRSessionActor : ReceiveActor, IWithUnboundedStash, I
         Receive<ShutdownSignalRSession>(_ =>
         {
             _log.Debug("Shutdown requested for session {SessionId}", _sessionId.Value);
-            Context.Stop(Self);
+            RunTask(async () =>
+            {
+                await _handle.DrainAsync();
+                Context.Stop(Self);
+            });
         });
 
         ReceiveAsync<DeliverTrustedSessionTurn>(async msg =>

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -556,7 +556,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
 
         var finishReason = ParseFinishReason(choice);
-        if (finishReason == ChatFinishReason.ToolCalls && pendingToolCalls.Count > 0)
+        if (pendingToolCalls.Count > 0 && (finishReason == ChatFinishReason.ToolCalls || finishReason == ChatFinishReason.Stop))
         {
             foreach (var pending in pendingToolCalls.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value))
             {

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -556,6 +556,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
 
         var finishReason = ParseFinishReason(choice);
+        // llama.cpp and other local servers often emit finish_reason:"stop" even when tool calls are present
         if (pendingToolCalls.Count > 0 && (finishReason == ChatFinishReason.ToolCalls || finishReason == ChatFinishReason.Stop))
         {
             foreach (var pending in pendingToolCalls.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value))


### PR DESCRIPTION
## Summary

Fixes three bugs causing headless/Slack session crashes and silent LLM stream failures after the v0.16.2 → v0.17.x upgrade:

- **Binding actor stream drain (#891)**: SignalR, Slack, and Discord binding actors called `Context.Stop(Self)` without draining the Akka.Streams pipeline first, causing `AbruptTerminationException` / `StreamDetachedException` crash logs. Applied the same drain-then-stop pattern already used in `ReminderExecutionActor` and `WebhookExecutionActor`.
- **Distillation UsageOutput missing ContextWindowTokens (#892)**: The distillation sidecar emitted `UsageOutput` without setting `ContextWindowTokens`, producing misleading `context_window=0` log lines that obscured diagnosis.
- **Thinking-only responses and dropped tool calls (#893)**: The empty response guard only checked `TextContent`, not `TextReasoningContent` — a response with thinking tokens but no text was classified as empty and retried with a nudge. Additionally, `OpenAiCompatibleChatClient` only emitted accumulated tool calls when `finish_reason` was `"tool_calls"`, but llama.cpp often sends `"stop"` even when structured tool calls are present.

## Changes

| File | Change |
|------|--------|
| `SignalRSessionActor.cs` | Drain pipeline before stopping on graceful shutdown |
| `SlackThreadBindingActor.cs` | Drain pipeline before stopping on ReceiveTimeout |
| `DiscordSessionBindingActor.cs` | Drain pipeline before stopping on ReceiveTimeout |
| `LlmSessionActor.cs` | Add `TextReasoningContent` to empty response guard (single-pass LINQ); set `ContextWindowTokens` on distillation UsageOutput |
| `OpenAiCompatibleChatClient.cs` | Accept `finish_reason: "stop"` for structured tool call emission |

## Test plan

- [x] Drain tests pass (5 tests)
- [x] Streaming/tool call tests pass (23 tests)
- [x] Slopwatch clean (0 violations)
- [x] Copyright headers verified
- [ ] Manual: stop a SignalR session while tools are running — confirm no crash log
- [ ] Manual: launch session with Qwen 3 that triggers tool calls — verify thinking-only responses not classified as empty
- [ ] Manual: verify `context_window` is non-zero on distillation USAGE lines

Closes #891, closes #892, closes #893