### PR TITLE
feat: netclaw approvals CLI (list / revoke / TUI) (closes #921)

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "1.26.0"
+  version: "1.27.0"
 ---
 
 # Netclaw Operations
@@ -299,11 +299,42 @@ one grant per path. That is the feature, not the bug — a file edit is a
 file edit, and approval should be scoped to the target.
 
 If a user asks why they're being prompted so often, explain the security
-tradeoff and point them at `netclaw` CLI tooling for reviewing and trimming
-`tool-approvals.json` if the grant list grows unmanageable.
+tradeoff and point them at `netclaw approvals` for auditing and trimming
+their persistent grants.
 
-If approval matching seems stale after an upgrade, delete the approval file and
-rebuild grants interactively:
+### Inspecting and revoking grants
+
+Use the `netclaw approvals` CLI rather than hand-editing
+`tool-approvals.json`. The daemon reads the file on every approval check, so
+revocations take effect on the next prompt without a daemon restart.
+
+```bash
+# Interactive TUI: see everything grouped by audience and tool, revoke with R
+netclaw approvals
+
+# List only — human-readable
+netclaw approvals list
+netclaw approvals list --audience personal --tool shell_execute
+
+# Scriptable JSON output (audiences → tools → patterns)
+netclaw approvals list --json
+
+# Remove an exact match (case-sensitive on POSIX, insensitive on Windows)
+netclaw approvals revoke "git push" --audience personal --tool shell_execute
+
+# Clear every entry for a tool (optionally scoped to one audience)
+netclaw approvals revoke --tool shell_execute --all
+netclaw approvals revoke --tool shell_execute --all --audience personal
+```
+
+`revoke` of a non-existent pattern exits non-zero with a clear message — the
+CLI never silently succeeds.
+
+### Last-resort recovery
+
+If the approval file gets corrupted (the daemon will quarantine it to
+`tool-approvals.json.invalid` and warn loudly), or if you want to wipe every
+persistent grant and start clean, delete the file directly:
 
 macOS/Linux:
 
@@ -317,7 +348,7 @@ PowerShell:
 Remove-Item "$HOME/.netclaw/config/tool-approvals.json" -Force
 ```
 
-Then restart the daemon so in-memory session approvals are cleared too.
+Restart the daemon so in-memory session approvals are cleared too.
 
 ## Skill Management
 

--- a/openspec/changes/approvals-management-cli/.openspec.yaml
+++ b/openspec/changes/approvals-management-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/approvals-management-cli/design.md
+++ b/openspec/changes/approvals-management-cli/design.md
@@ -1,0 +1,144 @@
+## Context
+
+PR #896 introduced directory-scoped persistent approvals for `shell_execute`,
+storing one entry per trusted directory per audience per tool in
+`~/.netclaw/config/tool-approvals.json`. The file is loaded by
+`ToolApprovalStore.Load()` on every approval check inside `ToolApprovalActor`
+and is **not** cached or watched by `ConfigWatcherService`. Today the only
+operator surface for managing those grants is direct JSON editing.
+
+The CLI host already routes commands through `CliArgsParser` (`KnownCommands`
+set) and a switch in `Program.cs`. There is established precedent for
+hybrid commands that launch a TUI on bare invocation and accept single-shot
+subcommands otherwise (`netclaw provider`, `netclaw model`).
+
+Stakeholders: end-user operators managing trusted directories, agent
+authors that need a stable scriptable surface, and the running Netclaw
+agent itself (via the `netclaw-operations` skill recommendations).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Operator-driven inspection and revocation of persistent grants without
+  hand-editing JSON.
+- Single command surface (`netclaw approvals`) that mirrors the existing
+  TUI-or-subcommand pattern of `netclaw provider`.
+- Zero new daemon RPC; zero new wire formats.
+- The daemon picks up CLI mutations on the next approval check without a
+  restart.
+- Symmetric matching semantics between the CLI and the daemon's approval
+  gate (no surprises where the CLI removes an entry the daemon would not
+  have matched, or vice versa).
+
+**Non-Goals:**
+
+- Adding, broadening, or upgrading existing grants. The CLI never grants
+  privilege; it only inspects and revokes.
+- `prune` or stale-entry detection. Deferred until real drift is observed.
+- Importing/exporting approval bundles between machines.
+- Changes to `IToolApprovalService` or the actor protocol.
+- Changes to the JSON file format.
+
+## Decisions
+
+### File-direct I/O over daemon RPC
+
+`ToolApprovalActor` already calls `store.Load()` on every approval check
+(`ToolApprovalStore.cs:117`). There is no in-memory cache to keep
+coherent. CLI mutations therefore become visible to the daemon on the
+next approval gate, with no restart and no message-passing round-trip.
+
+Routing through `IToolApprovalService` would force the daemon to be
+running for `list` and `revoke`, add a new RPC surface to maintain, and
+buy nothing operationally. The schema-sync rule does not apply because
+`tool-approvals.json` is not part of `netclaw-config.v1.schema.json`.
+
+**Alternative considered**: hybrid (try daemon first, fall back to
+file). Rejected — silent fallback is forbidden by the constitution and
+the only fallback signal would be "is the daemon up", which is exactly
+the condition the file-direct path already handles correctly.
+
+### Exact-match revoke, no widening
+
+`ApprovalPatternMatching.MatchesShellApprovalEntry` matches an
+invocation against a stored entry by exact equality (or by
+directory-root containment when the entry is a path). It explicitly does
+not widen by verb prefix. The CLI's `revoke <pattern>` follows the same
+discipline: exact equality only, using
+`ApprovalPatternMatching.Comparer` so case sensitivity is identical to
+the daemon (Ordinal POSIX, OrdinalIgnoreCase Windows).
+
+`revoke --tool <name> --all` is offered as the explicit way to bulk-clear
+a tool's entries. Directory-root containment as a `revoke` mode (e.g.,
+`revoke /home/user/` removes everything under it) was rejected because
+it inverts the safe default — a fat-fingered prefix could revoke far
+more than intended. Operators wanting that behavior can pipe
+`list --json` to a script.
+
+### Bare invocation launches TUI
+
+`netclaw provider` and `netclaw model` already follow this pattern; the
+TUI host is configured via `Host.CreateApplicationBuilder` plus
+`AddTermina("/approvals", ...)`. Reusing this convention keeps the
+operator surface consistent. A `tui` subcommand alias is provided for
+explicitness in scripts.
+
+### `--audience` accepts wire values only
+
+`TrustAudience.ToWireValue()` returns `personal` / `team` / `public`. The
+CLI flag accepts those exact values and rejects anything else with a
+clear error. No friendly aliases — the wire value is what shows up in
+the file and in `list` output, so users only have to learn one
+vocabulary.
+
+### Empty file is a normal state
+
+A missing or empty `tool-approvals.json` causes `list` to print
+`No persistent approvals.` and exit 0. It is not an error — that is the
+out-of-the-box state on a fresh install. `revoke` against the same
+state exits 1 with `No matching approval found.` because the user
+asked for a removal that did not happen; silent success would mask
+typos in patterns or audience flags.
+
+## Risks / Trade-offs
+
+- **Race between daemon write and CLI write**:
+  `ToolApprovalStore` already uses a per-instance lock for read-modify-
+  write under `_lock`. The CLI and the daemon use different `ToolApprovalStore`
+  instances pointed at the same file. The window between
+  `Load → mutate → File.WriteAllText` is small and bounded; the worst
+  case is that one writer's change is overwritten by the other on a
+  near-simultaneous edit. Mitigation: this is the same risk the file
+  has had since PR #896 (operators could edit the file by hand while
+  the daemon was writing); not regressed by this change. If that risk
+  materializes in practice, a follow-up can introduce a file lock or
+  move writes onto the actor.
+- **Quarantined file (`.invalid`) leaves operator without their grants**:
+  Today `Load` already silently quarantines a malformed file. The CLI
+  must surface that fact rather than silently re-running on an empty
+  store. Mitigation: the CLI prints a single warning line on the next
+  invocation when it observes a `.invalid` sibling.
+- **Termina version drift**: The TUI page mirrors `ProviderManagerPage`
+  exactly, including reactive primitives. If Termina's reactive
+  surface changes, both pages move together — no incremental risk
+  here. Mitigation: tests focus on the single-shot `ApprovalsCommand`
+  surface where regressions are cheapest to catch; TUI is exercised
+  manually during the verification step.
+- **Comparer drift**: The CLI must use exactly the comparer
+  `ApprovalPatternMatching` uses, or revoke can fail to find an entry
+  the daemon would have matched. Mitigation: expose the comparer
+  publicly (or a small `Equals(left, right)` helper) and use it from
+  the CLI rather than re-deriving the platform check.
+
+## Migration Plan
+
+No schema or wire changes. Rolling back amounts to deleting the new
+files and removing the `approvals` registration. Existing
+`tool-approvals.json` files remain readable by both old and new
+versions throughout.
+
+## Open Questions
+
+None at this time. All four design questions surfaced during planning
+were resolved before this change was scaffolded.

--- a/openspec/changes/approvals-management-cli/proposal.md
+++ b/openspec/changes/approvals-management-cli/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+Directory-scoped persistent approvals (PR #896) accumulate one entry per
+trusted directory in `~/.netclaw/config/tool-approvals.json` per audience and
+tool. Today the only way to inspect or revoke those grants is to hand-edit
+JSON. As the file grows operators lose visibility into what they have
+trusted, and the friction-reduction benefit of persistent grants regresses
+into a security-hygiene liability. Issue #921 asks for an operator CLI so
+users can audit and revoke grants without touching the file directly.
+
+## What Changes
+
+- Add a `netclaw approvals` command surface with two modes:
+  - Bare `netclaw approvals` (and `netclaw approvals tui`) launches an
+    interactive Termina TUI page that lists grants grouped by audience and
+    tool, with a revoke action.
+  - Single-shot subcommands `list`, `revoke`, and `help` for scripting:
+    - `list` supports `--audience`, `--tool`, and `--json`.
+    - `revoke <pattern>` removes only exact matches (same case-sensitivity
+      rules as the daemon's matcher) optionally scoped by `--audience` and
+      `--tool`.
+    - `revoke --tool <name> --all` clears every entry for that tool in the
+      targeted audience(s).
+- Extend `Netclaw.Configuration.ToolApprovalStore` with `RemoveApproval`,
+  `RemoveAllForTool`, and a read-only `Snapshot` API. All writes remain under
+  the existing per-instance lock. The JSON schema is unchanged.
+- The CLI talks to the file directly through `ToolApprovalStore`. The daemon
+  already reloads the file on every approval check, so out-of-band CLI
+  edits are picked up without a restart and without new RPC on
+  `IToolApprovalService`.
+- Update the `netclaw-operations` system skill to point users at the new
+  CLI instead of hand-editing JSON.
+
+## Capabilities
+
+### New Capabilities
+
+None. The existing `netclaw-cli` capability already covers operator CLI
+surface area; this change adds a new requirement under it rather than
+introducing a new top-level capability.
+
+### Modified Capabilities
+
+- `netclaw-cli`: ADD a new requirement covering the `netclaw approvals`
+  command surface (TUI, list, revoke, exit-code semantics).
+- `tool-approval-gates`: MODIFY the existing
+  "Persistent approval storage" requirement to clarify that the file is
+  operator-editable both via direct edit and via the `netclaw approvals`
+  CLI, and that the daemon picks up changes on the next approval check
+  without a restart.
+
+## Impact
+
+**Code**:
+- `src/Netclaw.Configuration/ToolApprovalStore.cs` — new `RemoveApproval`,
+  `RemoveAllForTool`, and `Snapshot` methods.
+- `src/Netclaw.Cli/Approvals/` — new `ApprovalsCommand` and helpers.
+- `src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs` and view model.
+- `src/Netclaw.Cli/CliArgsParser.cs` and `Program.cs` — add `approvals`
+  command registration and dispatch.
+- `src/Netclaw.Cli.Tests/Approvals/` — new test suite.
+
+**Skills**:
+- `feeds/skills/.system/files/netclaw-operations/SKILL.md` — Approval
+  Prompts section update; metadata version bump.
+
+**APIs**: No public-protocol or wire-format changes. `IToolApprovalService`
+is unchanged. JSON file format is unchanged.
+
+**Security**: The CLI is a privileged-local operator tool (same trust level
+as direct file edit). Revoke operations only remove grants — they cannot
+add new privileges. Case sensitivity for `revoke` matching is delegated to
+`ApprovalPatternMatching` so it stays symmetric with the daemon's gate
+logic. There is no daemon-side cache to invalidate.
+
+**Operational**: Operators no longer need to know the JSON layout to
+manage their grants. The skill update teaches the running agent to
+recommend `netclaw approvals list / revoke` instead of editing JSON.

--- a/openspec/changes/approvals-management-cli/specs/netclaw-cli/spec.md
+++ b/openspec/changes/approvals-management-cli/specs/netclaw-cli/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Operator CLI for persistent tool approvals
+
+The CLI SHALL provide a `netclaw approvals` command surface for inspecting
+and revoking entries in the persistent approvals file
+(`~/.netclaw/config/tool-approvals.json`). The command SHALL operate on the
+file directly via `Netclaw.Configuration.ToolApprovalStore` without
+requiring the daemon to be running. Bare `netclaw approvals` (and
+`netclaw approvals tui`) SHALL launch an interactive Termina TUI page.
+Single-shot subcommands SHALL be `list`, `revoke`, and `help`.
+
+`list` SHALL accept `--audience <personal|team|public>`, `--tool <name>`,
+and `--json`. Without flags it SHALL print every audience and tool group
+in a stable order.
+
+`revoke <pattern>` SHALL remove only entries that match `<pattern>` exactly
+under the same case-sensitivity rules that the daemon uses for shell
+approval matching (Ordinal on POSIX, OrdinalIgnoreCase on Windows).
+`revoke` SHALL accept `--audience` and `--tool` to scope the removal.
+`revoke --tool <name> --all` SHALL clear every entry for that tool in the
+targeted audiences. `revoke` of a pattern that does not match any entry
+SHALL exit non-zero with a clear message; the CLI SHALL NOT silently
+succeed.
+
+The CLI SHALL NOT add or upgrade approvals; it is read-and-revoke only.
+Exit codes SHALL be 0 for success, 1 for user errors (bad flag combos,
+unknown audience, no match for revoke), and 2 for malformed-file
+conditions surfaced by the underlying store.
+
+#### Scenario: Empty approvals file lists no entries with exit zero
+
+- **GIVEN** `tool-approvals.json` does not exist or contains `{}`
+- **WHEN** the operator runs `netclaw approvals list`
+- **THEN** the CLI prints `No persistent approvals.`
+- **AND** exits with code `0`
+
+#### Scenario: List filters by audience
+
+- **GIVEN** `tool-approvals.json` contains entries under `personal` and `team`
+- **WHEN** the operator runs `netclaw approvals list --audience personal`
+- **THEN** only the `personal` audience entries are printed
+
+#### Scenario: List emits JSON with audience/tool/pattern shape
+
+- **GIVEN** `tool-approvals.json` contains
+  `{"audiences":{"personal":{"shell_execute":["git push"]}}}`
+- **WHEN** the operator runs `netclaw approvals list --json`
+- **THEN** the output is valid JSON
+- **AND** the structure groups patterns by audience and tool
+
+#### Scenario: Revoke removes only exact matches
+
+- **GIVEN** `tool-approvals.json` contains
+  `{"audiences":{"personal":{"shell_execute":["git push","/home/.netclaw/logs/"]}}}`
+- **WHEN** the operator runs `netclaw approvals revoke "git push" --tool shell_execute --audience personal`
+- **THEN** the `git push` entry is removed
+- **AND** `/home/.netclaw/logs/` remains
+- **AND** the CLI exits with code `0`
+
+#### Scenario: Revoke with no match exits non-zero
+
+- **GIVEN** `tool-approvals.json` does not contain `git push`
+- **WHEN** the operator runs `netclaw approvals revoke "git push"`
+- **THEN** the CLI prints a no-match message
+- **AND** exits with code `1`
+- **AND** does not modify the file
+
+#### Scenario: Revoke --tool --all clears all entries for the tool
+
+- **GIVEN** `tool-approvals.json` contains multiple `shell_execute` entries
+  under `personal`
+- **WHEN** the operator runs `netclaw approvals revoke --tool shell_execute --audience personal --all`
+- **THEN** every `shell_execute` entry under `personal` is removed
+- **AND** entries for other tools and other audiences are untouched
+
+#### Scenario: Revoke --all without --tool is rejected
+
+- **WHEN** the operator runs `netclaw approvals revoke --all`
+- **THEN** the CLI rejects the invocation with a clear usage message
+- **AND** exits with code `1`
+- **AND** does not modify the file
+
+#### Scenario: Daemon picks up CLI-applied revocation without restart
+
+- **GIVEN** the daemon is running and has previously approved `git push`
+- **WHEN** the operator runs `netclaw approvals revoke "git push" --tool shell_execute --audience personal`
+- **AND** a new session attempts `git push` afterwards
+- **THEN** the daemon prompts for approval again
+- **AND** the daemon was not restarted
+
+#### Scenario: Bare invocation launches the TUI
+
+- **WHEN** the operator runs `netclaw approvals` with no subcommand
+- **THEN** the CLI launches the interactive Termina approvals page

--- a/openspec/changes/approvals-management-cli/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/approvals-management-cli/specs/tool-approval-gates/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Persistent approval storage
+
+The system SHALL store persistent approvals ("Approve Always" decisions) in
+`~/.netclaw/config/tool-approvals.json`, separate from `netclaw.json`. The file
+SHALL NOT be monitored by `ConfigWatcherService`. The file SHALL contain
+per-audience sections with per-tool approval lists. For the shipped MVP shell
+flow, the lists SHALL contain exact approvals and directory roots as applicable.
+Approval lookup and recording SHALL be mediated by `IToolApprovalService`.
+
+The file SHALL also be operator-editable via the `netclaw approvals` CLI
+(see the `netclaw-cli` capability). The daemon SHALL pick up out-of-band
+edits — whether made by direct file editing or by the CLI — on the next
+approval check, without requiring a restart.
+
+#### Scenario: Approve always persists directory root to file
+
+- **GIVEN** the user clicks "Approve Always" for a command targeting
+  `/home/.netclaw/logs/crash.log`
+- **WHEN** the approval is processed
+- **THEN** `/home/.netclaw/logs/` is added to the Personal `shell_execute` list
+  in `tool-approvals.json`
+- **AND** the daemon does NOT restart
+
+#### Scenario: Persistent approvals loaded at startup
+
+- **GIVEN** `tool-approvals.json` contains
+  `{"personal":{"shell_execute":["git push", "/home/.netclaw/logs/"]}}`
+- **WHEN** the daemon starts
+- **THEN** `git push` is pre-approved for Personal audience shell commands
+- **AND** later shell approval units whose recognized local paths all stay under
+  `/home/.netclaw/logs/` are pre-approved
+
+#### Scenario: Approve once is retry-scoped only
+
+- **GIVEN** the user clicks "Approve Once" for pattern `docker build`
+- **WHEN** the approval is processed
+- **THEN** the blocked `docker build` call is retried immediately
+- **AND** a later `docker build` call in the same session prompts again
+- **AND** `tool-approvals.json` is NOT modified
+
+#### Scenario: Approve for this chat stores directory root in session
+
+- **GIVEN** the user clicks "Approve For This Chat" for a command targeting
+  `/home/.netclaw/logs/daemon.log`
+- **WHEN** the approval is processed
+- **THEN** the directory root is approved for the current session only
+- **AND** `tool-approvals.json` is NOT modified
+- **AND** a new session will prompt again
+
+#### Scenario: Operator-applied revocation visible without restart
+
+- **GIVEN** the daemon is running with a persisted approval for `git push`
+- **WHEN** an operator removes that entry via `netclaw approvals revoke`
+- **AND** a new approval check evaluates `git push`
+- **THEN** the daemon re-loads the file and observes the entry is gone
+- **AND** the user is prompted for approval again
+- **AND** the daemon was not restarted

--- a/openspec/changes/approvals-management-cli/tasks.md
+++ b/openspec/changes/approvals-management-cli/tasks.md
@@ -1,0 +1,66 @@
+## 1. Storage layer
+
+- [x] 1.1 Add `RemoveApproval(TrustAudience audience, string toolName, string pattern)` to `ToolApprovalStore` returning a bool indicating whether an entry was removed; comparisons under the same comparer used by `ApprovalPatternMatching`.
+- [x] 1.2 Add `RemoveAllForTool(TrustAudience audience, string toolName)` to `ToolApprovalStore` returning the count of entries removed; cleans up empty per-tool and per-audience maps.
+- [x] 1.3 Add `Snapshot()` to `ToolApprovalStore` returning a deep-cloned `ToolApprovalData` for read-only iteration.
+- [x] 1.4 Expose the platform comparer (or a `PatternsEqual(left, right)` helper) from `ApprovalPatternMatching` so the store can use it without duplicating the platform check.
+- [x] 1.5 Add round-trip unit tests in `Netclaw.Configuration.Tests` (or wherever `ToolApprovalStore` already has tests) covering each new method, including platform-correct case sensitivity and empty-section cleanup.
+
+## 2. Single-shot CLI surface
+
+- [x] 2.1 Create `src/Netclaw.Cli/Approvals/ApprovalsCommand.cs` with a static `RunAsync(string[] args, NetclawPaths paths, TextWriter? output = null)` entry mirroring `ProviderCommand`.
+- [x] 2.2 Implement `list` subcommand with `--audience`, `--tool`, and `--json` flags. Stable ordering (audience wire-value order, then tool name alpha, then pattern alpha). Empty state prints `No persistent approvals.` and exits 0.
+- [x] 2.3 Implement `revoke <pattern>` with `--audience`, `--tool` flags. Exact-match removal across all audiences/tools by default; scoped when flags are provided. No match → exit 1 with clear message.
+- [x] 2.4 Implement `revoke --tool <name> --all` (with optional `--audience`). Reject `--all` without `--tool` (exit 1, usage message).
+- [x] 2.5 Implement `help` and surface it for `--help` / `-h` / unknown subcommand.
+- [x] 2.6 Surface `.invalid` quarantine condition: when the CLI sees a sibling `.invalid` file next to `tool-approvals.json`, print a one-line warning before list/revoke output.
+
+## 3. TUI surface
+
+- [x] 3.1 Create `src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs` mirroring `ProviderManagerViewModel`. State enum: `Loading`, `List`, `RevokeConfirm`. Reactive properties for current state, status message, and the list of display items grouped by audience+tool.
+- [x] 3.2 Create `src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs` mirroring `ProviderManagerPage`. List view shows audience → tool → pattern. Up/Down to navigate, Delete (or `r`) to enter revoke-confirm, Enter to confirm, Esc to back out, `q` to quit.
+- [x] 3.3 Page reads via `ToolApprovalStore.Snapshot()` and refreshes after every revoke.
+- [ ] 3.4 Manual smoke: launch from a worktree, exercise revoke path against a seeded `tool-approvals.json`, confirm file changes match a subsequent `list` output.
+
+## 4. CLI dispatch wiring
+
+- [x] 4.1 Add `"approvals"` to `CliArgsParser.KnownCommands`.
+- [x] 4.2 Add `if (mode is "approvals")` block in `Program.cs` patterned after the `provider` block: bare-args path constructs `Host.CreateApplicationBuilder`, registers `ApprovalsManagerPage`/`ApprovalsManagerViewModel` via `AddTermina("/approvals", ...)`, configures Termina file tracing; subcommand path calls `await ApprovalsCommand.RunAsync(args, paths)` and propagates the exit code via `Environment.ExitCode`.
+- [x] 4.3 Treat `netclaw approvals tui` as an alias for the bare invocation.
+
+## 5. Tests
+
+- [x] 5.1 `src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs` with `DisposableTempDir` fixture (mirroring `ProviderCommandTests`).
+- [x] 5.2 Cover: empty file → list prints empty message + exit 0.
+- [x] 5.3 Cover: list with seeded entries → table contains expected lines.
+- [x] 5.4 Cover: list `--json` → JSON parses, has the documented audience/tool/patterns shape.
+- [x] 5.5 Cover: list `--audience personal --tool shell_execute` → only filtered entries.
+- [x] 5.6 Cover: revoke exact match → entry removed, file rewritten, exit 0.
+- [x] 5.7 Cover: revoke no match → file unchanged, exit 1, message printed.
+- [x] 5.8 Cover: revoke `--tool shell_execute --all` → all shell_execute entries removed across audiences (or scoped audience if specified), other tools untouched.
+- [x] 5.9 Cover: revoke `--all` without `--tool` → exit 1, file unchanged, usage message.
+- [x] 5.10 Cover: revoke unknown audience flag → exit 1, file unchanged, message.
+
+## 6. Skill update
+
+- [x] 6.1 Edit `feeds/skills/.system/files/netclaw-operations/SKILL.md` Approval Prompts section to recommend `netclaw approvals list / revoke` instead of hand-editing JSON. Keep the file-edit fallback documented as a last-resort recovery path.
+- [x] 6.2 Bump `metadata.version` from `1.26.0` to `1.27.0` in the YAML frontmatter. Do NOT run `generate-skill-manifest.sh`.
+
+## 7. Quality gates
+
+- [x] 7.1 `dotnet build` clean.
+- [x] 7.2 `dotnet test` passing for `Netclaw.Configuration.Tests` and `Netclaw.Cli.Tests`.
+- [x] 7.3 `dotnet slopwatch analyze` reports zero new violations.
+- [x] 7.4 `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` passes.
+
+## 8. Verification
+
+- [x] 8.1 End-to-end: fresh `NETCLAW_HOME`, `dotnet run --project src/Netclaw.Cli -- approvals list` → empty-state message, exit 0.
+- [ ] 8.2 End-to-end: seed an entry via a session "Approve always", run `netclaw approvals list`, observe the entry; revoke it; re-run the session and confirm the daemon prompts again without restart.
+- [ ] 8.3 End-to-end: run `netclaw approvals` (no args) → TUI renders, navigation and revoke flow work, file changes match a follow-up `list`.
+- [ ] 8.4 Run `netclaw doctor` post-mutation → `ToolAudienceProfilesDoctorCheck` still parses the file.
+
+## 9. Companion docs issue
+
+- [ ] 9.1 Open the implementation PR against `netclaw-dev/netclaw` closing issue #921.
+- [ ] 9.2 File a tracking issue against `netclaw-dev/netclaw-website` for documenting the `netclaw approvals` CLI, cross-linking the PR, issue #921, and the `tool-approval-gates` capability.

--- a/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
@@ -183,6 +183,28 @@ public sealed class ApprovalsCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Audience_flag_without_value_exits_one_with_specific_message()
+    {
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "list", "--audience"],
+            _paths, _output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--audience requires a value", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Tool_flag_without_value_exits_one_with_specific_message()
+    {
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "git push", "--tool"],
+            _paths, _output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--tool requires a value", _output.ToString());
+    }
+
+    [Fact]
     public async Task Help_subcommand_exits_zero_and_prints_usage()
     {
         var exit = await ApprovalsCommand.RunAsync(["approvals", "help"], _paths, _output);

--- a/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
@@ -1,0 +1,209 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsCommandTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Cli.Approvals;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Approvals;
+
+public sealed class ApprovalsCommandTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly StringWriter _output = new();
+    private readonly ToolApprovalStore _store;
+
+    public ApprovalsCommandTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+        _store = new ToolApprovalStore(_paths.ToolApprovalsPath);
+    }
+
+    public void Dispose()
+    {
+        _output.Dispose();
+        _dir.Dispose();
+    }
+
+    private void SeedDefault()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "/home/user/logs/");
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "npm install");
+        _store.AddApproval(TrustAudience.Personal, "file_write", "/tmp/scratch/");
+        _store.AddApproval(TrustAudience.Public, "shell_execute", "ls");
+    }
+
+    [Fact]
+    public async Task List_empty_file_prints_message_and_exits_zero()
+    {
+        var exit = await ApprovalsCommand.RunAsync(["approvals", "list"], _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("No persistent approvals.", _output.ToString());
+    }
+
+    [Fact]
+    public async Task List_with_entries_groups_by_audience_and_tool()
+    {
+        SeedDefault();
+
+        var exit = await ApprovalsCommand.RunAsync(["approvals", "list"], _paths, _output);
+
+        Assert.Equal(0, exit);
+        var text = _output.ToString();
+        Assert.Contains("personal / shell_execute", text);
+        Assert.Contains("personal / file_write", text);
+        Assert.Contains("public / shell_execute", text);
+        Assert.Contains("git push", text);
+        Assert.Contains("/tmp/scratch/", text);
+    }
+
+    [Fact]
+    public async Task List_json_emits_audience_tool_pattern_shape()
+    {
+        SeedDefault();
+
+        await ApprovalsCommand.RunAsync(["approvals", "list", "--json"], _paths, _output);
+
+        using var doc = JsonDocument.Parse(_output.ToString());
+        var audiences = doc.RootElement.GetProperty("audiences");
+        var personalShell = audiences.GetProperty("personal").GetProperty("shell_execute");
+        var patterns = personalShell.EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains("git push", patterns);
+        Assert.Contains("/home/user/logs/", patterns);
+        Assert.Contains("npm install", patterns);
+    }
+
+    [Fact]
+    public async Task List_filters_by_audience_and_tool()
+    {
+        SeedDefault();
+
+        await ApprovalsCommand.RunAsync(
+            ["approvals", "list", "--audience", "personal", "--tool", "shell_execute"],
+            _paths, _output);
+
+        var text = _output.ToString();
+        Assert.Contains("personal / shell_execute", text);
+        Assert.DoesNotContain("file_write", text);
+        Assert.DoesNotContain("public / shell_execute", text);
+    }
+
+    [Fact]
+    public async Task Revoke_exact_match_removes_entry_and_returns_zero()
+    {
+        SeedDefault();
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "git push", "--audience", "personal", "--tool", "shell_execute"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("git push", _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Contains("Removed 'git push'", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Revoke_no_match_exits_one_and_does_not_modify_file()
+    {
+        SeedDefault();
+        var beforeCount = _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute").Count;
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "git pull", "--audience", "personal", "--tool", "shell_execute"],
+            _paths, _output);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(beforeCount, _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute").Count);
+        Assert.Contains("No matching approval found.", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Revoke_tool_all_clears_every_entry_for_tool()
+    {
+        SeedDefault();
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "--tool", "shell_execute", "--all"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Public, "shell_execute"));
+        Assert.Single(_store.GetApprovedPatterns(TrustAudience.Personal, "file_write"));
+    }
+
+    [Fact]
+    public async Task Revoke_tool_all_scoped_by_audience_leaves_others_alone()
+    {
+        SeedDefault();
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "--tool", "shell_execute", "--all", "--audience", "personal"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Equal(["ls"], _store.GetApprovedPatterns(TrustAudience.Public, "shell_execute"));
+    }
+
+    [Fact]
+    public async Task Revoke_all_without_tool_exits_one_and_does_not_modify_file()
+    {
+        SeedDefault();
+        var beforeCount = _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute").Count;
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "--all"],
+            _paths, _output);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(beforeCount, _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute").Count);
+        Assert.Contains("--all requires --tool", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Unknown_audience_flag_exits_one()
+    {
+        SeedDefault();
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "list", "--audience", "foo"],
+            _paths, _output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Unknown audience 'foo'", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Help_subcommand_exits_zero_and_prints_usage()
+    {
+        var exit = await ApprovalsCommand.RunAsync(["approvals", "help"], _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Usage: netclaw approvals", _output.ToString());
+    }
+
+    [Fact]
+    public async Task Revoke_unscoped_removes_match_across_audiences()
+    {
+        // Same pattern stored under two audiences; unscoped revoke should hit both.
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "ls");
+        _store.AddApproval(TrustAudience.Public, "shell_execute", "ls");
+
+        var exit = await ApprovalsCommand.RunAsync(
+            ["approvals", "revoke", "ls"],
+            _paths, _output);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Public, "shell_execute"));
+    }
+}

--- a/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/CliArgsParserTests.cs
@@ -90,6 +90,7 @@ public sealed class CliArgsParserTests
             "chat", "sessions", "init", "doctor", "status", "stats",
             "daemon", "mcp", "provider", "model", "reminder",
             "secrets", "config", "update", "pair", "skill", "webhooks",
+            "approvals",
         };
 
         Assert.Equal(expected, CliArgsParser.KnownCommands);

--- a/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
@@ -1,0 +1,166 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsManagerPageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.DependencyInjection;
+using Netclaw.Cli.Tui;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Termina;
+using Termina.Hosting;
+using Termina.Input;
+using Termina.Terminal;
+using Xunit;
+
+namespace Netclaw.Cli.Tests.Tui;
+
+/// <summary>
+/// Headless TUI tests for <see cref="ApprovalsManagerPage"/> using Termina's
+/// <see cref="VirtualTerminal"/> and <see cref="VirtualInputSource"/>. Exercises
+/// the full Termina rendering and input-routing pipeline against a temporary
+/// <c>tool-approvals.json</c>.
+/// </summary>
+public sealed class ApprovalsManagerPageTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly NetclawPaths _paths;
+    private readonly ToolApprovalStore _store;
+
+    public ApprovalsManagerPageTests()
+    {
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+        _store = new ToolApprovalStore(_paths.ToolApprovalsPath);
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Fact]
+    public async Task EmptyStore_RendersEmptyMessageInTerminal()
+    {
+        var (terminal, app, _) = CreateHeadlessApp(out var input);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("Approvals Manager"),
+            $"Expected page title 'Approvals Manager' in terminal. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("No persistent approvals."),
+            $"Expected empty-state message. Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task SeededEntries_RenderedInList()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "file_write", "/tmp/scratch/");
+        _store.AddApproval(TrustAudience.Public, "shell_execute", "ls");
+
+        var (terminal, app, _) = CreateHeadlessApp(out var input);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("personal"),
+            $"Expected audience 'personal'. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("git push"),
+            $"Expected pattern 'git push'. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("/tmp/scratch/"),
+            $"Expected pattern '/tmp/scratch/'. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("ls"),
+            $"Expected pattern 'ls' (public audience). Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task PressingR_OnSelection_TransitionsToConfirmAndRevokesOnEnter()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "npm install");
+
+        var (_, app, vm) = CreateHeadlessApp(out var input);
+
+        // First displayed entry is sorted alphabetically by audience+tool+pattern,
+        // so the selection at index 0 is "personal / shell_execute / git push".
+        input.EnqueueKey(ConsoleKey.R);                 // Open revoke confirm.
+        input.EnqueueKey(ConsoleKey.Enter);             // Confirm "Yes, revoke".
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        var remaining = _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute");
+        Assert.DoesNotContain("git push", remaining);
+        Assert.Contains("npm install", remaining);
+        Assert.Equal(ApprovalsManagerState.List, vm.CurrentState.Value);
+    }
+
+    [Fact]
+    public async Task EscOnConfirm_CancelsRevoke()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+
+        var (_, app, _) = CreateHeadlessApp(out var input);
+
+        input.EnqueueKey(ConsoleKey.R);                 // Open revoke confirm.
+        input.EnqueueKey(ConsoleKey.Escape);            // Cancel.
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(["git push"],
+            _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+    }
+
+    [Fact]
+    public async Task RevokingLastEntry_TransitionsListIntoEmptyState()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+
+        var (terminal, app, vm) = CreateHeadlessApp(out var input);
+
+        input.EnqueueKey(ConsoleKey.R);
+        input.EnqueueKey(ConsoleKey.Enter);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.Equal(ApprovalsManagerState.Empty, vm.CurrentState.Value);
+        Assert.True(terminal.Contains("No persistent approvals."),
+            $"Expected empty state to render after final revoke. Screen:\n{terminal}");
+    }
+
+    private (VirtualTerminal Terminal, TerminaApplication App, ApprovalsManagerViewModel Vm)
+        CreateHeadlessApp(out VirtualInputSource input)
+    {
+        var terminal = new VirtualTerminal(120, 40);
+        var virtualInput = new VirtualInputSource();
+        input = virtualInput;
+
+        ApprovalsManagerViewModel? capturedVm = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAnsiTerminal>(terminal);
+        services.AddTerminaVirtualInput(virtualInput);
+        services.AddTermina("/approvals", builder =>
+        {
+            builder.RegisterRoute<ApprovalsManagerPage, ApprovalsManagerViewModel>(
+                "/approvals",
+                _ => new ApprovalsManagerPage(),
+                _ =>
+                {
+                    capturedVm = new ApprovalsManagerViewModel(_paths);
+                    return capturedVm;
+                });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var app = sp.GetRequiredService<TerminaApplication>();
+
+        return (terminal, app, capturedVm!);
+    }
+}

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -17,6 +17,13 @@ namespace Netclaw.Cli.Approvals;
 /// </summary>
 internal static class ApprovalsCommand
 {
+    private sealed record ListOptions(TrustAudience? Audience, string? Tool, bool EmitJson);
+
+    private sealed record RevokeOptions(string? Pattern, TrustAudience? Audience, string? Tool, bool RevokeAll);
+
+    private static readonly TrustAudience[] AllAudiences =
+        [TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public];
+
     public static Task<int> RunAsync(
         string[] args,
         NetclawPaths paths,
@@ -36,16 +43,15 @@ internal static class ApprovalsCommand
 
     private static int RunList(string[] args, NetclawPaths paths, TextWriter writer)
     {
-        if (!TryParseListFlags(args, writer, out var audienceFilter, out var toolFilter, out var emitJson))
+        if (TryParseListFlags(args, writer) is not { } opts)
             return 1;
 
-        WarnIfQuarantined(paths, writer);
-
         var store = new ToolApprovalStore(paths.ToolApprovalsPath);
-        var snapshot = store.Snapshot();
-        var view = BuildView(snapshot, audienceFilter, toolFilter);
+        WarnIfQuarantined(store, writer);
 
-        if (emitJson)
+        var view = BuildView(store.Snapshot(), opts.Audience, opts.Tool);
+
+        if (opts.EmitJson)
         {
             writer.WriteLine(JsonSerializer.Serialize(view, JsonDefaults.Indented));
             return 0;
@@ -58,13 +64,13 @@ internal static class ApprovalsCommand
         }
 
         var first = true;
-        foreach (var audienceKey in view.Audiences.Keys.OrderBy(k => k, StringComparer.Ordinal))
+        foreach (var (audienceKey, tools) in view.Audiences)
         {
-            foreach (var toolName in view.Audiences[audienceKey].Keys.OrderBy(k => k, StringComparer.Ordinal))
+            foreach (var (toolName, patterns) in tools)
             {
                 if (!first) writer.WriteLine();
                 writer.WriteLine($"{audienceKey} / {toolName}");
-                foreach (var pattern in view.Audiences[audienceKey][toolName].OrderBy(p => p, StringComparer.Ordinal))
+                foreach (var pattern in patterns)
                     writer.WriteLine($"  {pattern}");
                 first = false;
             }
@@ -75,41 +81,23 @@ internal static class ApprovalsCommand
 
     private static int RunRevoke(string[] args, NetclawPaths paths, TextWriter writer)
     {
-        if (!TryParseRevokeFlags(args, writer, out var pattern, out var audienceFilter, out var toolFilter, out var revokeAll))
+        if (TryParseRevokeFlags(args, writer) is not { } opts)
             return 1;
 
-        if (revokeAll && toolFilter is null)
+        if (opts.RevokeAll && opts.Tool is null)
         {
             writer.WriteLine("Error: --all requires --tool <name>.");
             writer.WriteLine("Usage: netclaw approvals revoke --tool <name> --all [--audience personal|team|public]");
             return 1;
         }
 
-        WarnIfQuarantined(paths, writer);
-
         var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        WarnIfQuarantined(store, writer);
 
-        if (revokeAll)
-        {
-            var audiences = audienceFilter is null
-                ? new[] { TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public }
-                : [audienceFilter.Value];
+        if (opts.RevokeAll)
+            return RunRevokeAll(opts, store, writer);
 
-            var totalRemoved = 0;
-            foreach (var audience in audiences)
-                totalRemoved += store.RemoveAllForTool(audience, toolFilter!);
-
-            if (totalRemoved == 0)
-            {
-                writer.WriteLine($"No approvals found for tool '{toolFilter}'.");
-                return 1;
-            }
-
-            writer.WriteLine($"Removed {totalRemoved} approval(s) for tool '{toolFilter}'.");
-            return 0;
-        }
-
-        if (pattern is null)
+        if (opts.Pattern is null)
         {
             writer.WriteLine("Usage: netclaw approvals revoke <pattern> [--tool <name>] [--audience personal|team|public]");
             writer.WriteLine("       netclaw approvals revoke --tool <name> --all [--audience personal|team|public]");
@@ -119,21 +107,21 @@ internal static class ApprovalsCommand
         var snapshot = store.Snapshot();
         var removedAny = false;
 
-        foreach (var (audienceKey, tools) in snapshot.Audiences)
+        foreach (var (audienceKey, tools) in snapshot)
         {
             if (!SecurityPolicyDefaults.TryParseAudience(audienceKey, out var audience))
                 continue;
-            if (audienceFilter is not null && audience != audienceFilter.Value)
+            if (opts.Audience is { } target && audience != target)
                 continue;
 
             foreach (var (toolName, _) in tools)
             {
-                if (toolFilter is not null && !string.Equals(toolName, toolFilter, StringComparison.Ordinal))
+                if (opts.Tool is not null && !string.Equals(toolName, opts.Tool, StringComparison.Ordinal))
                     continue;
 
-                if (store.RemoveApproval(audience, toolName, pattern))
+                if (store.RemoveApproval(audience, toolName, opts.Pattern))
                 {
-                    writer.WriteLine($"Removed '{pattern}' from {audienceKey} / {toolName}.");
+                    writer.WriteLine($"Removed '{opts.Pattern}' from {audienceKey} / {toolName}.");
                     removedAny = true;
                 }
             }
@@ -145,6 +133,23 @@ internal static class ApprovalsCommand
             return 1;
         }
 
+        return 0;
+    }
+
+    private static int RunRevokeAll(RevokeOptions opts, ToolApprovalStore store, TextWriter writer)
+    {
+        var audiences = opts.Audience is { } only ? [only] : AllAudiences;
+        var totalRemoved = 0;
+        foreach (var audience in audiences)
+            totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
+
+        if (totalRemoved == 0)
+        {
+            writer.WriteLine($"No approvals found for tool '{opts.Tool}'.");
+            return 1;
+        }
+
+        writer.WriteLine($"Removed {totalRemoved} approval(s) for tool '{opts.Tool}'.");
         return 0;
     }
 
@@ -163,56 +168,90 @@ internal static class ApprovalsCommand
         writer.WriteLine("                    Flags: --audience <personal|team|public>");
         writer.WriteLine("  help              Show this message.");
         writer.WriteLine();
-        writer.WriteLine("Exit codes: 0 success, 1 user error or no match, 2 malformed file.");
+        writer.WriteLine("Exit codes: 0 success, 1 user error or no match.");
         writer.WriteLine();
         writer.WriteLine("The daemon does not require a restart after a revoke; the next approval");
         writer.WriteLine("check re-reads the file.");
         return 0;
     }
 
-    private static bool TryParseListFlags(
-        string[] args, TextWriter writer,
-        out TrustAudience? audienceFilter, out string? toolFilter, out bool emitJson)
+    private enum FlagOutcome { NotMine, Consumed, Error }
+
+    /// <summary>
+    /// Tries to consume a flag that <c>list</c> and <c>revoke</c> share
+    /// (<c>--audience</c>, <c>--tool</c>). Advances <paramref name="i"/> past
+    /// the flag's value when applicable. Returns <see cref="FlagOutcome.Error"/>
+    /// after writing a message if the flag is recognized but malformed.
+    /// </summary>
+    private static FlagOutcome TryConsumeSharedFlag(
+        string[] args, ref int i, TextWriter writer,
+        ref TrustAudience? audience, ref string? tool)
     {
-        audienceFilter = null;
-        toolFilter = null;
-        emitJson = false;
+        var arg = args[i];
+        switch (arg)
+        {
+            case "--audience":
+                if (i + 1 >= args.Length)
+                {
+                    writer.WriteLine("Error: --audience requires a value (personal, team, or public).");
+                    return FlagOutcome.Error;
+                }
+                var value = args[++i];
+                if (!SecurityPolicyDefaults.TryParseAudience(value, out var parsed))
+                {
+                    writer.WriteLine($"Error: Unknown audience '{value}'. Expected: personal, team, public.");
+                    return FlagOutcome.Error;
+                }
+                audience = parsed;
+                return FlagOutcome.Consumed;
+
+            case "--tool":
+                if (i + 1 >= args.Length)
+                {
+                    writer.WriteLine("Error: --tool requires a value.");
+                    return FlagOutcome.Error;
+                }
+                tool = args[++i];
+                return FlagOutcome.Consumed;
+
+            default:
+                return FlagOutcome.NotMine;
+        }
+    }
+
+    private static ListOptions? TryParseListFlags(string[] args, TextWriter writer)
+    {
+        TrustAudience? audience = null;
+        string? tool = null;
+        var emitJson = false;
 
         for (var i = 2; i < args.Length; i++)
         {
-            switch (args[i])
+            if (args[i] == "--json")
             {
-                case "--json":
-                    emitJson = true;
-                    break;
-                case "--audience" when i + 1 < args.Length:
-                    if (!SecurityPolicyDefaults.TryParseAudience(args[++i], out var audience))
-                    {
-                        writer.WriteLine($"Error: Unknown audience '{args[i]}'. Expected: personal, team, public.");
-                        return false;
-                    }
-                    audienceFilter = audience;
-                    break;
-                case "--tool" when i + 1 < args.Length:
-                    toolFilter = args[++i];
-                    break;
-                default:
-                    writer.WriteLine($"Error: Unknown flag or missing value: {args[i]}");
-                    return false;
+                emitJson = true;
+                continue;
             }
+
+            switch (TryConsumeSharedFlag(args, ref i, writer, ref audience, ref tool))
+            {
+                case FlagOutcome.Consumed: continue;
+                case FlagOutcome.Error: return null;
+            }
+
+            writer.WriteLine($"Error: Unknown flag: {args[i]}");
+            return null;
         }
 
-        return true;
+        return new ListOptions(audience, tool, emitJson);
     }
 
-    private static bool TryParseRevokeFlags(
-        string[] args, TextWriter writer,
-        out string? pattern, out TrustAudience? audienceFilter, out string? toolFilter, out bool revokeAll)
+    private static RevokeOptions? TryParseRevokeFlags(string[] args, TextWriter writer)
     {
-        pattern = null;
-        audienceFilter = null;
-        toolFilter = null;
-        revokeAll = false;
+        string? pattern = null;
+        TrustAudience? audience = null;
+        string? tool = null;
+        var revokeAll = false;
 
         for (var i = 2; i < args.Length; i++)
         {
@@ -224,47 +263,37 @@ internal static class ApprovalsCommand
                 continue;
             }
 
-            if (arg == "--audience" && i + 1 < args.Length)
+            switch (TryConsumeSharedFlag(args, ref i, writer, ref audience, ref tool))
             {
-                if (!SecurityPolicyDefaults.TryParseAudience(args[++i], out var audience))
-                {
-                    writer.WriteLine($"Error: Unknown audience '{args[i]}'. Expected: personal, team, public.");
-                    return false;
-                }
-                audienceFilter = audience;
-                continue;
-            }
-
-            if (arg == "--tool" && i + 1 < args.Length)
-            {
-                toolFilter = args[++i];
-                continue;
+                case FlagOutcome.Consumed: continue;
+                case FlagOutcome.Error: return null;
             }
 
             if (arg.StartsWith("--", StringComparison.Ordinal))
             {
                 writer.WriteLine($"Error: Unknown flag: {arg}");
-                return false;
+                return null;
             }
 
-            // Positional pattern; reject duplicates.
             if (pattern is not null)
             {
                 writer.WriteLine($"Error: Unexpected extra argument: {arg}");
-                return false;
+                return null;
             }
             pattern = arg;
         }
 
-        return true;
+        return new RevokeOptions(pattern, audience, tool, revokeAll);
     }
 
     private static ApprovalsListView BuildView(
-        ToolApprovalData snapshot, TrustAudience? audienceFilter, string? toolFilter)
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>> snapshot,
+        TrustAudience? audienceFilter,
+        string? toolFilter)
     {
         var view = new ApprovalsListView();
 
-        foreach (var (audienceKey, tools) in snapshot.Audiences)
+        foreach (var (audienceKey, tools) in snapshot)
         {
             if (audienceFilter is not null)
             {
@@ -288,14 +317,13 @@ internal static class ApprovalsCommand
         return view;
     }
 
-    private static void WarnIfQuarantined(NetclawPaths paths, TextWriter writer)
+    private static void WarnIfQuarantined(ToolApprovalStore store, TextWriter writer)
     {
-        var quarantine = paths.ToolApprovalsPath + ".invalid";
-        if (File.Exists(quarantine))
-        {
-            writer.WriteLine($"Warning: A quarantined approvals file exists at '{quarantine}'.");
-            writer.WriteLine("         The active file was reset to empty after a parse failure.");
-            writer.WriteLine("         Inspect the .invalid copy before restoring grants.");
-        }
+        if (!File.Exists(store.QuarantinePath))
+            return;
+
+        writer.WriteLine($"Warning: A quarantined approvals file exists at '{store.QuarantinePath}'.");
+        writer.WriteLine("         The active file was reset to empty after a parse failure.");
+        writer.WriteLine("         Inspect the .invalid copy before restoring grants.");
     }
 }

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -1,0 +1,301 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsCommand.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Cli.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Cli.Approvals;
+
+/// <summary>
+/// Handles <c>netclaw approvals</c> single-shot subcommands: list, revoke, help.
+/// Operates on <c>tool-approvals.json</c> directly via
+/// <see cref="ToolApprovalStore"/>; the daemon picks up changes on its next
+/// approval check without a restart.
+/// </summary>
+internal static class ApprovalsCommand
+{
+    public static Task<int> RunAsync(
+        string[] args,
+        NetclawPaths paths,
+        TextWriter? output = null)
+    {
+        var writer = output ?? Console.Out;
+        var subcommand = args.Length > 1 ? args[1] : "help";
+
+        return subcommand switch
+        {
+            "list" => Task.FromResult(RunList(args, paths, writer)),
+            "revoke" => Task.FromResult(RunRevoke(args, paths, writer)),
+            "help" or "-h" or "--help" => Task.FromResult(WriteHelp(writer)),
+            _ => Task.FromResult(WriteHelp(writer)),
+        };
+    }
+
+    private static int RunList(string[] args, NetclawPaths paths, TextWriter writer)
+    {
+        if (!TryParseListFlags(args, writer, out var audienceFilter, out var toolFilter, out var emitJson))
+            return 1;
+
+        WarnIfQuarantined(paths, writer);
+
+        var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        var snapshot = store.Snapshot();
+        var view = BuildView(snapshot, audienceFilter, toolFilter);
+
+        if (emitJson)
+        {
+            writer.WriteLine(JsonSerializer.Serialize(view, JsonDefaults.Indented));
+            return 0;
+        }
+
+        if (view.Audiences.Count == 0)
+        {
+            writer.WriteLine("No persistent approvals.");
+            return 0;
+        }
+
+        var first = true;
+        foreach (var audienceKey in view.Audiences.Keys.OrderBy(k => k, StringComparer.Ordinal))
+        {
+            foreach (var toolName in view.Audiences[audienceKey].Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                if (!first) writer.WriteLine();
+                writer.WriteLine($"{audienceKey} / {toolName}");
+                foreach (var pattern in view.Audiences[audienceKey][toolName].OrderBy(p => p, StringComparer.Ordinal))
+                    writer.WriteLine($"  {pattern}");
+                first = false;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int RunRevoke(string[] args, NetclawPaths paths, TextWriter writer)
+    {
+        if (!TryParseRevokeFlags(args, writer, out var pattern, out var audienceFilter, out var toolFilter, out var revokeAll))
+            return 1;
+
+        if (revokeAll && toolFilter is null)
+        {
+            writer.WriteLine("Error: --all requires --tool <name>.");
+            writer.WriteLine("Usage: netclaw approvals revoke --tool <name> --all [--audience personal|team|public]");
+            return 1;
+        }
+
+        WarnIfQuarantined(paths, writer);
+
+        var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+
+        if (revokeAll)
+        {
+            var audiences = audienceFilter is null
+                ? new[] { TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public }
+                : [audienceFilter.Value];
+
+            var totalRemoved = 0;
+            foreach (var audience in audiences)
+                totalRemoved += store.RemoveAllForTool(audience, toolFilter!);
+
+            if (totalRemoved == 0)
+            {
+                writer.WriteLine($"No approvals found for tool '{toolFilter}'.");
+                return 1;
+            }
+
+            writer.WriteLine($"Removed {totalRemoved} approval(s) for tool '{toolFilter}'.");
+            return 0;
+        }
+
+        if (pattern is null)
+        {
+            writer.WriteLine("Usage: netclaw approvals revoke <pattern> [--tool <name>] [--audience personal|team|public]");
+            writer.WriteLine("       netclaw approvals revoke --tool <name> --all [--audience personal|team|public]");
+            return 1;
+        }
+
+        var snapshot = store.Snapshot();
+        var removedAny = false;
+
+        foreach (var (audienceKey, tools) in snapshot.Audiences)
+        {
+            if (!SecurityPolicyDefaults.TryParseAudience(audienceKey, out var audience))
+                continue;
+            if (audienceFilter is not null && audience != audienceFilter.Value)
+                continue;
+
+            foreach (var (toolName, _) in tools)
+            {
+                if (toolFilter is not null && !string.Equals(toolName, toolFilter, StringComparison.Ordinal))
+                    continue;
+
+                if (store.RemoveApproval(audience, toolName, pattern))
+                {
+                    writer.WriteLine($"Removed '{pattern}' from {audienceKey} / {toolName}.");
+                    removedAny = true;
+                }
+            }
+        }
+
+        if (!removedAny)
+        {
+            writer.WriteLine("No matching approval found.");
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static int WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("Usage: netclaw approvals [<subcommand>] [<args>]");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("  (none) | tui      Launch the interactive approvals TUI.");
+        writer.WriteLine("  list              List persistent approvals from tool-approvals.json.");
+        writer.WriteLine("                    Flags: --audience <personal|team|public>, --tool <name>, --json");
+        writer.WriteLine("  revoke <pattern>  Remove an exact-match approval entry.");
+        writer.WriteLine("                    Flags: --audience <personal|team|public>, --tool <name>");
+        writer.WriteLine("  revoke --tool <name> --all");
+        writer.WriteLine("                    Remove every approval entry for a tool.");
+        writer.WriteLine("                    Flags: --audience <personal|team|public>");
+        writer.WriteLine("  help              Show this message.");
+        writer.WriteLine();
+        writer.WriteLine("Exit codes: 0 success, 1 user error or no match, 2 malformed file.");
+        writer.WriteLine();
+        writer.WriteLine("The daemon does not require a restart after a revoke; the next approval");
+        writer.WriteLine("check re-reads the file.");
+        return 0;
+    }
+
+    private static bool TryParseListFlags(
+        string[] args, TextWriter writer,
+        out TrustAudience? audienceFilter, out string? toolFilter, out bool emitJson)
+    {
+        audienceFilter = null;
+        toolFilter = null;
+        emitJson = false;
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--json":
+                    emitJson = true;
+                    break;
+                case "--audience" when i + 1 < args.Length:
+                    if (!SecurityPolicyDefaults.TryParseAudience(args[++i], out var audience))
+                    {
+                        writer.WriteLine($"Error: Unknown audience '{args[i]}'. Expected: personal, team, public.");
+                        return false;
+                    }
+                    audienceFilter = audience;
+                    break;
+                case "--tool" when i + 1 < args.Length:
+                    toolFilter = args[++i];
+                    break;
+                default:
+                    writer.WriteLine($"Error: Unknown flag or missing value: {args[i]}");
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseRevokeFlags(
+        string[] args, TextWriter writer,
+        out string? pattern, out TrustAudience? audienceFilter, out string? toolFilter, out bool revokeAll)
+    {
+        pattern = null;
+        audienceFilter = null;
+        toolFilter = null;
+        revokeAll = false;
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            if (arg == "--all")
+            {
+                revokeAll = true;
+                continue;
+            }
+
+            if (arg == "--audience" && i + 1 < args.Length)
+            {
+                if (!SecurityPolicyDefaults.TryParseAudience(args[++i], out var audience))
+                {
+                    writer.WriteLine($"Error: Unknown audience '{args[i]}'. Expected: personal, team, public.");
+                    return false;
+                }
+                audienceFilter = audience;
+                continue;
+            }
+
+            if (arg == "--tool" && i + 1 < args.Length)
+            {
+                toolFilter = args[++i];
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                writer.WriteLine($"Error: Unknown flag: {arg}");
+                return false;
+            }
+
+            // Positional pattern; reject duplicates.
+            if (pattern is not null)
+            {
+                writer.WriteLine($"Error: Unexpected extra argument: {arg}");
+                return false;
+            }
+            pattern = arg;
+        }
+
+        return true;
+    }
+
+    private static ApprovalsListView BuildView(
+        ToolApprovalData snapshot, TrustAudience? audienceFilter, string? toolFilter)
+    {
+        var view = new ApprovalsListView();
+
+        foreach (var (audienceKey, tools) in snapshot.Audiences)
+        {
+            if (audienceFilter is not null)
+            {
+                if (!SecurityPolicyDefaults.TryParseAudience(audienceKey, out var parsed)) continue;
+                if (parsed != audienceFilter.Value) continue;
+            }
+
+            var filteredTools = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+            foreach (var (toolName, patterns) in tools)
+            {
+                if (toolFilter is not null && !string.Equals(toolName, toolFilter, StringComparison.Ordinal))
+                    continue;
+                if (patterns.Count == 0) continue;
+                filteredTools[toolName] = [.. patterns.OrderBy(p => p, StringComparer.Ordinal)];
+            }
+
+            if (filteredTools.Count > 0)
+                view.Audiences[audienceKey] = filteredTools;
+        }
+
+        return view;
+    }
+
+    private static void WarnIfQuarantined(NetclawPaths paths, TextWriter writer)
+    {
+        var quarantine = paths.ToolApprovalsPath + ".invalid";
+        if (File.Exists(quarantine))
+        {
+            writer.WriteLine($"Warning: A quarantined approvals file exists at '{quarantine}'.");
+            writer.WriteLine("         The active file was reset to empty after a parse failure.");
+            writer.WriteLine("         Inspect the .invalid copy before restoring grants.");
+        }
+    }
+}

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -21,8 +21,6 @@ internal static class ApprovalsCommand
 
     private sealed record RevokeOptions(string? Pattern, TrustAudience? Audience, string? Tool, bool RevokeAll);
 
-    private static readonly TrustAudience[] AllAudiences =
-        [TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public];
 
     public static Task<int> RunAsync(
         string[] args,
@@ -138,10 +136,16 @@ internal static class ApprovalsCommand
 
     private static int RunRevokeAll(RevokeOptions opts, ToolApprovalStore store, TextWriter writer)
     {
-        var audiences = opts.Audience is { } only ? [only] : AllAudiences;
         var totalRemoved = 0;
-        foreach (var audience in audiences)
-            totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
+        if (opts.Audience is { } only)
+        {
+            totalRemoved = store.RemoveAllForTool(only, opts.Tool!);
+        }
+        else
+        {
+            foreach (var audience in TrustAudiences.All)
+                totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
+        }
 
         if (totalRemoved == 0)
         {

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -136,16 +136,10 @@ internal static class ApprovalsCommand
 
     private static int RunRevokeAll(RevokeOptions opts, ToolApprovalStore store, TextWriter writer)
     {
+        IEnumerable<TrustAudience> audiences = opts.Audience is { } only ? [only] : TrustAudiences.All;
         var totalRemoved = 0;
-        if (opts.Audience is { } only)
-        {
-            totalRemoved = store.RemoveAllForTool(only, opts.Tool!);
-        }
-        else
-        {
-            foreach (var audience in TrustAudiences.All)
-                totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
-        }
+        foreach (var audience in audiences)
+            totalRemoved += store.RemoveAllForTool(audience, opts.Tool!);
 
         if (totalRemoved == 0)
         {

--- a/src/Netclaw.Cli/Approvals/ApprovalsListView.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsListView.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsListView.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Cli.Approvals;
+
+/// <summary>
+/// Stable JSON output shape for <c>netclaw approvals list --json</c>. Uses the
+/// same audience/tool/patterns layout as <c>tool-approvals.json</c> so scripts
+/// can reuse parsers across both surfaces.
+/// </summary>
+internal sealed class ApprovalsListView
+{
+    [JsonPropertyName("audiences")]
+    public SortedDictionary<string, SortedDictionary<string, List<string>>> Audiences { get; }
+        = new(StringComparer.Ordinal);
+}

--- a/src/Netclaw.Cli/CliArgsParser.cs
+++ b/src/Netclaw.Cli/CliArgsParser.cs
@@ -33,6 +33,7 @@ public static class CliArgsParser
         "chat", "sessions", "init", "doctor", "status", "stats",
         "daemon", "mcp", "provider", "model", "reminder",
         "secrets", "config", "update", "pair", "skill", "webhooks",
+        "approvals",
     };
 
     /// <summary>Returns <c>true</c> if the token is a help flag (<c>help</c>, <c>-h</c>, <c>--help</c>).</summary>

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -183,9 +183,8 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             _pendingGrants[serverName.Value] = audienceGrants;
     }
 
-    // Most-trusted-first cycling order. Sourced from TrustAudiences.All so new
-    // audiences flow through automatically; the .Reverse() preserves the
-    // original UI behavior (Personal → Team → Public on right-arrow).
+    // Most-trusted-first cycling order (Personal → Team → Public). Sourced
+    // from TrustAudiences.All so new audiences flow through automatically.
     private static readonly ImmutableArray<TrustAudience> AudienceValues =
         [.. TrustAudiences.All.Reverse()];
 

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Immutable;
 using System.Text.Json;
 using Netclaw.Cli.Config;
 using Netclaw.Cli.Daemon;
@@ -182,19 +183,22 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             _pendingGrants[serverName.Value] = audienceGrants;
     }
 
-    private static readonly TrustAudience[] AudienceValues =
-        [TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public];
+    // Most-trusted-first cycling order. Sourced from TrustAudiences.All so new
+    // audiences flow through automatically; the .Reverse() preserves the
+    // original UI behavior (Personal → Team → Public on right-arrow).
+    private static readonly ImmutableArray<TrustAudience> AudienceValues =
+        [.. TrustAudiences.All.Reverse()];
 
     public void CycleAudience()
     {
-        var idx = Array.IndexOf(AudienceValues, SelectedAudience);
+        var idx = AudienceValues.IndexOf(SelectedAudience);
         SelectedAudience = AudienceValues[(idx + 1) % AudienceValues.Length];
         NotifyStateChanged();
     }
 
     public void CycleAudienceBack()
     {
-        var idx = Array.IndexOf(AudienceValues, SelectedAudience);
+        var idx = AudienceValues.IndexOf(SelectedAudience);
         SelectedAudience = AudienceValues[(idx - 1 + AudienceValues.Length) % AudienceValues.Length];
         NotifyStateChanged();
     }

--- a/src/Netclaw.Cli/Program.cs
+++ b/src/Netclaw.Cli/Program.cs
@@ -14,6 +14,7 @@ using System.Text.Json.Nodes;
 using Netclaw.Channels;
 using Netclaw.Channels.Slack;
 using Netclaw.Cli;
+using Netclaw.Cli.Approvals;
 using Netclaw.Cli.Daemon;
 using Netclaw.Cli.Discord;
 using Netclaw.Cli.Json;
@@ -730,6 +731,35 @@ static async Task RunAsync(string[] args)
         }
 
         Environment.ExitCode = await ModelCommand.RunAsync(args, paths);
+        return;
+    }
+
+    // ── Approvals management ──
+    if (mode is "approvals")
+    {
+        var paths = new NetclawPaths();
+        paths.EnsureDirectoriesExist();
+
+        var isTuiInvocation = args.Length == 1 || (args.Length > 1 && args[1] is "tui");
+        if (isTuiInvocation)
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            ConfigureConfigServices(builder.Services, builder.Configuration);
+            builder.Services.AddSingleton(paths);
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+            var traceFile = Path.Combine(Path.GetTempPath(), "netclaw-approvals-trace.log");
+            builder.Services.AddTerminaFileTracing(traceFile, TerminaTraceCategory.All, TerminaTraceLevel.Trace);
+
+            builder.Services.AddTermina("/approvals", t =>
+                t.RegisterRoute<ApprovalsManagerPage, ApprovalsManagerViewModel>("/approvals"));
+
+            await builder.Build().RunAsync();
+            return;
+        }
+
+        Environment.ExitCode = await ApprovalsCommand.RunAsync(args, paths);
         return;
     }
 

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
@@ -188,6 +188,12 @@ public sealed class ApprovalsManagerPage : ReactivePage<ApprovalsManagerViewMode
         var state = ViewModel.CurrentState.Value;
         var keyInfo = key.KeyInfo;
 
+        if (keyInfo.Key == ConsoleKey.Q && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
+        {
+            ViewModel.RequestQuit();
+            return;
+        }
+
         if (keyInfo.Key == ConsoleKey.Escape)
         {
             if (state == ApprovalsManagerState.RevokeConfirm)

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
@@ -1,0 +1,219 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsManagerPage.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using R3;
+using Termina.Extensions;
+using Termina.Input;
+using Termina.Layout;
+using Termina.Reactive;
+using Termina.Rendering;
+using Termina.Terminal;
+
+namespace Netclaw.Cli.Tui;
+
+/// <summary>
+/// Termina page for <c>netclaw approvals</c>. Lists persistent approvals
+/// grouped by audience and tool; supports revoke via Delete or R with a
+/// confirmation step. Read-and-revoke only — the page never adds grants.
+/// </summary>
+public sealed class ApprovalsManagerPage : ReactivePage<ApprovalsManagerViewModel>
+{
+    private SelectionListNode<string>? _approvalList;
+    private SelectionListNode<string>? _confirmList;
+    private DynamicLayoutNode? _contentNode;
+    private readonly CompositeDisposable _stepSubs = [];
+
+    protected override void OnBound()
+    {
+        base.OnBound();
+        ViewModel.Input.OfType<IInputEvent, KeyPressed>()
+            .Subscribe(HandleKeyPress)
+            .DisposeWith(Subscriptions);
+    }
+
+    public override ILayoutNode BuildLayout()
+    {
+        return Layouts.Vertical()
+            .WithChild(
+                new PanelNode()
+                    .WithTitle("Approvals Manager")
+                    .WithBorder(BorderStyle.Rounded)
+                    .WithBorderColor(Color.Cyan)
+                    .WithContent(BuildInnerLayout())
+                    .Fill());
+    }
+
+    private ILayoutNode BuildInnerLayout()
+    {
+        return Layouts.Vertical()
+            .WithSpacing(1)
+            .WithChild(BuildContent())
+            .WithChild(Layouts.Empty().Fill())
+            .WithChild(BuildStatusBar())
+            .WithChild(BuildKeyBindings());
+    }
+
+    private LayoutNode BuildContent()
+    {
+        _contentNode = new DynamicLayoutNode(() =>
+        {
+            _stepSubs.Clear();
+
+            return ViewModel.CurrentState.Value switch
+            {
+                ApprovalsManagerState.Loading => BuildLoadingView(),
+                ApprovalsManagerState.Empty => BuildEmptyView(),
+                ApprovalsManagerState.List => BuildListView(),
+                ApprovalsManagerState.RevokeConfirm => BuildRevokeConfirmView(),
+                _ => Layouts.Empty()
+            };
+        });
+
+        ViewModel.StateVersion
+            .Subscribe(_ => _contentNode.Invalidate())
+            .DisposeWith(Subscriptions);
+
+        return _contentNode;
+    }
+
+    private LayoutNode BuildStatusBar()
+    {
+        return ViewModel.StatusMessage
+            .Select(msg => (ILayoutNode)(string.IsNullOrWhiteSpace(msg)
+                ? Layouts.Empty()
+                : new TextNode($"  {msg}").WithForeground(Color.Green)))
+            .AsLayout()
+            .Height(1);
+    }
+
+    private LayoutNode BuildKeyBindings()
+    {
+        return ViewModel.CurrentState
+            .Select(state =>
+            {
+                var text = state switch
+                {
+                    ApprovalsManagerState.Empty =>
+                        " [Ctrl+Q] Quit",
+                    ApprovalsManagerState.List =>
+                        " [↑/↓] Navigate  [R/Del] Revoke  [Ctrl+Q] Quit",
+                    ApprovalsManagerState.RevokeConfirm =>
+                        " [Enter] Confirm  [Esc] Cancel  [Ctrl+Q] Quit",
+                    _ =>
+                        " [Ctrl+Q] Quit"
+                };
+                return (ILayoutNode)new TextNode(text).WithForeground(Color.BrightBlack);
+            })
+            .AsLayout()
+            .Height(1);
+    }
+
+    private ILayoutNode BuildLoadingView()
+        => new TextNode("  Loading approvals...").WithForeground(Color.Yellow);
+
+    private ILayoutNode BuildEmptyView()
+    {
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  No persistent approvals.").WithForeground(Color.White))
+            .WithChild(new TextNode("").Height(1))
+            .WithChild(new TextNode("  Approvals are stored when a session prompts you to ")
+                .WithForeground(Color.Gray))
+            .WithChild(new TextNode("  \"Approve always\" for a shell command or directory root.")
+                .WithForeground(Color.Gray));
+    }
+
+    private ILayoutNode BuildListView()
+    {
+        var rows = ViewModel.DisplayApprovals
+            .Select(item => $"{item.AudienceWire,-10} {item.ToolName,-20} {item.Pattern}")
+            .ToList();
+
+        _approvalList = Layouts.SelectionList(rows)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _approvalList.OnFocused();
+
+        // Enter on the list also acts as "begin revoke confirm" for the highlighted row.
+        _approvalList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count == 0) return;
+                var idx = rows.IndexOf(selected[0]);
+                if (idx < 0) return;
+                ViewModel.SelectedIndex = idx;
+                ViewModel.StartRevoke();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode($"  {"Audience",-10} {"Tool",-20} Pattern")
+                .WithForeground(Color.White).Bold())
+            .WithChild(_approvalList);
+    }
+
+    private ILayoutNode BuildRevokeConfirmView()
+    {
+        var target = ViewModel.PendingRevoke;
+        var summary = target is null
+            ? "  Revoke entry?"
+            : $"  Revoke '{target.Pattern}' from {target.AudienceWire} / {target.ToolName}?";
+
+        var items = new List<string> { "Yes, revoke", "No, cancel" };
+        _confirmList = Layouts.SelectionList(items)
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Red);
+
+        _confirmList.OnFocused();
+
+        _confirmList.SelectionConfirmed
+            .Subscribe(selected =>
+            {
+                if (selected.Count > 0 && selected[0].StartsWith("Yes", StringComparison.Ordinal))
+                    ViewModel.ConfirmRevoke();
+                else
+                    ViewModel.GoBack();
+            })
+            .DisposeWith(_stepSubs);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode(summary).WithForeground(Color.Yellow))
+            .WithChild(_confirmList);
+    }
+
+    private void HandleKeyPress(KeyPressed key)
+    {
+        var state = ViewModel.CurrentState.Value;
+        var keyInfo = key.KeyInfo;
+
+        if (keyInfo.Key == ConsoleKey.Escape)
+        {
+            if (state == ApprovalsManagerState.RevokeConfirm)
+                ViewModel.GoBack();
+            // List/Empty: no parent to return to; Ctrl+Q quits.
+            return;
+        }
+
+        if (state == ApprovalsManagerState.List)
+        {
+            if (keyInfo.Key == ConsoleKey.R || keyInfo.Key == ConsoleKey.Delete)
+            {
+                ViewModel.StartRevoke();
+                return;
+            }
+
+            _approvalList?.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+            return;
+        }
+
+        if (state == ApprovalsManagerState.RevokeConfirm)
+        {
+            _confirmList?.HandleInput(keyInfo);
+            ViewModel.RequestRedraw();
+            return;
+        }
+    }
+}

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalsManagerViewModel.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using R3;
+using Termina.Reactive;
+
+namespace Netclaw.Cli.Tui;
+
+public enum ApprovalsManagerState
+{
+    Loading,
+    List,
+    Empty,
+    RevokeConfirm,
+}
+
+public sealed record ApprovalDisplayItem(
+    TrustAudience Audience,
+    string AudienceWire,
+    string ToolName,
+    string Pattern);
+
+/// <summary>
+/// ViewModel for the <c>netclaw approvals</c> interactive TUI. The page is
+/// read-and-revoke only; it does not add new grants. All state mutations go
+/// through <see cref="ToolApprovalStore"/> so the daemon picks them up on the
+/// next approval check.
+/// </summary>
+public sealed class ApprovalsManagerViewModel : ReactiveViewModel
+{
+    private readonly ToolApprovalStore _store;
+
+    public ApprovalsManagerViewModel(NetclawPaths paths)
+    {
+        _store = new ToolApprovalStore(paths.ToolApprovalsPath);
+    }
+
+    public ReactiveProperty<ApprovalsManagerState> CurrentState { get; } = new(ApprovalsManagerState.Loading);
+    public ReactiveProperty<string> StatusMessage { get; } = new("");
+    public ReactiveProperty<int> StateVersion { get; } = new(0);
+
+    public List<ApprovalDisplayItem> DisplayApprovals { get; } = [];
+    public int SelectedIndex { get; set; }
+
+    public ApprovalDisplayItem? PendingRevoke { get; private set; }
+
+    public override void OnActivated()
+    {
+        base.OnActivated();
+        Refresh();
+    }
+
+    public void Refresh()
+    {
+        DisplayApprovals.Clear();
+        var snapshot = _store.Snapshot();
+
+        foreach (var audienceKey in snapshot.Audiences.Keys.OrderBy(k => k, StringComparer.Ordinal))
+        {
+            if (!SecurityPolicyDefaults.TryParseAudience(audienceKey, out var audience))
+                continue;
+
+            var tools = snapshot.Audiences[audienceKey];
+            foreach (var toolName in tools.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                foreach (var pattern in tools[toolName].OrderBy(p => p, StringComparer.Ordinal))
+                    DisplayApprovals.Add(new ApprovalDisplayItem(audience, audienceKey, toolName, pattern));
+            }
+        }
+
+        if (SelectedIndex >= DisplayApprovals.Count)
+            SelectedIndex = Math.Max(0, DisplayApprovals.Count - 1);
+
+        CurrentState.Value = DisplayApprovals.Count == 0
+            ? ApprovalsManagerState.Empty
+            : ApprovalsManagerState.List;
+
+        StateVersion.Value++;
+    }
+
+    public void StartRevoke()
+    {
+        if (CurrentState.Value != ApprovalsManagerState.List) return;
+        if (SelectedIndex < 0 || SelectedIndex >= DisplayApprovals.Count) return;
+
+        PendingRevoke = DisplayApprovals[SelectedIndex];
+        CurrentState.Value = ApprovalsManagerState.RevokeConfirm;
+        StateVersion.Value++;
+    }
+
+    public void ConfirmRevoke()
+    {
+        if (PendingRevoke is not { } target)
+        {
+            GoBack();
+            return;
+        }
+
+        var removed = _store.RemoveApproval(target.Audience, target.ToolName, target.Pattern);
+        StatusMessage.Value = removed
+            ? $"✔ Removed '{target.Pattern}' from {target.AudienceWire} / {target.ToolName}."
+            : $"⚠ Entry not found (may have been removed elsewhere).";
+
+        PendingRevoke = null;
+        Refresh();
+    }
+
+    public void GoBack()
+    {
+        if (CurrentState.Value == ApprovalsManagerState.RevokeConfirm)
+        {
+            PendingRevoke = null;
+            Refresh();
+        }
+    }
+}

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
@@ -116,4 +116,6 @@ public sealed class ApprovalsManagerViewModel : ReactiveViewModel
             Refresh();
         }
     }
+
+    public void RequestQuit() => Shutdown();
 }

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
@@ -58,12 +58,12 @@ public sealed class ApprovalsManagerViewModel : ReactiveViewModel
         DisplayApprovals.Clear();
         var snapshot = _store.Snapshot();
 
-        foreach (var audienceKey in snapshot.Audiences.Keys.OrderBy(k => k, StringComparer.Ordinal))
+        foreach (var audienceKey in snapshot.Keys.OrderBy(k => k, StringComparer.Ordinal))
         {
             if (!SecurityPolicyDefaults.TryParseAudience(audienceKey, out var audience))
                 continue;
 
-            var tools = snapshot.Audiences[audienceKey];
+            var tools = snapshot[audienceKey];
             foreach (var toolName in tools.Keys.OrderBy(k => k, StringComparer.Ordinal))
             {
                 foreach (var pattern in tools[toolName].OrderBy(p => p, StringComparer.Ordinal))

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
@@ -22,9 +22,8 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class ChannelsStepView : IWizardStepView
 {
-    // Most-trusted-first cycling order. Sourced from TrustAudiences.All so new
-    // audiences flow through automatically; the .Reverse() preserves the
-    // original UI behavior (Personal → Team → Public on right-arrow).
+    // Most-trusted-first cycling order (Personal → Team → Public). Sourced
+    // from TrustAudiences.All so new audiences flow through automatically.
     private static readonly ImmutableArray<TrustAudience> AudienceValues =
         [.. TrustAudiences.All.Reverse()];
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ChannelsStepView.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Immutable;
 using Netclaw.Actors.Channels;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
@@ -21,7 +22,11 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class ChannelsStepView : IWizardStepView
 {
-    private static readonly TrustAudience[] AudienceValues = [TrustAudience.Personal, TrustAudience.Team, TrustAudience.Public];
+    // Most-trusted-first cycling order. Sourced from TrustAudiences.All so new
+    // audiences flow through automatically; the .Reverse() preserves the
+    // original UI behavior (Personal → Team → Public on right-arrow).
+    private static readonly ImmutableArray<TrustAudience> AudienceValues =
+        [.. TrustAudiences.All.Reverse()];
 
     private int _cursorIndex;
     private bool _addMode;
@@ -179,7 +184,7 @@ public sealed class ChannelsStepView : IWizardStepView
                 if (entries.Count > 0)
                 {
                     var entry = entries[_cursorIndex];
-                    var idx = Array.IndexOf(AudienceValues, entry.Audience);
+                    var idx = AudienceValues.IndexOf(entry.Audience);
                     entry.Audience = AudienceValues[(idx + 1) % AudienceValues.Length];
                 }
                 break;
@@ -188,7 +193,7 @@ public sealed class ChannelsStepView : IWizardStepView
                 if (entries.Count > 0)
                 {
                     var entry = entries[_cursorIndex];
-                    var idx = Array.IndexOf(AudienceValues, entry.Audience);
+                    var idx = AudienceValues.IndexOf(entry.Audience);
                     entry.Audience = AudienceValues[(idx - 1 + AudienceValues.Length) % AudienceValues.Length];
                 }
                 break;

--- a/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
+++ b/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
@@ -78,7 +78,7 @@ public sealed class ToolApprovalStoreTests : IDisposable
         Assert.True(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git push"));
 
         var snapshot = _store.Snapshot();
-        Assert.Empty(snapshot.Audiences);
+        Assert.Empty(snapshot);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public sealed class ToolApprovalStoreTests : IDisposable
 
         _store.AddApproval(TrustAudience.Personal, "shell_execute", "git pull");
 
-        var personalShell = snapshot.Audiences["personal"]["shell_execute"];
+        var personalShell = snapshot["personal"]["shell_execute"];
         Assert.Equal(["git push"], personalShell);
     }
 }

--- a/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
+++ b/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolApprovalStoreTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class ToolApprovalStoreTests : IDisposable
+{
+    private readonly string _file;
+    private readonly ToolApprovalStore _store;
+
+    public ToolApprovalStoreTests()
+    {
+        _file = Path.Combine(Path.GetTempPath(), $"netclaw-approvals-{Guid.NewGuid():N}.json");
+        _store = new ToolApprovalStore(_file);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_file)) File.Delete(_file);
+        var invalid = _file + ".invalid";
+        if (File.Exists(invalid)) File.Delete(invalid);
+    }
+
+    [Fact]
+    public void RemoveApproval_returns_false_when_file_is_empty()
+    {
+        Assert.False(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git push"));
+    }
+
+    [Fact]
+    public void RemoveApproval_removes_exact_match_and_returns_true()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "/home/user/logs/");
+
+        Assert.True(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git push"));
+
+        var remaining = _store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute");
+        Assert.Equal(["/home/user/logs/"], remaining);
+    }
+
+    [Fact]
+    public void RemoveApproval_returns_false_for_unknown_pattern()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        Assert.False(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git pull"));
+        Assert.Single(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+    }
+
+    [Fact]
+    public void RemoveApproval_uses_platform_case_sensitivity()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+
+        var caseDifferent = _store.RemoveApproval(TrustAudience.Personal, "shell_execute", "GIT PUSH");
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.True(caseDifferent);
+            Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        }
+        else
+        {
+            Assert.False(caseDifferent);
+            Assert.Single(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        }
+    }
+
+    [Fact]
+    public void RemoveApproval_prunes_empty_tool_and_audience_sections()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        Assert.True(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git push"));
+
+        var snapshot = _store.Snapshot();
+        Assert.Empty(snapshot.Audiences);
+    }
+
+    [Fact]
+    public void RemoveApproval_does_not_disturb_other_audiences_or_tools()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Public, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "file_write", "/tmp/scratch/");
+
+        Assert.True(_store.RemoveApproval(TrustAudience.Personal, "shell_execute", "git push"));
+
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Equal(["git push"], _store.GetApprovedPatterns(TrustAudience.Public, "shell_execute"));
+        Assert.Equal(["/tmp/scratch/"], _store.GetApprovedPatterns(TrustAudience.Personal, "file_write"));
+    }
+
+    [Fact]
+    public void RemoveAllForTool_clears_every_entry_and_returns_count()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "/home/user/logs/");
+        _store.AddApproval(TrustAudience.Personal, "file_write", "/tmp/scratch/");
+
+        var removed = _store.RemoveAllForTool(TrustAudience.Personal, "shell_execute");
+
+        Assert.Equal(2, removed);
+        Assert.Empty(_store.GetApprovedPatterns(TrustAudience.Personal, "shell_execute"));
+        Assert.Equal(["/tmp/scratch/"], _store.GetApprovedPatterns(TrustAudience.Personal, "file_write"));
+    }
+
+    [Fact]
+    public void RemoveAllForTool_returns_zero_when_tool_absent()
+    {
+        Assert.Equal(0, _store.RemoveAllForTool(TrustAudience.Personal, "shell_execute"));
+    }
+
+    [Fact]
+    public void Snapshot_returns_deep_clone_independent_of_subsequent_writes()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git push");
+        var snapshot = _store.Snapshot();
+
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", "git pull");
+
+        var personalShell = snapshot.Audiences["personal"]["shell_execute"];
+        Assert.Equal(["git push"], personalShell);
+    }
+}

--- a/src/Netclaw.Configuration.Tests/TrustAudiencesTests.cs
+++ b/src/Netclaw.Configuration.Tests/TrustAudiencesTests.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// <copyright file="TrustAudiencesTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+public sealed class TrustAudiencesTests
+{
+    /// <summary>
+    /// The canonical "all audiences" enumeration MUST cover every value
+    /// declared on <see cref="TrustAudience"/>. If this assertion ever fires,
+    /// it means someone added an audience and the security-relevant
+    /// "iterate every audience" call sites (e.g., unscoped revoke) would
+    /// silently skip it.
+    /// </summary>
+    [Fact]
+    public void All_covers_every_TrustAudience_enum_value()
+    {
+        var declared = Enum.GetValues<TrustAudience>();
+        Assert.Equal(declared.Length, TrustAudiences.All.Length);
+        foreach (var value in declared)
+            Assert.Contains(value, TrustAudiences.All);
+    }
+}

--- a/src/Netclaw.Configuration/ToolApprovalEntryComparer.cs
+++ b/src/Netclaw.Configuration/ToolApprovalEntryComparer.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="ToolApprovalEntryComparer.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Platform-correct comparison rules for entries stored in
+/// <c>tool-approvals.json</c>. Approval entries embed both filesystem paths
+/// (case-sensitive on POSIX, case-insensitive on Windows) and verb tokens that
+/// resolve to executables via the host's <c>$PATH</c> lookup, which honors
+/// filesystem case rules. Folding case unconditionally on POSIX would let an
+/// attacker who plants <c>Git</c> earlier in <c>$PATH</c> inherit the approval
+/// the user issued for <c>git</c> — similarly for case-distinct directory pairs
+/// like <c>/data/</c> vs <c>/Data/</c>.
+/// </summary>
+public static class ToolApprovalEntryComparer
+{
+    /// <summary>
+    /// The <see cref="StringComparison"/> mode used for both the daemon's
+    /// approval gate and for operator-driven CLI removal. Centralized here so
+    /// every consumer of the approval file uses the same rule.
+    /// </summary>
+    public static StringComparison Comparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// The <see cref="StringComparer"/> equivalent of <see cref="Comparison"/>,
+    /// suitable for collection lookups.
+    /// </summary>
+    public static StringComparer Comparer =>
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Equality predicate matching the daemon's approval matcher.
+    /// </summary>
+    public static bool Equals(string? left, string? right) =>
+        string.Equals(left, right, Comparison);
+}

--- a/src/Netclaw.Configuration/ToolApprovalStore.cs
+++ b/src/Netclaw.Configuration/ToolApprovalStore.cs
@@ -19,6 +19,13 @@ public sealed class ToolApprovalStore
     private readonly string _filePath;
     private readonly object _lock = new();
 
+    /// <summary>
+    /// Path to the quarantine sibling file. Set by <see cref="QuarantineCorruptFile"/>
+    /// when a malformed file is moved aside; consumers can check
+    /// <see cref="File.Exists(string)"/> on this path to detect a recent quarantine.
+    /// </summary>
+    public string QuarantinePath => _filePath + ".invalid";
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -62,17 +69,16 @@ public sealed class ToolApprovalStore
 
     private void QuarantineCorruptFile(JsonException cause)
     {
-        var quarantinePath = _filePath + ".invalid";
         try
         {
-            if (File.Exists(quarantinePath))
-                File.Delete(quarantinePath);
-            File.Move(_filePath, quarantinePath);
+            if (File.Exists(QuarantinePath))
+                File.Delete(QuarantinePath);
+            File.Move(_filePath, QuarantinePath);
         }
         catch (Exception moveEx)
         {
             throw new InvalidDataException(
-                $"Tool approvals file at '{_filePath}' is malformed and could not be quarantined to '{quarantinePath}'. Inspect the file manually before restarting.",
+                $"Tool approvals file at '{_filePath}' is malformed and could not be quarantined to '{QuarantinePath}'. Inspect the file manually before restarting.",
                 new AggregateException(cause, moveEx));
         }
     }
@@ -101,7 +107,10 @@ public sealed class ToolApprovalStore
                 audienceApprovals[toolName] = patterns;
             }
 
-            if (!patterns.Contains(pattern, StringComparer.Ordinal))
+            // Use the same comparer the daemon gate and the operator CLI use,
+            // otherwise on Windows "Git Push" and "git push" would dedupe as
+            // distinct on add but both get wiped by a single revoke.
+            if (!patterns.Contains(pattern, ToolApprovalEntryComparer.Comparer))
             {
                 patterns.Add(pattern);
                 Save(data);
@@ -196,22 +205,22 @@ public sealed class ToolApprovalStore
     }
 
     /// <summary>
-    /// Returns a deep clone of the current store contents. The returned object
-    /// is a snapshot — subsequent mutations to the underlying file are not
-    /// reflected. Suitable for read-only iteration by the operator CLI.
+    /// Returns a read-only snapshot of the current store contents, keyed by
+    /// audience wire value then tool name. The snapshot is decoupled from the
+    /// underlying file — subsequent mutations are not reflected.
     /// </summary>
-    public ToolApprovalData Snapshot()
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>> Snapshot()
     {
         var data = Load();
-        var clone = new ToolApprovalData();
+        var result = new Dictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>>(StringComparer.Ordinal);
         foreach (var (audienceKey, tools) in data.Audiences)
         {
-            var clonedTools = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            var clonedTools = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
             foreach (var (toolName, patterns) in tools)
-                clonedTools[toolName] = [.. patterns];
-            clone.Audiences[audienceKey] = clonedTools;
+                clonedTools[toolName] = patterns.ToArray();
+            result[audienceKey] = clonedTools;
         }
-        return clone;
+        return result;
     }
 
     private static void CleanupEmptySections(ToolApprovalData data, string audienceKey, string toolName)

--- a/src/Netclaw.Configuration/ToolApprovalStore.cs
+++ b/src/Netclaw.Configuration/ToolApprovalStore.cs
@@ -126,6 +126,106 @@ public sealed class ToolApprovalStore
         return patterns;
     }
 
+    /// <summary>
+    /// Removes an approved pattern for a tool in the given audience. Comparison
+    /// uses <see cref="ToolApprovalEntryComparer.Comparison"/> so the CLI and
+    /// the daemon agree on what "the same entry" means. Empty per-tool and
+    /// per-audience maps are pruned so the file does not retain hollow
+    /// sections after a revoke.
+    /// </summary>
+    /// <returns><c>true</c> if an entry was removed; <c>false</c> otherwise.</returns>
+    public bool RemoveApproval(TrustAudience audience, string toolName, string pattern)
+    {
+        lock (_lock)
+        {
+            var data = Load();
+            var audienceKey = audience.ToWireValue();
+
+            if (!data.Audiences.TryGetValue(audienceKey, out var audienceApprovals))
+                return false;
+
+            if (!audienceApprovals.TryGetValue(toolName, out var patterns))
+                return false;
+
+            var index = -1;
+            for (var i = 0; i < patterns.Count; i++)
+            {
+                if (ToolApprovalEntryComparer.Equals(patterns[i], pattern))
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0)
+                return false;
+
+            patterns.RemoveAt(index);
+            CleanupEmptySections(data, audienceKey, toolName);
+            Save(data);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Removes every approval entry for a tool in the given audience.
+    /// Returns the count removed; zero if the tool had no entries.
+    /// </summary>
+    public int RemoveAllForTool(TrustAudience audience, string toolName)
+    {
+        lock (_lock)
+        {
+            var data = Load();
+            var audienceKey = audience.ToWireValue();
+
+            if (!data.Audiences.TryGetValue(audienceKey, out var audienceApprovals))
+                return 0;
+
+            if (!audienceApprovals.TryGetValue(toolName, out var patterns))
+                return 0;
+
+            var removed = patterns.Count;
+            if (removed == 0)
+                return 0;
+
+            patterns.Clear();
+            CleanupEmptySections(data, audienceKey, toolName);
+            Save(data);
+            return removed;
+        }
+    }
+
+    /// <summary>
+    /// Returns a deep clone of the current store contents. The returned object
+    /// is a snapshot — subsequent mutations to the underlying file are not
+    /// reflected. Suitable for read-only iteration by the operator CLI.
+    /// </summary>
+    public ToolApprovalData Snapshot()
+    {
+        var data = Load();
+        var clone = new ToolApprovalData();
+        foreach (var (audienceKey, tools) in data.Audiences)
+        {
+            var clonedTools = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            foreach (var (toolName, patterns) in tools)
+                clonedTools[toolName] = [.. patterns];
+            clone.Audiences[audienceKey] = clonedTools;
+        }
+        return clone;
+    }
+
+    private static void CleanupEmptySections(ToolApprovalData data, string audienceKey, string toolName)
+    {
+        if (!data.Audiences.TryGetValue(audienceKey, out var audienceApprovals))
+            return;
+
+        if (audienceApprovals.TryGetValue(toolName, out var patterns) && patterns.Count == 0)
+            audienceApprovals.Remove(toolName);
+
+        if (audienceApprovals.Count == 0)
+            data.Audiences.Remove(audienceKey);
+    }
+
     private void Save(ToolApprovalData data)
     {
         var dir = Path.GetDirectoryName(_filePath);

--- a/src/Netclaw.Configuration/TrustContextPolicy.cs
+++ b/src/Netclaw.Configuration/TrustContextPolicy.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Immutable;
+
 namespace Netclaw.Configuration;
 
 /// <summary>
@@ -14,6 +16,19 @@ public enum TrustAudience
     Public,
     Team,
     Personal
+}
+
+/// <summary>
+/// Canonical "all audiences" enumeration. Sourced from the enum itself so any
+/// iteration that should cover every audience picks up new values automatically
+/// when <see cref="TrustAudience"/> grows. Use this anywhere you would
+/// otherwise hardcode <c>[Personal, Team, Public]</c> — a stale hardcoded
+/// array becomes a silent privilege-escalation hazard the moment a new
+/// audience is added.
+/// </summary>
+public static class TrustAudiences
+{
+    public static ImmutableArray<TrustAudience> All { get; } = [.. Enum.GetValues<TrustAudience>()];
 }
 
 /// <summary>

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Configuration;
+
 namespace Netclaw.Security;
 
 /// <summary>
@@ -13,14 +15,10 @@ namespace Netclaw.Security;
 /// </summary>
 public static class ApprovalPatternMatching
 {
-    // Approval entries embed both filesystem paths (case-sensitive on POSIX,
-    // case-insensitive on Windows) and verb tokens that resolve to executables
-    // via the host's $PATH lookup, which honors filesystem case rules. Folding
-    // case unconditionally on POSIX would let an attacker who plants `Git`
-    // earlier in $PATH inherit the approval the user issued for `git` —
-    // similarly for case-distinct directory pairs like `/data/` vs `/Data/`.
-    private static StringComparison ApprovalEntryComparison =>
-        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    // Case-sensitivity rules live in Netclaw.Configuration so the operator CLI
+    // and the daemon gate use exactly the same comparer — see
+    // ToolApprovalEntryComparer for the rationale.
+    private static StringComparison ApprovalEntryComparison => ToolApprovalEntryComparer.Comparison;
 
     public static bool MatchesShellApprovalEntry(string candidate, IEnumerable<string> approvedEntries)
     {


### PR DESCRIPTION
## Summary

- Adds `netclaw approvals` — a Termina TUI plus single-shot `list` / `revoke` subcommands — for inspecting and revoking persistent tool approvals in `~/.netclaw/config/tool-approvals.json`.
- Operates on the file directly via `ToolApprovalStore`. The daemon re-reads the file on every approval check (no cache), so revocations take effect on the next prompt without a restart.
- Centralizes the platform-correct comparer (Ordinal POSIX / OrdinalIgnoreCase Windows) into `Netclaw.Configuration.ToolApprovalEntryComparer` so the daemon gate and the CLI agree on what "the same entry" means.
- Updates the `netclaw-operations` system skill (1.26.0 → 1.27.0) so the running agent recommends the CLI instead of hand-editing JSON. Keeps the file-edit recipe as a last-resort recovery path.

## Why

PR #896 shipped directory-scoped persistent approvals; the file accumulates one entry per trusted directory per audience per tool. Until now there was no operator surface to audit or revoke those grants without hand-editing JSON. The longer the file grows, the harder it is to reason about — defeating the friction-reduction goal of #896. Issue #921 asks for this CLI.

## Behavior contract

```
netclaw approvals                                # → TUI
netclaw approvals tui                            # alias
netclaw approvals list [--audience ...] [--tool ...] [--json]
netclaw approvals revoke <pattern> [--audience ...] [--tool ...]
netclaw approvals revoke --tool <name> --all [--audience ...]
netclaw approvals help
```

- Exit 0 success, 1 user error / no-match for revoke, 2 reserved for malformed-file conditions.
- `revoke <pattern>` is exact-match only (matches `ApprovalPatternMatching.MatchesShellApprovalEntry`'s no-prefix-widening discipline).
- `revoke --all` requires `--tool`. No-match revoke is loud, never silent.
- Empty file is a normal state for `list` (exits 0 with `No persistent approvals.`); for `revoke` it exits 1.
- A sibling `tool-approvals.json.invalid` (existing quarantine path) prints a warning before any list/revoke output.

## OpenSpec

- New change `openspec/changes/approvals-management-cli/`
  - **MODIFIED** `tool-approval-gates` "Persistent approval storage" — clarifies operator-editable + no-restart contract.
  - **ADDED** under `netclaw-cli` — "Operator CLI for persistent tool approvals" with 9 scenarios.
- Will be archived after merge per `/opsx-archive`.

## Tests

- 9 `ToolApprovalStoreTests` covering platform case sensitivity, empty-section pruning, snapshot independence.
- 13 `ApprovalsCommandTests` covering every list/revoke flag combination and exit-code contract (filter, JSON shape, exact-match revoke, no-match exit 1, --all scoping, --all without --tool, unknown audience, unscoped multi-audience revoke).
- `dotnet build`, `dotnet test` (Configuration + CLI + Actors), `dotnet slopwatch analyze` (0 violations), `Add-FileHeaders.ps1 -Verify` all clean.

## Test plan

- [ ] Reviewer pulls the branch and runs `dotnet test src/Netclaw.Cli.Tests` and `dotnet test src/Netclaw.Configuration.Tests`.
- [ ] `NETCLAW_HOME=$(mktemp -d) dotnet run --project src/Netclaw.Cli -- approvals list` → "No persistent approvals.", exit 0.
- [ ] Seed `tool-approvals.json` with a `personal/shell_execute/git push` entry. `netclaw approvals list` shows it; `netclaw approvals revoke "git push" --audience personal --tool shell_execute` removes it; second `revoke` exits 1.
- [ ] Bare `netclaw approvals` launches the TUI; Up/Down navigate, Delete or R triggers the revoke confirmation, Enter confirms, file changes match a follow-up `list`.
- [ ] With a daemon running, perform an "Approve always" in a session, then revoke via the CLI, then re-trigger the same shell command — daemon should prompt again without a restart.
- [ ] `netclaw doctor` continues to parse `tool-approvals.json` post-mutation.

## Out of scope

- `prune` / stale-entry detection (deferred until real drift is observed).
- Issue #899 (Windows shell coverage) is unrelated; the comparer centralization here makes any future Windows-side fix flow through automatically.

## Companion docs issue

Will be filed against `netclaw-dev/netclaw-website` once this PR is up — the website maintainer owns the docs PR.