### PR TITLE
fix(mcp): personal mode defaults all tools to Auto, toggle grants all (#942)

### DIFF
--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -118,7 +118,20 @@ public sealed class McpCommandTests : IDisposable
         var doc = ReadConfigFile(_paths.NetclawConfigPath);
         var profiles = doc.RootElement.GetProperty("Tools").GetProperty("AudienceProfiles");
 
-        foreach (var audience in new[] { "Personal", "Team", "Public" })
+        // Personal: no per-tool grants (all tools pass), Auto approval
+        var personal = profiles.GetProperty("Personal");
+        var hasPersonalGrants = personal.TryGetProperty("McpServerToolGrants", out var pg)
+            && pg.ValueKind == JsonValueKind.Object
+            && pg.TryGetProperty("notion", out _);
+        Assert.False(hasPersonalGrants);
+        Assert.Equal("Auto", personal
+            .GetProperty("ApprovalPolicy")
+            .GetProperty("McpServerDefaults")
+            .GetProperty("notion")
+            .GetString());
+
+        // Team/Public: empty grants, Approval/Deny
+        foreach (var audience in new[] { "Team", "Public" })
         {
             var profile = profiles.GetProperty(audience);
             var grants = profile.GetProperty("McpServerToolGrants").GetProperty("notion");
@@ -136,9 +149,9 @@ public sealed class McpCommandTests : IDisposable
         }
 
         var output = _output.ToString();
-        Assert.Contains("0 tools granted", output);
+        Assert.Contains("Personal grants all tools", output);
         Assert.Contains("netclaw mcp permissions", output);
-        Assert.Contains("Personal=Approval", output);
+        Assert.Contains("Personal=Auto", output);
         Assert.Contains("Public=Deny", output);
     }
 
@@ -168,7 +181,12 @@ public sealed class McpCommandTests : IDisposable
                 .GetProperty("McpServerDefaults")
                 .GetProperty("trusted")
                 .GetString();
-            var expected = audience == "Public" ? "Deny" : "Approval";
+            var expected = audience switch
+            {
+                "Personal" => "Auto",
+                "Public" => "Deny",
+                _ => "Approval"
+            };
             Assert.Equal(expected, approvalMode);
         }
 
@@ -203,11 +221,23 @@ public sealed class McpCommandTests : IDisposable
         var doc = ReadConfigFile(_paths.NetclawConfigPath);
         var profiles = doc.RootElement.GetProperty("Tools").GetProperty("AudienceProfiles");
 
-        foreach (var audience in new[] { "Personal", "Team", "Public" })
+        // Personal: no per-tool grants written for new-server (all tools pass)
+        var personalProfile = profiles.GetProperty("Personal");
+        var hasPersonalGrants = personalProfile.TryGetProperty("McpServerToolGrants", out var personalGrants)
+            && personalGrants.ValueKind == JsonValueKind.Object
+            && personalGrants.TryGetProperty("new-server", out _);
+        Assert.False(hasPersonalGrants);
+        var personalApproval = personalProfile
+            .GetProperty("ApprovalPolicy")
+            .GetProperty("McpServerDefaults");
+        Assert.False(personalApproval.TryGetProperty("old-server", out _));
+        Assert.True(personalApproval.TryGetProperty("new-server", out _));
+
+        // Team/Public: empty grants written, old-server untouched
+        foreach (var audience in new[] { "Team", "Public" })
         {
             var profile = profiles.GetProperty(audience);
 
-            // old-server MUST NOT have defaults written.
             Assert.True(profile.TryGetProperty("McpServerToolGrants", out var grants));
             Assert.False(grants.TryGetProperty("old-server", out _));
             Assert.True(grants.TryGetProperty("new-server", out _));
@@ -254,7 +284,7 @@ public sealed class McpCommandTests : IDisposable
 
         Assert.True(personal.TryGetProperty("ApprovalPolicy", out var approvalPolicy));
         Assert.Equal(
-            "Approval",
+            "Auto",
             approvalPolicy.GetProperty("McpServerDefaults").GetProperty("notion").GetString());
 
         // Pre-existing property should still be there.

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -237,6 +237,23 @@ public sealed class McpToolPermissionsViewModelTests : IDisposable
             Assert.True(vm.IsToolGranted(new ToolName(tool)));
     }
 
+    [Fact]
+    public void ToggleServerAccess_DisablingClearsGrantedTools()
+    {
+        var vm = CreateVm();
+        var tools = new[] { "create-pages", "search" };
+        vm.InitializeForTests(new McpServerName("notion"), tools);
+        vm.SetSelectedAudienceForTests(TrustAudience.Team);
+
+        vm.ToggleServerAccess(); // enable
+        Assert.True(vm.IsToolGranted(new ToolName("create-pages")));
+
+        vm.ToggleServerAccess(); // disable
+        Assert.False(vm.IsServerAllowedForSelectedAudience());
+        foreach (var tool in tools)
+            Assert.False(vm.IsToolGranted(new ToolName(tool)));
+    }
+
     private sealed class NoopHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();

--- a/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpToolPermissionsViewModelTests.cs
@@ -220,6 +220,23 @@ public sealed class McpToolPermissionsViewModelTests : IDisposable
         Assert.True(isInherited);
     }
 
+    [Fact]
+    public void ToggleServerAccess_GrantsAllDiscoveredTools()
+    {
+        var vm = CreateVm();
+        var tools = new[] { "create-pages", "search", "list-databases" };
+        vm.InitializeForTests(new McpServerName("notion"), tools);
+        vm.SetSelectedAudienceForTests(TrustAudience.Team);
+
+        Assert.False(vm.IsServerAllowedForSelectedAudience());
+
+        vm.ToggleServerAccess();
+
+        Assert.True(vm.IsServerAllowedForSelectedAudience());
+        foreach (var tool in tools)
+            Assert.True(vm.IsToolGranted(new ToolName(tool)));
+    }
+
     private sealed class NoopHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -232,21 +232,22 @@ internal static class McpCommand
         }
         else
         {
-            writer.WriteLine("Security: 0 tools granted for any audience. Personal/Team/Public tool grants");
-            writer.WriteLine("          were written as empty lists to block all tools until you opt in.");
+            writer.WriteLine("Security: Personal grants all tools (auto-approved). Team/Public grant 0 tools");
+            writer.WriteLine("          until you opt in via `netclaw mcp permissions`.");
         }
-        writer.WriteLine("Approval defaults: Personal=Approval, Team=Approval, Public=Deny");
+        writer.WriteLine("Approval defaults: Personal=Auto, Team=Approval, Public=Deny");
         writer.WriteLine($"Next: run `netclaw mcp permissions` to grant tools and adjust approvals for '{serverName.Value}'.");
         return 0;
     }
 
     /// <summary>
-    /// Writes fail-closed defaults for a newly added MCP server across all
-    /// audience profiles: empty <c>McpServerToolGrants[serverName]</c> lists
-    /// (skipped when <paramref name="grantAll"/> is true) and
-    /// <c>ApprovalPolicy.McpServerDefaults[serverName]</c> per-audience
-    /// entries (Personal=Approval, Team=Approval, Public=Deny). The
-    /// <c>ApprovalPolicy</c> section is created if missing.
+    /// Writes secure defaults for a newly added MCP server across all audience
+    /// profiles. Personal gets <c>Auto</c> approval and no per-tool grants
+    /// (all tools pass). Team/Public get empty <c>McpServerToolGrants[serverName]</c>
+    /// lists (skipped when <paramref name="grantAll"/> is true) and
+    /// <c>ApprovalPolicy.McpServerDefaults[serverName]</c> entries
+    /// (Team=Approval, Public=Deny). The <c>ApprovalPolicy</c> section is
+    /// created if missing.
     /// </summary>
     private static void ApplySecureDefaultsForNewServer(
         Dictionary<string, object> config, McpServerName serverName, bool grantAll)
@@ -254,18 +255,19 @@ internal static class McpCommand
         var toolsSection = GetOrCreateSection(config, "Tools");
         var profilesSection = GetOrCreateSection(toolsSection, "AudienceProfiles");
 
-        (string audience, string approvalMode)[] audiences =
+        (TrustAudience audience, string approvalMode)[] audiences =
         [
-            ("Personal", "Approval"),
-            ("Team", "Approval"),
-            ("Public", "Deny"),
+            (TrustAudience.Personal, "Auto"),
+            (TrustAudience.Team, "Approval"),
+            (TrustAudience.Public, "Deny"),
         ];
 
-        foreach (var (audienceName, approvalMode) in audiences)
+        foreach (var (audience, approvalMode) in audiences)
         {
+            var audienceName = audience.ToString();
             var audienceSection = GetOrCreateSection(profilesSection, audienceName);
 
-            if (!grantAll)
+            if (!grantAll && audience != TrustAudience.Personal)
             {
                 var grants = GetOrCreateSection(audienceSection, "McpServerToolGrants");
                 grants[serverName.Value] = new List<string>();

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -584,8 +584,6 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
 
         if (!allowed)
         {
-            // Enabling server for this audience — start with empty tool grants
-            // so the operator explicitly selects which tools to expose
             if (!_pendingGrants.TryGetValue(SelectedServer, out var serverGrants))
             {
                 serverGrants = [];
@@ -593,7 +591,7 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             }
 
             if (!serverGrants.ContainsKey(audienceName))
-                serverGrants[audienceName] = new HashSet<string>(StringComparer.Ordinal);
+                serverGrants[audienceName] = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
         }
 
         NotifyStateChanged();

--- a/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
+++ b/src/Netclaw.Cli/Mcp/McpToolPermissionsViewModel.cs
@@ -593,6 +593,10 @@ public sealed class McpToolPermissionsViewModel : ReactiveViewModel
             if (!serverGrants.ContainsKey(audienceName))
                 serverGrants[audienceName] = new HashSet<string>(DiscoveredTools, StringComparer.Ordinal);
         }
+        else if (_pendingGrants.TryGetValue(SelectedServer, out var existingGrants))
+        {
+            existingGrants.Remove(audienceName);
+        }
 
         NotifyStateChanged();
     }


### PR DESCRIPTION
## Summary
- Personal audience now gets `Auto` approval and skips empty tool grants when adding a server via `netclaw mcp add` — all tools pass by default
- Toggling "Server enabled" in the `netclaw mcp permissions` TUI now grants all discovered tools instead of starting with an empty set
- Uses `TrustAudience` enum instead of raw strings in `ApplySecureDefaultsForNewServer`

Closes #942

## Test plan
- [x] `Add_WritesEmptyGrantsAndApprovalDefaultsAcrossAudiences` — Personal gets `Auto` + no grants; Team/Public unchanged
- [x] `Add_WithGrantAll_SkipsGrantsButWritesApprovalDefaults` — Personal approval is `Auto`
- [x] `Add_DoesNotMutateExistingServers` — Personal skips grants for new server
- [x] `Add_CreatesApprovalPolicySectionWhenMissing` — Personal approval is `Auto`
- [x] `ToggleServerAccess_GrantsAllDiscoveredTools` — new test: enabling server grants all tools
- [x] All 30 tests in `McpCommandTests` + `McpToolPermissionsViewModelTests` pass