### PR TITLE
feat(smoke): VHS tape harness for interactive CLI smoke tests

### DIFF
--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -77,6 +77,16 @@ jobs:
           set -o pipefail
           bash scripts/smoke/check.sh 2>&1 | tee smoke-logs/check.log
 
+      - name: Install vhs (for interactive tapes)
+        run: bash scripts/smoke/install-vhs.sh
+
+      - name: Run interactive tapes (light)
+        run: |
+          mkdir -p smoke-logs
+          set -o pipefail
+          bash scripts/smoke/run-tapes.sh light --no-up --keep-stack 2>&1 \
+            | tee smoke-logs/tapes.log
+
       - name: Collect smoke logs
         if: always()
         run: |

--- a/.github/workflows/smoke_sandbox.yml
+++ b/.github/workflows/smoke_sandbox.yml
@@ -22,19 +22,14 @@ permissions:
   contents: read
 
 jobs:
-  smoke:
-    name: Smoke Sandbox
+  # Build the smoke image once and share it via an artifact. The two
+  # smoke jobs below load the image and run in parallel against their
+  # own copy of the compose stack, so a flake or failure in one layer
+  # (REST/JSON vs interactive TUI) does not mask the other.
+  build-image:
+    name: Build smoke image
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    env:
-      PROJECT_NAME: netclaw-smoke-${{ github.run_id }}-${{ github.run_attempt }}
-      SMOKE_OLLAMA_MODEL: qwen2:0.5b
-      SMOKE_BUILD: 0
-      INIT_TIMEOUT_SECONDS: 1200
-      START_TIMEOUT_SECONDS: 180
-      STEP_TIMEOUT_SECONDS: 120
-      STOP_TIMEOUT_SECONDS: 120
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -68,6 +63,45 @@ jobs:
           build-args: |
             NETCLAW_VERSION=local
 
+      - name: Save image to tarball
+        run: docker save netclaw-smoke:local | gzip > /tmp/netclaw-smoke.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: netclaw-smoke-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/netclaw-smoke.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+  smoke-rest:
+    name: Smoke Sandbox (REST/JSON)
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      PROJECT_NAME: netclaw-smoke-rest-${{ github.run_id }}-${{ github.run_attempt }}
+      SMOKE_OLLAMA_MODEL: qwen2:0.5b
+      SMOKE_BUILD: 0
+      INIT_TIMEOUT_SECONDS: 1200
+      START_TIMEOUT_SECONDS: 180
+      STEP_TIMEOUT_SECONDS: 120
+      STOP_TIMEOUT_SECONDS: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: netclaw-smoke-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp
+
+      - name: Load image
+        run: gunzip < /tmp/netclaw-smoke.tar.gz | docker load
+
       - name: Start smoke sandbox
         run: bash scripts/smoke/up.sh
 
@@ -76,16 +110,6 @@ jobs:
           mkdir -p smoke-logs
           set -o pipefail
           bash scripts/smoke/check.sh 2>&1 | tee smoke-logs/check.log
-
-      - name: Install vhs (for interactive tapes)
-        run: bash scripts/smoke/install-vhs.sh
-
-      - name: Run interactive tapes (light)
-        run: |
-          mkdir -p smoke-logs
-          set -o pipefail
-          bash scripts/smoke/run-tapes.sh light --no-up --keep-stack 2>&1 \
-            | tee smoke-logs/tapes.log
 
       - name: Collect smoke logs
         if: always()
@@ -97,7 +121,64 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: smoke-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          name: smoke-logs-rest-${{ github.run_id }}-${{ github.run_attempt }}
+          path: smoke-logs
+          if-no-files-found: warn
+
+      - name: Tear down smoke sandbox
+        if: always()
+        run: |
+          SMOKE_REMOVE_VOLUMES=1 bash scripts/smoke/down.sh
+
+  smoke-interactive:
+    name: Smoke Sandbox (Interactive Tapes)
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      PROJECT_NAME: netclaw-smoke-tape-${{ github.run_id }}-${{ github.run_attempt }}
+      SMOKE_OLLAMA_MODEL: qwen2:0.5b
+      SMOKE_BUILD: 0
+      INIT_TIMEOUT_SECONDS: 1200
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: netclaw-smoke-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp
+
+      - name: Load image
+        run: gunzip < /tmp/netclaw-smoke.tar.gz | docker load
+
+      - name: Install vhs
+        run: bash scripts/smoke/install-vhs.sh
+
+      - name: Run interactive tapes (light)
+        # --keep-stack so the post-step `collect-logs` runs against a
+        # still-up stack on failure; the explicit teardown step below
+        # always closes the stack out.
+        run: |
+          mkdir -p smoke-logs
+          set -o pipefail
+          bash scripts/smoke/run-tapes.sh light --keep-stack 2>&1 \
+            | tee smoke-logs/tapes.log
+
+      - name: Collect smoke logs
+        if: always()
+        run: |
+          mkdir -p smoke-logs
+          bash scripts/smoke/collect-logs.sh smoke-logs || true
+
+      - name: Upload tape logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-logs-tapes-${{ github.run_id }}-${{ github.run_attempt }}
           path: smoke-logs
           if-no-files-found: warn
 

--- a/.gitignore
+++ b/.gitignore
@@ -435,3 +435,4 @@ feeds/skills/.system/manifest.json
 # Eval run archives (persistent logs and results per run)
 evals/runs/
 .claude/scheduled_tasks.lock
+smoke-logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,21 @@ auto-fix common schema validation errors. To ensure smooth upgrades for existing
   - Use Akka.TestKit's `AwaitAssertAsync` for polling assertions on async state.
   - `Task.Delay` in fake/mock services to simulate latency is acceptable only in
     the fake itself, never in test orchestration logic.
+- **TUI / Termina changes MUST be validated with the interactive tape
+  harness** before being marked done. xUnit cannot drive Spectre-style
+  prompts and `scripts/smoke/check.sh` only covers the HTTP/JSON surface,
+  so a Termina change that breaks the wizard, model picker, provider
+  picker, or any other prompt flow will pass every other gate. Run:
+
+  ```bash
+  ./scripts/smoke/run-tapes.sh light --keep-stack    # all PR-gating tapes
+  ./scripts/smoke/run-tapes.sh init-wizard --no-up --keep-stack   # one tape, fastest loop
+  ```
+
+  See `TOOLING.md` § Interactive CLI Smoke Tests for the full set of
+  commands and `tests/smoke-interactive/tapes/README.md` for tape
+  authoring conventions (no `Sleep`, anchor every step, pair with an
+  assertion).
 
 ## Post-Code Quality Check
 
@@ -262,6 +277,9 @@ Done means all of the following are true:
 - system skills updated if a mapped feature area was changed (see table above)
 - eval suite passes for changes to identity, skills, memory, or tools (see
   Eval Suite section)
+- interactive tape harness passes for changes to Termina TUI surfaces
+  (init wizard, model/provider/webhook pickers, chat page) — see
+  Testing Guidelines and `TOOLING.md` § Interactive CLI Smoke Tests
 
 ## Agent Guidance: dotnet-skills
 

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -27,6 +27,37 @@
 | `scripts/Add-FileHeaders.ps1 -Verify` | CI: check all files have headers (exit 1 if missing) |
 | `scripts/Add-FileHeaders.ps1 -WhatIf` | Preview which files need headers |
 
+## Interactive CLI Smoke Tests (Tape Harness)
+
+A VHS-driven smoke harness exercises the interactive Termina TUI surface
+that `scripts/smoke/check.sh` cannot reach (Spectre-style prompts,
+wizard flows, model/provider/webhook TUIs). Tape bodies live at
+`tests/smoke-interactive/tapes/<name>.tape`; sibling assertion scripts at
+`tests/smoke-interactive/assertions/<name>.sh` validate the artefacts
+each tape produced. The same scripts run in CI (inside the Smoke
+Sandbox job) and locally — agents working on TUI code SHOULD run the
+harness before declaring a change done.
+
+| Command | Purpose |
+|---------|---------|
+| `./scripts/smoke/run-tapes.sh light` | PR-gating subset; auto brings the smoke compose stack up and tears down |
+| `./scripts/smoke/run-tapes.sh full` | Full nightly suite (placeholder: identical to light until backfilled) |
+| `./scripts/smoke/run-tapes.sh <tape-name>` | Single tape, e.g. `init-wizard` |
+| `./scripts/smoke/run-tapes.sh <tape-name> --keep-stack` | Leave the compose stack running between iterations |
+| `./scripts/smoke/run-tapes.sh <tape-name> --no-up --keep-stack` | Re-run against an already-running stack (fastest inner loop) |
+| `./scripts/smoke/install-vhs.sh` | Idempotent VHS install (Linux/x86_64 only; macOS/Windows install manually) |
+
+When a tape fails, `smoke-logs/tapes/<name>/` collects: a debug GIF of the
+last frame, the combined tape file, container logs, and a tarball of
+the produced `NETCLAW_HOME`. CI uploads the same directory as a job
+artefact.
+
+**Authoring conventions are in `tests/smoke-interactive/tapes/README.md`**
+— the short version: `Wait+Screen /pattern/` only (no `Sleep`), 1400×800
+default surface, no `Screenshot` directives, pair every non-trivial tape
+with an assertion script that re-validates `netclaw doctor` and the
+relevant `--json` output.
+
 ## Source Control and CI Signals
 
 - `git` repository with active `dev` branch

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -32,9 +32,11 @@ services:
       NETCLAW_Models__Fallback__ModelId: ${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}
       NETCLAW_Models__Compaction__Provider: local-ollama
       NETCLAW_Models__Compaction__ModelId: ${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}
-    volumes:
-      - netclaw-home:/root/.netclaw
+    # tmpfs (not a named volume) so smoke runs always start with empty
+    # netclaw state and never collide with a host ~/.netclaw on a dev
+    # machine. Path matches the image's USER netclaw home (see Dockerfile).
+    tmpfs:
+      - /home/netclaw/.netclaw:uid=1654,gid=1654,mode=0755
 
 volumes:
   netclaw-ollama-data:
-  netclaw-home:

--- a/scripts/smoke/collect-logs.sh
+++ b/scripts/smoke/collect-logs.sh
@@ -29,15 +29,15 @@ for service in ollama ollama-init netclaw-sandbox; do
 done
 
 run_timed "$STEP_TIMEOUT_SECONDS" docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox sh -lc \
-  'if [ -f /root/.netclaw/logs/daemon.log ]; then cat /root/.netclaw/logs/daemon.log; fi' \
+  'if [ -f /home/netclaw/.netclaw/logs/daemon.log ]; then cat /home/netclaw/.netclaw/logs/daemon.log; fi' \
   >"$LOG_DIR/daemon.log" || true
 
 run_timed "$STEP_TIMEOUT_SECONDS" docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox sh -lc \
-  'if [ -f /root/.netclaw/netclaw.pid ]; then cat /root/.netclaw/netclaw.pid; fi' \
+  'if [ -f /home/netclaw/.netclaw/netclaw.pid ]; then cat /home/netclaw/.netclaw/netclaw.pid; fi' \
   >"$LOG_DIR/netclaw.pid" || true
 
 run_timed "$STEP_TIMEOUT_SECONDS" docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox sh -lc \
-  'ls -la /root/.netclaw || true' \
+  'ls -la /home/netclaw/.netclaw || true' \
   >"$LOG_DIR/netclaw-home-ls.txt" || true
 
 echo "Smoke logs collected at: $LOG_DIR"

--- a/scripts/smoke/install-vhs.sh
+++ b/scripts/smoke/install-vhs.sh
@@ -14,8 +14,10 @@
 
 set -euo pipefail
 
-VHS_VERSION="${VHS_VERSION:-0.8.0}"
+VHS_VERSION="${VHS_VERSION:-0.11.0}"
 VHS_LINUX_X64_SHA256="${VHS_LINUX_X64_SHA256:-SKIP_VERIFY}"
+# 0.11.0 is the minimum that supports `Wait+Screen /pattern/`.
+# Earlier versions (e.g. 0.8.0) parse `Wait` as an unknown command.
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -54,12 +56,16 @@ esac
 
 if have apt-get; then
   echo "Installing vhs runtime deps (ttyd, ffmpeg) via apt-get..."
+  # Force non-interactive mode so apt never tries to open whiptail dialogs
+  # (e.g., the kernel-upgrade prompt) when running on a CI runner or under
+  # an SSH/agent session.
+  export DEBIAN_FRONTEND=noninteractive
   if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
     apt-get update
     apt-get install -y --no-install-recommends ttyd ffmpeg ca-certificates curl
   else
-    sudo apt-get update
-    sudo apt-get install -y --no-install-recommends ttyd ffmpeg ca-certificates curl
+    sudo -E apt-get update
+    sudo -E apt-get install -y --no-install-recommends ttyd ffmpeg ca-certificates curl
   fi
 else
   for dep in ttyd ffmpeg curl; do

--- a/scripts/smoke/install-vhs.sh
+++ b/scripts/smoke/install-vhs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Ensure VHS (charmbracelet/vhs) is installed for the interactive tape harness.
+#
+# Installation strategy:
+#   - If `vhs` is already on PATH, do nothing.
+#   - On Linux x86_64: install vhs from the upstream release with SHA256 verification,
+#     and ensure ttyd / ffmpeg are present (apt-get if available).
+#   - Other platforms: print install hints and fail.
+#
+# Pin the VHS version + SHA256 here. Bumping vhs requires updating both.
+# Refresh by running:
+#   curl -fsSL https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/checksums.txt \
+#     | grep "Linux_x86_64.tar.gz"
+
+set -euo pipefail
+
+VHS_VERSION="${VHS_VERSION:-0.8.0}"
+VHS_LINUX_X64_SHA256="${VHS_LINUX_X64_SHA256:-SKIP_VERIFY}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if have vhs; then
+  installed="$(vhs --version 2>/dev/null | awk '{print $NF}' | sed 's/^v//')"
+  echo "vhs ${installed:-unknown} already installed at $(command -v vhs)"
+  exit 0
+fi
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+
+case "${uname_s}/${uname_m}" in
+  Linux/x86_64)
+    : # supported below
+    ;;
+  Darwin/*)
+    cat >&2 <<'EOF'
+ERROR: vhs is not installed and automatic install is Linux/x86_64 only.
+On macOS install with Homebrew:
+    brew install vhs ttyd ffmpeg
+Then re-run.
+EOF
+    exit 1
+    ;;
+  *)
+    cat >&2 <<EOF
+ERROR: vhs is not installed and automatic install is not supported on ${uname_s}/${uname_m}.
+See https://github.com/charmbracelet/vhs#installation for manual instructions.
+EOF
+    exit 1
+    ;;
+esac
+
+# Linux x86_64 path.
+
+if have apt-get; then
+  echo "Installing vhs runtime deps (ttyd, ffmpeg) via apt-get..."
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    apt-get update
+    apt-get install -y --no-install-recommends ttyd ffmpeg ca-certificates curl
+  else
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends ttyd ffmpeg ca-certificates curl
+  fi
+else
+  for dep in ttyd ffmpeg curl; do
+    if ! have "$dep"; then
+      echo "WARNING: '$dep' is not on PATH and apt-get is unavailable. vhs will likely fail." >&2
+    fi
+  done
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+archive="$tmp/vhs.tar.gz"
+url="https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz"
+
+echo "Downloading vhs v${VHS_VERSION} from ${url}..."
+curl -fsSL "$url" -o "$archive"
+
+if [[ "${VHS_LINUX_X64_SHA256}" != "SKIP_VERIFY" ]]; then
+  echo "Verifying SHA256..."
+  echo "${VHS_LINUX_X64_SHA256}  ${archive}" | sha256sum -c -
+else
+  echo "WARNING: SHA256 verification skipped (VHS_LINUX_X64_SHA256=SKIP_VERIFY)." >&2
+  echo "         Set VHS_LINUX_X64_SHA256 to the upstream checksum to enable verification." >&2
+fi
+
+tar -xzf "$archive" -C "$tmp"
+
+# Archive layout: vhs_<version>_Linux_x86_64/vhs
+binary="$(find "$tmp" -type f -name vhs -perm -u+x | head -n1)"
+if [[ -z "${binary:-}" ]]; then
+  echo "ERROR: vhs binary not found in extracted archive." >&2
+  exit 1
+fi
+
+dest="${VHS_INSTALL_PATH:-/usr/local/bin/vhs}"
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  install -m 0755 "$binary" "$dest"
+else
+  sudo install -m 0755 "$binary" "$dest"
+fi
+
+echo "vhs v${VHS_VERSION} installed at ${dest}"
+vhs --version || true

--- a/scripts/smoke/run-tape.sh
+++ b/scripts/smoke/run-tape.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Run a single VHS tape against the smoke compose stack.
+#
+# Usage:
+#   scripts/smoke/run-tape.sh <tape-short-name>
+#
+# Where <tape-short-name> matches a file at:
+#   tests/smoke-interactive/tapes/<tape-short-name>.tape
+#
+# Steps:
+#   1) Substitute placeholders in preamble.tape and prepend it to the
+#      tape body, producing a combined temp tape.
+#   2) Run `vhs` against the combined tape with a hard timeout.
+#   3) If a per-tape assertion exists at
+#      tests/smoke-interactive/assertions/<short-name>.sh, run it.
+#   4) On failure, collect artifacts (last-frame PNG, daemon log,
+#      NETCLAW_HOME tarball, compose logs) into ${ARTIFACT_DIR}.
+#
+# Environment knobs:
+#   PROJECT_NAME       compose project (default: netclaw-smoke)
+#   COMPOSE_FILE       compose file path (default: docker-compose.smoke.yml)
+#   TAPE_TIMEOUT_S     hard timeout per tape (default: 600)
+#   ARTIFACT_DIR       failure artifact dir (default: smoke-logs/tapes/<name>)
+#   KEEP_TEMP          set to 1 to retain the combined tape for inspection
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <tape-short-name>" >&2
+  exit 2
+fi
+
+TAPE_NAME="$1"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TAPES_DIR="${ROOT_DIR}/tests/smoke-interactive/tapes"
+ASSERT_DIR="${ROOT_DIR}/tests/smoke-interactive/assertions"
+
+PROJECT_NAME="${PROJECT_NAME:-netclaw-smoke}"
+COMPOSE_FILE="${COMPOSE_FILE:-${ROOT_DIR}/docker-compose.smoke.yml}"
+TAPE_TIMEOUT_S="${TAPE_TIMEOUT_S:-600}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/smoke-logs/tapes/${TAPE_NAME}}"
+
+preamble="${TAPES_DIR}/preamble.tape"
+body="${TAPES_DIR}/${TAPE_NAME}.tape"
+assertion="${ASSERT_DIR}/${TAPE_NAME}.sh"
+
+if [[ ! -f "$preamble" ]]; then
+  echo "ERROR: preamble not found at $preamble" >&2
+  exit 1
+fi
+
+if [[ ! -f "$body" ]]; then
+  echo "ERROR: tape body not found at $body" >&2
+  exit 1
+fi
+
+if ! command -v vhs >/dev/null 2>&1; then
+  echo "ERROR: vhs not on PATH. Run scripts/smoke/install-vhs.sh first." >&2
+  exit 1
+fi
+
+# Per-tape NETCLAW_HOME inside the container, written into preamble + exposed
+# to the assertion script for post-tape inspection.
+NETCLAW_HOME_IN="/tmp/tape-${TAPE_NAME}"
+
+tmp_dir="$(mktemp -d)"
+combined="${tmp_dir}/${TAPE_NAME}.tape"
+
+cleanup() {
+  if [[ "${KEEP_TEMP:-0}" == "1" ]]; then
+    echo "KEEP_TEMP=1 — combined tape retained at: $combined"
+  else
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+collect_failure_artifacts() {
+  echo "==> Collecting failure artifacts to ${ARTIFACT_DIR}"
+  set +e
+  cp -v "/tmp/tape-${TAPE_NAME}.gif" "${ARTIFACT_DIR}/" 2>/dev/null
+  cp -v "/tmp/tape-${TAPE_NAME}.png" "${ARTIFACT_DIR}/" 2>/dev/null
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" logs --no-color \
+    > "${ARTIFACT_DIR}/compose.log" 2>&1
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox \
+    sh -c "ls -la '$NETCLAW_HOME_IN' 2>/dev/null && cat '$NETCLAW_HOME_IN/config.json' 2>/dev/null" \
+    > "${ARTIFACT_DIR}/netclaw_home.txt" 2>&1
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T netclaw-sandbox \
+    tar -C "$NETCLAW_HOME_IN" -czf - . 2>/dev/null \
+    > "${ARTIFACT_DIR}/netclaw_home.tar.gz" \
+    || true
+  cp -v "$combined" "${ARTIFACT_DIR}/${TAPE_NAME}.combined.tape" 2>/dev/null
+  set -e
+  echo "    artifacts: $(ls "${ARTIFACT_DIR}" 2>/dev/null | tr '\n' ' ')"
+}
+
+# Substitute placeholders in preamble. Sed delimiter is '|' since paths
+# contain '/'. PROJECT_NAME and TAPE_NAME are restricted to safe chars
+# by convention (set by us), so escaping is minimal.
+sed \
+  -e "s|__PROJECT__|${PROJECT_NAME}|g" \
+  -e "s|__COMPOSE_FILE__|${COMPOSE_FILE}|g" \
+  -e "s|__TAPE_NAME__|${TAPE_NAME}|g" \
+  "$preamble" > "$combined"
+
+# Append body (skip its `Output ...` line if present, since the preamble
+# does not declare one and vhs expects exactly one Output directive).
+# Easier: keep both, last-write-wins on Output is fine in vhs.
+cat "$body" >> "$combined"
+
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Running tape: ${TAPE_NAME} (timeout=${TAPE_TIMEOUT_S}s)"
+echo "    PROJECT_NAME=${PROJECT_NAME}"
+echo "    COMPOSE_FILE=${COMPOSE_FILE}"
+echo "    NETCLAW_HOME_IN=${NETCLAW_HOME_IN}"
+
+vhs_status=0
+if command -v timeout >/dev/null 2>&1; then
+  timeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+else
+  vhs "$combined" || vhs_status=$?
+fi
+
+if [[ $vhs_status -ne 0 ]]; then
+  echo "FAIL: vhs exited with status ${vhs_status} for tape ${TAPE_NAME}" >&2
+  collect_failure_artifacts
+  exit "$vhs_status"
+fi
+
+# Run per-tape assertion if present.
+if [[ -x "$assertion" ]]; then
+  echo "==> Running post-tape assertion: ${assertion}"
+  assert_status=0
+  PROJECT_NAME="$PROJECT_NAME" \
+  COMPOSE_FILE="$COMPOSE_FILE" \
+  TAPE_NAME="$TAPE_NAME" \
+  NETCLAW_HOME_IN="$NETCLAW_HOME_IN" \
+    "$assertion" || assert_status=$?
+  if [[ $assert_status -ne 0 ]]; then
+    echo "FAIL: assertion failed for tape ${TAPE_NAME} (status=${assert_status})" >&2
+    collect_failure_artifacts
+    exit "$assert_status"
+  fi
+elif [[ -f "$assertion" ]]; then
+  echo "WARNING: $assertion exists but is not executable; skipping." >&2
+fi
+
+echo "==> ${TAPE_NAME}: OK"

--- a/scripts/smoke/run-tapes.sh
+++ b/scripts/smoke/run-tapes.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Driver for the interactive tape suite. CI and local devs share this
+# same entrypoint so the two paths can't drift.
+#
+# Usage:
+#   scripts/smoke/run-tapes.sh light                 # PR-gating subset
+#   scripts/smoke/run-tapes.sh full                  # nightly full suite
+#   scripts/smoke/run-tapes.sh <tape-short-name>     # one-off iteration
+#
+# Flags:
+#   --keep-stack    don't bring the smoke compose stack down at end
+#                   (useful for inner-loop tape iteration)
+#   --no-up         assume the smoke stack is already running; skip up.sh
+#
+# By default this script:
+#   1) ensures vhs is installed (scripts/smoke/install-vhs.sh)
+#   2) brings up the smoke stack (scripts/smoke/up.sh)
+#   3) waits for ollama-init + daemon health (re-using check.sh helpers)
+#   4) runs each requested tape via run-tape.sh
+#   5) tears the stack down on exit unless --keep-stack
+#
+# Exit code is non-zero if any tape fails. All tapes are attempted
+# regardless of earlier failures so CI gets a complete artifact set.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_SCRIPTS="${ROOT_DIR}/scripts/smoke"
+TAPES_DIR="${ROOT_DIR}/tests/smoke-interactive/tapes"
+
+# PR-gating subset. Order matters: help.tape is the cheapest harness check.
+LIGHT_TAPES=(
+  help
+  init-wizard
+)
+
+# Nightly full suite. As more tapes are authored, append them here.
+FULL_TAPES=(
+  help
+  init-wizard
+)
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+mode="$1"; shift || true
+keep_stack=0
+do_up=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-stack) keep_stack=1; shift ;;
+    --no-up)      do_up=0; shift ;;
+    -h|--help)    usage ;;
+    *)            echo "Unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+case "$mode" in
+  light) tapes=("${LIGHT_TAPES[@]}") ;;
+  full)  tapes=("${FULL_TAPES[@]}") ;;
+  *)
+    candidate="${TAPES_DIR}/${mode}.tape"
+    if [[ -f "$candidate" ]]; then
+      tapes=("$mode")
+    else
+      echo "ERROR: '${mode}' is not 'light', 'full', or a valid tape name." >&2
+      echo "       Looked for ${candidate}" >&2
+      exit 2
+    fi
+    ;;
+esac
+
+# 1) vhs install (idempotent).
+"${SMOKE_SCRIPTS}/install-vhs.sh"
+
+# 2) bring stack up (unless --no-up).
+if [[ $do_up -eq 1 ]]; then
+  echo "==> Bringing smoke stack up..."
+  bash "${SMOKE_SCRIPTS}/up.sh"
+fi
+
+# 3) wait for ollama-init to complete. Reuse check.sh's helper by
+#    sourcing the relevant fragment. To keep coupling loose we just
+#    poll docker inspect inline.
+PROJECT_NAME="${PROJECT_NAME:-netclaw-smoke}"
+COMPOSE_FILE="${COMPOSE_FILE:-${ROOT_DIR}/docker-compose.smoke.yml}"
+INIT_TIMEOUT_SECONDS="${INIT_TIMEOUT_SECONDS:-1200}"
+
+wait_for_ollama_init() {
+  local id status code deadline=$((SECONDS + INIT_TIMEOUT_SECONDS))
+  id="$(docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" ps -a -q ollama-init)"
+  if [[ -z "$id" ]]; then
+    echo "ERROR: ollama-init container not found." >&2
+    return 1
+  fi
+  while (( SECONDS < deadline )); do
+    status="$(docker inspect -f '{{.State.Status}}' "$id")"
+    code="$(docker inspect -f '{{.State.ExitCode}}' "$id")"
+    if [[ "$status" == "exited" ]]; then
+      if [[ "$code" == "0" ]]; then
+        echo "    ollama-init: ready."
+        return 0
+      fi
+      echo "ERROR: ollama-init exited with code $code." >&2
+      docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" logs ollama-init >&2
+      return 1
+    fi
+    sleep 5
+  done
+  echo "ERROR: ollama-init did not complete within ${INIT_TIMEOUT_SECONDS}s." >&2
+  return 1
+}
+
+if [[ $do_up -eq 1 ]]; then
+  echo "==> Waiting for ollama-init..."
+  wait_for_ollama_init
+fi
+
+# 4) run tapes. Track failures but keep going.
+failed=()
+for tape in "${tapes[@]}"; do
+  echo
+  echo "════════════════════════════════════════════════════════"
+  echo "Running tape: ${tape}"
+  echo "════════════════════════════════════════════════════════"
+  if ! PROJECT_NAME="$PROJECT_NAME" COMPOSE_FILE="$COMPOSE_FILE" \
+       bash "${SMOKE_SCRIPTS}/run-tape.sh" "$tape"; then
+    failed+=("$tape")
+  fi
+done
+
+# 5) teardown unless --keep-stack.
+if [[ $keep_stack -eq 1 ]]; then
+  echo "==> --keep-stack: leaving smoke compose stack running."
+else
+  echo "==> Tearing down smoke compose stack..."
+  SMOKE_REMOVE_VOLUMES="${SMOKE_REMOVE_VOLUMES:-1}" \
+    bash "${SMOKE_SCRIPTS}/down.sh" || true
+fi
+
+if (( ${#failed[@]} > 0 )); then
+  echo
+  echo "FAILURE: ${#failed[@]} tape(s) failed: ${failed[*]}" >&2
+  exit 1
+fi
+
+echo
+echo "All ${#tapes[@]} tape(s) passed."

--- a/tests/smoke-interactive/assertions/help.sh
+++ b/tests/smoke-interactive/assertions/help.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# help.tape post-tape assertion.
+#
+# help.tape's purpose is to smoke-test the harness itself, not the CLI.
+# vhs exit code (non-zero on any Wait+Screen timeout) is the only signal
+# we need. This script intentionally does nothing.
+
+set -euo pipefail
+echo "help: no post-tape assertion (vhs exit code is the test)"

--- a/tests/smoke-interactive/assertions/init-wizard.sh
+++ b/tests/smoke-interactive/assertions/init-wizard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# init-wizard.tape post-tape assertion.
+#
+# Validates that the wizard produced a usable, schema-valid config:
+#   1) ${NETCLAW_HOME}/config.json exists and parses as JSON
+#   2) `netclaw doctor` (which runs ConfigSchemaDoctorCheck) exits 0
+#   3) The top-level fields the tape was supposed to set are present
+#      with the expected values (provider type, model id, posture,
+#      identity user name).
+#
+# Invoked by scripts/smoke/run-tape.sh with these env vars exported:
+#   PROJECT_NAME      docker compose project
+#   COMPOSE_FILE      path to docker-compose.smoke.yml
+#   TAPE_NAME         short tape name (init-wizard)
+#   NETCLAW_HOME_IN   per-tape NETCLAW_HOME inside the container
+
+set -euo pipefail
+
+: "${PROJECT_NAME:?PROJECT_NAME must be set by run-tape.sh}"
+: "${COMPOSE_FILE:?COMPOSE_FILE must be set by run-tape.sh}"
+: "${NETCLAW_HOME_IN:?NETCLAW_HOME_IN must be set by run-tape.sh}"
+
+compose() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
+
+# Run a command inside the sandbox with NETCLAW_HOME pointed at the
+# per-tape directory we just populated.
+in_sandbox() {
+  compose exec -T \
+    -e "NETCLAW_HOME=${NETCLAW_HOME_IN}" \
+    netclaw-sandbox "$@"
+}
+
+config_path="${NETCLAW_HOME_IN}/config.json"
+
+echo "init-wizard: checking config exists at ${config_path}..."
+if ! in_sandbox test -f "$config_path"; then
+  echo "FAIL: ${config_path} does not exist after wizard run." >&2
+  in_sandbox ls -la "$NETCLAW_HOME_IN" >&2 || true
+  exit 1
+fi
+
+echo "init-wizard: validating JSON parses..."
+if ! in_sandbox sh -c "jq empty < '$config_path'"; then
+  echo "FAIL: ${config_path} is not valid JSON." >&2
+  in_sandbox cat "$config_path" >&2 || true
+  exit 1
+fi
+
+echo "init-wizard: running 'netclaw doctor' against produced config..."
+if ! in_sandbox netclaw doctor; then
+  echo "FAIL: netclaw doctor exited non-zero against the produced config." >&2
+  exit 1
+fi
+
+echo "init-wizard: checking expected fields are present..."
+expected_provider_type='ollama'
+expected_user='SmokeTester'
+
+actual_provider_type="$(in_sandbox sh -c "jq -r '.providers | to_entries[0].value.type' < '$config_path'")"
+actual_user="$(in_sandbox sh -c "jq -r '.identity.userName // empty' < '$config_path'")"
+
+fail=0
+
+if [[ "$actual_provider_type" != "$expected_provider_type" ]]; then
+  echo "FAIL: expected provider type '${expected_provider_type}', got '${actual_provider_type}'." >&2
+  fail=1
+fi
+
+if [[ "$actual_user" != "$expected_user" ]]; then
+  echo "FAIL: expected identity.userName '${expected_user}', got '${actual_user}'." >&2
+  fail=1
+fi
+
+if (( fail )); then
+  echo "--- config.json contents ---" >&2
+  in_sandbox cat "$config_path" >&2 || true
+  exit 1
+fi
+
+echo "init-wizard: assertions passed."

--- a/tests/smoke-interactive/assertions/init-wizard.sh
+++ b/tests/smoke-interactive/assertions/init-wizard.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # init-wizard.tape post-tape assertion.
 #
-# Validates that the wizard produced a usable, schema-valid config:
-#   1) ${NETCLAW_HOME}/config.json exists and parses as JSON
+# Validates that the wizard produced a usable, schema-valid state:
+#   1) ${NETCLAW_HOME}/config/netclaw.json exists and parses as JSON
 #   2) `netclaw doctor` (which runs ConfigSchemaDoctorCheck) exits 0
-#   3) The top-level fields the tape was supposed to set are present
-#      with the expected values (provider type, model id, posture,
-#      identity user name).
+#   3) Top-level fields the tape was supposed to set look right:
+#        - Providers["ollama"].Type        == "ollama"
+#        - Providers["ollama"].Endpoint    == "http://ollama:11434"
+#        - Models.Main.Provider            == "ollama"
+#        - Models.Main.ModelId             == "qwen2:0.5b"
+#        - Security.DeploymentPosture      == "Personal"
+#   4) Identity/SOUL.md contains the user name we typed (SmokeTester).
 #
 # Invoked by scripts/smoke/run-tape.sh with these env vars exported:
 #   PROJECT_NAME      docker compose project
@@ -24,57 +28,79 @@ compose() {
   docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
 }
 
-# Run a command inside the sandbox with NETCLAW_HOME pointed at the
-# per-tape directory we just populated.
 in_sandbox() {
   compose exec -T \
     -e "NETCLAW_HOME=${NETCLAW_HOME_IN}" \
     netclaw-sandbox "$@"
 }
 
-config_path="${NETCLAW_HOME_IN}/config.json"
+config_path="${NETCLAW_HOME_IN}/config/netclaw.json"
+soul_path="${NETCLAW_HOME_IN}/identity/SOUL.md"
 
 echo "init-wizard: checking config exists at ${config_path}..."
 if ! in_sandbox test -f "$config_path"; then
   echo "FAIL: ${config_path} does not exist after wizard run." >&2
-  in_sandbox ls -la "$NETCLAW_HOME_IN" >&2 || true
+  in_sandbox sh -lc "ls -la '$NETCLAW_HOME_IN' 2>&1; ls -la '$NETCLAW_HOME_IN/config' 2>&1" >&2 || true
   exit 1
 fi
 
-echo "init-wizard: validating JSON parses..."
-if ! in_sandbox sh -c "jq empty < '$config_path'"; then
+echo "init-wizard: validating config JSON parses..."
+if ! in_sandbox sh -lc "jq empty < '$config_path'"; then
   echo "FAIL: ${config_path} is not valid JSON." >&2
   in_sandbox cat "$config_path" >&2 || true
   exit 1
 fi
 
 echo "init-wizard: running 'netclaw doctor' against produced config..."
-if ! in_sandbox netclaw doctor; then
-  echo "FAIL: netclaw doctor exited non-zero against the produced config." >&2
+# DoctorRunner exit codes (src/Netclaw.Cli/Doctor/DoctorRunner.cs):
+#   0 = all checks passed
+#   1 = at least one check failed (treat as assertion failure)
+#   2 = warnings only, no failures (acceptable in smoke — e.g. "Personal posture
+#       with HostAllowed shell" is an expected WARN for the Personal flow)
+doctor_status=0
+in_sandbox netclaw doctor || doctor_status=$?
+if [[ $doctor_status -eq 1 ]]; then
+  echo "FAIL: netclaw doctor reported errors (exit code 1)." >&2
+  exit 1
+fi
+if [[ $doctor_status -ne 0 && $doctor_status -ne 2 ]]; then
+  echo "FAIL: netclaw doctor exited with unexpected status $doctor_status." >&2
   exit 1
 fi
 
-echo "init-wizard: checking expected fields are present..."
-expected_provider_type='ollama'
-expected_user='SmokeTester'
-
-actual_provider_type="$(in_sandbox sh -c "jq -r '.providers | to_entries[0].value.type' < '$config_path'")"
-actual_user="$(in_sandbox sh -c "jq -r '.identity.userName // empty' < '$config_path'")"
-
+echo "init-wizard: checking expected fields in netclaw.json..."
 fail=0
 
-if [[ "$actual_provider_type" != "$expected_provider_type" ]]; then
-  echo "FAIL: expected provider type '${expected_provider_type}', got '${actual_provider_type}'." >&2
-  fail=1
-fi
+assert_field() {
+  local jq_expr="$1"
+  local expected="$2"
+  local actual
+  actual="$(in_sandbox sh -lc "jq -r '$jq_expr // empty' < '$config_path'" | tr -d '\r')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: expected '${jq_expr}' == '${expected}', got '${actual}'." >&2
+    fail=1
+  else
+    echo "  ok  ${jq_expr} == '${expected}'"
+  fi
+}
 
-if [[ "$actual_user" != "$expected_user" ]]; then
-  echo "FAIL: expected identity.userName '${expected_user}', got '${actual_user}'." >&2
+assert_field '.Providers.ollama.Type'       'ollama'
+assert_field '.Providers.ollama.Endpoint'   'http://ollama:11434'
+assert_field '.Models.Main.Provider'        'ollama'
+assert_field '.Models.Main.ModelId'         'qwen2:0.5b'
+assert_field '.Security.DeploymentPosture'  'Personal'
+
+echo "init-wizard: checking identity/SOUL.md for typed user name..."
+if ! in_sandbox grep -q 'Name: SmokeTester' "$soul_path"; then
+  echo "FAIL: identity/SOUL.md does not contain 'Name: SmokeTester'." >&2
+  in_sandbox cat "$soul_path" >&2 | head -40 || true
   fail=1
+else
+  echo "  ok  identity/SOUL.md contains 'Name: SmokeTester'"
 fi
 
 if (( fail )); then
-  echo "--- config.json contents ---" >&2
+  echo "--- netclaw.json contents ---" >&2
   in_sandbox cat "$config_path" >&2 || true
   exit 1
 fi

--- a/tests/smoke-interactive/tapes/README.md
+++ b/tests/smoke-interactive/tapes/README.md
@@ -50,9 +50,12 @@ that breaks them.
    but no `Screenshot` directives in the body. Visual diffs are not how
    we assert anything here.
 
-4. **Minimum terminal surface.** `Set Width 100` / `Set Height 30`,
-   `Set Padding 0`, no theme. Anything bigger reduces determinism and
-   slows vhs renders.
+4. **Terminal sizing is in pixels, not columns.** VHS interprets
+   `Set Width` / `Set Height` as pixel dimensions (minimum 120x120).
+   The preamble sets a sensible default (1400x800 at FontSize 14, which
+   gives ~95 cols × 50 rows). Don't override unless a specific tape
+   needs more vertical room — and even then, prefer scrolling-friendly
+   anchors over taller terminals.
 
 5. **Anchor regexes at every step.** After every `Type` / `Enter` /
    `Down` / etc. that changes the visible state, immediately

--- a/tests/smoke-interactive/tapes/README.md
+++ b/tests/smoke-interactive/tapes/README.md
@@ -1,0 +1,99 @@
+# Interactive Smoke Tapes
+
+This directory holds VHS tape scripts that drive netclaw's interactive
+CLI surface (Spectre prompts, wizard flows, TUI menus) inside the smoke
+compose stack. They exist to catch regressions like the netclaw/knit
+interactive-wizard bug that the non-interactive smoke (`scripts/smoke/check.sh`)
+cannot reach.
+
+These tapes are **end-to-end test scenarios**, not screenshot fodder.
+The pretty-screenshots tapes live in
+`netclaw-website/screenshots/tapes/` and are completely separate.
+
+## Running locally
+
+```bash
+# Light suite (PR-gating subset).
+./scripts/smoke/run-tapes.sh light
+
+# Full suite (nightly).
+./scripts/smoke/run-tapes.sh full
+
+# Single tape, fast iteration.
+./scripts/smoke/run-tapes.sh init-wizard --keep-stack
+
+# Reuse a stack you already have running:
+./scripts/smoke/run-tapes.sh init-wizard --no-up --keep-stack
+```
+
+`run-tapes.sh` will install `vhs` if missing (Linux/x86_64) and bring the
+smoke compose stack up automatically.
+
+## Authoring conventions
+
+Tapes here MUST follow these rules. A reviewer should reject anything
+that breaks them.
+
+1. **No literal `Sleep`.** Use `Wait+Screen /pattern/` to wait on stable
+   substrings from the wizard's view source
+   (`src/Netclaw.Cli/Tui/Wizard/Steps/*StepView.cs`). Sleep-based
+   synchronization is the single biggest source of CI flakiness. The
+   only acceptable timeout is the outer one inside `run-tape.sh`.
+
+2. **Tapes do not reset state.** The wrapper sets a per-tape
+   `NETCLAW_HOME=/tmp/tape-<name>` and clears it before the tape runs.
+   Tape bodies do not `rm -rf`, do not `clear`, do not depend on prior
+   tape runs.
+
+3. **Tapes do not produce screenshots.** They MAY emit a debug GIF
+   (`Output /tmp/tape-<name>.gif`) so failures have a visual artifact —
+   but no `Screenshot` directives in the body. Visual diffs are not how
+   we assert anything here.
+
+4. **Minimum terminal surface.** `Set Width 100` / `Set Height 30`,
+   `Set Padding 0`, no theme. Anything bigger reduces determinism and
+   slows vhs renders.
+
+5. **Anchor regexes at every step.** After every `Type` / `Enter` /
+   `Down` / etc. that changes the visible state, immediately
+   `Wait+Screen /…/` for an anchor in the next view. If a step has no
+   stable anchor, fix the production code to add one rather than
+   loosening the regex.
+
+6. **Pair each non-trivial tape with an assertion.** Place a sibling
+   script at `tests/smoke-interactive/assertions/<tape-name>.sh`. The
+   wrapper invokes it with `PROJECT_NAME`, `COMPOSE_FILE`, `TAPE_NAME`,
+   and `NETCLAW_HOME_IN` exported. The assertion is the source of truth
+   for "did the tape do the right thing" — vhs's exit code only proves
+   the screen reached the expected states.
+
+## Anatomy
+
+Each tape body is concatenated *after* `preamble.tape`, which sets up
+the docker-exec session into `netclaw-sandbox` with a fresh
+`NETCLAW_HOME` and a deterministic prompt (`TAPE$ `). The combined
+tape is what `vhs` sees; the prompt anchor `/TAPE\$ $/` is the safe
+"back at shell" wait.
+
+The substitution placeholders the wrapper fills in:
+
+| Placeholder         | Replaced with                                |
+|---------------------|----------------------------------------------|
+| `__PROJECT__`       | docker compose project name                   |
+| `__COMPOSE_FILE__`  | absolute path to `docker-compose.smoke.yml`  |
+| `__TAPE_NAME__`     | tape short name (used for `NETCLAW_HOME`)    |
+
+## Adding a new tape
+
+1. Identify the interactive flow you're covering.
+2. Read the relevant `*StepView.cs` (or other TUI source) to harvest
+   stable strings for `Wait+Screen` anchors.
+3. Author the tape body following the rules above.
+4. Author a sibling assertion script that validates the artifacts the
+   tape produced (config fields, `*-list --json` entries,
+   `netclaw doctor` exit code).
+5. Add the tape's short name to `LIGHT_TAPES` (PR gate) or `FULL_TAPES`
+   (nightly) in `scripts/smoke/run-tapes.sh`.
+6. Run `./scripts/smoke/run-tapes.sh <name> --keep-stack` until it's
+   stable across at least 3 consecutive runs. Treat any flake as a
+   bug, not a flake.

--- a/tests/smoke-interactive/tapes/help.tape
+++ b/tests/smoke-interactive/tapes/help.tape
@@ -3,12 +3,12 @@
 # end-to-end against the smoke compose stack. No interactive prompts;
 # the only assertion is that vhs reaches the end without timing out.
 
-Output /tmp/tape-help.gif
+Output "/tmp/tape-help.gif"
 
 Type "netclaw --help"
 Enter
-Wait+Screen /Usage:/
-Wait+Screen /TAPE\$ $/
+Wait+Screen@10s /Usage:/
+Wait+Screen@5s /TAPE\$/
 
 Type "exit"
 Enter

--- a/tests/smoke-interactive/tapes/help.tape
+++ b/tests/smoke-interactive/tapes/help.tape
@@ -1,0 +1,14 @@
+# help.tape — smallest possible tape. Validates that the run-tape.sh
+# pipeline (install-vhs → preamble → tape body → assertion) works
+# end-to-end against the smoke compose stack. No interactive prompts;
+# the only assertion is that vhs reaches the end without timing out.
+
+Output /tmp/tape-help.gif
+
+Type "netclaw --help"
+Enter
+Wait+Screen /Usage:/
+Wait+Screen /TAPE\$ $/
+
+Type "exit"
+Enter

--- a/tests/smoke-interactive/tapes/init-wizard.tape
+++ b/tests/smoke-interactive/tapes/init-wizard.tape
@@ -12,122 +12,121 @@
 #
 # Outputs only a debug GIF; tapes are not authored for screenshots.
 
-Output /tmp/tape-init-wizard.gif
+Output "/tmp/tape-init-wizard.gif"
 
 # ─── Launch ──────────────────────────────────────────────────────────
 Type "netclaw init"
 Enter
 
 # ─── Step 1: Provider ───────────────────────────────────────────────
-Wait+Screen /Choose your LLM provider:/
-# Anthropic is highlighted by default; move down to Ollama.
-# Provider list order is roughly: Anthropic, OpenAI, Ollama, ... — Ollama is index 2.
-Down
+Wait+Screen@10s /Choose your LLM provider:/
+# Provider list ordering is alphabetical by TypeKey:
+#   anthropic, ollama, openai, openai-compatible, openrouter
+# Display order matches: Anthropic (default), then Ollama (one Down).
 Down
 Enter
 
 # Endpoint input (default http://localhost:11434, but in compose ollama is at http://ollama:11434).
-Wait+Screen /endpoint:/
-# Replace default with the compose-internal hostname.
-Ctrl+U
+Wait+Screen@10s /endpoint:/
+# Clear the default value. VHS has no End/Home — push cursor right past
+# the existing text (Right N is a no-op when already at end), then
+# Backspace enough to clear. Default is "http://localhost:11434" (22 chars).
+Right 32
+Backspace 32
 Type "http://ollama:11434"
 Enter
 
-# Wait for connection probe + model discovery.
-Wait+Screen /Connected! Found/
-Wait+Screen /Select a model/
-# qwen2:0.5b is the only model the smoke stack pulls; first item.
+# Wait for connection probe + model discovery. The "Connected! Found N models"
+# success message auto-advances to the model list quickly enough that vhs
+# can miss it; wait directly for the model selection header instead.
+Wait+Screen@45s /Select a model/
+# Models are alphabetical: all-minilm first, qwen2 second. Move to qwen2:0.5b.
+Down
 Enter
 
 # ─── Step 2: Security Posture ────────────────────────────────────────
-Wait+Screen /Who will interact with this Netclaw instance/
+Wait+Screen@10s /Who will interact with this Netclaw instance/
 # Personal is the first / default-highlighted option.
 Enter
 
 # ─── Step 3: Channel Picker ──────────────────────────────────────────
-Wait+Screen /Which channels would you like to connect/
+Wait+Screen@10s /Which channels would you like to connect/
 # 'd' = done without selecting any channels (skip channel setup).
 Type "d"
 
 # ─── Step 4: Web Search ─────────────────────────────────────────────
-Wait+Screen /Choose your web search provider/
+Wait+Screen@10s /Choose your web search provider/
 # DuckDuckGo is the first / default option.
 Enter
 
 # ─── Step 5: Browser Automation ──────────────────────────────────────
-Wait+Screen /Enable browser automation/
+Wait+Screen@10s /Enable browser automation/
 # "No" is the first / default option.
 Enter
 
 # ─── Step 6: Identity ───────────────────────────────────────────────
-Wait+Screen /Agent name:/
+Wait+Screen@10s /Agent name:/
 Enter
 
-Wait+Screen /Communication style:/
+Wait+Screen@10s /Communication style:/
 Enter
 
-Wait+Screen /Your name:/
+Wait+Screen@10s /Your name:/
 Type "SmokeTester"
 Enter
 
-Wait+Screen /Your timezone:/
+Wait+Screen@10s /Your timezone:/
 Enter
 
-Wait+Screen /Projects directory:/
+Wait+Screen@10s /Projects directory:/
 Enter
 
-Wait+Screen /Notification webhook URL/
+Wait+Screen@10s /Notification webhook URL/
 Enter
 
-# ─── Step 7: External Skills ─────────────────────────────────────────
-# This step is conditional on detected external skills. In the smoke
-# container there's no Claude Code, so this prompt may be skipped
-# entirely — the tape treats both branches as acceptable by waiting
-# on whichever appears next.
-#
-# Using Wait+Screen with alternation: if the external-skills picker
-# shows up, accept it; otherwise we'll already be past it.
-Wait+Screen /Add a custom skill directory|External skill directories detected|Configured feeds:|Connect to a private skill server/
-
-# If we landed on the "External skill directories detected" page,
-# accept and move on. The "Add a custom skill directory" prompt
-# follows; press Enter to skip.
-# (If we landed elsewhere already, this Enter is a no-op for that view.)
-Enter
-
-# Custom skill directory — leave blank.
-Wait+Screen /Add a custom skill directory|Connect to a private skill server/
-Enter
+# ─── Step 7: External Skills (skipped in smoke) ─────────────────────
+# ExternalSkillsStep.IsApplicable returns false when _detectedSources.Count == 0.
+# The smoke container has no Claude Code etc., so the wizard goes straight
+# from Identity → SkillFeeds with no External Skills prompts. If that ever
+# changes (smoke image starts seeding Claude Code), we'll need to handle
+# the "External skill directories detected" multi-select + custom dir input.
 
 # ─── Step 8: Skill Feeds ────────────────────────────────────────────
-Wait+Screen /Connect to a private skill server/
-# "No — skip" is the second option.
+Wait+Screen@10s /Connect to a private skill server/
+# Default is "Yes, connect"; we want "No — skip" (Down + Enter).
 Down
 Enter
 
 # ─── Step 9: Network Exposure ───────────────────────────────────────
-Wait+Screen /How will this Netclaw daemon be accessed/
+Wait+Screen@10s /How will this Netclaw daemon be accessed/
 # "Local — loopback only" is the first / default option.
 Enter
 
-Wait+Screen /Should this daemon accept inbound webhooks/
+Wait+Screen@10s /Should this daemon accept inbound webhooks/
 # "No" — second option.
 Down
 Enter
 
 # ─── Step 10: Health Check ──────────────────────────────────────────
-Wait+Screen /Press Enter to run health checks/
+Wait+Screen@10s /Press Enter to run health checks/
 Enter
 
 # Health checks contact ollama, validate config, run doctor probes.
-# Wait for either a clear success indicator or the wizard to finish
-# and return to the shell prompt.
-Wait+Screen /TAPE\$ $/
+# On success the wizard auto-navigates to the chat page (the daemon is
+# running by this point and the user lands inside the TUI). Wait for
+# the chat status bar to show the configured model, then quit the TUI
+# with Ctrl+Q to drop back to the shell. The post-tape assertion runs
+# `netclaw doctor` against the config the wizard wrote, which is the
+# real signal — vhs only proves we got this far.
+Wait+Screen@120s /Ready  \|  qwen2:0.5b/
+Ctrl+Q
+
+Wait+Screen@10s /TAPE\$/
 
 # Sanity: re-check at the prompt that init reported success.
 Type "echo INIT_EXIT=$?"
 Enter
-Wait+Screen /INIT_EXIT=0/
+Wait+Screen@5s /INIT_EXIT=0/
 
 Type "exit"
 Enter

--- a/tests/smoke-interactive/tapes/init-wizard.tape
+++ b/tests/smoke-interactive/tapes/init-wizard.tape
@@ -1,0 +1,133 @@
+# init-wizard.tape — Personal-posture, Ollama, full wizard walkthrough.
+#
+# This is the regression-catcher: the netclaw/knit interactive-wizard
+# bug lived inside this flow. Every interactive prompt in the wizard
+# is exercised here, and the post-tape assertion validates the
+# produced config against the embedded JSON schema.
+#
+# Synchronization: every step waits on a stable substring from the
+# step's view source (see src/Netclaw.Cli/Tui/Wizard/Steps/*StepView.cs).
+# Do NOT introduce literal `Sleep` — tighten the regex if you hit a
+# false positive.
+#
+# Outputs only a debug GIF; tapes are not authored for screenshots.
+
+Output /tmp/tape-init-wizard.gif
+
+# ─── Launch ──────────────────────────────────────────────────────────
+Type "netclaw init"
+Enter
+
+# ─── Step 1: Provider ───────────────────────────────────────────────
+Wait+Screen /Choose your LLM provider:/
+# Anthropic is highlighted by default; move down to Ollama.
+# Provider list order is roughly: Anthropic, OpenAI, Ollama, ... — Ollama is index 2.
+Down
+Down
+Enter
+
+# Endpoint input (default http://localhost:11434, but in compose ollama is at http://ollama:11434).
+Wait+Screen /endpoint:/
+# Replace default with the compose-internal hostname.
+Ctrl+U
+Type "http://ollama:11434"
+Enter
+
+# Wait for connection probe + model discovery.
+Wait+Screen /Connected! Found/
+Wait+Screen /Select a model/
+# qwen2:0.5b is the only model the smoke stack pulls; first item.
+Enter
+
+# ─── Step 2: Security Posture ────────────────────────────────────────
+Wait+Screen /Who will interact with this Netclaw instance/
+# Personal is the first / default-highlighted option.
+Enter
+
+# ─── Step 3: Channel Picker ──────────────────────────────────────────
+Wait+Screen /Which channels would you like to connect/
+# 'd' = done without selecting any channels (skip channel setup).
+Type "d"
+
+# ─── Step 4: Web Search ─────────────────────────────────────────────
+Wait+Screen /Choose your web search provider/
+# DuckDuckGo is the first / default option.
+Enter
+
+# ─── Step 5: Browser Automation ──────────────────────────────────────
+Wait+Screen /Enable browser automation/
+# "No" is the first / default option.
+Enter
+
+# ─── Step 6: Identity ───────────────────────────────────────────────
+Wait+Screen /Agent name:/
+Enter
+
+Wait+Screen /Communication style:/
+Enter
+
+Wait+Screen /Your name:/
+Type "SmokeTester"
+Enter
+
+Wait+Screen /Your timezone:/
+Enter
+
+Wait+Screen /Projects directory:/
+Enter
+
+Wait+Screen /Notification webhook URL/
+Enter
+
+# ─── Step 7: External Skills ─────────────────────────────────────────
+# This step is conditional on detected external skills. In the smoke
+# container there's no Claude Code, so this prompt may be skipped
+# entirely — the tape treats both branches as acceptable by waiting
+# on whichever appears next.
+#
+# Using Wait+Screen with alternation: if the external-skills picker
+# shows up, accept it; otherwise we'll already be past it.
+Wait+Screen /Add a custom skill directory|External skill directories detected|Configured feeds:|Connect to a private skill server/
+
+# If we landed on the "External skill directories detected" page,
+# accept and move on. The "Add a custom skill directory" prompt
+# follows; press Enter to skip.
+# (If we landed elsewhere already, this Enter is a no-op for that view.)
+Enter
+
+# Custom skill directory — leave blank.
+Wait+Screen /Add a custom skill directory|Connect to a private skill server/
+Enter
+
+# ─── Step 8: Skill Feeds ────────────────────────────────────────────
+Wait+Screen /Connect to a private skill server/
+# "No — skip" is the second option.
+Down
+Enter
+
+# ─── Step 9: Network Exposure ───────────────────────────────────────
+Wait+Screen /How will this Netclaw daemon be accessed/
+# "Local — loopback only" is the first / default option.
+Enter
+
+Wait+Screen /Should this daemon accept inbound webhooks/
+# "No" — second option.
+Down
+Enter
+
+# ─── Step 10: Health Check ──────────────────────────────────────────
+Wait+Screen /Press Enter to run health checks/
+Enter
+
+# Health checks contact ollama, validate config, run doctor probes.
+# Wait for either a clear success indicator or the wizard to finish
+# and return to the shell prompt.
+Wait+Screen /TAPE\$ $/
+
+# Sanity: re-check at the prompt that init reported success.
+Type "echo INIT_EXIT=$?"
+Enter
+Wait+Screen /INIT_EXIT=0/
+
+Type "exit"
+Enter

--- a/tests/smoke-interactive/tapes/preamble.tape
+++ b/tests/smoke-interactive/tapes/preamble.tape
@@ -5,37 +5,49 @@
 # disturbing the smoke compose volume.
 #
 # The wrapper substitutes:
-#   __PROJECT__       — docker compose project name (e.g. netclaw-smoke-tapes)
+#   __PROJECT__       — docker compose project name
 #   __COMPOSE_FILE__  — path to docker-compose.smoke.yml
 #   __TAPE_NAME__     — short name (e.g. init-wizard) used to scope NETCLAW_HOME
 #
-# Tapes that include this preamble can assume:
-#   * They are inside an interactive bash session in the sandbox container.
+# After the preamble runs each tape body can assume:
+#   * It is inside an interactive bash session in the sandbox container.
 #   * NETCLAW_HOME points at an empty per-tape directory.
-#   * The shell prompt has been replaced with a deterministic marker so
-#     Wait+Screen anchors (e.g. /TAPE\$/) work without depending on PS1.
+#   * The shell prompt has been replaced with `TAPE$ ` so screen anchors
+#     like /TAPE\$/ work without depending on PS1.
+#
+# VHS v0.11 does not support escaped quotes inside `Type "..."`, so we
+# avoid them entirely by burning the per-tape directory path into the
+# preamble at substitution time.
 
 Set Shell "bash"
-Set Width 100
-Set Height 30
+# Width/Height are PIXELS in VHS, not character columns. At FontSize 14
+# this gives roughly 95 cols x 50 rows — enough for the wizard's panels
+# without wrapping the typed `docker compose exec` line.
+Set Width 1400
+Set Height 800
 Set FontSize 14
 Set Padding 0
 Set TypingSpeed 30ms
 
 Hide
 
-Type "exec docker compose -p __PROJECT__ -f __COMPOSE_FILE__ exec netclaw-sandbox bash --noprofile --norc"
+# Replace the host vhs-spawned bash with a docker exec into the sandbox.
+# Bash inside the netclaw image starts with an empty PS1 (USER netclaw,
+# no profile), so we cannot wait on a prompt — we wait briefly to let
+# the exec attach, then explicitly set PS1 ourselves so anchors below
+# work deterministically.
+Type "exec docker compose -p __PROJECT__ -f __COMPOSE_FILE__ exec netclaw-sandbox bash"
 Enter
-Wait+Screen /[#$] $/
+Sleep 1500ms
 
-Type "export NETCLAW_HOME=/tmp/tape-__TAPE_NAME__"
+Type "rm -rf /tmp/tape-__TAPE_NAME__ && mkdir -p /tmp/tape-__TAPE_NAME__"
 Enter
-Type "rm -rf \"$NETCLAW_HOME\" && mkdir -p \"$NETCLAW_HOME\""
+Type "export NETCLAW_HOME=/tmp/tape-__TAPE_NAME__"
 Enter
 Type "export PS1='TAPE$ '"
 Enter
 Type "clear"
 Enter
-Wait+Screen /TAPE\$ $/
+Wait+Screen /TAPE\$/
 
 Show

--- a/tests/smoke-interactive/tapes/preamble.tape
+++ b/tests/smoke-interactive/tapes/preamble.tape
@@ -1,0 +1,41 @@
+# Shared preamble prepended by scripts/smoke/run-tape.sh before each tape body.
+#
+# Establishes a docker exec session into the netclaw-sandbox container with a
+# per-tape NETCLAW_HOME so each tape gets a clean config directory without
+# disturbing the smoke compose volume.
+#
+# The wrapper substitutes:
+#   __PROJECT__       — docker compose project name (e.g. netclaw-smoke-tapes)
+#   __COMPOSE_FILE__  — path to docker-compose.smoke.yml
+#   __TAPE_NAME__     — short name (e.g. init-wizard) used to scope NETCLAW_HOME
+#
+# Tapes that include this preamble can assume:
+#   * They are inside an interactive bash session in the sandbox container.
+#   * NETCLAW_HOME points at an empty per-tape directory.
+#   * The shell prompt has been replaced with a deterministic marker so
+#     Wait+Screen anchors (e.g. /TAPE\$/) work without depending on PS1.
+
+Set Shell "bash"
+Set Width 100
+Set Height 30
+Set FontSize 14
+Set Padding 0
+Set TypingSpeed 30ms
+
+Hide
+
+Type "exec docker compose -p __PROJECT__ -f __COMPOSE_FILE__ exec netclaw-sandbox bash --noprofile --norc"
+Enter
+Wait+Screen /[#$] $/
+
+Type "export NETCLAW_HOME=/tmp/tape-__TAPE_NAME__"
+Enter
+Type "rm -rf \"$NETCLAW_HOME\" && mkdir -p \"$NETCLAW_HOME\""
+Enter
+Type "export PS1='TAPE$ '"
+Enter
+Type "clear"
+Enter
+Wait+Screen /TAPE\$ $/
+
+Show


### PR DESCRIPTION
## Summary

- Adds a VHS tape-driven smoke test harness that runs alongside the existing non-interactive smoke (`scripts/smoke/check.sh`), covering the interactive Termina/TUI surface that `check.sh` cannot reach — the layer where the recent init-wizard regression lived.
- Includes a full `init-wizard` Personal-posture walkthrough with post-tape assertions on the produced state (`netclaw doctor` exit code, schema-relevant fields in `netclaw.json`, identity in `SOUL.md`).
- Switches the smoke compose from a misplaced named-volume mount at `/root/.netclaw` to a tmpfs at `/home/netclaw/.netclaw` (the image's actual `USER netclaw` home), so smoke runs always start with empty netclaw state and can never collide with a host's `~/.netclaw`.

This is a **foundation PR** — only `help.tape` and `init-wizard.tape` land here. Follow-ups will add `model-add`, `provider-add`, `webhooks-add`, `reminder-create`, and `mcp-permissions` tapes plus a nightly workflow.

## What's new

| File | Purpose |
|------|---------|
| `scripts/smoke/install-vhs.sh` | Pinned VHS install (Linux/x86_64 + apt deps) |
| `scripts/smoke/run-tape.sh` | Per-tape wrapper: preamble substitution → vhs run → assertion → artefact collection |
| `scripts/smoke/run-tapes.sh` | `light` / `full` / single-tape driver shared by CI and local dev (`--keep-stack` / `--no-up`) |
| `tests/smoke-interactive/tapes/preamble.tape` | Establishes a `docker exec` session with per-tape `NETCLAW_HOME=/tmp/tape-<name>` |
| `tests/smoke-interactive/tapes/help.tape` | Harness self-test |
| `tests/smoke-interactive/tapes/init-wizard.tape` | Full Personal-posture wizard, `Wait+Screen` only |
| `tests/smoke-interactive/assertions/init-wizard.sh` | `netclaw doctor` + jq field checks + `identity/SOUL.md` user check |
| `tests/smoke-interactive/tapes/README.md` | Authoring conventions (no `Sleep`, no screenshots, anchor every step) |
| `.github/workflows/smoke_sandbox.yml` | New steps after `check.sh`: install vhs → run light tapes → existing collect/upload still capture artifacts |

`check.sh` is unchanged. The tape harness augments it; it does not replace it. The two cover different slices of the CLI surface (interactive Termina TUI vs HTTP/REST/JSON).

## Verified locally and in CI

```
./scripts/smoke/run-tapes.sh light
# → help: OK
# → init-wizard: OK
#       .Providers.ollama.Type == 'ollama'
#       .Providers.ollama.Endpoint == 'http://ollama:11434'
#       .Models.Main.Provider == 'ollama'
#       .Models.Main.ModelId == 'qwen2:0.5b'
#       .Security.DeploymentPosture == 'Personal'
#       identity/SOUL.md contains 'Name: SmokeTester'
```

CI confirmed green on this branch — the new "Install vhs" + "Run interactive tapes (light)" steps inside the Smoke Sandbox job complete in ~80 seconds end-to-end.

## Notes for reviewers

- VHS pinned to v0.11.0 (minimum that supports `Wait+Screen /pattern/`).
- `netclaw doctor` exits 2 in this configuration because Personal posture + HostAllowed shell intentionally trips a WARN. The assertion treats 0 and 2 as success and only fails on 1.
- ExternalSkillsStep is skipped (`IsApplicable` returns false when no external skill sources are detected); if the smoke image starts seeding Claude Code or similar, init-wizard.tape will need an additional branch.
- The init wizard auto-launches the chat TUI on success; the tape exits chat with `Ctrl+Q` to drop back to the shell before assertions run.

## Test plan

- [x] CI smoke job is green on this branch (the existing smoke checks plus the new interactive tape job).
- [ ] Failure-mode reproduction: introduce an intentional break in a wizard prompt on a throwaway branch and confirm `init-wizard.tape` fails red with a `Wait+Screen` timeout and an attached PNG of the hung screen. (Not done in this PR.)