### PR TITLE
fix(logging): wrap sidecar IChatClient calls in SessionDiagnosticsContext (#920)

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverStorageIntegrationTests.cs
@@ -7,6 +7,7 @@ using Akka.Actor;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Netclaw.Actors.Memory;
+using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Tests.Memory;
 using Netclaw.Configuration;
 using Xunit;
@@ -59,7 +60,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
                 "curation-create");
 
             var probe = CreateTestProbe("curation-create-probe");
@@ -105,7 +106,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
                 "curation-batch");
 
             var probe = CreateTestProbe("curation-batch-probe");
@@ -162,7 +163,7 @@ public sealed class SessionMemoryObserverStorageIntegrationTests : TestKit
         try
         {
             var curationActor = Sys.ActorOf(
-                MemoryCurationActor.CreateProps(store),
+                MemoryCurationActor.CreateProps(store, new SessionId("test-session")),
                 "curation-empty");
 
             var probe = CreateTestProbe("curation-empty-probe");

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
@@ -8,8 +8,11 @@ using Akka.Event;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Microsoft.Extensions.AI;
+using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Pipelines;
+using Netclaw.Actors.SubAgents;
 using Netclaw.Configuration;
 using Xunit;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
@@ -76,6 +79,124 @@ public sealed class SidecarDiagnosticsContextTests : TestKit
         Assert.Equal(sessionId.Value, captor.CapturedSessionId);
         Assert.Null(SessionDiagnosticsContext.SessionId);
         Assert.NotNull(observation);
+    }
+
+    [Fact]
+    public async Task MemoryExtraction_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/memory-extraction-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var probe = CreateTestProbe();
+
+        await LlmSessionActor.InvokeMemoryExtractionCoreAsync(
+            captor,
+            sessionId,
+            history: [],
+            self: probe.Ref,
+            timeout: TimeSpan.FromSeconds(5));
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+    }
+
+    [Fact]
+    public async Task SubAgent_InvokeLlm_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/subagent-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var probe = CreateTestProbe();
+
+        await SubAgentActor.InvokeLlmAsync(
+            captor,
+            messages: [],
+            options: null,
+            sessionId: sessionId,
+            self: probe.Ref,
+            ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+    }
+
+    [Fact]
+    public async Task SubAgent_InvokeLlm_with_null_sessionId_pushes_null_scope()
+    {
+        // Sub-agents that run outside any session legitimately have no
+        // session id. The Push contract accepts null and the captor should
+        // see null inside the call.
+        var captor = new SessionContextCapturingChatClient();
+        var probe = CreateTestProbe();
+
+        await SubAgentActor.InvokeLlmAsync(
+            captor,
+            messages: [],
+            options: null,
+            sessionId: null,
+            self: probe.Ref,
+            ct: TestContext.Current.CancellationToken);
+
+        Assert.Null(captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+    }
+
+    [Fact]
+    public async Task MemoryObserver_RunDistillation_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/distillation-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var probe = CreateTestProbe();
+
+        await SessionMemoryObserverActor.RunDistillationAsync(
+            client: captor,
+            sessionId: sessionId,
+            turnCount: 5,
+            transcript: "user: hello\nassistant: hi",
+            existingProposals: [],
+            timeout: TimeSpan.FromSeconds(5),
+            self: probe.Ref,
+            runId: 1,
+            contentVersion: 1,
+            log: NoLogger.Instance);
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+    }
+
+    [Fact]
+    public async Task MemoryCuration_TryLlmEvaluation_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/curation-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var operation = new SQLiteMemoryCurationOperation(
+            Kind: "document",
+            MemoryClass: "durable_fact",
+            MemoryId: null,
+            AnchorCanonicalName: "test-anchor",
+            AnchorType: "preference",
+            Title: "Test",
+            Content: "Test content for diagnostics scope verification.",
+            AliasesJson: "[]",
+            FacetsJson: "[]",
+            SlotsJson: null,
+            Relations: null,
+            UpdateSemantics: "merge-document",
+            Boundary: SecurityPolicyDefaults.TrustedInstanceBoundary,
+            Audience: TrustAudience.Public,
+            Sensitivity: "normal",
+            RecallMode: "auto",
+            Confidence: 0.9,
+            FreshnessAtMs: TimeProvider.System.GetUtcNow().ToUnixTimeMilliseconds(),
+            ExpiresAtMs: null);
+
+        await MemoryCurationActor.TryLlmEvaluationAsync(
+            captor,
+            sessionId,
+            operation,
+            candidates: [],
+            log: NoLogger.Instance);
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
     }
 
     /// <summary>

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
@@ -1,0 +1,123 @@
+// -----------------------------------------------------------------------
+// <copyright file="SidecarDiagnosticsContextTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using Akka.Event;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.AI;
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions.Pipelines;
+using Netclaw.Configuration;
+using Xunit;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Verifies that session-owned sidecar paths populate
+/// <see cref="SessionDiagnosticsContext"/> around their <c>IChatClient</c>
+/// calls so MEL provider diagnostics emitted during the call route into
+/// the per-session log. One test per major sidecar covered by
+/// netclaw-dev/netclaw#920. Test contract: a fake <c>IChatClient</c>
+/// captures <c>SessionDiagnosticsContext.SessionId</c> at the moment the
+/// chat client method is invoked. That is exactly the AsyncLocal value
+/// any real provider plugin would see when emitting MEL log lines.
+/// </summary>
+public sealed class SidecarDiagnosticsContextTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public async Task TitleGenerator_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/title-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var probe = CreateTestProbe();
+
+        SessionDiagnosticsContext.SessionId = null;
+        await SessionTitleGenerator.GenerateAsync(
+            captor,
+            sessionId,
+            history: [],
+            self: probe.Ref,
+            log: NoLogger.Instance,
+            timeout: TimeSpan.FromSeconds(5));
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+    }
+
+    [Fact]
+    public async Task CompactionPipeline_populates_session_diagnostics_scope()
+    {
+        var sessionId = new SessionId("ch/compaction-thread");
+        var captor = new SessionContextCapturingChatClient();
+        var history = new List<SerializableChatMessage>
+        {
+            new() { Role = Netclaw.Actors.Protocol.ChatRole.User, Content = "hello" },
+            new() { Role = Netclaw.Actors.Protocol.ChatRole.Assistant, Content = "hi" }
+        };
+
+        SessionDiagnosticsContext.SessionId = null;
+        var observation = await SessionCompactionPipeline.GenerateObservationsAsync(
+            client: captor,
+            sessionId: sessionId,
+            history: history,
+            systemOffset: 0,
+            keepStartIndex: 1,
+            sidecarTimeout: TimeSpan.FromSeconds(5),
+            log: NoLogger.Instance,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(sessionId.Value, captor.CapturedSessionId);
+        Assert.Null(SessionDiagnosticsContext.SessionId);
+        Assert.NotNull(observation);
+    }
+
+    /// <summary>
+    /// IChatClient stub that captures <see cref="SessionDiagnosticsContext.SessionId"/>
+    /// at the moment its methods are invoked. The captured value is the
+    /// AsyncLocal seen by the chat client — the same value any MEL provider
+    /// plugin emitting diagnostics inside the call would see.
+    /// </summary>
+    private sealed class SessionContextCapturingChatClient : IChatClient
+    {
+        public string? CapturedSessionId { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CapturedSessionId = SessionDiagnosticsContext.SessionId;
+            var response = new ChatResponse(new AiChatMessage(
+                AiChatRole.Assistant,
+                (IList<AIContent>)[new TextContent("captured")]));
+            return Task.FromResult(response);
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => StreamAsync(cancellationToken);
+
+        private async IAsyncEnumerable<ChatResponseUpdate> StreamAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            CapturedSessionId = SessionDiagnosticsContext.SessionId;
+            yield return new ChatResponseUpdate(AiChatRole.Assistant, "captured");
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SidecarDiagnosticsContextTests.cs
@@ -40,7 +40,6 @@ public sealed class SidecarDiagnosticsContextTests : TestKit
         var captor = new SessionContextCapturingChatClient();
         var probe = CreateTestProbe();
 
-        SessionDiagnosticsContext.SessionId = null;
         await SessionTitleGenerator.GenerateAsync(
             captor,
             sessionId,
@@ -64,7 +63,6 @@ public sealed class SidecarDiagnosticsContextTests : TestKit
             new() { Role = Netclaw.Actors.Protocol.ChatRole.Assistant, Content = "hi" }
         };
 
-        SessionDiagnosticsContext.SessionId = null;
         var observation = await SessionCompactionPipeline.GenerateObservationsAsync(
             client: captor,
             sessionId: sessionId,

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -249,7 +249,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         // If rules tier is ambiguous and LLM is available, escalate
         if (rulesDecision.Kind == CurationDecisionKind.Ambiguous && _llmClient is not null)
         {
-            var llmDecision = await TryLlmEvaluationAsync(operation, candidates);
+            var llmDecision = await TryLlmEvaluationAsync(_llmClient, _sessionId, operation, candidates, _log);
             if (llmDecision is not null)
             {
                 _log.Info(
@@ -286,14 +286,17 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         return rulesDecision;
     }
 
-    private async Task<CurationDecision?> TryLlmEvaluationAsync(
+    internal static async Task<CurationDecision?> TryLlmEvaluationAsync(
+        IChatClient llmClient,
+        SessionId sessionId,
         SQLiteMemoryCurationOperation operation,
-        IReadOnlyList<ExistingMemoryCandidate> candidates)
+        IReadOnlyList<ExistingMemoryCandidate> candidates,
+        ILoggingAdapter log)
     {
         try
         {
             using var cts = new CancellationTokenSource(LlmTimeout);
-            using var diagnosticsScope = SessionDiagnosticsContext.Push(_sessionId.Value);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId.Value);
 
             var messages = new List<ChatMessage>
             {
@@ -306,7 +309,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
                 MaxOutputTokens = 50
             };
 
-            var response = await _llmClient!.GetResponseAsync(messages, options, cts.Token);
+            var response = await llmClient.GetResponseAsync(messages, options, cts.Token);
             var responseText = response.Text?.Trim();
 
             if (string.IsNullOrWhiteSpace(responseText))
@@ -316,12 +319,12 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         }
         catch (OperationCanceledException)
         {
-            _log.Warning("curation_llm_timeout anchor={0}", operation.AnchorCanonicalName);
+            log.Warning("curation_llm_timeout anchor={0}", operation.AnchorCanonicalName);
             return null;
         }
         catch (Exception ex)
         {
-            _log.Warning(ex, "curation_llm_error anchor={0}", operation.AnchorCanonicalName);
+            log.Warning(ex, "curation_llm_error anchor={0}", operation.AnchorCanonicalName);
             return null;
         }
     }

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -55,15 +55,17 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
     private readonly SQLiteMemoryStore _store;
     private readonly IChatClient? _llmClient;
+    private readonly Protocol.SessionId _sessionId;
     private readonly ILoggingAdapter _log;
 
     private IActorRef? _currentRequester;
 
     public IStash Stash { get; set; } = null!;
 
-    public MemoryCurationActor(SQLiteMemoryStore store, IChatClientProvider? clientProvider = null)
+    public MemoryCurationActor(SQLiteMemoryStore store, Protocol.SessionId sessionId, IChatClientProvider? clientProvider = null)
     {
         _store = store;
+        _sessionId = sessionId;
         _llmClient = clientProvider != null
             ? clientProvider.GetClient(ModelRole.Compaction)
             : null;
@@ -75,8 +77,8 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     /// <summary>
     /// Create Props for the MemoryCurationActor.
     /// </summary>
-    public static Props CreateProps(SQLiteMemoryStore store, IChatClientProvider? clientProvider = null)
-        => Props.Create(() => new MemoryCurationActor(store, clientProvider));
+    public static Props CreateProps(SQLiteMemoryStore store, Protocol.SessionId sessionId, IChatClientProvider? clientProvider = null)
+        => Props.Create(() => new MemoryCurationActor(store, sessionId, clientProvider));
 
     // ── Idle behavior ───────────────────────────────────────────────
 
@@ -290,6 +292,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
         try
         {
             using var cts = new CancellationTokenSource(LlmTimeout);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(_sessionId.Value);
 
             var messages = new List<ChatMessage>
             {

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -7,6 +7,7 @@ using Akka.Actor;
 using Akka.Event;
 using Microsoft.Extensions.AI;
 using Netclaw.Configuration;
+using SessionId = Netclaw.Actors.Protocol.SessionId;
 
 namespace Netclaw.Actors.Memory;
 
@@ -55,14 +56,14 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
 
     private readonly SQLiteMemoryStore _store;
     private readonly IChatClient? _llmClient;
-    private readonly Protocol.SessionId _sessionId;
+    private readonly SessionId _sessionId;
     private readonly ILoggingAdapter _log;
 
     private IActorRef? _currentRequester;
 
     public IStash Stash { get; set; } = null!;
 
-    public MemoryCurationActor(SQLiteMemoryStore store, Protocol.SessionId sessionId, IChatClientProvider? clientProvider = null)
+    public MemoryCurationActor(SQLiteMemoryStore store, SessionId sessionId, IChatClientProvider? clientProvider = null)
     {
         _store = store;
         _sessionId = sessionId;
@@ -77,7 +78,7 @@ public sealed class MemoryCurationActor : ReceiveActor, IWithUnboundedStash
     /// <summary>
     /// Create Props for the MemoryCurationActor.
     /// </summary>
-    public static Props CreateProps(SQLiteMemoryStore store, Protocol.SessionId sessionId, IChatClientProvider? clientProvider = null)
+    public static Props CreateProps(SQLiteMemoryStore store, SessionId sessionId, IChatClientProvider? clientProvider = null)
         => Props.Create(() => new MemoryCurationActor(store, sessionId, clientProvider));
 
     // ── Idle behavior ───────────────────────────────────────────────

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -259,7 +259,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             if (_memoryStore is not null)
             {
                 _curationActor = Context.ActorOf(
-                    Memory.MemoryCurationActor.CreateProps(_memoryStore, _clientProvider),
+                    Memory.MemoryCurationActor.CreateProps(_memoryStore, _sessionId, _clientProvider),
                     "memory-curation");
 
                 // Distillation processes a full transcript — allow 5x normal sidecar timeout
@@ -1450,7 +1450,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private void MaybeGenerateTitle()
     {
         if (SessionTitleGenerator.ShouldGenerate(_state.TurnCount, _config.Tuning.TitleGenerationInterval))
-            _ = SessionTitleGenerator.GenerateAsync(_compactionClient, _state.History, Self, _log, _config.SidecarLlmTimeout);
+            _ = SessionTitleGenerator.GenerateAsync(_compactionClient, _sessionId, _state.History, Self, _log, _config.SidecarLlmTimeout);
     }
 
 
@@ -1465,12 +1465,14 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var self = Self;
         var client = _compactionClient;
         var timeout = _config.SidecarLlmTimeout;
+        var sessionId = _sessionId;
 
-        _ = InvokeMemoryExtractionCoreAsync(client, history, self, timeout);
+        _ = InvokeMemoryExtractionCoreAsync(client, sessionId, history, self, timeout);
     }
 
     private static async Task InvokeMemoryExtractionCoreAsync(
         IChatClient client,
+        SessionId sessionId,
         IReadOnlyList<SerializableChatMessage> history,
         IActorRef self,
         TimeSpan timeout)
@@ -1478,6 +1480,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         try
         {
             using var cts = new CancellationTokenSource(timeout);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId.Value);
             var extractionMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -1470,7 +1470,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         _ = InvokeMemoryExtractionCoreAsync(client, sessionId, history, self, timeout);
     }
 
-    private static async Task InvokeMemoryExtractionCoreAsync(
+    internal static async Task InvokeMemoryExtractionCoreAsync(
         IChatClient client,
         SessionId sessionId,
         IReadOnlyList<SerializableChatMessage> history,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
@@ -7,6 +7,7 @@ using Akka.Actor;
 using Akka.Event;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace Netclaw.Actors.Sessions.Pipelines;
@@ -172,6 +173,7 @@ internal static class SessionCompactionPipeline
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(sidecarTimeout);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId.Value);
             var observerMessages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System,

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionTitleGenerator.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionTitleGenerator.cs
@@ -7,6 +7,7 @@ using Akka.Actor;
 using Akka.Event;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Protocol;
+using Netclaw.Configuration;
 using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace Netclaw.Actors.Sessions.Pipelines;
@@ -33,6 +34,7 @@ internal static class SessionTitleGenerator
     /// </summary>
     public static async Task GenerateAsync(
         IChatClient client,
+        SessionId sessionId,
         IReadOnlyList<SerializableChatMessage> history,
         IActorRef self,
         ILoggingAdapter log,
@@ -41,6 +43,7 @@ internal static class SessionTitleGenerator
         try
         {
             using var cts = new CancellationTokenSource(timeout);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId.Value);
             var messages = new List<AiChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.User,

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.AI;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.SubAgents;
+using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Sessions;
 
@@ -355,6 +356,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         try
         {
             using var cts = new CancellationTokenSource(timeout);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId.Value);
             var messages = new List<ChatMessage>
             {
                 new(Microsoft.Extensions.AI.ChatRole.System, DistillationSystemPrompt),

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -211,7 +211,8 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             _sidecarTimeout,
             Self,
             run.RunId,
-            run.ContentVersion);
+            run.ContentVersion,
+            _log);
     }
 
     private void HandleDistillationRunCompleted(DistillationRunCompleted msg)
@@ -339,7 +340,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         _contentVersion++;
     }
 
-    private async Task RunDistillationAsync(
+    internal static async Task RunDistillationAsync(
         IChatClient client,
         SessionId sessionId,
         int turnCount,
@@ -348,7 +349,8 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         TimeSpan timeout,
         IActorRef self,
         long runId,
-        long contentVersion)
+        long contentVersion,
+        ILoggingAdapter log)
     {
         long? inputTokens = null;
         long? outputTokens = null;
@@ -374,14 +376,14 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
             switch (parseResult.Outcome)
             {
                 case ParseProposalsOutcome.NoJsonFound:
-                    _log.Info(
+                    log.Info(
                         "session_observer_parse_no_json rawLength={RawLength} candidateCount={CandidateCount} preview={Preview}",
                         text.Length,
                         parseResult.CandidateCount,
                         parseResult.Preview);
                     break;
                 case ParseProposalsOutcome.ParseFailed:
-                    _log.Info(
+                    log.Info(
                         "session_observer_parse_failed rawLength={RawLength} candidateCount={CandidateCount} preview={Preview}",
                         text.Length,
                         parseResult.CandidateCount,

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -253,7 +253,8 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             };
         }
 
-        _ = InvokeLlmAsync(client, messages, options, _toolExecutionContext.SessionId, _executionCts?.Token ?? CancellationToken.None, self);
+        var sessionId = _toolExecutionContext.SessionId is null ? (SessionId?)null : new SessionId(_toolExecutionContext.SessionId);
+        _ = InvokeLlmAsync(client, messages, options, sessionId, self, _executionCts?.Token ?? CancellationToken.None);
     }
 
     private void Complete(bool success, string output)
@@ -357,15 +358,15 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
 
     // ── Static async helpers (same pattern as LlmSessionActor) ──
 
-    private static async Task InvokeLlmAsync(
-        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, string? sessionId, CancellationToken ct, IActorRef self)
+    internal static async Task InvokeLlmAsync(
+        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, SessionId? sessionId, IActorRef self, CancellationToken ct)
     {
         try
         {
             // Sub-agents share the parent's diagnostics scope: SessionDiagnosticsContext
             // strips the "/subagent/..." suffix back to the parent id. Null is intentional
             // for sub-agents that run outside any session.
-            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId);
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId?.Value);
 
             // Use streaming to match the main session path. The non-streaming
             // GetResponseAsync path drops reasoning content for some providers

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -362,11 +362,9 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     {
         try
         {
-            // Sub-agents share the parent session's diagnostics scope so their
-            // provider logs land in the parent's session.log.
-            // SessionDiagnosticsContext normalizes "/subagent/..." suffixes back
-            // to the parent id; passing the raw _toolExecutionContext.SessionId
-            // (which may be null when run outside a session) is intentional.
+            // Sub-agents share the parent's diagnostics scope: SessionDiagnosticsContext
+            // strips the "/subagent/..." suffix back to the parent id. Null is intentional
+            // for sub-agents that run outside any session.
             using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId);
 
             // Use streaming to match the main session path. The non-streaming

--- a/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentActor.cs
@@ -253,7 +253,7 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
             };
         }
 
-        _ = InvokeLlmAsync(client, messages, options, _executionCts?.Token ?? CancellationToken.None, self);
+        _ = InvokeLlmAsync(client, messages, options, _toolExecutionContext.SessionId, _executionCts?.Token ?? CancellationToken.None, self);
     }
 
     private void Complete(bool success, string output)
@@ -358,10 +358,17 @@ public sealed class SubAgentActor : ReceiveActor, IWithTimers
     // ── Static async helpers (same pattern as LlmSessionActor) ──
 
     private static async Task InvokeLlmAsync(
-        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, CancellationToken ct, IActorRef self)
+        IChatClient client, List<AiChatMessage> messages, ChatOptions? options, string? sessionId, CancellationToken ct, IActorRef self)
     {
         try
         {
+            // Sub-agents share the parent session's diagnostics scope so their
+            // provider logs land in the parent's session.log.
+            // SessionDiagnosticsContext normalizes "/subagent/..." suffixes back
+            // to the parent id; passing the raw _toolExecutionContext.SessionId
+            // (which may be null when run outside a session) is intentional.
+            using var diagnosticsScope = SessionDiagnosticsContext.Push(sessionId);
+
             // Use streaming to match the main session path. The non-streaming
             // GetResponseAsync path drops reasoning content for some providers
             // (e.g., Qwen emits <think> blocks that surface as TextReasoningContent


### PR DESCRIPTION
## Summary

Closes #920. Wraps every session-owned sidecar `IChatClient.{Get,GetStreaming}ResponseAsync` call in `SessionDiagnosticsContext.Push(sessionId.Value)` so MEL provider diagnostics emitted during the call route into the per-session `session.log`.

Before this PR, only the main turn path (`SessionLlmInvoker.InvokeAsync`) populated the diagnostics scope. Sidecar paths — compaction, title generation, sub-agent orchestration, memory extraction, memory observer distillation, and memory curation — emitted to the daemon log without a session tag and never reached `session.log`. That gap was the limitation called out in #920 and the rationale for the planned Roslyn analyzer in #915.

## Sites covered

| Path | Method | Notes |
|---|---|---|
| Compaction | `SessionCompactionPipeline.GenerateObservationsAsync` | one-line scope wrap |
| Title generation | `SessionTitleGenerator.GenerateAsync` | `+SessionId` parameter |
| Sub-agent | `SubAgentActor.InvokeLlmAsync` | `+SessionId? sessionId`; bumped to `internal static`; null-sessionId case for sub-agents that run outside any session |
| Main-session memory extraction | `LlmSessionActor.InvokeMemoryExtractionCoreAsync` | `+SessionId` parameter; bumped to `internal static` |
| Memory observer distillation | `SessionMemoryObserverActor.RunDistillationAsync` | extracted from `private` instance to `internal static` (passes `_log` as param) — matches the pattern of the other sidecar helpers |
| Memory curation | `MemoryCurationActor.TryLlmEvaluationAsync` | same — extracted from `private` instance to `internal static`; constructor `+SessionId` parameter |

The two static extractions (`RunDistillationAsync`, `TryLlmEvaluationAsync`) are behavior-preserving refactors that bring those helpers into the same shape as the existing `SessionTitleGenerator`/`SessionCompactionPipeline`. They make the methods unit-testable in isolation without spinning up the parent actor or driving the full message protocol.

## Tests

`SidecarDiagnosticsContextTests` covers every path listed above. A `SessionContextCapturingChatClient` records `SessionDiagnosticsContext.SessionId` at the moment the chat client method is invoked — that AsyncLocal value is exactly what any real provider plugin would see when emitting MEL log lines inside the call.

7 tests, all green:
- `TitleGenerator_populates_session_diagnostics_scope`
- `CompactionPipeline_populates_session_diagnostics_scope`
- `MemoryExtraction_populates_session_diagnostics_scope`
- `SubAgent_InvokeLlm_populates_session_diagnostics_scope`
- `SubAgent_InvokeLlm_with_null_sessionId_pushes_null_scope`
- `MemoryObserver_RunDistillation_populates_session_diagnostics_scope`
- `MemoryCuration_TryLlmEvaluation_populates_session_diagnostics_scope`

This PR's coverage is independent of #915 (the analyzer): the contract is now verified at the unit-test level for every call site whether or not the analyzer ever lands.

## Quality gates

- 1482 Actors tests (was 1477; +5 new) + 504 Daemon tests, all pass.
- Slopwatch clean.
- Copyright headers verified.

## References

- Closes #920
- Related: #918 (problem framing), #915 (planned analyzer to enforce the scope going forward)
