### PR TITLE
chore: remove unused DocFX dependency

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,13 +9,6 @@
       ],
       "rollForward": false
     },
-    "docfx": {
-      "version": "2.78.3",
-      "commands": [
-        "docfx"
-      ],
-      "rollForward": false
-    },
     "slopwatch.cmd": {
       "version": "0.4.0",
       "commands": [


### PR DESCRIPTION
## Summary
Removed DocFX from dotnet-tools.json as it is not used in this project.

## Changes
- Removed docfx tool entry from .config/dotnet-tools.json
- Closed associated Dependabot PR #18

## Test plan
- Verify builds succeed without DocFX