### PR TITLE
feat: harden SearXNG backend (UA, 429 retry, timeout, 403 detection)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,6 +68,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Verify.XunitV3" Version="31.16.2" />
+    <PackageVersion Include="Testcontainers" Version="4.7.0" />
   </ItemGroup>
   <!-- Source generators -->
   <ItemGroup>

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.24.0"
+  version: "1.25.0"
 ---
 
 # Netclaw Operations
@@ -27,6 +27,7 @@ problems, how to update preferences, or how to maintain itself.
 | Check health, update self | [Self-Maintenance](#self-maintenance) |
 | Run long shell commands in background | [Background Jobs](#background-jobs) |
 | Manage inbound webhooks | [Webhook Management](#webhook-management) |
+| Search backend errors, configure SearXNG | [Search Providers](#search-providers) |
 
 ## Project Directory
 
@@ -444,6 +445,34 @@ full exception internally. Exception details are **never** forwarded to Slack.
 | Download timeout | bot token valid? Slack network reachable? check `daemon-{date}.log` |
 | Content scan rejection | `netclaw status` scanner section; check scan config |
 | Inbox write failure | disk space? permissions on `~/.netclaw/sessions/`? |
+
+## Search Providers
+
+The `web_search` and `web_fetch` tools route through one configured search
+backend, selected by `Search.Backend` in `netclaw.json`:
+
+| Backend | Shape | Notes |
+|---------|-------|-------|
+| `SearXng` | Self-hosted | Operator runs the instance; `Search.SearXngEndpoint` points at it. JSON output must be enabled in the instance's `settings.yml`. Authenticated instances are not supported in current releases. |
+| `Brave`   | Managed | Requires `Search.BraveApiKey` in `secrets.json`. |
+| `DuckDuckGo` | Scraped | No config; least reliable, may hit bot detection. |
+
+When a search tool returns an error mentioning `settings.yml`,
+`search.formats`, or "rate limit exceeded", the operator's SearXNG instance
+is misconfigured or being throttled. Point them at the canonical setup
+guide:
+
+```
+https://netclaw.dev/docs/configuration/search-providers/
+```
+
+That page lists the supported `settings.yml` keys, reverse-proxy header
+requirements (Netclaw's outbound `User-Agent` is `Netclaw/{version}
+(+https://netclaw.dev)` — non-empty UAs must pass), and the limiter
+behavior we honor (HTTP 429 + `Retry-After`).
+
+For Brave, an authentication error surfaces as "API authentication failed"
+— the fix is updating `Search.BraveApiKey` in `secrets.json`.
 
 ## Diagnostics
 

--- a/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
+++ b/src/Netclaw.Search.Tests/BraveSearchBackendTests.cs
@@ -141,37 +141,6 @@ public class BraveSearchBackendTests
     }
 
     [Fact]
-    public void ParseRetryAfter_returns_delta_from_header()
-    {
-        var header = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
-        var delay = BraveSearchBackend.ParseRetryAfter(header, 0, TimeProvider.System);
-        Assert.Equal(TimeSpan.FromSeconds(30), delay);
-    }
-
-    [Fact]
-    public void ParseRetryAfter_returns_remaining_time_from_date_header()
-    {
-        var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
-        var future = now.AddSeconds(45);
-        var header = new RetryConditionHeaderValue(future);
-        var fakeTime = new FixedTimeProvider(now);
-
-        var delay = BraveSearchBackend.ParseRetryAfter(header, 0, fakeTime);
-
-        Assert.Equal(TimeSpan.FromSeconds(45), delay);
-    }
-
-    [Theory]
-    [InlineData(0, 5)]
-    [InlineData(1, 10)]
-    [InlineData(2, 20)]
-    public void ParseRetryAfter_falls_back_to_exponential_backoff_when_header_absent(int attempt, int expectedSeconds)
-    {
-        var delay = BraveSearchBackend.ParseRetryAfter(null, attempt, TimeProvider.System);
-        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
-    }
-
-    [Fact]
     public async Task SearchAsync_handles_gzip_encoded_response()
     {
         var handler = new FakeHttpMessageHandler();
@@ -260,10 +229,5 @@ public class BraveSearchBackendTests
                 throw new InvalidOperationException("No more responses queued.");
             return Task.FromResult(_responses.Dequeue());
         }
-    }
-
-    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/src/Netclaw.Search.Tests/Fixtures/searxng-settings.yml
+++ b/src/Netclaw.Search.Tests/Fixtures/searxng-settings.yml
@@ -1,0 +1,24 @@
+# Minimal SearXNG configuration used by SearXngBackendIntegrationTests.
+#
+# IMPORTANT: do not run a Valkey container alongside this. SearXNG's bot-detection
+# limiter requires Valkey to operate; without it, the limiter is inactive by
+# construction, which is what we want for a deterministic test run. Adding
+# Valkey "for realism" will reintroduce CI flakiness when the image is bumped.
+
+use_default_settings: true
+
+general:
+  instance_name: "Netclaw integration test"
+
+server:
+  # Static secret is fine — this instance is ephemeral and bound to a random
+  # localhost port during the test run.
+  secret_key: "netclaw-integration-test-do-not-use-in-production"
+  limiter: false
+  image_proxy: false
+
+search:
+  # Required: JSON output is what Netclaw queries for. Without this we get HTTP 403.
+  formats:
+    - html
+    - json

--- a/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
+++ b/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
     <PackageReference Include="Testcontainers"/>
   </ItemGroup>
 

--- a/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
+++ b/src/Netclaw.Search.Tests/Netclaw.Search.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
+    <PackageReference Include="Testcontainers"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Fixtures/**/*.html" />
     <EmbeddedResource Include="Fixtures/**/*.json" />
+    <EmbeddedResource Include="Fixtures/**/*.yml" />
   </ItemGroup>
 
 </Project>

--- a/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
@@ -12,12 +12,8 @@ using Xunit;
 namespace Netclaw.Search.Tests;
 
 /// <summary>
-/// Layer 2 smoke test against a real SearXNG container. Catches wire-format drift
-/// when the upstream image is bumped — the day SearXNG renames "results" to
-/// "web_results", this test fails before users do.
-///
-/// Self-skips when Docker is unavailable (Windows CI runners, dev machines without
-/// Docker), so the test runs naturally on Linux CI but never breaks elsewhere.
+/// Smoke test against a real SearXNG container; catches wire-format drift on image bump.
+/// Self-skips when Docker is unavailable.
 /// </summary>
 [Trait("Category", "Integration")]
 public class SearXngBackendIntegrationTests : IAsyncLifetime

--- a/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendIntegrationTests.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearXngBackendIntegrationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Netclaw.Search;
+using Xunit;
+
+namespace Netclaw.Search.Tests;
+
+/// <summary>
+/// Layer 2 smoke test against a real SearXNG container. Catches wire-format drift
+/// when the upstream image is bumped — the day SearXNG renames "results" to
+/// "web_results", this test fails before users do.
+///
+/// Self-skips when Docker is unavailable (Windows CI runners, dev machines without
+/// Docker), so the test runs naturally on Linux CI but never breaks elsewhere.
+/// </summary>
+[Trait("Category", "Integration")]
+public class SearXngBackendIntegrationTests : IAsyncLifetime
+{
+    // Pin a specific tag — never `latest`. Bump deliberately so wire-format drift
+    // surfaces as an explicit code change, not a silent CI run.
+    private const string SearXngImage = "searxng/searxng:2026.5.6-a9909c497";
+
+    private IContainer? _container;
+    private string? _endpoint;
+
+    public async ValueTask InitializeAsync()
+    {
+        var settingsYml = LoadFixture("searxng-settings.yml");
+
+        var container = new ContainerBuilder()
+            .WithImage(SearXngImage)
+            .WithPortBinding(8080, assignRandomHostPort: true)
+            .WithResourceMapping(
+                Encoding.UTF8.GetBytes(settingsYml),
+                "/etc/searxng/settings.yml")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r =>
+                r.ForPort(8080).ForPath("/healthz")))
+            .Build();
+
+        try
+        {
+            await container.StartAsync();
+        }
+        catch (Exception ex) when (IsDockerUnavailable(ex))
+        {
+            await container.DisposeAsync();
+            Assert.Skip($"Docker is not available; integration test skipped. ({ex.GetType().Name}: {ex.Message})");
+            return;
+        }
+
+        _container = container;
+        _endpoint = $"http://localhost:{container.GetMappedPublicPort(8080)}";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Live_query_returns_parseable_json()
+    {
+        if (_endpoint is null)
+        {
+            Assert.Skip("Container did not start (Docker unavailable).");
+            return;
+        }
+
+        var backend = new SearXngBackend(_endpoint);
+        var result = await backend.SearchAsync("akka.net", 5, CancellationToken.None);
+
+        // We assert on the wire-format contract, not result count: a sandboxed CI runner
+        // may have limited or no upstream-engine connectivity, in which case SearXNG returns
+        // an empty results array. That still proves JSON output works and our parser handled
+        // the response shape. Failure here means SearXNG changed its JSON contract.
+        Assert.IsType<SearchBackendResult.Success>(result);
+    }
+
+    /// <summary>
+    /// Recognizes the exception types Testcontainers throws when no Docker daemon is reachable.
+    /// On Windows CI runners and dev machines without Docker, StartAsync surfaces these as
+    /// the underlying transport error ("Cannot connect to the Docker daemon", named pipe errors,
+    /// or Docker.DotNet's connection-failure exceptions). On Linux runners with Docker, none
+    /// of these match and the test runs normally.
+    /// </summary>
+    private static bool IsDockerUnavailable(Exception ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            var typeName = current.GetType().Name;
+            if (typeName.Contains("Docker", StringComparison.Ordinal))
+                return true;
+
+            var msg = current.Message ?? "";
+            if (msg.Contains("Docker", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("named pipe", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("/var/run/docker.sock", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string LoadFixture(string filename)
+    {
+        var assembly = typeof(SearXngBackendIntegrationTests).Assembly;
+        var resourceName = $"Netclaw.Search.Tests.Fixtures.{filename}";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Netclaw.Search.Tests/SearXngBackendTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendTests.cs
@@ -1,8 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SearXngBackendTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
+using System.Net.Http.Headers;
 using Netclaw.Search;
 using Xunit;
 
@@ -85,6 +87,172 @@ public class SearXngBackendTests
         Assert.Equal("https://example.com", results[0].Url);
     }
 
+    [Fact]
+    public async Task SearchAsync_sends_user_agent_header()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(CreateSuccessResponse());
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        // UA parses as a product + a comment, so there are 2 entries (Netclaw/x.y.z and "(+https://...)").
+        var product = handler.LastRequest!.Headers.UserAgent.First(p => p.Product is not null).Product!;
+        Assert.Equal("Netclaw", product.Name);
+        Assert.False(string.IsNullOrEmpty(product.Version));
+    }
+
+    [Fact]
+    public async Task SearchAsync_retries_on_429_then_succeeds()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var rateLimit = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        rateLimit.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+        handler.Enqueue(rateLimit);
+        handler.Enqueue(CreateSuccessResponse());
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        Assert.IsType<SearchBackendResult.Success>(result);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_error_after_max_retries_on_429()
+    {
+        var handler = new FakeHttpMessageHandler();
+        for (var i = 0; i < 3; i++)
+        {
+            var r = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            r.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+            handler.Enqueue(r);
+        }
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("rate limit", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(3, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_honors_retry_after_http_date()
+    {
+        var fakeNow = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var handler = new FakeHttpMessageHandler();
+        var rateLimit = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        rateLimit.Headers.RetryAfter = new RetryConditionHeaderValue(fakeNow.AddMilliseconds(1));
+        handler.Enqueue(rateLimit);
+        handler.Enqueue(CreateSuccessResponse());
+
+        var backend = new SearXngBackend(
+            "http://searxng.local",
+            new HttpClient(handler),
+            new FixedTimeProvider(fakeNow));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        Assert.IsType<SearchBackendResult.Success>(result);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_error_for_html_response()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<html><body>...</body></html>", System.Text.Encoding.UTF8, "text/html"),
+        });
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("settings.yml", error.Message, StringComparison.Ordinal);
+        Assert.Contains("search.formats", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_error_for_403_format_not_enabled()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.Forbidden));
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("settings.yml", error.Message, StringComparison.Ordinal);
+        Assert.Contains("search.formats", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_error_for_malformed_json()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("not json at all", System.Text.Encoding.UTF8, "application/json"),
+        });
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("malformed", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_empty_results_for_empty_array()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"results":[]}""", System.Text.Encoding.UTF8, "application/json"),
+        });
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var success = Assert.IsType<SearchBackendResult.Success>(result);
+        Assert.Empty(success.Results);
+    }
+
+    [Fact]
+    public async Task SearchAsync_surfaces_timeout_as_error()
+    {
+        // Simulate hang-then-cancel by handing back a response only after the test cancels.
+        // Using HttpClient.Timeout would require real wall-clock time; instead we cancel
+        // via the response delegate to exercise the TaskCanceledException catch.
+        using var cts = new CancellationTokenSource();
+        var handler = new FakeHttpMessageHandler();
+        handler.SetSendCallback((_, ct) =>
+        {
+            cts.Cancel();
+            // Throw the same exception HttpClient would on internal-timeout.
+            throw new TaskCanceledException("simulated timeout");
+        });
+
+        var backend = new SearXngBackend("http://searxng.local", new HttpClient(handler));
+        var result = await backend.SearchAsync("test", 5, CancellationToken.None);
+
+        var error = Assert.IsType<SearchBackendResult.Error>(result);
+        Assert.Contains("timed out", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static HttpResponseMessage CreateSuccessResponse()
+    {
+        const string json = """{"results":[{"title":"Test","url":"https://example.com","content":"snippet"}]}""";
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+        };
+    }
+
     private static string LoadFixture(string filename)
     {
         var assembly = typeof(SearXngBackendTests).Assembly;
@@ -93,5 +261,39 @@ public class SearXngBackendTests
             ?? throw new FileNotFoundException($"Fixture not found: {resourceName}");
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        private Func<HttpRequestMessage, CancellationToken, HttpResponseMessage>? _callback;
+
+        public int RequestCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+        public void SetSendCallback(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> callback)
+            => _callback = callback;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+
+            if (_callback is not null)
+                return Task.FromResult(_callback(request, cancellationToken));
+
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("No more responses queued.");
+
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/src/Netclaw.Search.Tests/SearXngBackendTests.cs
+++ b/src/Netclaw.Search.Tests/SearXngBackendTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System.Net;
 using System.Net.Http.Headers;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Search;
 using Xunit;
 
@@ -150,7 +151,7 @@ public class SearXngBackendTests
         var backend = new SearXngBackend(
             "http://searxng.local",
             new HttpClient(handler),
-            new FixedTimeProvider(fakeNow));
+            new FakeTimeProvider(fakeNow));
         var result = await backend.SearchAsync("test", 5, CancellationToken.None);
 
         Assert.IsType<SearchBackendResult.Success>(result);
@@ -292,8 +293,4 @@ public class SearXngBackendTests
         }
     }
 
-    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => utcNow;
-    }
 }

--- a/src/Netclaw.Search.Tests/SearchRetryHelpersTests.cs
+++ b/src/Netclaw.Search.Tests/SearchRetryHelpersTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchRetryHelpersTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net.Http.Headers;
+using Netclaw.Search;
+using Xunit;
+
+namespace Netclaw.Search.Tests;
+
+public class SearchRetryHelpersTests
+{
+    [Fact]
+    public void ParseRetryAfter_returns_delta_from_header()
+    {
+        var header = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+        var delay = SearchRetryHelpers.ParseRetryAfter(header, 0, TimeProvider.System);
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
+    }
+
+    [Fact]
+    public void ParseRetryAfter_returns_remaining_time_from_date_header()
+    {
+        var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var future = now.AddSeconds(45);
+        var header = new RetryConditionHeaderValue(future);
+        var fakeTime = new FixedTimeProvider(now);
+
+        var delay = SearchRetryHelpers.ParseRetryAfter(header, 0, fakeTime);
+
+        Assert.Equal(TimeSpan.FromSeconds(45), delay);
+    }
+
+    [Fact]
+    public void ParseRetryAfter_falls_back_to_exponential_when_date_in_past()
+    {
+        var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var past = now.AddSeconds(-30);
+        var header = new RetryConditionHeaderValue(past);
+        var fakeTime = new FixedTimeProvider(now);
+
+        var delay = SearchRetryHelpers.ParseRetryAfter(header, 0, fakeTime);
+
+        Assert.Equal(TimeSpan.FromSeconds(5), delay);
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(1, 10)]
+    [InlineData(2, 20)]
+    public void ParseRetryAfter_falls_back_to_exponential_backoff_when_header_absent(int attempt, int expectedSeconds)
+    {
+        var delay = SearchRetryHelpers.ParseRetryAfter(null, attempt, TimeProvider.System);
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Fact]
+    public void UserAgent_starts_with_Netclaw_slash()
+    {
+        Assert.StartsWith("Netclaw/", SearchRetryHelpers.UserAgent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UserAgent_includes_homepage_url()
+    {
+        Assert.Contains("netclaw.dev", SearchRetryHelpers.UserAgent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UserAgent_does_not_contain_plus_suffix()
+    {
+        // The "+" in "(+https://netclaw.dev)" is part of the URL marker, but the version
+        // portion (between "/" and " ") should never contain a "+...commitsha" suffix.
+        var ua = SearchRetryHelpers.UserAgent;
+        var slash = ua.IndexOf('/', StringComparison.Ordinal);
+        var space = ua.IndexOf(' ', StringComparison.Ordinal);
+        var versionPart = ua[(slash + 1)..space];
+        Assert.DoesNotContain('+', versionPart);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/src/Netclaw.Search.Tests/SearchRetryHelpersTests.cs
+++ b/src/Netclaw.Search.Tests/SearchRetryHelpersTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net.Http.Headers;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Search;
 using Xunit;
 
@@ -25,7 +26,7 @@ public class SearchRetryHelpersTests
         var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
         var future = now.AddSeconds(45);
         var header = new RetryConditionHeaderValue(future);
-        var fakeTime = new FixedTimeProvider(now);
+        var fakeTime = new FakeTimeProvider(now);
 
         var delay = SearchRetryHelpers.ParseRetryAfter(header, 0, fakeTime);
 
@@ -38,7 +39,7 @@ public class SearchRetryHelpersTests
         var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
         var past = now.AddSeconds(-30);
         var header = new RetryConditionHeaderValue(past);
-        var fakeTime = new FixedTimeProvider(now);
+        var fakeTime = new FakeTimeProvider(now);
 
         var delay = SearchRetryHelpers.ParseRetryAfter(header, 0, fakeTime);
 
@@ -79,8 +80,4 @@ public class SearchRetryHelpersTests
         Assert.DoesNotContain('+', versionPart);
     }
 
-    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => utcNow;
-    }
 }

--- a/src/Netclaw.Search/BraveSearchBackend.cs
+++ b/src/Netclaw.Search/BraveSearchBackend.cs
@@ -54,7 +54,7 @@ public sealed partial class BraveSearchBackend : ISearchBackend
                     if (attempt == MaxRetries - 1)
                         break;
 
-                    var delay = ParseRetryAfter(response.Headers.RetryAfter, attempt, _timeProvider);
+                    var delay = SearchRetryHelpers.ParseRetryAfter(response.Headers.RetryAfter, attempt, _timeProvider);
                     await Task.Delay(delay, ct);
                     continue;
                 }
@@ -107,29 +107,6 @@ public sealed partial class BraveSearchBackend : ISearchBackend
 
         return new SearchBackendResult.Error(
             "Brave Search API rate limit exceeded. Wait before retrying or upgrade your plan.");
-    }
-
-    /// <summary>
-    /// Parses the Retry-After response header into a wait duration.
-    /// Falls back to exponential backoff (5s, 10s, 20s) when the header is absent or in the past.
-    /// </summary>
-    internal static TimeSpan ParseRetryAfter(RetryConditionHeaderValue? retryAfter, int attempt, TimeProvider timeProvider)
-    {
-        if (retryAfter is not null)
-        {
-            if (retryAfter.Delta.HasValue)
-                return retryAfter.Delta.Value;
-
-            if (retryAfter.Date.HasValue)
-            {
-                var remaining = retryAfter.Date.Value - timeProvider.GetUtcNow();
-                if (remaining > TimeSpan.Zero)
-                    return remaining;
-            }
-        }
-
-        // Exponential backoff: 5s, 10s, 20s
-        return TimeSpan.FromSeconds(5 * Math.Pow(2, attempt));
     }
 
     internal static List<SearchResult> ParseResults(string json, int maxResults)

--- a/src/Netclaw.Search/SearXngBackend.cs
+++ b/src/Netclaw.Search/SearXngBackend.cs
@@ -1,8 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SearXngBackend.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
@@ -10,53 +11,95 @@ namespace Netclaw.Search;
 
 /// <summary>
 /// Search backend using a self-hosted SearXNG instance.
-/// Requires the instance to have JSON format enabled in settings.yml.
+/// Requires the instance to have JSON format enabled in <c>settings.yml</c>
+/// (<c>search.formats</c> must include <c>json</c>). Authenticated instances
+/// are not supported. See https://netclaw.dev/docs/configuration/search-providers/.
 /// </summary>
 public sealed class SearXngBackend : ISearchBackend
 {
+    private const int MaxRetries = 3;
+    private const string DocsUrl = "https://netclaw.dev/docs/configuration/search-providers/";
+    private const string FormatErrorMessage =
+        "SearXNG returned a non-JSON response. Enable JSON output in settings.yml: " +
+        "set 'search.formats' to include 'json'. See " + DocsUrl + " for the supported configuration.";
+
     private readonly HttpClient _httpClient;
     private readonly string _endpoint;
+    private readonly TimeProvider _timeProvider;
 
-    public SearXngBackend(string endpoint, HttpClient? httpClient = null)
+    public SearXngBackend(string endpoint, HttpClient? httpClient = null, TimeProvider? timeProvider = null)
     {
         _endpoint = endpoint.TrimEnd('/');
-        _httpClient = httpClient ?? new HttpClient();
+        // When constructing our own HttpClient, set a default timeout so a misbehaving server
+        // can't hang a tool turn longer than intended. Caller-supplied clients are not mutated —
+        // tests inject their own and shouldn't be surprised by timeout side effects.
+        _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<SearchBackendResult> SearchAsync(string query, int maxResults, CancellationToken ct)
     {
-        try
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
         {
-            var url = $"{_endpoint}/search?q={Uri.EscapeDataString(query)}&format=json";
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-            using var response = await _httpClient.SendAsync(request, ct);
-            response.EnsureSuccessStatusCode();
-
-            var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
-            var body = await response.Content.ReadAsStringAsync(ct);
-
-            // Detect HTML response — means JSON format is not enabled
-            if (contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase)
-                || body.TrimStart().StartsWith('<'))
+            try
             {
-                return new SearchBackendResult.Error(
-                    "SearXNG returned HTML instead of JSON. Enable JSON format in your SearXNG settings.yml: " +
-                    "search.formats should include 'json'.");
-            }
+                var url = $"{_endpoint}/search?q={Uri.EscapeDataString(query)}&format=json";
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.UserAgent.ParseAdd(SearchRetryHelpers.UserAgent);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            var results = ParseResults(body, maxResults);
-            return new SearchBackendResult.Success(results);
+                using var response = await _httpClient.SendAsync(request, ct);
+
+                // 403 = format not enabled in settings.yml. Permanent server-side
+                // configuration error; do not retry.
+                if (response.StatusCode == HttpStatusCode.Forbidden)
+                    return new SearchBackendResult.Error(FormatErrorMessage);
+
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    if (attempt == MaxRetries - 1)
+                        break;
+
+                    var delay = SearchRetryHelpers.ParseRetryAfter(response.Headers.RetryAfter, attempt, _timeProvider);
+                    await Task.Delay(delay, ct);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
+                var body = await response.Content.ReadAsStringAsync(ct);
+
+                // HTML body on 200 = format silently ignored by some configurations.
+                // Same actionable cause as 403; same terminal error.
+                if (contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase)
+                    || body.TrimStart().StartsWith('<'))
+                    return new SearchBackendResult.Error(FormatErrorMessage);
+
+                try
+                {
+                    var results = ParseResults(body, maxResults);
+                    return new SearchBackendResult.Success(results);
+                }
+                catch (JsonException ex)
+                {
+                    return new SearchBackendResult.Error(
+                        $"SearXNG returned malformed JSON ({_endpoint}): {ex.Message}. See {DocsUrl}.");
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new SearchBackendResult.Error($"SearXNG endpoint unreachable ({_endpoint}): {ex.Message}");
+            }
+            catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+            {
+                return new SearchBackendResult.Error($"SearXNG request timed out ({_endpoint}).");
+            }
         }
-        catch (HttpRequestException ex)
-        {
-            return new SearchBackendResult.Error($"SearXNG endpoint unreachable ({_endpoint}): {ex.Message}");
-        }
-        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return new SearchBackendResult.Error($"SearXNG request timed out ({_endpoint}).");
-        }
+
+        return new SearchBackendResult.Error(
+            $"SearXNG rate limit exceeded ({_endpoint}). The instance's bot-detection limiter is throttling requests; " +
+            $"reduce concurrency or whitelist the Netclaw user agent. See {DocsUrl}.");
     }
 
     internal static List<SearchResult> ParseResults(string json, int maxResults)

--- a/src/Netclaw.Search/SearXngBackend.cs
+++ b/src/Netclaw.Search/SearXngBackend.cs
@@ -20,8 +20,8 @@ public sealed class SearXngBackend : ISearchBackend
     private const int MaxRetries = 3;
     private const string DocsUrl = "https://netclaw.dev/docs/configuration/search-providers/";
     private const string FormatErrorMessage =
-        "SearXNG returned a non-JSON response. Enable JSON output in settings.yml: " +
-        "set 'search.formats' to include 'json'. See " + DocsUrl + " for the supported configuration.";
+        $"SearXNG returned a non-JSON response. Enable JSON output in settings.yml: "
+        + $"set 'search.formats' to include 'json'. See {DocsUrl} for the supported configuration.";
 
     private readonly HttpClient _httpClient;
     private readonly string _endpoint;
@@ -30,9 +30,7 @@ public sealed class SearXngBackend : ISearchBackend
     public SearXngBackend(string endpoint, HttpClient? httpClient = null, TimeProvider? timeProvider = null)
     {
         _endpoint = endpoint.TrimEnd('/');
-        // When constructing our own HttpClient, set a default timeout so a misbehaving server
-        // can't hang a tool turn longer than intended. Caller-supplied clients are not mutated —
-        // tests inject their own and shouldn't be surprised by timeout side effects.
+        // Don't mutate caller-supplied clients; only set a default timeout when we own the instance.
         _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
         _timeProvider = timeProvider ?? TimeProvider.System;
     }

--- a/src/Netclaw.Search/SearchRetryHelpers.cs
+++ b/src/Netclaw.Search/SearchRetryHelpers.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchRetryHelpers.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Net.Http.Headers;
+using System.Reflection;
+
+namespace Netclaw.Search;
+
+/// <summary>
+/// Shared HTTP helpers used by multiple search backends:
+/// <see cref="ParseRetryAfter"/> for honoring server-supplied retry hints,
+/// and <see cref="UserAgent"/> for identifying outbound search traffic.
+/// </summary>
+internal static class SearchRetryHelpers
+{
+    /// <summary>
+    /// Parses the Retry-After response header into a wait duration.
+    /// Falls back to exponential backoff (5s, 10s, 20s) when the header is absent or in the past.
+    /// </summary>
+    internal static TimeSpan ParseRetryAfter(RetryConditionHeaderValue? retryAfter, int attempt, TimeProvider timeProvider)
+    {
+        if (retryAfter is not null)
+        {
+            if (retryAfter.Delta.HasValue)
+                return retryAfter.Delta.Value;
+
+            if (retryAfter.Date.HasValue)
+            {
+                var remaining = retryAfter.Date.Value - timeProvider.GetUtcNow();
+                if (remaining > TimeSpan.Zero)
+                    return remaining;
+            }
+        }
+
+        // Exponential backoff: 5s, 10s, 20s
+        return TimeSpan.FromSeconds(5 * Math.Pow(2, attempt));
+    }
+
+    /// <summary>
+    /// User-Agent value sent by every outbound search request. Format:
+    /// <c>Netclaw/{informational-version} (+https://netclaw.dev)</c>. Cached at type initialization.
+    /// </summary>
+    internal static string UserAgent { get; } = BuildUserAgent();
+
+    private static string BuildUserAgent()
+    {
+        var asm = typeof(SearchRetryHelpers).Assembly;
+        var version = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                      ?? asm.GetName().Version?.ToString()
+                      ?? "0.0.0";
+
+        // Strip any "+commitsha" suffix that source-link-style versioning attaches.
+        var plus = version.IndexOf('+', StringComparison.Ordinal);
+        if (plus >= 0)
+            version = version[..plus];
+
+        return $"Netclaw/{version} (+https://netclaw.dev)";
+    }
+}

--- a/src/Netclaw.Search/SearchRetryHelpers.cs
+++ b/src/Netclaw.Search/SearchRetryHelpers.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net.Http.Headers;
-using System.Reflection;
+using Netclaw.Configuration;
 
 namespace Netclaw.Search;
 
@@ -40,22 +40,8 @@ internal static class SearchRetryHelpers
 
     /// <summary>
     /// User-Agent value sent by every outbound search request. Format:
-    /// <c>Netclaw/{informational-version} (+https://netclaw.dev)</c>. Cached at type initialization.
+    /// <c>Netclaw/{version} (+https://netclaw.dev)</c>. Cached at type initialization.
     /// </summary>
-    internal static string UserAgent { get; } = BuildUserAgent();
-
-    private static string BuildUserAgent()
-    {
-        var asm = typeof(SearchRetryHelpers).Assembly;
-        var version = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                      ?? asm.GetName().Version?.ToString()
-                      ?? "0.0.0";
-
-        // Strip any "+commitsha" suffix that source-link-style versioning attaches.
-        var plus = version.IndexOf('+', StringComparison.Ordinal);
-        if (plus >= 0)
-            version = version[..plus];
-
-        return $"Netclaw/{version} (+https://netclaw.dev)";
-    }
+    internal static string UserAgent { get; } =
+        $"Netclaw/{BuildInfo.GetVersion(typeof(SearchRetryHelpers).Assembly)} (+https://netclaw.dev)";
 }


### PR DESCRIPTION
## Summary

- Adds a `User-Agent` header (`Netclaw/{version} (+https://netclaw.dev)`), 3-attempt retry on `HTTP 429` honoring `Retry-After` (delta and HTTP-date forms), default 15s `HttpClient.Timeout`, and an `HTTP 403` terminal branch citing `settings.yml`.
- Extracts `ParseRetryAfter` from `BraveSearchBackend` into a shared `SearchRetryHelpers` module so both backends share one implementation; `User-Agent` is built via the existing `BuildInfo.GetVersion(...)` helper.
- Adds Layer 1 mocked-handler tests for every behavioral edge plus a Layer 2 TestContainers smoke test against a pinned SearXNG image. The integration test self-skips when Docker is unavailable so the existing `pr_validation` matrix doesn't need a new stage to keep `windows-latest` green.
- Declares the supported SearXNG configuration surface in the new "Search Providers" section of the `netclaw-operations` skill (with a link to a forthcoming `netclaw-website` docs page).

Closes #909, addresses #910 (SearXNG-scoped). Authenticated-instance support tracked as a follow-up in #912.

## Out of scope (intentionally)

- Brave / DuckDuckGo HTTP-level test layering — the user explicitly scoped this to SearXNG.
- Authenticated SearXNG instances — explicitly declared unsupported in this pass; deferred to #912.
- Companion `netclaw-website` PR adding `src/content/docs/configuration/search-providers.md`. The URL is already referenced from error messages and the skill; the page can land in parallel.

## Test plan

- [x] `dotnet build -c Release` succeeds across the solution
- [x] `dotnet test src/Netclaw.Search.Tests` — 46 tests pass (was 31)
- [x] `dotnet test --filter "Category=Integration"` against a local Docker daemon — passes against `searxng/searxng:2026.5.6-a9909c497`
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — clean
- [ ] Manual smoke test: 5 parallel `web_search` tool calls against a real SearXNG instance with limiter enabled — confirm 429s retry and don't all surface as Errors to the LLM