### PR TITLE
fix: wizard init with Personal posture silently disables all features

### DIFF
--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -345,6 +345,8 @@ public sealed class InitWizardPageTests : IDisposable
         var config = System.Text.Json.JsonSerializer.Deserialize<
             System.Text.Json.JsonElement>(configText);
 
+        // Webhooks is omitted: Personal posture skips FeatureSelection, so only
+        // ExposureModeStep can write Webhooks — and it only does so when enabled.
         string[] featureSections = ["Memory", "Search", "SkillSync", "Scheduling", "SubAgents"];
         foreach (var section in featureSections)
         {

--- a/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/InitWizardPageTests.cs
@@ -311,6 +311,98 @@ public sealed class InitWizardPageTests : IDisposable
             "Expected DM to be enabled after selecting 'Yes' on the DM sub-step");
     }
 
+    // ── Config integrity: wizard choices must match written config ──────────
+
+    /// <summary>
+    /// Crash barrier: selecting Personal posture via keyboard, then writing config,
+    /// must not produce Enabled=false for any feature subsystem. Reproduces #905.
+    /// </summary>
+    [Fact]
+    public async Task PersonalPosture_WrittenConfig_DoesNotDisableFeatures()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        // Skip provider step programmatically (too many sub-steps to drive via keyboard)
+        vm.Orchestrator.GoNext(); // provider → security-posture
+
+        // Select Personal (index 0) via keyboard — this is the critical decision
+        input.EnqueueKey(ConsoleKey.Enter);
+
+        // Ctrl+Q to exit after posture selection routes us past feature-selection
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        // Verify posture was selected correctly
+        Assert.Equal(DeploymentPosture.Personal, vm.Context.SelectedPosture);
+
+        // Now write config through the orchestrator (same path the health check step uses)
+        vm.Orchestrator.WriteConfig();
+
+        // Read back the written config and verify no features were silently disabled
+        var configText = File.ReadAllText(_paths.NetclawConfigPath);
+        var config = System.Text.Json.JsonSerializer.Deserialize<
+            System.Text.Json.JsonElement>(configText);
+
+        string[] featureSections = ["Memory", "Search", "SkillSync", "Scheduling", "SubAgents"];
+        foreach (var section in featureSections)
+        {
+            if (config.TryGetProperty(section, out var sectionObj)
+                && sectionObj.TryGetProperty("Enabled", out var enabled))
+            {
+                Assert.True(enabled.GetBoolean(),
+                    $"Section '{section}' has Enabled=false in written config — " +
+                    $"Personal posture must not disable features. Full config:\n{configText}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Crash barrier: selecting Team posture and advancing through feature selection
+    /// (all defaults = all enabled) must produce Enabled=true for every feature.
+    /// </summary>
+    [Fact]
+    public async Task TeamPosture_DefaultFeatures_AllEnabledInWrittenConfig()
+    {
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        vm.Orchestrator.GoNext(); // provider → security-posture
+
+        // Select Team (index 1) via keyboard: DownArrow then Enter
+        input.EnqueueKey(ConsoleKey.DownArrow);
+        input.EnqueueKey(ConsoleKey.Enter);
+
+        // Now on feature-selection step (Team posture shows it).
+        // Team defaults all features ON. Press Enter to accept defaults.
+        input.EnqueueKey(ConsoleKey.Enter);
+
+        input.EnqueueKey(ConsoleKey.Q, control: true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(DeploymentPosture.Team, vm.Context.SelectedPosture);
+
+        vm.Orchestrator.WriteConfig();
+
+        var configText = File.ReadAllText(_paths.NetclawConfigPath);
+        var config = System.Text.Json.JsonSerializer.Deserialize<
+            System.Text.Json.JsonElement>(configText);
+
+        string[] featureSections = ["Memory", "Search", "SkillSync", "Scheduling", "SubAgents", "Webhooks"];
+        foreach (var section in featureSections)
+        {
+            Assert.True(config.TryGetProperty(section, out var sectionObj),
+                $"Section '{section}' missing from config");
+            Assert.True(sectionObj.TryGetProperty("Enabled", out var enabled),
+                $"Section '{section}' missing 'Enabled' key");
+            Assert.True(enabled.GetBoolean(),
+                $"Section '{section}' has Enabled=false — Team defaults should be all-on. " +
+                $"Full config:\n{configText}");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private (VirtualTerminal Terminal, TerminaApplication App, InitWizardViewModel Vm)

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ChannelPickerStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ChannelPickerStepViewModelTests.cs
@@ -237,6 +237,25 @@ public sealed class ChannelPickerStepViewModelTests : WizardStepTestBase
     }
 
     [Fact]
+    public void ContributeConfig_DisabledAdapters_DoNotPolluteConfig()
+    {
+        using var picker = new ChannelPickerStepViewModel(_fakeProbe, _fakeDiscordProbe);
+        picker.OnEnter(Context, NavigationDirection.Forward);
+
+        // Neither Slack nor Discord enabled — ContributeConfig delegates to both adapters
+        picker.OnLeave();
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        picker.ContributeConfig(builder);
+        var config = builder.BuildConfigDictionary();
+
+        Assert.Null(builder.Slack);
+        Assert.Null(builder.Discord);
+        Assert.False(config.ContainsKey("Slack"));
+        Assert.False(config.ContainsKey("Discord"));
+    }
+
+    [Fact]
     public void GetHelpText_PickerMode_ReturnsPickerHelp()
     {
         using var picker = new ChannelPickerStepViewModel(_fakeProbe, _fakeDiscordProbe);

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/FeatureSelectionStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/FeatureSelectionStepViewModelTests.cs
@@ -146,6 +146,46 @@ public sealed class FeatureSelectionStepViewModelTests : WizardStepTestBase
         Assert.False(Context.FeatureSelections.WebhooksEnabled);
     }
 
+    [Fact]
+    public void ContributeConfig_SkippedStep_DoesNotSetFeatureSelections()
+    {
+        using var step = new FeatureSelectionStepViewModel();
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.Null(builder.FeatureSelections);
+    }
+
+    [Fact]
+    public void ContributeConfig_SkippedStep_ConfigDictionary_OmitsFeatureFlags()
+    {
+        using var step = new FeatureSelectionStepViewModel();
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        step.ContributeConfig(builder);
+        var config = builder.BuildConfigDictionary();
+
+        // Feature sections should NOT have an Enabled flag injected by the skipped step.
+        // Some sections (e.g., SkillSync) exist unconditionally with other keys — the key
+        // assertion is that no Enabled:false was written.
+        AssertNoEnabledKey(config, "Memory");
+        AssertNoEnabledKey(config, "Search");
+        AssertNoEnabledKey(config, "SkillSync");
+        AssertNoEnabledKey(config, "Scheduling");
+        AssertNoEnabledKey(config, "SubAgents");
+        AssertNoEnabledKey(config, "Webhooks");
+    }
+
+    private static void AssertNoEnabledKey(Dictionary<string, object> config, string sectionKey)
+    {
+        if (config.TryGetValue(sectionKey, out var obj) && obj is Dictionary<string, object> section)
+        {
+            Assert.False(section.ContainsKey("Enabled"),
+                $"Section '{sectionKey}' should not have an 'Enabled' key when feature step was skipped");
+        }
+    }
+
     private static void AssertSectionEnabled(Dictionary<string, object> config, string sectionKey, bool expected)
     {
         Assert.True(config.ContainsKey(sectionKey), $"Config should contain '{sectionKey}' section");

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/FeatureSelectionStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/FeatureSelectionStepViewModelTests.cs
@@ -177,19 +177,4 @@ public sealed class FeatureSelectionStepViewModelTests : WizardStepTestBase
         AssertNoEnabledKey(config, "Webhooks");
     }
 
-    private static void AssertNoEnabledKey(Dictionary<string, object> config, string sectionKey)
-    {
-        if (config.TryGetValue(sectionKey, out var obj) && obj is Dictionary<string, object> section)
-        {
-            Assert.False(section.ContainsKey("Enabled"),
-                $"Section '{sectionKey}' should not have an 'Enabled' key when feature step was skipped");
-        }
-    }
-
-    private static void AssertSectionEnabled(Dictionary<string, object> config, string sectionKey, bool expected)
-    {
-        Assert.True(config.ContainsKey(sectionKey), $"Config should contain '{sectionKey}' section");
-        var section = (Dictionary<string, object>)config[sectionKey];
-        Assert.Equal(expected, section["Enabled"]);
-    }
 }

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -6,7 +6,6 @@
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Configuration;
-using Netclaw.Tests.Utilities;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui.Wizard;
@@ -14,23 +13,13 @@ namespace Netclaw.Cli.Tests.Tui.Wizard;
 /// <summary>
 /// Tests for <see cref="WizardConfigBuilder"/> config dictionary assembly.
 /// </summary>
-public sealed class WizardConfigBuilderTests : IDisposable
+public sealed class WizardConfigBuilderTests : WizardStepTestBase
 {
-    private readonly DisposableTempDir _dir = new();
-    private readonly NetclawPaths _paths;
-
-    public WizardConfigBuilderTests()
-    {
-        _paths = new NetclawPaths(_dir.Path);
-        _paths.EnsureDirectoriesExist();
-    }
-
-    public void Dispose() => _dir.Dispose();
 
     [Fact]
     public void BuildConfigDictionary_AlwaysIncludesConfigVersion()
     {
-        var builder = new WizardConfigBuilder(_paths);
+        var builder = new WizardConfigBuilder(Context.Paths);
         var config = builder.BuildConfigDictionary();
 
         Assert.Equal(1, config["configVersion"]);
@@ -39,7 +28,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesProviderSection()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Provider = new ProviderConfigSection
             {
@@ -61,7 +50,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsAuthMethod_WhenNone()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Provider = new ProviderConfigSection
             {
@@ -80,7 +69,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesModelsSection()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Model = new ModelConfigSection
             {
@@ -100,7 +89,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesSlackSection_WhenEnabled()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Slack = new SlackConfigSection
             {
@@ -126,7 +115,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsSlack_WhenNotEnabled()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Slack = new SlackConfigSection { Enabled = false }
         };
@@ -139,7 +128,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesDiscordSection_WhenEnabled()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Discord = new DiscordConfigSection
             {
@@ -165,7 +154,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsDiscord_WhenNotEnabled()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Discord = new DiscordConfigSection { Enabled = false }
         };
@@ -178,7 +167,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesSecuritySection()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Security = new SecurityConfigSection
             {
@@ -198,7 +187,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsSearch_WhenDuckDuckGo()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Search = new SearchConfigSection { Backend = SearchBackend.DuckDuckGo }
         };
@@ -211,7 +200,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesSearch_WhenBrave()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Search = new SearchConfigSection { Backend = SearchBackend.Brave }
         };
@@ -225,7 +214,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesNotifications_WhenWebhookSet()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Notifications = new NotificationsConfigSection
             {
@@ -241,7 +230,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsNotifications_WhenNoWebhook()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             Notifications = new NotificationsConfigSection { WebhookUrl = null }
         };
@@ -254,7 +243,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_IncludesExternalSkills_WhenSet()
     {
-        var builder = new WizardConfigBuilder(_paths)
+        var builder = new WizardConfigBuilder(Context.Paths)
         {
             ExternalSkillSources =
             [
@@ -298,7 +287,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsExternalSkills_WhenNull()
     {
-        var builder = new WizardConfigBuilder(_paths);
+        var builder = new WizardConfigBuilder(Context.Paths);
 
         var config = builder.BuildConfigDictionary();
 
@@ -308,7 +297,7 @@ public sealed class WizardConfigBuilderTests : IDisposable
     [Fact]
     public void BuildConfigDictionary_OmitsFeatureFlags_WhenFeatureSelectionsNull()
     {
-        var builder = new WizardConfigBuilder(_paths);
+        var builder = new WizardConfigBuilder(Context.Paths);
 
         var config = builder.BuildConfigDictionary();
 
@@ -322,12 +311,4 @@ public sealed class WizardConfigBuilderTests : IDisposable
         AssertNoEnabledKey(config, "Webhooks");
     }
 
-    private static void AssertNoEnabledKey(Dictionary<string, object> config, string sectionKey)
-    {
-        if (config.TryGetValue(sectionKey, out var obj) && obj is Dictionary<string, object> section)
-        {
-            Assert.False(section.ContainsKey("Enabled"),
-                $"Section '{sectionKey}' should not have an 'Enabled' key when FeatureSelections is null");
-        }
-    }
 }

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigBuilderTests.cs
@@ -304,4 +304,30 @@ public sealed class WizardConfigBuilderTests : IDisposable
 
         Assert.False(config.ContainsKey("ExternalSkills"));
     }
+
+    [Fact]
+    public void BuildConfigDictionary_OmitsFeatureFlags_WhenFeatureSelectionsNull()
+    {
+        var builder = new WizardConfigBuilder(_paths);
+
+        var config = builder.BuildConfigDictionary();
+
+        // No Enabled flag should be injected into any feature section.
+        // Some sections (e.g., SkillSync) exist unconditionally with other keys.
+        AssertNoEnabledKey(config, "Memory");
+        AssertNoEnabledKey(config, "Search");
+        AssertNoEnabledKey(config, "SkillSync");
+        AssertNoEnabledKey(config, "Scheduling");
+        AssertNoEnabledKey(config, "SubAgents");
+        AssertNoEnabledKey(config, "Webhooks");
+    }
+
+    private static void AssertNoEnabledKey(Dictionary<string, object> config, string sectionKey)
+    {
+        if (config.TryGetValue(sectionKey, out var obj) && obj is Dictionary<string, object> section)
+        {
+            Assert.False(section.ContainsKey("Enabled"),
+                $"Section '{sectionKey}' should not have an 'Enabled' key when FeatureSelections is null");
+        }
+    }
 }

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
@@ -1,0 +1,295 @@
+// -----------------------------------------------------------------------
+// <copyright file="WizardConfigScenarioTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Cli.Tui;
+using Netclaw.Cli.Tui.Wizard;
+using Netclaw.Cli.Tui.Wizard.Steps;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui.Wizard;
+
+/// <summary>
+/// End-to-end scenario tests that simulate complete wizard flows and verify the
+/// entire assembled config dictionary matches the user's choices. Each scenario
+/// exercises the real step ViewModels through the config assembly pipeline.
+/// </summary>
+public sealed class WizardConfigScenarioTests : WizardStepTestBase
+{
+    [Fact]
+    public void PersonalPosture_MinimalSetup_DoesNotDisableFeatures()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Personal);
+        ConfigureSearch(steps, SearchBackend.Brave);
+        ConfigureExposure(steps, ExposureMode.Local, webhooks: false);
+        ConfigureIdentity(steps, "Netclaw", "America/Chicago");
+
+        var config = AssembleConfig(steps);
+
+        AssertPosture(config, "Personal");
+        AssertShellMode(config, "HostAllowed");
+        AssertSearchBackend(config, "brave");
+        Assert.False(config.ContainsKey("Daemon"));
+
+        // The bug: Personal posture must not inject Enabled:false for any feature
+        AssertNoDisabledFeatureFlags(config);
+    }
+
+    [Fact]
+    public void TeamPosture_AllFeaturesEnabled()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Team);
+        EnterFeatureSelection(steps, DeploymentPosture.Team);
+        ConfigureSearch(steps, SearchBackend.DuckDuckGo);
+        ConfigureExposure(steps, ExposureMode.TailscaleServe, webhooks: true);
+        ConfigureIdentity(steps, "TeamBot", "UTC");
+
+        var config = AssembleConfig(steps);
+
+        AssertPosture(config, "Team");
+        AssertShellMode(config, "Off");
+        AssertSectionEnabled(config, "Memory", true);
+        AssertSectionEnabled(config, "Search", true);
+        AssertSectionEnabled(config, "SkillSync", true);
+        AssertSectionEnabled(config, "Scheduling", true);
+        AssertSectionEnabled(config, "SubAgents", true);
+        AssertSectionEnabled(config, "Webhooks", true);
+
+        var daemon = GetSection(config, "Daemon");
+        Assert.Equal("tailscale-serve", daemon["ExposureMode"]);
+    }
+
+    [Fact]
+    public void PublicPosture_SelectiveFeatures()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Public);
+
+        // Public defaults all OFF — toggle on Memory and Search only
+        var featureStep = GetStep<FeatureSelectionStepViewModel>(steps);
+        featureStep.OnEnter(Context, NavigationDirection.Forward);
+        featureStep.ToggleFeature(0); // Memory
+        featureStep.ToggleFeature(1); // Search
+        featureStep.OnLeave();
+
+        ConfigureSearch(steps, SearchBackend.SearXng, searXngEndpoint: "https://search.example.com");
+        ConfigureExposure(steps, ExposureMode.TailscaleFunnel, webhooks: false);
+        ConfigureIdentity(steps, "PublicBot", "Europe/London");
+
+        var config = AssembleConfig(steps);
+
+        AssertPosture(config, "Public");
+        AssertSectionEnabled(config, "Memory", true);
+        AssertSectionEnabled(config, "Search", true);
+        AssertSectionEnabled(config, "SkillSync", false);
+        AssertSectionEnabled(config, "Scheduling", false);
+        AssertSectionEnabled(config, "SubAgents", false);
+        AssertSectionEnabled(config, "Webhooks", false);
+
+        var search = GetSection(config, "Search");
+        Assert.Equal("searxng", search["Backend"]);
+        Assert.Equal("https://search.example.com", search["SearXngEndpoint"]);
+
+        var daemon = GetSection(config, "Daemon");
+        Assert.Equal("tailscale-funnel", daemon["ExposureMode"]);
+    }
+
+    [Fact]
+    public void TeamPosture_SelectivelyDisabledFeatures()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Team);
+
+        // Team defaults all ON — toggle off Memory and Scheduling
+        var featureStep = GetStep<FeatureSelectionStepViewModel>(steps);
+        featureStep.OnEnter(Context, NavigationDirection.Forward);
+        featureStep.ToggleFeature(0); // Memory OFF
+        featureStep.ToggleFeature(3); // Scheduling OFF
+        featureStep.OnLeave();
+
+        ConfigureSearch(steps, SearchBackend.Brave);
+        ConfigureExposure(steps, ExposureMode.Local, webhooks: false);
+        ConfigureIdentity(steps, "Netclaw", "America/New_York");
+
+        var config = AssembleConfig(steps);
+
+        AssertSectionEnabled(config, "Memory", false);
+        AssertSectionEnabled(config, "Search", true);
+        AssertSectionEnabled(config, "SkillSync", true);
+        AssertSectionEnabled(config, "Scheduling", false);
+        AssertSectionEnabled(config, "SubAgents", true);
+        AssertSectionEnabled(config, "Webhooks", true);
+    }
+
+    [Fact]
+    public void PersonalPosture_WithIdentityAndWorkspaces_ConfigMatchesChoices()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Personal);
+        ConfigureSearch(steps, SearchBackend.DuckDuckGo);
+        ConfigureExposure(steps, ExposureMode.Local, webhooks: false);
+
+        var identityStep = GetStep<IdentityStepViewModel>(steps);
+        identityStep.AgentName = "Jarvis";
+        identityStep.UserName = "Aaron";
+        identityStep.UserTimezone = "America/Chicago";
+        identityStep.WorkspacesDirectory = "~/projects";
+
+        var config = AssembleConfig(steps);
+
+        // Identity is written to separate files, not the config dict.
+        // Workspaces IS in the config dict.
+        var workspaces = GetSection(config, "Workspaces");
+        Assert.Equal("~/projects", workspaces["Directory"]);
+
+        AssertNoDisabledFeatureFlags(config);
+    }
+
+    [Fact]
+    public void PersonalPosture_ExposureModeLocal_NoDaemonSection()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Personal);
+        ConfigureSearch(steps, SearchBackend.DuckDuckGo);
+        ConfigureExposure(steps, ExposureMode.Local, webhooks: false);
+        ConfigureIdentity(steps, "Netclaw", "UTC");
+
+        var config = AssembleConfig(steps);
+
+        Assert.False(config.ContainsKey("Daemon"));
+        // Webhooks section should not appear when webhooks are off and
+        // there's no FeatureSelection step to explicitly write it
+        Assert.False(config.ContainsKey("Webhooks") && GetSection(config, "Webhooks").ContainsKey("Enabled")
+            && (bool)GetSection(config, "Webhooks")["Enabled"]);
+    }
+
+    [Fact]
+    public void TeamPosture_ExposureTailscaleFunnel_WebhooksOn()
+    {
+        var steps = BuildCoreSteps();
+        EnterAndConfigurePosture(steps, DeploymentPosture.Team);
+        EnterFeatureSelection(steps, DeploymentPosture.Team);
+        ConfigureSearch(steps, SearchBackend.Brave);
+        ConfigureExposure(steps, ExposureMode.TailscaleFunnel, webhooks: true);
+        ConfigureIdentity(steps, "Netclaw", "UTC");
+
+        var config = AssembleConfig(steps);
+
+        var daemon = GetSection(config, "Daemon");
+        Assert.Equal("tailscale-funnel", daemon["ExposureMode"]);
+
+        // Webhooks: both the feature gate and the exposure step contribute
+        AssertSectionEnabled(config, "Webhooks", true);
+    }
+
+    // ── Helpers ──
+
+    private List<IWizardStepViewModel> BuildCoreSteps()
+    {
+        return
+        [
+            new SecurityPostureStepViewModel(),
+            new FeatureSelectionStepViewModel(),
+            new SearchStepViewModel(),
+            new IdentityStepViewModel(),
+            new ExposureModeStepViewModel()
+        ];
+    }
+
+    private void EnterAndConfigurePosture(List<IWizardStepViewModel> steps, DeploymentPosture posture)
+    {
+        var step = GetStep<SecurityPostureStepViewModel>(steps);
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.SelectedPosture = posture;
+        step.OnLeave();
+        Context.SelectedPosture = posture;
+    }
+
+    private void EnterFeatureSelection(List<IWizardStepViewModel> steps, DeploymentPosture posture)
+    {
+        var step = GetStep<FeatureSelectionStepViewModel>(steps);
+        if (!step.IsApplicable(Context))
+            return;
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.OnLeave();
+    }
+
+    private static void ConfigureSearch(List<IWizardStepViewModel> steps, SearchBackend backend,
+        string? searXngEndpoint = null)
+    {
+        var step = GetStep<SearchStepViewModel>(steps);
+        step.SelectedBackend = backend;
+        if (searXngEndpoint is not null)
+            step.SearXngEndpoint = searXngEndpoint;
+    }
+
+    private static void ConfigureExposure(List<IWizardStepViewModel> steps, ExposureMode mode, bool webhooks)
+    {
+        var step = GetStep<ExposureModeStepViewModel>(steps);
+        step.SelectedMode = mode;
+        step.WebhooksEnabled = webhooks;
+    }
+
+    private static void ConfigureIdentity(List<IWizardStepViewModel> steps, string name, string timezone)
+    {
+        var step = GetStep<IdentityStepViewModel>(steps);
+        step.AgentName = name;
+        step.UserTimezone = timezone;
+    }
+
+    private Dictionary<string, object> AssembleConfig(List<IWizardStepViewModel> steps)
+    {
+        var builder = new WizardConfigBuilder(Context.Paths);
+        foreach (var step in steps.Where(s => s.IsApplicable(Context)))
+            step.ContributeConfig(builder);
+        return builder.BuildConfigDictionary();
+    }
+
+    private static T GetStep<T>(List<IWizardStepViewModel> steps) where T : IWizardStepViewModel
+        => steps.OfType<T>().Single();
+
+    private static Dictionary<string, object> GetSection(Dictionary<string, object> config, string key)
+        => (Dictionary<string, object>)config[key];
+
+    private static void AssertPosture(Dictionary<string, object> config, string expected)
+    {
+        var security = GetSection(config, "Security");
+        Assert.Equal(expected, security["DeploymentPosture"]);
+    }
+
+    private static void AssertShellMode(Dictionary<string, object> config, string expected)
+    {
+        var security = GetSection(config, "Security");
+        Assert.Equal(expected, security["ShellExecutionMode"]);
+    }
+
+    private static void AssertSearchBackend(Dictionary<string, object> config, string expected)
+    {
+        var search = GetSection(config, "Search");
+        Assert.Equal(expected, search["Backend"]);
+    }
+
+    private static void AssertSectionEnabled(Dictionary<string, object> config, string sectionKey, bool expected)
+    {
+        Assert.True(config.ContainsKey(sectionKey), $"Config should contain '{sectionKey}' section");
+        var section = GetSection(config, sectionKey);
+        Assert.Equal(expected, section["Enabled"]);
+    }
+
+    private static void AssertNoDisabledFeatureFlags(Dictionary<string, object> config)
+    {
+        string[] featureSections = ["Memory", "Scheduling", "SubAgents"];
+        foreach (var section in featureSections)
+        {
+            if (config.TryGetValue(section, out var obj) && obj is Dictionary<string, object> dict)
+            {
+                Assert.False(dict.TryGetValue("Enabled", out var enabled) && enabled is false,
+                    $"Section '{section}' should not have Enabled=false for Personal posture");
+            }
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Cli.Tui;
 using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Cli.Tui.Wizard.Steps;
@@ -18,15 +19,11 @@ namespace Netclaw.Cli.Tests.Tui.Wizard;
 /// </summary>
 public sealed class WizardConfigScenarioTests : WizardStepTestBase
 {
-    private List<IWizardStepViewModel>? _steps;
+    private WizardOrchestrator? _orchestrator;
 
     public override void Dispose()
     {
-        if (_steps is not null)
-        {
-            foreach (var step in _steps)
-                step.Dispose();
-        }
+        _orchestrator?.Dispose();
         base.Dispose();
     }
 
@@ -197,9 +194,9 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
 
     // ── Helpers ──
 
-    private List<IWizardStepViewModel> BuildCoreSteps()
+    private static List<IWizardStepViewModel> BuildCoreSteps()
     {
-        _steps =
+        return
         [
             new SecurityPostureStepViewModel(),
             new FeatureSelectionStepViewModel(),
@@ -207,7 +204,6 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
             new IdentityStepViewModel(),
             new ExposureModeStepViewModel()
         ];
-        return _steps;
     }
 
     private void EnterAndConfigurePosture(List<IWizardStepViewModel> steps, DeploymentPosture posture)
@@ -253,11 +249,33 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
 
     private Dictionary<string, object> AssembleConfig(List<IWizardStepViewModel> steps)
     {
-        var builder = new WizardConfigBuilder(Context.Paths);
-        foreach (var step in steps.Where(s => s.IsApplicable(Context)))
-            step.ContributeConfig(builder);
-        return builder.BuildConfigDictionary();
+        _orchestrator = new WizardOrchestrator(steps, Context);
+        _orchestrator.WriteConfig();
+
+        var json = File.ReadAllText(Context.Paths.NetclawConfigPath);
+        var doc = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)!;
+        return ConvertToDictionary(doc);
     }
+
+    private static Dictionary<string, object> ConvertToDictionary(Dictionary<string, JsonElement> source)
+    {
+        var result = new Dictionary<string, object>();
+        foreach (var (key, element) in source)
+            result[key] = ConvertElement(element);
+        return result;
+    }
+
+    private static object ConvertElement(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Object => element.EnumerateObject()
+            .ToDictionary(p => p.Name, p => ConvertElement(p.Value)),
+        JsonValueKind.Array => element.EnumerateArray().Select(ConvertElement).ToArray(),
+        JsonValueKind.String => element.GetString()!,
+        JsonValueKind.True => (object)true,
+        JsonValueKind.False => false,
+        JsonValueKind.Number => element.TryGetInt32(out var i) ? i : element.GetDouble(),
+        _ => element.ToString()
+    };
 
     private static T GetStep<T>(List<IWizardStepViewModel> steps) where T : IWizardStepViewModel
         => steps.OfType<T>().Single();

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardConfigScenarioTests.cs
@@ -18,6 +18,18 @@ namespace Netclaw.Cli.Tests.Tui.Wizard;
 /// </summary>
 public sealed class WizardConfigScenarioTests : WizardStepTestBase
 {
+    private List<IWizardStepViewModel>? _steps;
+
+    public override void Dispose()
+    {
+        if (_steps is not null)
+        {
+            foreach (var step in _steps)
+                step.Dispose();
+        }
+        base.Dispose();
+    }
+
     [Fact]
     public void PersonalPosture_MinimalSetup_DoesNotDisableFeatures()
     {
@@ -43,7 +55,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
     {
         var steps = BuildCoreSteps();
         EnterAndConfigurePosture(steps, DeploymentPosture.Team);
-        EnterFeatureSelection(steps, DeploymentPosture.Team);
+        EnterFeatureSelection(steps);
         ConfigureSearch(steps, SearchBackend.DuckDuckGo);
         ConfigureExposure(steps, ExposureMode.TailscaleServe, webhooks: true);
         ConfigureIdentity(steps, "TeamBot", "UTC");
@@ -161,10 +173,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
         var config = AssembleConfig(steps);
 
         Assert.False(config.ContainsKey("Daemon"));
-        // Webhooks section should not appear when webhooks are off and
-        // there's no FeatureSelection step to explicitly write it
-        Assert.False(config.ContainsKey("Webhooks") && GetSection(config, "Webhooks").ContainsKey("Enabled")
-            && (bool)GetSection(config, "Webhooks")["Enabled"]);
+        AssertNoEnabledKey(config, "Webhooks");
     }
 
     [Fact]
@@ -172,7 +181,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
     {
         var steps = BuildCoreSteps();
         EnterAndConfigurePosture(steps, DeploymentPosture.Team);
-        EnterFeatureSelection(steps, DeploymentPosture.Team);
+        EnterFeatureSelection(steps);
         ConfigureSearch(steps, SearchBackend.Brave);
         ConfigureExposure(steps, ExposureMode.TailscaleFunnel, webhooks: true);
         ConfigureIdentity(steps, "Netclaw", "UTC");
@@ -190,7 +199,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
 
     private List<IWizardStepViewModel> BuildCoreSteps()
     {
-        return
+        _steps =
         [
             new SecurityPostureStepViewModel(),
             new FeatureSelectionStepViewModel(),
@@ -198,6 +207,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
             new IdentityStepViewModel(),
             new ExposureModeStepViewModel()
         ];
+        return _steps;
     }
 
     private void EnterAndConfigurePosture(List<IWizardStepViewModel> steps, DeploymentPosture posture)
@@ -209,7 +219,7 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
         Context.SelectedPosture = posture;
     }
 
-    private void EnterFeatureSelection(List<IWizardStepViewModel> steps, DeploymentPosture posture)
+    private void EnterFeatureSelection(List<IWizardStepViewModel> steps)
     {
         var step = GetStep<FeatureSelectionStepViewModel>(steps);
         if (!step.IsApplicable(Context))
@@ -273,16 +283,9 @@ public sealed class WizardConfigScenarioTests : WizardStepTestBase
         Assert.Equal(expected, search["Backend"]);
     }
 
-    private static void AssertSectionEnabled(Dictionary<string, object> config, string sectionKey, bool expected)
-    {
-        Assert.True(config.ContainsKey(sectionKey), $"Config should contain '{sectionKey}' section");
-        var section = GetSection(config, sectionKey);
-        Assert.Equal(expected, section["Enabled"]);
-    }
-
     private static void AssertNoDisabledFeatureFlags(Dictionary<string, object> config)
     {
-        string[] featureSections = ["Memory", "Scheduling", "SubAgents"];
+        string[] featureSections = ["Memory", "Search", "SkillSync", "Scheduling", "SubAgents", "Webhooks"];
         foreach (var section in featureSections)
         {
             if (config.TryGetValue(section, out var obj) && obj is Dictionary<string, object> dict)

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardOrchestratorTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardOrchestratorTests.cs
@@ -282,6 +282,40 @@ public sealed class WizardOrchestratorTests : WizardStepTestBase
     }
 
     [Fact]
+    public void WriteConfig_OnlyCallsContributeConfig_OnActiveSteps()
+    {
+        var steps = CreateSteps("a", "skipped", "c");
+        ((FakeStep)steps[1]).Applicable = false;
+
+        using var orchestrator = new WizardOrchestrator(steps, Context);
+
+        // Advance to end so all active steps are entered
+        orchestrator.GoNext(); // a → c (skipping "skipped")
+
+        orchestrator.WriteConfig();
+
+        Assert.True(((FakeStep)steps[0]).ContributeConfigCalled, "Active step 'a' should have ContributeConfig called");
+        Assert.False(((FakeStep)steps[1]).ContributeConfigCalled, "Non-applicable step 'skipped' should NOT have ContributeConfig called");
+        Assert.True(((FakeStep)steps[2]).ContributeConfigCalled, "Active step 'c' should have ContributeConfig called");
+    }
+
+    [Fact]
+    public void WriteConfig_OnlyCallsContributeSecrets_OnActiveSteps()
+    {
+        var steps = CreateSteps("a", "skipped", "c");
+        ((FakeStep)steps[1]).Applicable = false;
+
+        using var orchestrator = new WizardOrchestrator(steps, Context);
+        orchestrator.GoNext();
+
+        orchestrator.WriteConfig();
+
+        Assert.True(((FakeStep)steps[0]).ContributeSecretsCalled);
+        Assert.False(((FakeStep)steps[1]).ContributeSecretsCalled);
+        Assert.True(((FakeStep)steps[2]).ContributeSecretsCalled);
+    }
+
+    [Fact]
     public void StatusMessage_ClearedOnNavigation()
     {
         var steps = CreateSteps("a", "b");
@@ -361,8 +395,11 @@ public sealed class WizardOrchestratorTests : WizardStepTestBase
             LeftCalled = true;
         }
 
-        public void ContributeConfig(WizardConfigBuilder builder) { }
-        public void ContributeSecrets(WizardSecretsBuilder builder) { }
+        public bool ContributeConfigCalled { get; private set; }
+        public bool ContributeSecretsCalled { get; private set; }
+
+        public void ContributeConfig(WizardConfigBuilder builder) { ContributeConfigCalled = true; }
+        public void ContributeSecrets(WizardSecretsBuilder builder) { ContributeSecretsCalled = true; }
         public Task ContributeHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct) => Task.CompletedTask;
 
         public void Dispose()

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/WizardStepTestBase.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/WizardStepTestBase.cs
@@ -7,6 +7,7 @@ using Netclaw.Cli.Tui.Wizard;
 using Netclaw.Configuration;
 using Netclaw.Providers;
 using Netclaw.Tests.Utilities;
+using Xunit;
 
 namespace Netclaw.Cli.Tests.Tui.Wizard;
 
@@ -31,5 +32,21 @@ public abstract class WizardStepTestBase : IDisposable
     {
         Context.Dispose();
         _dir.Dispose();
+    }
+
+    protected static void AssertSectionEnabled(Dictionary<string, object> config, string sectionKey, bool expected)
+    {
+        Assert.True(config.ContainsKey(sectionKey), $"Config should contain '{sectionKey}' section");
+        var section = (Dictionary<string, object>)config[sectionKey];
+        Assert.Equal(expected, section["Enabled"]);
+    }
+
+    protected static void AssertNoEnabledKey(Dictionary<string, object> config, string sectionKey)
+    {
+        if (config.TryGetValue(sectionKey, out var obj) && obj is Dictionary<string, object> section)
+        {
+            Assert.False(section.ContainsKey("Enabled"),
+                $"Section '{sectionKey}' should not have an 'Enabled' key");
+        }
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/FeatureSelectionStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/FeatureSelectionStepViewModel.cs
@@ -101,6 +101,9 @@ public sealed class FeatureSelectionStepViewModel : IWizardStepViewModel
 
     public void ContributeConfig(WizardConfigBuilder builder)
     {
+        if (_context is null)
+            return;
+
         builder.FeatureSelections = new FeatureSelectionsConfigSection
         {
             MemoryEnabled = _enabledFlags[0],

--- a/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
@@ -160,11 +160,11 @@ public sealed class WizardOrchestrator : IDisposable
         secretsBuilder.WriteSecretsFile();
 
         // Write provider credentials (deferred from ContributeSecrets to finalization)
-        var providerStep = _allSteps.OfType<ProviderStepViewModel>().FirstOrDefault();
+        var providerStep = _activeSteps.OfType<ProviderStepViewModel>().FirstOrDefault();
         providerStep?.WriteProviderCredentials(_context.Paths);
 
         // Write identity files and seed built-in agents from the identity step
-        var identityStep = _allSteps.OfType<IdentityStepViewModel>().FirstOrDefault();
+        var identityStep = _activeSteps.OfType<IdentityStepViewModel>().FirstOrDefault();
         if (identityStep is not null)
         {
             identityStep.WriteIdentityFiles(_context.Paths);
@@ -173,7 +173,7 @@ public sealed class WizardOrchestrator : IDisposable
 
         // Write bootstrap paired device for non-Local exposure modes so the daemon
         // can start with at least one paired device (satisfies ExposureModeValidationService).
-        var exposureStep = _allSteps.OfType<ExposureModeStepViewModel>().FirstOrDefault();
+        var exposureStep = _activeSteps.OfType<ExposureModeStepViewModel>().FirstOrDefault();
         exposureStep?.WriteBootstrapDevice(_context.Paths);
     }
 

--- a/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardOrchestrator.cs
@@ -150,7 +150,7 @@ public sealed class WizardOrchestrator : IDisposable
         var configBuilder = new WizardConfigBuilder(_context.Paths);
         var secretsBuilder = new WizardSecretsBuilder(_context.Paths);
 
-        foreach (var step in _allSteps)
+        foreach (var step in _activeSteps)
         {
             step.ContributeConfig(configBuilder);
             step.ContributeSecrets(secretsBuilder);
@@ -182,7 +182,7 @@ public sealed class WizardOrchestrator : IDisposable
     /// </summary>
     public async Task RunHealthChecksAsync(HealthCheckRunner runner, CancellationToken ct)
     {
-        foreach (var step in _allSteps)
+        foreach (var step in _activeSteps)
         {
             ct.ThrowIfCancellationRequested();
             await step.ContributeHealthChecksAsync(runner, ct);


### PR DESCRIPTION
## Summary

- **Root cause fix:** `WizardOrchestrator.WriteConfig()` iterated `_allSteps` instead of `_activeSteps`, causing skipped steps (like `FeatureSelectionStepViewModel` for Personal posture) to contribute all-false `Enabled` flags to the config — silently disabling Memory, Search, SkillSync, Scheduling, SubAgents, and Webhooks.
- **Defense-in-depth:** Added null-guard in `FeatureSelectionStepViewModel.ContributeConfig()` so the step is safe even if called without `OnEnter`.
- **Scenario-driven tests:** 7 end-to-end `WizardConfigScenarioTests` exercising Personal/Team/Public postures with various feature combinations through the real config assembly pipeline.
- **Headless TUI integration tests:** 2 new `InitWizardPageTests` driving the full wizard via `VirtualInputSource` and verifying the written JSON config matches user choices.
- **Unit-level regression tests:** Extended `FeatureSelectionStepViewModelTests`, `WizardConfigBuilderTests`, and `WizardOrchestratorTests` with targeted regression cases.
- **Test cleanup:** Extracted duplicate `AssertSectionEnabled`/`AssertNoEnabledKey` helpers into `WizardStepTestBase`, removed dead parameters, added proper step disposal.

Closes #905

Affected versions: 0.16.0 through 0.17.2.

## Test plan

- [x] `dotnet test --filter "WizardConfigScenario"` — all 7 scenario tests pass
- [x] `dotnet test --filter "InitWizardPage"` — all 10 headless TUI tests pass
- [x] `dotnet test --filter "FeatureSelection"` — step-level regression tests pass
- [x] `dotnet test --filter "WizardOrchestrator"` — orchestrator active-steps-only tests pass
- [x] `dotnet test --filter "WizardConfigBuilder"` — builder null-selections test passes
- [x] `dotnet test --project src/Netclaw.Cli.Tests` — full CLI test suite (596 tests) passes
- [ ] Manual: `netclaw init` with Personal posture → verify config has no `Enabled: false` entries