### PR TITLE
Update release notes for version 0.17.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,52 +8,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.17.1</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.17.1 — First public release with Docker support, non-interactive approval, and open-source infrastructure
-
-This is the first release of Netclaw published as an open-source project under [netclaw-dev/netclaw](https://github.com/netclaw-dev/netclaw). It includes the first official Docker image for `netclawd`, new agent autonomy features, and the infrastructure changes needed to support public distribution.
-
-**Docker**
-
-* Official multi-arch Docker image for `netclawd` is now published to GHCR (`ghcr.io/netclaw-dev/netclaw`) on every release, supporting both `linux/amd64` and `linux/arm64`. ([#858](https://github.com/netclaw-dev/netclaw/pull/858))
-
-* The `netclawd` Docker container now runs as a non-root user (`netclaw`, UID 1654) instead of root — the entrypoint creates the data directory with correct ownership and `su-exec`s into the unprivileged user. ([#874](https://github.com/netclaw-dev/netclaw/pull/874))
-
-* Schema files are now included in the Docker image so `netclaw doctor` works correctly inside containers. ([#863](https://github.com/netclaw-dev/netclaw/pull/863))
-
-* Exposure mode validation now accepts container and reverse-proxy deployments — the daemon no longer rejects `https` exposure mode when bound to a loopback address, since TLS termination is handled externally in these topologies. ([#862](https://github.com/netclaw-dev/netclaw/pull/862), [#864](https://github.com/netclaw-dev/netclaw/pull/864))
-
-**Features**
-
-* Non-interactive approval, sub-agent approval chaining, and shell trust zone enforcement — operators can now pre-approve tool categories in `netclaw.yaml` so the daemon can execute tools without interactive confirmation. Sub-agents inherit their parent's approval grants. A new shell trust zone restricts which directories and commands the agent can use in autonomous mode. ([#851](https://github.com/netclaw-dev/netclaw/pull/851))
-
-* Improved ambient skill activation for small models — skill keyword matching now uses normalized scoring so smaller-context models (Haiku, Gemini Flash) trigger the right skills without requiring exact phrasing. ([#856](https://github.com/netclaw-dev/netclaw/pull/856))
+    <VersionPrefix>0.17.2</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.17.2 — MCP reconnection resilience and README improvements
 
 **Bug Fixes**
 
-* Fixed `cancel_reminder` deleting config files instead of disabling them — reminder cancellation now sets a disabled flag rather than removing the underlying file, so reminder metadata is preserved for audit and re-enable. ([#848](https://github.com/netclaw-dev/netclaw/pull/848))
+* MCP servers that become unreachable (DNS failure, server down) no longer stay permanently stuck in `Unreachable` state — a new `McpReconnectionService` polls every 30 seconds with per-server exponential backoff (30s → 300s cap) and emits an operational alert on recovery. ([#884](https://github.com/netclaw-dev/netclaw/pull/884))
 
-* Fixed provider-reported context window being ignored — the LLM session now uses the context window size reported by the provider instead of falling back to a hardcoded 32k default. ([#865](https://github.com/netclaw-dev/netclaw/pull/865))
+**Documentation**
 
-* Fixed health check state not resetting on re-entry — the `netclaw init` wizard's go-back-and-retry flow now resets health check state so a previously-failed check can succeed on retry without restarting the wizard. Closes [#859](https://github.com/netclaw-dev/netclaw/issues/859). ([#871](https://github.com/netclaw-dev/netclaw/pull/871))
-
-* Fixed daemon bootstrap pairing in non-local modes — the daemon now preserves the bootstrap pairing token when running in container or remote exposure modes, fixing a regression where pairing failed after switching away from local mode. ([#872](https://github.com/netclaw-dev/netclaw/pull/872))
-
-* Consolidated duplicated path utilities into a single `PathUtility` class, eliminating three independent copies of home-directory and config-path resolution logic. Closes [#852](https://github.com/netclaw-dev/netclaw/issues/852). ([#873](https://github.com/netclaw-dev/netclaw/pull/873))
-
-**Open-Source Infrastructure**
-
-* Migrated all repository references from `Aaronontheweb/netclaw` to `netclaw-dev/netclaw`. ([#838](https://github.com/netclaw-dev/netclaw/pull/838))
-
-* Migrated CI from self-hosted ARC runners to GitHub-hosted runners. ([#837](https://github.com/netclaw-dev/netclaw/pull/837))
-
-* Prepared README and documentation for open-source launch — added CONTRIBUTING.md with build instructions and smoke sandbox docs, clarified secrets encryption, and added netclaw.dev website links. ([#843](https://github.com/netclaw-dev/netclaw/pull/843), [#846](https://github.com/netclaw-dev/netclaw/pull/846), [#847](https://github.com/netclaw-dev/netclaw/pull/847), [#878](https://github.com/netclaw-dev/netclaw/pull/878))
-
-**Dependencies**
-
-* Bumped `Netclaw.SkillClient` from 0.2.0 to 0.2.1. ([#836](https://github.com/netclaw-dev/netclaw/pull/836))
-
-* Bumped `NSec.Cryptography` from 24.4.0 to 26.4.0. ([#840](https://github.com/netclaw-dev/netclaw/pull/840))</PackageReleaseNotes>
+* Refocused README on end-user content — moved architecture, design goals, and build-from-source sections to CONTRIBUTING.md; added Docker quickstart, netclaw.dev documentation links, and Discord link. ([#888](https://github.com/netclaw-dev/netclaw/pull/888))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,15 +9,27 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.17.2</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.17.2 — MCP reconnection resilience and README improvements
+    <PackageReleaseNotes>Netclaw v0.17.2 — Session stability fixes, MCP reconnection, and schema packaging
 
 **Bug Fixes**
 
-* MCP servers that become unreachable (DNS failure, server down) no longer stay permanently stuck in `Unreachable` state — a new `McpReconnectionService` polls every 30 seconds with per-server exponential backoff (30s → 300s cap) and emits an operational alert on recovery. ([#884](https://github.com/netclaw-dev/netclaw/pull/884))
+* Fixed binding actor stream crashes on shutdown — SignalR, Slack, and Discord binding actors now drain their Akka.Streams pipeline before stopping, eliminating `AbruptTerminationException` / `StreamDetachedException` crash logs on graceful shutdown and idle timeout. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed thinking-only LLM responses being classified as empty — the empty response guard now checks `TextReasoningContent` in addition to `TextContent`, so models that emit thinking tokens without text (e.g., Qwen 3) are no longer incorrectly retried with a nudge. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed dropped tool calls from llama.cpp-compatible providers — `OpenAiCompatibleChatClient` now emits accumulated tool calls when `finish_reason` is `"stop"`, not just `"tool_calls"`. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed `netclaw doctor` schema validation failing on `Search.Backend` — schema now matches wire format (`duckduckgo`, `brave`, `searxng`). ([#894](https://github.com/netclaw-dev/netclaw/pull/894))
+
+* Embedded config schema as assembly resource so `netclaw doctor` works in all distribution formats. ([#894](https://github.com/netclaw-dev/netclaw/pull/894))
+
+* Added `CursorAdvanced` serialization bindings for Slack and Discord binding actors. Closes [#887](https://github.com/netclaw-dev/netclaw/issues/887). ([#890](https://github.com/netclaw-dev/netclaw/pull/890))
+
+* MCP servers that become unreachable no longer stay permanently stuck — new `McpReconnectionService` with exponential backoff. ([#884](https://github.com/netclaw-dev/netclaw/pull/884))
 
 **Documentation**
 
-* Refocused README on end-user content — moved architecture, design goals, and build-from-source sections to CONTRIBUTING.md; added Docker quickstart, netclaw.dev documentation links, and Discord link. ([#888](https://github.com/netclaw-dev/netclaw/pull/888))</PackageReleaseNotes>
+* Refocused README on end-user content with Docker quickstart, netclaw.dev links, and Discord link. ([#888](https://github.com/netclaw-dev/netclaw/pull/888))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 0.17.2 2026-05-06 ####
+
+Netclaw v0.17.2 — MCP reconnection resilience and README improvements
+
+**Bug Fixes**
+
+* MCP servers that become unreachable (DNS failure, server down) no longer stay permanently stuck in `Unreachable` state — a new `McpReconnectionService` polls every 30 seconds with per-server exponential backoff (30s → 300s cap) and emits an operational alert on recovery. ([#884](https://github.com/netclaw-dev/netclaw/pull/884))
+
+**Documentation**
+
+* Refocused README on end-user content — moved architecture, design goals, and build-from-source sections to CONTRIBUTING.md; added Docker quickstart, netclaw.dev documentation links, and Discord link. ([#888](https://github.com/netclaw-dev/netclaw/pull/888))
+
 #### 0.17.1 2026-05-06 ####
 
 Netclaw v0.17.1 — First public release with Docker support, non-interactive approval, and open-source infrastructure

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,20 @@
 #### 0.17.2 2026-05-06 ####
 
-Netclaw v0.17.2 — MCP reconnection resilience and README improvements
+Netclaw v0.17.2 — Session stability fixes, MCP reconnection, and schema packaging
 
 **Bug Fixes**
+
+* Fixed binding actor stream crashes on shutdown — SignalR, Slack, and Discord binding actors now drain their Akka.Streams pipeline before stopping, eliminating `AbruptTerminationException` / `StreamDetachedException` crash logs on graceful shutdown and idle timeout. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed thinking-only LLM responses being classified as empty — the empty response guard now checks `TextReasoningContent` in addition to `TextContent`, so models that emit thinking tokens without text (e.g., Qwen 3) are no longer incorrectly retried with a nudge. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed dropped tool calls from llama.cpp-compatible providers — `OpenAiCompatibleChatClient` now emits accumulated tool calls when `finish_reason` is `"stop"`, not just `"tool_calls"`, since llama.cpp often sends `"stop"` even when structured tool calls are present. ([#895](https://github.com/netclaw-dev/netclaw/pull/895))
+
+* Fixed `netclaw doctor` schema validation failing on `Search.Backend` — the config schema used PascalCase enum values but the wizard writes lowercase via `ToWireValue()`. Schema now matches wire format (`duckduckgo`, `brave`, `searxng`). ([#894](https://github.com/netclaw-dev/netclaw/pull/894))
+
+* Embedded config schema as assembly resource — the tar.gz/zip CLI archives only shipped the single-file binary, silently dropping the `Schemas/` directory. `netclaw doctor` now always has access to the schema regardless of distribution format. ([#894](https://github.com/netclaw-dev/netclaw/pull/894))
+
+* Added `CursorAdvanced` serialization bindings — replaced private nested cursor types in Slack and Discord binding actors with a shared, protobuf-serializable `CursorAdvanced(string Cursor)` record. Fixes persistence recovery failures when cursor state was written by the old unregistered type. Closes [#887](https://github.com/netclaw-dev/netclaw/issues/887). ([#890](https://github.com/netclaw-dev/netclaw/pull/890))
 
 * MCP servers that become unreachable (DNS failure, server down) no longer stay permanently stuck in `Unreachable` state — a new `McpReconnectionService` polls every 30 seconds with per-server exponential backoff (30s → 300s cap) and emits an operational alert on recovery. ([#884](https://github.com/netclaw-dev/netclaw/pull/884))
 


### PR DESCRIPTION
## Summary

- Bump `VersionPrefix` to 0.17.2 in `Directory.Build.props`
- Add v0.17.2 release notes to `RELEASE_NOTES.md`

### Changes in this release

- **fix:** Background reconnection for unreachable MCP servers (#884)
- **docs:** Refocus README on end-user content (#888)

## Test plan

- [ ] CI build passes
- [ ] Version reads 0.17.2 in build output
- [ ] Release notes render correctly