### PR TITLE
fix(config-watcher): handle atomic-replace writes (Renamed event)

### DIFF
--- a/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Services/ConfigWatcherServiceTests.cs
@@ -115,6 +115,55 @@ public sealed class ConfigWatcherServiceTests : IDisposable
         Assert.Equal(1, _restartCoordinator.RequestCount);
     }
 
+    // Integration tests — exercise real FileSystemWatcher + filesystem operations.
+    // These are inherently async and use generous timeouts to stay stable on slow CI.
+
+    [Fact]
+    public async Task AtomicReplace_TriggersReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Simulate the write-temp-then-rename pattern used by safe editors and CLI tools
+        await _sut.StartAsync(ct);
+
+        File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
+
+        var tempPath = _paths.NetclawConfigPath + ".tmp." + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllText(tempPath, """{ "Providers": {} }""");
+        File.Move(tempPath, _paths.NetclawConfigPath, overwrite: true);
+
+        // Wait up to 3 s for the debounce + reload to fire
+        var deadline = TimeSpan.FromSeconds(3);
+        var started = DateTime.UtcNow;
+        while (_restartCoordinator.RequestCount == 0 && DateTime.UtcNow - started < deadline)
+            await Task.Delay(50, ct);
+
+        Assert.Equal(1, _restartCoordinator.RequestCount);
+    }
+
+    [Fact]
+    public async Task InPlaceWrite_TriggersReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Regression: direct in-place writes (e.g. shell > redirect) must still work
+        await _sut.StartAsync(ct);
+
+        // Write once to create the file, then overwrite in place
+        File.WriteAllText(_paths.NetclawConfigPath, """{ "Providers": {} }""");
+        await Task.Delay(100, ct); // let any initial events settle
+
+        _restartCoordinator.Reset();
+        await File.WriteAllTextAsync(_paths.NetclawConfigPath, """{ "Providers": {} }""", ct);
+
+        var deadline = TimeSpan.FromSeconds(3);
+        var started = DateTime.UtcNow;
+        while (_restartCoordinator.RequestCount == 0 && DateTime.UtcNow - started < deadline)
+            await Task.Delay(50, ct);
+
+        Assert.Equal(1, _restartCoordinator.RequestCount);
+    }
+
     [Fact]
     public void ReadDaemonConfigFromFile_MissingFile_ReturnsDefaults()
     {
@@ -144,6 +193,8 @@ public sealed class ConfigWatcherServiceTests : IDisposable
         public int RequestCount { get; private set; }
 
         public bool ThrowOnRequest { get; set; }
+
+        public void Reset() => RequestCount = 0;
 
         public Task RequestConfigRestartAsync(CancellationToken cancellationToken)
         {

--- a/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
+++ b/src/Netclaw.Daemon/Services/ConfigWatcherService.cs
@@ -65,13 +65,14 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
 
         _watcher = new FileSystemWatcher(configDir)
         {
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.FileName,
             EnableRaisingEvents = true
         };
 
         _watcher.Changed += OnFileChanged;
         _watcher.Created += OnFileChanged;
         _watcher.Deleted += OnFileDeleted;
+        _watcher.Renamed += OnFileRenamed;
 
         _logger.LogInformation("Config hot-reload watching: {ConfigDir}", configDir);
         return Task.CompletedTask;
@@ -112,6 +113,30 @@ public sealed class ConfigWatcherService : IHostedService, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled exception in config watcher Deleted callback for {FileName}", e.Name);
+        }
+    }
+
+    private void OnFileRenamed(object sender, RenamedEventArgs e)
+    {
+        try
+        {
+            // Rename INTO our watched filename = atomic-replace write (write-temp + rename).
+            if (IsWatchedFile(e.Name))
+            {
+                _logger.LogDebug("Config file rename detected: {OldName} -> {NewName}", e.OldName, e.Name);
+                ScheduleReload();
+                return;
+            }
+
+            // Rename OUT of our watched filename = treat like a delete.
+            if (IsWatchedFile(e.OldName))
+            {
+                _logger.LogWarning("Config file renamed away: {OldName} -> {NewName}. Keeping current config.", e.OldName, e.Name);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in config watcher Renamed callback for {FileName}", e.Name);
         }
     }
 


### PR DESCRIPTION
## Summary

- Subscribe `ConfigWatcherService` to `FileSystemWatcher.Renamed` so write-temp-then-rename sequences (used by vim, VS Code, and most CLI tools) trigger the existing debounce → validate → restart path.
- Add `NotifyFilters.FileName` to the watcher so OS-level rename notifications are delivered.
- Rename-away from `netclaw.json` logs a warning (same behaviour as delete) without triggering a reload.

Fixes #959.

## Test plan

- [x] `AtomicReplace_TriggersReload` — starts the live watcher, writes via write-temp + `File.Move`, asserts `RequestConfigRestartAsync` fires within 3 s.
- [x] `InPlaceWrite_TriggersReload` — regression guard confirming direct in-place writes still trigger the reload path.
- [x] All 15 existing `ConfigWatcherServiceTests` pass.