### PR TITLE
fix(reminders): remove spurious 5-minute execution timeout; prevent duplicate concurrent execution

### DIFF
--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -833,6 +833,47 @@ public class ReminderManagerActorTests : TestKit
         }
     }
 
+    [Fact]
+    public async Task Second_fire_of_executing_reminder_is_skipped_as_duplicate()
+    {
+        var manager = await GetManagerAsync();
+
+        // NeverReplyGateway accepts the turn but never sends CommandAck —
+        // this keeps the first execution actor alive (its Ask is pending)
+        // so the reminder ID stays in _activeExecutions when the second
+        // envelope arrives.
+        var deliveryProbe = CreateTestProbe("delivery-probe");
+        var slowGateway = Sys.ActorOf(
+            Props.Create(() => new NeverReplyGateway(deliveryProbe.Ref)),
+            "never-reply-gateway");
+        ActorRegistry.For(Sys).Register<SlackGatewayActorKey>(slowGateway);
+
+        var definition = CreateCurrentSessionDefinition("dup-guard-test", deliveryRequired: false);
+        _definitionStore.Save(definition);
+
+        var envelope1 = CreateEnvelope(definition.Id);
+        var envelope2 = CreateEnvelope(definition.Id);
+
+        // Both envelopes go into the actor's mailbox before either is processed,
+        // so the second always arrives while the first execution is still in flight.
+        manager.Tell(envelope1);
+        manager.Tell(envelope2);
+
+        // Exactly one delivery should reach the gateway.
+        await deliveryProbe.ExpectMsgAsync<DeliverTrustedSessionTurn>(
+            TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await deliveryProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300), TestContext.Current.CancellationToken);
+
+        // Health reflects one active execution — the duplicate was dropped, not queued.
+        var health = await manager.Ask<ReminderHealthResponse>(
+            GetReminderHealthQuery.Instance, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal(1, health.ActiveExecutions);
+
+        // No failure alert — duplicate skip is silent from an alert standpoint.
+        Assert.DoesNotContain(_notificationSink.Alerts, a =>
+            a.Category == AlertType.ReminderExecutionFailed && a.Source == definition.Id);
+    }
+
     /// <summary>
     /// Test-only gateway stub: handles <see cref="DeliverTrustedSessionTurn"/>
     /// by forwarding to a probe for assertions and immediately replying
@@ -849,6 +890,19 @@ public class ReminderManagerActorTests : TestKit
                 probe.Tell(msg);
                 Sender.Tell(CommandAck.For(msg.SessionId));
             });
+        }
+    }
+
+    /// <summary>
+    /// Accepts <see cref="DeliverTrustedSessionTurn"/> messages and forwards them
+    /// to a probe, but never replies to <c>Sender</c>. Keeps the execution actor's
+    /// gateway Ask pending indefinitely so the reminder stays in _activeExecutions.
+    /// </summary>
+    private sealed class NeverReplyGateway : ReceiveActor
+    {
+        public NeverReplyGateway(IActorRef probe)
+        {
+            Receive<DeliverTrustedSessionTurn>(msg => probe.Tell(msg));
         }
     }
 

--- a/src/Netclaw.Actors/Reminders/ActiveExecutionTracker.cs
+++ b/src/Netclaw.Actors/Reminders/ActiveExecutionTracker.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="ActiveExecutionTracker.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Netclaw.Actors.Reminders;
+
+/// <summary>
+/// Tracks in-flight reminder executions.
+/// Enforces the invariant that only one execution of a given reminder runs at a time.
+/// </summary>
+internal sealed class ActiveExecutionTracker
+{
+    private readonly HashSet<ReminderId> _executing = [];
+
+    public int Count => _executing.Count;
+
+    public bool IsExecuting(ReminderId reminderId) => _executing.Contains(reminderId);
+
+    public void Add(ReminderId reminderId) => _executing.Add(reminderId);
+
+    /// <returns><c>true</c> if the reminder was tracked and has been removed.</returns>
+    public bool Remove(ReminderId reminderId) => _executing.Remove(reminderId);
+}

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -24,18 +24,10 @@ namespace Netclaw.Actors.Reminders;
 internal sealed class ReminderExecutionActor : ReceiveActor
 {
     /// <summary>
-    /// Per-execution timeout that forces a stuck reminder turn to terminate.
-    /// Netclaw-specific — no Akka.Reminders equivalent.
-    /// </summary>
-    internal const int ExecutionTimeoutSeconds = 300;
-
-    /// <summary>
     /// How long CurrentSession reminders with <c>DeliveryRequired=true</c>
     /// wait for outbound delivery observation after session <see cref="CommandAck"/>.
-    /// Matches <see cref="ExecutionTimeoutSeconds"/> — a delivery-required reminder
-    /// should be allowed the full execution window for the LLM to produce output.
     /// </summary>
-    internal static TimeSpan DeliveryObservedTimeout = TimeSpan.FromSeconds(ExecutionTimeoutSeconds);
+    internal static TimeSpan DeliveryObservedTimeout = TimeSpan.FromHours(1);
 
     private readonly Guid _executionId;
     private readonly ReminderDefinition _definition;
@@ -96,18 +88,9 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                         _executionId, _definition.Id, tool, callId);
             });
 
-        Context.SetReceiveTimeout(TimeSpan.FromSeconds(ExecutionTimeoutSeconds));
-
         Receive<ExecutionOutput>(HandleOutput);
         Receive<ExecutionStarted>(_ => { });
         Receive<ReminderDeliveryObserved>(HandleDeliveryObserved);
-        Receive<ReceiveTimeout>(_ =>
-        {
-            var elapsed = (int)(_timeProvider.GetUtcNow() - _dispatchedAt).TotalSeconds;
-            _log.Warning(
-                $"ReminderExecution Timeout: execution_id={_executionId} reminder_id={_definition.Id} title={_definition.Title} dispatched_at={_dispatchedAt} elapsed_s={elapsed}");
-            ReportAndStop(false, "Execution timed out");
-        });
     }
 
     protected override void PreStart()

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -47,7 +47,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
     private IReminderClient? _client;
 
-    private readonly HashSet<Guid> _activeExecutionIds = [];
+    private readonly ActiveExecutionTracker _activeExecutions = new();
     private readonly Queue<ReminderId> _deferredQueue = new();
     private readonly Dictionary<ReminderId, int> _failureCounts = [];
 
@@ -520,6 +520,14 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         _log.Info("Reminder fired: id='{0}', title='{1}', schedule_type={2}",
             reminderId.Value, definition.Title, definition.Schedule.Type);
 
+        if (_activeExecutions.IsExecuting(reminderId))
+        {
+            _log.Warning("reminder_skipped_duplicate_execution reminder_id={0} title={1}",
+                reminderId.Value, definition.Title);
+            await _client!.AckAsync(envelope);
+            return;
+        }
+
         // Cron reminders are implemented as recurring single-shot schedules.
         if (definition.Schedule.Type == ReminderScheduleType.Cron)
         {
@@ -532,7 +540,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
         var isCurrentSessionDelivery = definition.Delivery.Kind == DeliveryKind.CurrentSession;
 
-        if (_activeExecutionIds.Count >= MaxConcurrentExecutions)
+        if (_activeExecutions.Count >= MaxConcurrentExecutions)
         {
             _log.Info("Concurrency limit reached ({0}), deferring reminder '{1}'",
                 MaxConcurrentExecutions, reminderId.Value);
@@ -561,7 +569,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
     private async Task HandleExecutionCompletedAsync(ReminderExecutionCompleted completed)
     {
-        if (!_activeExecutionIds.Remove(completed.ExecutionId))
+        if (!_activeExecutions.Remove(completed.Id))
             return;
 
         var definition = _definitionStore.Get(completed.Id);
@@ -715,7 +723,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     private void StartExecution(ReminderDefinition definition, ReminderEnvelope<ReminderPayload>? envelope = null)
     {
         var executionId = Guid.NewGuid();
-        _activeExecutionIds.Add(executionId);
+        _activeExecutions.Add(new ReminderId(definition.Id));
 
         var actorName = $"exec-{SanitizeActorName(definition.Id)}-{_timeProvider.GetUtcNow().ToUnixTimeMilliseconds()}";
         var executionActor = Context.ActorOf(
@@ -735,12 +743,19 @@ public sealed partial class ReminderManagerActor : ReceiveActor
 
     private async Task ProcessDeferredQueueAsync()
     {
-        while (_deferredQueue.Count > 0 && _activeExecutionIds.Count < MaxConcurrentExecutions)
+        while (_deferredQueue.Count > 0 && _activeExecutions.Count < MaxConcurrentExecutions)
         {
             var nextId = _deferredQueue.Dequeue();
             var definition = _definitionStore.Get(nextId);
             if (definition is null || !definition.Enabled)
                 continue;
+
+            if (_activeExecutions.IsExecuting(nextId))
+            {
+                _log.Warning("reminder_skipped_duplicate_execution reminder_id={0} title={1} source=deferred_queue",
+                    nextId.Value, definition.Title);
+                continue;
+            }
 
             var now = _timeProvider.GetUtcNow();
             if (definition.Schedule.Type is not ReminderScheduleType.OneShot
@@ -918,7 +933,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
         var scheduledCount = _definitionStore.List().Count(d => d.Enabled);
         Sender.Tell(new ReminderHealthResponse(
             scheduledCount,
-            _activeExecutionIds.Count,
+            _activeExecutions.Count,
             _failureCounts.Count));
     }
 


### PR DESCRIPTION
## Summary

- **Removes `ReceiveTimeout` from `ReminderExecutionActor`** — the actor was being killed after 5 minutes of silence, but for `CurrentSession` (Mode B) reminders it receives no messages while the LLM is working. Long tool chains were causing false execution failures, which accumulated toward the auto-disable threshold (5 consecutive failures) and silently killed reminders that were actually working fine. The actor already terminates itself on every natural exit path (`TurnCompleted`, `Error`, `CommandAck`, `CommandNack`, `AskTimeoutException`), so the timeout was guarding against nothing.
- **`DeliveryObservedTimeout` bumped to 1 hour** (was 5 minutes, the same value as the removed timeout).
- **Adds `ActiveExecutionTracker`** — a `HashSet<ReminderId>` wrapper — and wires duplicate-execution guards into `ReminderManagerActor` so a second fire of an already-executing reminder is acked and silently dropped instead of spawning a parallel execution. Previously `_activeExecutionIds` was a `HashSet<Guid>` keyed by execution ID with no way to look up by reminder ID.

## Test plan

- [ ] All 103 existing reminder tests pass
- [ ] New test `Second_fire_of_executing_reminder_is_skipped_as_duplicate` verifies that a second envelope for an in-flight reminder reaches the gateway exactly once, health shows 1 active execution, and no failure alert is emitted