### PR TITLE
fix(security): reject non-loopback Daemon.Host in Local exposure mode

### DIFF
--- a/.github/workflows/validate_docker_image.yml
+++ b/.github/workflows/validate_docker_image.yml
@@ -85,9 +85,9 @@ jobs:
           # without secrets. The endpoint is fake (:11434 on loopback) —
           # the daemon doesn't actually call it during startup or health
           # checks, so unreachable is fine.
+          # Bind loopback (Local mode default) — the health probe runs
+          # inside the container via docker exec, so no port mapping needed.
           docker run -d --name netclaw-validate-ok \
-            -p 5399:5199 \
-            -e NETCLAW_Daemon__Host=0.0.0.0 \
             -e NETCLAW_Daemon__Port=5199 \
             -e NETCLAW_Providers__validate__Type=ollama \
             -e NETCLAW_Providers__validate__Endpoint=http://127.0.0.1:11434 \
@@ -95,9 +95,9 @@ jobs:
             -e NETCLAW_Models__Main__ModelId=qwen2:0.5b \
             "netclawd-pr:${{ steps.tag.outputs.tag }}" >/dev/null
 
-          # Poll /api/health/ready for up to 60s.
+          # Poll /api/health/ready for up to 60s from inside the container.
           for i in $(seq 1 60); do
-            if curl -fsS http://127.0.0.1:5399/api/health/ready >/dev/null 2>&1; then
+            if docker exec netclaw-validate-ok curl -fsS http://127.0.0.1:5199/api/health/ready >/dev/null 2>&1; then
               echo "✓ Daemon reported healthy after ${i}s"
               docker rm -f netclaw-validate-ok >/dev/null 2>&1 || true
               exit 0

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ docker run -d --name netclawd \
   -p 5199:5199 \
   -v ~/.netclaw:/home/netclaw/.netclaw \
   -e NETCLAW_Daemon__Host=0.0.0.0 \
+  -e NETCLAW_Daemon__ExposureMode=reverse-proxy \
+  -e NETCLAW_Daemon__TrustedProxies__0=172.16.0.0/12 \
   ghcr.io/netclaw-dev/netclaw:latest
 ```
 

--- a/src/Netclaw.Cli.Tests/Doctor/ExposureModeDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ExposureModeDoctorCheckTests.cs
@@ -141,10 +141,10 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
         Assert.Contains("cloudflare-tunnel", result.Message);
     }
 
-    // ── Warning cases ─────────────────────────────────────────────────────────
+    // ── Local + non-loopback error cases ────────────────────────────────────
 
     [Fact]
-    public async Task Local_NonLoopbackHost_Warns()
+    public async Task Local_NonLoopbackHost_IsError()
     {
         WriteConfig("""
             {
@@ -157,14 +157,14 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
         Assert.Contains("0.0.0.0", result.Message);
         Assert.Contains("loopback", result.Message);
         Assert.NotNull(result.Remediation);
     }
 
     [Fact]
-    public async Task Local_WithPublicIp_Warns()
+    public async Task Local_WithPrivateIp_IsError()
     {
         WriteConfig("""
             {
@@ -177,7 +177,7 @@ public sealed class ExposureModeDoctorCheckTests : IDisposable
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
         Assert.Contains("192.168.1.100", result.Message);
     }
 

--- a/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ExposureModeDoctorCheck.cs
@@ -83,15 +83,12 @@ public sealed class ExposureModeDoctorCheck : IDoctorCheck
                 "Each Daemon.TrustedProxies entry must be a literal IP address or CIDR, for example '10.0.0.5' or '10.0.0.0/24'."));
         }
 
-        // Warning: local mode with non-loopback bind address — daemon exposed without tunnel.
-        if (mode == ExposureMode.Local && !DaemonExposureValidator.IsLoopbackHost(host))
+        if (DaemonExposureValidator.GetLoopbackViolationIssue(config) is { } loopbackIssue)
         {
-            return Task.FromResult(DoctorCheckResult.Warning(
+            return Task.FromResult(DoctorCheckResult.Error(
                 CheckName,
-                $"ExposureMode is 'local' but bind address '{host}' is not loopback. " +
-                "The daemon is reachable beyond loopback without tunnel protection.",
-                "Set ExposureMode to a tunnel mode (tailscale-serve, tailscale-funnel, " +
-                "cloudflare-tunnel) or bind to 127.0.0.1 in netclaw.json."));
+                loopbackIssue.Message,
+                loopbackIssue.Remediation));
         }
 
         if (DaemonExposureValidator.GetMissingRequiredProcessIssue(config, _processDetector) is { } processIssue)

--- a/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
+++ b/src/Netclaw.Configuration.Tests/DaemonConfigTests.cs
@@ -175,6 +175,40 @@ public sealed class DaemonConfigTests
         Assert.Equal(["10.0.0.5", "10.0.0.0/24"], result.TrustedProxies);
     }
 
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("10.0.0.5")]
+    [InlineData("192.168.1.100")]
+    public void Validator_rejects_non_loopback_host_in_local_mode(string host)
+    {
+        var issues = DaemonExposureValidator.Validate(
+            new DaemonConfig
+            {
+                ExposureMode = ExposureMode.Local,
+                Host = host
+            },
+            hasRemoteAuthenticationPath: false);
+
+        Assert.Contains(issues, issue => issue.Message.Contains("Invalid local topology", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    [InlineData("localhost")]
+    public void Validator_accepts_loopback_host_in_local_mode(string host)
+    {
+        var issues = DaemonExposureValidator.Validate(
+            new DaemonConfig
+            {
+                ExposureMode = ExposureMode.Local,
+                Host = host
+            },
+            hasRemoteAuthenticationPath: false);
+
+        Assert.Empty(issues);
+    }
+
     [Fact]
     public void Validator_rejects_loopback_reverse_proxy_topology()
     {

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -124,6 +124,9 @@ public static class DaemonExposureValidator
                 IsTrustedProxyIssue: true));
         }
 
+        if (GetLoopbackViolationIssue(config) is { } loopbackIssue)
+            issues.Add(loopbackIssue);
+
         if (!config.ExposureMode.RequiresRemoteAuthentication())
             return issues;
 
@@ -244,6 +247,16 @@ public static class DaemonExposureValidator
 
         error = null;
         return false;
+    }
+
+    public static DaemonExposureValidationIssue? GetLoopbackViolationIssue(DaemonConfig config)
+    {
+        if (config.ExposureMode != ExposureMode.Local || IsLoopbackHost(config.Host))
+            return null;
+
+        return new DaemonExposureValidationIssue(
+            $"Invalid local topology: Daemon.Host '{config.Host}' is not a loopback address. ExposureMode 'local' requires binding to 127.0.0.1, ::1, or localhost.",
+            "Either bind to a loopback address, or set Daemon.ExposureMode to the appropriate tunnel or reverse-proxy mode for non-loopback traffic.");
     }
 
     public static DaemonExposureValidationIssue? GetMissingRequiredProcessIssue(

--- a/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ExposureModeValidationServiceTests.cs
@@ -17,13 +17,29 @@ public sealed class ExposureModeValidationServiceTests
     // ── Local mode ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Local_SkipsAllValidation_EvenWhenNoProcessesExist()
+    public async Task Local_LoopbackHost_SkipsAllValidation()
     {
         var config = new DaemonConfig { ExposureMode = ExposureMode.Local };
         var sut = BuildService(config, _ => false); // no processes found
 
         // Must not throw
         await sut.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("10.0.0.5")]
+    [InlineData("192.168.1.100")]
+    public async Task Local_NonLoopbackHost_Throws(string host)
+    {
+        var config = new DaemonConfig { ExposureMode = ExposureMode.Local, Host = host };
+        var sut = BuildService(config, _ => false);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Contains("Invalid local topology", ex.Message);
+        Assert.Contains(host, ex.Message);
     }
 
     // ── TailscaleServe ───────────────────────────────────────────────────────

--- a/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
+++ b/src/Netclaw.Daemon/Services/ExposureModeValidationService.cs
@@ -83,7 +83,19 @@ internal sealed class ExposureModeValidationService : IHostedService
         }
 
         if (_config.ExposureMode == ExposureMode.Local)
+        {
+            if (DaemonExposureValidator.GetLoopbackViolationIssue(_config) is { } loopbackIssue)
+            {
+                _logger.LogCritical(
+                    "Daemon startup aborted: {Message} Remediation: {Remediation}",
+                    loopbackIssue.Message,
+                    loopbackIssue.Remediation);
+
+                throw new InvalidOperationException($"{loopbackIssue.Message} {loopbackIssue.Remediation}");
+            }
+
             return;
+        }
 
         if (DaemonExposureValidator.GetMissingRequiredProcessIssue(_config, _processDetector) is { } processIssue)
         {


### PR DESCRIPTION
## Summary

- `ExposureMode.Local` now rejects non-loopback `Daemon.Host` values at daemon startup and via `netclaw doctor` (upgraded from warning to hard error)
- Extracted `DaemonExposureValidator.GetLoopbackViolationIssue()` helper to keep message strings in one place, matching the existing `GetMissingRequiredProcessIssue()` pattern
- Users who need a non-loopback bind must set an explicit `ExposureMode` (reverse-proxy, tailscale-serve, etc.)

Closes #900  
Related: #189 (closed), #866, #868

## Test plan

- [x] `Validator_rejects_non_loopback_host_in_local_mode` — 0.0.0.0, 10.0.0.5, 192.168.1.100 all produce validation issues
- [x] `Validator_accepts_loopback_host_in_local_mode` — 127.0.0.1, ::1, localhost pass clean
- [x] `Local_NonLoopbackHost_Throws` — startup service aborts with `InvalidOperationException`
- [x] `Local_LoopbackHost_SkipsAllValidation` — default config still starts fine
- [x] `Local_NonLoopbackHost_IsError` / `Local_WithPrivateIp_IsError` — doctor surfaces error severity
- [x] All existing exposure mode tests pass (no regressions in reverse-proxy, tunnel, or device pairing flows)