### PR TITLE
chore(deps): bump Microsoft platform/AI packages + add Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,24 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    microsoft-platform:
+      patterns:
+        - "Microsoft.AspNetCore.*"
+        - "Microsoft.Extensions.Configuration.*"
+        - "Microsoft.Extensions.Hosting*"
+        - "Microsoft.Extensions.Http*"
+        - "Microsoft.Extensions.Logging.*"
+        - "Microsoft.Data.*"
+        - "System.Security.Cryptography.*"
+    microsoft-extensions-ai:
+      patterns:
+        - "Microsoft.Extensions.AI*"
+        - "Microsoft.Extensions.TimeProvider.*"
+    opentelemetry:
+      patterns:
+        - "OpenTelemetry*"
+    akka:
+      patterns:
+        - "Akka.*"
+        - "Aaron.Akka.*"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,8 @@
     <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SlackNetVersion>0.17.10</SlackNetVersion>
     <DiscordNetVersion>3.19.1</DiscordNetVersion>
-    <MicrosoftExtensionsAIVersion>10.5.0</MicrosoftExtensionsAIVersion>
-    <MicrosoftAspNetCoreVersion>10.0.7</MicrosoftAspNetCoreVersion>
+    <MicrosoftExtensionsAIVersion>10.6.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftAspNetCoreVersion>10.0.8</MicrosoftAspNetCoreVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
@@ -26,14 +26,11 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreVersion)" />
-    <!-- Pinned to 10.0.6 to patch GHSA-w3x6-4m5h-cxqf (CVE-2026-26171) and GHSA-37gx-xxp4-5rgx (CVE-2026-33116).
-         Cannot bump Microsoft.AspNetCore.DataProtection to 10.0.6 because of a regression in ManagedAuthenticatedEncryptor
-         that breaks all Unprotect calls on Linux/macOS (dotnet/aspnetcore#65889). Drop this pin when 10.0.7 ships. -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="$(MicrosoftExtensionsAIVersion)" />


### PR DESCRIPTION
## Summary

- Bumps `$(MicrosoftAspNetCoreVersion)` from `10.0.7` → `10.0.8`, covering all 9 platform packages in one variable change
- Bumps `$(MicrosoftExtensionsAIVersion)` from `10.5.0` → `10.6.0`
- Wires `System.Security.Cryptography.Xml` to `$(MicrosoftAspNetCoreVersion)`; drops the now-stale CVE pin comment (workaround was for a 10.0.6 Linux regression that was resolved in 10.0.7)
- Wires `Microsoft.Extensions.TimeProvider.Testing` to `$(MicrosoftExtensionsAIVersion)` — it ships on the AI/Extensions cadence, not the .NET platform train
- Adds Dependabot `groups:` config so `microsoft-platform`, `microsoft-extensions-ai`, `opentelemetry`, and `akka` packages each arrive in a single PR instead of N conflicting ones

Closes #969, #971

## Test plan

- [ ] `dotnet build` passes
- [ ] CI green