### PR TITLE
chore: replace hand-rolled TimeProvider subclasses with FakeTimeProvider

### DIFF
--- a/src/Netclaw.Cli.Tests/Doctor/DaemonCrashDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/DaemonCrashDoctorCheckTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Cli.Doctor;
 using Netclaw.Configuration;
 using Xunit;
@@ -23,7 +24,7 @@ public sealed class DaemonCrashDoctorCheckTests
             "Netclaw daemon-unhandled crash at 2026-04-14T18:29:00.0000000+00:00\n\nSystem.InvalidOperationException: boom",
             TestContext.Current.CancellationToken);
 
-        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var check = new DaemonCrashDoctorCheck(paths, new FakeTimeProvider(now));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
@@ -42,7 +43,7 @@ public sealed class DaemonCrashDoctorCheckTests
             "Netclaw CLI crash at 2026-04-14T18:29:00.0000000+00:00\n\nSystem.InvalidOperationException: cli failure",
             TestContext.Current.CancellationToken);
 
-        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var check = new DaemonCrashDoctorCheck(paths, new FakeTimeProvider(now));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
@@ -62,7 +63,7 @@ public sealed class DaemonCrashDoctorCheckTests
 
         File.SetLastWriteTimeUtc(crashPath, new DateTime(2026, 4, 1, 8, 0, 0, DateTimeKind.Utc));
 
-        var check = new DaemonCrashDoctorCheck(paths, new FixedTimeProvider(now));
+        var check = new DaemonCrashDoctorCheck(paths, new FakeTimeProvider(now));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
@@ -76,10 +77,4 @@ public sealed class DaemonCrashDoctorCheckTests
         return paths;
     }
 
-    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
-    {
-        private DateTimeOffset _now = now;
-
-        public override DateTimeOffset GetUtcNow() => _now;
-    }
 }

--- a/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
+++ b/src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSec.Cryptography" />
     <PackageReference Include="Termina" />

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -6,6 +6,7 @@
 using Akka.Actor;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Gateway;
 using Netclaw.Tests.Utilities;
@@ -29,7 +30,7 @@ public sealed class DailyStatsActorTests : IDisposable
     [Fact]
     public async Task QuerySkillUsageStats_returns_groupable_rows_for_each_method()
     {
-        var time = new AdjustableTimeProvider(new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero));
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero));
         var actor = _system.ActorOf(Props.Create(() => new DailyStatsActor(
             _paths,
             time,
@@ -69,10 +70,5 @@ public sealed class DailyStatsActorTests : IDisposable
         _dir.Dispose();
     }
 
-    private sealed class AdjustableTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        private DateTimeOffset _utcNow = utcNow;
 
-        public override DateTimeOffset GetUtcNow() => _utcNow;
-    }
 }

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Telemetry;
@@ -409,7 +410,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
     public void OnSessionActivated_DoesNotRewriteLastActivity_ForExistingSession()
     {
         var paths = CreatePaths();
-        var fakeTime = new AdjustableTimeProvider(DateTimeOffset.Parse("2026-03-21T10:00:00Z"));
+        var fakeTime = new FakeTimeProvider(DateTimeOffset.Parse("2026-03-21T10:00:00Z"));
         var service = CreateService(paths, timeProvider: fakeTime);
         var sessionId = new SessionId("signalr/test-active-last-activity");
 
@@ -445,15 +446,6 @@ public sealed class SessionCatalogServiceTests : IDisposable
         public void RecordMemoriesRecalled(int count) { }
         public void RecordSkillsLoaded(int count) { }
         public void RecordSkillLoaded(string skillName, SkillLoadMethod method) { }
-    }
-
-    private sealed class AdjustableTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        private DateTimeOffset _utcNow = utcNow;
-
-        public override DateTimeOffset GetUtcNow() => _utcNow;
-
-        public void Advance(TimeSpan by) => _utcNow = _utcNow.Add(by);
     }
 
     private static SqliteConnection OpenConn(NetclawPaths paths)

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -6,6 +6,7 @@
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Search;
 using Xunit;
 
@@ -154,7 +155,7 @@ public class BraveSearchBackendTests
         var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
         var future = now.AddSeconds(45);
         var header = new RetryConditionHeaderValue(future);
-        var fakeTime = new FixedTimeProvider(now);
+        var fakeTime = new FakeTimeProvider(now);
 
         var delay = BraveSearchBackend.ParseRetryAfter(header, 0, fakeTime);
 
@@ -262,8 +263,4 @@ public class BraveSearchBackendTests
         }
     }
 
-    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => utcNow;
-    }
 }

--- a/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
+++ b/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>


### PR DESCRIPTION
## Summary

- Removes four hand-rolled `TimeProvider` subclasses (`AdjustableTimeProvider` x2, `FixedTimeProvider` x2) from `DailyStatsActorTests`, `SessionCatalogServiceTests`, `BraveSearchBackendTests`, and `DaemonCrashDoctorCheckTests`
- Adds `Microsoft.Extensions.TimeProvider.Testing` package reference to `Netclaw.Search.Tests` and `Netclaw.Cli.Tests` (already present in `Directory.Packages.props` and the other test projects)
- All 36 affected tests continue to pass

Closes #146.

## Test plan

- [x] `dotnet test` passes for `Netclaw.Daemon.Tests`, `Netclaw.Search.Tests`, and `Netclaw.Cli.Tests`