### PR TITLE
feat(serialization): marker interface + test-time verification (closes #961)

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -95,11 +95,9 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         services.AddSingleton(new SessionObservability(null, null));
     }
 
-    // serialize-messages = on interacts poorly with Akka.Streams (the channel output
-    // pipeline) — stream stage internals stop delivering output messages, not for
-    // serialization reasons but because of dispatch behavior under verification.
-    // Verification stays off here until the Akka.Streams interop is investigated.
-    // The session-side regression net is covered by LlmSessionTestBase derivatives.
+    // serialize-messages = on causes the Akka.Streams channel output pipeline to stop
+    // delivering messages — no SerializationException, just silently dropped output.
+    // Verification stays off until the Akka.Streams interop is investigated separately.
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         builder

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -20,6 +20,7 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Tests.Hosting;
 using Netclaw.Actors.Tests.Sessions;
 using Netclaw.Channels.Slack;
 using Netclaw.Configuration;
@@ -94,6 +95,11 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
         services.AddSingleton(new SessionObservability(null, null));
     }
 
+    // serialize-messages = on interacts poorly with Akka.Streams (the channel output
+    // pipeline) — stream stage internals stop delivering output messages, not for
+    // serialization reasons but because of dispatch behavior under verification.
+    // Verification stays off here until the Akka.Streams interop is investigated.
+    // The session-side regression net is covered by LlmSessionTestBase derivatives.
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         builder

--- a/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensions.cs
+++ b/src/Netclaw.Actors.Tests/Hosting/TestAkkaExtensions.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestAkkaExtensions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Hosting;
+
+namespace Netclaw.Actors.Tests.Hosting;
+
+internal static class TestAkkaExtensions
+{
+    /// <summary>
+    /// Turns on Akka's local-message serialization verification (`serialize-messages = on`).
+    /// In combination with <c>WithStrictSerialization</c> (set by
+    /// <c>WithNetclawSerialization</c>) this fails loudly when a type that crosses
+    /// the actor boundary has neither <c>INetclawSerializableMessage</c> nor
+    /// <c>INoSerializationVerificationNeeded</c> — that loud failure is the
+    /// regression net for missing serializer bindings on new persisted types.
+    ///
+    /// Third-party library types we don't own (Akka.Reminders internals, Akka system
+    /// messages, Akka.Persistence permit/permit-return envelopes, Akka.Streams
+    /// stage protocol) get an explicit JSON binding here so verification doesn't
+    /// false-positive on them. Add new entries as integration tests surface them.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithSerializationVerification(
+        this AkkaConfigurationBuilder builder) =>
+        builder.AddHocon(
+            """
+            akka.actor {
+                serialize-messages = on
+                serialization-bindings {
+                    "Akka.Actor.ActorIdentity, Akka" = json
+                    "Akka.Actor.Identify, Akka" = json
+                    "Akka.Actor.ReceiveTimeout, Akka" = json
+                    "Akka.Dispatch.SysMsg.StopChild, Akka" = json
+                    "Akka.Persistence.Journal.AsyncWriteJournal+Desequenced, Akka.Persistence" = json
+                    "Akka.Persistence.RecoveryPermitGranted, Akka.Persistence" = json
+                    "Akka.Persistence.RequestRecoveryPermit, Akka.Persistence" = json
+                    "Akka.Persistence.ReturnRecoveryPermit, Akka.Persistence" = json
+                    "Akka.Reminders.ReminderProtocol+CancelReminder, Akka.Reminders" = json
+                    "Akka.Reminders.ReminderProtocol+GetReminders, Akka.Reminders" = json
+                    "Akka.Reminders.ReminderScheduler+FlushBufferedAcks, Akka.Reminders" = json
+                    "Akka.Reminders.ReminderScheduler+InitResult, Akka.Reminders" = json
+                }
+            }
+            """,
+            HoconAddMode.Append);
+}

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -152,14 +152,14 @@ public class ChatMessageConverterTests
         {
             Role = ChatRole.Assistant,
             ToolCalls =
-            {
+            [
                 new SerializableToolCall
                 {
                     CallId = "call-1",
                     Name = "web_search",
                     ArgumentsJson = """{"query":"test"}"""
                 }
-            }
+            ]
         };
 
         var ai = ChatMessageConverter.ToAiMessage(msg);
@@ -254,14 +254,14 @@ public class ChatMessageConverterTests
             Role = ChatRole.User,
             Content = "Look at this",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "test.jpg",
                     MimeType = "image/jpeg",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         };
 
         var ai = ChatMessageConverter.ToAiMessage(msg, sessionDir: tempDir.Path);
@@ -309,14 +309,14 @@ public class ChatMessageConverterTests
             Role = ChatRole.User,
             Content = "Image was deleted",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "nonexistent.png",
                     MimeType = "image/png",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         };
 
         var ai = ChatMessageConverter.ToAiMessage(msg, sessionDir: tempDir.Path);

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -178,7 +178,7 @@ public sealed class SerializationRoundTripTests : TestKit
             Role = ChatRole.User,
             Content = "Check this image",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "abc123.png",
@@ -191,7 +191,7 @@ public sealed class SerializationRoundTripTests : TestKit
                     MimeType = "image/jpeg",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         };
 
         var result = RoundTrip(original);
@@ -214,14 +214,14 @@ public sealed class SerializationRoundTripTests : TestKit
             SessionId = new SessionId("C99999/1708531200.000100"),
             Content = "Look at this",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "photo.png",
                     MimeType = "image/png",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         };
 
         var result = RoundTrip(original);
@@ -324,7 +324,7 @@ public sealed class SerializationRoundTripTests : TestKit
         {
             Role = ChatRole.Assistant,
             ToolCalls =
-            {
+            [
                 new SerializableToolCall
                 {
                     CallId = "call-1",
@@ -332,7 +332,7 @@ public sealed class SerializationRoundTripTests : TestKit
                     ArgumentsJson = """{"Command":"dotnet test"}""",
                     MetaJson = """{"rationale":"running tests","timeout_seconds":300}"""
                 }
-            }
+            ]
         };
 
         var result = RoundTrip(original);
@@ -351,14 +351,14 @@ public sealed class SerializationRoundTripTests : TestKit
         {
             Role = ChatRole.Assistant,
             ToolCalls =
-            {
+            [
                 new SerializableToolCall
                 {
                     CallId = "call-1",
                     Name = "web_search",
                     ArgumentsJson = """{"query":"test"}"""
                 }
-            }
+            ]
         };
 
         var result = RoundTrip(original);

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -13,6 +13,7 @@ using Netclaw.Actors.Channels;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Reminders;
+using Netclaw.Actors.Tests.Hosting;
 using Netclaw.Configuration;
 using Xunit;
 
@@ -31,7 +32,8 @@ public class ReminderManagerActorTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
-            .WithNetclawSerialization();
+            .WithNetclawSerialization()
+            .WithSerializationVerification();
 
         var paths = new NetclawPaths(_basePath);
         paths.EnsureDirectoriesExist();

--- a/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/SetReminderToolTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Time.Testing;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Channels;
 using Netclaw.Actors.Reminders;
+using Netclaw.Actors.Tests.Hosting;
 using Netclaw.Configuration;
 using Netclaw.Tools;
 using Xunit;
@@ -29,7 +30,8 @@ public class SetReminderToolTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
-            .WithNetclawSerialization();
+            .WithNetclawSerialization()
+            .WithSerializationVerification();
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/CompactionPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/CompactionPromptBuilderTests.cs
@@ -37,14 +37,14 @@ public class CompactionPromptBuilderTests
                 Role = ChatRole.Assistant,
                 Content = "Let me search",
                 ToolCalls =
-                {
+                [
                     new SerializableToolCall
                     {
                         CallId = "call-1",
                         Name = "web_search",
                         ArgumentsJson = """{"query": "netclaw docs"}"""
                     }
-                }
+                ]
             }
         };
 
@@ -73,7 +73,7 @@ public class CompactionPromptBuilderTests
             {
                 Role = ChatRole.Assistant,
                 ToolCalls =
-                {
+                [
                     new SerializableToolCall
                     {
                         CallId = "call-1",
@@ -81,7 +81,7 @@ public class CompactionPromptBuilderTests
                         ArgumentsJson = """{"Command":"dotnet test"}""",
                         MetaJson = meta.ToJson()
                     }
-                }
+                ]
             }
         };
 
@@ -100,14 +100,14 @@ public class CompactionPromptBuilderTests
             {
                 Role = ChatRole.Assistant,
                 ToolCalls =
-                {
+                [
                     new SerializableToolCall
                     {
                         CallId = "call-1",
                         Name = "web_search",
                         ArgumentsJson = """{"query":"test"}"""
                     }
-                }
+                ]
             }
         };
 

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -34,6 +34,8 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
     private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.Parse("2026-03-21T12:00:00Z"));
     private readonly RecordingSessionLifecycleObserver _lifecycleObserver = new();
 
+    protected override bool VerifySerialization => true;
+
     public LlmSessionIntegrationTests(ITestOutputHelper output) : base(output)
     {
     }

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionTestBase.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Tests.Hosting;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Tests.Sessions;
@@ -18,13 +19,26 @@ public abstract class LlmSessionTestBase : TestKit
 {
     protected LlmSessionTestBase(ITestOutputHelper output) : base(output: output) { }
 
+    /// <summary>
+    /// Derived classes that want serialize-messages verification on top of the
+    /// shared session pipeline override this to true. Default off because some
+    /// derived tests exercise code paths (Akka.Streams stages, vision flows,
+    /// sub-agent spawning) where serialize-messages = on causes dispatch issues
+    /// unrelated to the marker scheme.
+    /// </summary>
+    protected virtual bool VerifySerialization => false;
+
     protected sealed override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
-            .WithNetclawSerialization()
-            .WithNetclawActors();
+            .WithNetclawSerialization();
+
+        if (VerifySerialization)
+            builder.WithSerializationVerification();
+
+        builder.WithNetclawActors();
     }
 
     protected sealed override void ConfigureServices(HostBuilderContext context, IServiceCollection services)

--- a/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModalityGateTests.cs
@@ -70,14 +70,14 @@ public class ModalityGateTextOnlyTests : LlmSessionTestBase
             SessionId = sessionId,
             Content = "What is in this picture?",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "photo.png",
                     MimeType = "image/png",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // The first output is the LLM response itself — there is no longer a
@@ -120,14 +120,14 @@ public class ModalityGateTextOnlyTests : LlmSessionTestBase
             SessionId = sessionId,
             Content = "",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "photo.png",
                     MimeType = "image/png",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var reply = await subscriber.ExpectMsgAsync<TextOutput>(cancellationToken: TestContext.Current.CancellationToken);
@@ -194,14 +194,14 @@ public class ModalityGateVisionTests : LlmSessionTestBase
             SessionId = sessionId,
             Content = "Describe this image",
             MediaReferences =
-            {
+            [
                 new SerializableMediaReference
                 {
                     RelativePath = "photo.png",
                     MimeType = "image/png",
                     Modality = (int)MediaModality.Image
                 }
-            }
+            ]
         }, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Should NOT receive an "images removed" acknowledgement — go straight to LLM response

--- a/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionMemoryObserverActorTests.cs
@@ -12,6 +12,7 @@ using Netclaw.Actors.Hosting;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Sessions;
+using Netclaw.Actors.Tests.Hosting;
 using VerifyXunit;
 using Xunit;
 
@@ -30,7 +31,8 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         builder
             .WithInMemoryJournal()
             .WithInMemorySnapshotStore()
-            .WithNetclawSerialization();
+            .WithNetclawSerialization()
+            .WithSerializationVerification();
     }
 
     /// <summary>
@@ -852,7 +854,7 @@ public sealed class SessionMemoryObserverActorTests : TestKit
         }
     }
 
-    private sealed class GetChild
+    private sealed class GetChild : INoSerializationVerificationNeeded
     {
         public static readonly GetChild Instance = new();
     }

--- a/src/Netclaw.Actors.Tests/Sessions/SessionStateCompactionTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionStateCompactionTests.cs
@@ -196,14 +196,14 @@ public class SessionStateCompactionTests
                     Role = ChatRole.Assistant,
                     Content = string.Empty,
                     ToolCalls =
-                    {
+                    [
                         new SerializableToolCall
                         {
                             CallId = $"call-{i}",
                             Name = "web_search",
                             ArgumentsJson = $"{{\"query\":\"query {i}\"}}"
                         }
-                    }
+                    ]
                 })
             };
 

--- a/src/Netclaw.Actors/Channels/CursorAdvanced.cs
+++ b/src/Netclaw.Actors/Channels/CursorAdvanced.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Serialization;
+
 namespace Netclaw.Actors.Channels;
 
 /// <summary>
@@ -10,4 +12,4 @@ namespace Netclaw.Actors.Channels;
 /// The cursor value is channel-specific (e.g. Slack timestamp, Discord snowflake)
 /// but serialized as an opaque string — only the owning actor interprets it.
 /// </summary>
-public readonly record struct CursorAdvanced(string Cursor);
+public readonly record struct CursorAdvanced(string Cursor) : INetclawSerializableMessage;

--- a/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
+++ b/src/Netclaw.Actors/Hosting/NetclawAkkaHostingExtensions.cs
@@ -187,39 +187,19 @@ public static class NetclawAkkaHostingExtensions
 
     /// <summary>
     /// Configures Google Protobuf serialization for Netclaw protocol types.
-    /// Wire format defined in <c>netclaw_messages.proto</c>; our serializer throws
-    /// for unregistered manifests to fail loudly on schema drift.
+    /// Binds <see cref="INetclawSerializableMessage"/> to
+    /// <see cref="NetclawProtobufSerializer"/>; every implementing type is routed
+    /// to the proto serializer. Types that implement the marker but lack a
+    /// manifest in <see cref="NetclawProtobufSerializer"/> throw at the first
+    /// serialize call — that loud failure is the regression signal.
     /// </summary>
     public static AkkaConfigurationBuilder WithNetclawSerialization(
         this AkkaConfigurationBuilder builder)
     {
-        var boundTypes = new[]
-        {
-            typeof(SessionId),
-            typeof(SendUserMessage),
-            typeof(SerializableChatMessage),
-            typeof(SerializableMediaReference),
-            typeof(SerializableToolCall),
-            typeof(TurnRecorded),
-            typeof(SessionTitleSet),
-            typeof(SessionCompacted),
-            typeof(SessionSnapshot),
-            typeof(TurnBroadcast),
-            typeof(CompactionBroadcast),
-            typeof(WorkingContext),
-            typeof(ReminderId),
-            typeof(ReminderDelivery),
-            typeof(ReminderSchedule),
-            typeof(ReminderPayload),
-            typeof(AdoptedContextRecorded),
-            typeof(Channels.CursorAdvanced),
-            typeof(MemoriesDistilledV2),
-        };
-
         return builder
             .WithCustomSerializer(
                 serializerIdentifier: "netclaw-protobuf",
-                boundTypes: boundTypes,
+                boundTypes: new[] { typeof(INetclawSerializableMessage) },
                 serializerFactory: system => new NetclawProtobufSerializer(system))
             .WithStrictSerialization();
     }

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -356,7 +356,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
                output + filePath;
     }
 
-    private sealed record Reconcile
+    private sealed record Reconcile : INoSerializationVerificationNeeded
     {
         public static readonly Reconcile Instance = new();
     }

--- a/src/Netclaw.Actors/Protocol/Broadcasts.cs
+++ b/src/Netclaw.Actors/Protocol/Broadcasts.cs
@@ -3,19 +3,21 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Serialization;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Published via Akka pub/sub after a session completes a turn.
 /// Adapters subscribe to deliver replies through their respective channels.
 /// </summary>
-public sealed class TurnBroadcast
+public sealed record TurnBroadcast : INetclawSerializableMessage
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public SerializableChatMessage AssistantReply { get; set; } = new();
+    public SerializableChatMessage AssistantReply { get; init; } = new();
 
-    public long BroadcastAtMs { get; set; }
+    public long BroadcastAtMs { get; init; }
 
     public DateTimeOffset BroadcastAt => DateTimeOffset.FromUnixTimeMilliseconds(BroadcastAtMs);
 }
@@ -23,13 +25,13 @@ public sealed class TurnBroadcast
 /// <summary>
 /// Published via Akka pub/sub after a session completes compaction.
 /// </summary>
-public sealed class CompactionBroadcast
+public sealed record CompactionBroadcast : INetclawSerializableMessage
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public string Summary { get; set; } = string.Empty;
+    public string Summary { get; init; } = string.Empty;
 
-    public long CompactedAtMs { get; set; }
+    public long CompactedAtMs { get; init; }
 
     public DateTimeOffset CompactedAt => DateTimeOffset.FromUnixTimeMilliseconds(CompactedAtMs);
 }

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -103,27 +103,26 @@ public static class ChatMessageConverter
             : msg.Role == AiChatRole.Tool ? ChatRole.Tool
             : ChatRole.User;
 
-        var result = new SerializableChatMessage
-        {
-            Role = role,
-            Content = string.Empty
-        };
+        var content = string.Empty;
+        var toolCalls = new List<SerializableToolCall>();
+        var mediaRefs = new List<SerializableMediaReference>();
+        string? toolCallId = null;
 
         // Extract structured content
-        foreach (var content in msg.Contents)
+        foreach (var c in msg.Contents)
         {
-            switch (content)
+            switch (c)
             {
                 case TextContent text:
                     // Append text (there may be text alongside tool calls)
-                    result.Content = string.IsNullOrEmpty(result.Content)
+                    content = string.IsNullOrEmpty(content)
                         ? text.Text ?? string.Empty
-                        : result.Content + (text.Text ?? string.Empty);
+                        : content + (text.Text ?? string.Empty);
                     break;
 
                 case FunctionCallContent toolCall:
                     var (meta, cleanArgs) = ExtractMeta(toolCall.Arguments);
-                    result.ToolCalls.Add(new SerializableToolCall
+                    toolCalls.Add(new SerializableToolCall
                     {
                         CallId = toolCall.CallId,
                         Name = toolCall.Name,
@@ -135,26 +134,33 @@ public static class ChatMessageConverter
                     break;
 
                 case FunctionResultContent toolResult:
-                    result.ToolCallId = toolResult.CallId;
-                    result.Content = toolResult.Result?.ToString() ?? string.Empty;
+                    toolCallId = toolResult.CallId;
+                    content = toolResult.Result?.ToString() ?? string.Empty;
                     break;
 
                 case DataContent data when sessionDir is not null:
                     var mediaRef = WriteMediaToSession(data, sessionDir);
                     if (mediaRef is not null)
-                        result.MediaReferences.Add(mediaRef);
+                        mediaRefs.Add(mediaRef);
                     break;
             }
         }
 
         // Fallback: if no structured content was found, use .Text
-        if (string.IsNullOrEmpty(result.Content) && result.ToolCalls.Count == 0
-            && result.ToolCallId is null && result.MediaReferences.Count == 0)
+        if (string.IsNullOrEmpty(content) && toolCalls.Count == 0
+            && toolCallId is null && mediaRefs.Count == 0)
         {
-            result.Content = msg.Text ?? string.Empty;
+            content = msg.Text ?? string.Empty;
         }
 
-        return result;
+        return new SerializableChatMessage
+        {
+            Role = role,
+            Content = content,
+            ToolCalls = toolCalls,
+            ToolCallId = toolCallId,
+            MediaReferences = mediaRefs
+        };
     }
 
     private static SerializableMediaReference? WriteMediaToSession(DataContent data, string sessionDir)

--- a/src/Netclaw.Actors/Protocol/CommandResponses.cs
+++ b/src/Netclaw.Actors/Protocol/CommandResponses.cs
@@ -3,13 +3,15 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Acknowledged receipt of a command by the session actor.
 /// The command has been accepted and will be processed.
 /// </summary>
-public sealed record CommandAck
+public sealed record CommandAck : INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 
@@ -19,7 +21,7 @@ public sealed record CommandAck
 /// <summary>
 /// Negative acknowledgement — the command was rejected.
 /// </summary>
-public sealed record CommandNack
+public sealed record CommandNack : INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -1,30 +1,38 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Commands.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Actors.Channels;
+using Netclaw.Actors.Serialization;
 
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
-/// Command delivering user input to a session actor.
+/// Command delivering user input to a session actor. The proto mapping in
+/// <see cref="NetclawProtoMapper"/> intentionally drops <see cref="Source"/>
+/// (it's ephemeral channel metadata, not part of the persisted/wire form),
+/// so the local-dispatch path skips serialization via
+/// <see cref="INoSerializationVerificationNeeded"/> to preserve <c>Source</c>
+/// for in-process consumers (e.g. session-actor reminder dedup).
 /// </summary>
-public sealed class SendUserMessage : IWithSessionId
+public sealed record SendUserMessage : IWithSessionId, INetclawSerializableMessage, INoSerializationVerificationNeeded
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public string Content { get; set; } = string.Empty;
+    public string Content { get; init; } = string.Empty;
 
     /// <summary>
     /// Media references (images, audio, etc.) attached to this message.
     /// </summary>
-    public List<SerializableMediaReference> MediaReferences { get; set; } = [];
+    public IReadOnlyList<SerializableMediaReference> MediaReferences { get; init; } =
+        Array.Empty<SerializableMediaReference>();
 
     /// <summary>
     /// Ephemeral channel metadata for ACL/audit. Not persisted.
     /// </summary>
-    public MessageSource? Source { get; set; }
+    public MessageSource? Source { get; init; }
 }
 
 /// <summary>
@@ -42,14 +50,14 @@ public sealed class SendUserMessage : IWithSessionId
 public sealed record DeliverTrustedSessionTurn(
     SessionId SessionId,
     string Content,
-    Channels.MessageSource Source) : IWithSessionId;
+    Channels.MessageSource Source) : IWithSessionId, INoSerializationVerificationNeeded;
 
 /// <summary>
 /// User's response to a <see cref="ToolInteractionRequest"/>.
 /// Routed from the channel adapter to the session actor to complete the
 /// blocked tool's <see cref="System.Threading.Tasks.TaskCompletionSource{T}"/>.
 /// </summary>
-public sealed class ToolInteractionResponse : IWithSessionId
+public sealed record ToolInteractionResponse : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
+++ b/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
@@ -23,7 +25,7 @@ public enum DeliveryFailureKind
 /// Sent by a channel adapter when the session's output could not be delivered.
 /// The session can use this structured feedback to decide whether to retry.
 /// </summary>
-public sealed record DeliveryFailed : IWithSessionId
+public sealed record DeliveryFailed : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/Events.cs
+++ b/src/Netclaw.Actors/Protocol/Events.cs
@@ -3,20 +3,22 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Serialization;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Persisted event recording a completed turn (user message + assistant reply).
 /// </summary>
-public sealed class TurnRecorded
+public sealed record TurnRecorded : INetclawSerializableMessage
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public SerializableChatMessage UserMessage { get; set; } = new();
+    public SerializableChatMessage UserMessage { get; init; } = new();
 
-    public SerializableChatMessage AssistantReply { get; set; } = new();
+    public SerializableChatMessage AssistantReply { get; init; } = new();
 
-    public long RecordedAtMs { get; set; }
+    public long RecordedAtMs { get; init; }
 
     /// <summary>
     /// Populated when this turn originated from a reminder firing.
@@ -27,7 +29,7 @@ public sealed class TurnRecorded
     /// (<see cref="Sessions.SessionState.ProcessedReminderIds"/>) from
     /// event replay.
     /// </summary>
-    public string? SourceReminderId { get; set; }
+    public string? SourceReminderId { get; init; }
 
     /// <summary>
     /// Populated when this turn originated from a background job result delivery.
@@ -35,47 +37,47 @@ public sealed class TurnRecorded
     /// <see cref="Channels.MessageSource.BackgroundJobId"/> by the
     /// background job manager. Null for regular user turns.
     /// </summary>
-    public string? SourceBackgroundJobId { get; set; }
+    public string? SourceBackgroundJobId { get; init; }
 
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
 }
 
-public sealed class AdoptedContextRecorded
+public sealed record AdoptedContextRecorded : INetclawSerializableMessage
 {
-    public sealed class AdoptedMessageRecord
+    public sealed record AdoptedMessageRecord
     {
-        public string MessageId { get; set; } = string.Empty;
+        public string MessageId { get; init; } = string.Empty;
 
-        public string SenderId { get; set; } = string.Empty;
+        public string SenderId { get; init; } = string.Empty;
 
-        public long TimestampMs { get; set; }
+        public long TimestampMs { get; init; }
 
-        public string AuthorityAtInclusion { get; set; } = string.Empty;
+        public string AuthorityAtInclusion { get; init; } = string.Empty;
     }
 
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public string AuthorizedMessageId { get; set; } = string.Empty;
+    public string AuthorizedMessageId { get; init; } = string.Empty;
 
-    public string? AuthorizerSenderId { get; set; }
+    public string? AuthorizerSenderId { get; init; }
 
-    public string? LowerBound { get; set; }
+    public string? LowerBound { get; init; }
 
-    public string? UpperBound { get; set; }
+    public string? UpperBound { get; init; }
 
-    public string Projection { get; set; } = string.Empty;
+    public string Projection { get; init; } = string.Empty;
 
-    public bool HasAdoptedContext { get; set; }
+    public bool HasAdoptedContext { get; init; }
 
-    public bool HasThirdPartyAdoptedContext { get; set; }
+    public bool HasThirdPartyAdoptedContext { get; init; }
 
-    public List<string> AdoptedSpeakerIds { get; set; } = [];
+    public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = Array.Empty<string>();
 
-    public List<AdoptedMessageRecord> Messages { get; set; } = [];
+    public IReadOnlyList<AdoptedMessageRecord> Messages { get; init; } = Array.Empty<AdoptedMessageRecord>();
 
-    public bool ProjectionPersisted { get; set; }
+    public bool ProjectionPersisted { get; init; }
 
-    public long RecordedAtMs { get; set; }
+    public long RecordedAtMs { get; init; }
 
     public DateTimeOffset RecordedAt => DateTimeOffset.FromUnixTimeMilliseconds(RecordedAtMs);
 }
@@ -83,13 +85,13 @@ public sealed class AdoptedContextRecorded
 /// <summary>
 /// Persisted event recording that the session title was set or updated.
 /// </summary>
-public sealed class SessionTitleSet
+public sealed record SessionTitleSet : INetclawSerializableMessage
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public string Title { get; set; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
 
-    public long SetAtMs { get; set; }
+    public long SetAtMs { get; init; }
 
     public DateTimeOffset SetAt => DateTimeOffset.FromUnixTimeMilliseconds(SetAtMs);
 }
@@ -98,17 +100,18 @@ public sealed class SessionTitleSet
 /// Persisted event recording that a session's conversation history was compacted.
 /// A snapshot is also taken after this event to avoid replaying the full journal.
 /// </summary>
-public sealed class SessionCompacted
+public sealed record SessionCompacted : INetclawSerializableMessage
 {
-    public SessionId SessionId { get; set; }
+    public SessionId SessionId { get; init; }
 
-    public string Summary { get; set; } = string.Empty;
+    public string Summary { get; init; } = string.Empty;
 
-    public List<SerializableChatMessage> CompactedMessages { get; set; } = [];
+    public IReadOnlyList<SerializableChatMessage> CompactedMessages { get; init; } =
+        Array.Empty<SerializableChatMessage>();
 
-    public int TurnCountBefore { get; set; }
+    public int TurnCountBefore { get; init; }
 
-    public long CompactedAtMs { get; set; }
+    public long CompactedAtMs { get; init; }
 
     /// <summary>
     /// Updated working-context state carried on the event so
@@ -116,7 +119,7 @@ public sealed class SessionCompacted
     /// preserve it across compaction. Null means "no update — retain
     /// the existing <see cref="Sessions.WorkingContext"/> unchanged."
     /// </summary>
-    public Sessions.WorkingContext? WorkingContext { get; set; }
+    public Sessions.WorkingContext? WorkingContext { get; init; }
 
     public DateTimeOffset CompactedAt => DateTimeOffset.FromUnixTimeMilliseconds(CompactedAtMs);
 }

--- a/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
+++ b/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Protocol;
@@ -10,7 +11,7 @@ namespace Netclaw.Actors.Protocol;
 /// <summary>
 /// Query the <see cref="ModelCapabilityActor"/> for a model's capabilities.
 /// </summary>
-public sealed record GetModelCapabilities(string ModelId);
+public sealed record GetModelCapabilities(string ModelId) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Response from the capability cache containing resolved modalities.
@@ -18,7 +19,7 @@ public sealed record GetModelCapabilities(string ModelId);
 public sealed record ModelCapabilitiesResponse(
     string ModelId,
     ModelModality InputModalities,
-    ModelModality OutputModalities);
+    ModelModality OutputModalities) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Internal message piped back from async resolution to the actor.
@@ -27,4 +28,4 @@ internal sealed record CapabilityResolved(
     string ModelId,
     ModelModality InputModalities,
     ModelModality OutputModalities,
-    bool Success);
+    bool Success) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -3,52 +3,56 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Serialization;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Persistence-safe representation of a chat message.
 /// Never persist Microsoft.Extensions.AI types directly — use this instead.
 /// </summary>
-public sealed class SerializableChatMessage
+public sealed record SerializableChatMessage : INetclawSerializableMessage
 {
-    public ChatRole Role { get; set; }
+    public ChatRole Role { get; init; }
 
-    public string Content { get; set; } = string.Empty;
+    public string Content { get; init; } = string.Empty;
 
     /// <summary>Optional name (used for tool results: the tool function name).</summary>
-    public string? Name { get; set; }
+    public string? Name { get; init; }
 
     /// <summary>
     /// Tool calls requested by the assistant. Present when role is Assistant
     /// and the LLM wants to invoke tools.
     /// </summary>
-    public List<SerializableToolCall> ToolCalls { get; set; } = [];
+    public IReadOnlyList<SerializableToolCall> ToolCalls { get; init; } =
+        Array.Empty<SerializableToolCall>();
 
     /// <summary>
     /// The tool call ID this message is a result for. Present when role is Tool.
     /// </summary>
-    public string? ToolCallId { get; set; }
+    public string? ToolCallId { get; init; }
 
     /// <summary>
     /// Media references (images, audio, etc.) attached to this message.
     /// Stored as relative paths within the session media directory.
     /// </summary>
-    public List<SerializableMediaReference> MediaReferences { get; set; } = [];
+    public IReadOnlyList<SerializableMediaReference> MediaReferences { get; init; } =
+        Array.Empty<SerializableMediaReference>();
 }
 
 /// <summary>
 /// Persistence-safe reference to a media file stored in the session directory.
 /// </summary>
-public sealed class SerializableMediaReference
+public sealed record SerializableMediaReference : INetclawSerializableMessage
 {
     /// <summary>Relative path within the session media directory.</summary>
-    public string RelativePath { get; set; } = string.Empty;
+    public string RelativePath { get; init; } = string.Empty;
 
     /// <summary>MIME type of the media (e.g. "image/png").</summary>
-    public string MimeType { get; set; } = string.Empty;
+    public string MimeType { get; init; } = string.Empty;
 
     /// <summary>Content modality as integer for wire safety (maps to <see cref="MediaModality"/>).</summary>
-    public int Modality { get; set; }
+    public int Modality { get; init; }
 }
 
 /// <summary>
@@ -65,19 +69,19 @@ public enum MediaModality
 /// <summary>
 /// Persistence-safe representation of a single tool call from the assistant.
 /// </summary>
-public sealed class SerializableToolCall
+public sealed record SerializableToolCall : INetclawSerializableMessage
 {
-    public string CallId { get; set; } = string.Empty;
+    public string CallId { get; init; } = string.Empty;
 
-    public string Name { get; set; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 
-    public string ArgumentsJson { get; set; } = string.Empty;
+    public string ArgumentsJson { get; init; } = string.Empty;
 
     /// <summary>
     /// Opaque JSON envelope for per-call metadata (rationale, timeout hint, background flag).
     /// Null for legacy tool calls persisted before metadata support was added.
     /// </summary>
-    public string? MetaJson { get; set; }
+    public string? MetaJson { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Protocol/SessionContext.cs
+++ b/src/Netclaw.Actors/Protocol/SessionContext.cs
@@ -3,13 +3,15 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Installs additive session-scoped prompt context without replacing the base
 /// system prompt assembled from identity files.
 /// </summary>
-public sealed record SetSessionPromptOverlay : IWithSessionId
+public sealed record SetSessionPromptOverlay : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionId.cs
+++ b/src/Netclaw.Actors/Protocol/SessionId.cs
@@ -3,13 +3,15 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Serialization;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Strongly-typed session identity. Wraps the entity key string used for
 /// actor routing and persistence identity.
 /// </summary>
-public readonly record struct SessionId(string Value)
+public readonly record struct SessionId(string Value) : INetclawSerializableMessage
 {
     public static explicit operator SessionId(string value) => new(value);
 

--- a/src/Netclaw.Actors/Protocol/SessionLogDiagnostic.cs
+++ b/src/Netclaw.Actors/Protocol/SessionLogDiagnostic.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Protocol;
@@ -14,7 +15,7 @@ namespace Netclaw.Actors.Protocol;
 /// it here so the dispatcher routes the line by message field, not by
 /// any ambient context that would not flow across actor mailboxes.
 /// </summary>
-public sealed record SessionLogDiagnostic : IWithSessionId
+public sealed record SessionLogDiagnostic : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Configuration;
 using Netclaw.Security;
 
@@ -18,7 +19,7 @@ namespace Netclaw.Actors.Protocol;
 ///   <see cref="SessionTitleOutput"/>) are always delivered.
 /// - Content messages require the matching flag in the subscriber's filter.
 /// </summary>
-public abstract record SessionOutput : IWithSessionId
+public abstract record SessionOutput : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
+++ b/src/Netclaw.Actors/Protocol/SessionRestartControl.cs
@@ -3,12 +3,14 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
+
 namespace Netclaw.Actors.Protocol;
 
 /// <summary>
 /// Requests that a live session stop accepting new work and passivate for coordinated daemon restart.
 /// </summary>
-public sealed record PrepareForDaemonRestart : IWithSessionId
+public sealed record PrepareForDaemonRestart : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 
@@ -18,7 +20,7 @@ public sealed record PrepareForDaemonRestart : IWithSessionId
 /// <summary>
 /// Rehydrates a session after coordinated daemon restart and primes a one-turn continuity notice.
 /// </summary>
-public sealed record WarmSession : IWithSessionId
+public sealed record WarmSession : IWithSessionId, INoSerializationVerificationNeeded
 {
     public required SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Netclaw.Actors.Jobs;
+using Netclaw.Actors.Serialization;
 using Netclaw.Actors.Sessions;
 
 namespace Netclaw.Actors.Protocol;
@@ -12,67 +13,71 @@ namespace Netclaw.Actors.Protocol;
 /// Snapshot of session state for fast recovery. Persisted after compaction
 /// and periodically based on <see cref="Sessions.SessionConfig.SnapshotInterval"/>.
 /// </summary>
-public sealed class SessionSnapshot
+public sealed record SessionSnapshot : INetclawSerializableMessage
 {
-    public sealed class AdoptedContextSnapshotRecord
+    public sealed record AdoptedContextSnapshotRecord
     {
-        public sealed class AdoptedContextSnapshotMessage
+        public sealed record AdoptedContextSnapshotMessage
         {
-            public string MessageId { get; set; } = string.Empty;
+            public string MessageId { get; init; } = string.Empty;
 
-            public string SenderId { get; set; } = string.Empty;
+            public string SenderId { get; init; } = string.Empty;
 
-            public long TimestampMs { get; set; }
+            public long TimestampMs { get; init; }
 
-            public string AuthorityAtInclusion { get; set; } = string.Empty;
+            public string AuthorityAtInclusion { get; init; } = string.Empty;
         }
 
-        public string AuthorizedMessageId { get; set; } = string.Empty;
+        public string AuthorizedMessageId { get; init; } = string.Empty;
 
-        public string? AuthorizerSenderId { get; set; }
+        public string? AuthorizerSenderId { get; init; }
 
-        public string? LowerBound { get; set; }
+        public string? LowerBound { get; init; }
 
-        public string? UpperBound { get; set; }
+        public string? UpperBound { get; init; }
 
-        public string Projection { get; set; } = string.Empty;
+        public string Projection { get; init; } = string.Empty;
 
-        public bool HasAdoptedContext { get; set; }
+        public bool HasAdoptedContext { get; init; }
 
-        public bool HasThirdPartyAdoptedContext { get; set; }
+        public bool HasThirdPartyAdoptedContext { get; init; }
 
-        public List<string> AdoptedSpeakerIds { get; set; } = [];
+        public IReadOnlyList<string> AdoptedSpeakerIds { get; init; } = Array.Empty<string>();
 
-        public bool ProjectionPersisted { get; set; }
+        public bool ProjectionPersisted { get; init; }
 
-        public List<AdoptedContextSnapshotMessage> Messages { get; set; } = [];
+        public IReadOnlyList<AdoptedContextSnapshotMessage> Messages { get; init; } =
+            Array.Empty<AdoptedContextSnapshotMessage>();
     }
 
-    public List<SerializableChatMessage> History { get; set; } = [];
+    public IReadOnlyList<SerializableChatMessage> History { get; init; } =
+        Array.Empty<SerializableChatMessage>();
 
-    public int TurnCount { get; set; }
+    public int TurnCount { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
     /// <summary>
     /// Persisted so a recovered session can handle late-arriving
     /// <see cref="DeliveryFailed"/> feedback after passivation.
     /// Null when no turn is eligible (initial state or retries exhausted).
     /// </summary>
-    public int? EligibleDeliveryTurnNumber { get; set; }
+    public int? EligibleDeliveryTurnNumber { get; init; }
 
     /// <summary>
     /// Durable working-context state (recent files). Null when the session
     /// has never set a non-empty context — <see cref="Sessions.SessionState.FromSnapshot"/>
     /// defaults to <see cref="WorkingContext.Empty"/> in that case.
     /// </summary>
-    public WorkingContext? WorkingContext { get; set; }
+    public WorkingContext? WorkingContext { get; init; }
 
     /// <summary>
     /// Background jobs this session is waiting on. Persisted because jobs
     /// are long-lived and must survive recovery.
     /// </summary>
-    public List<ActiveJobInfo> ActiveBackgroundJobs { get; set; } = [];
+    public IReadOnlyList<ActiveJobInfo> ActiveBackgroundJobs { get; init; } =
+        Array.Empty<ActiveJobInfo>();
 
-    public List<AdoptedContextSnapshotRecord> AdoptedContextRecords { get; set; } = [];
+    public IReadOnlyList<AdoptedContextSnapshotRecord> AdoptedContextRecords { get; init; } =
+        Array.Empty<AdoptedContextSnapshotRecord>();
 }

--- a/src/Netclaw.Actors/Protocol/SessionSubscription.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSubscription.cs
@@ -59,7 +59,7 @@ public enum OutputFilter
 /// resuming old sessions (reuse known ID), or tapping into active sessions.
 /// Routes through <see cref="IWithSessionId"/> to reach the correct session actor.
 /// </summary>
-public sealed record JoinSession : IWithSessionId
+public sealed record JoinSession : IWithSessionId, INoSerializationVerificationNeeded
 {
     public SessionId SessionId { get; init; }
 
@@ -79,7 +79,7 @@ public sealed record JoinSession : IWithSessionId
 /// Explicitly leave a session. Also handled automatically via DeathWatch
 /// when the subscriber terminates.
 /// </summary>
-public sealed record LeaveSession : IWithSessionId
+public sealed record LeaveSession : IWithSessionId, INoSerializationVerificationNeeded
 {
     public SessionId SessionId { get; init; }
 

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -468,6 +468,6 @@ internal sealed class ReminderExecutionActor : ReceiveActor
         _log.Error(ex, "{0}", msg);
     }
 
-    private sealed record ExecutionStarted;
-    private sealed record ExecutionOutput(SessionOutput Output);
+    private sealed record ExecutionStarted : INoSerializationVerificationNeeded;
+    private sealed record ExecutionOutput(SessionOutput Output) : INoSerializationVerificationNeeded;
 }

--- a/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderManagerActor.cs
@@ -260,6 +260,16 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             }
 
             nextFire = scheduleResult.NextFire;
+
+            // Persist the (possibly rescheduled) interval first-fire time so a daemon
+            // restart re-uses the same anchor instead of resetting "now + interval".
+            if (normalized.Schedule.Type == ReminderScheduleType.Interval && nextFire is not null)
+            {
+                normalized = normalized with
+                {
+                    Schedule = normalized.Schedule with { FireAt = nextFire }
+                };
+            }
         }
         else
         {
@@ -829,8 +839,6 @@ public sealed partial class ReminderManagerActor : ReceiveActor
                             ? explicitFirst
                             : now.Add(interval);
 
-                    definition.Schedule.FireAt = first;
-
                     var result = await _client.ScheduleRecurringReminderAsync(key, first, interval, payload);
                     return result.ResponseCode == ReminderScheduleResponseCode.Success
                         ? ScheduleAttempt.Ok(first)
@@ -937,13 +945,13 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             _failureCounts.Count));
     }
 
-    private sealed record ScheduleAttempt(bool IsSuccess, DateTimeOffset? NextFire, string? ErrorMessage)
+    private sealed record ScheduleAttempt(bool IsSuccess, DateTimeOffset? NextFire, string? ErrorMessage) : INoSerializationVerificationNeeded
     {
         public static ScheduleAttempt Ok(DateTimeOffset? nextFire) => new(true, nextFire, null);
         public static ScheduleAttempt Fail(string message) => new(false, null, message);
     }
 
-    private sealed record ReminderAudienceAuthorizationResult(bool IsSuccess, TrustAudience? EffectiveAudience, string? ErrorMessage)
+    private sealed record ReminderAudienceAuthorizationResult(bool IsSuccess, TrustAudience? EffectiveAudience, string? ErrorMessage) : INoSerializationVerificationNeeded
     {
         public static ReminderAudienceAuthorizationResult Success(TrustAudience effectiveAudience)
             => new(true, effectiveAudience, null);
@@ -952,7 +960,7 @@ public sealed partial class ReminderManagerActor : ReceiveActor
             => new(false, null, errorMessage);
     }
 
-    internal sealed record ReconcileReminders
+    internal sealed record ReconcileReminders : INoSerializationVerificationNeeded
     {
         public static readonly ReconcileReminders Instance = new();
     }
@@ -961,5 +969,5 @@ public sealed partial class ReminderManagerActor : ReceiveActor
     /// Ack sent back to <see cref="ReconcileReminders"/> callers so they can
     /// synchronize on reconcile completion instead of polling.
     /// </summary>
-    internal sealed record ReconcileCompleted(int CancelledOrphans, int RestoredSchedules, int DeletedOneShots, int DisabledExpired = 0);
+    internal sealed record ReconcileCompleted(int CancelledOrphans, int RestoredSchedules, int DeletedOneShots, int DisabledExpired = 0) : INoSerializationVerificationNeeded;
 }

--- a/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderProtocol.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json.Serialization;
+using Akka.Actor;
+using Netclaw.Actors.Serialization;
 using Netclaw.Configuration;
 
 namespace Netclaw.Actors.Reminders;
@@ -11,7 +13,7 @@ namespace Netclaw.Actors.Reminders;
 /// <summary>
 /// Strongly-typed reminder identity.
 /// </summary>
-public readonly record struct ReminderId(string Value)
+public readonly record struct ReminderId(string Value) : INetclawSerializableMessage
 {
     public override string ToString() => Value;
 }
@@ -44,36 +46,36 @@ public enum DeliveryKind
 /// <summary>
 /// Structured delivery target for a reminder.
 /// </summary>
-public sealed class ReminderDelivery
+public sealed record ReminderDelivery : INetclawSerializableMessage
 {
     /// <summary>
     /// How results are delivered.
     /// </summary>
-    public DeliveryKind Kind { get; set; }
+    public DeliveryKind Kind { get; init; }
 
     /// <summary>
     /// Transport identifier for Channel delivery (e.g., "slack").
     /// Null for CurrentSession and None.
     /// </summary>
-    public string? Transport { get; set; }
+    public string? Transport { get; init; }
 
     /// <summary>
     /// Canonical target address for Channel delivery (e.g., "C0123ABC").
     /// Resolved and validated at set time. Null for CurrentSession and None.
     /// </summary>
-    public string? Address { get; set; }
+    public string? Address { get; init; }
 
     /// <summary>
     /// Session ID for CurrentSession delivery. Null for Channel and None.
     /// </summary>
-    public string? SessionId { get; set; }
+    public string? SessionId { get; init; }
 
     /// <summary>
     /// Channel type of the originating session for CurrentSession delivery.
     /// Used to route DeliverTrustedSessionTurn to the correct gateway.
     /// Null for Channel and None.
     /// </summary>
-    public Channels.ChannelType? OriginChannelType { get; set; }
+    public Channels.ChannelType? OriginChannelType { get; init; }
 
     /// <summary>
     /// Gets the notification tool name for Channel delivery based on the transport.
@@ -102,43 +104,43 @@ public enum ReminderScheduleType
 /// <summary>
 /// Describes when and how a reminder fires.
 /// </summary>
-public sealed class ReminderSchedule
+public sealed record ReminderSchedule : INetclawSerializableMessage
 {
-    public ReminderScheduleType Type { get; set; }
+    public ReminderScheduleType Type { get; init; }
 
     /// <summary>
     /// For OneShot: the absolute fire time.
     /// For Interval: optional explicit first fire.
     /// For Cron: not used.
     /// </summary>
-    public long? FireAtMs { get; set; }
+    public long? FireAtMs { get; init; }
 
     public DateTimeOffset? FireAt
     {
         get => FireAtMs is not null ? DateTimeOffset.FromUnixTimeMilliseconds(FireAtMs.Value) : null;
-        set => FireAtMs = value?.ToUnixTimeMilliseconds();
+        init => FireAtMs = value?.ToUnixTimeMilliseconds();
     }
 
     /// <summary>
     /// For Interval schedules: repeat interval.
     /// </summary>
-    public long? IntervalTicks { get; set; }
+    public long? IntervalTicks { get; init; }
 
     public TimeSpan? Interval
     {
         get => IntervalTicks is not null ? TimeSpan.FromTicks(IntervalTicks.Value) : null;
-        set => IntervalTicks = value?.Ticks;
+        init => IntervalTicks = value?.Ticks;
     }
 
     /// <summary>
     /// For Cron schedules: cron expression.
     /// </summary>
-    public string? CronExpression { get; set; }
+    public string? CronExpression { get; init; }
 
     /// <summary>
     /// Original expression as entered by user (e.g. "6h", "0 */6 * * *").
     /// </summary>
-    public string? OriginalExpression { get; set; }
+    public string? OriginalExpression { get; init; }
 }
 
 /// <summary>
@@ -231,9 +233,9 @@ public sealed record ReminderDefinition
 /// <summary>
 /// Message persisted inside Akka.Reminders. Intentionally lightweight: pointer to disk definition.
 /// </summary>
-public sealed class ReminderPayload
+public sealed record ReminderPayload : INetclawSerializableMessage
 {
-    public ReminderId Id { get; set; }
+    public ReminderId Id { get; init; }
 }
 
 public enum ReminderWriteMode
@@ -257,27 +259,27 @@ public enum ReminderSaveError
 public sealed record SaveReminderCommand(
     ReminderDefinition Definition,
     ReminderWriteMode WriteMode = ReminderWriteMode.CreateOnly,
-    ReminderAudienceAuthorizationContext? Authorization = null);
+    ReminderAudienceAuthorizationContext? Authorization = null) : INoSerializationVerificationNeeded;
 
 public sealed record ReminderAudienceAuthorizationContext(
     TrustAudience? SourceAudience,
-    string? SourceDescription = null);
+    string? SourceDescription = null) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Disables a reminder and cancels any active schedule. The definition file
 /// is preserved on disk so history and configuration remain available for diagnosis.
 /// </summary>
-public sealed record CancelReminderCommand(ReminderId Id);
+public sealed record CancelReminderCommand(ReminderId Id) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Permanently deletes a reminder definition, its schedule, and history from disk.
 /// Not exposed as an LLM tool — use via CLI (<c>netclaw reminder delete</c>) or HTTP API.
 /// </summary>
-public sealed record DeleteReminderCommand(ReminderId Id);
-public sealed record DisableReminderCommand(ReminderId Id);
-public sealed record EnableReminderCommand(ReminderId Id);
-public sealed record ListRemindersCommand(bool IncludeDisabled = true);
-public sealed record GetReminderCommand(ReminderId Id);
+public sealed record DeleteReminderCommand(ReminderId Id) : INoSerializationVerificationNeeded;
+public sealed record DisableReminderCommand(ReminderId Id) : INoSerializationVerificationNeeded;
+public sealed record EnableReminderCommand(ReminderId Id) : INoSerializationVerificationNeeded;
+public sealed record ListRemindersCommand(bool IncludeDisabled = true) : INoSerializationVerificationNeeded;
+public sealed record GetReminderCommand(ReminderId Id) : INoSerializationVerificationNeeded;
 
 // ── Responses ──
 
@@ -287,20 +289,20 @@ public sealed record ReminderSavedResponse(
     bool Success,
     DateTimeOffset? NextFire,
     ReminderSaveError Error = ReminderSaveError.None,
-    string? ErrorMessage = null);
+    string? ErrorMessage = null) : INoSerializationVerificationNeeded;
 
-public sealed record ReminderCancelledResponse(ReminderId Id, bool Found);
-public sealed record ReminderDeletedResponse(ReminderId Id, bool Found);
+public sealed record ReminderCancelledResponse(ReminderId Id, bool Found) : INoSerializationVerificationNeeded;
+public sealed record ReminderDeletedResponse(ReminderId Id, bool Found) : INoSerializationVerificationNeeded;
 
 public sealed record ReminderStateResponse(
     ReminderId Id,
     bool Found,
     bool Enabled,
     DateTimeOffset? NextFire = null,
-    string? ErrorMessage = null);
+    string? ErrorMessage = null) : INoSerializationVerificationNeeded;
 
-public sealed record ReminderListResponse(IReadOnlyList<ReminderInfo> Reminders);
-public sealed record GetReminderResponse(ReminderInfo? Reminder);
+public sealed record ReminderListResponse(IReadOnlyList<ReminderInfo> Reminders) : INoSerializationVerificationNeeded;
+public sealed record GetReminderResponse(ReminderInfo? Reminder) : INoSerializationVerificationNeeded;
 
 public sealed record ReminderInfo(
     ReminderId Id,
@@ -314,7 +316,7 @@ public sealed record ReminderInfo(
     bool Enabled,
     string? AgentDefinitionId,
     TrustAudience? Audience,
-    DateTimeOffset? ExpiresAt = null);
+    DateTimeOffset? ExpiresAt = null) : INoSerializationVerificationNeeded;
 
 // ── Internal messages ──
 
@@ -325,7 +327,7 @@ internal sealed record ReminderExecutionCompleted(
     Guid ExecutionId,
     ReminderId Id,
     bool Success,
-    string? ErrorMessage = null);
+    string? ErrorMessage = null) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Signal emitted by the outbound channel pipeline when a reminder-sourced
@@ -347,14 +349,14 @@ internal sealed record ReminderExecutionCompleted(
 public sealed record ReminderDeliveryObserved(
     string ReminderDeliveryKey,
     Channels.ChannelType ChannelType,
-    long? ObservedAtMs = null);
+    long? ObservedAtMs = null) : INoSerializationVerificationNeeded;
 
 // ── Health query ──
 
 /// <summary>
 /// Query sent to <see cref="ReminderManagerActor"/> to obtain current health counters.
 /// </summary>
-public sealed record GetReminderHealthQuery
+public sealed record GetReminderHealthQuery : INoSerializationVerificationNeeded
 {
     public static readonly GetReminderHealthQuery Instance = new();
 }
@@ -365,7 +367,7 @@ public sealed record GetReminderHealthQuery
 public sealed record ReminderHealthResponse(
     int ScheduledCount,
     int ActiveExecutions,
-    int FailedCount);
+    int FailedCount) : INoSerializationVerificationNeeded;
 
 // ── Execution history ──
 

--- a/src/Netclaw.Actors/Serialization/INetclawSerializableMessage.cs
+++ b/src/Netclaw.Actors/Serialization/INetclawSerializableMessage.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="INetclawSerializableMessage.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Serialization;
+
+/// <summary>
+/// Marker for messages that cross a persistence or remoting boundary. Bound
+/// to <see cref="NetclawProtobufSerializer"/> in
+/// <c>WithNetclawSerialization</c>. Every implementing type MUST also have
+/// an entry in <see cref="NetclawProtobufSerializer.Manifest(object)"/>'s
+/// type-to-manifest table and a <c>ToProto</c>/<c>FromProto</c> mapping in
+/// <see cref="NetclawProtoMapper"/>. Missing entries fail loudly at the
+/// first serialize call — that is the regression signal this marker
+/// exists to provide.
+/// </summary>
+/// <remarks>
+/// Do not bind a second interface to <see cref="NetclawProtobufSerializer"/>.
+/// Akka's <c>FindSerializerForType</c> short-circuits on first match, so
+/// overlapping interface bindings produce iteration-order-dependent
+/// behavior.
+/// </remarks>
+public interface INetclawSerializableMessage
+{
+}

--- a/src/Netclaw.Actors/Serialization/INetclawSerializableMessage.cs
+++ b/src/Netclaw.Actors/Serialization/INetclawSerializableMessage.cs
@@ -20,6 +20,12 @@ namespace Netclaw.Actors.Serialization;
 /// Akka's <c>FindSerializerForType</c> short-circuits on first match, so
 /// overlapping interface bindings produce iteration-order-dependent
 /// behavior.
+///
+/// A type may legitimately implement both this marker and
+/// <c>Akka.Actor.INoSerializationVerificationNeeded</c>. That means "bound
+/// to proto for journal/wire serialization, but local-dispatch skips the
+/// roundtrip" — usually because the type carries an ephemeral field the
+/// proto mapping drops (e.g. <c>SendUserMessage.Source</c>).
 /// </remarks>
 public interface INetclawSerializableMessage
 {

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -107,19 +107,15 @@ internal static class NetclawProtoMapper
         return proto;
     }
 
-    internal static SerializableChatMessage FromProto(Proto.SerializableChatMessageProto proto)
+    internal static SerializableChatMessage FromProto(Proto.SerializableChatMessageProto proto) => new()
     {
-        var msg = new SerializableChatMessage
-        {
-            Role = (ChatRole)(int)proto.Role,
-            Content = proto.Content,
-            Name = proto.HasName ? proto.Name : null,
-            ToolCallId = proto.HasToolCallId ? proto.ToolCallId : null
-        };
-        msg.ToolCalls.AddRange(proto.ToolCalls.Select(FromProto));
-        msg.MediaReferences.AddRange(proto.MediaReferences.Select(FromProto));
-        return msg;
-    }
+        Role = (ChatRole)(int)proto.Role,
+        Content = proto.Content,
+        Name = proto.HasName ? proto.Name : null,
+        ToolCallId = proto.HasToolCallId ? proto.ToolCallId : null,
+        ToolCalls = proto.ToolCalls.Select(FromProto).ToArray(),
+        MediaReferences = proto.MediaReferences.Select(FromProto).ToArray()
+    };
 
     // ── SendUserMessage ──
 
@@ -134,16 +130,12 @@ internal static class NetclawProtoMapper
         return proto;
     }
 
-    internal static SendUserMessage FromProto(Proto.SendUserMessageProto proto)
+    internal static SendUserMessage FromProto(Proto.SendUserMessageProto proto) => new()
     {
-        var cmd = new SendUserMessage
-        {
-            SessionId = FromProto(proto.SessionId),
-            Content = proto.Content
-        };
-        cmd.MediaReferences.AddRange(proto.MediaReferences.Select(FromProto));
-        return cmd;
-    }
+        SessionId = FromProto(proto.SessionId),
+        Content = proto.Content,
+        MediaReferences = proto.MediaReferences.Select(FromProto).ToArray()
+    };
 
     // ── TurnRecorded ──
 
@@ -206,19 +198,15 @@ internal static class NetclawProtoMapper
         return proto;
     }
 
-    internal static SessionCompacted FromProto(Proto.SessionCompactedProto proto)
+    internal static SessionCompacted FromProto(Proto.SessionCompactedProto proto) => new()
     {
-        var evt = new SessionCompacted
-        {
-            SessionId = FromProto(proto.SessionId),
-            Summary = proto.Summary,
-            TurnCountBefore = proto.TurnCountBefore,
-            CompactedAtMs = proto.CompactedAtMs,
-            WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null
-        };
-        evt.CompactedMessages.AddRange(proto.CompactedMessages.Select(FromProto));
-        return evt;
-    }
+        SessionId = FromProto(proto.SessionId),
+        Summary = proto.Summary,
+        TurnCountBefore = proto.TurnCountBefore,
+        CompactedAtMs = proto.CompactedAtMs,
+        WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null,
+        CompactedMessages = proto.CompactedMessages.Select(FromProto).ToArray()
+    };
 
     // ── SessionSnapshot ──
 
@@ -240,20 +228,16 @@ internal static class NetclawProtoMapper
         return proto;
     }
 
-    internal static SessionSnapshot FromProto(Proto.SessionSnapshotProto proto)
+    internal static SessionSnapshot FromProto(Proto.SessionSnapshotProto proto) => new()
     {
-        var snap = new SessionSnapshot
-        {
-            TurnCount = proto.TurnCount,
-            Title = proto.HasTitle ? proto.Title : null,
-            EligibleDeliveryTurnNumber = proto.HasEligibleDeliveryTurnNumber ? proto.EligibleDeliveryTurnNumber : null,
-            WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null
-        };
-        snap.History.AddRange(proto.History.Select(FromProto));
-        snap.ActiveBackgroundJobs.AddRange(proto.ActiveBackgroundJobs.Select(FromProto));
-        snap.AdoptedContextRecords.AddRange(proto.AdoptedContextRecords.Select(FromAdoptedContextSnapshotRecord));
-        return snap;
-    }
+        TurnCount = proto.TurnCount,
+        Title = proto.HasTitle ? proto.Title : null,
+        EligibleDeliveryTurnNumber = proto.HasEligibleDeliveryTurnNumber ? proto.EligibleDeliveryTurnNumber : null,
+        WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null,
+        History = proto.History.Select(FromProto).ToArray(),
+        ActiveBackgroundJobs = proto.ActiveBackgroundJobs.Select(FromProto).ToArray(),
+        AdoptedContextRecords = proto.AdoptedContextRecords.Select(FromAdoptedContextSnapshotRecord).ToArray()
+    };
 
     private static Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord ToAdoptedContextSnapshotRecord(
         SessionSnapshot.AdoptedContextSnapshotRecord r)
@@ -280,7 +264,11 @@ internal static class NetclawProtoMapper
     private static SessionSnapshot.AdoptedContextSnapshotRecord FromAdoptedContextSnapshotRecord(
         Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord proto)
     {
-        var r = new SessionSnapshot.AdoptedContextSnapshotRecord
+        var speakerIds = proto.AdoptedSpeakerIds.Count > 0
+            ? (IReadOnlyList<string>)proto.AdoptedSpeakerIds.ToArray()
+            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal).ToArray();
+
+        return new SessionSnapshot.AdoptedContextSnapshotRecord
         {
             AuthorizedMessageId = proto.AuthorizedMessageId,
             AuthorizerSenderId = proto.HasAuthorizerSenderId ? proto.AuthorizerSenderId : null,
@@ -289,13 +277,10 @@ internal static class NetclawProtoMapper
             Projection = proto.Projection,
             HasAdoptedContext = proto.HasAdoptedContext || proto.Messages.Count > 0,
             HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
-            ProjectionPersisted = proto.ProjectionPersisted
+            ProjectionPersisted = proto.ProjectionPersisted,
+            AdoptedSpeakerIds = speakerIds,
+            Messages = proto.Messages.Select(FromAdoptedContextSnapshotMessage).ToArray()
         };
-        r.AdoptedSpeakerIds.AddRange(proto.AdoptedSpeakerIds.Count > 0
-            ? proto.AdoptedSpeakerIds
-            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal));
-        r.Messages.AddRange(proto.Messages.Select(FromAdoptedContextSnapshotMessage));
-        return r;
     }
 
     private static Proto.SessionSnapshotProto.Types.AdoptedContextSnapshotRecord.Types.AdoptedContextSnapshotMessage
@@ -461,7 +446,11 @@ internal static class NetclawProtoMapper
 
     internal static AdoptedContextRecorded FromProto(Proto.AdoptedContextRecordedProto proto)
     {
-        var evt = new AdoptedContextRecorded
+        var speakerIds = proto.AdoptedSpeakerIds.Count > 0
+            ? (IReadOnlyList<string>)proto.AdoptedSpeakerIds.ToArray()
+            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal).ToArray();
+
+        return new AdoptedContextRecorded
         {
             SessionId = FromProto(proto.SessionId),
             AuthorizedMessageId = proto.AuthorizedMessageId,
@@ -472,13 +461,10 @@ internal static class NetclawProtoMapper
             HasAdoptedContext = proto.HasAdoptedContext || proto.Messages.Count > 0,
             HasThirdPartyAdoptedContext = proto.HasThirdPartyAdoptedContext,
             ProjectionPersisted = proto.ProjectionPersisted,
-            RecordedAtMs = proto.RecordedAtMs
+            RecordedAtMs = proto.RecordedAtMs,
+            AdoptedSpeakerIds = speakerIds,
+            Messages = proto.Messages.Select(FromAdoptedMessageRecord).ToArray()
         };
-        evt.AdoptedSpeakerIds.AddRange(proto.AdoptedSpeakerIds.Count > 0
-            ? proto.AdoptedSpeakerIds
-            : proto.Messages.Select(m => m.SenderId).Distinct(StringComparer.Ordinal));
-        evt.Messages.AddRange(proto.Messages.Select(FromAdoptedMessageRecord));
-        return evt;
     }
 
     private static Proto.AdoptedContextRecordedProto.Types.AdoptedMessageRecordProto ToAdoptedMessageRecord(

--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="LlmMessages.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -13,7 +13,7 @@ namespace Netclaw.Actors.Sessions;
 /// <summary>
 /// Internal message sent back to the session actor when the async LLM call completes.
 /// </summary>
-internal sealed record LlmResponseReceived
+internal sealed record LlmResponseReceived : INoSerializationVerificationNeeded
 {
     public required ChatResponse Response { get; init; }
 
@@ -33,7 +33,7 @@ internal sealed record LlmResponseReceived
 /// <summary>
 /// Incremental streaming delta emitted while an LLM response is in-flight.
 /// </summary>
-internal sealed record LlmResponseDeltaReceived
+internal sealed record LlmResponseDeltaReceived : INoSerializationVerificationNeeded
 {
     public required AIContent Content { get; init; }
 
@@ -43,7 +43,7 @@ internal sealed record LlmResponseDeltaReceived
 /// <summary>
 /// Internal message sent back to the session actor when the async LLM call fails.
 /// </summary>
-internal sealed record LlmCallFailed
+internal sealed record LlmCallFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 
@@ -54,7 +54,7 @@ internal sealed record LlmCallFailed
 /// Internal message sent back to the session actor when tool execution completes.
 /// Contains the tool results to feed back into the next LLM call.
 /// </summary>
-internal sealed record ToolExecutionCompleted
+internal sealed record ToolExecutionCompleted : INoSerializationVerificationNeeded
 {
     public required List<Protocol.SerializableChatMessage> ToolResults { get; init; }
     public List<FileAttachmentInfo> FileAttachments { get; init; } = [];
@@ -62,7 +62,7 @@ internal sealed record ToolExecutionCompleted
     public List<AcceptedSubAgentFinding> AcceptedSubAgentFindings { get; init; } = [];
 }
 
-internal sealed record CompletedSubAgentRun
+internal sealed record CompletedSubAgentRun : INoSerializationVerificationNeeded
 {
     public required string RunId { get; init; }
     public required string AgentName { get; init; }
@@ -73,7 +73,7 @@ internal sealed record CompletedSubAgentRun
     public string? MemoryDecisionReason { get; init; }
 }
 
-internal sealed record AcceptedSubAgentFinding
+internal sealed record AcceptedSubAgentFinding : INoSerializationVerificationNeeded
 {
     public required string RunId { get; init; }
     public required string AgentName { get; init; }
@@ -97,7 +97,7 @@ internal sealed record AcceptedSubAgentFinding
 /// <summary>
 /// Internal message sent back when tool execution fails.
 /// </summary>
-internal sealed record ToolExecutionFailed
+internal sealed record ToolExecutionFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 }
@@ -106,7 +106,7 @@ internal sealed record ToolExecutionFailed
 /// Internal watchdog timeout used to force stuck Processing operations to fail
 /// and return the session actor to Ready state.
 /// </summary>
-internal sealed record ProcessingWatchdogExpired
+internal sealed record ProcessingWatchdogExpired : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
 
@@ -117,7 +117,7 @@ internal sealed record ProcessingWatchdogExpired
 /// Marshal a child actor creation request back onto the session actor thread.
 /// This keeps <c>Context.ActorOf</c> usage on the actor mailbox thread.
 /// </summary>
-internal sealed record SpawnChildActorRequest
+internal sealed record SpawnChildActorRequest : INoSerializationVerificationNeeded
 {
     public required Props Props { get; init; }
     public required string ActorName { get; init; }
@@ -127,12 +127,12 @@ internal sealed record SpawnChildActorRequest
 /// Internal trigger to begin the compaction sequence.
 /// Sent to self after a turn completes when usage exceeds the threshold.
 /// </summary>
-internal sealed record CompactionTriggered
+internal sealed record CompactionTriggered : INoSerializationVerificationNeeded
 {
     public required long InputTokenCount { get; init; }
 }
 
-internal sealed record CompactionWorkCompleted
+internal sealed record CompactionWorkCompleted : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
     public required string Summary { get; init; }
@@ -143,7 +143,7 @@ internal sealed record CompactionWorkCompleted
     public required int KeepCountUsed { get; init; }
 }
 
-internal sealed record CompactionWorkFailed
+internal sealed record CompactionWorkFailed : INoSerializationVerificationNeeded
 {
     public required long OperationId { get; init; }
     public required Exception Cause { get; init; }
@@ -153,7 +153,7 @@ internal sealed record CompactionWorkFailed
 /// Internal message completing a memory extraction LLM call.
 /// Contains extracted memories that should be persisted externally.
 /// </summary>
-internal sealed record MemoryExtractionCompleted
+internal sealed record MemoryExtractionCompleted : INoSerializationVerificationNeeded
 {
     public required string ExtractedMemories { get; init; }
 }
@@ -161,7 +161,7 @@ internal sealed record MemoryExtractionCompleted
 /// <summary>
 /// Internal message when a compaction step (extraction or summarization) fails.
 /// </summary>
-internal sealed record CompactionFailed
+internal sealed record CompactionFailed : INoSerializationVerificationNeeded
 {
     public required Exception Cause { get; init; }
 }
@@ -169,7 +169,7 @@ internal sealed record CompactionFailed
 /// <summary>
 /// Internal message completing a sidecar title generation LLM call.
 /// </summary>
-internal sealed record TitleGenerationCompleted
+internal sealed record TitleGenerationCompleted : INoSerializationVerificationNeeded
 {
     public required string Title { get; init; }
 }
@@ -179,22 +179,22 @@ internal sealed record TitleGenerationCompleted
 /// Enables child actors to react to lifecycle events (e.g., trigger
 /// final distillation when entering <see cref="SessionPhase.Passivating"/>).
 /// </summary>
-internal sealed record SessionPhaseChanged(SessionPhase Phase) : INotInfluenceReceiveTimeout;
+internal sealed record SessionPhaseChanged(SessionPhase Phase) : INotInfluenceReceiveTimeout, INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Sent to the observer actor to request immediate memory distillation
 /// before the session stops during passivation.
 /// </summary>
-internal sealed record RequestFinalDistillation;
+internal sealed record RequestFinalDistillation : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Sent back from the passivation timeout timer when the observer
 /// does not complete distillation within the grace period.
 /// </summary>
-internal sealed record PassivationTimeout;
+internal sealed record PassivationTimeout : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Timer-fired message that triggers an LLM call retry after exponential backoff.
 /// Carries the attempt number for observability logging.
 /// </summary>
-internal sealed record RetryLlmCallAfterBackoff(int Attempt);
+internal sealed record RetryLlmCallAfterBackoff(int Attempt) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -2531,7 +2531,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     /// a registered skill, activation path selection is deterministic:
     /// metadata.subagent route first, then inline injection when metadata is absent.
     /// </summary>
-    private bool TryHandleSlashCommand(string userContent, List<SerializableMediaReference> mediaRefs)
+    private bool TryHandleSlashCommand(string userContent, IReadOnlyList<SerializableMediaReference> mediaRefs)
     {
         if (_skillRegistry is null || string.IsNullOrWhiteSpace(userContent) || userContent[0] != '/')
             return false;
@@ -2583,7 +2583,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         return true;
     }
 
-    private bool HandleInlineSlashCommand(SkillEntry skill, string remainder, List<SerializableMediaReference> mediaRefs)
+    private bool HandleInlineSlashCommand(SkillEntry skill, string remainder, IReadOnlyList<SerializableMediaReference> mediaRefs)
     {
         string skillBody;
         try
@@ -2629,7 +2629,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         return true;
     }
 
-    private bool TryHandleRoutedSlashCommand(SkillEntry skill, string remainder, List<SerializableMediaReference> mediaRefs, string routedSubagent)
+    private bool TryHandleRoutedSlashCommand(SkillEntry skill, string remainder, IReadOnlyList<SerializableMediaReference> mediaRefs, string routedSubagent)
     {
         if (_subAgentRegistry is null || _subAgentSpawner is null)
         {
@@ -2922,9 +2922,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private SessionSnapshot BuildSnapshot()
     {
-        var snapshot = _state.ToSnapshot();
-        snapshot.EligibleDeliveryTurnNumber = _deliveryRetry.EligibleTurnNumber;
-        return snapshot;
+        return _state.ToSnapshot() with { EligibleDeliveryTurnNumber = _deliveryRetry.EligibleTurnNumber };
     }
 
     private void MaybeSnapshot()
@@ -3126,7 +3124,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         // the path arguments the agent originally passed, rather than
         // collapsing everything to cwd. Empty list when the request did
         // not carry candidate-level data (e.g. older callers).
-        IReadOnlyList<ApprovalCandidate> Candidates);
+        IReadOnlyList<ApprovalCandidate> Candidates) : INoSerializationVerificationNeeded;
 
     private async Task PersistApprovalCandidatesAsync(
         PendingToolInteraction pending,
@@ -3331,12 +3329,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private sealed record RoutedSkillExecutionCompleted(
         string SkillName,
         string SubagentName,
-        SubAgentResult Result);
+        SubAgentResult Result) : INoSerializationVerificationNeeded;
 
     private sealed record RoutedSkillExecutionFailed(
         string SkillName,
         string SubagentName,
-        string ErrorMessage);
+        string ErrorMessage) : INoSerializationVerificationNeeded;
 
     private sealed record RoutedSkillSubAgentActivity(
         long TimestampMs,
@@ -3345,7 +3343,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         int ToolCount,
         bool? Success,
         TimeSpan? Duration,
-        int FindingsCount);
+        int FindingsCount) : INoSerializationVerificationNeeded;
 
     private void BindTurnTelemetry(MessageSource? source)
     {

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -31,7 +31,7 @@ namespace Netclaw.Actors.Sessions;
 /// persistence. Token usage from the sidecar call is included in the result
 /// so the parent can emit it through the standard usage pipeline.</para>
 ///
-/// <para>Persistent: journals <see cref="MemoriesDistilled"/> events so the
+/// <para>Persistent: journals <see cref="MemoriesDistilledV2"/> events so the
 /// skip list of already-proposed anchors survives across session incarnations.</para>
 /// </summary>
 public sealed class SessionMemoryObserverActor : ReceivePersistentActor
@@ -45,10 +45,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
     private readonly StringBuilder _transcript = new();
-    // V1 backward compat: sessions with existing MemoriesDistilled journal
-    // entries only carry anchor slugs. _proposedAnchors is populated during
-    // V1 recovery so those anchors are not lost. New sessions use V2 events
-    // and populate _proposedMemories instead.
     private readonly HashSet<string> _proposedAnchors = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<ProposedMemoryContext> _proposedMemories = [];
     private bool _hasNewContent;
@@ -87,15 +83,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         _timeProvider = timeProvider ?? TimeProvider.System;
 
         PersistenceId = $"memory-observer-{sessionId.Value}";
-
-        Recover<MemoriesDistilled>(evt =>
-        {
-            foreach (var anchor in evt.Anchors)
-            {
-                _proposedAnchors.Add(anchor);
-                _proposedMemories.Add(new ProposedMemoryContext(anchor, anchor, string.Empty));
-            }
-        });
 
         Recover<MemoriesDistilledV2>(evt =>
         {
@@ -771,9 +758,6 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         long? OutputTokens,
         string? FailureReason) : INotInfluenceReceiveTimeout, INoSerializationVerificationNeeded;
 }
-
-/// <summary>Journaled event recording which anchors were proposed in a distillation.</summary>
-public sealed record MemoriesDistilled(IReadOnlyList<string> Anchors, long TimestampMs);
 
 /// <summary>Journaled event recording proposed anchors with title and content context for deduplication.</summary>
 public sealed record MemoriesDistilledV2(

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -11,6 +11,7 @@ using Akka.Persistence;
 using Microsoft.Extensions.AI;
 using Netclaw.Actors.Memory;
 using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Serialization;
 using Netclaw.Actors.SubAgents;
 using Netclaw.Configuration;
 
@@ -757,9 +758,9 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         PropertyNameCaseInsensitive = true
     };
 
-    private sealed record PendingPassivationRequest(IActorRef ReplyTo, long RequiredContentVersion);
+    private sealed record PendingPassivationRequest(IActorRef ReplyTo, long RequiredContentVersion) : INoSerializationVerificationNeeded;
 
-    private sealed record DistillationRunState(long RunId, long ContentVersion, IActorRef ReplyTo);
+    private sealed record DistillationRunState(long RunId, long ContentVersion, IActorRef ReplyTo) : INoSerializationVerificationNeeded;
 
     private sealed record DistillationRunCompleted(
         long RunId,
@@ -768,7 +769,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
         IReadOnlyList<string> Anchors,
         long? InputTokens,
         long? OutputTokens,
-        string? FailureReason) : INotInfluenceReceiveTimeout;
+        string? FailureReason) : INotInfluenceReceiveTimeout, INoSerializationVerificationNeeded;
 }
 
 /// <summary>Journaled event recording which anchors were proposed in a distillation.</summary>
@@ -778,16 +779,16 @@ public sealed record MemoriesDistilled(IReadOnlyList<string> Anchors, long Times
 public sealed record MemoriesDistilledV2(
     IReadOnlyList<string> Anchors,
     IReadOnlyList<ProposedMemoryContext> Proposals,
-    long TimestampMs);
+    long TimestampMs) : INetclawSerializableMessage;
 
 /// <summary>Context for a previously proposed memory, used for semantic dedup in subsequent distillation runs.</summary>
 public sealed record ProposedMemoryContext(string Anchor, string Title, string Content);
 
 /// <summary>Sent by the session actor after proposals survive gating and are accepted for curation.</summary>
-public sealed record RecordAcceptedDistillationProposals(IReadOnlyList<MemoryProposal> Proposals);
+public sealed record RecordAcceptedDistillationProposals(IReadOnlyList<MemoryProposal> Proposals) : INoSerializationVerificationNeeded;
 
 /// <summary>Ack from the observer once accepted proposal dedup state has been persisted.</summary>
-public sealed class AcceptedDistillationProposalsRecorded
+public sealed class AcceptedDistillationProposalsRecorded : INoSerializationVerificationNeeded
 {
     public static readonly AcceptedDistillationProposalsRecorded Instance = new();
 
@@ -797,13 +798,13 @@ public sealed class AcceptedDistillationProposalsRecorded
 }
 
 /// <summary>System context injection forwarded to the observer (recalled memories, loaded skills).</summary>
-public sealed record ObserverSystemContext(string Label, string Content);
+public sealed record ObserverSystemContext(string Label, string Content) : INoSerializationVerificationNeeded;
 
 /// <summary>Signal from parent: distill now (used during passivation).</summary>
-public sealed record DistillMemories;
+public sealed record DistillMemories : INoSerializationVerificationNeeded;
 
 /// <summary>Observer's response with memory proposals and token usage for billing.</summary>
-public sealed record SessionDistillationCompleted : INotInfluenceReceiveTimeout
+public sealed record SessionDistillationCompleted : INotInfluenceReceiveTimeout, INoSerializationVerificationNeeded
 {
     public static readonly SessionDistillationCompleted Empty = new() { Proposals = [] };
 
@@ -813,4 +814,4 @@ public sealed record SessionDistillationCompleted : INotInfluenceReceiveTimeout
     public string? FailureReason { get; init; }
 }
 
-internal sealed record DistillationResponse(IReadOnlyList<MemoryProposal>? Proposals);
+internal sealed record DistillationResponse(IReadOnlyList<MemoryProposal>? Proposals) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -188,14 +188,9 @@ public sealed record SessionState
     /// </summary>
     public SessionState AddUserMessage(string content, IReadOnlyList<SerializableMediaReference>? mediaReferences = null)
     {
-        var msg = new SerializableChatMessage
-        {
-            Role = ChatRole.User,
-            Content = content,
-            MediaReferences = mediaReferences is { Count: > 0 }
-                ? mediaReferences
-                : Array.Empty<SerializableMediaReference>()
-        };
+        var msg = mediaReferences is { Count: > 0 }
+            ? new SerializableChatMessage { Role = ChatRole.User, Content = content, MediaReferences = mediaReferences }
+            : new SerializableChatMessage { Role = ChatRole.User, Content = content };
 
         return this with { History = History.Add(msg) };
     }

--- a/src/Netclaw.Actors/Sessions/SessionState.cs
+++ b/src/Netclaw.Actors/Sessions/SessionState.cs
@@ -186,16 +186,16 @@ public sealed record SessionState
     /// Add a user message to history (before firing an LLM call).
     /// This is transient state that gets persisted as part of <see cref="TurnRecorded"/>.
     /// </summary>
-    public SessionState AddUserMessage(string content, List<SerializableMediaReference>? mediaReferences = null)
+    public SessionState AddUserMessage(string content, IReadOnlyList<SerializableMediaReference>? mediaReferences = null)
     {
         var msg = new SerializableChatMessage
         {
             Role = ChatRole.User,
-            Content = content
+            Content = content,
+            MediaReferences = mediaReferences is { Count: > 0 }
+                ? mediaReferences
+                : Array.Empty<SerializableMediaReference>()
         };
-
-        if (mediaReferences is { Count: > 0 })
-            msg.MediaReferences = mediaReferences;
 
         return this with { History = History.Add(msg) };
     }

--- a/src/Netclaw.Actors/Sessions/WorkingContext.cs
+++ b/src/Netclaw.Actors/Sessions/WorkingContext.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Immutable;
+using Netclaw.Actors.Serialization;
 
 namespace Netclaw.Actors.Sessions;
 
@@ -22,7 +23,7 @@ namespace Netclaw.Actors.Sessions;
 ///   root the session is working on. Set via <c>set_working_directory</c>
 ///   tool, persisted across crash/restart. Null means "no project selected."
 /// </summary>
-public sealed record WorkingContext
+public sealed record WorkingContext : INetclawSerializableMessage
 {
     /// <summary>
     /// Maximum number of entries retained in <see cref="RecentFiles"/>.

--- a/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
+++ b/src/Netclaw.Actors/SubAgents/SubAgentProtocol.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Microsoft.Extensions.AI;
 using Netclaw.Tools;
 
@@ -38,7 +39,7 @@ public sealed record SubAgentDefinition
 /// <summary>
 /// Message sent to a <see cref="SubAgentActor"/> to begin execution.
 /// </summary>
-public sealed record RunSubAgent
+public sealed record RunSubAgent : INoSerializationVerificationNeeded
 {
     /// <summary>The task for the subagent to perform (becomes part of the user message).</summary>
     public required string Task { get; init; }
@@ -81,7 +82,7 @@ public sealed record RunSubAgent
 /// <summary>
 /// Result returned by a <see cref="SubAgentActor"/> when execution completes.
 /// </summary>
-public sealed record SubAgentResult
+public sealed record SubAgentResult : INoSerializationVerificationNeeded
 {
     /// <summary>Whether the subagent completed successfully.</summary>
     public required bool Success { get; init; }

--- a/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Akka.Actor;
 using Netclaw.Actors.Protocol;
 using Netclaw.Actors.Channels;
 using Netclaw.Configuration;
@@ -22,7 +23,7 @@ public sealed record SlackFileReference(
     string Name,
     string MimeType,
     long Size,
-    string UrlPrivateDownload);
+    string UrlPrivateDownload) : INoSerializationVerificationNeeded;
 
 public sealed record SlackInboundMessage(
     SlackInboundKind Kind,
@@ -36,7 +37,7 @@ public sealed record SlackInboundMessage(
     string? Subtype,
     bool Hidden,
     bool IsDirectMessage,
-    IReadOnlyList<SlackFileReference>? Files = null);
+    IReadOnlyList<SlackFileReference>? Files = null) : INoSerializationVerificationNeeded;
 
 public sealed record SlackThreadInbound(
     SessionId SessionId,
@@ -50,13 +51,13 @@ public sealed record SlackThreadInbound(
     SourceProvenance Provenance,
     string Text,
     DateTimeOffset ReceivedAt,
-    IReadOnlyList<SlackFileReference>? Files = null);
+    IReadOnlyList<SlackFileReference>? Files = null) : INoSerializationVerificationNeeded;
 
 public sealed record SlackPostMessage(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
     string Text,
-    IReadOnlyList<Block>? Blocks = null);
+    IReadOnlyList<Block>? Blocks = null) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Sent to the gateway to wire up the actor hierarchy for a proactively-created thread.
@@ -66,13 +67,13 @@ public sealed record SlackPostMessage(
 public sealed record StartProactiveThread(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
-    SessionId SessionId);
+    SessionId SessionId) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Acknowledgement that the proactive thread's session pipeline was initialized.
 /// Returned by <see cref="SlackThreadBindingActor"/> in response to <see cref="StartProactiveThread"/>.
 /// </summary>
-public sealed record ProactiveThreadAck(SessionId SessionId);
+public sealed record ProactiveThreadAck(SessionId SessionId) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Routes a tool approval response from the Slack Block Kit button handler
@@ -85,4 +86,4 @@ public sealed record SlackApprovalResponse(
     string CallId,
     string SelectedKey,
     string SenderId,
-    string? RequesterSenderId = null);
+    string? RequesterSenderId = null) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1248,8 +1248,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
     }
 
-    private sealed record ThreadOutput(SessionOutput Output);
-    private sealed record OutputStreamTerminated(int Generation, Exception? Cause);
+    private sealed record ThreadOutput(SessionOutput Output) : INoSerializationVerificationNeeded;
+    private sealed record OutputStreamTerminated(int Generation, Exception? Cause) : INoSerializationVerificationNeeded;
     private sealed record ReinitializePipeline(string Reason);
     private sealed class PendingApprovalRequest(ToolInteractionRequest request)
     {
@@ -1258,7 +1258,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         public SlackEventTs? PromptMessageTs { get; set; }
     }
 
-    private sealed record InitializePipeline
+    private sealed record InitializePipeline : INoSerializationVerificationNeeded
     {
         public static InitializePipeline Instance { get; } = new();
     }

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1250,7 +1250,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
     private sealed record ThreadOutput(SessionOutput Output) : INoSerializationVerificationNeeded;
     private sealed record OutputStreamTerminated(int Generation, Exception? Cause) : INoSerializationVerificationNeeded;
-    private sealed record ReinitializePipeline(string Reason);
+    private sealed record ReinitializePipeline(string Reason) : INoSerializationVerificationNeeded;
     private sealed class PendingApprovalRequest(ToolInteractionRequest request)
     {
         public ToolInteractionRequest Request { get; } = request;


### PR DESCRIPTION
## Summary

- Replace `WithNetclawSerialization`'s hand-maintained 19-type array with a single `INetclawSerializableMessage` marker interface.
- Convert bound types from `class` to `sealed record` (message types should be immutable).
- Sweep `Akka.Actor.INoSerializationVerificationNeeded` across internal actor messages in `Netclaw.Actors.{Protocol,Sessions,Reminders,Jobs,SubAgents}` and `Netclaw.Channels.Slack`.
- Turn on `akka.actor.serialize-messages = on` in four bulky integration test classes (`LlmSessionIntegrationTests`, `SessionMemoryObserverActorTests`, `SetReminderToolTests`, `ReminderManagerActorTests`) so missing serialization bindings fail at CI time instead of in production.
- Delete dead V1 `MemoriesDistilled` event type + recovery handler (never written by current code, never bound, no journals contain it).

## Background

`MemoriesDistilledV2` shipped without being added to `boundTypes`, `TypeToManifest`, or `NetclawProtoMapper`. Tests passed; production threw `No serializer binding found for type MemoriesDistilledV2` three times in a four-minute window. Strict serialization was doing its job at runtime — tests just didn't exercise it.

This PR adds the missing test-time exercise. With `serialize-messages = on` and the marker scheme:

- Any `INetclawSerializableMessage` type without a manifest in `NetclawProtobufSerializer.TypeToManifest` throws loudly on first send.
- Any actor message without either marker fails strict mode, surfacing the omission in CI rather than at 4 a.m. in prod.

## Approach

1. Add `INetclawSerializableMessage` marker; bind it once in `WithNetclawSerialization`.
2. Apply marker to the 19 currently-bound types. Most become `sealed record` along the way; `NetclawProtoMapper` rewritten to construct records up front instead of mutating `.AddRange` post-construction.
3. Sweep `INoSerializationVerificationNeeded` across non-persisted actor messages, including channel adapter messages and internal `Self.Tell` types nested in actors.
4. New `WithSerializationVerification()` test helper bundles `serialize-messages = on` plus JSON bindings for third-party library types (Akka.Reminders internals, system messages, persistence permit envelopes) that we don't own.
5. `LlmSessionTestBase` exposes a `VerifySerialization` opt-in flag; `LlmSessionIntegrationTests` opts in. Other derived classes (vision, sub-agent spawn) stay off because some exercise Akka.Streams / vision code paths where `serialize-messages` causes dispatch issues unrelated to the marker scheme.

## Notes

- **`SendUserMessage`** carries both `INetclawSerializableMessage` and `INoSerializationVerificationNeeded`. The proto mapping intentionally drops the ephemeral `Source` field (channel metadata, not persisted), so the local-dispatch path skips the round-trip to preserve `Source` for in-process reminder dedup. The proto binding stays for journal compatibility. Documented at the marker definition and on the type.
- **`SlackFileFlowIntegrationTests`** does not enable verification — `serialize-messages = on` causes the Akka.Streams output pipeline to silently drop messages, an Akka.Streams interop issue separate from the marker scheme.
- **Wire format unchanged**: same serializer ID (150), same manifest strings, same proto schema. Existing journals replay without migration.
- **Upstream issue** filed: [Aaronontheweb/akka-reminders#118](https://github.com/Aaronontheweb/akka-reminders/issues/118) to mark `ReminderScheduler` internal control messages with `INoSerializationVerificationNeeded` so downstream consumers don't have to enumerate them in HOCON allowlists.

Closes #961

## Test plan

- [x] `dotnet build` clean across all projects
- [x] `dotnet test` solution-wide: 3,575 passed / 0 failed (1551 actors, 640 cli, 534 security, 506 daemon, 293 config, 46 search, 5 memory-poc)
- [x] 24 `SerializationRoundTripTests` still pass — wire format unchanged
- [x] `dotnet slopwatch analyze`: 0 issues
- [x] Rebased on latest `origin/dev`