### PR TITLE
fix(memory): separate adopted-context provenance from third-party policy

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -63,7 +63,7 @@ log patterns** (skill loading, memory recall, checkpoint formation).
 |----------|-------|-------------------|
 | Identity & Self-Awareness | 4 | Bot knows its name, version, repo, session ID |
 | Skill Auto-Loading | 4 | Keyword matching triggers correct skills |
-| Memory Pipeline | 2 | Memory recall is active, new memories form |
+| Memory Pipeline | 4 | Memory recall is active, identity-vs-memory routing is correct, explicit saves use memory tools, and automatic checkpointing still fires |
 | Tool Discovery & Use | 4 | Progressive tool discovery and invocation |
 | Grounding & Alignment | 3 | Uses tools to verify facts, admits uncertainty |
 | Autonomy & Execution | 2 | Executes tasks rather than describing them |
@@ -80,8 +80,26 @@ phrasing — not just one magic prompt.
   (`[tool:call]`), text content, or absence of hallucinated content.
 - **daemon log assertions** — check the daemon's file log (tailed from
   `$EVAL_HOME/logs/daemon-$(date +%F).log`) for structured patterns like
-  `turn_skill_auto_load`, `turn_memory_recall`,
+  `turn_skill_auto_load`, `turn_memory_recall`, and
   `turn_memory_checkpoint_enqueued`.
+
+### Memory Pipeline Semantics
+
+The memory category intentionally separates three behaviors that used to be
+conflated by a single case:
+
+- **Identity preference routing** validates that personal preferences can be
+  routed into `SOUL.md` when identity guidance says they should shape future
+  sessions.
+- **Explicit memory write** validates that a direct save request results in a
+  `store_memory` tool call.
+- **Automatic checkpoint enqueue** validates that the session enqueues a memory
+  checkpoint for non-identity facts without requiring an explicit memory tool
+  call.
+
+This means `memory_checkpoint_enqueue` is the case to watch for automatic memory
+formation regressions, while `memory_identity_preference_routing` and
+`memory_explicit_store` cover user-facing routing behavior.
 
 ## Environment Variables
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -88,14 +88,14 @@ phrasing — not just one magic prompt.
 The memory category intentionally separates three behaviors that used to be
 conflated by a single case:
 
-- **Identity preference routing** validates that personal preferences can be
-  routed into `SOUL.md` when identity guidance says they should shape future
-  sessions.
+- **Identity preference routing** validates that personal preferences route into
+  `SOUL.md` through identity-file edits when identity guidance says they should
+  shape future sessions.
 - **Explicit memory write** validates that a direct save request results in a
   `store_memory` tool call.
 - **Automatic checkpoint enqueue** validates that the session enqueues a memory
-  checkpoint for non-identity facts without requiring an explicit memory tool
-  call.
+  checkpoint for non-identity facts without taking an explicit memory-write tool
+  path.
 
 This means `memory_checkpoint_enqueue` is the case to watch for automatic memory
 formation regressions, while `memory_identity_preference_routing` and

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -107,12 +107,10 @@ check_prerequisites() {
         exit 1
     fi
 
-    # Operator must have run `netclaw init` so we can borrow the identity
-    # fixture for the eval container. We never read the host's netclaw.db,
-    # sessions, or config — only the identity markdown files.
-    if [[ ! -f "$HOME/.netclaw/identity/SOUL.md" ]]; then
-        echo "ERROR: no identity at $HOME/.netclaw/identity/SOUL.md." >&2
-        echo "       Run 'netclaw init' on the host first — evals borrow its identity files." >&2
+    # Identity files are rendered from repo templates into an isolated eval
+    # home; the host does not need a pre-initialized ~/.netclaw tree.
+    if [[ ! -f "$REPO_ROOT/src/Netclaw.Cli/Resources/identity/SOUL.template.md" ]]; then
+        echo "ERROR: missing identity template at $REPO_ROOT/src/Netclaw.Cli/Resources/identity/SOUL.template.md." >&2
         exit 1
     fi
 
@@ -927,7 +925,7 @@ assert_memory_recall_active() {
 }
 
 assert_memory_identity_preference_routing() {
-    (stdout_tool_called 'file_write' && stdout_contains 'SOUL\.md') || stdout_tool_called 'store_memory'
+    stdout_contains 'SOUL\.md' && (stdout_tool_called 'file_edit' || stdout_tool_called 'file_write')
 }
 
 assert_memory_explicit_store() {
@@ -935,7 +933,9 @@ assert_memory_explicit_store() {
 }
 
 assert_memory_checkpoint_enqueue() {
-    daemon_log_contains 'turn_memory_checkpoint_enqueued'
+    daemon_log_contains 'turn_memory_checkpoint_enqueued' \
+        && ! stdout_tool_called 'store_memory' \
+        && ! stdout_tool_called 'update_memory'
 }
 
 assert_memory_recall_filters() {

--- a/evals/run-evals.sh
+++ b/evals/run-evals.sh
@@ -307,16 +307,16 @@ substitute_identity_template() {
         -e 's/{{STYLE_DESCRIPTION}}/Be concise and casual. Keep responses short and conversational./g' \
         -e 's/{{USER_NAME}}/Eval User/g' \
         -e 's/{{USER_TIMEZONE}}/UTC/g' \
-        -e 's|{{SYSTEM_SKILLS_DIR}}|/root/.netclaw/skills/.system/files|g' \
-        -e 's|{{IDENTITY_DIR}}|/root/.netclaw/identity|g' \
-        -e 's|{{SOUL_PATH}}|/root/.netclaw/identity/SOUL.md|g' \
-        -e 's|{{AGENTS_PATH}}|/root/.netclaw/identity/AGENTS.md|g' \
-        -e 's|{{TOOLING_PATH}}|/root/.netclaw/identity/TOOLING.md|g' \
-        -e 's|{{SOUL_DETAIL_DIR}}|/root/.netclaw/identity/soul|g' \
-        -e 's|{{AGENTS_DETAIL_DIR}}|/root/.netclaw/identity/agents|g' \
-        -e 's|{{TOOLING_DETAIL_DIR}}|/root/.netclaw/identity/tooling|g' \
-        -e 's|{{SKILLS_DIR}}|/root/.netclaw/skills|g' \
-        -e 's|{{WORKSPACES_DIR}}|/root/.netclaw/workspaces|g' \
+        -e 's|{{SYSTEM_SKILLS_DIR}}|/home/netclaw/.netclaw/skills/.system/files|g' \
+        -e 's|{{IDENTITY_DIR}}|/home/netclaw/.netclaw/identity|g' \
+        -e 's|{{SOUL_PATH}}|/home/netclaw/.netclaw/identity/SOUL.md|g' \
+        -e 's|{{AGENTS_PATH}}|/home/netclaw/.netclaw/identity/AGENTS.md|g' \
+        -e 's|{{TOOLING_PATH}}|/home/netclaw/.netclaw/identity/TOOLING.md|g' \
+        -e 's|{{SOUL_DETAIL_DIR}}|/home/netclaw/.netclaw/identity/soul|g' \
+        -e 's|{{AGENTS_DETAIL_DIR}}|/home/netclaw/.netclaw/identity/agents|g' \
+        -e 's|{{TOOLING_DETAIL_DIR}}|/home/netclaw/.netclaw/identity/tooling|g' \
+        -e 's|{{SKILLS_DIR}}|/home/netclaw/.netclaw/skills|g' \
+        -e 's|{{WORKSPACES_DIR}}|/home/netclaw/.netclaw/workspaces|g' \
         "$template_file" > "$output_file"
 }
 
@@ -351,16 +351,22 @@ start_eval_daemon() {
         cp -r "$REPO_ROOT/evals/fixtures/skills/." "$EVAL_HOME/skills/"
     fi
 
+    # The eval container runs as the non-root `netclaw` user and needs write
+    # access to the bind-mounted identity, logs, skills, and data trees.
+    chmod -R ugo+rwX "$EVAL_HOME/identity" "$EVAL_HOME/logs" "$EVAL_HOME/data" "$EVAL_HOME/skills"
+
     local -a docker_args=(
         run -d --rm
         --name "$EVAL_CONTAINER_NAME"
         --network host
-        -v "$EVAL_HOME/data:/root/.netclaw"
-        -v "$EVAL_HOME/identity:/root/.netclaw/identity"
-        -v "$EVAL_HOME/skills:/root/.netclaw/skills"
-        -v "$EVAL_HOME/logs:/root/.netclaw/logs"
+        -v "$EVAL_HOME/data:/home/netclaw/.netclaw"
+        -v "$EVAL_HOME/identity:/home/netclaw/.netclaw/identity"
+        -v "$EVAL_HOME/skills:/home/netclaw/.netclaw/skills"
+        -v "$EVAL_HOME/logs:/home/netclaw/.netclaw/logs"
         -e "NETCLAW_Daemon__Host=127.0.0.1"
         -e "NETCLAW_Daemon__Port=$EVAL_PORT"
+        -e "HOME=/home/netclaw"
+        -e "NETCLAW_HOME=/home/netclaw/.netclaw"
         -e "NETCLAW_Providers__eval__Type=$EVAL_PROVIDER_TYPE"
         -e "NETCLAW_Providers__eval__Endpoint=$EVAL_PROVIDER_ENDPOINT"
         -e "NETCLAW_Models__Main__Provider=eval"
@@ -422,7 +428,7 @@ start_eval_daemon() {
 # ─── Memory Seeding ──────────────────────────────────────────────────────────
 
 seed_eval_memories() {
-    local db_path="/root/.netclaw/netclaw.db"
+    local db_path="/home/netclaw/.netclaw/netclaw.db"
     local fixtures_path="$REPO_ROOT/evals/fixtures/eval-memories.json"
     local seed_script="$REPO_ROOT/evals/seed-memories.py"
 
@@ -434,6 +440,16 @@ seed_eval_memories() {
     if [[ ! -f "$seed_script" ]]; then
         echo "WARN: no seed script at $seed_script — memory tests may fail" >&2
         return
+    fi
+
+    # If the daemon has not touched memory yet, send one warm-up prompt through
+    # the normal headless path so the session pipeline creates netclaw.db before
+    # fixture seeding runs.
+    if ! docker exec "$EVAL_CONTAINER_NAME" test -f "$db_path" 2>/dev/null; then
+        NETCLAW_DAEMON_ENDPOINT="http://127.0.0.1:$EVAL_PORT" \
+        NETCLAW_HOME="$EVAL_HOME" \
+            timeout "$PROMPT_TIMEOUT" "$NETCLAW_BIN" chat -p "Warm up memory initialization. Reply with OK only." \
+            >/dev/null 2>&1 || true
     fi
 
     # Wait for the daemon to create the database.
@@ -910,7 +926,15 @@ assert_memory_recall_active() {
     daemon_log_contains 'turn_memory_recall.*degraded=False'
 }
 
-assert_memory_formation() {
+assert_memory_identity_preference_routing() {
+    (stdout_tool_called 'file_write' && stdout_contains 'SOUL\.md') || stdout_tool_called 'store_memory'
+}
+
+assert_memory_explicit_store() {
+    stdout_tool_called 'store_memory' || stdout_tool_called 'update_memory'
+}
+
+assert_memory_checkpoint_enqueue() {
     daemon_log_contains 'turn_memory_checkpoint_enqueued'
 }
 
@@ -1262,8 +1286,14 @@ run_all() {
     run_case memory_recall_active "recall active, not degraded" \
         "What do you know about me?"
 
-    run_case memory_formation "checkpoint enqueued" \
-        "Remember that my favorite color is blue"
+    run_case memory_identity_preference_routing "personal preference routed to SOUL.md" \
+        "Please remember this new preference for future conversations: my favorite color is chartreuse. Use whichever persistent storage path Netclaw's identity-vs-memory rules require, then acknowledge once you've saved it."
+
+    run_case memory_explicit_store "explicit remember request uses store_memory" \
+        "Please save this to your cross-session memory for later reference using store_memory: my preferred airline is United. Just acknowledge once you've saved it."
+
+    run_case memory_checkpoint_enqueue "checkpoint enqueued for non-identity fact" \
+        "During my commute I prefer aisle seats on flights because I like to stand up easily. Just acknowledge and do not save anything explicitly."
 
     run_case memory_recall_filters "candidate selection with score filtering" \
         "Tell me about my travel preferences"

--- a/evals/seed-memories.py
+++ b/evals/seed-memories.py
@@ -58,7 +58,7 @@ def seed_documents(conn, fixtures):
             INSERT INTO memory_documents(document_id, anchor_id, memory_class, title, markdown_body,
               update_semantics, boundary, audience, sensitivity, recall_mode, confidence,
               freshness_at, created_at, updated_at)
-            VALUES(?, ?, 'durable_fact', ?, ?, 'merge-document', 'boundary:trusted-instance', 'public',
+            VALUES(?, ?, 'durable_fact', ?, ?, 'merge-document', 'boundary:trusted-instance', 'personal',
               ?, ?, ?, ?, ?, ?)
             ON CONFLICT(document_id) DO UPDATE SET
               title=excluded.title,
@@ -96,7 +96,9 @@ def seed_documents(conn, fixtures):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Seed eval memories into netclaw database")
+    parser = argparse.ArgumentParser(
+        description="Seed eval memories into netclaw database"
+    )
     parser.add_argument("--db-path", required=True, help="Path to netclaw.db")
     parser.add_argument("--fixtures", required=True, help="Path to fixtures JSON file")
     args = parser.parse_args()
@@ -108,7 +110,9 @@ def main():
     conn.row_factory = sqlite3.Row
 
     seed_documents(conn, fixtures)
-    print(f"[seed] seeded {len(fixtures.get('seedDocuments', []))} memories into {args.db_path}")
+    print(
+        f"[seed] seeded {len(fixtures.get('seedDocuments', []))} memories into {args.db_path}"
+    )
 
     conn.close()
 

--- a/feeds/skills/.system/files/netclaw-memory/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-memory/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-memory
 description: "REQUIRED when the user asks what you remember, recall, or know from past conversations, previous sessions, or cross-session memory. Also before using memory tools: find_memories, get_memories, store_memory, update_memory."
 metadata:
   author: netclaw
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Netclaw Memory
@@ -71,6 +71,14 @@ Policy rules for explicit writes:
 - explicit writes still inherit the current turn's `audience` and `boundary`
 - explicit writes may narrow policy scope, but must never widen it
 - raw secrets, credentials, tokens, and private keys are never durable memory
+
+Automatic observation note:
+- a non-empty adopted thread window still counts as adopted context for audit
+  and approval provenance
+- automatic memory suppression only kicks in when the adopted window includes a
+  sender other than the current authorized author
+- self-only adopted history does not suppress automatic memory formation by
+  itself
 
 ### `update_memory`
 

--- a/openspec/changes/clarify-adopted-context-third-party-policy/.openspec.yaml
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/clarify-adopted-context-third-party-policy/design.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/design.md
@@ -1,0 +1,137 @@
+## Context
+
+The archived multi-speaker attribution change already established the core trust
+model: only the current authorized message is executable, while the adopted
+window is quoted context captured for audit and model grounding. The regression
+investigation showed that later consumers could read "adopted context exists"
+as a proxy for "third-party adopted context exists," which is incorrect for
+self-only adopted history and causes policy drift in memory formation.
+
+This clarification change keeps the architecture intact. Threaded adapters still
+hydrate an adopted window, the session still persists the exact adopted record
+and canonical projection, and approval surfaces still report adopted provenance.
+The design work here is about making each consumer read the same facts the same
+way.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one stable meaning for `HasAdoptedContext`: any non-empty adopted
+  window.
+- Define one stable meaning for adopted-speaker provenance: all sender ids in
+  that adopted window.
+- Introduce a distinct third-party adopted policy concept derived by comparing
+  adopted sender ids against the current authorized author.
+- Keep automatic memory suppression tied to third-party adopted context rather
+  than to adopted context in general.
+- Preserve the current security model that adopted context is quoted and
+  non-executable.
+
+**Non-Goals:**
+
+- Changing which messages become adopted.
+- Allowing adopted content to execute tools, slash commands, jobs, reminders, or
+  memory writes directly.
+- Changing approval UX, ACL rules, or watermark mechanics beyond the clarified
+  metadata contract.
+- Implementing the runtime changes in this planning turn.
+
+## Decisions
+
+### 1. Split factual provenance from policy interpretation
+
+**Decision:** All persisted and surfaced adopted-context provenance remains a
+literal description of the adopted window: if the window is non-empty,
+`HasAdoptedContext=true` and adopted-speaker provenance lists every sender id in
+that window, even if the only sender is the current author.
+
+**Rationale:** Audit and security artifacts should answer "what context was
+adopted?" rather than "what policy outcome did we infer?" Overloading
+`HasAdoptedContext` to mean "third-party present" makes self-only adopted
+history invisible to audit surfaces and invites contradictory interpretations
+across subsystems.
+
+**Alternatives considered:**
+
+- Reinterpret `HasAdoptedContext` to mean "contains a non-self sender." Rejected
+  because it makes the audit trail incomplete and breaks the archived
+  multi-speaker attribution contract.
+- Keep one overloaded flag and document call-site-specific interpretation.
+  Rejected because the regression came from exactly that ambiguity.
+
+### 2. Add a derived third-party adopted policy concept
+
+**Decision:** Introduce `HasThirdPartyAdoptedContext` as a derived policy signal
+that is true when any sender id in the adopted window differs from the current
+authorized author of the executable message.
+
+**Rationale:** This preserves the current trust model while giving policy
+consumers a direct, explicit input for "someone else participated in the adopted
+window." The derivation is deterministic and can be computed from persisted
+truthful provenance without mutating the underlying facts.
+
+**Alternatives considered:**
+
+- Store only the sender-id set and force every consumer to derive the policy on
+  its own. Rejected because repeated ad hoc derivation is how drift reappears.
+- Introduce per-message trust tiers for every adopted line. Rejected as broader
+  than the regression requires.
+
+### 3. Automatic memory suppression follows third-party policy only
+
+**Decision:** Automatic memory-formation suppression, caution, or other policy
+branching that exists because adopted context might represent somebody else's
+words SHALL key off `HasThirdPartyAdoptedContext`, not `HasAdoptedContext`.
+
+**Rationale:** Self-only adopted history still reflects quoted, non-executable
+context, but it does not create the cross-speaker provenance concern that the
+memory regression was trying to guard against. Tying suppression to the derived
+third-party signal restores the intended policy boundary without hiding the full
+adopted window.
+
+### 4. Approval and security provenance stay fully inclusive
+
+**Decision:** Approval prompts, stored approval context, and session audit
+artifacts continue to report adopted-context presence whenever the adopted
+window is non-empty and continue to list all adopted sender ids. These surfaces
+may also carry `HasThirdPartyAdoptedContext` as a separate policy field, but
+they SHALL NOT trim or reinterpret the full adopted provenance.
+
+**Rationale:** Approval and security reviews need the whole adopted window to
+understand what background was present when the current authorized message ran.
+The truthful record and the derived policy bit serve different purposes and both
+need to survive.
+
+## Risks / Trade-offs
+
+- **[Risk]** Future implementation updates one metadata producer but not all
+  consumers. -> **Mitigation:** define the semantics in five affected
+  capabilities and require tests that cover self-only and third-party adopted
+  windows across adapter, session, approval, and memory paths.
+- **[Risk]** Reviewers may mistake the new policy concept for a trust-model
+  relaxation. -> **Mitigation:** every affected spec repeats that adopted context
+  remains quoted and non-executable; only suppression logic changes.
+- **[Trade-off]** More metadata fields means slightly more persistence and test
+  surface. -> **Mitigation:** the separation removes ambiguity and prevents more
+  expensive policy regressions.
+
+## Migration Plan
+
+This change is clarification-only for now. The eventual implementation should:
+
+1. Extend the runtime metadata shape so `HasAdoptedContext` and
+   `HasThirdPartyAdoptedContext` are both explicit where needed.
+2. Backfill or derive the new policy field for any already-persisted
+   adopted-context records if those records are reused across restarts.
+3. Update automatic memory formation tests before enabling the behavior change.
+
+Rollback is specification-only at this stage: revert the change plan if the team
+decides to preserve the ambiguous contract.
+
+## Open Questions
+
+- None for the change-plan phase. The implementation phase can decide whether
+  `HasThirdPartyAdoptedContext` is persisted directly everywhere or derived on
+  read in some internal models, so long as the observable contract remains
+  consistent.

--- a/openspec/changes/clarify-adopted-context-third-party-policy/proposal.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+The memory formation regression investigation exposed an ambiguity in the
+adopted-context contract: some paths were treating any non-empty adopted window
+as if it implied third-party participation, while other paths were using the
+same signal for truthful audit provenance. Netclaw needs those concerns split so
+approval and security artifacts stay factually complete, while automatic memory
+suppression keys only off adopted context that actually includes someone other
+than the current author.
+
+## Source PRDs
+
+- `PRD-002`: Gateway security envelope and truthful audit/security provenance.
+- `PRD-007`: Agent memory formation, durable memory authority, and local-memory
+  safety rules.
+- `PRD-009`: Input adapter contract and transport-agnostic session handoff.
+
+## What Changes
+
+- Clarify that `HasAdoptedContext` means exactly: the adopted window is
+  non-empty.
+- Clarify that adopted-speaker provenance means all stable sender ids present in
+  the adopted window, including self-only adopted history.
+- Add a separate policy concept for third-party adopted context:
+  `HasThirdPartyAdoptedContext` is true only when any adopted sender id differs
+  from the current authorized author of the executable message.
+- Keep approval, audit, and security provenance inclusive of the full adopted
+  window whenever it is non-empty, even when the window contains only prior
+  messages from the current author.
+- Clarify that automatic memory suppression and related memory-formation caution
+  rules key off third-party adopted context rather than mere adopted context.
+- Preserve the existing trust model: adopted context is quoted,
+  non-executable context; only the current authorized message is executable.
+- Make the contract explicit and consistent across `thread-history-backfill`,
+  `netclaw-agent-memory`, `netclaw-input-adapters`, `netclaw-session`, and
+  `tool-approval-gates`.
+- Out of scope: runtime implementation, migration of persisted data, or any new
+  trust relaxation for adopted content.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `thread-history-backfill`: Clarify adopted-window semantics so non-empty
+  windows set `HasAdoptedContext`, all adopted sender ids are preserved as
+  provenance, and third-party adopted context is derived separately from the
+  current author comparison.
+- `netclaw-agent-memory`: Clarify that automatic memory suppression keys off
+  third-party adopted context, while full adopted-window provenance remains
+  truthful and explicit-elevation behavior is unchanged.
+- `netclaw-input-adapters`: Clarify that threaded adapters hand off full
+  adopted-window provenance plus distinct `HasAdoptedContext` and
+  `HasThirdPartyAdoptedContext` semantics.
+- `netclaw-session`: Clarify that persisted adopted-context records and session
+  turn metadata keep the full adopted window truthful, derive third-party policy
+  state separately, and preserve quoted/non-executable semantics.
+- `tool-approval-gates`: Clarify that approval prompts and stored approval
+  context stay inclusive of any non-empty adopted window, while policy-facing
+  third-party-adopted state is tracked separately from full provenance.
+
+## Impact
+
+- **Security impact**: keeps approval and audit artifacts truthful without
+  widening execution authority; third-party-sensitive policy remains explicit
+  rather than inferred from an overloaded flag.
+- **Operational impact**: implementers will need one additional policy concept
+  in session/approval/memory metadata, but no new channel or ACL model.
+- **Data model impact**: future implementation will likely touch adopted-context
+  record shape, approval context shape, and memory-formation policy inputs so
+  `HasAdoptedContext` and `HasThirdPartyAdoptedContext` cannot drift.
+- **Code impact**: expected future work spans threaded adapter handoff, session
+  persistence/projection, approval context construction, and automatic memory
+  formation guards.

--- a/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-agent-memory/spec.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-agent-memory/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Adopted thread context is not direct durable-memory authority
 

--- a/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-input-adapters/spec.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-input-adapters/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Adopted-context handoff distinguishes presence from third-party policy
+
+Threaded adapters SHALL preserve two distinct handoff facts when constructing an authorized turn with an adopted window:
+
+- `HasAdoptedContext`: true when the adopted window is non-empty.
+- `HasThirdPartyAdoptedContext`: true when any adopted sender id differs from
+  the current authorized sender for the executable message.
+
+The handoff SHALL also preserve adopted-speaker provenance as the full set of
+sender ids present in the adopted window. That provenance SHALL remain inclusive
+even when the adopted window contains only prior messages from the current
+authorized sender.
+
+#### Scenario: Self-only adopted window carries truthful handoff metadata
+
+- **GIVEN** a threaded adapter adopts prior messages from the same sender as the
+  current authorized message
+- **WHEN** it constructs the authorized turn handoff
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is false
+- **AND** adopted-speaker provenance still includes that sender id
+
+#### Scenario: Mixed-sender adopted window marks third-party state
+
+- **GIVEN** a threaded adapter adopts prior messages from `U111` and `U222`
+- **AND** the current authorized sender is `U111`
+- **WHEN** it constructs the authorized turn handoff
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is true
+- **AND** adopted-speaker provenance includes both `U111` and `U222`

--- a/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-session/spec.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/specs/netclaw-session/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Persisted adopted-context metadata separates truthful provenance from third-party policy
+
+When the session persists or reuses an adopted-context record, it SHALL preserve
+the full adopted window truthfully and SHALL NOT collapse self-only adopted
+history into "no adopted context."
+
+For persisted session metadata:
+
+- `HasAdoptedContext` SHALL mean the adopted window is non-empty.
+- Adopted-speaker provenance SHALL include all sender ids present in that
+  adopted window.
+- `HasThirdPartyAdoptedContext` SHALL be tracked as a separate policy concept and
+  SHALL be true only when any adopted sender id differs from the current
+  authorized author of the executable message.
+
+This metadata split SHALL coexist with the existing trust model that adopted
+context is quoted, non-executable context and only the current authorized
+message is executable.
+
+#### Scenario: Persisted record keeps self-only adopted window truthful
+
+- **GIVEN** an adopted-context record is written for an authorized turn
+- **AND** every adopted sender id matches the current authorized sender
+- **WHEN** the session persists the record
+- **THEN** `HasAdoptedContext` is true
+- **AND** adopted-speaker provenance includes that sender id
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Persisted record marks third-party policy separately
+
+- **GIVEN** an adopted-context record is written for an authorized turn
+- **AND** the adopted window includes a sender id different from the current
+  authorized sender
+- **WHEN** the session persists the record
+- **THEN** adopted-speaker provenance includes all adopted sender ids
+- **AND** `HasThirdPartyAdoptedContext` is true
+
+#### Scenario: Adopted context remains non-executable after metadata split
+
+- **GIVEN** a persisted record reports `HasAdoptedContext=true`
+- **WHEN** the session later uses that record for audit, retry, or recovery
+- **THEN** the adopted window remains quoted, non-executable context
+- **AND** only the current authorized message remains executable

--- a/openspec/changes/clarify-adopted-context-third-party-policy/specs/thread-history-backfill/spec.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/specs/thread-history-backfill/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: Hydration merges into an adopted-context window on authorized inbound
+
+Threaded channel adapters SHALL hydrate prior thread messages only when an
+authorized inbound message is about to create an executable turn. The adapter
+SHALL merge unsynced prior thread messages into an explicit adopted-context
+window before the current authorized message, not as separate turns and not as
+ordinary live message history.
+
+The session layer SHALL receive one authorized turn consisting of the adopted
+window plus the current authorized message. The session layer SHALL NOT receive
+distinct backfill turns for pending speakers.
+
+For adoption semantics, `HasAdoptedContext` SHALL mean exactly that the adopted
+window is non-empty. `HasThirdPartyAdoptedContext` SHALL be derived separately
+and SHALL be true only when at least one sender id in the adopted window differs
+from the current authorized sender for the executable message. Adopted-speaker
+provenance SHALL include all sender ids present in the adopted window, including
+self-only adopted history.
+
+#### Scenario: Unsynced thread gap adopted only on authorized inbound
+
+- **GIVEN** a thread contains prior unsynced messages
+- **WHEN** an authorized user sends the next inbound message
+- **THEN** the prior unsynced messages are hydrated into adopted context
+- **AND** the current authorized message is appended as the executable message
+
+#### Scenario: Unauthorized inbound does not trigger hydration turn
+
+- **GIVEN** a non-allowed user sends a threaded message
+- **WHEN** no authorized user is speaking on that inbound event
+- **THEN** the adapter does not dispatch a hydrated turn
+- **AND** the message remains pending source-thread context
+
+#### Scenario: Self-only adopted history still counts as adopted context
+
+- **GIVEN** the adopted window contains one or more prior messages from the same
+  sender as the current authorized message
+- **WHEN** the adapter prepares the authorized turn
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Third-party speaker sets third-party adopted policy state
+
+- **GIVEN** the adopted window contains messages from `U222`
+- **AND** the current authorized sender is `U111`
+- **WHEN** the adapter prepares the authorized turn
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is true
+
+### Requirement: Adopted-message inclusion metadata
+
+Each adopted message in the hydrated gap SHALL record message id, sender id,
+timestamp, and authority-at-inclusion. Authority-at-inclusion SHALL be captured
+at adoption time from the same live turn-creation authorization basis applied
+to the inbound event and SHALL be persisted in the adopted-context record.
+
+The adopted-context metadata for the turn SHALL also preserve the complete set of
+sender ids present in the adopted window. That provenance SHALL remain inclusive
+of any non-empty adopted window and SHALL NOT omit self-only adopted history
+merely because no third-party sender is present.
+
+#### Scenario: Unauthorized speaker captured as pending at inclusion time
+
+- **GIVEN** `AllowedUserIds` contains `"U111"`
+- **AND** adopted gap history contains a message from `"U999"`
+- **WHEN** the adopted-context record is written
+- **THEN** that included message records `authority-at-inclusion=pending`
+
+#### Scenario: Authorized historical speaker captured as authorized at inclusion time
+
+- **GIVEN** `AllowedUserIds` contains `"U111"`
+- **AND** adopted gap history contains a message from `"U111"`
+- **WHEN** the adopted-context record is written
+- **THEN** that included message records `authority-at-inclusion=authorized`
+
+#### Scenario: Self-only adopted provenance is preserved
+
+- **GIVEN** the adopted window is non-empty
+- **AND** every adopted message sender id matches the current authorized sender
+- **WHEN** adopted-context metadata is materialized
+- **THEN** the adopted-speaker provenance still includes that sender id
+- **AND** the turn still reports adopted context as present

--- a/openspec/changes/clarify-adopted-context-third-party-policy/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/specs/tool-approval-gates/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Approval provenance stays inclusive while third-party adopted policy is separate
+
+Approval prompts and stored approval context SHALL preserve truthful adopted
+provenance for any non-empty adopted window.
+
+For approval context:
+
+- `HasAdoptedContext` SHALL mean the adopted window is non-empty.
+- Adopted-speaker provenance SHALL list all adopted sender ids present in that
+  window, including self-only adopted history.
+- `HasThirdPartyAdoptedContext` MAY be carried as a separate policy field, but it
+  SHALL be derived independently and SHALL NOT replace or trim the full adopted
+  provenance.
+
+This clarification SHALL NOT alter the trust model: approval requests still
+originate only from the current authorized executable message, and adopted
+context remains quoted, non-executable background.
+
+#### Scenario: Self-only adopted history still appears in approval provenance
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the adopted window is non-empty
+- **AND** every adopted sender id matches the current authorized sender
+- **WHEN** the approval prompt and stored context are created
+- **THEN** `HasAdoptedContext` is true
+- **AND** adopted-speaker provenance includes that sender id
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Third-party adopted history preserves full provenance
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the adopted window includes sender ids `U111` and `U222`
+- **WHEN** the approval prompt and stored context are created
+- **THEN** adopted-speaker provenance includes both `U111` and `U222`
+- **AND** `HasThirdPartyAdoptedContext` is true
+
+#### Scenario: Empty adopted window omits adopted provenance entirely
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the turn has no adopted window
+- **WHEN** the approval prompt and stored context are created
+- **THEN** `HasAdoptedContext` is false
+- **AND** no adopted-speaker provenance is included

--- a/openspec/changes/clarify-adopted-context-third-party-policy/tasks.md
+++ b/openspec/changes/clarify-adopted-context-third-party-policy/tasks.md
@@ -1,0 +1,29 @@
+## 1. Session and adapter metadata contract
+
+- [x] 1.1 Extend the threaded-adapter to session handoff model so it carries both `HasAdoptedContext` and `HasThirdPartyAdoptedContext`, with deterministic derivation from the adopted sender-id set and current authorized sender.
+- [x] 1.2 Update adopted-context persistence models and serializers so persisted records keep the full adopted sender-id provenance plus the separate third-party-adopted policy field without reinterpreting self-only adopted history as empty.
+- [x] 1.3 Audit recovery and retry paths that reuse adopted-context records to ensure they preserve the clarified semantics instead of recomputing an inconsistent policy view.
+
+## 2. Memory policy alignment
+
+- [x] 2.1 Update automatic memory-formation policy inputs so suppression/caution logic keys off `HasThirdPartyAdoptedContext` rather than `HasAdoptedContext`.
+- [x] 2.2 Keep explicit-elevation behavior unchanged: the current authorized message may still elevate adopted facts under existing memory policy rules.
+- [x] 2.3 Add focused tests covering no adopted window, self-only adopted window, and third-party adopted window for automatic memory formation.
+
+## 3. Approval and audit provenance alignment
+
+- [x] 3.1 Update approval prompt and stored approval-context builders so any non-empty adopted window sets `HasAdoptedContext` and includes all adopted sender ids.
+- [x] 3.2 Add or update approval-path tests covering self-only adopted provenance versus third-party adopted provenance, ensuring the full adopted sender-id set remains visible in both cases.
+- [x] 3.3 Verify the current authorized message remains the only executable source for approval requests after the metadata split.
+
+## 4. Spec and implementation verification
+
+- [x] 4.1 Add unit/integration coverage in threaded adapter and session tests for the clarified `HasAdoptedContext` and `HasThirdPartyAdoptedContext` semantics.
+- [x] 4.2 Run `openspec validate clarify-adopted-context-third-party-policy` after implementation artifacts and any follow-on spec sync are complete.
+- [x] 4.3 Run the normal quality gates for the implementation PR (`dotnet build`, relevant tests, `dotnet slopwatch analyze`, `./scripts/Add-FileHeaders.ps1 -Verify`).
+
+## 5. OpenSpec completion
+
+- [x] 5.1 `/opsx-verify clarify-adopted-context-third-party-policy` once implementation lands.
+- [x] 5.2 `/opsx-sync clarify-adopted-context-third-party-policy` to propagate the deltas into the main capability specs.
+- [ ] 5.3 `/opsx-archive clarify-adopted-context-third-party-policy` after merge.

--- a/openspec/specs/netclaw-input-adapters/spec.md
+++ b/openspec/specs/netclaw-input-adapters/spec.md
@@ -55,3 +55,34 @@ user responses by option number, letter, or keyword matching.
 - **GIVEN** the user replies "B" to an approval prompt
 - **WHEN** the channel parses the reply
 - **THEN** it sends a `ToolInteractionResponse` with `ApprovedSession`
+
+### Requirement: Adopted-context handoff distinguishes presence from third-party policy
+
+Threaded adapters SHALL preserve two distinct handoff facts when constructing an authorized turn with an adopted window:
+
+- `HasAdoptedContext`: true when the adopted window is non-empty.
+- `HasThirdPartyAdoptedContext`: true when any adopted sender id differs from
+  the current authorized sender for the executable message.
+
+The handoff SHALL also preserve adopted-speaker provenance as the full set of
+sender ids present in the adopted window. That provenance SHALL remain inclusive
+even when the adopted window contains only prior messages from the current
+authorized sender.
+
+#### Scenario: Self-only adopted window carries truthful handoff metadata
+
+- **GIVEN** a threaded adapter adopts prior messages from the same sender as the
+  current authorized message
+- **WHEN** it constructs the authorized turn handoff
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is false
+- **AND** adopted-speaker provenance still includes that sender id
+
+#### Scenario: Mixed-sender adopted window marks third-party state
+
+- **GIVEN** a threaded adapter adopts prior messages from `U111` and `U222`
+- **AND** the current authorized sender is `U111`
+- **WHEN** it constructs the authorized turn handoff
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is true
+- **AND** adopted-speaker provenance includes both `U111` and `U222`

--- a/openspec/specs/netclaw-session/spec.md
+++ b/openspec/specs/netclaw-session/spec.md
@@ -58,3 +58,47 @@ ApproveAlways).
 - **GIVEN** a tool requires approval
 - **WHEN** the pipeline emits a `ToolInteractionRequest`
 - **THEN** all subscribers receive it regardless of their `OutputFilter`
+
+### Requirement: Persisted adopted-context metadata separates truthful provenance from third-party policy
+
+When the session persists or reuses an adopted-context record, it SHALL preserve
+the full adopted window truthfully and SHALL NOT collapse self-only adopted
+history into "no adopted context."
+
+For persisted session metadata:
+
+- `HasAdoptedContext` SHALL mean the adopted window is non-empty.
+- Adopted-speaker provenance SHALL include all sender ids present in that
+  adopted window.
+- `HasThirdPartyAdoptedContext` SHALL be tracked as a separate policy concept and
+  SHALL be true only when any adopted sender id differs from the current
+  authorized author of the executable message.
+
+This metadata split SHALL coexist with the existing trust model that adopted
+context is quoted, non-executable context and only the current authorized
+message is executable.
+
+#### Scenario: Persisted record keeps self-only adopted window truthful
+
+- **GIVEN** an adopted-context record is written for an authorized turn
+- **AND** every adopted sender id matches the current authorized sender
+- **WHEN** the session persists the record
+- **THEN** `HasAdoptedContext` is true
+- **AND** adopted-speaker provenance includes that sender id
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Persisted record marks third-party policy separately
+
+- **GIVEN** an adopted-context record is written for an authorized turn
+- **AND** the adopted window includes a sender id different from the current
+  authorized sender
+- **WHEN** the session persists the record
+- **THEN** adopted-speaker provenance includes all adopted sender ids
+- **AND** `HasThirdPartyAdoptedContext` is true
+
+#### Scenario: Adopted context remains non-executable after metadata split
+
+- **GIVEN** a persisted record reports `HasAdoptedContext=true`
+- **WHEN** the session later uses that record for audit, retry, or recovery
+- **THEN** the adopted window remains quoted, non-executable context
+- **AND** only the current authorized message remains executable

--- a/openspec/specs/thread-history-backfill/spec.md
+++ b/openspec/specs/thread-history-backfill/spec.md
@@ -12,6 +12,13 @@ The session layer SHALL receive one authorized turn consisting of the adopted
 window plus the current authorized message. The session layer SHALL NOT receive
 distinct backfill turns for pending speakers.
 
+For adoption semantics, `HasAdoptedContext` SHALL mean exactly that the adopted
+window is non-empty. `HasThirdPartyAdoptedContext` SHALL be derived separately
+and SHALL be true only when at least one sender id in the adopted window differs
+from the current authorized sender for the executable message. Adopted-speaker
+provenance SHALL include all sender ids present in the adopted window, including
+self-only adopted history.
+
 #### Scenario: Unsynced thread gap adopted only on authorized inbound
 
 - **GIVEN** a thread contains prior unsynced messages
@@ -25,6 +32,22 @@ distinct backfill turns for pending speakers.
 - **WHEN** no authorized user is speaking on that inbound event
 - **THEN** the adapter does not dispatch a hydrated turn
 - **AND** the message remains pending source-thread context
+
+#### Scenario: Self-only adopted history still counts as adopted context
+
+- **GIVEN** the adopted window contains one or more prior messages from the same
+  sender as the current authorized message
+- **WHEN** the adapter prepares the authorized turn
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Third-party speaker sets third-party adopted policy state
+
+- **GIVEN** the adopted window contains messages from `U222`
+- **AND** the current authorized sender is `U111`
+- **WHEN** the adapter prepares the authorized turn
+- **THEN** `HasAdoptedContext` is true
+- **AND** `HasThirdPartyAdoptedContext` is true
 
 ### Requirement: Authorized sync watermark and gap computation
 
@@ -122,6 +145,11 @@ timestamp, and authority-at-inclusion. Authority-at-inclusion SHALL be captured
 at adoption time from the same live turn-creation authorization basis applied
 to the inbound event and SHALL be persisted in the adopted-context record.
 
+The adopted-context metadata for the turn SHALL also preserve the complete set of
+sender ids present in the adopted window. That provenance SHALL remain inclusive
+of any non-empty adopted window and SHALL NOT omit self-only adopted history
+merely because no third-party sender is present.
+
 #### Scenario: Unauthorized speaker captured as pending at inclusion time
 
 - **GIVEN** `AllowedUserIds` contains `"U111"`
@@ -135,3 +163,11 @@ to the inbound event and SHALL be persisted in the adopted-context record.
 - **AND** adopted gap history contains a message from `"U111"`
 - **WHEN** the adopted-context record is written
 - **THEN** that included message records `authority-at-inclusion=authorized`
+
+#### Scenario: Self-only adopted provenance is preserved
+
+- **GIVEN** the adopted window is non-empty
+- **AND** every adopted message sender id matches the current authorized sender
+- **WHEN** adopted-context metadata is materialized
+- **THEN** the adopted-speaker provenance still includes that sender id
+- **AND** the turn still reports adopted context as present

--- a/openspec/specs/tool-approval-gates/spec.md
+++ b/openspec/specs/tool-approval-gates/spec.md
@@ -242,6 +242,50 @@ SHALL record the directory roots instead of exact shell approval patterns.
 - **THEN** the channel sends a `ToolInteractionResponse` to the session actor
 - **AND** the response includes `CallId` and the selected option key
 
+### Requirement: Approval provenance stays inclusive while third-party adopted policy is separate
+
+Approval prompts and stored approval context SHALL preserve truthful adopted
+provenance for any non-empty adopted window.
+
+For approval context:
+
+- `HasAdoptedContext` SHALL mean the adopted window is non-empty.
+- Adopted-speaker provenance SHALL list all adopted sender ids present in that
+  window, including self-only adopted history.
+- `HasThirdPartyAdoptedContext` MAY be carried as a separate policy field, but it
+  SHALL be derived independently and SHALL NOT replace or trim the full adopted
+  provenance.
+
+This clarification SHALL NOT alter the trust model: approval requests still
+originate only from the current authorized executable message, and adopted
+context remains quoted, non-executable background.
+
+#### Scenario: Self-only adopted history still appears in approval provenance
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the adopted window is non-empty
+- **AND** every adopted sender id matches the current authorized sender
+- **WHEN** the approval prompt and stored context are created
+- **THEN** `HasAdoptedContext` is true
+- **AND** adopted-speaker provenance includes that sender id
+- **AND** `HasThirdPartyAdoptedContext` is false
+
+#### Scenario: Third-party adopted history preserves full provenance
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the adopted window includes sender ids `U111` and `U222`
+- **WHEN** the approval prompt and stored context are created
+- **THEN** adopted-speaker provenance includes both `U111` and `U222`
+- **AND** `HasThirdPartyAdoptedContext` is true
+
+#### Scenario: Empty adopted window omits adopted provenance entirely
+
+- **GIVEN** the current authorized message requires tool approval
+- **AND** the turn has no adopted window
+- **WHEN** the approval prompt and stored context are created
+- **THEN** `HasAdoptedContext` is false
+- **AND** no adopted-speaker provenance is included
+
 ### Requirement: Persistent approval storage
 
 The system SHALL store persistent approvals ("Approve Always" decisions) in

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -746,6 +746,7 @@ public abstract class SessionBindingContractTests : TestKit
             Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
             Assert.Equal("live message", input.ExecutableText);
             Assert.True(input.HasAdoptedContext);
+            Assert.True(input.HasThirdPartyAdoptedContext);
             var textContent = string.Join("\n", input.Contents
                 .OfType<TextContent>()
                 .Select(t => t.Text));
@@ -789,12 +790,51 @@ public abstract class SessionBindingContractTests : TestKit
             Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
             Assert.Equal("tell me what they said", input.ExecutableText);
             Assert.True(input.HasAdoptedContext);
+            Assert.True(input.HasThirdPartyAdoptedContext);
 
             var textContent = string.Join("\n", input.Contents
                 .OfType<TextContent>()
                 .Select(t => t.Text));
             Assert.Contains("/opsx-sync", textContent, StringComparison.Ordinal);
             Assert.Contains("tell me what they said", textContent, StringComparison.Ordinal);
+        }, cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Self_only_thread_history_sets_adopted_context_without_third_party_flag()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hydration-self-only");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        var historyItem = Assert.Single(CreateHistoryItems(1));
+        historyFetcher.SetHistory(
+        [
+            historyItem with
+            {
+                SenderId = "user-1"
+            }
+        ]);
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "hydrated reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        actor.Tell(CreateHydrationTriggerInboundMessage("summarize what I said", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
+            Assert.True(input.HasAdoptedContext);
+            Assert.False(input.HasThirdPartyAdoptedContext);
+            Assert.Equal(["user-1"], input.AdoptedSpeakerIds);
         }, cancellationToken: ct);
     }
 
@@ -904,6 +944,7 @@ public abstract class SessionBindingContractTests : TestKit
             Assert.Equal(1, historyFetcher.FetchCount);
             Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
             Assert.False(input.HasAdoptedContext);
+            Assert.False(input.HasThirdPartyAdoptedContext);
             var textContent = string.Join("\n", input.Contents
                 .OfType<TextContent>()
                 .Select(t => t.Text));

--- a/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
@@ -118,4 +118,44 @@ public sealed class MessageSourceFactoryTests : TestKit
         Assert.Equal("check-pr:1712000000000", result.ReminderId);
         Assert.Same(probe.Ref, result.AckTarget);
     }
+
+    [Fact]
+    public void Create_propagates_self_only_adopted_context_without_third_party_flag()
+    {
+        var input = new ChannelInput
+        {
+            SenderId = "user-1",
+            Contents = [new TextContent("hello")],
+            ReceivedAt = DateTimeOffset.UtcNow,
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = false,
+            AdoptedSpeakerIds = ["user-1"]
+        };
+
+        var result = MessageSourceFactory.Create(input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+
+        Assert.True(result.HasAdoptedContext);
+        Assert.False(result.HasThirdPartyAdoptedContext);
+        Assert.Equal(["user-1"], result.AdoptedSpeakerIds);
+    }
+
+    [Fact]
+    public void Create_propagates_third_party_adopted_context_flag()
+    {
+        var input = new ChannelInput
+        {
+            SenderId = "user-1",
+            Contents = [new TextContent("hello")],
+            ReceivedAt = DateTimeOffset.UtcNow,
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["user-1", "user-2"]
+        };
+
+        var result = MessageSourceFactory.Create(input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+
+        Assert.True(result.HasAdoptedContext);
+        Assert.True(result.HasThirdPartyAdoptedContext);
+        Assert.Equal(["user-1", "user-2"], result.AdoptedSpeakerIds);
+    }
 }

--- a/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
@@ -127,7 +127,6 @@ public sealed class MessageSourceFactoryTests : TestKit
             SenderId = "user-1",
             Contents = [new TextContent("hello")],
             ReceivedAt = DateTimeOffset.UtcNow,
-            HasAdoptedContext = true,
             HasThirdPartyAdoptedContext = false,
             AdoptedSpeakerIds = ["user-1"]
         };
@@ -147,7 +146,6 @@ public sealed class MessageSourceFactoryTests : TestKit
             SenderId = "user-1",
             Contents = [new TextContent("hello")],
             ReceivedAt = DateTimeOffset.UtcNow,
-            HasAdoptedContext = true,
             HasThirdPartyAdoptedContext = true,
             AdoptedSpeakerIds = ["user-1", "user-2"]
         };

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -380,6 +380,9 @@ public sealed class SerializationRoundTripTests : TestKit
             LowerBound = "msg-40",
             UpperBound = "msg-42",
             Projection = "Alice said hello; Bob replied",
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["U12345", "U67890"],
             ProjectionPersisted = true,
             RecordedAtMs = 1708531200000,
             Messages =
@@ -402,6 +405,9 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.Equal("msg-40", result.LowerBound);
         Assert.Equal("msg-42", result.UpperBound);
         Assert.Equal("Alice said hello; Bob replied", result.Projection);
+        Assert.True(result.HasAdoptedContext);
+        Assert.True(result.HasThirdPartyAdoptedContext);
+        Assert.Equal(["U12345", "U67890"], result.AdoptedSpeakerIds);
         Assert.True(result.ProjectionPersisted);
         Assert.Equal(1708531200000, result.RecordedAtMs);
         var msg = Assert.Single(result.Messages);
@@ -422,6 +428,8 @@ public sealed class SerializationRoundTripTests : TestKit
             LowerBound = null,
             UpperBound = null,
             Projection = "",
+            HasAdoptedContext = false,
+            HasThirdPartyAdoptedContext = false,
             ProjectionPersisted = false,
             RecordedAtMs = 1708531200000
         };
@@ -431,6 +439,9 @@ public sealed class SerializationRoundTripTests : TestKit
         Assert.Null(result.AuthorizerSenderId);
         Assert.Null(result.LowerBound);
         Assert.Null(result.UpperBound);
+        Assert.False(result.HasAdoptedContext);
+        Assert.False(result.HasThirdPartyAdoptedContext);
+        Assert.Empty(result.AdoptedSpeakerIds);
         Assert.Empty(result.Messages);
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -29,6 +29,7 @@ public sealed class ParentSessionApprovalBridgeTests
             requesterSenderId: "user-123",
             requesterPrincipal: PrincipalClassification.Operator,
             hasAdoptedContext: true,
+            hasThirdPartyAdoptedContext: true,
             adoptedSpeakerIds: ["user-123", "user-456"]);
 
         var decision = await bridge.RequestApprovalAsync(
@@ -45,6 +46,7 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.Equal("user-123", emitted!.RequesterSenderId);
         Assert.Equal(PrincipalClassification.Operator, emitted.RequesterPrincipal);
         Assert.True(emitted.HasAdoptedContext);
+        Assert.True(emitted.HasThirdPartyAdoptedContext);
         Assert.True(emitted.PersistedAdoptedContext);
         Assert.Equal(["user-123", "user-456"], emitted.AdoptedSpeakerIds);
         Assert.Equal(["grep timeout logs/app.log | wc -l"], emitted.Patterns);
@@ -52,5 +54,40 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.Equal(["logs/"], emitted.DirectoryRoots);
         Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, emitted.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession).Label);
         Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, emitted.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways).Label);
+    }
+
+    [Fact]
+    public async Task Bridge_preserves_self_only_adopted_context_without_third_party_flag()
+    {
+        var channel = new ApprovalChannel();
+        ToolInteractionRequest? emitted = null;
+        var bridge = new ParentSessionApprovalBridge(
+            channel,
+            request =>
+            {
+                emitted = request;
+                channel.Complete(new ToolCallId(request.CallId), ApprovalDecision.ApprovedOnce);
+            },
+            new SessionId("signalr/thread-2"),
+            requesterSenderId: "user-123",
+            requesterPrincipal: PrincipalClassification.Operator,
+            hasAdoptedContext: true,
+            hasThirdPartyAdoptedContext: false,
+            adoptedSpeakerIds: ["user-123"]);
+
+        var decision = await bridge.RequestApprovalAsync(
+            new ToolCallId("call-2"),
+            "shell_execute",
+            "cat logs/app.log",
+            ["cat logs/app.log"],
+            ["/tmp/work/logs/"],
+            ["logs/"],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ParentApprovalDecision.ApprovedOnce, decision);
+        Assert.NotNull(emitted);
+        Assert.True(emitted!.HasAdoptedContext);
+        Assert.False(emitted.HasThirdPartyAdoptedContext);
+        Assert.Equal(["user-123"], emitted.AdoptedSpeakerIds);
     }
 }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateTests.cs
@@ -372,6 +372,9 @@ public class SessionStateTests
             LowerBound = "cursor-0",
             UpperBound = "authorized-1",
             Projection = "[adopted-context]",
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["user-1", "observer-1"],
             ProjectionPersisted = true,
             Messages =
             [
@@ -392,6 +395,9 @@ public class SessionStateTests
         Assert.Equal("user-1", record.Value.AuthorizerSenderId);
         Assert.Equal("cursor-0", record.Value.LowerBound);
         Assert.Equal("authorized-1", record.Value.UpperBound);
+        Assert.True(record.Value.HasAdoptedContext);
+        Assert.True(record.Value.HasThirdPartyAdoptedContext);
+        Assert.Equal(["user-1", "observer-1"], record.Value.AdoptedSpeakerIds);
         Assert.True(record.Value.ProjectionPersisted);
         Assert.Equal("[adopted-context]", record.Value.Projection);
         var message = Assert.Single(record.Value.Messages);

--- a/src/Netclaw.Actors/Channels/ChannelInput.cs
+++ b/src/Netclaw.Actors/Channels/ChannelInput.cs
@@ -87,6 +87,12 @@ public sealed record ChannelInput
     public bool HasAdoptedContext { get; init; }
 
     /// <summary>
+    /// True when the adopted context window includes at least one sender other than
+    /// the current authorized sender.
+    /// </summary>
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    /// <summary>
     /// Stable sender ids that appeared in the adopted context window.
     /// </summary>
     public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = [];

--- a/src/Netclaw.Actors/Channels/ChannelInput.cs
+++ b/src/Netclaw.Actors/Channels/ChannelInput.cs
@@ -84,7 +84,10 @@ public sealed record ChannelInput
     /// True when the turn contains quoted adopted thread context ahead of the current
     /// executable message.
     /// </summary>
-    public bool HasAdoptedContext { get; init; }
+    public bool HasAdoptedContext
+        => (AdoptedSpeakerIds?.Count ?? 0) > 0
+           || (AdoptedContextEntries?.Count ?? 0) > 0
+           || !string.IsNullOrWhiteSpace(AdoptedContextProjection);
 
     /// <summary>
     /// True when the adopted context window includes at least one sender other than

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -81,6 +81,7 @@ public static class MessageSourceFactory
             ReceivedAt = input.ReceivedAt,
             ExecutableText = input.ExecutableText ?? textContent,
             HasAdoptedContext = input.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = input.HasThirdPartyAdoptedContext,
             AdoptedSpeakerIds = input.AdoptedSpeakerIds,
             AdoptedContextProjection = input.AdoptedContextProjection,
             AdoptedContextLowerBound = input.AdoptedContextLowerBound,

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -80,7 +80,6 @@ public static class MessageSourceFactory
             Provenance = input.Provenance ?? options.DefaultProvenance,
             ReceivedAt = input.ReceivedAt,
             ExecutableText = input.ExecutableText ?? textContent,
-            HasAdoptedContext = input.HasAdoptedContext,
             HasThirdPartyAdoptedContext = input.HasThirdPartyAdoptedContext,
             AdoptedSpeakerIds = input.AdoptedSpeakerIds,
             AdoptedContextProjection = input.AdoptedContextProjection,

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -89,6 +89,12 @@ public sealed record MessageSource
     public bool HasAdoptedContext { get; init; }
 
     /// <summary>
+    /// True when the adopted-context window includes at least one sender other than
+    /// the current authorized sender.
+    /// </summary>
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    /// <summary>
     /// Stable sender ids present in the adopted-context window for this turn.
     /// </summary>
     public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = [];

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -86,7 +86,10 @@ public sealed record MessageSource
     /// <summary>
     /// True when the model input contains a quoted adopted-context window.
     /// </summary>
-    public bool HasAdoptedContext { get; init; }
+    public bool HasAdoptedContext
+        => (AdoptedSpeakerIds?.Count ?? 0) > 0
+           || (AdoptedContextEntries?.Count ?? 0) > 0
+           || !string.IsNullOrWhiteSpace(AdoptedContextProjection);
 
     /// <summary>
     /// True when the adopted-context window includes at least one sender other than

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -65,6 +65,12 @@ public sealed class AdoptedContextRecorded
 
     public string Projection { get; set; } = string.Empty;
 
+    public bool HasAdoptedContext { get; set; }
+
+    public bool HasThirdPartyAdoptedContext { get; set; }
+
+    public List<string> AdoptedSpeakerIds { get; set; } = [];
+
     public List<AdoptedMessageRecord> Messages { get; set; } = [];
 
     public bool ProjectionPersisted { get; set; }

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -390,6 +390,12 @@ public sealed record ToolInteractionRequest : SessionOutput
     public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = [];
 
     /// <summary>
+    /// True when the adopted-context window includes at least one sender other than
+    /// the current authorized sender.
+    /// </summary>
+    public bool HasThirdPartyAdoptedContext { get; init; }
+
+    /// <summary>
     /// True when adopted-context provenance was preserved in stored approval state.
     /// </summary>
     public bool PersistedAdoptedContext { get; init; }

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -110,6 +110,7 @@ public sealed record SessionOutputDto
     public List<string>? InteractionDirectoryRoots { get; init; }
     public List<ToolInteractionOption>? InteractionOptions { get; init; }
     public bool? InteractionHasAdoptedContext { get; init; }
+    public bool? InteractionHasThirdPartyAdoptedContext { get; init; }
     public List<string>? InteractionAdoptedSpeakerIds { get; init; }
 
     // SubAgent

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -183,6 +183,7 @@ public static class SessionOutputDtoMapper
             InteractionDirectoryRoots = [.. msg.DirectoryRoots],
             InteractionOptions = [.. msg.Options],
             InteractionHasAdoptedContext = msg.HasAdoptedContext,
+            InteractionHasThirdPartyAdoptedContext = msg.HasThirdPartyAdoptedContext,
             InteractionAdoptedSpeakerIds = [.. msg.AdoptedSpeakerIds]
         },
 
@@ -336,6 +337,7 @@ public static class SessionOutputDtoMapper
                 DisplayText = dto.InteractionDisplayText ?? string.Empty,
                 RequesterSenderId = dto.RequesterSenderId,
                 HasAdoptedContext = dto.InteractionHasAdoptedContext ?? false,
+                HasThirdPartyAdoptedContext = dto.InteractionHasThirdPartyAdoptedContext ?? false,
                 AdoptedSpeakerIds = dto.InteractionAdoptedSpeakerIds ?? [],
                 Patterns = dto.InteractionPatterns ?? [],
                 ApprovalEntries = dto.InteractionApprovalEntries ?? [],

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -37,6 +37,12 @@ public sealed class SessionSnapshot
 
         public string Projection { get; set; } = string.Empty;
 
+        public bool HasAdoptedContext { get; set; }
+
+        public bool HasThirdPartyAdoptedContext { get; set; }
+
+        public List<string> AdoptedSpeakerIds { get; set; } = [];
+
         public bool ProjectionPersisted { get; set; }
 
         public List<AdoptedContextSnapshotMessage> Messages { get; set; } = [];

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -261,6 +261,8 @@ internal static class NetclawProtoMapper
         {
             AuthorizedMessageId = r.AuthorizedMessageId,
             Projection = r.Projection,
+            HasAdoptedContext = r.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = r.HasThirdPartyAdoptedContext,
             ProjectionPersisted = r.ProjectionPersisted
         };
         if (r.AuthorizerSenderId is not null)
@@ -269,6 +271,7 @@ internal static class NetclawProtoMapper
             proto.LowerBound = r.LowerBound;
         if (r.UpperBound is not null)
             proto.UpperBound = r.UpperBound;
+        proto.AdoptedSpeakerIds.AddRange(r.AdoptedSpeakerIds);
         proto.Messages.AddRange(r.Messages.Select(ToAdoptedContextSnapshotMessage));
         return proto;
     }
@@ -283,8 +286,13 @@ internal static class NetclawProtoMapper
             LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
             UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
             Projection = proto.Projection,
+            HasAdoptedContext = proto.HasAdoptedContext || proto.Messages.Count > 0,
+            HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
             ProjectionPersisted = proto.ProjectionPersisted
         };
+        r.AdoptedSpeakerIds.AddRange(proto.AdoptedSpeakerIds.Count > 0
+            ? proto.AdoptedSpeakerIds
+            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal));
         r.Messages.AddRange(proto.Messages.Select(FromAdoptedContextSnapshotMessage));
         return r;
     }
@@ -434,6 +442,8 @@ internal static class NetclawProtoMapper
             SessionId = ToProto(evt.SessionId),
             AuthorizedMessageId = evt.AuthorizedMessageId,
             Projection = evt.Projection,
+            HasAdoptedContext = evt.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = evt.HasThirdPartyAdoptedContext,
             ProjectionPersisted = evt.ProjectionPersisted,
             RecordedAtMs = evt.RecordedAtMs
         };
@@ -443,6 +453,7 @@ internal static class NetclawProtoMapper
             proto.LowerBound = evt.LowerBound;
         if (evt.UpperBound is not null)
             proto.UpperBound = evt.UpperBound;
+        proto.AdoptedSpeakerIds.AddRange(evt.AdoptedSpeakerIds);
         proto.Messages.AddRange(evt.Messages.Select(ToAdoptedMessageRecord));
         return proto;
     }
@@ -457,9 +468,14 @@ internal static class NetclawProtoMapper
             LowerBound = proto.HasLowerBound ? proto.LowerBound : null,
             UpperBound = proto.HasUpperBound ? proto.UpperBound : null,
             Projection = proto.Projection,
+            HasAdoptedContext = proto.HasAdoptedContext || proto.Messages.Count > 0,
+            HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
             ProjectionPersisted = proto.ProjectionPersisted,
             RecordedAtMs = proto.RecordedAtMs
         };
+        evt.AdoptedSpeakerIds.AddRange(proto.AdoptedSpeakerIds.Count > 0
+            ? proto.AdoptedSpeakerIds
+            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal));
         evt.Messages.AddRange(proto.Messages.Select(FromAdoptedMessageRecord));
         return evt;
     }

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -127,6 +127,9 @@ message AdoptedContextRecordedProto {
   repeated AdoptedMessageRecordProto messages = 7;
   bool projection_persisted = 8;
   int64 recorded_at_ms = 9;
+  bool has_third_party_adopted_context = 10;
+  bool has_adopted_context = 11;
+  repeated string adopted_speaker_ids = 12;
 }
 
 // ── Snapshots ──
@@ -156,6 +159,9 @@ message SessionSnapshotProto {
     string projection = 5;
     bool projection_persisted = 6;
     repeated AdoptedContextSnapshotMessage messages = 7;
+    bool has_third_party_adopted_context = 8;
+    bool has_adopted_context = 9;
+    repeated string adopted_speaker_ids = 10;
   }
 
   repeated SerializableChatMessageProto history = 1;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -786,6 +786,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 msg.RequesterSenderId,
                 msg.RequesterPrincipal,
                 msg.HasAdoptedContext,
+                msg.HasThirdPartyAdoptedContext,
                 msg.AdoptedSpeakerIds);
 
             PauseToolExecutionWatchdogForApprovalWait(msg.CallId);
@@ -1011,9 +1012,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (msg.Proposals.Count > 0 && _curationActor is not null
             && CurrentTurnAudience() != TrustAudience.Public && _memoryConfig.Enabled)
         {
-            if (_currentTurnSource?.HasAdoptedContext == true)
+            if (_currentTurnSource?.HasThirdPartyAdoptedContext == true)
             {
-                TurnLog().Info("memory_curation_skipped adopted-context present; waiting for explicit elevation");
+                TurnLog().Info("memory_curation_skipped third-party adopted-context present; waiting for explicit elevation");
                 if (stopAfterAcceptedProposalPersistence)
                     CompletePassivation();
                 return;
@@ -1900,7 +1901,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
         // Quoted adopted thread context is useful for the live turn, but it should not
         // silently become durable memory authority via the automatic observer path.
-        if (cmd.Source?.HasAdoptedContext != true)
+        if (cmd.Source?.HasThirdPartyAdoptedContext != true)
             _observerActor?.Tell(cmd);
 
         _turnState.ResetForNewTurn();
@@ -3089,6 +3090,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         string? RequesterSenderId,
         PrincipalClassification? RequesterPrincipal,
         bool HasAdoptedContext,
+        bool HasThirdPartyAdoptedContext,
         IReadOnlyList<string> AdoptedSpeakerIds);
 
     private void PersistAdoptedContextIfNeeded(MessageSource? source)
@@ -3113,6 +3115,9 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             LowerBound = source.AdoptedContextLowerBound,
             UpperBound = source.AdoptedContextUpperBound ?? source.MessageId,
             Projection = source.AdoptedContextProjection ?? string.Empty,
+            HasAdoptedContext = source.HasAdoptedContext,
+            HasThirdPartyAdoptedContext = source.HasThirdPartyAdoptedContext,
+            AdoptedSpeakerIds = [.. source.AdoptedSpeakerIds],
             ProjectionPersisted = true,
             RecordedAtMs = NowMs(),
             Messages = [.. source.AdoptedContextEntries

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -22,6 +22,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
     private readonly string? _requesterSenderId;
     private readonly PrincipalClassification? _requesterPrincipal;
     private readonly bool _hasAdoptedContext;
+    private readonly bool _hasThirdPartyAdoptedContext;
     private readonly IReadOnlyList<string> _adoptedSpeakerIds;
 
     public ParentSessionApprovalBridge(
@@ -31,6 +32,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
         string? requesterSenderId,
         PrincipalClassification? requesterPrincipal,
         bool hasAdoptedContext,
+        bool hasThirdPartyAdoptedContext,
         IReadOnlyList<string> adoptedSpeakerIds)
     {
         _channel = channel;
@@ -39,6 +41,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
         _requesterSenderId = requesterSenderId;
         _requesterPrincipal = requesterPrincipal;
         _hasAdoptedContext = hasAdoptedContext;
+        _hasThirdPartyAdoptedContext = hasThirdPartyAdoptedContext;
         _adoptedSpeakerIds = adoptedSpeakerIds;
     }
 
@@ -68,6 +71,7 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             ApprovalEntries = approvalEntries,
             DirectoryRoots = directoryRoots,
             HasAdoptedContext = _hasAdoptedContext,
+            HasThirdPartyAdoptedContext = _hasThirdPartyAdoptedContext,
             AdoptedSpeakerIds = _adoptedSpeakerIds,
             PersistedAdoptedContext = _hasAdoptedContext,
             Options =

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -150,6 +150,7 @@ internal static class SessionToolExecutionPipeline
                 source?.SenderId,
                 source?.Principal,
                 source?.HasAdoptedContext ?? false,
+                source?.HasThirdPartyAdoptedContext ?? false,
                 source?.AdoptedSpeakerIds ?? []);
         }
         var completedRuns = new List<CompletedSubAgentRun>();
@@ -281,6 +282,7 @@ internal static class SessionToolExecutionPipeline
                 RequesterSenderId = source?.SenderId,
                 RequesterPrincipal = source?.Principal,
                 HasAdoptedContext = source?.HasAdoptedContext ?? false,
+                HasThirdPartyAdoptedContext = source?.HasThirdPartyAdoptedContext ?? false,
                 AdoptedSpeakerIds = source?.AdoptedSpeakerIds ?? [],
                 PersistedAdoptedContext = source?.HasAdoptedContext ?? false,
                 Patterns = ctx.Patterns,

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -26,6 +26,9 @@ public sealed record SessionState
         string? LowerBound,
         string? UpperBound,
         string Projection,
+        bool HasAdoptedContext,
+        bool HasThirdPartyAdoptedContext,
+        ImmutableList<string> AdoptedSpeakerIds,
         bool ProjectionPersisted,
         ImmutableList<AdoptedContextAuditMessage> Messages);
 
@@ -126,6 +129,9 @@ public sealed record SessionState
             evt.LowerBound,
             evt.UpperBound,
             evt.Projection,
+            evt.HasAdoptedContext,
+            evt.HasThirdPartyAdoptedContext,
+            [.. evt.AdoptedSpeakerIds],
             evt.ProjectionPersisted,
             [.. evt.Messages
                 .Select(message => new AdoptedContextAuditMessage(
@@ -324,6 +330,9 @@ public sealed record SessionState
                     LowerBound = record.LowerBound,
                     UpperBound = record.UpperBound,
                     Projection = record.Projection,
+                    HasAdoptedContext = record.HasAdoptedContext,
+                    HasThirdPartyAdoptedContext = record.HasThirdPartyAdoptedContext,
+                    AdoptedSpeakerIds = [.. record.AdoptedSpeakerIds],
                     ProjectionPersisted = record.ProjectionPersisted,
                     Messages = [.. record.Messages
                         .Select(message => new SessionSnapshot.AdoptedContextSnapshotRecord.AdoptedContextSnapshotMessage
@@ -353,6 +362,9 @@ public sealed record SessionState
                     record.LowerBound,
                     record.UpperBound,
                     record.Projection,
+                    record.HasAdoptedContext,
+                    record.HasThirdPartyAdoptedContext,
+                    [.. record.AdoptedSpeakerIds],
                     record.ProjectionPersisted,
                     [.. record.Messages
                         .Select(message => new AdoptedContextAuditMessage(

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -305,6 +305,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             ReceivedAt = message.ReceivedAt,
             ExecutableText = message.Text,
             HasAdoptedContext = adoptedSpeakerIds.Count > 0,
+            HasThirdPartyAdoptedContext = adoptedSpeakerIds.Any(id => !string.Equals(id, message.SenderId.Value, StringComparison.Ordinal)),
             AdoptedSpeakerIds = adoptedSpeakerIds,
             AdoptedContextProjection = projection,
             AdoptedContextLowerBound = _cursorSnowflake?.ToString(),

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -304,7 +304,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             Contents = mergedContents,
             ReceivedAt = message.ReceivedAt,
             ExecutableText = message.Text,
-            HasAdoptedContext = adoptedSpeakerIds.Count > 0,
             HasThirdPartyAdoptedContext = adoptedSpeakerIds.Any(id => !string.Equals(id, message.SenderId.Value, StringComparison.Ordinal)),
             AdoptedSpeakerIds = adoptedSpeakerIds,
             AdoptedContextProjection = projection,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -797,6 +797,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         {
             Contents = merged.Contents,
             HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggeringMessage.SenderId, StringComparison.Ordinal)),
             AdoptedSpeakerIds = merged.SpeakerIds,
             AdoptedContextProjection = merged.Projection,
             AdoptedContextLowerBound = cursor?.Value,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -796,7 +796,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         return new InboundBuildResult(baseInput with
         {
             Contents = merged.Contents,
-            HasAdoptedContext = true,
             HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggeringMessage.SenderId, StringComparison.Ordinal)),
             AdoptedSpeakerIds = merged.SpeakerIds,
             AdoptedContextProjection = merged.Projection,

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -265,6 +265,9 @@ public sealed class DaemonClientMappingTests
             ToolName = "shell_execute",
             DisplayText = "git push origin main",
             RequesterSenderId = "device-1",
+            HasAdoptedContext = true,
+            HasThirdPartyAdoptedContext = true,
+            AdoptedSpeakerIds = ["device-1", "device-2"],
             Patterns = ["git push"],
             ApprovalEntries = ["git push"],
             DirectoryRoots = [],
@@ -282,6 +285,9 @@ public sealed class DaemonClientMappingTests
         Assert.Equal("approval", dto.InteractionKind);
         Assert.Equal("git push origin main", dto.InteractionDisplayText);
         Assert.Equal("device-1", dto.RequesterSenderId);
+        Assert.True(dto.InteractionHasAdoptedContext);
+        Assert.True(dto.InteractionHasThirdPartyAdoptedContext);
+        Assert.Equal(["device-1", "device-2"], dto.InteractionAdoptedSpeakerIds);
         Assert.Equal(["git push"], dto.InteractionApprovalEntries);
         Assert.Equal([], dto.InteractionDirectoryRoots ?? []);
 
@@ -291,6 +297,9 @@ public sealed class DaemonClientMappingTests
         Assert.Equal("shell_execute", result.ToolName);
         Assert.Equal("git push origin main", result.DisplayText);
         Assert.Equal("device-1", result.RequesterSenderId);
+        Assert.True(result.HasAdoptedContext);
+        Assert.True(result.HasThirdPartyAdoptedContext);
+        Assert.Equal(["device-1", "device-2"], result.AdoptedSpeakerIds);
         Assert.Equal(["git push"], result.Patterns);
         Assert.Equal(["git push"], result.ApprovalEntries);
         Assert.Equal([], result.DirectoryRoots);


### PR DESCRIPTION
## Summary
- separate adopted-context presence from third-party adopted-context policy across adapters, session state, approval flows, and memory suppression
- persist the full adopted-context audit contract, including non-empty adopted-window state and adopted speaker provenance, without breaking protobuf compatibility
- sync the OpenSpec change and tighten the memory eval harness so identity routing, explicit memory writes, recall, and automatic checkpointing are measured separately

## Validation
- dotnet build Netclaw.slnx -m:1
- dotnet test src/Netclaw.Actors.Tests/Netclaw.Actors.Tests.csproj --filter \"FullyQualifiedName~SessionBindingContractTests|FullyQualifiedName~MessageSourceFactoryTests|FullyQualifiedName~ParentSessionApprovalBridgeTests|FullyQualifiedName~SerializationRoundTripTests|FullyQualifiedName~SessionStateTests\"
- dotnet test src/Netclaw.Cli.Tests/Netclaw.Cli.Tests.csproj --filter \"FullyQualifiedName~DaemonClientMappingTests\"
- dotnet slopwatch analyze
- pwsh \"./scripts/Add-FileHeaders.ps1\" -Verify
- openspec validate \"clarify-adopted-context-third-party-policy\"
- `./evals/run-evals.sh` with the local Netclaw eval provider settings and `NETCLAW_EVAL_RUNS=1 NETCLAW_EVAL_THRESHOLD=1.0 NETCLAW_EVAL_CATEGORY=\"Memory Pipeline\"`

## Eval Before / After
### Before eval harness fixes
- `memory_formation` on `upstream/dev`: failed (`667d3794-d1d9-4adc-a13d-0b5d93c707c3`)
- `memory_formation` on the feature branch before the harness cleanup: failed (`18df286b-440c-4034-81ff-0f10d7d9d412`)
- those runs were ambiguous because the old case conflated identity routing, explicit memory writes, and automatic checkpoint enqueue, and the harness was also seeding the wrong runtime home / audience

### After eval harness fixes
- memory pipeline category run: `d312d24d-554b-488e-a586-8d0aabf620e5`
- result: `5/5` passing
- passing cases:
  - `memory_recall_active`
  - `memory_identity_preference_routing`
  - `memory_explicit_store`
  - `memory_checkpoint_enqueue`
  - `memory_recall_filters`

## Notes
- the eval harness now uses the container's real runtime home at `/home/netclaw/.netclaw`, seeds memories with `audience=personal`, removes the stale host `netclaw init` prerequisite, and distinguishes identity-file routing from explicit memory writes and automatic checkpointing