### PR TITLE
fix(tests): sync DaemonClient reconnect tests on Reconnecting|Disconnected

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -36,9 +36,17 @@ public sealed class DaemonClientReconnectIntegrationTests
         var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reconnectedOutput = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        // Sync on Reconnecting OR Disconnected: SignalR fires Reconnecting from
+        // its state machine as soon as the transport drops, before any retry
+        // attempt. Waiting for Disconnected alone requires WithAutomaticReconnect
+        // to exhaust its retries, which on Windows can exceed the test budget
+        // because ConnectEx to a closed loopback port is not immediate (Winsock
+        // SYN-retransmit path, exacerbated by WFP/AV filter drivers on hosted
+        // runners). Either event is sufficient evidence the client has observed
+        // the drop.
         using var connectionSub = client.ConnectionEvents.Subscribe(evt =>
         {
-            if (evt.State is DaemonConnectionState.Disconnected)
+            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.Disconnected)
                 disconnected.TrySetResult();
 
             if (evt.State is DaemonConnectionState.Connected && disconnected.Task.IsCompleted)
@@ -89,11 +97,10 @@ public sealed class DaemonClientReconnectIntegrationTests
         var port = GetFreeTcpPort();
         var host1 = await StartFakeHubAsync(port);
 
-        // Fast reconnect delays exhaust auto-reconnect in ~50ms instead of ~17s,
-        // so the Disconnected event fires quickly and the test budget is not wasted
-        // waiting for built-in retries to time out.
-        // Short ServerTimeout (2s) ensures the client detects the server going away
-        // quickly on all platforms (Windows TCP stack can be slow to detect drops).
+        // Fast reconnect delays keep the post-restart reconnect tight on the happy
+        // path. Short ServerTimeout (2s) bounds how long the client can spend
+        // Connected-but-blind after host1 stops, on platforms where TCP-level
+        // detection is slow.
         await using var client = new DaemonClient(
             $"http://127.0.0.1:{port}",
             reconnectDelays: [TimeSpan.Zero, TimeSpan.FromMilliseconds(50)],
@@ -105,15 +112,22 @@ public sealed class DaemonClientReconnectIntegrationTests
         var clientDisconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reconnectedAfterRestart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Wait for Disconnected (auto-reconnect exhausted, Closed handler fired)
-        // before starting host2. This ensures host1's port is fully released
-        // before host2 binds, and that the client is not mid-reconnect when
-        // host2 starts. Using Task.IsCompleted as the guard is safe: the
-        // Disconnected event always fires before any subsequent Connected event
-        // from ReconnectLoopAsync.
+        // Sync on Reconnecting OR Disconnected. SignalR fires Reconnecting from
+        // its state machine as soon as the transport drops, before any retry
+        // attempt. Waiting for Disconnected alone requires WithAutomaticReconnect
+        // to exhaust its retries, which on Windows can exceed the test budget:
+        // ConnectEx to a closed loopback port is not immediate (Winsock
+        // SYN-retransmit path, exacerbated by WFP/AV filter drivers on hosted
+        // runners), so each StartAsync retry can take seconds rather than the
+        // sub-millisecond ECONNREFUSED seen on Linux.
+        //
+        // The IsCompleted guard for reconnectedAfterRestart is still safe: at
+        // least one Reconnecting/Disconnected always precedes any subsequent
+        // Connected emission. host1's port release is already synchronous via
+        // host1.Dispose(), so it is not gated on the client observing anything.
         using var connectionSub = client.ConnectionEvents.Subscribe(evt =>
         {
-            if (evt.State is DaemonConnectionState.Disconnected)
+            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.Disconnected)
                 clientDisconnected.TrySetResult();
 
             if (evt.State is DaemonConnectionState.Connected && clientDisconnected.Task.IsCompleted)
@@ -144,10 +158,11 @@ public sealed class DaemonClientReconnectIntegrationTests
         await host1.StopAsync(TestContext.Current.CancellationToken);
         host1.Dispose();
 
-        // Wait for the client to observe Disconnected (auto-reconnect exhausted,
-        // Closed handler fired). With short reconnect delays this takes ~50ms.
-        // This ensures host1's port is fully released before host2 tries to bind,
-        // avoiding Windows TIME_WAIT conflicts.
+        // Wait for the client to observe the drop (Reconnecting or Disconnected).
+        // We do not gate on retry exhaustion: that is platform-dependent on
+        // Windows and not what this test cares about. host1's listener socket
+        // was released synchronously by host1.Dispose(); listener sockets do
+        // not enter TIME_WAIT.
         await WaitFor(clientDisconnected.Task, TimeSpan.FromSeconds(10));
 
         // Start the replacement server. ReconnectLoopAsync is already running at


### PR DESCRIPTION
## Summary

- Fixes intermittent Windows-CI failure of `DaemonClientReconnectIntegrationTests.EnsureSession_recreates_session_after_server_restart` (e.g. https://github.com/netclaw-dev/netclaw/actions/runs/25699821461/job/75457108840) without touching timeouts.
- Tests now sync on `Reconnecting OR Disconnected`. `Reconnecting` fires from `HubConnection`'s state machine as soon as transport drops, before any retry. The previous wait on `Disconnected` alone required `WithAutomaticReconnect` to exhaust its retries — fast on Linux (sub-millisecond `ECONNREFUSED`), but on Windows each retry's `ConnectEx` to a closed loopback port goes through the Winsock SYN-retransmit path (1–3+s per attempt, worse with WFP/AV filter drivers on hosted runners), which routinely exceeds the 10s budget.
- `host1`'s listener-socket release is synchronous via `host1.Dispose()`; nothing was actually gated on the client observing the drop, so no loss of correctness. The `IsCompleted` guard for the second TCS is still safe: at least one `Reconnecting`/`Disconnected` always precedes any subsequent `Connected`.
- Stale comments rewritten to match the new sync contract. No production code changes; no timeout values changed.

Issue #956 tracks the underlying overload of `DaemonConnectionState.Disconnected` (transient handoff vs. terminal exhaustion) that made the racy assertion possible to write in the first place.

## Test plan

- [x] `dotnet test --filter DaemonClientReconnectIntegrationTests` passes locally (Linux, Release) — 285ms across 5 consecutive runs (down from a 10s timeout on the failing Windows run).
- [x] `dotnet slopwatch analyze` clean.
- [ ] CI green on Windows (this PR).