### PR TITLE
fix(sessions): close passivation race with post-snapshot grace window

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmMessages.cs
+++ b/src/Netclaw.Actors/Sessions/LlmMessages.cs
@@ -194,6 +194,15 @@ internal sealed record RequestFinalDistillation : INoSerializationVerificationNe
 internal sealed record PassivationTimeout : INoSerializationVerificationNeeded;
 
 /// <summary>
+/// Fired by a short timer after the session has finished its passivation
+/// distillation/snapshot work. The Passivating receive ignores in-flight
+/// snapshot acks but treats any user-initiated message as a signal to abort
+/// the stop, so this timer is the explicit "no one woke us up; commit now"
+/// signal. See <c>LlmSessionActor.CompletePassivation</c>.
+/// </summary>
+internal sealed record PassivationFinalStop : INoSerializationVerificationNeeded;
+
+/// <summary>
 /// Timer-fired message that triggers an LLM call retry after exponential backoff.
 /// Carries the attempt number for observability logging.
 /// </summary>

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -161,6 +161,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
 
     private bool _restartDrainRequested;
     private bool _passivationCompleted;
+    private bool _passivationFinalStopScheduled;
     private IActorRef? _restartDrainReplyTo;
     private string? _pendingRestartNotice;
     private string? _turnRestartNotice;
@@ -1358,6 +1359,15 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private static readonly TimeSpan PassivationGracePeriod = TimeSpan.FromSeconds(5);
     private static readonly object PassivationTimerKey = new();
 
+    // After distillation + snapshot complete we wait this long for a racing
+    // user-initiated message to abort the stop. Closes the race where a
+    // SendUserMessage forwarded by the parent arrives in the child's mailbox
+    // microseconds after Context.Stop(Self) would have been dispatched.
+    // 100 ms is geological time for an in-proc Akka hop, and idle-driven
+    // passivation does not care about an extra 100 ms.
+    private static readonly TimeSpan PassivationFinalStopDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly object PassivationFinalStopTimerKey = new();
+
     private void Passivating()
     {
         // Disable idle timeout — we're shutting down
@@ -1391,7 +1401,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             _log.Info("Aborting passivation due to new user message");
-            Timers.Cancel(PassivationTimerKey);
+            AbortPassivationTimers();
             TransitionTo(SessionPhase.Ready);
             HandleIncomingUserMessage(cmd);
         });
@@ -1409,6 +1419,13 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             CompletePassivation();
         });
 
+        // No racing message arrived during the post-snapshot grace window — commit the stop.
+        Command<PassivationFinalStop>(_ =>
+        {
+            _log.Info("Passivation grace window elapsed, finalizing stop");
+            FinalizePassivation();
+        });
+
         Command<DeliveryFailed>(msg =>
         {
             if (_restartDrainRequested)
@@ -1418,7 +1435,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             }
 
             _log.Info("Aborting passivation due to delivery feedback");
-            Timers.Cancel(PassivationTimerKey);
+            AbortPassivationTimers();
             TransitionTo(SessionPhase.Ready);
             HandleDeliveryFailedWhenReady(msg);
         });
@@ -1435,17 +1452,45 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }
     }
 
+    // Enters the post-distillation grace window: persist the final snapshot
+    // and arm a short timer. Any user-initiated message arriving in the
+    // mailbox during this window cancels the timer (via AbortPassivationTimers)
+    // and resurrects the actor in Ready — avoiding a full stop + respawn +
+    // recovery cycle. If nothing arrives, the timer fires PassivationFinalStop
+    // and we proceed to FinalizePassivation.
     private void CompletePassivation()
+    {
+        if (_passivationFinalStopScheduled)
+            return;
+
+        _passivationFinalStopScheduled = true;
+        SaveSnapshot(BuildSnapshot());
+        Timers.StartSingleTimer(
+            PassivationFinalStopTimerKey,
+            new PassivationFinalStop(),
+            PassivationFinalStopDelay);
+    }
+
+    // Actual termination after the grace window expires. The observer
+    // notification is deferred to this point so it never fires for an
+    // aborted passivation.
+    private void FinalizePassivation()
     {
         if (_passivationCompleted)
             return;
 
         _passivationCompleted = true;
         _lifecycleObserver?.OnSessionDeactivated(_sessionId);
-        SaveSnapshot(BuildSnapshot());
         _restartDrainReplyTo?.Tell(CommandAck.For(_sessionId));
         _restartDrainReplyTo = null;
         Context.Stop(Self);
+    }
+
+    private void AbortPassivationTimers()
+    {
+        Timers.Cancel(PassivationTimerKey);
+        Timers.Cancel(PassivationFinalStopTimerKey);
+        _passivationFinalStopScheduled = false;
     }
 
     // Outer hang-detector for the whole compaction pipeline. The inner observer


### PR DESCRIPTION
## Summary

Fixes the flaky `LlmSessionIntegrationTests.New_user_message_during_passivation_aborts_shutdown_and_processes_message` test by closing the underlying production race.

`LlmSessionActor` synchronously called `Context.Stop(Self)` the moment distillation finished, so any `SendUserMessage` forwarded via `SessionManager` (through `GenericChildPerEntityParent`) that arrived microseconds later landed in dead letters — and the caller's `Ask` timed out. The existing in-state abort handler at `LlmSessionActor.cs:1384-1397` was structurally unreachable for Manager-routed traffic on the fast "no new content" distillation path (sub-millisecond from `Passivating` entry to `Stop(Self)`).

## Fix

Split `CompletePassivation` into two phases:

1. **`CompletePassivation()`** — persist the final snapshot and arm a 100 ms `PassivationFinalStop` timer. The actor stays in `Passivating`.
2. **`FinalizePassivation()`** — fire `OnSessionDeactivated`, ack any restart-drain `Ask`, then `Context.Stop(Self)`.

The existing `SendUserMessage` / `DeliveryFailed` abort handlers now call `AbortPassivationTimers()` (cancels both the outer hang-guard and the new grace timer). Any user-initiated message arriving during the 100 ms window resurrects the actor in `Ready` with **no snapshot recovery, no respawn, no observer re-subscribe**. If nothing arrives, the timer fires `PassivationFinalStop` and shutdown proceeds normally.

`OnSessionDeactivated` is deferred from `CompletePassivation` to `FinalizePassivation` so aborted passivations no longer falsely mark the session as deactivated (the existing test assertions at `LlmSessionIntegrationTests.cs:1454` / `:1526` rely on this).

`_passivationCompleted` retains its existing "observer-notified" semantics for the `PostStop` safety net; a new `_passivationFinalStopScheduled` flag guards grace-window re-entry independently.

## Test plan

- [x] Originally-failing test runs 10/10 green on repeat
- [x] Passivation / lifecycle test slice (12 tests) passes
- [x] Full `LlmSessionIntegrationTests` (34 tests) passes
- [x] Full `Netclaw.Actors.Tests` project (1551 tests) passes
- [x] `dotnet slopwatch analyze` clean
- [x] Copyright headers verified