### PR TITLE
fix(streaming): thinking-only retry guard + 3-layer SSE/middleware/actor diagnostics + RollingFileLogger Debug fix

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -363,6 +363,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         });
 
         Command<ProcessingWatchdogExpired>(_ => { });
+        Command<LlmCallFailed>(_ => { }); // stale failure arriving after watchdog timeout
+        Command<LlmResponseReceived>(_ => { }); // stale response arriving after transition to Ready
         Command<CompactionWorkCompleted>(_ => { });
         Command<CompactionWorkFailed>(_ => { });
         CommandDistillationAckNoOp();
@@ -443,8 +445,31 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             var response = msg.Response;
             var lastMessage = response.Messages[^1];
 
-            // Check for tool calls
-            var toolCalls = lastMessage.Contents.OfType<FunctionCallContent>().ToList();
+            var toolCalls = new List<FunctionCallContent>();
+            bool hasText = false, hasThinking = false;
+            int textChars = 0, thinkingChars = 0;
+            foreach (var c in lastMessage.Contents)
+            {
+                switch (c)
+                {
+                    case TextContent tc:
+                        textChars += tc.Text?.Length ?? 0;
+                        if (!string.IsNullOrWhiteSpace(tc.Text)) hasText = true;
+                        break;
+                    case TextReasoningContent rc:
+                        thinkingChars += rc.Text?.Length ?? 0;
+                        if (!string.IsNullOrWhiteSpace(rc.Text)) hasThinking = true;
+                        break;
+                    case FunctionCallContent fc:
+                        toolCalls.Add(fc);
+                        break;
+                }
+            }
+
+            _log.Debug(
+                "LLM response content breakdown: text={TextChars}ch thinking={ThinkingChars}ch toolCalls={ToolCallCount} finishReason={FinishReason}",
+                textChars, thinkingChars, toolCalls.Count, response.FinishReason?.ToString() ?? "null");
+
             if (toolCalls.Count > 0 && _turnState.ForceNoToolsActive)
             {
                 TurnLog().Warning(
@@ -465,21 +490,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            // Guard: empty response (no text, no thinking, no tool calls) — delegate decision to tracker
-            var hasContent = lastMessage.Contents.Any(c =>
-                (c is TextContent tc && !string.IsNullOrWhiteSpace(tc.Text)) ||
-                (c is TextReasoningContent rc && !string.IsNullOrWhiteSpace(rc.Text)));
-            if (!hasContent)
+            if (!hasText && toolCalls.Count == 0)
             {
+                var label = hasThinking ? "thinking-only" : "empty";
                 switch (_turnState.EvaluateEmptyResponse())
                 {
                     case EmptyResponseAction.Retry retry:
-                        _log.Warning("LLM produced empty response — retrying with nudge");
+                        _log.Warning("LLM produced {Label} response ({ThinkingChars} chars) — retrying with nudge",
+                            label, thinkingChars);
                         _state = _state.AddSystemNudge(retry.NudgeText);
                         FireLlmCall();
                         return;
                     case EmptyResponseAction.Fail fail:
-                        _log.Warning("LLM produced empty response — failing turn");
+                        _log.Warning("LLM produced {Label} response — failing turn", label);
                         FailCurrentTurn(fail.ErrorMessage, fail.Cause, ErrorCategory.ProviderFailure);
                         return;
                 }

--- a/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
+++ b/src/Netclaw.Daemon/Configuration/LoggingChatClient.cs
@@ -72,6 +72,12 @@ public sealed class LoggingChatClient : DelegatingChatClient
         var start = _timeProvider.GetTimestamp();
         long inputTokens = 0;
         long outputTokens = 0;
+        int textDeltaCount = 0;
+        int textDeltaChars = 0;
+        int thinkingDeltaCount = 0;
+        int thinkingDeltaChars = 0;
+        int toolCallDeltaCount = 0;
+        ChatFinishReason? lastFinishReason = null;
 
         IAsyncEnumerable<ChatResponseUpdate> stream;
         try
@@ -87,16 +93,41 @@ public sealed class LoggingChatClient : DelegatingChatClient
 
         await foreach (var update in stream)
         {
-            if (update.Contents?.OfType<UsageContent>().FirstOrDefault() is { } usage)
+            foreach (var item in update.Contents)
             {
-                inputTokens += usage.Details?.InputTokenCount ?? 0;
-                outputTokens += usage.Details?.OutputTokenCount ?? 0;
+                switch (item)
+                {
+                    case TextContent tc:
+                        textDeltaCount++;
+                        textDeltaChars += tc.Text?.Length ?? 0;
+                        break;
+                    case TextReasoningContent rc:
+                        thinkingDeltaCount++;
+                        thinkingDeltaChars += rc.Text?.Length ?? 0;
+                        break;
+                    case FunctionCallContent:
+                        toolCallDeltaCount++;
+                        break;
+                    case UsageContent usage:
+                        inputTokens += usage.Details?.InputTokenCount ?? 0;
+                        outputTokens += usage.Details?.OutputTokenCount ?? 0;
+                        break;
+                }
             }
+
+            if (update.FinishReason is not null)
+                lastFinishReason = update.FinishReason;
 
             yield return update;
         }
 
         var totalElapsed = _timeProvider.GetElapsedTime(start);
+
+        _logger.LogDebug(
+            "LLM streaming response content breakdown: textDeltas={TextDeltaCount} textChars={TextChars} thinkingDeltas={ThinkingDeltaCount} thinkingChars={ThinkingChars} toolCallDeltas={ToolCallDeltaCount} finishReason={FinishReason}",
+            textDeltaCount, textDeltaChars, thinkingDeltaCount, thinkingDeltaChars, toolCallDeltaCount,
+            lastFinishReason?.ToString() ?? "null");
+
         if (inputTokens > 0 || outputTokens > 0)
         {
             var delta = RecordInputTokens(inputTokens);

--- a/src/Netclaw.Daemon/Configuration/RollingFileLoggerProvider.cs
+++ b/src/Netclaw.Daemon/Configuration/RollingFileLoggerProvider.cs
@@ -212,7 +212,7 @@ internal sealed class RollingFileLogger : ILogger
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
-    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Information;
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Netclaw.Providers.SelfHosted;
 
@@ -22,11 +24,15 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
     private readonly HttpClient _httpClient;
     private readonly OpenAiCompatibleEndpoint _endpoint;
     private readonly string _modelId;
-    public OpenAiCompatibleChatClient(HttpClient httpClient, OpenAiCompatibleEndpoint endpoint, string modelId)
+    private readonly ILogger _logger;
+
+    public OpenAiCompatibleChatClient(HttpClient httpClient, OpenAiCompatibleEndpoint endpoint, string modelId,
+        ILogger? logger = null)
     {
         _httpClient = httpClient;
         _endpoint = endpoint;
         _modelId = modelId;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     public async Task<ChatResponse> GetResponseAsync(
@@ -67,6 +73,9 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         var hadStructuredToolCalls = false;
         ChatResponseUpdate? finalUpdate = null;
         var filter = new ToolCallTextFilter();
+        int textDeltaCount = 0, textDeltaChars = 0;
+        int thinkingDeltaCount = 0, thinkingDeltaChars = 0;
+        int toolCallDeltaCount = 0, suppressedDeltaCount = 0;
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -99,11 +108,18 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                     {
                         case TextContent tc:
                             accumulatedText.Append(tc.Text);
+                            textDeltaCount++;
+                            textDeltaChars += tc.Text?.Length ?? 0;
                             if (filter.ShouldSuppress(tc.Text))
                                 suppressThisUpdate = true;
                             break;
+                        case TextReasoningContent rc:
+                            thinkingDeltaCount++;
+                            thinkingDeltaChars += rc.Text?.Length ?? 0;
+                            break;
                         case FunctionCallContent:
                             hadStructuredToolCalls = true;
+                            toolCallDeltaCount++;
                             break;
                     }
                 }
@@ -115,6 +131,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                 // content-free keepalive so the caller knows the stream is alive.
                 if (suppressThisUpdate)
                 {
+                    suppressedDeltaCount++;
                     yield return KeepaliveUpdate;
                     continue;
                 }
@@ -122,6 +139,11 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                 yield return update;
             }
         }
+
+        _logger.LogDebug(
+            "SSE stream content breakdown: textDeltas={TextDeltas} textChars={TextChars} thinkingDeltas={ThinkingDeltas} thinkingChars={ThinkingChars} toolCallDeltas={ToolCallDeltas} suppressedDeltas={SuppressedDeltas} finishReason={FinishReason}",
+            textDeltaCount, textDeltaChars, thinkingDeltaCount, thinkingDeltaChars, toolCallDeltaCount,
+            suppressedDeltaCount, finalUpdate?.FinishReason?.ToString() ?? "null");
 
         // Fallback: if the model stopped without structured tool calls but the text
         // contains XML-like tool call blocks, emit a synthetic tool call update.

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleProviderPlugin.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleProviderPlugin.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 using Netclaw.Providers;
 
@@ -14,7 +15,13 @@ namespace Netclaw.Providers.SelfHosted;
 /// </summary>
 public sealed class OpenAiCompatibleProviderPlugin : ProviderPluginBase<OpenAiCompatibleDescriptor>
 {
-    public OpenAiCompatibleProviderPlugin(OpenAiCompatibleDescriptor descriptor) : base(descriptor) { }
+    private readonly ILoggerFactory _loggerFactory;
+
+    public OpenAiCompatibleProviderPlugin(OpenAiCompatibleDescriptor descriptor, ILoggerFactory loggerFactory)
+        : base(descriptor)
+    {
+        _loggerFactory = loggerFactory;
+    }
 
     public override IChatClient CreateChatClient(ProviderEntry entry, ModelReference model)
     {
@@ -25,6 +32,7 @@ public sealed class OpenAiCompatibleProviderPlugin : ProviderPluginBase<OpenAiCo
         return new OpenAiCompatibleChatClient(
             CreateLlmHttpClient(endpoint.BaseUri),
             endpoint,
-            model.ModelId);
+            model.ModelId,
+            _loggerFactory.CreateLogger<OpenAiCompatibleChatClient>());
     }
 }


### PR DESCRIPTION
## Summary

- **Thinking-only retry guard**: when a streaming LLM call completes with reasoning content but no visible text/tool calls (Qwen3 + `--jinja` regime), retry via `EvaluateEmptyResponse` instead of letting Slack post a silent fallback reply.
- **Stale-message absorption** in `LlmSessionActor.Ready` for late `LlmCallFailed` / `LlmResponseReceived` after watchdog timeouts (kills noisy dead letters).
- **3-layer streaming diagnostics** (Debug level): `OpenAiCompatibleChatClient` (SSE wire), `LoggingChatClient` (middleware), `LlmSessionActor` (post-assembly). Counts text deltas/chars, thinking deltas/chars, tool-call deltas, and finish reason at each layer so operators can pinpoint where deltas land or get dropped.
- **`ILoggerFactory` injection** in `OpenAiCompatibleProviderPlugin` so the SSE-layer log isn't swallowed by `NullLogger.Instance`.
- **`RollingFileLogger` Debug-floor fix**: removes the hardcoded `>= LogLevel.Information` filter so `Logging:LogLevel:Default=Debug` actually persists Debug logs to `~/.netclaw/logs/daemon-*.log` (#908). Without this, the new diagnostics — and any other Debug logs — never reach disk regardless of config.

## Related

Refs netclaw-dev/netclaw-website#16 — delivers the **3-layer SSE / middleware / actor diagnostic counters** described in that issue's "What Netclaw provides to help diagnose this" section. Does not close it: the docs/troubleshooting article portion of #16 is still open and should be addressed separately on the netclaw-website repo.

## Context

Symptom: a recent self-hosted Slack session (`D0AC6CKBK5K/1778333220.192409`, 2026-05-09) produced three consecutive streaming turns with `output: 2/4/28` final tokens despite many `Thinking delta:` events arriving. Each turn ended with `Turn completed without visible Slack output; posting fallback reply`. Same backend, the non-streaming title and distillation calls returned full output (1752 / 1358 / 466 tokens), so the failure was specific to the streaming path with reasoning content.

Pattern lines up with the May 8 testlab fix `fix(llama-server): add --jinja so Qwen3 tool-call template is honored`. With `--jinja` + `--reasoning-format deepseek`, llama-server now correctly emits Qwen3's `<think>` content as `delta.reasoning_content` (separate channel) rather than jumbling it into `delta.content`. Our streaming consumer surfaces those reasoning deltas as Thinking but the assistant response can be empty if the model never transitions to content — that's the case the new retry guard handles.

## Composition

Three commits, smallest-change-first:

1. `a64819c3` — diagnostics + thinking-only retry guard (cherry-picked from prior investigation branch `claude-wt-netclaw-insta-crash`)
2. `3a86cf54` — `ILoggerFactory` injection (cherry-picked; otherwise SSE-layer log is silent)
3. `1bf8da37` — `RollingFileLogger` Debug-floor fix (`#908`)

The temporary Warning/Info level bump from the original investigation branch was deliberately not included — the diagnostics stay at Debug and configuration decides what gets persisted.

## Test plan

- [x] Full test suite passes (3,342 / 3,342, 0 failures)
- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] Live validation against testlab (`https://llm.testlab.petabridge.net`, `Qwen3.6-27B-UD-Q4_K_XL.gguf`) in an isolated Docker container with `NETCLAW_Logging__LogLevel__Default=Debug`. All three breakdown logs landed in the daemon log file at `[DBG]`:

  ```
  SSE        : textDeltas=2 textChars=3 thinkingDeltas=37 thinkingChars=150 toolCallDeltas=0 finishReason=stop
  Middleware : textDeltas=2 textChars=3 thinkingDeltas=37 thinkingChars=150 toolCallDeltas=0 finishReason=stop
  Actor      : text=3ch thinking=150ch toolCalls=0 finishReason=stop
  ```

  Counts agree across all three layers for a healthy call — confirming no delta loss in the happy path and that the instrumentation is wired correctly to compare against fault scenarios.
- [ ] Reproduce the May 9 fault pattern with the retry guard active and confirm a real assistant message replaces the fallback reply.
