### PR TITLE
fix(security): swap skill content scanner to NoOp to unblock system skills

### DIFF
--- a/src/Netclaw.Security.Tests/SecurityServiceExtensionsTests.cs
+++ b/src/Netclaw.Security.Tests/SecurityServiceExtensionsTests.cs
@@ -44,8 +44,12 @@ public sealed class SecurityServiceExtensionsTests
     }
 
     [Fact]
-    public void AddContentSecurity_registers_regex_skill_content_scanner()
+    public void AddContentSecurity_registers_noop_skill_content_scanner()
     {
+        // Skill content scanning is temporarily wired to the no-op until the
+        // regex detector is hardened against false positives on legitimate ops
+        // documentation. RegexSkillContentScanner remains exercised by its own
+        // unit tests so the implementation does not bit-rot.
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddContentSecurity();
@@ -53,6 +57,6 @@ public sealed class SecurityServiceExtensionsTests
         using var provider = services.BuildServiceProvider();
         var scanner = provider.GetRequiredService<ISkillContentScanner>();
 
-        Assert.IsType<RegexSkillContentScanner>(scanner);
+        Assert.IsType<NoOpSkillContentScanner>(scanner);
     }
 }

--- a/src/Netclaw.Security/SecurityServiceExtensions.cs
+++ b/src/Netclaw.Security/SecurityServiceExtensions.cs
@@ -19,7 +19,14 @@ public static class SecurityServiceExtensions
         services.AddSingleton<ContentPolicy>();
         services.AddSingleton<IContentScanner, MagicByteContentScanner>();
         services.AddSingleton<IPromptInjectionDetector, RegexPromptInjectionDetector>();
-        services.AddSingleton<ISkillContentScanner, RegexSkillContentScanner>();
+        // Skill content scanning is temporarily disabled (see netclaw-dev/netclaw issue
+        // for the hardening tracker): the regex detector false-positives on legitimate
+        // ops documentation — e.g. "re-enable after fixing the root cause" trips the
+        // PrivilegeEscalation pattern — and we re-scan trusted local skills at every
+        // skill_load invocation, which keeps reopening that false-positive surface.
+        // The RegexSkillContentScanner class is retained for tests and for the
+        // eventual re-enable once trust-tier / scanner hardening lands.
+        services.AddSingleton<ISkillContentScanner, NoOpSkillContentScanner>();
         return services;
     }
 


### PR DESCRIPTION
## Summary

- Wire `ISkillContentScanner` to `NoOpSkillContentScanner` so the daemon stops rejecting our own shipped system skills at `skill_load` time.
- Update the DI registration test to match.
- Tracking issue #976 captures the hardening work needed before we re-enable the regex scanner.

## Why

Session `D0AC6CKBK5K/1778196073.574119` failed with:

```
Skill 'netclaw-operations' blocked by content scan:
[PrivilegeEscalation] Unrestricted privilege grant attempt
```

`GrantAdminRegex` (`src/Netclaw.Security/RegexPromptInjectionDetector.cs:199`):

```regex
(grant|allow|enable)\b.{0,40}\b(admin|root|unrestricted|all\s+tools?|all\s+permissions?)
```

matched line 121 of `feeds/skills/.system/files/netclaw-operations/SKILL.md`:

> "operator can diagnose and re-enable after fixing the root cause."

`enable` + 22 chars + `root` — but the document means *root cause of a bug*, not *root user*. The 40-character gap between two common English words is wide enough to swallow ordinary ops prose.

Compounded by `SkillLoadTool.cs:117,149` re-scanning the file on every `skill_load` call, including skills sourced from our own signed manifest under `~/.netclaw/skills/.system/`.

`RegexSkillContentScanner` and `RegexPromptInjectionDetector` remain in the repo and remain unit-tested so they don't bit-rot. Attachment-side `MagicByteContentScanner` is unchanged.

## Test plan

- [x] `dotnet test src/Netclaw.Security.Tests/Netclaw.Security.Tests.csproj` — 534/534 passing
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [ ] CI green on this PR

Closes part of #976 (the immediate unblock). The full hardening work stays tracked in #976.