### PR TITLE
fix(doctor): suppress warnings for explicit Personal posture and tool profile

### DIFF
--- a/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/SecurityPolicyDoctorCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SecurityPolicyDoctorCheckTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -57,8 +57,10 @@ public sealed class SecurityPolicyDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task ExplicitPersonalPosture_HostAllowed_Warns()
+    public async Task ExplicitPersonalPosture_HostAllowed_Passes()
     {
+        // When the user explicitly sets Personal + HostAllowed, doctor should
+        // respect that intentional choice and pass cleanly.
         WriteConfig("""
             {
               "configVersion": 1,
@@ -73,8 +75,31 @@ public sealed class SecurityPolicyDoctorCheckTests : IDisposable
         var check = new SecurityPolicyDoctorCheck(_paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("full host access", result.Message);
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+        Assert.Contains("Personal", result.Message);
+    }
+
+    [Fact]
+    public async Task ImplicitPersonalPosture_HostAllowed_Warns()
+    {
+        // When DeploymentPosture is missing and StrictDefaults is false,
+        // the fallback resolves to Personal with HostAllowed — this should
+        // warn because the user didn't explicitly choose this.
+        WriteConfig("""
+            {
+              "configVersion": 1,
+              "Security": {
+                "StrictDefaults": false
+              }
+            }
+            """);
+
+        var check = new SecurityPolicyDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        // StrictDefaults=false with no DeploymentPosture is an Error first
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+        Assert.Contains("silently assumes Personal posture", result.Message);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ToolAudienceProfilesDoctorCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ToolAudienceProfilesDoctorCheckTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -87,8 +87,11 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task UnrestrictedPersonalProfile_Warns()
+    public async Task UnrestrictedPersonalProfile_Explicit_NoUnrestrictedWarning()
     {
+        // When Personal profile is explicitly written, unrestricted access is intentional.
+        // Doctor should not warn about the unrestricted profile itself, but may still
+        // warn about missing shell_execute approval gate.
         WriteConfig(
             """
             {
@@ -111,9 +114,38 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
         var check = new ToolAudienceProfilesDoctorCheck(_paths);
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(DoctorSeverity.Warning, result.Severity);
+        // Should not warn about unrestricted profile when it's explicit
+        Assert.DoesNotContain("Personal profile allows all tools", result.Message);
+        // May still warn about missing shell approval gate (different message)
+        Assert.Contains("without an explicit shell_execute approval gate", result.Message);
+    }
+
+    [Fact]
+    public async Task UnrestrictedPersonalProfile_Implicit_Warns()
+    {
+        // When Personal profile is NOT in config (fallback defaults), unrestricted
+        // access should warn. AudienceProfiles must exist but Personal must be absent.
+        WriteConfig(
+            """
+            {
+              "configVersion": 1,
+              "Tools": {
+                "ShellMode": "HostAllowed",
+                "AudienceProfiles": {
+                  "Public": {
+                    "ToolsMode": "AllowList"
+                  }
+                }
+              }
+            }
+            """);
+
+        var check = new ToolAudienceProfilesDoctorCheck(_paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        // Should warn about missing profiles and unrestricted fallback
+        Assert.Contains("Missing explicit profiles for", result.Message);
         Assert.Contains("Personal profile allows all tools", result.Message);
-        Assert.Contains("host shell", result.Message);
     }
 
     [Fact]
@@ -191,8 +223,11 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
     }
 
     [Fact]
-    public async Task RecommendedProfiles_Pass()
+    public async Task RecommendedProfiles_WarnsAboutShellGateOnly()
     {
+        // CreateProfiles() writes all three profiles explicitly, so Personal is
+        // explicit. The unrestricted warning is suppressed, but the shell
+        // approval gate warning still fires (no ApprovalPolicy on Personal).
         var toolConfig = new ToolConfig
         {
             ShellMode = ShellExecutionMode.HostAllowed,
@@ -209,7 +244,9 @@ public sealed class ToolAudienceProfilesDoctorCheckTests : IDisposable
         var result = await check.RunAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(DoctorSeverity.Warning, result.Severity);
-        Assert.Contains("Personal profile allows all tools", result.Message);
+        // Unrestricted warning suppressed for explicit Personal
+        Assert.DoesNotContain("Personal profile allows all tools", result.Message);
+        // Shell approval gate warning still fires
         Assert.Contains("without an explicit shell_execute approval gate", result.Message);
     }
 

--- a/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/SecurityPolicyDoctorCheck.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SecurityPolicyDoctorCheck.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -63,8 +63,12 @@ public sealed class SecurityPolicyDoctorCheck(NetclawPaths paths) : IDoctorCheck
             warnings.Add("DeploymentPosture not set; strict fallback resolved to Public.");
         }
 
+        // Only warn about Personal + HostAllowed when the posture is implicit
+        // (resolved from fallback defaults). If the user explicitly set
+        // DeploymentPosture = Personal, they chose this intentionally.
         if (effective.DeploymentPosture == DeploymentPosture.Personal
-            && effective.ShellExecutionMode == ShellExecutionMode.HostAllowed)
+            && effective.ShellExecutionMode == ShellExecutionMode.HostAllowed
+            && !config.DeploymentPosture.HasValue)
         {
             warnings.Add("Personal posture with HostAllowed shell — full host access is enabled.");
         }

--- a/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
+++ b/src/Netclaw.Cli/Doctor/ToolAudienceProfilesDoctorCheck.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ToolAudienceProfilesDoctorCheck.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -90,7 +90,12 @@ public sealed class ToolAudienceProfilesDoctorCheck(NetclawPaths paths) : IDocto
             warnings.Add($"Missing explicit profiles for {string.Join(", ", missingProfiles)}; fallback defaults are in effect.");
         }
 
-        if (IsUnrestrictedPersonalProfile(toolConfig.AudienceProfiles.Personal))
+        // Only warn about unrestricted Personal when it's using fallback defaults.
+        // If the Personal profile was explicitly written (e.g., by `netclaw init`),
+        // the user made an intentional choice and this warning is noise.
+        var personalExplicit = !missingProfiles.Contains("personal");
+        if (IsUnrestrictedPersonalProfile(toolConfig.AudienceProfiles.Personal)
+            && !personalExplicit)
         {
             warnings.Add("Personal profile allows all tools and unrestricted filesystem access.");
             if (toolConfig.ShellMode == ShellExecutionMode.HostAllowed)


### PR DESCRIPTION
## Problem

Running `netclaw init` and choosing **Personal** audience results in immediate warnings from `netclaw doctor` the moment you finish setup:

- **Security Policy:** _"Personal posture with HostAllowed shell — full host access is enabled"_
- **Tool Audience Profiles:** _"Personal profile allows all tools and unrestricted filesystem access"_ and MCP approval defaults warnings

These fire even though the user **explicitly chose** Personal through the init wizard. There's no distinction between an intentional Personal configuration and an ambiguous / fallback default that landed there.

## Expected behavior

When `DeploymentPosture` is explicitly set to `Personal` and the Personal tool profile is explicitly configured (not falling back to defaults), doctor should pass these checks cleanly. The warnings are advisory noise when the user has already made an informed choice.

Doctor should still warn when:
- `DeploymentPosture` is missing and a fallback resolved to Personal
- The Personal profile is using implicit defaults rather than explicit values
- Non-personal profiles (Public, Team) have `ToolsMode: All` or unrestricted filesystem access

## Proposed fix

**`SecurityPolicyDoctorCheck.cs`:** Only emit the "Personal + HostAllowed" warning when the posture is implicit (not explicitly set in config). If `config.DeploymentPosture` is explicitly `Personal`, suppress it — the user chose this.

**`ToolAudienceProfilesDoctorCheck.cs`:** Only warn about unrestricted Personal profile when the values are coming from fallback defaults. If the Personal profile has been explicitly written to config (e.g., by `netclaw init`), treat it as intentional and skip the unrestricted warning.

For MCP servers without approval defaults on Personal, consider downgrading from warning to info-level, or only warn when there are other audiences configured (implying a multi-audience setup where gating matters more).

## Impact

- Fixes the onboarding experience — users who choose Personal shouldn't get yelled at immediately after setup
- Preserves doctor's defensive posture for ambiguous / misconfigured setups
- No config schema changes needed — purely a doctor logic fix
