### PR TITLE
fix: use daemon-reported context window in TUI status bar (#906)

### DIFF
--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWindowResolutionTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Netclaw.Cli.Daemon;
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Daemon;
+
+public sealed class ContextWindowResolutionTests
+{
+    [Fact]
+    public void ConfiguredValue_ReturnedWithoutDaemonQuery()
+    {
+        var daemon = CreateDaemonApi(_ => throw new HttpRequestException("should not be called"));
+
+        var result = ContextWindowResolution.Resolve(131_072, daemon, "test-model");
+
+        Assert.Equal(131_072, result);
+    }
+
+    [Fact]
+    public void NullConfig_DaemonReturnsContextWindow_ReturnsDaemonValue()
+    {
+        var daemon = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(262_144)));
+
+        var result = ContextWindowResolution.Resolve(null, daemon, "qwen3:30b");
+
+        Assert.Equal(262_144, result);
+    }
+
+    [Fact]
+    public void NullConfig_DaemonReturnsZeroContextWindow_Throws()
+    {
+        var daemon = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(0)));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+
+        Assert.Contains("no context window", ex.Message);
+    }
+
+    [Fact]
+    public void NullConfig_DaemonReturnsNullModel_Throws()
+    {
+        var response = new
+        {
+            Overall = "healthy",
+            Build = new { Version = "1.0.0", CommitHash = "abc123", BuildTimestamp = "2026-01-01T00:00:00Z" },
+            Process = new { Pid = 1234, StartedAtUtc = "2026-01-01T00:00:00Z", UptimeSeconds = 3600 },
+            Connectors = Array.Empty<object>(),
+            Persistence = new { Provider = "sqlite" },
+            Telemetry = new { Enabled = false },
+        };
+        var daemon = CreateDaemonApi(_ => JsonResponse(response));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+
+        Assert.Contains("no context window", ex.Message);
+    }
+
+    [Fact]
+    public void NullConfig_DaemonOffline_Throws()
+    {
+        var daemon = CreateDaemonApi(_ => throw new HttpRequestException("connection refused"));
+
+        Assert.Throws<HttpRequestException>(
+            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static DaemonApi CreateDaemonApi(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-ctx-res-test-{Guid.NewGuid():N}"));
+        paths.EnsureDirectoriesExist();
+        return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
+    }
+
+    private static object BuildStatusResponse(int contextWindow) => new
+    {
+        Overall = "healthy",
+        Build = new { Version = "1.0.0", CommitHash = "abc123", BuildTimestamp = "2026-01-01T00:00:00Z" },
+        Process = new { Pid = 1234, StartedAtUtc = "2026-01-01T00:00:00Z", UptimeSeconds = 3600 },
+        Connectors = Array.Empty<object>(),
+        Persistence = new { Provider = "sqlite" },
+        Telemetry = new { Enabled = false },
+        Model = new
+        {
+            ModelId = "qwen3:30b",
+            Provider = "openai-compatible",
+            ContextWindow = contextWindow,
+            InputModalities = "Text",
+            OutputModalities = "Text"
+        }
+    };
+
+    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+
+    private sealed class StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+            => new(new StubHttpMessageHandler(handler));
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(handler(request));
+        }
+    }
+}

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -3,12 +3,10 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Net;
-using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
 using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
 using Xunit;
 
 namespace Netclaw.Cli.Tests.Daemon;
@@ -28,7 +26,7 @@ public sealed class ContextWindowResolutionTests
     [Fact]
     public void NullConfig_DaemonReturnsContextWindow_ReturnsDaemonValue()
     {
-        var daemon = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(262_144)));
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(262_144)));
 
         var result = ContextWindowResolution.Resolve(null, daemon, "qwen3:30b");
 
@@ -38,7 +36,7 @@ public sealed class ContextWindowResolutionTests
     [Fact]
     public void NullConfig_DaemonReturnsZeroContextWindow_Throws()
     {
-        var daemon = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(0)));
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(0)));
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
@@ -58,7 +56,7 @@ public sealed class ContextWindowResolutionTests
             Persistence = new { Provider = "sqlite" },
             Telemetry = new { Enabled = false },
         };
-        var daemon = CreateDaemonApi(_ => JsonResponse(response));
+        var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(response));
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
@@ -103,24 +101,9 @@ public sealed class ContextWindowResolutionTests
         }
     };
 
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-        => new(status)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
-        };
-
     private sealed class StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name)
-            => new(new StubHttpMessageHandler(handler));
-    }
-
-    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(handler(request));
-        }
+            => new(new FakeHttpMessageHandler(handler));
     }
 }

--- a/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
+++ b/src/Netclaw.Cli.Tests/Daemon/ContextWindowResolutionTests.cs
@@ -14,38 +14,38 @@ namespace Netclaw.Cli.Tests.Daemon;
 public sealed class ContextWindowResolutionTests
 {
     [Fact]
-    public void ConfiguredValue_ReturnedWithoutDaemonQuery()
+    public async Task ConfiguredValue_ReturnedWithoutDaemonQuery()
     {
         var daemon = CreateDaemonApi(_ => throw new HttpRequestException("should not be called"));
 
-        var result = ContextWindowResolution.Resolve(131_072, daemon, "test-model");
+        var result = await ContextWindowResolution.ResolveAsync(131_072, daemon, "test-model");
 
         Assert.Equal(131_072, result);
     }
 
     [Fact]
-    public void NullConfig_DaemonReturnsContextWindow_ReturnsDaemonValue()
+    public async Task NullConfig_DaemonReturnsContextWindow_ReturnsDaemonValue()
     {
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(262_144)));
 
-        var result = ContextWindowResolution.Resolve(null, daemon, "qwen3:30b");
+        var result = await ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b");
 
         Assert.Equal(262_144, result);
     }
 
     [Fact]
-    public void NullConfig_DaemonReturnsZeroContextWindow_Throws()
+    public async Task NullConfig_DaemonReturnsZeroContextWindow_Throws()
     {
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(0)));
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
 
         Assert.Contains("no context window", ex.Message);
     }
 
     [Fact]
-    public void NullConfig_DaemonReturnsNullModel_Throws()
+    public async Task NullConfig_DaemonReturnsNullModel_Throws()
     {
         var response = new
         {
@@ -58,19 +58,19 @@ public sealed class ContextWindowResolutionTests
         };
         var daemon = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(response));
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
 
         Assert.Contains("no context window", ex.Message);
     }
 
     [Fact]
-    public void NullConfig_DaemonOffline_Throws()
+    public async Task NullConfig_DaemonOffline_Throws()
     {
         var daemon = CreateDaemonApi(_ => throw new HttpRequestException("connection refused"));
 
-        Assert.Throws<HttpRequestException>(
-            () => ContextWindowResolution.Resolve(null, daemon, "qwen3:30b"));
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => ContextWindowResolution.ResolveAsync(null, daemon, "qwen3:30b"));
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContextWindowResolution.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Cli.Daemon;
+
+/// <summary>
+/// Resolves the effective context window for the main model by combining
+/// the explicit config value with a daemon status query fallback.
+/// </summary>
+internal static class ContextWindowResolution
+{
+    /// <summary>
+    /// Returns the explicit config value when set; otherwise queries the daemon
+    /// status endpoint for the auto-detected context window.
+    /// </summary>
+    public static int Resolve(int? configuredContextWindow, DaemonApi daemon, string modelId)
+    {
+        if (configuredContextWindow is > 0)
+            return configuredContextWindow.Value;
+
+        var status = daemon.GetStatusAsync().GetAwaiter().GetResult()
+            ?? throw new InvalidOperationException(
+                "Daemon returned empty status. Cannot resolve effective context window. " +
+                "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
+        return status.Model?.ContextWindow is > 0 and var daemonCw
+            ? daemonCw
+            : throw new InvalidOperationException(
+                $"Daemon reported no context window for model '{modelId}'. " +
+                "Set Models.Main.ContextWindow in netclaw.json.");
+    }
+}

--- a/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
+++ b/src/Netclaw.Cli/Daemon/ContextWindowResolution.cs
@@ -15,12 +15,12 @@ internal static class ContextWindowResolution
     /// Returns the explicit config value when set; otherwise queries the daemon
     /// status endpoint for the auto-detected context window.
     /// </summary>
-    public static int Resolve(int? configuredContextWindow, DaemonApi daemon, string modelId)
+    public static async Task<int> ResolveAsync(int? configuredContextWindow, DaemonApi daemon, string modelId)
     {
         if (configuredContextWindow is > 0)
             return configuredContextWindow.Value;
 
-        var status = daemon.GetStatusAsync().GetAwaiter().GetResult()
+        var status = await daemon.GetStatusAsync()
             ?? throw new InvalidOperationException(
                 "Daemon returned empty status. Cannot resolve effective context window. " +
                 "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -178,10 +178,15 @@ static async Task RunAsync(string[] args)
                 var models = initConfig.GetSection("Models")
                     .Get<ModelSelection>() ?? new ModelSelection();
 
+                var contextWindow = ContextWindowResolution.Resolve(
+                    models.Main.ContextWindow,
+                    sp.GetRequiredService<DaemonApi>(),
+                    models.Main.ModelId);
+
                 return new ModelCapabilities
                 {
                     ModelId = models.Main.ModelId,
-                    ContextWindowTokens = models.Main.ContextWindow ?? 32_768,
+                    ContextWindowTokens = contextWindow,
                     CompactionModelId = models.Compaction?.ModelId,
                 };
             });
@@ -1745,25 +1750,15 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
     services.AddSingleton(sessionConfig);
     services.AddSingleton(sp =>
     {
-        var contextWindow = models.Main.ContextWindow;
-        if (contextWindow is null)
-        {
-            var daemon = sp.GetRequiredService<DaemonApi>();
-            var status = daemon.GetStatusAsync().GetAwaiter().GetResult()
-                ?? throw new InvalidOperationException(
-                    "Daemon returned empty status. Cannot resolve effective context window. " +
-                    "Set Models.Main.ContextWindow in netclaw.json or ensure the daemon is healthy.");
-            contextWindow = status.Model?.ContextWindow is > 0 and var daemonCw
-                ? daemonCw
-                : throw new InvalidOperationException(
-                    $"Daemon reported no context window for model '{models.Main.ModelId}'. " +
-                    "Set Models.Main.ContextWindow in netclaw.json.");
-        }
+        var contextWindow = ContextWindowResolution.Resolve(
+            models.Main.ContextWindow,
+            sp.GetRequiredService<DaemonApi>(),
+            models.Main.ModelId);
 
         return new ModelCapabilities
         {
             ModelId = models.Main.ModelId,
-            ContextWindowTokens = contextWindow.Value,
+            ContextWindowTokens = contextWindow,
             CompactionModelId = models.Compaction?.ModelId,
         };
     });

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -178,10 +178,10 @@ static async Task RunAsync(string[] args)
                 var models = initConfig.GetSection("Models")
                     .Get<ModelSelection>() ?? new ModelSelection();
 
-                var contextWindow = ContextWindowResolution.Resolve(
+                var contextWindow = ContextWindowResolution.ResolveAsync(
                     models.Main.ContextWindow,
                     sp.GetRequiredService<DaemonApi>(),
-                    models.Main.ModelId);
+                    models.Main.ModelId).GetAwaiter().GetResult();
 
                 return new ModelCapabilities
                 {
@@ -1750,10 +1750,10 @@ static void ConfigureCliChatServices(IServiceCollection services, IConfiguration
     services.AddSingleton(sessionConfig);
     services.AddSingleton(sp =>
     {
-        var contextWindow = ContextWindowResolution.Resolve(
+        var contextWindow = ContextWindowResolution.ResolveAsync(
             models.Main.ContextWindow,
             sp.GetRequiredService<DaemonApi>(),
-            models.Main.ModelId);
+            models.Main.ModelId).GetAwaiter().GetResult();
 
         return new ModelCapabilities
         {

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -336,9 +336,11 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 break;
 
             case UsageOutput msg:
-                // Compute context % from ViewModel's SessionConfig (known-good)
-                // rather than msg.ContextWindowTokens which may be default(0)
-                var ctxWindow = ViewModel.ContextWindowTokens;
+                // Prefer the daemon-reported context window (authoritative, auto-detected
+                // from the provider); fall back to the DI-injected value when absent.
+                var ctxWindow = msg.ContextWindowTokens > 0
+                    ? msg.ContextWindowTokens
+                    : ViewModel.ContextWindowTokens;
                 var usagePercent = msg.InputTokens.HasValue && ctxWindow > 0
                     ? (double)msg.InputTokens.Value / ctxWindow
                     : (double?)null;

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -336,6 +336,8 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 break;
 
             case UsageOutput msg:
+                // Prefer the daemon-reported context window (authoritative, auto-detected
+                // from the provider); fall back to the DI-injected value when absent.
                 var ctxWindow = msg.ContextWindowTokens > 0
                     ? msg.ContextWindowTokens
                     : ViewModel.ContextWindowTokens;

--- a/src/Netclaw.Cli/Tui/ChatPage.cs
+++ b/src/Netclaw.Cli/Tui/ChatPage.cs
@@ -336,8 +336,6 @@ public sealed class ChatPage : ReactivePage<ChatViewModel>
                 break;
 
             case UsageOutput msg:
-                // Prefer the daemon-reported context window (authoritative, auto-detected
-                // from the provider); fall back to the DI-injected value when absent.
                 var ctxWindow = msg.ContextWindowTokens > 0
                     ? msg.ContextWindowTokens
                     : ViewModel.ContextWindowTokens;


### PR DESCRIPTION
## Summary

- **ChatPage**: Prefer the daemon-reported `msg.ContextWindowTokens` (authoritative, auto-detected from provider) over the DI-injected `ViewModel.ContextWindowTokens` which may be the 32K fallback
- **Init wizard path**: Query the daemon status endpoint for context window instead of falling back to 32K — the previous fix in #865 only addressed the standalone `netclaw chat` path but missed the init wizard → chat navigation
- **Extract `ContextWindowResolution.Resolve`**: Shared helper used by both code paths, replacing inline duplication

Closes #906

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (13/13 context window tests including 5 new)
- [ ] `dotnet slopwatch analyze` — no new violations
- [ ] Copyright headers verified
- [ ] Manual: `netclaw init` → navigate to chat → status bar shows correct context window %
- [ ] Manual: `netclaw chat` → status bar shows correct context window %