### PR TITLE
fix(security): expand `~`/$HOME in configured filesystem roots

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ScopedFileAccessPolicyHomeExpansionTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedFileAccessPolicyHomeExpansionTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Tools;
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tests.Utilities;
 using Netclaw.Tools;
 using Xunit;
@@ -28,7 +29,6 @@ public sealed class ScopedFileAccessPolicyHomeExpansionTests : IDisposable
         _sessionDir = Path.Combine(_dir.Path, "sessions", "test-session");
         Directory.CreateDirectory(_sessionDir);
         _paths = new NetclawPaths(_dir.Path);
-        _paths.EnsureDirectoriesExist();
     }
 
     public void Dispose() => _dir.Dispose();
@@ -46,10 +46,9 @@ public sealed class ScopedFileAccessPolicyHomeExpansionTests : IDisposable
         var roots = policy.GetRootsForContext(context, ScopedFileAccessPolicy.AccessKind.Write);
 
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var expected = Normalize(Path.Combine(home, "repositories"));
+        var expected = PathUtility.Normalize(Path.Combine(home, "repositories"));
 
         Assert.Contains(roots, r => r.Equals(expected, StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(roots, r => r.Contains("~", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -99,7 +98,4 @@ public sealed class ScopedFileAccessPolicyHomeExpansionTests : IDisposable
             Boundary = SecurityPolicyDefaults.ResolveBoundaryFromAudience(audience),
             ChannelType = "signalr"
         };
-
-    private static string Normalize(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 }

--- a/src/Netclaw.Actors.Tests/Tools/ScopedFileAccessPolicyHomeExpansionTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ScopedFileAccessPolicyHomeExpansionTests.cs
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------
+// <copyright file="ScopedFileAccessPolicyHomeExpansionTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Tools;
+
+/// <summary>
+/// Regression coverage for tilde / $HOME expansion in configured filesystem
+/// roots. Without expansion, <see cref="ScopedFileAccessPolicy"/> rejects
+/// access to real files under the user's home because <c>Path.GetFullPath</c>
+/// treats <c>~</c> as a literal subdirectory of CWD.
+/// </summary>
+public sealed class ScopedFileAccessPolicyHomeExpansionTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly string _sessionDir;
+    private readonly NetclawPaths _paths;
+
+    public ScopedFileAccessPolicyHomeExpansionTests()
+    {
+        _sessionDir = Path.Combine(_dir.Path, "sessions", "test-session");
+        Directory.CreateDirectory(_sessionDir);
+        _paths = new NetclawPaths(_dir.Path);
+        _paths.EnsureDirectoriesExist();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    [Theory]
+    [InlineData("~/repositories")]
+    [InlineData("$HOME/repositories")]
+    [InlineData("${HOME}/repositories")]
+    public void Personal_roots_expand_shell_home_tokens(string configured)
+    {
+        var toolConfig = BuildPersonalWriteRootsConfig(configured);
+        var policy = new ScopedFileAccessPolicy(toolConfig, _paths);
+        var context = CreateContext(TrustAudience.Personal);
+
+        var roots = policy.GetRootsForContext(context, ScopedFileAccessPolicy.AccessKind.Write);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var expected = Normalize(Path.Combine(home, "repositories"));
+
+        Assert.Contains(roots, r => r.Equals(expected, StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(roots, r => r.Contains("~", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Personal_write_to_home_relative_root_is_allowed()
+    {
+        var toolConfig = BuildPersonalWriteRootsConfig("~/repositories");
+        var policy = new ScopedFileAccessPolicy(toolConfig, _paths);
+        var context = CreateContext(TrustAudience.Personal);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var target = Path.Combine(home, "repositories", "any-project", "RELEASE_NOTES.md");
+
+        var allowed = policy.TryResolveWritePath(target, context, out _, out var error);
+
+        Assert.True(allowed, error);
+    }
+
+    [Fact]
+    public void Personal_write_outside_home_relative_root_is_rejected()
+    {
+        var toolConfig = BuildPersonalWriteRootsConfig("~/repositories");
+        var policy = new ScopedFileAccessPolicy(toolConfig, _paths);
+        var context = CreateContext(TrustAudience.Personal);
+
+        var unrelated = Path.Combine(Path.GetTempPath(), "outside-the-root.txt");
+
+        var allowed = policy.TryResolveWritePath(unrelated, context, out _, out _);
+
+        Assert.False(allowed);
+    }
+
+    private static ToolConfig BuildPersonalWriteRootsConfig(string configuredRoot)
+    {
+        var toolConfig = new ToolConfig();
+        toolConfig.AudienceProfiles.Personal.WriteFiles = new ToolFilesystemAccessProfile
+        {
+            Mode = ToolFilesystemMode.Roots
+        };
+        toolConfig.AudienceProfiles.Personal.WriteFiles.Roots.Add(configuredRoot);
+        return toolConfig;
+    }
+
+    private ToolExecutionContext CreateContext(TrustAudience audience)
+        => new("personal/test-session", _sessionDir)
+        {
+            Audience = audience.ToWireValue(),
+            Boundary = SecurityPolicyDefaults.ResolveBoundaryFromAudience(audience),
+            ChannelType = "signalr"
+        };
+
+    private static string Normalize(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+}

--- a/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
+++ b/src/Netclaw.Actors/Tools/ToolAudienceProfileResolver.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Configuration;
+using Netclaw.Security;
 using Netclaw.Tools;
 
 namespace Netclaw.Actors.Tools;
@@ -111,7 +112,9 @@ internal sealed class ToolAudienceProfileResolver
     /// <summary>
     /// Resolves a path token (e.g. <c>{skills_dir}</c>, <c>{identity_dir}</c>, <c>{workspaces_dir}</c>) to an absolute path.
     /// Returns null for empty input or if <see cref="_paths"/> is not available for path-based tokens.
-    /// Unrecognized values are treated as literal paths.
+    /// Unrecognized values are treated as literal paths and have shell home tokens
+    /// (<c>~</c>, <c>$HOME</c>, <c>${HOME}</c>, <c>%USERPROFILE%</c>) expanded so they
+    /// resolve correctly when the daemon's CWD is not the user's home directory.
     /// </summary>
     private string? ResolvePathToken(string? token)
     {
@@ -129,8 +132,7 @@ internal sealed class ToolAudienceProfileResolver
         if (string.Equals(trimmed, ToolAudienceProfileDefaults.WorkspacesDirectoryToken, StringComparison.OrdinalIgnoreCase))
             return _paths?.WorkspacesDirectory;
 
-        // Literal path
-        return trimmed;
+        return PathUtility.ExpandHome(trimmed);
     }
 
     private string? ResolveToken(string root, ToolExecutionContext context)

--- a/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
+++ b/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
@@ -110,7 +110,6 @@ public sealed class NetclawPathsTests : IDisposable
         var paths = new NetclawPaths(workspacesDirectory: configured);
 
         Assert.Equal(expected, paths.WorkspacesDirectory);
-        Assert.DoesNotContain("~", paths.WorkspacesDirectory);
     }
 
     [Fact]

--- a/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
+++ b/src/Netclaw.Configuration.Tests/NetclawPathsTests.cs
@@ -97,6 +97,44 @@ public sealed class NetclawPathsTests : IDisposable
         Assert.Equal(envPath, paths.BasePath);
         Assert.Equal(workspacePath, paths.WorkspacesDirectory);
     }
+
+    [Theory]
+    [InlineData("~/repositories")]
+    [InlineData("$HOME/repositories")]
+    [InlineData("${HOME}/repositories")]
+    public void Tilde_and_HOME_tokens_in_workspacesDirectory_expand_to_user_home(string configured)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var expected = Path.Combine(home, "repositories");
+
+        var paths = new NetclawPaths(workspacesDirectory: configured);
+
+        Assert.Equal(expected, paths.WorkspacesDirectory);
+        Assert.DoesNotContain("~", paths.WorkspacesDirectory);
+    }
+
+    [Fact]
+    public void Tilde_in_basePath_expands_to_user_home()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var expected = Path.Combine(home, ".netclaw-test");
+
+        var paths = new NetclawPaths("~/.netclaw-test");
+
+        Assert.Equal(expected, paths.BasePath);
+    }
+
+    [Fact]
+    public void Tilde_in_NETCLAW_HOME_env_var_expands_to_user_home()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, "~/.netclaw-env-test");
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var expected = Path.Combine(home, ".netclaw-env-test");
+
+        var paths = new NetclawPaths();
+
+        Assert.Equal(expected, paths.BasePath);
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -109,16 +109,48 @@ public sealed class NetclawPaths
 
     public NetclawPaths(string? basePath = null, string? workspacesDirectory = null)
     {
-        BasePath = basePath
-            ?? NormalizeEnvHome(Environment.GetEnvironmentVariable("NETCLAW_HOME"))
+        BasePath = ExpandHome(basePath)
+            ?? ExpandHome(NormalizeEnvHome(Environment.GetEnvironmentVariable("NETCLAW_HOME")))
             ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".netclaw");
-        WorkspacesDirectory = workspacesDirectory ?? Path.Combine(BasePath, "workspaces");
+        WorkspacesDirectory = ExpandHome(workspacesDirectory) ?? Path.Combine(BasePath, "workspaces");
     }
 
     private static string? NormalizeEnvHome(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// Expands shell home tokens (<c>~</c>, <c>$HOME</c>, <c>${HOME}</c>,
+    /// <c>%USERPROFILE%</c>) in a configured path so values like
+    /// <c>~/repositories</c> resolve correctly when the daemon's CWD is not
+    /// the user's home directory. Inlined here (rather than reusing
+    /// <c>Netclaw.Security.PathUtility</c>) because <c>Netclaw.Configuration</c>
+    /// is the foundation project and cannot depend on Security.
+    /// </summary>
+    private static string? ExpandHome(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var trimmed = value.Trim();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return trimmed;
+
+        if (trimmed.StartsWith('~'))
+        {
+            trimmed = trimmed.Length == 1
+                ? home
+                : Path.Combine(home, trimmed[1..].TrimStart('/', '\\'));
+        }
+
+        trimmed = trimmed.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
+        trimmed = trimmed.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
+        trimmed = trimmed.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
+
+        return trimmed;
+    }
 
     /// <summary>
     /// Create all standard subdirectories if they don't exist.

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -110,23 +110,20 @@ public sealed class NetclawPaths
     public NetclawPaths(string? basePath = null, string? workspacesDirectory = null)
     {
         BasePath = ExpandHome(basePath)
-            ?? ExpandHome(NormalizeEnvHome(Environment.GetEnvironmentVariable("NETCLAW_HOME")))
+            ?? ExpandHome(Environment.GetEnvironmentVariable("NETCLAW_HOME"))
             ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".netclaw");
         WorkspacesDirectory = ExpandHome(workspacesDirectory) ?? Path.Combine(BasePath, "workspaces");
     }
 
-    private static string? NormalizeEnvHome(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
     /// <summary>
     /// Expands shell home tokens (<c>~</c>, <c>$HOME</c>, <c>${HOME}</c>,
-    /// <c>%USERPROFILE%</c>) in a configured path so values like
-    /// <c>~/repositories</c> resolve correctly when the daemon's CWD is not
-    /// the user's home directory. Inlined here (rather than reusing
-    /// <c>Netclaw.Security.PathUtility</c>) because <c>Netclaw.Configuration</c>
-    /// is the foundation project and cannot depend on Security.
+    /// <c>%USERPROFILE%</c>) in a configured path, also collapsing null and
+    /// whitespace-only input to <c>null</c> and trimming surrounding whitespace.
+    /// Inlined here rather than reusing <c>Netclaw.Security.PathUtility.ExpandHome</c>
+    /// because <c>Netclaw.Configuration</c> is the foundation project and cannot
+    /// depend on Security; the Security variant has no null/trim normalization.
     /// </summary>
     private static string? ExpandHome(string? value)
     {

--- a/src/Netclaw.Configuration/NetclawPaths.cs
+++ b/src/Netclaw.Configuration/NetclawPaths.cs
@@ -109,44 +109,12 @@ public sealed class NetclawPaths
 
     public NetclawPaths(string? basePath = null, string? workspacesDirectory = null)
     {
-        BasePath = ExpandHome(basePath)
-            ?? ExpandHome(Environment.GetEnvironmentVariable("NETCLAW_HOME"))
+        BasePath = PathExpansion.ExpandHome(basePath)
+            ?? PathExpansion.ExpandHome(Environment.GetEnvironmentVariable("NETCLAW_HOME"))
             ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".netclaw");
-        WorkspacesDirectory = ExpandHome(workspacesDirectory) ?? Path.Combine(BasePath, "workspaces");
-    }
-
-    /// <summary>
-    /// Expands shell home tokens (<c>~</c>, <c>$HOME</c>, <c>${HOME}</c>,
-    /// <c>%USERPROFILE%</c>) in a configured path, also collapsing null and
-    /// whitespace-only input to <c>null</c> and trimming surrounding whitespace.
-    /// Inlined here rather than reusing <c>Netclaw.Security.PathUtility.ExpandHome</c>
-    /// because <c>Netclaw.Configuration</c> is the foundation project and cannot
-    /// depend on Security; the Security variant has no null/trim normalization.
-    /// </summary>
-    private static string? ExpandHome(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-
-        var trimmed = value.Trim();
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (string.IsNullOrWhiteSpace(home))
-            return trimmed;
-
-        if (trimmed.StartsWith('~'))
-        {
-            trimmed = trimmed.Length == 1
-                ? home
-                : Path.Combine(home, trimmed[1..].TrimStart('/', '\\'));
-        }
-
-        trimmed = trimmed.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
-        trimmed = trimmed.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
-        trimmed = trimmed.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
-
-        return trimmed;
+        WorkspacesDirectory = PathExpansion.ExpandHome(workspacesDirectory) ?? Path.Combine(BasePath, "workspaces");
     }
 
     /// <summary>

--- a/src/Netclaw.Configuration/PathExpansion.cs
+++ b/src/Netclaw.Configuration/PathExpansion.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+// <copyright file="PathExpansion.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Single canonical home-token expander for configured path strings. Lives in
+/// <c>Netclaw.Configuration</c> (the foundation project) so both Configuration
+/// itself and downstream projects such as <c>Netclaw.Security</c> share one
+/// implementation; previously each project carried its own copy with subtly
+/// different behavior on Windows.
+/// </summary>
+public static class PathExpansion
+{
+    /// <summary>
+    /// Expands shell-style home tokens in <paramref name="value"/>:
+    /// <c>~</c> (alone or as a prefix), <c>$HOME</c>, <c>${HOME}</c>, and
+    /// <c>%USERPROFILE%</c> (all case-insensitive). Returns <c>null</c> for
+    /// <c>null</c> or whitespace-only input; otherwise returns the expanded
+    /// path with surrounding whitespace trimmed.
+    /// </summary>
+    /// <remarks>
+    /// When a token is actually replaced, the result has forward slashes
+    /// rewritten to <see cref="Path.DirectorySeparatorChar"/> so output is
+    /// consistent across the four token forms on Windows. Without this,
+    /// <c>~/x</c> goes through <see cref="Path.Combine(string, string)"/> and
+    /// emits a backslash, while <c>$HOME/x</c> goes through
+    /// <see cref="string.Replace(string, string?)"/> and keeps the literal
+    /// forward slash — producing visually inconsistent paths that break
+    /// equality comparisons against <c>Path.Combine</c>-built expectations.
+    /// Inputs that contain no tokens are returned verbatim (no separator
+    /// rewriting), preserving the established "absolute path unchanged"
+    /// contract used by security path callers.
+    /// </remarks>
+    public static string? ExpandHome(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var trimmed = value.Trim();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return trimmed;
+
+        var expanded = trimmed;
+
+        if (expanded.StartsWith('~'))
+        {
+            expanded = expanded.Length == 1
+                ? home
+                : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
+        }
+
+        expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
+        expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
+        expanded = expanded.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
+
+        // Only canonicalize separators when an expansion actually happened.
+        // string.Replace returns the same instance when no match is found, so
+        // ReferenceEquals reliably detects the no-op case and lets us return
+        // the original verbatim — which matters for callers that expect a
+        // path like "/absolute/path" to round-trip unchanged on Windows.
+        if (ReferenceEquals(expanded, trimmed))
+            return trimmed;
+
+        return expanded.Replace('/', Path.DirectorySeparatorChar);
+    }
+}

--- a/src/Netclaw.Security/PathUtility.cs
+++ b/src/Netclaw.Security/PathUtility.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Netclaw.Configuration;
+
 namespace Netclaw.Security;
 
 /// <summary>
@@ -110,33 +112,14 @@ public static class PathUtility
     }
 
     /// <summary>
-    /// Expands shell path tokens: ~, $HOME, ${HOME}, %USERPROFILE%.
-    /// Does not normalize the path.
+    /// Expands shell path tokens: ~, $HOME, ${HOME}, %USERPROFILE%. Does not
+    /// normalize the path. Delegates to <see cref="PathExpansion.ExpandHome"/>
+    /// so Configuration and Security share one canonical implementation;
+    /// preserves the historical non-null contract by passing through the
+    /// original input on whitespace-only values.
     /// </summary>
     public static string ExpandHome(string path)
-    {
-        var expanded = path;
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-        if (expanded.StartsWith('~'))
-        {
-            if (!string.IsNullOrWhiteSpace(home))
-            {
-                expanded = expanded.Length == 1
-                    ? home
-                    : Path.Combine(home, expanded[1..].TrimStart('/', '\\'));
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(home))
-        {
-            expanded = expanded.Replace("$HOME", home, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("${HOME}", home, StringComparison.OrdinalIgnoreCase);
-            expanded = expanded.Replace("%USERPROFILE%", home, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return expanded;
-    }
+        => PathExpansion.ExpandHome(path) ?? path;
 
     /// <summary>
     /// Expands shell path tokens and normalizes relative to working directory.


### PR DESCRIPTION
Closes #974

## Summary

- `PathUtility.Normalize` calls `Path.GetFullPath` directly, which on .NET does **not** expand `~`. When the daemon's CWD is not the user's home, a config root like `~/repositories` resolves to `<cwd>/~/repositories` and `ScopedFileAccessPolicy` rejects every real file under `<HOME>/…` as outside the configured roots.
- Fix is applied at the boundaries where raw config strings become resolved paths:
  - `ToolAudienceProfileResolver.ResolvePathToken` literal-path branch now returns `PathUtility.ExpandHome(trimmed)`, so per-audience `Roots` and `GlobalReadRoots` get `~`, `$HOME`, `${HOME}`, and `%USERPROFILE%` expanded before downstream normalization.
  - `NetclawPaths` constructor expands `basePath`, `workspacesDirectory`, and the `NETCLAW_HOME` env var via an inlined expander (Configuration is the foundation project and cannot reference Security).

## Why not centralize the expander?

`Netclaw.Security` already depends on `Netclaw.Configuration`, so `NetclawPaths` cannot call `PathUtility.ExpandHome`. The expander is duplicated inside `NetclawPaths` (~20 lines) rather than reorganizing the dependency graph. If we later want a single source of truth, the natural move is to push `ExpandHome` down into `Netclaw.Configuration`; deferred to keep this change minimal.

## Test plan

- [x] New `NetclawPathsTests` cases: `~`, `$HOME`, `${HOME}` in `workspacesDirectory`; `~` in `basePath`; `~` in `NETCLAW_HOME` env var.
- [x] New `ScopedFileAccessPolicyHomeExpansionTests`: tilde/$HOME/${HOME} in Personal write `Roots` resolve to `<HOME>/…`; a real path under `<HOME>/repositories` is allowed; an unrelated path is still rejected.
- [x] `dotnet test` for `Netclaw.Configuration.Tests` (293 pass) and `Netclaw.Actors.Tests` Tools filter (389 pass) — no regressions.
- [x] `dotnet slopwatch analyze` — 0 issues.
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all headers present.

## Not a security regression

Failure mode was denial of legitimate access, not unintended access. The gate erred on the side of refusing the operation. Fix loosens nothing; it simply makes user-home-relative roots resolve to their intended absolute paths.