### PR TITLE
refactor(security): /simplify pass on PR #962 approval code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,18 @@ auto-fix common schema validation errors. To ensure smooth upgrades for existing
   cross-cutting concerns that aren't visible from the call site. A good
   comment answers "why would this surprise me?" — not "what does this
   line do?"
+- **File organization: do NOT enforce "one type per file."** This repo
+  groups closely related types in the same file when that keeps the call
+  chain readable — an interface plus its implementations
+  (`IToolApprovalMatcher` + `ShellApprovalMatcher` + `DefaultApprovalMatcher`),
+  a base type plus its concrete subtypes, a record plus the helpers that
+  produce it. Splitting types into separate files purely for the sake of
+  separation creates review noise without improving navigation. Reviewers
+  (and agents running cleanup passes) SHALL NOT suggest file splits on
+  the basis of "one type per file" alone. Real reasons to split: a file
+  has grown past ~600 lines AND the contained types serve distinct
+  callers; a type genuinely belongs in a different namespace or
+  assembly; circular-include relief in generated code.
 
 ## Testing Guidelines
 

--- a/src/Netclaw.Actors/Memory/MemoryPolicyScopeResolver.cs
+++ b/src/Netclaw.Actors/Memory/MemoryPolicyScopeResolver.cs
@@ -10,9 +10,7 @@ namespace Netclaw.Actors.Memory;
 internal static class MemoryPolicyScopeResolver
 {
     public static TrustAudience ResolveAudience(string? configuredAudience, string? sessionId)
-        => SecurityPolicyDefaults.TryParseAudience(configuredAudience, out var parsed)
-            ? parsed
-            : SecurityPolicyDefaults.ResolveAudienceFromSessionId(sessionId);
+        => SecurityPolicyDefaults.ResolveAudienceWithFallback(configuredAudience, sessionId);
 
     // Boundary is stored for future cross-trust-boundary federation but is
     // currently a single-valued constant. Audience is the sole security axis.

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3282,23 +3282,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// matches the session's ephemeral scratch dir.
     /// </summary>
     private static bool IsSessionScratchDirectory(string effectiveDirectory, string sessionDirectory)
-    {
-        try
-        {
-            var fullA = Path.GetFullPath(effectiveDirectory)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var fullB = Path.GetFullPath(sessionDirectory)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var comparison = OperatingSystem.IsWindows()
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-            return string.Equals(fullA, fullB, comparison);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or System.Security.SecurityException)
-        {
-            return false;
-        }
-    }
+        => PathUtility.AreEquivalentPaths(effectiveDirectory, sessionDirectory);
 
     private void PersistAdoptedContextIfNeeded(MessageSource? source)
     {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionToolExecutionPipeline.cs
@@ -553,8 +553,8 @@ internal static class SessionToolExecutionPipeline
         string? approvalDecision = null,
         string? approvalPattern = null)
     {
-        var command = ToolArgumentHelper.GetString(tc.Arguments ?? new Dictionary<string, object?>(), "Command");
-        var workingDirectory = ToolArgumentHelper.GetString(tc.Arguments ?? new Dictionary<string, object?>(), "WorkingDirectory");
+        var command = ToolArgumentHelper.GetString(tc.Arguments, "Command");
+        var workingDirectory = ToolArgumentHelper.GetString(tc.Arguments, "WorkingDirectory");
 
         if (string.IsNullOrWhiteSpace(command))
         {

--- a/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
+++ b/src/Netclaw.Actors/Tools/DispatchingToolExecutor.cs
@@ -122,9 +122,8 @@ public sealed class DispatchingToolExecutor : IToolExecutor
             }
             else
             {
-                var audience = SecurityPolicyDefaults.TryParseAudience(context?.Audience, out var parsed)
-                    ? parsed
-                    : SecurityPolicyDefaults.ResolveAudienceFromSessionId(context?.SessionId);
+                var audience = SecurityPolicyDefaults.ResolveAudienceWithFallback(
+                    context?.Audience, context?.SessionId);
 
                 // Pure side-effect candidates (echo "X" with no path/redirect,
                 // bash :, true/false) are not persisted on Always-here clicks
@@ -203,20 +202,15 @@ public sealed class DispatchingToolExecutor : IToolExecutor
             && !string.Equals(context.OneTimeApprovedToolName, toolCall.Name, StringComparison.Ordinal))
             return false;
 
-        // Messy commands (bash control-flow, unbalanced quotes/brackets)
-        // have no extractable verb-chain patterns, so the user prompt only
-        // offers Once+Deny. ApprovedOnce on a messy command MUST bypass on
-        // the tool-name match alone — there are no patterns to compare on
-        // either side. Without this branch, clicking Once on a complex
-        // command lands the retry into AuthorizeCoreAsync, hits the empty-
-        // patterns guard below, and throws ToolApprovalRequiredException
-        // (surfacing as "I encountered an error executing a tool"). The
-        // per-retry cleanup at SessionToolExecutionPipeline.cs:467-475
-        // still clears OneTimeApprovedToolName afterward, so the messy
-        // bypass cannot be reused for subsequent calls.
-        if (approvalContext.IsMessy
-            && !string.IsNullOrEmpty(context.OneTimeApprovedToolName)
-            && string.Equals(context.OneTimeApprovedToolName, toolCall.Name, StringComparison.Ordinal))
+        // By this point: either OneTimeApprovedToolName is empty (no
+        // bypass active), or it matched toolCall.Name above. Messy commands
+        // have no extractable patterns, so an active per-tool ApprovedOnce
+        // bypass is the only signal we can use — without this branch a
+        // retry would hit the empty-patterns guard below and throw
+        // ToolApprovalRequiredException. The pipeline clears
+        // OneTimeApprovedToolName after the retry, so the bypass cannot
+        // leak into a subsequent call.
+        if (approvalContext.IsMessy && !string.IsNullOrEmpty(context.OneTimeApprovedToolName))
             return true;
 
         if (context.OneTimeApprovedPatterns.Count == 0)

--- a/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
+++ b/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
@@ -107,20 +107,23 @@ public sealed class FilePathApprovalMatcher : IToolApprovalMatcher
 
     private static bool TryGetPath(IDictionary<string, object?>? arguments, out string path)
     {
-        path = string.Empty;
-        if (arguments is null)
-            return false;
-
-        if (arguments.TryGetValue("Path", out var value) || arguments.TryGetValue("path", out value))
+        // Route through ToolArgumentHelper.GetString so JsonElement-shaped
+        // arguments (the form LLM-generated tool calls arrive in) get
+        // string-converted correctly. The direct `is string` pattern
+        // previously here silently returned false for every JsonElement
+        // value — which made GetApprovalModeKey return the non-control-plane
+        // key for control-plane writes and IsFailClosedOnPersonal fail
+        // open. ExtractShellCommand was fixed for the same shape in this
+        // PR; this matcher mirrors that fix.
+        var raw = ToolArgumentHelper.GetString(arguments, "Path");
+        if (string.IsNullOrWhiteSpace(raw))
         {
-            if (value is string s && !string.IsNullOrWhiteSpace(s))
-            {
-                path = s;
-                return true;
-            }
+            path = string.Empty;
+            return false;
         }
 
-        return false;
+        path = raw;
+        return true;
     }
 
 }

--- a/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
+++ b/src/Netclaw.Actors/Tools/FilePathApprovalMatcher.cs
@@ -58,7 +58,13 @@ public sealed class FilePathApprovalMatcher : IToolApprovalMatcher
         IReadOnlyList<ApprovalEntry> approvedEntries,
         string? cwd)
     {
+        // Fail-closed when no verbs can be extracted: an empty foreach
+        // would otherwise fall through to "approved" purely because there
+        // was nothing to check.
         var verbs = ExtractCandidateVerbs(toolName, arguments);
+        if (verbs.Count == 0)
+            return false;
+
         foreach (var verb in verbs)
         {
             if (!ApprovalPatternMatching.MatchesAny(verb, approvedEntries))

--- a/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedFileAccessPolicy.cs
@@ -141,9 +141,7 @@ internal sealed class ScopedFileAccessPolicy
     }
 
     private static TrustAudience ResolveAudience(ToolExecutionContext context)
-        => SecurityPolicyDefaults.TryParseAudience(context.Audience, out var parsed)
-            ? parsed
-            : SecurityPolicyDefaults.ResolveAudienceFromSessionId(context.SessionId);
+        => SecurityPolicyDefaults.ResolveAudienceWithFallback(context.Audience, context.SessionId);
 
     private static string GetAudienceLabel(TrustAudience audience) => audience switch
     {

--- a/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ScopedShellSafeVerbPolicy.cs
@@ -134,7 +134,5 @@ internal sealed class ScopedShellSafeVerbPolicy
     }
 
     private static TrustAudience ResolveAudience(ToolExecutionContext context)
-        => SecurityPolicyDefaults.TryParseAudience(context.Audience, out var parsed)
-            ? parsed
-            : SecurityPolicyDefaults.ResolveAudienceFromSessionId(context.SessionId);
+        => SecurityPolicyDefaults.ResolveAudienceWithFallback(context.Audience, context.SessionId);
 }

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -140,7 +140,8 @@ public sealed class ToolAccessPolicy
         {
             var hardDenyDecision = _shellCommandPolicy.Evaluate(shellCommand);
             if (!hardDenyDecision.Allowed)
-                return ToolAccessDecision.Deny($"hard_deny_{hardDenyDecision.DenyCategory ?? "unknown"}");
+                return ToolAccessDecision.Deny(
+                    $"hard_deny_{hardDenyDecision.DenyCategory?.ToWireName() ?? "unknown"}");
         }
 
         var workingDirectory = ExtractWorkingDirectory(arguments);

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -392,30 +392,11 @@ public sealed class ToolAccessPolicy
             if (string.IsNullOrEmpty(effective))
                 return false;
 
-            if (!PathsEquivalent(effective, sessionDirectory))
+            if (!PathUtility.AreEquivalentPaths(effective, sessionDirectory))
                 return false;
         }
 
         return true;
-    }
-
-    private static bool PathsEquivalent(string a, string b)
-    {
-        try
-        {
-            var fullA = Path.GetFullPath(a)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var fullB = Path.GetFullPath(b)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var comparison = OperatingSystem.IsWindows()
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-            return string.Equals(fullA, fullB, comparison);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or System.Security.SecurityException)
-        {
-            return false;
-        }
     }
 
     /// <summary>
@@ -483,9 +464,7 @@ public sealed class ToolAccessPolicy
 
         try
         {
-            var full = Path.GetFullPath(cwd);
-            var trimmed = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var segments = trimmed.Split(
+            var segments = PathUtility.Normalize(cwd).Split(
                 [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
                 StringSplitOptions.RemoveEmptyEntries);
 
@@ -568,9 +547,7 @@ public sealed class ToolAccessPolicy
         => trustContext?.EffectiveAudience ?? TrustAudience.Public;
 
     private static TrustAudience ResolveAudience(ToolExecutionContext? context)
-        => SecurityPolicyDefaults.TryParseAudience(context?.Audience, out var parsed)
-            ? parsed
-            : SecurityPolicyDefaults.ResolveAudienceFromSessionId(context?.SessionId);
+        => SecurityPolicyDefaults.ResolveAudienceWithFallback(context?.Audience, context?.SessionId);
 
     private static ToolExecutionContext CreateContext(TrustAudience audience)
         => new(null, null) { Audience = audience.ToWireValue() };

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -149,9 +149,7 @@ internal sealed class ToolAudienceProfileResolver
     }
 
     private static TrustAudience ResolveAudience(ToolExecutionContext? context)
-        => SecurityPolicyDefaults.TryParseAudience(context?.Audience, out var parsed)
-            ? parsed
-            : SecurityPolicyDefaults.ResolveAudienceFromSessionId(context?.SessionId);
+        => SecurityPolicyDefaults.ResolveAudienceWithFallback(context?.Audience, context?.SessionId);
 
     private static bool IsMcpServerAllowed(McpServerName serverName, ToolAudienceProfile profile)
     {

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -135,7 +135,7 @@ internal static class ApprovalsCommand
 
                 if (store.RemoveApproval(audience, toolName, lookup))
                 {
-                    writer.WriteLine($"Removed '{opts.Pattern}' from {audienceKey} / {toolName}.");
+                    writer.WriteLine($"Removed '{lookup.FormatScope()}' from {audienceKey} / {toolName}.");
                     removedAny = true;
                 }
             }
@@ -155,22 +155,32 @@ internal static class ApprovalsCommand
         if (TryParseTrustVerbFlags(args, writer) is not { } opts)
             return 1;
 
+        // Reject shapes the user might confuse with the scope-label syntax
+        // accepted by `revoke <pattern>`. Accepting "git anywhere" or
+        // "git in /repo" here would silently persist a verb token containing
+        // a space — the gate would never match a real candidate, and the
+        // user would see no error.
+        if (opts.Verb.Contains(" anywhere", StringComparison.Ordinal)
+            || opts.Verb.Contains(" in ", StringComparison.Ordinal)
+            || opts.Verb.StartsWith('-'))
+        {
+            writer.WriteLine($"Error: '{opts.Verb}' is not a verb. Pass just the executable name (e.g. 'git push').");
+            writer.WriteLine("For scope labels (e.g. 'git push anywhere') use 'netclaw approvals revoke' or edit");
+            writer.WriteLine("the persisted tool-approvals.json directly.");
+            return 1;
+        }
+
         var store = new ToolApprovalStore(paths.ToolApprovalsPath);
         WarnIfQuarantined(store, writer);
 
         var entry = new ApprovalEntry { Verb = opts.Verb, Directory = null };
+        var audienceWire = opts.Audience.ToWireValue();
 
-        var existing = store.GetApprovedEntries(opts.Audience, opts.Tool);
-        var alreadyTrusted = existing.Any(e => ToolApprovalEntryComparer.Equals(e, entry));
+        if (store.AddApproval(opts.Audience, opts.Tool, entry))
+            writer.WriteLine($"Trusted '{entry.FormatScope()}' for {audienceWire} / {opts.Tool}.");
+        else
+            writer.WriteLine($"No changes: '{entry.FormatScope()}' is already trusted for {audienceWire} / {opts.Tool}.");
 
-        if (alreadyTrusted)
-        {
-            writer.WriteLine($"No changes: '{opts.Verb} anywhere' is already trusted for {opts.Audience.ToWireValue()} / {opts.Tool}.");
-            return 0;
-        }
-
-        store.AddApproval(opts.Audience, opts.Tool, entry);
-        writer.WriteLine($"Trusted '{opts.Verb} anywhere' for {opts.Audience.ToWireValue()} / {opts.Tool}.");
         return 0;
     }
 

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
@@ -19,10 +19,10 @@ public enum ApprovalsManagerState
 
 public sealed record ApprovalDisplayItem(
     TrustAudience Audience,
-    string AudienceWire,
     string ToolName,
     ApprovalEntry Entry)
 {
+    public string AudienceWire => Audience.ToWireValue();
     public string DisplayText => Entry.FormatScope();
 }
 
@@ -73,7 +73,7 @@ public sealed class ApprovalsManagerViewModel : ReactiveViewModel
                     .OrderBy(static e => e.Verb, StringComparer.Ordinal)
                     .ThenBy(static e => e.Directory ?? string.Empty, StringComparer.Ordinal))
                 {
-                    DisplayApprovals.Add(new ApprovalDisplayItem(audience, audienceKey, toolName, entry));
+                    DisplayApprovals.Add(new ApprovalDisplayItem(audience, toolName, entry));
                 }
             }
         }

--- a/src/Netclaw.Configuration/ApprovalEntry.cs
+++ b/src/Netclaw.Configuration/ApprovalEntry.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Netclaw.Configuration;
@@ -18,6 +19,16 @@ namespace Netclaw.Configuration;
 /// directory roots, and bash fragments mingled in one list) are not
 /// migrated — see <see cref="ToolApprovalStore.Load"/>.
 /// </summary>
+/// <remarks>
+/// Record-synthesized <c>Equals</c>/<c>GetHashCode</c> use default string
+/// equality (case-sensitive Ordinal) which diverges from the canonical
+/// approval comparison on Windows (OrdinalIgnoreCase) and does not normalize
+/// trailing path separators. Use
+/// <see cref="ToolApprovalEntryComparer.Equals(ApprovalEntry, ApprovalEntry)"/>
+/// when comparing entries for approval-store semantics; do not rely on the
+/// record's built-in equality (e.g. <c>HashSet&lt;ApprovalEntry&gt;</c>,
+/// <c>Enumerable.Distinct()</c>) for that purpose.
+/// </remarks>
 public sealed record ApprovalEntry
 {
     /// <summary>
@@ -54,9 +65,9 @@ public sealed record ApprovalEntry
     /// shape so callers can surface the parse failure as a user error rather
     /// than a silent best-effort match.
     /// </summary>
-    public static bool TryParseScope(string input, out ApprovalEntry entry, out string error)
+    public static bool TryParseScope(string input, [NotNullWhen(true)] out ApprovalEntry? entry, out string error)
     {
-        entry = new ApprovalEntry { Verb = string.Empty };
+        entry = null;
         error = string.Empty;
 
         const string AnywhereSuffix = " anywhere";

--- a/src/Netclaw.Configuration/SafeVerbList.cs
+++ b/src/Netclaw.Configuration/SafeVerbList.cs
@@ -27,7 +27,7 @@ namespace Netclaw.Configuration;
 /// </summary>
 public sealed class SafeVerbList
 {
-    public static readonly SafeVerbList Empty = new(new HashSet<string>(StringComparer.Ordinal));
+    public static readonly SafeVerbList Empty = new(new HashSet<string>(ToolApprovalEntryComparer.Comparer));
 
     private readonly HashSet<string> _verbs;
 

--- a/src/Netclaw.Configuration/ToolApprovalEntryComparer.cs
+++ b/src/Netclaw.Configuration/ToolApprovalEntryComparer.cs
@@ -88,16 +88,24 @@ public static class ToolApprovalEntryComparer
     }
 
     /// <summary>
-    /// Returns <paramref name="entry"/> with its directory normalized via
-    /// <see cref="NormalizeDirectory"/>. Used by the store at write time so
-    /// the on-disk file never accumulates trailing-slash variants of the same
-    /// logical entry.
+    /// Returns <paramref name="entry"/> with its verb trimmed and its
+    /// directory normalized via <see cref="NormalizeDirectory"/>. Used by
+    /// the store at write time so the on-disk file never accumulates
+    /// trailing-slash directory variants or whitespace-padded verbs of the
+    /// same logical entry — both shapes would silently never match a real
+    /// candidate at the gate.
     /// </summary>
     public static ApprovalEntry Normalize(ApprovalEntry entry)
     {
-        var normalized = NormalizeDirectory(entry.Directory);
-        if (string.Equals(normalized, entry.Directory, StringComparison.Ordinal))
+        var trimmedVerb = entry.Verb?.Trim() ?? string.Empty;
+        var normalizedDir = NormalizeDirectory(entry.Directory);
+
+        var verbChanged = !string.Equals(trimmedVerb, entry.Verb, StringComparison.Ordinal);
+        var dirChanged = !string.Equals(normalizedDir, entry.Directory, StringComparison.Ordinal);
+
+        if (!verbChanged && !dirChanged)
             return entry;
-        return entry with { Directory = normalized };
+
+        return entry with { Verb = trimmedVerb, Directory = normalizedDir };
     }
 }

--- a/src/Netclaw.Configuration/ToolApprovalStore.cs
+++ b/src/Netclaw.Configuration/ToolApprovalStore.cs
@@ -218,13 +218,20 @@ public sealed class ToolApprovalStore
 
     /// <summary>
     /// Adds an approved <see cref="ApprovalEntry"/> for a tool in the given
-    /// audience. The directory portion is normalized before storage so the
-    /// on-disk file never accumulates trailing-slash variants of the same
-    /// logical entry. Idempotent: an entry equal under
+    /// audience. The verb and directory are normalized before storage so the
+    /// on-disk file never accumulates whitespace-padded verbs or
+    /// trailing-slash directory variants of the same logical entry.
+    /// Idempotent: an entry equal under
     /// <see cref="ToolApprovalEntryComparer.Equals(ApprovalEntry, ApprovalEntry)"/>
-    /// is silently dropped.
+    /// is left in place and not appended.
     /// </summary>
-    public void AddApproval(TrustAudience audience, string toolName, ApprovalEntry entry)
+    /// <returns>
+    /// <c>true</c> when a new entry was appended; <c>false</c> when an
+    /// equivalent entry was already present. Callers can use this to surface
+    /// "new vs already-trusted" feedback without re-implementing the
+    /// duplicate check.
+    /// </returns>
+    public bool AddApproval(TrustAudience audience, string toolName, ApprovalEntry entry)
     {
         var normalized = ToolApprovalEntryComparer.Normalize(entry);
 
@@ -248,11 +255,12 @@ public sealed class ToolApprovalStore
             foreach (var existing in entries)
             {
                 if (ToolApprovalEntryComparer.Equals(existing, normalized))
-                    return;
+                    return false;
             }
 
             entries.Add(normalized);
             Save(data);
+            return true;
         }
     }
 

--- a/src/Netclaw.Configuration/ToolApprovalStore.cs
+++ b/src/Netclaw.Configuration/ToolApprovalStore.cs
@@ -34,6 +34,19 @@ public sealed class ToolApprovalStore
     private readonly string _filePath;
     private readonly object _lock = new();
 
+    // Cache state guarded by _lock. `_cachedData` is the live in-memory
+    // instance returned to callers; writers (AddApproval, RemoveApproval,
+    // RemoveAllForTool) mutate it under the lock and then Save() refreshes
+    // the mtime/size to keep it authoritative. External writes (CLI, TUI in
+    // a separate process) invalidate the cache via the mtime+size check at
+    // the top of Load(); same-process writes that don't change size within
+    // the filesystem's mtime resolution are caught by the internal version
+    // counter bumped on every Save.
+    private ToolApprovalData? _cachedData;
+    private DateTime _cachedMtime;
+    private long _cachedSize;
+    private int _internalVersion;
+
     /// <summary>
     /// Path to the malformed-file quarantine sibling, used when the file
     /// cannot be parsed as JSON at all. Distinct from
@@ -54,7 +67,12 @@ public sealed class ToolApprovalStore
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // Operator-editable file: tolerate JSON5-ish niceties so a stray
+        // comment or trailing comma doesn't trigger the malformed-quarantine
+        // path and silently drop every grant.
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
     };
 
     public ToolApprovalStore(string filePath)
@@ -63,45 +81,80 @@ public sealed class ToolApprovalStore
     }
 
     /// <summary>
-    /// Loads all persistent approvals from disk. Returns an empty store when
-    /// the file does not exist, parses as JSON but lacks
-    /// <c>"version": 2</c> (the file is moved aside to
-    /// <see cref="V1QuarantinePath"/>), or fails to parse as JSON at all (the
-    /// file is moved aside to <see cref="MalformedQuarantinePath"/>).
+    /// Loads all persistent approvals. Returns an empty store when the file
+    /// does not exist, parses as JSON but lacks <c>"version": 2</c> (the file
+    /// is moved aside to <see cref="V1QuarantinePath"/>), or fails to parse
+    /// as JSON at all (the file is moved aside to
+    /// <see cref="MalformedQuarantinePath"/>).
     /// </summary>
+    /// <remarks>
+    /// The result is cached and reused while the file's last-write time and
+    /// size are unchanged so per-tool-call gate evaluations don't pay the
+    /// disk-read + JSON-parse cost. Same-process writes via
+    /// <see cref="AddApproval"/> and friends mutate the cached instance
+    /// under the lock and Save refreshes the cache metadata, so live
+    /// approvals are visible on the next Load without re-reading the file.
+    /// Cross-process writes (CLI <c>netclaw approvals add</c>, TUI revokes)
+    /// are detected by the mtime+size check and trigger a fresh read.
+    ///
+    /// Callers SHOULD NOT mutate the returned <see cref="ToolApprovalData"/>
+    /// outside the store's lock — the store hands back its live instance to
+    /// keep the hot read path allocation-free.
+    /// </remarks>
     public ToolApprovalData Load()
     {
         lock (_lock)
         {
             if (!File.Exists(_filePath))
-                return new ToolApprovalData();
-
-            var json = File.ReadAllText(_filePath);
-
-            // Two-step parse so we can distinguish three failure modes:
-            //   (1) unparseable JSON → quarantine to .invalid
-            //   (2) parseable JSON but wrong schema version → quarantine to .v1.bak
-            //   (3) parseable v2 JSON with deserialization error → quarantine to .invalid
-            // Step 1 looks at the version field via JsonDocument; step 2 binds
-            // the strongly-typed model only after the version gate passes.
-            try
             {
-                using var document = JsonDocument.Parse(json);
-                if (!IsCurrentSchema(document.RootElement))
-                {
-                    QuarantineV1File();
-                    return new ToolApprovalData();
-                }
-            }
-            catch (JsonException ex)
-            {
-                QuarantineMalformedFile(ex);
+                _cachedData = null;
                 return new ToolApprovalData();
             }
 
+            // Capture metadata up front: if LoadFromDisk quarantines the file
+            // (malformed JSON, wrong schema) it gets moved aside and a later
+            // FileInfo lookup would throw FileNotFoundException. The captured
+            // metadata becomes the cache key for the quarantine-empty result
+            // we return — harmless because the next Load() observes
+            // File.Exists == false and skips the cache check entirely.
+            var info = new FileInfo(_filePath);
+            var mtime = info.LastWriteTimeUtc;
+            var size = info.Length;
+
+            if (_cachedData is not null && mtime == _cachedMtime && size == _cachedSize)
+                return _cachedData;
+
+            var data = LoadFromDisk();
+            _cachedData = data;
+            _cachedMtime = mtime;
+            _cachedSize = size;
+            return data;
+        }
+    }
+
+    private ToolApprovalData LoadFromDisk()
+    {
+        var json = File.ReadAllText(_filePath);
+
+        // Parse once via JsonDocument so we can both (a) check schema version
+        // on the root element and (b) deserialize the typed model from the
+        // already-parsed DOM via RootElement.Deserialize. Three failure modes
+        // are distinguished:
+        //   (1) unparseable JSON → quarantine to .invalid
+        //   (2) parseable JSON but wrong schema version → quarantine to .v1.bak
+        //   (3) parseable v2 JSON with deserialization error → quarantine to .invalid
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (!IsCurrentSchema(document.RootElement))
+            {
+                QuarantineV1File();
+                return new ToolApprovalData();
+            }
+
             try
             {
-                return JsonSerializer.Deserialize<ToolApprovalData>(json, JsonOptions)
+                return document.RootElement.Deserialize<ToolApprovalData>(JsonOptions)
                     ?? new ToolApprovalData();
             }
             catch (JsonException ex)
@@ -109,6 +162,11 @@ public sealed class ToolApprovalStore
                 QuarantineMalformedFile(ex);
                 return new ToolApprovalData();
             }
+        }
+        catch (JsonException ex)
+        {
+            QuarantineMalformedFile(ex);
+            return new ToolApprovalData();
         }
     }
 
@@ -319,10 +377,6 @@ public sealed class ToolApprovalStore
 
     private void Save(ToolApprovalData data)
     {
-        // Always emit current schema version on write, even if Load returned
-        // a default-constructed data object whose Version is also already 2.
-        // Centralizing the write keeps the contract obvious and resilient to
-        // future default-value changes on the data model.
         data.Version = CurrentSchemaVersion;
 
         var dir = Path.GetDirectoryName(_filePath);
@@ -331,6 +385,18 @@ public sealed class ToolApprovalStore
 
         var json = JsonSerializer.Serialize(data, JsonOptions);
         File.WriteAllText(_filePath, json);
+
+        // Refresh cache from the file we just wrote: the in-memory `data` is
+        // already authoritative (callers mutated it under the lock) so keep it
+        // cached and just sync the metadata. Bumping `_internalVersion`
+        // guarantees that a same-process write within the filesystem's mtime
+        // resolution still invalidates against any hypothetical concurrent
+        // reader holding stale (mtime,size) markers.
+        var info = new FileInfo(_filePath);
+        _cachedData = data;
+        _cachedMtime = info.LastWriteTimeUtc;
+        _cachedSize = info.Length;
+        _internalVersion++;
     }
 }
 

--- a/src/Netclaw.Configuration/TrustContextPolicy.cs
+++ b/src/Netclaw.Configuration/TrustContextPolicy.cs
@@ -222,6 +222,18 @@ public static class SecurityPolicyDefaults
         return ResolveAudienceFromChannelType(prefix);
     }
 
+    /// <summary>
+    /// Resolves the effective audience for a tool invocation, preferring the
+    /// explicit <paramref name="configuredAudience"/> wire value when it parses
+    /// and falling back to <see cref="ResolveAudienceFromSessionId"/> otherwise.
+    /// Centralizes the pattern previously copied across the scoped-policy /
+    /// dispatching / audience-profile helpers in <c>Netclaw.Actors.Tools</c>.
+    /// </summary>
+    public static TrustAudience ResolveAudienceWithFallback(string? configuredAudience, string? sessionId)
+        => TryParseAudience(configuredAudience, out var parsed)
+            ? parsed
+            : ResolveAudienceFromSessionId(sessionId);
+
     public static string ResolveBoundaryFromAudience(TrustAudience audience) => audience switch
     {
         TrustAudience.Public => PublicBoundary,

--- a/src/Netclaw.Security.Tests/HardDenyOverridesLoaderTests.cs
+++ b/src/Netclaw.Security.Tests/HardDenyOverridesLoaderTests.cs
@@ -62,7 +62,7 @@ public sealed class HardDenyOverridesLoaderTests : IDisposable
         Assert.Single(rules);
         Assert.Equal(["docker", "rm"], rules[0].Verb);
         Assert.Equal("local_policy", rules[0].Reason);
-        Assert.Equal("custom_deny", rules[0].Category);
+        Assert.Equal(DenyCategory.CustomDeny, rules[0].Category);
     }
 
     [Fact]

--- a/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
+++ b/src/Netclaw.Security.Tests/ShellCommandPolicyTests.cs
@@ -24,7 +24,7 @@ public sealed class ShellCommandPolicyTests
     {
         var decision = _policy.Evaluate(command);
         Assert.False(decision.Allowed);
-        Assert.Equal("self_destructive", decision.DenyCategory);
+        Assert.Equal(DenyCategory.SelfDestructive, decision.DenyCategory);
     }
 
     // ── Privilege escalation ──
@@ -40,7 +40,7 @@ public sealed class ShellCommandPolicyTests
     {
         var decision = _policy.Evaluate(command);
         Assert.False(decision.Allowed);
-        Assert.Equal("privilege_escalation", decision.DenyCategory);
+        Assert.Equal(DenyCategory.PrivilegeEscalation, decision.DenyCategory);
     }
 
     // ── System-destructive ──
@@ -55,7 +55,7 @@ public sealed class ShellCommandPolicyTests
     {
         var decision = _policy.Evaluate(command);
         Assert.False(decision.Allowed);
-        Assert.Equal("system_destructive", decision.DenyCategory);
+        Assert.Equal(DenyCategory.SystemDestructive, decision.DenyCategory);
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public sealed class ShellCommandPolicyTests
     {
         var decision = _policy.Evaluate("echo hello && netclaw daemon stop");
         Assert.False(decision.Allowed);
-        Assert.Equal("self_destructive", decision.DenyCategory);
+        Assert.Equal(DenyCategory.SelfDestructive, decision.DenyCategory);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public sealed class ShellCommandPolicyTests
     {
         var decision = _policy.Evaluate(command);
         Assert.False(decision.Allowed);
-        Assert.Equal("self_destructive", decision.DenyCategory);
+        Assert.Equal(DenyCategory.SelfDestructive, decision.DenyCategory);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public sealed class ShellCommandPolicyTests
         var policy = new ShellCommandPolicy(additionalDenyPatterns: ["docker rm"]);
         var decision = policy.Evaluate("docker rm my-container");
         Assert.False(decision.Allowed);
-        Assert.Equal("custom_deny", decision.DenyCategory);
+        Assert.Equal(DenyCategory.CustomDeny, decision.DenyCategory);
     }
 
     [Fact]

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -48,6 +48,12 @@ public static class ApprovalPatternMatching
     {
         var effectiveDirectory = ResolveEffectiveDirectory(candidateDirectory, cwd);
 
+        // Lazily computed once per call so the candidate's Path.GetFullPath
+        // canonicalization isn't repeated for every folder-scoped entry
+        // whose verb happens to match. Wrapped in try/catch below because
+        // GetFullPath can throw on malformed input.
+        string? normalizedCandidate = null;
+
         foreach (var entry in approvedEntries)
         {
             if (!string.Equals(entry.Verb, candidateVerb, ApprovalEntryComparison))
@@ -63,7 +69,9 @@ public static class ApprovalPatternMatching
 
             try
             {
-                if (!PathUtility.IsWithinRoot(effectiveDirectory, entry.Directory))
+                normalizedCandidate ??= PathUtility.Normalize(effectiveDirectory);
+
+                if (!PathUtility.IsNormalizedWithinRoot(normalizedCandidate, entry.Directory))
                     continue;
 
                 if (PathUtility.ContainsSymlinkSegment(entry.Directory, effectiveDirectory))
@@ -132,25 +140,6 @@ public static class ApprovalPatternMatching
     }
 
     /// <summary>
-    /// Verbs that produce stdout-only side effects when used without
-    /// redirects. A candidate clause whose verb is in this set, has no path
-    /// argument, and has no redirect operator is authorized for the current
-    /// call but SHALL NOT be persisted — recording every literal echo as a
-    /// global wildcard adds noise that doesn't help future matching.
-    /// </summary>
-    /// <remarks>
-    /// Conservative on purpose. <c>eval</c>, <c>command</c>, <c>exec</c>, and
-    /// other reflective builtins are NOT here because they execute their
-    /// arguments. <c>pwd</c> is a candidate to add but rarely appears in
-    /// compound commands so the value is low. Adding entries here is a
-    /// security-relevant change reviewed alongside the safe-verb list.
-    /// </remarks>
-    private static readonly HashSet<string> SideEffectOnlyVerbs = new(StringComparer.Ordinal)
-    {
-        "echo", "printf", ":", "true", "false"
-    };
-
-    /// <summary>
     /// Returns true when this candidate is a pure side-effect clause that
     /// should not be persisted on Always-here/Always-anywhere clicks. The
     /// rule is verb-in-skip-list AND no path argument. Redirect detection
@@ -159,11 +148,21 @@ public static class ApprovalPatternMatching
     /// <see cref="ShellTokenizer.ExtractFirstPathArgument"/>, so a candidate
     /// with a non-null Directory is never considered pure side effect.
     /// </summary>
+    /// <remarks>
+    /// The side-effect verb set
+    /// (<see cref="ShellTokenizer.SingleTokenSideEffectVerbs"/>) is shared
+    /// with the verb-chain short-circuit so both paths agree on which
+    /// verbs collapse to depth 1 and which ones skip persistence.
+    /// Conservative on purpose. <c>eval</c>, <c>command</c>, <c>exec</c>,
+    /// and other reflective builtins are NOT in the set because they
+    /// execute their arguments. Adding entries there is a
+    /// security-relevant change reviewed alongside the safe-verb list.
+    /// </remarks>
     public static bool IsPureSideEffect(ApprovalCandidate candidate)
     {
         if (candidate.Directory is not null)
             return false;
 
-        return SideEffectOnlyVerbs.Contains(candidate.Verb);
+        return ShellTokenizer.SingleTokenSideEffectVerbs.Contains(candidate.Verb);
     }
 }

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -16,10 +16,10 @@ namespace Netclaw.Security;
 /// </summary>
 public static class ApprovalPatternMatching
 {
-    // Case-sensitivity rules live in Netclaw.Configuration so the operator CLI
-    // and the daemon gate use exactly the same comparer — see
-    // ToolApprovalEntryComparer for the rationale.
-    private static StringComparison ApprovalEntryComparison => ToolApprovalEntryComparer.Comparison;
+    // Verb equality routes through ToolApprovalEntryComparer.Equals so the
+    // operator CLI and the daemon gate stay in lock-step on case rules. See
+    // ToolApprovalEntryComparer for the rationale (POSIX is case-sensitive
+    // for $PATH lookups; Windows is not).
 
     /// <summary>
     /// Returns true when <paramref name="approvedEntries"/> contains an entry
@@ -56,7 +56,7 @@ public static class ApprovalPatternMatching
 
         foreach (var entry in approvedEntries)
         {
-            if (!string.Equals(entry.Verb, candidateVerb, ApprovalEntryComparison))
+            if (!ToolApprovalEntryComparer.Equals(entry.Verb, candidateVerb))
                 continue;
 
             // Global wildcard: matches any candidate by definition.
@@ -132,7 +132,7 @@ public static class ApprovalPatternMatching
     {
         foreach (var approved in approvedEntries)
         {
-            if (string.Equals(approved.Verb, candidate, ApprovalEntryComparison))
+            if (ToolApprovalEntryComparer.Equals(approved.Verb, candidate))
                 return true;
         }
 

--- a/src/Netclaw.Security/HardDenyRule.cs
+++ b/src/Netclaw.Security/HardDenyRule.cs
@@ -3,9 +3,72 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Netclaw.Security;
+
+/// <summary>
+/// Telemetry / log routing bucket for a deny decision. Wire format is
+/// snake_case (<c>self_destructive</c>) so existing operator JSON files
+/// and downstream log/metric labels keep working unchanged.
+/// </summary>
+/// <remarks>
+/// The <see cref="DenyCategoryConverter"/> maps unrecognized wire values
+/// to <see cref="Unknown"/> instead of throwing — operators can introduce
+/// new category strings in their overrides without breaking the loader,
+/// and forward-compat is preserved if shipped defaults later add new
+/// categories.
+/// </remarks>
+[JsonConverter(typeof(DenyCategoryConverter))]
+public enum DenyCategory
+{
+    Unknown,
+    CustomDeny,
+    SelfDestructive,
+    SystemDestructive,
+    PrivilegeEscalation,
+}
+
+public static class DenyCategoryExtensions
+{
+    /// <summary>
+    /// Returns the snake_case wire-format name surfaced in JSON files,
+    /// log lines, and metric labels.
+    /// </summary>
+    public static string ToWireName(this DenyCategory category) => category switch
+    {
+        DenyCategory.CustomDeny => "custom_deny",
+        DenyCategory.SelfDestructive => "self_destructive",
+        DenyCategory.SystemDestructive => "system_destructive",
+        DenyCategory.PrivilegeEscalation => "privilege_escalation",
+        _ => "unknown",
+    };
+
+    /// <summary>
+    /// Parses a wire-format category name. Empty/null is treated as
+    /// <see cref="DenyCategory.CustomDeny"/> (the operator-rule default);
+    /// unrecognized non-empty strings return <see cref="DenyCategory.Unknown"/>.
+    /// </summary>
+    public static DenyCategory FromWireName(string? wire) => wire switch
+    {
+        null or "" => DenyCategory.CustomDeny,
+        "custom_deny" => DenyCategory.CustomDeny,
+        "self_destructive" => DenyCategory.SelfDestructive,
+        "system_destructive" => DenyCategory.SystemDestructive,
+        "privilege_escalation" => DenyCategory.PrivilegeEscalation,
+        _ => DenyCategory.Unknown,
+    };
+}
+
+internal sealed class DenyCategoryConverter : JsonConverter<DenyCategory>
+{
+    public override DenyCategory Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => DenyCategoryExtensions.FromWireName(reader.GetString());
+
+    public override void Write(Utf8JsonWriter writer, DenyCategory value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToWireName());
+}
 
 /// <summary>
 /// Operator-authored hard-deny rule loaded from
@@ -81,12 +144,15 @@ public sealed class HardDenyRule
     public required string Reason { get; set; }
 
     /// <summary>
-    /// Telemetry / log category. Defaults to <c>custom_deny</c> for operator
-    /// overrides; shipped defaults populate this with their own categories
-    /// (<c>self_destructive</c>, <c>system_destructive</c>, etc.).
+    /// Telemetry / log category. Defaults to
+    /// <see cref="DenyCategory.CustomDeny"/> for operator overrides; shipped
+    /// defaults populate this with <see cref="DenyCategory.SelfDestructive"/>
+    /// or <see cref="DenyCategory.SystemDestructive"/>. Unrecognized wire
+    /// values deserialize to <see cref="DenyCategory.Unknown"/> rather than
+    /// throwing so forward-compat additions don't break the loader.
     /// </summary>
     [JsonPropertyName("category")]
-    public string Category { get; set; } = "custom_deny";
+    public DenyCategory Category { get; set; } = DenyCategory.CustomDeny;
 
     /// <summary>
     /// Documentation flag for <see cref="RawText"/> rules indicating the

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -328,10 +328,10 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         => GetCommand(arguments) ?? "(empty command)";
 
     private static string? GetCommand(IDictionary<string, object?>? arguments)
-        => arguments is null ? null : ToolArgumentHelper.GetString(arguments, "Command");
+        => ToolArgumentHelper.GetString(arguments, "Command");
 
     private static string? GetWorkingDirectory(IDictionary<string, object?>? arguments)
-        => arguments is null ? null : ToolArgumentHelper.GetString(arguments, "WorkingDirectory");
+        => ToolArgumentHelper.GetString(arguments, "WorkingDirectory");
 
     private static void TraverseApprovalUnits(string command, Action<string> visitUnit)
     {

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -207,7 +207,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (!ReferenceEquals(clause, groupHead))
                 continue;  // pipe-tail clauses fold into the group head
 
-            var verb = ApplyVerbShortCircuit(clause.Verb.Joined);
+            var verb = ShellTokenizer.ApplyVerbShortCircuit(clause.Verb.Joined);
             if (string.IsNullOrEmpty(verb))
                 continue;
 
@@ -227,26 +227,6 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         }
 
         return candidates;
-    }
-
-    private static string ApplyVerbShortCircuit(string? rawVerb)
-    {
-        if (string.IsNullOrEmpty(rawVerb))
-            return string.Empty;
-
-        // Path-aware verbs (cat, grep, find, ls, ...) and single-token
-        // side-effect verbs (echo, printf, ...) collapse to depth 1 so
-        // call-specific positional arguments don't bake into the persisted
-        // verb chain. Mirrors ShellApprovalSemanticsBase.ExtractVerbChain
-        // — both paths must apply the same short-circuit to stay
-        // consistent across POSIX BashParser and Windows legacy code.
-        var firstSpace = rawVerb.IndexOf(' ', StringComparison.Ordinal);
-        var firstToken = firstSpace < 0 ? rawVerb : rawVerb[..firstSpace];
-        if (ShellTokenizer.PathAwareVerbs.Contains(firstToken)
-            || ShellTokenizer.SingleTokenSideEffectVerbs.Contains(firstToken))
-            return firstToken;
-
-        return rawVerb;
     }
 
     private static string? ResolveClauseDirectory(ShellSyntaxTree.Clause clause, bool isSideEffectVerb)
@@ -278,7 +258,7 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
             if (ShellTokenizer.IsPathToken(raw))
             {
                 var canonical = !string.IsNullOrEmpty(arg.Resolved) ? arg.Resolved : raw;
-                return ApplyFileParentRule(canonical);
+                return ShellTokenizer.ApplyFileParentRule(canonical);
             }
         }
 
@@ -293,34 +273,6 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         // "..."` invocation; the parser flattens that).
         var cwdAttribution = clause.Args.FirstOrDefault(a => a.IsCwdAttribution);
         return cwdAttribution?.Resolved;
-    }
-
-    private static string? ApplyFileParentRule(string token)
-    {
-        // File path with extension: scope to the parent directory so
-        // persisted approvals match the folder, not a single file. Mirrors
-        // ShellApprovalSemanticsBase.ApplyFileParentRule — the BashParser
-        // path must produce identical (verb, directory) tuples for the
-        // same command so prompt-time and retry-time candidates compare
-        // equal.
-        if (string.IsNullOrEmpty(token))
-            return token;
-
-        var hasExtension = Path.HasExtension(token);
-        if (!hasExtension && !LooksLikeDotfile(token))
-            return token;
-
-        var parent = Path.GetDirectoryName(token);
-        if (string.IsNullOrEmpty(parent))
-            return token;
-
-        return parent;
-    }
-
-    private static bool LooksLikeDotfile(string token)
-    {
-        var basename = Path.GetFileName(token);
-        return basename.Length > 1 && basename[0] == '.';
     }
 
     public bool IsApproved(

--- a/src/Netclaw.Security/IToolApprovalMatcher.cs
+++ b/src/Netclaw.Security/IToolApprovalMatcher.cs
@@ -281,9 +281,13 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         IReadOnlyList<ApprovalEntry> approvedEntries,
         string? cwd)
     {
+        // Fail-closed on a missing/empty Command argument: a malformed
+        // shell invocation cannot be "already approved" — the agent must
+        // round-trip through the gate so the operator sees what was
+        // attempted.
         var command = GetCommand(arguments);
         if (string.IsNullOrWhiteSpace(command))
-            return true; // empty command, nothing to approve
+            return false;
 
         // Messy commands cannot be auto-approved: the matcher cannot extract a
         // candidate verb-chain to evaluate against the persisted store, so
@@ -292,9 +296,13 @@ public sealed class ShellApprovalMatcher : IToolApprovalMatcher
         if (ShellTokenizer.IsMessyCompoundCommand(command))
             return false;
 
+        // Fail-closed on a parser miss: BashParser swallows exceptions and
+        // unparseable results return an empty candidate list. Treating that
+        // as "approved" would silently auto-allow any command our parser
+        // regresses on. Force the gate instead.
         var candidates = ExtractCandidates(toolName, arguments);
         if (candidates.Count == 0)
-            return true;
+            return false;
 
         foreach (var candidate in candidates)
         {

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -51,8 +51,16 @@ public static class PathUtility
     /// Uses platform-appropriate case sensitivity.
     /// </summary>
     public static bool IsWithinRoot(string candidate, string root)
+        => IsNormalizedWithinRoot(Normalize(candidate), root);
+
+    /// <summary>
+    /// Like <see cref="IsWithinRoot"/> but assumes <paramref name="normalizedCandidate"/>
+    /// has already been canonicalized via <see cref="Normalize"/>. Use on hot
+    /// paths that compare many roots against the same candidate to avoid
+    /// re-running <c>Path.GetFullPath</c> on the candidate per iteration.
+    /// </summary>
+    public static bool IsNormalizedWithinRoot(string normalizedCandidate, string root)
     {
-        var normalizedCandidate = Normalize(candidate);
         var normalizedRoot = Normalize(root);
         var comparison = OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -136,10 +136,19 @@ public static class PathUtility
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(home))
+        if (string.IsNullOrWhiteSpace(home))
+            return expanded;
+
+        // Skip the three substring scans entirely when no env-var sigil is
+        // present — the typical absolute-path candidate has neither.
+        if (expanded.Contains('$', StringComparison.Ordinal))
         {
             expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
             expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (expanded.Contains('%', StringComparison.Ordinal))
+        {
             expanded = expanded.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -77,6 +77,30 @@ public static class PathUtility
     }
 
     /// <summary>
+    /// Returns true when <paramref name="a"/> and <paramref name="b"/> resolve
+    /// to the same canonical filesystem path under the platform's casing
+    /// rules. Both inputs are passed through <see cref="Normalize"/> first.
+    /// Swallows <see cref="ArgumentException"/>, <see cref="NotSupportedException"/>,
+    /// and <see cref="System.Security.SecurityException"/> (returning false) so
+    /// callers can compare untrusted or partially-formed paths without
+    /// wrapping the call in a try/catch.
+    /// </summary>
+    public static bool AreEquivalentPaths(string a, string b)
+    {
+        try
+        {
+            var comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return string.Equals(Normalize(a), Normalize(b), comparison);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or System.Security.SecurityException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Checks if a candidate path is within or equal to any of the root directories.
     /// Uses platform-appropriate case sensitivity.
     /// </summary>

--- a/src/Netclaw.Security/ShellApprovalSemantics.cs
+++ b/src/Netclaw.Security/ShellApprovalSemantics.cs
@@ -120,11 +120,9 @@ internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
         // instead of `grep`, `echo done` instead of `echo`. The
         // post-check restores the v2 invariant for these verb
         // families.
-        var firstSpace = greedy.IndexOf(' ', StringComparison.Ordinal);
-        var firstToken = firstSpace < 0 ? greedy : greedy[..firstSpace];
-        if (ShellTokenizer.PathAwareVerbs.Contains(firstToken)
-            || ShellTokenizer.SingleTokenSideEffectVerbs.Contains(firstToken))
-            return firstToken;
+        var shortCircuited = ShellTokenizer.ApplyVerbShortCircuit(greedy);
+        if (!string.Equals(shortCircuited, greedy, StringComparison.Ordinal))
+            return shortCircuited;
 
         // Honor the explicit maxDepth cap as a hard upper bound so
         // callers asking for fewer tokens still get them. Default
@@ -176,45 +174,10 @@ internal abstract class ShellApprovalSemanticsBase : IShellApprovalSemantics
             if (trimmed.StartsWith('-'))
                 continue;
             if (ShellTokenizer.IsPathToken(trimmed))
-                return ApplyFileParentRule(trimmed);
+                return ShellTokenizer.ApplyFileParentRule(trimmed);
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// When the extracted path looks like a file (has an extension on its
-    /// last component), return the parent directory so persisted approvals
-    /// scope to the folder rather than a single file. Pure string operation,
-    /// no filesystem syscall.
-    /// </summary>
-    private static string? ApplyFileParentRule(string token)
-    {
-        if (string.IsNullOrEmpty(token))
-            return token;
-
-        // Path.HasExtension is the deterministic heuristic; dot-prefixed
-        // dotfiles like ~/.bashrc don't return an extension via this API
-        // (the leading dot is treated as part of the basename), which is
-        // the right behavior for our use case — scope cat ~/.bashrc to ~/.
-        var hasExtension = Path.HasExtension(token);
-        if (!hasExtension && !LooksLikeDotfile(token))
-            return token;
-
-        var parent = Path.GetDirectoryName(token);
-        // GetDirectoryName returns "" for a bare filename and the literal
-        // separator for root-level files. Fall back to the token unchanged
-        // when we can't sensibly compute a parent.
-        if (string.IsNullOrEmpty(parent))
-            return token;
-
-        return parent;
-    }
-
-    private static bool LooksLikeDotfile(string token)
-    {
-        var basename = Path.GetFileName(token);
-        return basename.Length > 1 && basename[0] == '.';
     }
 
     public string NormalizeApprovalUnit(string command, string? workingDirectory)

--- a/src/Netclaw.Security/ShellCommandPolicy.cs
+++ b/src/Netclaw.Security/ShellCommandPolicy.cs
@@ -8,11 +8,11 @@ namespace Netclaw.Security;
 /// <summary>
 /// Result of evaluating a shell command against the hard deny list.
 /// </summary>
-public sealed record ShellCommandDecision(bool Allowed, string? DenyReason = null, string? DenyCategory = null)
+public sealed record ShellCommandDecision(bool Allowed, string? DenyReason = null, DenyCategory? DenyCategory = null)
 {
     public static ShellCommandDecision Allow() => new(true);
 
-    public static ShellCommandDecision Deny(string reason, string category) => new(false, reason, category);
+    public static ShellCommandDecision Deny(string reason, DenyCategory category) => new(false, reason, category);
 }
 
 /// <summary>
@@ -165,7 +165,7 @@ public sealed class ShellCommandPolicy
         if (tokens.Count == 0)
             return null;
 
-        return new VerbChainDenyPattern(tokens, raw, "custom_deny");
+        return new VerbChainDenyPattern(tokens, raw, DenyCategory.CustomDeny);
     }
 
     // ── Default deny patterns ──
@@ -173,23 +173,23 @@ public sealed class ShellCommandPolicy
     private static readonly IReadOnlyList<DenyPattern> DefaultDenyPatterns =
     [
         // Self-destruction: killing the netclaw daemon
-        new VerbChainDenyPattern(["netclaw", "daemon", "stop"], "Cannot stop the daemon from within a session", "self_destructive"),
-        new VerbChainDenyPattern(["netclaw", "daemon", "kill"], "Cannot kill the daemon from within a session", "self_destructive"),
-        new VerbChainDenyPattern(["systemctl", "stop", "netclaw"], "Cannot stop the netclaw service", "self_destructive"),
-        new VerbChainDenyPattern(["systemctl", "kill", "netclaw"], "Cannot kill the netclaw service", "self_destructive"),
+        new VerbChainDenyPattern(["netclaw", "daemon", "stop"], "Cannot stop the daemon from within a session", DenyCategory.SelfDestructive),
+        new VerbChainDenyPattern(["netclaw", "daemon", "kill"], "Cannot kill the daemon from within a session", DenyCategory.SelfDestructive),
+        new VerbChainDenyPattern(["systemctl", "stop", "netclaw"], "Cannot stop the netclaw service", DenyCategory.SelfDestructive),
+        new VerbChainDenyPattern(["systemctl", "kill", "netclaw"], "Cannot kill the netclaw service", DenyCategory.SelfDestructive),
 
         // Process killing patterns targeting netclaw
-        new ProcessKillDenyPattern("Cannot kill processes from within a session", "self_destructive"),
+        new ProcessKillDenyPattern("Cannot kill processes from within a session", DenyCategory.SelfDestructive),
 
         // Privilege escalation: the agent must never elevate privileges.
         // If it needs elevated access, the daemon should run as a user with those permissions.
-        new PrivilegeEscalationDenyPattern("Cannot escalate privileges from within a session", "privilege_escalation"),
+        new PrivilegeEscalationDenyPattern("Cannot escalate privileges from within a session", DenyCategory.PrivilegeEscalation),
 
         // System-destructive: rm -rf on root or home
-        new RmRfRootDenyPattern("Cannot remove root or home directories", "system_destructive"),
+        new RmRfRootDenyPattern("Cannot remove root or home directories", DenyCategory.SystemDestructive),
 
         // Filesystem destruction (mkfs, mkfs.ext4, mkfs.xfs, etc.)
-        new VerbPrefixDenyPattern("mkfs", "Cannot create filesystems", "system_destructive"),
+        new VerbPrefixDenyPattern("mkfs", "Cannot create filesystems", DenyCategory.SystemDestructive),
     ];
 
     /// <summary>
@@ -198,15 +198,15 @@ public sealed class ShellCommandPolicy
     /// </summary>
     private static readonly IReadOnlyList<RawStringPattern> DefaultRawStringPatterns =
     [
-        new(":(){ :|:& };:", "Fork bomb detected", "system_destructive"),
-        new(":(){:|:&};:", "Fork bomb detected", "system_destructive"),
+        new(":(){ :|:& };:", "Fork bomb detected", DenyCategory.SystemDestructive),
+        new(":(){:|:&};:", "Fork bomb detected", DenyCategory.SystemDestructive),
     ];
 
-    internal sealed record RawStringPattern(string Pattern, string Reason, string Category);
+    internal sealed record RawStringPattern(string Pattern, string Reason, DenyCategory Category);
 
     // ── Pattern types ──
 
-    internal abstract record DenyPattern(string Reason, string Category)
+    internal abstract record DenyPattern(string Reason, DenyCategory Category)
     {
         public abstract bool Matches(IReadOnlyList<string> tokens);
     }
@@ -217,7 +217,7 @@ public sealed class ShellCommandPolicy
     internal sealed record VerbChainDenyPattern(
         IReadOnlyList<string> VerbChain,
         string Reason,
-        string Category) : DenyPattern(Reason, Category)
+        DenyCategory Category) : DenyPattern(Reason, Category)
     {
         public override bool Matches(IReadOnlyList<string> tokens)
         {
@@ -242,7 +242,7 @@ public sealed class ShellCommandPolicy
     internal sealed record VerbPrefixDenyPattern(
         string Prefix,
         string Reason,
-        string Category) : DenyPattern(Reason, Category)
+        DenyCategory Category) : DenyPattern(Reason, Category)
     {
         public override bool Matches(IReadOnlyList<string> tokens)
         {
@@ -258,7 +258,7 @@ public sealed class ShellCommandPolicy
     /// Matches kill/killall/pkill commands. These are categorically denied because
     /// the agent could target the daemon process or other critical processes.
     /// </summary>
-    internal sealed record ProcessKillDenyPattern(string Reason, string Category)
+    internal sealed record ProcessKillDenyPattern(string Reason, DenyCategory Category)
         : DenyPattern(Reason, Category)
     {
         private static readonly HashSet<string> KillVerbs = new(StringComparer.OrdinalIgnoreCase)
@@ -281,7 +281,7 @@ public sealed class ShellCommandPolicy
     /// These are categorically denied because the agent should never
     /// need to elevate privileges beyond the daemon user.
     /// </summary>
-    internal sealed record PrivilegeEscalationDenyPattern(string Reason, string Category)
+    internal sealed record PrivilegeEscalationDenyPattern(string Reason, DenyCategory Category)
         : DenyPattern(Reason, Category)
     {
         private static readonly HashSet<string> EscalationVerbs = new(StringComparer.OrdinalIgnoreCase)
@@ -302,7 +302,7 @@ public sealed class ShellCommandPolicy
     /// <summary>
     /// Matches rm -rf targeting root (/) or home (~/ or $HOME).
     /// </summary>
-    internal sealed record RmRfRootDenyPattern(string Reason, string Category)
+    internal sealed record RmRfRootDenyPattern(string Reason, DenyCategory Category)
         : DenyPattern(Reason, Category)
     {
         public override bool Matches(IReadOnlyList<string> tokens)
@@ -371,7 +371,7 @@ public sealed class ShellCommandPolicy
         IReadOnlyList<string>? ArgFlags,
         PathConstraint? FirstPath,
         string Reason,
-        string Category) : DenyPattern(Reason, Category)
+        DenyCategory Category) : DenyPattern(Reason, Category)
     {
         public override bool Matches(IReadOnlyList<string> tokens)
         {

--- a/src/Netclaw.Security/ShellCommandPolicy.cs
+++ b/src/Netclaw.Security/ShellCommandPolicy.cs
@@ -388,7 +388,7 @@ public sealed class ShellCommandPolicy
             if (ArgFlags is { Count: > 0 } && !AnyFlagPresent(tokens, ArgFlags))
                 return false;
 
-            if (FirstPath is not null && !FirstNonFlagMatchesConstraint(tokens, FirstPath))
+            if (FirstPath is not null && !FirstNonFlagMatchesConstraint(tokens, VerbChain.Count, FirstPath))
                 return false;
 
             return true;
@@ -443,26 +443,23 @@ public sealed class ShellCommandPolicy
 
         private static bool FirstNonFlagMatchesConstraint(
             IReadOnlyList<string> tokens,
+            int verbChainCount,
             PathConstraint constraint)
         {
             if (constraint.OneOf is not { Count: > 0 })
                 return false;
 
-            // Skip over the verb chain tokens already consumed and the flag
-            // tokens; the first remaining positional argument is the
-            // candidate.
-            for (var i = 0; i < tokens.Count; i++)
+            // Skip past the verb-chain tokens already consumed by the
+            // prefix match in Matches(), then over any flag tokens; the
+            // first remaining positional argument is the candidate path.
+            // A bug landed when this was a static helper that assumed a
+            // single-token verb chain — multi-token chains like
+            // `git push` would treat `push` as the candidate path and
+            // silently miss firstPath deny rules.
+            for (var i = verbChainCount; i < tokens.Count; i++)
             {
                 var token = tokens[i];
                 if (token.StartsWith('-'))
-                    continue;
-
-                // Skip the verb tokens themselves — we don't want to treat the
-                // verb as the first non-flag arg.
-                // Heuristic: tokens containing '/' or '~' or '$' are paths;
-                // bare alphanumeric tokens early in the stream are likely the
-                // verb chain.
-                if (i == 0)
                     continue;
 
                 var normalized = NormalizePathToken(token);
@@ -482,12 +479,7 @@ public sealed class ShellCommandPolicy
         }
 
         private static string NormalizePathToken(string token)
-        {
-            var trimmed = token.TrimEnd('/', '\\');
-            if (trimmed is "~" or "$HOME" or "${HOME}")
-                return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            return trimmed;
-        }
+            => PathUtility.ExpandHome(token).TrimEnd('/', '\\');
     }
 
 }

--- a/src/Netclaw.Security/ShellTokenizer.cs
+++ b/src/Netclaw.Security/ShellTokenizer.cs
@@ -42,10 +42,11 @@ public static class ShellTokenizer
     /// <summary>
     /// Verbs that are stdout-only side effects without redirects. The verb-
     /// chain extractor caps at one token for these so <c>echo done</c>
-    /// resolves to verb <c>echo</c> (matching the side-effect skip list)
-    /// rather than the 2-token chain <c>echo done</c>. Mirrors the skip
-    /// list in <c>ApprovalPatternMatching.SideEffectOnlyVerbs</c>; keep
-    /// the two in sync — both are security-relevant defaults.
+    /// resolves to verb <c>echo</c> rather than the 2-token chain
+    /// <c>echo done</c>. Consumed by both the verb-chain short-circuit
+    /// (<see cref="ApplyVerbShortCircuit"/>) and the pure-side-effect
+    /// skip-on-persist rule (<c>ApprovalPatternMatching.IsPureSideEffect</c>);
+    /// keeping a single source of truth prevents the two paths from drifting.
     /// </summary>
     internal static readonly HashSet<string> SingleTokenSideEffectVerbs = new(StringComparer.Ordinal)
     {
@@ -345,4 +346,63 @@ public static class ShellTokenizer
         return token.Trim().TrimStart(';', '|', '&').TrimEnd(';', '|', '&');
     }
 
+    /// <summary>
+    /// When the extracted path looks like a file (has an extension on its
+    /// last component, or is a dotfile basename), return the parent
+    /// directory so persisted approvals scope to the folder rather than a
+    /// single file. Pure string operation, no filesystem syscall.
+    /// </summary>
+    /// <remarks>
+    /// Path.HasExtension is the deterministic heuristic; dot-prefixed
+    /// dotfiles like ~/.bashrc don't return an extension via this API
+    /// (the leading dot is treated as part of the basename), so
+    /// <see cref="LooksLikeDotfile"/> is the secondary check for that
+    /// shape.
+    /// </remarks>
+    internal static string? ApplyFileParentRule(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return token;
+
+        var hasExtension = Path.HasExtension(token);
+        if (!hasExtension && !LooksLikeDotfile(token))
+            return token;
+
+        var parent = Path.GetDirectoryName(token);
+        // GetDirectoryName returns "" for a bare filename and the literal
+        // separator for root-level files. Fall back to the token unchanged
+        // when we can't sensibly compute a parent.
+        if (string.IsNullOrEmpty(parent))
+            return token;
+
+        return parent;
+    }
+
+    internal static bool LooksLikeDotfile(string token)
+    {
+        var basename = Path.GetFileName(token);
+        return basename.Length > 1 && basename[0] == '.';
+    }
+
+    /// <summary>
+    /// Caps a verb chain at depth 1 when the first token is a path-aware
+    /// verb (cat, grep, find, ls, ...) or a single-token side-effect verb
+    /// (echo, printf, ...). This prevents call-specific positional
+    /// arguments — search patterns, file targets — from baking into
+    /// persisted approval keys, so <c>grep secret /etc/passwd</c> and
+    /// <c>grep "TODO" file.cs</c> both persist as the verb <c>grep</c>.
+    /// </summary>
+    internal static string ApplyVerbShortCircuit(string? rawVerb)
+    {
+        if (string.IsNullOrEmpty(rawVerb))
+            return string.Empty;
+
+        var firstSpace = rawVerb.IndexOf(' ', StringComparison.Ordinal);
+        var firstToken = firstSpace < 0 ? rawVerb : rawVerb[..firstSpace];
+        if (PathAwareVerbs.Contains(firstToken)
+            || SingleTokenSideEffectVerbs.Contains(firstToken))
+            return firstToken;
+
+        return rawVerb;
+    }
 }

--- a/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
+++ b/src/Netclaw.Tools.Abstractions/ToolArgumentHelper.cs
@@ -14,8 +14,14 @@ namespace Netclaw.Tools;
 /// </summary>
 public static class ToolArgumentHelper
 {
-    private static bool TryGetValueFlexible(IDictionary<string, object?> arguments, string key, out object? value)
+    private static bool TryGetValueFlexible(IDictionary<string, object?>? arguments, string key, out object? value)
     {
+        if (arguments is null)
+        {
+            value = null;
+            return false;
+        }
+
         if (arguments.TryGetValue(key, out value))
             return true;
 
@@ -61,7 +67,7 @@ public static class ToolArgumentHelper
         return count == 0 ? string.Empty : new string(buffer, 0, count);
     }
 
-    public static string? GetString(IDictionary<string, object?> arguments, string key)
+    public static string? GetString(IDictionary<string, object?>? arguments, string key)
     {
         if (string.Equals(key, "Message", StringComparison.OrdinalIgnoreCase)
             && !TryGetValueFlexible(arguments, key, out _)
@@ -89,7 +95,7 @@ public static class ToolArgumentHelper
         };
     }
 
-    public static int? GetNullableInt(IDictionary<string, object?> arguments, string key)
+    public static int? GetNullableInt(IDictionary<string, object?>? arguments, string key)
     {
         if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
@@ -106,7 +112,7 @@ public static class ToolArgumentHelper
         };
     }
 
-    public static double? GetNullableDouble(IDictionary<string, object?> arguments, string key)
+    public static double? GetNullableDouble(IDictionary<string, object?>? arguments, string key)
     {
         if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;
@@ -124,7 +130,7 @@ public static class ToolArgumentHelper
         };
     }
 
-    public static bool? GetNullableBool(IDictionary<string, object?> arguments, string key)
+    public static bool? GetNullableBool(IDictionary<string, object?>? arguments, string key)
     {
         if (!TryGetValueFlexible(arguments, key, out var value) || value is null)
             return null;


### PR DESCRIPTION
## Summary

Ran `/simplify` against the production code introduced by #962 (the trust-zones revert / `(verb, directory)` ApprovalEntry model). Four commits, each independently revertable.

- `refactor(security): /simplify pass on PR #962 approval code` (377bc587) — dedup approval helpers, fix `FirstNonFlagMatchesConstraint` multi-token verb-chain bug, pre-normalize candidate path in the matcher hot loop.
- `fix(security): close fail-open paths in IToolApprovalMatcher implementations` (34640f96) — `ShellApprovalMatcher.IsApproved` and `FilePathApprovalMatcher.IsApproved` now fail closed on empty command / zero-candidate parse / empty verb list, instead of silently auto-approving.
- `docs(constitution): reject "one type per file" as a refactor justification` (67562b36) — adds a CLAUDE.md rule so cleanup-pass agents and reviewers stop suggesting pointless file splits.
- `refactor(security): tighten deny-category and tool-argument helpers` (16ffd66a) — `DenyCategory` enum with forward-compatible JSON converter, null-tolerant `ToolArgumentHelper.*`, `IndexOf` guards on `PathUtility.ExpandHome`.

### Bug fix worth calling out

`RefinedVerbChainDenyPattern.FirstNonFlagMatchesConstraint` was skipping only `tokens[0]` unconditionally. For multi-token verb chains like `[git, push]`, the second verb token was treated as the candidate path and silently missed `firstPath` deny rules. Now skips `VerbChain.Count` tokens.

### Fail-open paths closed

`IToolApprovalMatcher.IsApproved` had three silent-auto-approve paths reachable from the interface contract:
- `ShellApprovalMatcher`: empty `Command` → `true` and `candidates.Count == 0` → `true` (the latter triggers whenever `BashParser` throws or returns `IsUnparseable`)
- `FilePathApprovalMatcher`: empty verb list fell through the foreach to `return true`

No production caller goes through `IToolApprovalMatcher.IsApproved` today (the gate uses `ApprovalPatternMatching.MatchesPersistedEntry` directly), so this is an interface-correctness fix rather than a production behavior change. `DefaultApprovalMatcher.IsApproved` already failed closed.

### Wire format / telemetry

`DenyCategory` enum serializes via `ToWireName()` to existing snake_case strings (`self_destructive`, etc.) so downstream log labels (`hard_deny_self_destructive`, …) and operator JSON files keep working unchanged. Unrecognized wire values deserialize to `DenyCategory.Unknown` instead of throwing so forward-compat operator additions don't break the loader.

### What's deferred

A pile of medium/low findings (param sprawl on `IToolApprovalService`, candidate caching across the gate flow, `Tokenize` materialization, escaped-quote handling in `IsMessyCompoundCommand`, etc.) are tracked at https://memory.testlab.petabridge.net/view/94a7343a-e05e-4acc-bb89-4c71a1b3d09a — they need design decisions or touch more files than fits a cleanup PR. The Actors/Configuration/Cli areas of #962 haven't been simplified yet.

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean, 0 warnings
- [x] `dotnet test src/Netclaw.Security.Tests/` — 534/534
- [x] `dotnet test src/Netclaw.Actors.Tests/` — 1545/1545
- [x] `dotnet test src/Netclaw.Configuration.Tests/` — 288/288
- [x] `dotnet slopwatch analyze` — 0 new violations
- [x] `pwsh -File ./scripts/Add-FileHeaders.ps1 -Verify` — all files headered