### PR TITLE
Protocol marker interface for serialization management

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Persistence.Hosting;
@@ -24,7 +26,8 @@ public abstract class LlmSessionTestBase : TestKit
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
             .WithNetclawSerialization()
-            .WithNetclawActors();
+            .WithNetclawActors()
+            .WithStrictSerialization();
     }
 
     protected sealed override void ConfigureServices(HostBuilderContext context, IServiceCollection services)

--- a/src/Netclaw.Actors/Channels/CursorAdvanced.cs
+++ b/src/Netclaw.Actors/Channels/CursorAdvanced.cs
@@ -5,9 +5,11 @@
 // -----------------------------------------------------------------------
 namespace Netclaw.Actors.Channels;
 
+using Netclaw.Actors.Protocol;
+
 /// <summary>
 /// Persistence event indicating a channel binding actor's inbound cursor moved forward.
 /// The cursor value is channel-specific (e.g. Slack timestamp, Discord snowflake)
 /// but serialized as an opaque string — only the owning actor interprets it.
 /// </summary>
-public readonly record struct CursorAdvanced(string Cursor);
+public readonly record struct CursorAdvanced(string Cursor) : IPersistableMessage;

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -194,10 +194,9 @@ public static class NetclawAkkaHostingExtensions
     public static AkkaConfigurationBuilder WithNetclawSerialization(
         this AkkaConfigurationBuilder builder)
     {
-        var boundTypes = new[]
-        {
-            typeof(IPersistableMessage),
-        };
+        var boundTypes = typeof(IPersistableMessage).Assembly.GetTypes()
+            .Where(t => typeof(IPersistableMessage).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+            .ToArray();
 
         return builder
             .WithCustomSerializer(

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Linq;
 using Akka.Actor;
 using Akka.DependencyInjection;
 using Akka.Hosting;
@@ -195,24 +196,7 @@ public static class NetclawAkkaHostingExtensions
     {
         var boundTypes = new[]
         {
-            typeof(SessionId),
-            typeof(SendUserMessage),
-            typeof(SerializableChatMessage),
-            typeof(SerializableMediaReference),
-            typeof(SerializableToolCall),
-            typeof(TurnRecorded),
-            typeof(SessionTitleSet),
-            typeof(SessionCompacted),
-            typeof(SessionSnapshot),
-            typeof(TurnBroadcast),
-            typeof(CompactionBroadcast),
-            typeof(WorkingContext),
-            typeof(ReminderId),
-            typeof(ReminderDelivery),
-            typeof(ReminderSchedule),
-            typeof(ReminderPayload),
-            typeof(AdoptedContextRecorded),
-            typeof(Channels.CursorAdvanced),
+            typeof(IPersistableMessage),
         };
 
         return builder

--- a/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using System.Text.Json.Serialization;
 using Netclaw.Configuration;
 
@@ -89,7 +90,7 @@ public sealed record BackgroundJobCancelResponse(BackgroundJobId JobId, bool Fou
 /// <summary>
 /// Sent by <see cref="BackgroundJobExecutionActor"/> to parent when execution completes.
 /// </summary>
-internal sealed record BackgroundJobCompleted
+internal sealed record BackgroundJobCompleted : INoSerializationVerificationNeeded
 {
     public required BackgroundJobId JobId { get; init; }
     public required BackgroundJobStatus Status { get; init; }

--- a/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCurationActor.cs
@@ -37,11 +37,11 @@ public sealed record CurationFailed(string Reason);
 // ── Internal messages ───────────────────────────────────────────────
 
 internal sealed record EvaluationBatchResult(
-    IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationDecision Decision)> Decisions);
+    IReadOnlyList<(SQLiteMemoryCurationOperation Operation, CurationDecision Decision)> Decisions) : INoSerializationVerificationNeeded;
 
-internal sealed record WriteBatchResult(CurationCompleted Summary);
+internal sealed record WriteBatchResult(CurationCompleted Summary) : INoSerializationVerificationNeeded;
 
-internal sealed record WriteBatchFailed(Exception Exception);
+internal sealed record WriteBatchFailed(Exception Exception) : INoSerializationVerificationNeeded;
 
 // ── Actor ───────────────────────────────────────────────────────────
 

--- a/src/Netclaw.Actors/Protocol/Broadcasts.cs
+++ b/src/Netclaw.Actors/Protocol/Broadcasts.cs
@@ -9,7 +9,7 @@ namespace Netclaw.Actors.Protocol;
 /// Published via Akka pub/sub after a session completes a turn.
 /// Adapters subscribe to deliver replies through their respective channels.
 /// </summary>
-public sealed class TurnBroadcast
+public sealed class TurnBroadcast : IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 
@@ -23,7 +23,7 @@ public sealed class TurnBroadcast
 /// <summary>
 /// Published via Akka pub/sub after a session completes compaction.
 /// </summary>
-public sealed class CompactionBroadcast
+public sealed class CompactionBroadcast : IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Actors.Protocol;
 /// <summary>
 /// Command delivering user input to a session actor.
 /// </summary>
-public sealed class SendUserMessage : IWithSessionId
+public sealed class SendUserMessage : IWithSessionId, IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 
@@ -42,14 +42,14 @@ public sealed class SendUserMessage : IWithSessionId
 public sealed record DeliverTrustedSessionTurn(
     SessionId SessionId,
     string Content,
-    Channels.MessageSource Source) : IWithSessionId;
+    Channels.MessageSource Source) : IWithSessionId, IPersistableMessage;
 
 /// <summary>
 /// User's response to a <see cref="ToolInteractionRequest"/>.
 /// Routed from the channel adapter to the session actor to complete the
 /// blocked tool's <see cref="System.Threading.Tasks.TaskCompletionSource{T}"/>.
 /// </summary>
-public sealed class ToolInteractionResponse : IWithSessionId
+public sealed class ToolInteractionResponse : IWithSessionId, IPersistableMessage
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -8,7 +8,7 @@ namespace Netclaw.Actors.Protocol;
 /// <summary>
 /// Persisted event recording a completed turn (user message + assistant reply).
 /// </summary>
-public sealed class TurnRecorded
+public sealed class TurnRecorded : IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 
@@ -40,7 +40,7 @@ public sealed class TurnRecorded
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
 }
 
-public sealed class AdoptedContextRecorded
+public sealed class AdoptedContextRecorded : IPersistableMessage
 {
     public sealed class AdoptedMessageRecord
     {
@@ -83,7 +83,7 @@ public sealed class AdoptedContextRecorded
 /// <summary>
 /// Persisted event recording that the session title was set or updated.
 /// </summary>
-public sealed class SessionTitleSet
+public sealed class SessionTitleSet : IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 
@@ -98,7 +98,7 @@ public sealed class SessionTitleSet
 /// Persisted event recording that a session's conversation history was compacted.
 /// A snapshot is also taken after this event to avoid replaying the full journal.
 /// </summary>
-public sealed class SessionCompacted
+public sealed class SessionCompacted : IPersistableMessage
 {
     public SessionId SessionId { get; set; }
 

--- a/src/Netclaw.Actors/Protocol/IPersistableMessage.cs
+++ b/src/Netclaw.Actors/Protocol/IPersistableMessage.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPersistableMessage.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Marker interface for messages that need to be serialized (persisted or sent across process boundaries).
+/// All messages implementing this interface must be registered in the protobuf serializer.
+/// </summary>
+public interface IPersistableMessage { }

--- a/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
+++ b/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Protocol;
@@ -27,4 +28,4 @@ internal sealed record CapabilityResolved(
     string ModelId,
     ModelModality InputModalities,
     ModelModality OutputModalities,
-    bool Success);
+    bool Success) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -9,7 +9,7 @@ namespace Netclaw.Actors.Protocol;
 /// Persistence-safe representation of a chat message.
 /// Never persist Microsoft.Extensions.AI types directly — use this instead.
 /// </summary>
-public sealed class SerializableChatMessage
+public sealed class SerializableChatMessage : IPersistableMessage
 {
     public ChatRole Role { get; set; }
 
@@ -39,7 +39,7 @@ public sealed class SerializableChatMessage
 /// <summary>
 /// Persistence-safe reference to a media file stored in the session directory.
 /// </summary>
-public sealed class SerializableMediaReference
+public sealed class SerializableMediaReference : IPersistableMessage
 {
     /// <summary>Relative path within the session media directory.</summary>
     public string RelativePath { get; set; } = string.Empty;
@@ -65,7 +65,7 @@ public enum MediaModality
 /// <summary>
 /// Persistence-safe representation of a single tool call from the assistant.
 /// </summary>
-public sealed class SerializableToolCall
+public sealed class SerializableToolCall : IPersistableMessage
 {
     public string CallId { get; set; } = string.Empty;
 

--- a/src/Netclaw.Actors/Protocol/SessionId.cs
+++ b/src/Netclaw.Actors/Protocol/SessionId.cs
@@ -9,7 +9,7 @@ namespace Netclaw.Actors.Protocol;
 /// Strongly-typed session identity. Wraps the entity key string used for
 /// actor routing and persistence identity.
 /// </summary>
-public readonly record struct SessionId(string Value)
+public readonly record struct SessionId(string Value) : IPersistableMessage
 {
     public static explicit operator SessionId(string value) => new(value);
 

--- a/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
+++ b/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
@@ -3,12 +3,14 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Requests that a live session stop accepting new work and passivate for coordinated daemon restart.
 /// </summary>
-public sealed record PrepareForDaemonRestart : IWithSessionId
+public sealed record PrepareForDaemonRestart : IWithSessionId, IPersistableMessage
 {
     public required SessionId SessionId { get; init; }
 
@@ -18,7 +20,7 @@ public sealed record PrepareForDaemonRestart : IWithSessionId
 /// <summary>
 /// Rehydrates a session after coordinated daemon restart and primes a one-turn continuity notice.
 /// </summary>
-public sealed record WarmSession : IWithSessionId
+public sealed record WarmSession : IWithSessionId, IPersistableMessage
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -12,7 +12,7 @@ namespace Netclaw.Actors.Protocol;
 /// Snapshot of session state for fast recovery. Persisted after compaction
 /// and periodically based on <see cref="Sessions.SessionConfig.SnapshotInterval"/>.
 /// </summary>
-public sealed class SessionSnapshot
+public sealed class SessionSnapshot : IPersistableMessage
 {
     public sealed class AdoptedContextSnapshotRecord
     {

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -3,15 +3,17 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using System.Text.Json.Serialization;
 using Netclaw.Configuration;
+using Netclaw.Actors.Protocol;
 
 namespace Netclaw.Actors.Reminders;
 
 /// <summary>
 /// Strongly-typed reminder identity.
 /// </summary>
-public readonly record struct ReminderId(string Value)
+public readonly record struct ReminderId(string Value) : IPersistableMessage
 {
     public override string ToString() => Value;
 }
@@ -44,7 +46,7 @@ public enum DeliveryKind
 /// <summary>
 /// Structured delivery target for a reminder.
 /// </summary>
-public sealed class ReminderDelivery
+public sealed class ReminderDelivery : IPersistableMessage
 {
     /// <summary>
     /// How results are delivered.
@@ -102,7 +104,7 @@ public enum ReminderScheduleType
 /// <summary>
 /// Describes when and how a reminder fires.
 /// </summary>
-public sealed class ReminderSchedule
+public sealed class ReminderSchedule : IPersistableMessage
 {
     public ReminderScheduleType Type { get; set; }
 
@@ -142,7 +144,8 @@ public sealed class ReminderSchedule
 }
 
 /// <summary>
-/// Canonical reminder definition persisted to disk.
+/// Canonical reminder definition persisted to disk as JSON.
+/// Not serialized via Akka.NET - scheduled messages only carry a pointer (reminder ID).
 /// </summary>
 public sealed record ReminderDefinition
 {
@@ -231,7 +234,7 @@ public sealed record ReminderDefinition
 /// <summary>
 /// Message persisted inside Akka.Reminders. Intentionally lightweight: pointer to disk definition.
 /// </summary>
-public sealed class ReminderPayload
+public sealed class ReminderPayload : IPersistableMessage
 {
     public ReminderId Id { get; set; }
 }
@@ -325,7 +328,7 @@ internal sealed record ReminderExecutionCompleted(
     Guid ExecutionId,
     ReminderId Id,
     bool Success,
-    string? ErrorMessage = null);
+    string? ErrorMessage = null) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Signal emitted by the outbound channel pipeline when a reminder-sourced
@@ -347,14 +350,14 @@ internal sealed record ReminderExecutionCompleted(
 public sealed record ReminderDeliveryObserved(
     string ReminderDeliveryKey,
     Channels.ChannelType ChannelType,
-    long? ObservedAtMs = null);
+    long? ObservedAtMs = null) : INoSerializationVerificationNeeded;
 
 // ── Health query ──
 
 /// <summary>
 /// Query sent to <see cref="ReminderManagerActor"/> to obtain current health counters.
 /// </summary>
-public sealed record GetReminderHealthQuery
+public sealed record GetReminderHealthQuery : INoSerializationVerificationNeeded
 {
     public static readonly GetReminderHealthQuery Instance = new();
 }
@@ -365,7 +368,7 @@ public sealed record GetReminderHealthQuery
 public sealed record ReminderHealthResponse(
     int ScheduledCount,
     int ActiveExecutions,
-    int FailedCount);
+    int FailedCount) : INoSerializationVerificationNeeded;
 
 // ── Execution history ──
 

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -36,6 +36,7 @@ internal static class NetclawProtoMapper
         ReminderPayload v => ToProto(v),
         AdoptedContextRecorded v => ToProto(v),
         CursorAdvanced v => ToProto(v),
+        MemoriesDistilledV2 v => ToProto(v),
         _ => throw new ArgumentException($"No proto mapping for {obj.GetType().FullName}")
     };
 
@@ -502,6 +503,32 @@ internal static class NetclawProtoMapper
 
     internal static Proto.CursorAdvancedProto ToProto(CursorAdvanced ca) => new() { Cursor = ca.Cursor };
     internal static CursorAdvanced FromProto(Proto.CursorAdvancedProto proto) => new(proto.Cursor);
+
+    // ── MemoriesDistilledV2 / ProposedMemoryContext ──
+
+    internal static Proto.ProposedMemoryContextProto ToProto(ProposedMemoryContext ctx) => new()
+    {
+        Anchor = ctx.Anchor,
+        Title = ctx.Title,
+        Content = ctx.Content
+    };
+
+    internal static ProposedMemoryContext FromProto(Proto.ProposedMemoryContextProto proto) =>
+        new(proto.Anchor, proto.Title, proto.Content);
+
+    internal static Proto.MemoriesDistilledV2Proto ToProto(MemoriesDistilledV2 evt)
+    {
+        var proto = new Proto.MemoriesDistilledV2Proto { TimestampMs = evt.TimestampMs };
+        proto.Anchors.AddRange(evt.Anchors);
+        foreach (var p in evt.Proposals)
+            proto.Proposals.Add(ToProto(p));
+        return proto;
+    }
+
+    internal static MemoriesDistilledV2 FromProto(Proto.MemoriesDistilledV2Proto proto) => new(
+        Anchors: proto.Anchors.ToList(),
+        Proposals: proto.Proposals.Select(FromProto).ToList(),
+        TimestampMs: proto.TimestampMs);
 
     // ── ActiveJobInfo ──
 

--- a/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs
@@ -38,6 +38,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
     private const string ReminderPayloadManifest = "rp-v1";
     private const string AdoptedContextRecordedManifest = "acr-v1";
     private const string CursorAdvancedManifest = "ca-v1";
+    private const string MemoriesDistilledV2Manifest = "mdv2-v1";
 
     private static readonly FrozenDictionary<Type, string> TypeToManifest = new Dictionary<Type, string>
     {
@@ -59,6 +60,7 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
         [typeof(ReminderPayload)] = ReminderPayloadManifest,
         [typeof(AdoptedContextRecorded)] = AdoptedContextRecordedManifest,
         [typeof(Channels.CursorAdvanced)] = CursorAdvancedManifest,
+        [typeof(MemoriesDistilledV2)] = MemoriesDistilledV2Manifest,
     }.ToFrozenDictionary();
 
     public override int Identifier => 150;
@@ -121,6 +123,8 @@ public sealed class NetclawProtobufSerializer : SerializerWithStringManifest
                 Proto.AdoptedContextRecordedProto.Parser.ParseFrom(bytes)),
             CursorAdvancedManifest => NetclawProtoMapper.FromProto(
                 Proto.CursorAdvancedProto.Parser.ParseFrom(bytes)),
+            MemoriesDistilledV2Manifest => NetclawProtoMapper.FromProto(
+                Proto.MemoriesDistilledV2Proto.Parser.ParseFrom(bytes)),
             _ => throw new ArgumentException(
                 $"Unknown manifest '{manifest}'. Add it to NetclawProtobufSerializer.")
         };

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -222,3 +222,17 @@ message ReminderPayloadProto {
 message CursorAdvancedProto {
   string cursor = 1;
 }
+
+// ── MemoriesDistilledV2 / ProposedMemoryContext ──
+
+message ProposedMemoryContextProto {
+  string anchor = 1;
+  string title = 2;
+  string content = 3;
+}
+
+message MemoriesDistilledV2Proto {
+  repeated string anchors = 1;
+  repeated ProposedMemoryContextProto proposals = 2;
+  int64 timestamp_ms = 3;
+}

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -13,7 +13,7 @@ namespace Netclaw.Actors.Sessions;
 /// <summary>
 /// Internal message sent back to the session actor when the async LLM call completes.
 /// </summary>
-internal sealed record LlmResponseReceived
+internal sealed record LlmResponseReceived : INoSerializationVerificationNeeded
 {
     public required ChatResponse Response { get; init; }
 
@@ -33,7 +33,7 @@ internal sealed record LlmResponseReceived
 /// <summary>
 /// Incremental streaming delta emitted while an LLM response is in-flight.
 /// </summary>
-internal sealed record LlmResponseDeltaReceived
+internal sealed record LlmResponseDeltaReceived : INoSerializationVerificationNeeded
 {
     public required AIContent Content { get; init; }
 
@@ -43,7 +43,7 @@ internal sealed record LlmResponseDeltaReceived
 /// <summary>
 /// Internal message sent back to the session actor when the async LLM call fails.
 /// </summary>
-internal sealed record LlmCallFailed
+internal sealed record LlmCallFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 
@@ -54,7 +54,7 @@ internal sealed record LlmCallFailed
 /// Internal message sent back to the session actor when tool execution completes.
 /// Contains the tool results to feed back into the next LLM call.
 /// </summary>
-internal sealed record ToolExecutionCompleted
+internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeeded
 {
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
@@ -62,7 +62,7 @@ internal sealed record ToolExecutionCompleted
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];
 }
 
-internal sealed record CompletedSubAgentRun
+internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
     public required string RunId { get; init; }
     public required string AgentName { get; init; }
@@ -73,7 +73,7 @@ internal sealed record CompletedSubAgentRun
     public string? MemoryDecisionReason { get; init; }
 }
 
-internal sealed record AcceptedSubAgentFinding
+internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNeeded
 {
     public required string RunId { get; init; }
     public required string AgentName { get; init; }
@@ -97,7 +97,7 @@ internal sealed record AcceptedSubAgentFinding
 /// <summary>
 /// Internal message sent back when tool execution fails.
 /// </summary>
-internal sealed record ToolExecutionFailed
+internal sealed record ToolExecutionFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 }
@@ -106,7 +106,7 @@ internal sealed record ToolExecutionFailed
 /// Internal watchdog timeout used to force stuck Processing operations to fail
 /// and return the session actor to Ready state.
 /// </summary>
-internal sealed record ProcessingWatchdogExpired
+internal sealed record ProcessingWatchdogExpired : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
 
@@ -117,7 +117,7 @@ internal sealed record ProcessingWatchdogExpired
 /// Marshal a child actor creation request back onto the session actor thread.
 /// This keeps <c>Context.ActorOf</c> usage on the actor mailbox thread.
 /// </summary>
-internal sealed record SpawnChildActorRequest
+internal sealed record SpawnChildActorRequest : INoSerializationVerificationNeeded
 {
     public required Props Props { get; init; }
     public required string ActorName { get; init; }
@@ -127,12 +127,12 @@ internal sealed record SpawnChildActorRequest
 /// Internal trigger to begin the compaction sequence.
 /// Sent to self after a turn completes when usage exceeds the threshold.
 /// </summary>
-internal sealed record CompactionTriggered
+internal sealed record CompactionTriggered : INoSerializationVerificationNeeded
 {
     public required long InputTokenCount { get; init; }
 }
 
-internal sealed record CompactionWorkCompleted
+internal sealed record CompactionWorkCompleted : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
     public required string Summary { get; init; }
@@ -143,7 +143,7 @@ internal sealed record CompactionWorkCompleted
     public required int KeepCountUsed { get; init; }
 }
 
-internal sealed record CompactionWorkFailed
+internal sealed record CompactionWorkFailed : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
     public required Exception Cause { get; init; }
@@ -153,7 +153,7 @@ internal sealed record CompactionWorkFailed
 /// Internal message completing a memory extraction LLM call.
 /// Contains extracted memories that should be persisted externally.
 /// </summary>
-internal sealed record MemoryExtractionCompleted
+internal sealed record MemoryExtractionCompleted : INoSerializationVerificationNeeded
 {
     public required string ExtractedMemories { get; init; }
 }
@@ -161,7 +161,7 @@ internal sealed record MemoryExtractionCompleted
 /// <summary>
 /// Internal message when a compaction step (extraction or summarization) fails.
 /// </summary>
-internal sealed record CompactionFailed
+internal sealed record CompactionFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 }
@@ -169,7 +169,7 @@ internal sealed record CompactionFailed
 /// <summary>
 /// Internal message completing a sidecar title generation LLM call.
 /// </summary>
-internal sealed record TitleGenerationCompleted
+internal sealed record TitleGenerationCompleted : INoSerializationVerificationNeeded
 {
     public required string Title { get; init; }
 }
@@ -179,22 +179,22 @@ internal sealed record TitleGenerationCompleted
 /// Enables child actors to react to lifecycle events (e.g., trigger
 /// final distillation when entering <see cref="SessionPhase.Passivating"/>).
 /// </summary>
-internal sealed record SessionPhaseChanged(SessionPhase Phase) : INotInfluenceReceiveTimeout;
+internal sealed record SessionPhaseChanged(SessionPhase Phase) : INotInfluenceReceiveTimeout, INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Sent to the observer actor to request immediate memory distillation
 /// before the session stops during passivation.
 /// </summary>
-internal sealed record RequestFinalDistillation;
+internal sealed record RequestFinalDistillation : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Sent back from the passivation timeout timer when the observer
 /// does not complete distillation within the grace period.
 /// </summary>
-internal sealed record PassivationTimeout;
+internal sealed record PassivationTimeout : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Timer-fired message that triggers an LLM call retry after exponential backoff.
 /// Carries the attempt number for observability logging.
 /// </summary>
-internal sealed record RetryLlmCallAfterBackoff(int Attempt);
+internal sealed record RetryLlmCallAfterBackoff(int Attempt) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -778,10 +778,10 @@ public sealed record MemoriesDistilled(IReadOnlyList<string> Anchors, long Times
 public sealed record MemoriesDistilledV2(
     IReadOnlyList<string> Anchors,
     IReadOnlyList<ProposedMemoryContext> Proposals,
-    long TimestampMs);
+    long TimestampMs) : IPersistableMessage;
 
 /// <summary>Context for a previously proposed memory, used for semantic dedup in subsequent distillation runs.</summary>
-public sealed record ProposedMemoryContext(string Anchor, string Title, string Content);
+public sealed record ProposedMemoryContext(string Anchor, string Title, string Content) : IPersistableMessage;
 
 /// <summary>Sent by the session actor after proposals survive gating and are accepted for curation.</summary>
 public sealed record RecordAcceptedDistillationProposals(IReadOnlyList<MemoryProposal> Proposals);

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Immutable;
+using Netclaw.Actors.Protocol;
 
 namespace Netclaw.Actors.Sessions;
 
@@ -22,7 +23,7 @@ namespace Netclaw.Actors.Sessions;
 ///   root the session is working on. Set via <c>set_working_directory</c>
 ///   tool, persisted across crash/restart. Null means "no project selected."
 /// </summary>
-public sealed record WorkingContext
+public sealed record WorkingContext : IPersistableMessage
 {
     /// <summary>
     /// Maximum number of entries retained in <see cref="RecentFiles"/>.

--- a/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalMessages.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Tools;
@@ -13,13 +14,13 @@ internal sealed record GetUnapprovedPatterns(
     SessionId? SessionId,
     TrustAudience Audience,
     ToolName ToolName,
-    IReadOnlyList<string> Patterns);
+    IReadOnlyList<string> Patterns) : INoSerializationVerificationNeeded;
 
-internal sealed record UnapprovedPatternsResponse(IReadOnlyList<string> Patterns);
+internal sealed record UnapprovedPatternsResponse(IReadOnlyList<string> Patterns) : INoSerializationVerificationNeeded;
 
 internal sealed record RecordToolApproval(
     SessionId SessionId,
     TrustAudience Audience,
     ToolName ToolName,
     IReadOnlyList<string> Patterns,
-    bool Persistent);
+    bool Persistent) : INoSerializationVerificationNeeded;


### PR DESCRIPTION
## Summary

- Created `IPersistableMessage` marker interface for messages that need Akka.NET serialization
- Added `IPersistableMessage` to 19 protocol message types (17 original + 2 new)
- Added `INoSerializationVerificationNeeded` to 36 internal messages that should not be serialized
- Updated `WithNetclawSerialization` to use reflection-based type discovery via marker interface
- Added `MemoriesDistilledV2` and `ProposedMemoryContext` serialization support

## Changes

### New Files
- `src/Netclaw.Actors/Protocol/IPersistableMessage.cs` - Marker interface for serializable protocol types

### Modified Files
- `src/Netclaw.Actors/Protocol/*.cs` - Added `IPersistableMessage` to protocol message types
- `src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs` - Added `IPersistableMessage` to `MemoriesDistilledV2` and `ProposedMemoryContext`
- `src/Netclaw.Actors/Sessions/LlmMessages.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Reminders/ReminderProtocol.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Jobs/BackgroundJobProtocol.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Tools/ToolApprovalMessages.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Memory/MemoryCurationActor.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs` - Added `INoSerializationVerificationNeeded` to internal messages
- `src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs` - Updated to use reflection-based type discovery
- `src/Netclaw.Actors/Serialization/NetclawProtobufSerializer.cs` - Added manifest for `MemoriesDistilledV2`
- `src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs` - Added proto mappings for new types
- `src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto` - Added protobuf definitions for new types

## Testing

- All 1497 tests pass
- 22 serialization round-trip tests pass
- No new slopwatch violations
- Copyright headers present on all files