### PR TITLE
fix: add pipeline init gate to wrong-requester approval tests

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -603,6 +603,8 @@ public abstract class SessionBindingContractTests : TestKit
         ]);
 
         var actor = CreateBindingActor(sid, pipeline, detector);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions),
+            cancellationToken: ct);
         await AwaitAssertAsync(() =>
         {
             var texts = GetPostedTexts();
@@ -650,6 +652,8 @@ public abstract class SessionBindingContractTests : TestKit
         ]);
 
         var actor = CreateBindingActor(sid, pipeline, detector);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions),
+            cancellationToken: ct);
         await AwaitAssertAsync(() =>
         {
             var texts = GetPostedTexts();


### PR DESCRIPTION
## Summary

- Fixes racy Windows CI failure in `Text_approval_from_wrong_requester_posts_warning` (and sibling `Button_approval_from_wrong_requester_posts_warning`)
- Both tests were missing the `AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions))` initialization gate that all 11 other tests in `SessionBindingContractTests` use
- On Windows CI under load, Akka.Streams pipeline materialization can exceed the 3s default `AwaitAssertAsync` timeout, causing the first assertion to exhaust the entire budget before the actor finishes initializing — leaving no time for the second phase assertion

Observed in PR #940 CI: https://github.com/netclaw-dev/netclaw/actions/runs/25565523273/job/75047844078

## Test plan

- [x] Both wrong-requester tests pass locally (4 variants: Slack + Discord × Button + Text)
- [ ] CI passes on Windows (`Test-windows-latest`)