### PR TITLE
refactor: extract shared FakeHttpClientFactory and remove duplicated JsonResponse helpers

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
@@ -145,7 +145,7 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
         ClientConfigFile.WriteEndpoint(_paths, endpoint);
         var configuration = new ConfigurationBuilder().Build();
 
-        return new DaemonApi(new StubHttpClientFactory(handler), configuration, _paths);
+        return new DaemonApi(new FakeHttpClientFactory(handler), configuration, _paths);
     }
 
     private void WriteDeviceToken(string token)
@@ -164,32 +164,4 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
         };
 
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        public HttpClient CreateClient(string name)
-            => new(new StubHttpMessageHandler(_handler));
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_handler(request));
-        }
-    }
 }

--- a/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs
@@ -3,8 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Net;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Config;
@@ -43,7 +41,7 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
             request =>
             {
                 capturedRequest = request;
-                return JsonResponse(Array.Empty<object>());
+                return FakeHttpMessageHandler.JsonResponse(Array.Empty<object>());
             });
 
         var devices = await api.ListPairedDevicesAsync(TestContext.Current.CancellationToken);
@@ -66,7 +64,7 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
             request =>
             {
                 capturedRequest = request;
-                return JsonResponse(Array.Empty<object>());
+                return FakeHttpMessageHandler.JsonResponse(Array.Empty<object>());
             });
 
         var devices = await api.ListPairedDevicesAsync(TestContext.Current.CancellationToken);
@@ -88,7 +86,7 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
             request =>
             {
                 capturedRequest = request;
-                return JsonResponse(Array.Empty<object>());
+                return FakeHttpMessageHandler.JsonResponse(Array.Empty<object>());
             });
 
         var devices = await api.ListPairedDevicesAsync(TestContext.Current.CancellationToken);
@@ -157,11 +155,5 @@ public sealed class DaemonApiAuthenticationTests : IDisposable
 
         File.WriteAllText(_paths.SecretsPath, json);
     }
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-        => new(status)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
-        };
 
 }

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -3,8 +3,6 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Net;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
@@ -90,7 +88,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             Models = new { Main = new { ModelId = "qwen3:30b", Provider = "local-ollama" } }
         });
 
-        var daemonApi = CreateDaemonApi(_ => JsonResponse(BuildStatusResponse(262144)));
+        var daemonApi = CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(BuildStatusResponse(262144)));
         var check = CreateCheck(daemonApi);
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
@@ -211,11 +209,5 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             OutputModalities = "Text"
         }
     };
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-        => new(status)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
-        };
 
 }

--- a/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs
@@ -191,7 +191,7 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
         var configuration = new ConfigurationBuilder().Build();
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-ctx-test-{Guid.NewGuid():N}"));
         paths.EnsureDirectoriesExist();
-        return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
+        return new DaemonApi(new FakeHttpClientFactory(handler), configuration, paths);
     }
 
     private static object BuildStatusResponse(int contextWindow) => new
@@ -218,18 +218,4 @@ public sealed class ContextWindowDoctorCheckTests : IDisposable
             Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
         };
 
-    private sealed class StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
-    {
-        public HttpClient CreateClient(string name)
-            => new(new StubHttpMessageHandler(handler));
-    }
-
-    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(handler(request));
-        }
-    }
 }

--- a/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
@@ -272,7 +272,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-daemon-api-test-{Guid.NewGuid():N}"));
         paths.EnsureDirectoriesExist();
 
-        return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
+        return new DaemonApi(new FakeHttpClientFactory(handler), configuration, paths);
     }
 
     private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
@@ -280,35 +280,6 @@ public sealed class McpServersDoctorCheckTests : IDisposable
         {
             Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
         };
-
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        public HttpClient CreateClient(string name)
-            => new(new StubHttpMessageHandler(_handler));
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_handler(request));
-        }
-    }
 
     private sealed class UnauthorizedHttpServer : IDisposable
     {

--- a/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs
@@ -6,7 +6,6 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
-using System.Text;
 using Microsoft.Extensions.Configuration;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Doctor;
@@ -32,7 +31,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
     [Fact]
     public async Task NoConfigFile_Passes()
     {
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
@@ -42,7 +41,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
     public async Task NoMcpServersSection_Passes()
     {
         WriteConfig(new { configVersion = 1 });
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
 
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
@@ -92,7 +91,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
@@ -115,7 +114,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
@@ -138,7 +137,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Error, result.Severity);
@@ -157,7 +156,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new { })));
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new { })));
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         // Only disabled servers → all pass (no enabled servers to fail)
@@ -182,7 +181,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new
         {
             notion = new
             {
@@ -216,7 +215,7 @@ public sealed class McpServersDoctorCheckTests : IDisposable
             }
         });
 
-        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => JsonResponse(new
+        var check = new McpServersDoctorCheck(_paths, CreateDaemonApi(_ => FakeHttpMessageHandler.JsonResponse(new
         {
             textforge = new
             {
@@ -274,12 +273,6 @@ public sealed class McpServersDoctorCheckTests : IDisposable
 
         return new DaemonApi(new FakeHttpClientFactory(handler), configuration, paths);
     }
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-        => new(status)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
-        };
 
     private sealed class UnauthorizedHttpServer : IDisposable
     {

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -278,7 +278,7 @@ public sealed class McpCommandTests : IDisposable
 
         var daemonApi = CreateDaemonApi(request => request.RequestUri!.AbsolutePath switch
         {
-            "/api/mcp/statuses" => JsonResponse(new
+            "/api/mcp/statuses" => FakeHttpMessageHandler.JsonResponse(new
             {
                 memorizer = new
                 {
@@ -326,7 +326,7 @@ public sealed class McpCommandTests : IDisposable
 
         var daemonApi = CreateDaemonApi(request => request.RequestUri!.AbsolutePath switch
         {
-            "/api/mcp/statuses" => JsonResponse(new { }),
+            "/api/mcp/statuses" => FakeHttpMessageHandler.JsonResponse(new { }),
             _ => new HttpResponseMessage(HttpStatusCode.NotFound)
         });
 
@@ -522,14 +522,6 @@ public sealed class McpCommandTests : IDisposable
         paths.EnsureDirectoriesExist();
 
         return new DaemonApi(new FakeHttpClientFactory(handler), configuration, paths);
-    }
-
-    private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
-    {
-        return new HttpResponseMessage(status)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
-        };
     }
 
 }

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -521,7 +521,7 @@ public sealed class McpCommandTests : IDisposable
         var paths = new NetclawPaths(Path.Combine(Path.GetTempPath(), $"netclaw-daemon-api-test-{Guid.NewGuid():N}"));
         paths.EnsureDirectoriesExist();
 
-        return new DaemonApi(new StubHttpClientFactory(handler), configuration, paths);
+        return new DaemonApi(new FakeHttpClientFactory(handler), configuration, paths);
     }
 
     private static HttpResponseMessage JsonResponse(object body, HttpStatusCode status = HttpStatusCode.OK)
@@ -532,32 +532,4 @@ public sealed class McpCommandTests : IDisposable
         };
     }
 
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        public HttpClient CreateClient(string name)
-            => new(new StubHttpMessageHandler(_handler));
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
-
-        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-        {
-            _handler = handler;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_handler(request));
-        }
-    }
 }

--- a/src/Netclaw.Tests.Utilities/FakeHttpClientFactory.cs
+++ b/src/Netclaw.Tests.Utilities/FakeHttpClientFactory.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="FakeHttpClientFactory.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Tests.Utilities;
+
+internal sealed class FakeHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name)
+        => new(new FakeHttpMessageHandler(handler));
+}

--- a/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
+++ b/src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj
@@ -8,4 +8,8 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

- Adds `FakeHttpClientFactory` to `Netclaw.Tests.Utilities` — a shared `IHttpClientFactory` implementation that wraps `FakeHttpMessageHandler`, replacing five identical `StubHttpClientFactory`/`StubHttpMessageHandler` nested class pairs spread across test files
- Replaces four identical private `JsonResponse(object body, ...)` helpers in the same test files with direct calls to `FakeHttpMessageHandler.JsonResponse<T>`, which already existed for this purpose
- Removes now-orphaned `using System.Net` and `using System.Text` directives from the affected files
- Adds `Microsoft.Extensions.Http` package reference to `Netclaw.Tests.Utilities.csproj` (via central package management) so `IHttpClientFactory` resolves in the utilities assembly

Closes #911

## Files changed

- `src/Netclaw.Tests.Utilities/FakeHttpClientFactory.cs` — new shared factory
- `src/Netclaw.Tests.Utilities/Netclaw.Tests.Utilities.csproj` — `Microsoft.Extensions.Http` reference
- `src/Netclaw.Cli.Tests/Cli/DaemonApiAuthenticationTests.cs` — removed stubs and local helper
- `src/Netclaw.Cli.Tests/Doctor/ContextWindowDoctorCheckTests.cs` — removed stubs and local helper
- `src/Netclaw.Cli.Tests/Doctor/McpServersDoctorCheckTests.cs` — removed stubs and local helper
- `src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs` — removed stubs and local helper

## Test plan

- [ ] `dotnet test` passes for `Netclaw.Cli.Tests` — 47/47 tests green
- [ ] `dotnet slopwatch analyze` — 0 issues
- [ ] `Add-FileHeaders.ps1 -Verify` — all headers present