### PR TITLE
fix: drop SQLite DDL from DailyStatsActor.PreStart + surface wizard crash logs (closes #925, #936)

### DIFF
--- a/src/Netclaw.Cli/Daemon/DaemonManager.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonManager.cs
@@ -598,7 +598,15 @@ public sealed partial class DaemonManager
         }
     }
 
-    private string? TryReadStartupFailureFromCrashLog(DateTimeOffset startedAt, out string? crashLogPath)
+    /// <summary>
+    /// Searches for a crash log written since <paramref name="startedAt"/> and extracts
+    /// the structured "Daemon startup aborted: …" line if present. Returns the failure
+    /// line (or <c>null</c> if none found) and the absolute path of the most recent
+    /// matching crash log via <paramref name="crashLogPath"/>. Public so callers that
+    /// observe a daemon-not-ready timeout can surface the same diagnostic as the
+    /// immediate-start-failure path.
+    /// </summary>
+    public string? TryReadStartupFailureFromCrashLog(DateTimeOffset startedAt, out string? crashLogPath)
     {
         crashLogPath = null;
 

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/HealthCheckStepViewModel.cs
@@ -15,20 +15,24 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 public sealed class HealthCheckStepViewModel : IWizardStepViewModel
 {
     private static readonly TimeSpan OverallHealthCheckTimeout = TimeSpan.FromMinutes(5);
+    private const string NotReadyMessage = "Daemon did not become ready (personality setup skipped)";
 
     private readonly DaemonManager? _daemonManager;
     private readonly DaemonApi? _daemonApi;
     private readonly ChatNavigationState? _navigationState;
+    private readonly TimeProvider _timeProvider;
     private WizardContext? _context;
 
     public HealthCheckStepViewModel(
         DaemonManager? daemonManager = null,
         DaemonApi? daemonApi = null,
-        ChatNavigationState? navigationState = null)
+        ChatNavigationState? navigationState = null,
+        TimeProvider? timeProvider = null)
     {
         _daemonManager = daemonManager;
         _daemonApi = daemonApi;
         _navigationState = navigationState;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public string StepId => WizardStepIds.HealthCheck;
@@ -182,7 +186,7 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
             }
             else if (Results.Count > 0 && Results[^1].Passed is null)
             {
-                runner.UpdateLast(new HealthCheckItem("Daemon did not become ready (personality setup skipped)", false));
+                runner.UpdateLast(new HealthCheckItem(NotReadyMessage, false));
             }
         }
 
@@ -205,6 +209,10 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
     private async Task<bool> StartAndPollDaemonAsync(CancellationToken ct)
     {
         if (_daemonManager is null) return false;
+
+        // DaemonManager.Start only consults the crash log on its 1.5s WaitForExit
+        // branch — anything that crashes after Start returns is invisible to it.
+        var startedAt = _timeProvider.GetUtcNow();
 
         var result = _daemonManager.Start();
         if (!result.Success && !result.Message.Contains("already running", StringComparison.OrdinalIgnoreCase))
@@ -236,7 +244,23 @@ public sealed class HealthCheckStepViewModel : IWizardStepViewModel
                 NotifyChanged();
             }
 
+            if (!_daemonManager.GetStatus().IsRunning)
+                break;
+
             await Task.Delay(1000, ct);
+        }
+
+        var crashFailure = _daemonManager.TryReadStartupFailureFromCrashLog(startedAt, out var crashLogPath);
+        var failureMessage = (crashFailure, crashLogPath) switch
+        {
+            (not null, _)  => $"{crashFailure} See crash log: {crashLogPath}",
+            (null, not null) => $"{NotReadyMessage}. See crash log: {crashLogPath}",
+            _ => null
+        };
+        if (failureMessage is not null)
+        {
+            Results[^1] = new HealthCheckItem(failureMessage, false);
+            NotifyChanged();
         }
 
         return false;

--- a/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/DailyStatsActorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Netclaw.Configuration;
 using Netclaw.Daemon.Gateway;
+using Netclaw.Daemon.Services;
 using Netclaw.Tests.Utilities;
 using Xunit;
 
@@ -30,6 +31,12 @@ public sealed class DailyStatsActorTests : IDisposable
     [Fact]
     public async Task QuerySkillUsageStats_returns_groupable_rows_for_each_method()
     {
+        // Schema DDL no longer runs in PreStart — production initializes it via
+        // SchemaMigrator. Mirror that by running migrations here before ActorOf
+        // so the actor's mailbox is never blocked on disk I/O.
+        var migrator = new SchemaMigrator(_paths, NullLogger<SchemaMigrator>.Instance);
+        await migrator.MigrateAsync(_paths.SqliteDbPath, TestContext.Current.CancellationToken);
+
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero));
         var actor = _system.ActorOf(Props.Create(() => new DailyStatsActor(
             _paths,
@@ -41,13 +48,9 @@ public sealed class DailyStatsActorTests : IDisposable
         actor.Tell(new DailyStatsActor.RecordSkillLoaded("create-release", SkillLoadMethod.SkillLoadTool));
         actor.Tell(new DailyStatsActor.RecordSkillLoaded("create-release", SkillLoadMethod.SlashCommand));
 
-        // 10s timeout: PreStart performs synchronous SQLite DDL (CREATE TABLE +
-        // COMMIT) on a fresh on-disk db, plus the query handler opens a second
-        // connection. On Windows CI cold-start with AV / Defender scanning, 3s
-        // is too tight. See netclaw-dev/netclaw#925 for the proper fix.
         var rows = await actor.Ask<DailyStatsActor.QuerySkillUsageStatsResult>(
             new DailyStatsActor.QuerySkillUsageStats(7),
-            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(3, rows.Rows.Count);
@@ -62,7 +65,7 @@ public sealed class DailyStatsActorTests : IDisposable
 
         var totals = await actor.Ask<DailyStatsActor.ProcessStatsResult>(
             new DailyStatsActor.QueryProcessStats(),
-            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3),
             cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(4, totals.SkillsLoadedTotal);
     }

--- a/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
+++ b/src/Netclaw.Daemon/Gateway/DailyStatsActor.cs
@@ -104,8 +104,11 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
 
     protected override void PreStart()
     {
+        // Schema DDL is initialized synchronously at daemon startup by
+        // SchemaMigrationHostedService — see DailyStatsSchema.EnsureAsync.
+        // Keeping it off the actor's mailbox prevents Windows cold-start
+        // (AV scan + first-time fsync) from delaying the first Ask.
         base.PreStart();
-        EnsureTable();
         Timers.StartPeriodicTimer(FlushTimerKey, Flush.Instance, FlushInterval, FlushInterval);
     }
 
@@ -386,52 +389,6 @@ public sealed class DailyStatsActor : ReceiveActor, IWithTimers
 
             return string.Compare(a.Method.ToWireValue(), b.Method.ToWireValue(), StringComparison.Ordinal);
         });
-    }
-
-    private void EnsureTable()
-    {
-        try
-        {
-            using var conn = new SqliteConnection(_connectionString);
-            conn.Open();
-            using var tx = conn.BeginTransaction();
-            using var cmd = conn.CreateCommand();
-            cmd.Transaction = tx;
-            cmd.CommandText =
-                """
-                CREATE TABLE IF NOT EXISTS daily_stats (
-                    date_key          TEXT NOT NULL PRIMARY KEY,
-                    input_tokens      INTEGER NOT NULL DEFAULT 0,
-                    output_tokens     INTEGER NOT NULL DEFAULT 0,
-                    turns             INTEGER NOT NULL DEFAULT 0,
-                    sessions          INTEGER NOT NULL DEFAULT 0,
-                    memories_formed   INTEGER NOT NULL DEFAULT 0,
-                    memories_recalled INTEGER NOT NULL DEFAULT 0,
-                    skills_loaded     INTEGER NOT NULL DEFAULT 0
-                )
-                """;
-            cmd.ExecuteNonQuery();
-
-            using var usageCmd = conn.CreateCommand();
-            usageCmd.Transaction = tx;
-            usageCmd.CommandText =
-                """
-                CREATE TABLE IF NOT EXISTS daily_skill_usage (
-                    date_key    TEXT NOT NULL,
-                    skill_name  TEXT NOT NULL,
-                    load_method TEXT NOT NULL,
-                    count       INTEGER NOT NULL DEFAULT 0,
-                    PRIMARY KEY (date_key, skill_name, load_method)
-                )
-                """;
-            usageCmd.ExecuteNonQuery();
-
-            tx.Commit();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to ensure daily_stats table");
-        }
     }
 
     // ── Messages ─────────────────────────────────────────────────────

--- a/src/Netclaw.Daemon/migrations/sqlite/005_daily_skill_usage.sql
+++ b/src/Netclaw.Daemon/migrations/sqlite/005_daily_skill_usage.sql
@@ -1,0 +1,11 @@
+-- Per-day, per-skill, per-load-method usage counters.
+-- Written by DailyStatsActor when a RecordSkillLoaded message lands.
+-- Consumed by GET /api/stats/skills?days=N for the wizard's usage breakdown.
+
+CREATE TABLE IF NOT EXISTS daily_skill_usage (
+    date_key    TEXT NOT NULL,
+    skill_name  TEXT NOT NULL,
+    load_method TEXT NOT NULL,
+    count       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (date_key, skill_name, load_method)
+);


### PR DESCRIPTION
## Summary

- **#925**: `DailyStatsActor.PreStart` no longer runs synchronous SQLite DDL. Schema is owned by migration files: existing `004_daily_stats.sql` + new `005_daily_skill_usage.sql`, applied unconditionally by `SchemaMigrator` before the actor system starts. On Windows CI cold-start (AV scan + first-time fsync) this DDL regularly pushed the first `Ask` past its 3s timeout.
- **#936**: `HealthCheckStepViewModel.StartAndPollDaemonAsync` now (a) fast-fails when `DaemonManager.GetStatus().IsRunning` flips false during the polling loop and (b) reads any structured "Daemon startup aborted: …" line from the crash log on poll-timeout, so the wizard reports the real failure reason instead of a generic "Daemon did not become ready" message after 30s of waiting.
- Drive-by: `HealthCheckStepViewModel` now takes `TimeProvider` (constitution compliance), and the "not ready" message is a single named constant.

## Why the test was flaking

Both flakes were Windows-CI-specific:
- DailyStatsActor: the `Ask` raced the AV-scanned cold-start fsync of the SQLite db file. Issue body has the agent analysis.
- HealthCheckStep: when `WaitForExit(1500)` missed a fast-failing fake daemon (cmd.exe startup overhead exceeds 1.5s on a contested Windows runner), `Start()` returned success and the polling loop spun for 30s before reporting a generic message that hid the crash reason.

The daemon-liveness check is a real production improvement, not just a test-speed tweak — if a user's daemon dies during startup, the wizard now reports it within ~1s instead of waiting 30s.

## Test plan

- [x] `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj` — 504/504 pass
- [x] `dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj` — 621/621 pass
- [x] Target tests run fast on Linux (`HealthCheckStepViewModelTests.RunWithOrchestrator_PreservesSpecificStartupFailureMessage` ~92ms; `DailyStatsActorTests.QuerySkillUsageStats…` ~490ms)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — clean
- [ ] CI green on Windows (the failure mode this PR targets)