### PR TITLE
feat(providers): vLLM-aware capability resolver + timings split (#619)

### DIFF
--- a/openspec/changes/vllm-capability-strategy-and-timings/.openspec.yaml
+++ b/openspec/changes/vllm-capability-strategy-and-timings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/vllm-capability-strategy-and-timings/design.md
+++ b/openspec/changes/vllm-capability-strategy-and-timings/design.md
@@ -1,0 +1,400 @@
+# Design: vLLM Capability Strategy & Timings Extraction
+
+## Context
+
+The `openai-compatible` provider type today serves two real backends —
+llama.cpp's `llama-server` and (newly) vLLM 0.20. They share the
+OpenAI-standard endpoint shape but diverge on every capability /
+telemetry extension:
+
+| Concern               | llama.cpp                              | vLLM                                                  |
+|-----------------------|----------------------------------------|-------------------------------------------------------|
+| Context window source | `/v1/models[].meta.n_ctx_train` + `/props.default_generation_settings.params.n_ctx` | `/v1/models[].max_model_len`                          |
+| Modality signal       | `/props.modalities.vision`             | _none on `/v1/models` or `/props` (404)_              |
+| Prefix-cache stat     | `timings.cache_n`                      | `usage.prompt_tokens_details.cached_tokens` (OpenAI-std) |
+| Prompt latency        | `timings.prompt_ms`                    | _none — must be measured client-side_                 |
+
+The existing resolver was written when llama.cpp was the only target.
+It also short-circuits the composite chain on first non-null result —
+which means the already-registered `HuggingFaceCapabilityResolver`,
+which would correctly identify Qwen3.6-VL as `Text|Image`, never runs
+when the OpenAI-compatible resolver returns its (wrong) text-only
+answer for vLLM.
+
+This design refactors capability detection along two axes —
+**backend-aware parsing** (strategies inside the OpenAI-compatible
+resolver) and **partial-answer composition** (field-merge in the
+composite resolver) — so adding new OpenAI-compatible backends in the
+future is a matter of writing one strategy class, not patching parsing
+heuristics across the codebase.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect correct context window on vLLM (`max_model_len`) without
+  regressing llama.cpp detection (`meta.n_ctx_train`, `/props.n_ctx`).
+- Detect correct modality on vLLM by routing the unresolved-modality
+  case to `HuggingFaceCapabilityResolver`, which already knows how to
+  map `pipeline_tag` to `ModelModality` flags.
+- Keep `usage.cached_tokens` flowing into eval-suite Multi-Turn Cache
+  Evolution metrics when running on vLLM.
+- Establish a strategy seam where future per-backend quirks (tool-call
+  streaming parsers, strict `model` field diagnostics) can land
+  cleanly.
+- Preserve the existing user-facing escape hatch:
+  `ModelReference.InputModalities` / `OutputModalities` /
+  `ContextWindow` overrides still take precedence over all detection.
+
+**Non-Goals:**
+
+- Solving the remaining gaps from issue #619 (tool-call parser quirks,
+  strict model-field diagnostics, error shape alignment, stop-sequence
+  semantics). Those land in follow-up changes.
+- Active vision-capability probing (sending a 1-pixel image to
+  `/v1/chat/completions` at startup). HuggingFace fallback covers the
+  common case; we can revisit this if config burden grows for
+  HF-orphan model ids.
+- Persisting backend identification (vLLM vs llama.cpp) anywhere
+  durable. The probe runs each time the resolver is invoked; the
+  capability cache actor handles caching the result.
+
+## Decisions
+
+### D1. One resolver, multiple strategies (vs one resolver per backend)
+
+**Choice:** Keep a single `OpenAiCompatibleCapabilityResolver` registered
+in the composite chain. Refactor its parse logic into an internal
+`IOpenAiBackendStrategy` interface with three implementations
+(`Vllm`, `LlamaCpp`, `Generic`). The resolver performs **one** HTTP
+probe (`/v1/models` + `/props`), wraps results in a `BackendProbe`
+record, and walks strategies in priority order — first to match wins.
+
+**Alternatives considered:**
+
+- _Three sibling resolvers registered in the composite chain
+  (`VllmCapabilityResolver`, `LlamaCppCapabilityResolver`,
+  `GenericOpenAiCompatibleCapabilityResolver`)._ Cleaner DI surface but
+  each resolver would re-probe the same endpoint, tripling network
+  calls on every cache miss. Composite-merge would naturally pick the
+  right backend's fields, but at 3× the request load.
+- _Single resolver with `if/else` branching in `ParseModelsResponse`._
+  Works for two backends; gets hairy at three or four. Strategy
+  pattern keeps the dispatch readable and tested per-backend.
+
+**Trade-off accepted:** Strategies live inside the
+`Netclaw.Providers.SelfHosted` namespace alongside the resolver
+(single-file grouping per CLAUDE.md "do NOT enforce one type per
+file"). DI registration stays at the resolver level; strategies are
+constructor-injected as `IEnumerable<IOpenAiBackendStrategy>` so they
+remain unit-testable.
+
+### D2. Composite resolver merges instead of short-circuiting
+
+**Choice:** `CompositeCapabilityResolver` walks **every** resolver in
+the chain and merges field-by-field with first-non-null wins. The
+existing "default to text-only at the resolver chain" final fallback
+moves out — defaulting already lives at the consumption boundary in
+`ModelCapabilityResolution.cs:34-36`.
+
+**Why this matters:** The chain today is
+`OpenAiCodex → Ollama → OpenAiCompatible → OpenRouter → HuggingFace`.
+With short-circuit semantics, `OpenAiCompatible` returning
+`(Text, Text, null)` for vLLM ends the walk and HuggingFace never
+runs. With field-merge, the same vLLM resolver returning
+`(null, null, 256000)` lets HuggingFace fill the modality fields on
+the next iteration.
+
+**Alternatives considered:**
+
+- _Have the OpenAI-compatible resolver itself call HuggingFace as a
+  helper._ Couples backends tightly and duplicates resolution logic.
+- _Add an explicit "I cannot determine modality" sentinel value._
+  Discriminating `null` from `Text` is semantically correct and matches
+  how `ContextWindowTokens` is already modeled (`int?`).
+
+### D3. Nullable modalities on `ResolvedModelCapabilities`
+
+**Choice:** Change `InputModalities` and `OutputModalities` on
+`ResolvedModelCapabilities` from `ModelModality` to `ModelModality?`.
+This is a small breaking change to the resolver-author contract;
+downstream consumers in `ModelCapabilityResolution`,
+`DaemonRuntimeStatusService`, and the `Program.cs` log lines either
+already null-coalesce or are trivial to update.
+
+**Alternative considered:** Introduce a separate
+`PartialModelCapabilities` type for internal merge use, with public
+resolvers continuing to return non-null fields. Rejected — adds a type
+without solving the original "I don't know" expression problem at the
+resolver boundary.
+
+### D3a. Provider-aware resolver scoping in composite
+
+**Choice:** Add a `string? ProviderType { get; }` property to
+`IModelCapabilityResolver`. Provider-native resolvers (`OpenAiCodex`,
+`Ollama`, `OpenAiCompatible`) return their provider type literal
+(`"openai"`, `"ollama"`, `"openai-compatible"`). Cross-provider oracle
+resolvers (`OpenRouterOracle`, `HuggingFace`) return `null`.
+
+The composite resolves the active model's provider from
+`ModelReference.Provider` and only invokes resolvers where
+`ProviderType is null || ProviderType == activeProvider`. Filtering
+happens **before** the merge walk so foreign provider-native resolvers
+never burn a network call.
+
+**Why this matters:** Under field-merge semantics (D2), every eligible
+resolver runs. The testlab cutover plan keeps llama.cpp and vLLM
+running in parallel as separate `openai-compatible` providers — both
+native resolvers would be registered. Without scoping, both resolvers
+probe both endpoints on every model lookup, with only one returning
+useful data. Scoping ties each capability query to the provider that
+actually serves the model.
+
+**Alternatives considered:**
+
+- _Per-provider composite chains registered separately in DI._
+  Architecturally clean but adds N×M registration combinatorics; the
+  scoping property keeps registration flat.
+- _Make oracles enumerate every provider they cover._ Forces
+  HuggingFace/OpenRouter to list "openai-compatible", "openai",
+  "anthropic", etc. — duplicates the cross-cutting intent and rots
+  when new providers land.
+
+### D4. Apply both timings extractors on every response (no backend dispatch)
+
+**Choice:** Run `LlamaCppTimingsExtractor` and `VllmTimingsExtractor`
+in sequence on every chat response. Field paths don't overlap
+(llama.cpp puts cache stats inside the `timings` sibling object; vLLM
+puts them inside `usage.prompt_tokens_details`). Whichever shape is
+present writes its values; the other extractor finds no fields and
+writes nothing.
+
+**Alternative considered:** Reuse the backend strategy from D1 to
+pick a single extractor. Rejected as over-engineering — strategy
+dispatch makes sense for parse logic with mutually exclusive shapes;
+here the shapes are additive and free of conflict.
+
+### D5. Wall-clock `prompt_ms` only as fallback
+
+**Choice:** Capture the elapsed time between HTTP `SendAsync` start and
+first-byte-received in both streaming and non-streaming paths. Use it
+to populate `UsageDetails.PromptMs` **only** when no extractor set a
+server-side value. llama.cpp continues to win on its own backend; vLLM
+gets a wall-clock value that's actually more honest than any single
+server-reported timing.
+
+**Trade-off:** Wall-clock includes network round-trip, so on a remote
+vLLM it overstates server-side prompt processing. Acceptable — the
+metric is for observability, not SLA evaluation. We log it tagged as
+client-measured.
+
+## Risks / Trade-offs
+
+- **[Risk]** Making modality fields nullable on
+  `ResolvedModelCapabilities` is a contract change for any third-party
+  resolver implementations. → Mitigation: There are no third-party
+  implementations in tree or known out of tree. All in-tree resolvers
+  are updated in the same change.
+- **[Risk]** `HuggingFace` lookups now run more often (on every vLLM
+  modality miss). → Mitigation: HF returns 304 / cached responses fast;
+  the capability cache actor (`ModelCapabilityActor`) caches resolved
+  results, so HF is hit once per (model, daemon-restart). 5-second
+  per-resolver timeout already in `CompositeCapabilityResolver` keeps
+  startup bounded.
+- **[Risk]** vLLM strategy match predicate (`owned_by: "vllm"` or
+  `max_model_len` + `/props` 404) misclassifies a backend that
+  partially mimics vLLM. → Mitigation: `max_model_len` is a stable
+  vLLM-specific schema field; misclassification would only affect
+  parsing fields that vLLM happens to provide, and the generic
+  fallback handles anything truly unknown.
+- **[Risk]** Wall-clock `prompt_ms` measurement during streaming reads
+  the time-to-headers, not time-to-first-content-chunk. → Mitigation:
+  Use `HttpCompletionOption.ResponseHeadersRead` (already in place);
+  measure to first **content** byte read from the response stream, not
+  to `SendAsync` completion. Document the precise measurement point in
+  the extractor.
+- **[Trade-off]** `BackendProbe` includes the raw JSON response strings
+  (not deserialized DTOs) so strategies can read freely. Slight
+  duplicate parsing across strategies; acceptable for the small
+  payload sizes involved.
+
+## Migration Plan
+
+This is an in-process refactor — no external migration. Deployment
+order:
+
+1. Land the code change behind no feature flag (the behavior change is
+   strictly better than current).
+2. On daemon restart, capability cache rebuilds from the new chain.
+3. Verify against live vLLM via `netclaw models --provider vllm-local`:
+   expect `ContextWindow=256000`, `Input=Text|Image` for Qwen3.6-VL.
+4. Verify against llama.cpp by repointing a provider and rerunning the
+   same command: no regression in `meta.n_ctx_train` / `/props`
+   detection.
+
+Rollback: revert the PR. Capability cache is in-memory only; no
+persistent state to undo.
+
+## Open Questions
+
+- Should we log the detected backend (vLLM / llama.cpp / generic) at
+  resolver-info level so operators can see which strategy matched? Lean
+  yes — useful for support diagnostics, free given we already detect it.
+- Does `ModelIdNormalizer.GetCandidates` need any vLLM-specific
+  candidate-generation logic? Open question; expect not, since vLLM's
+  served model name is typically the literal HF id when admins
+  configure `--served-model-name`. Will validate empirically against
+  live deployment.
+
+## Appendix A — Structural Composition
+
+```
+                       IModelCapabilityResolver
+                       + string? ProviderType { get; }   // null = oracle, always runs
+                       + Task<ResolvedModelCapabilities?> ResolveAsync(...)
+                                 △
+                                 │ implements
+        ┌────────────────────────┼──────────────────────────┐
+        │                        │                          │
+        │                  CompositeCapabilityResolver      │
+        │                  (NEW: field-merge, not short-circuit)
+        │                  (NEW: filters by model.Provider) │
+        │                  - timeout: 5s per resolver       │
+        │                  - holds IReadOnlyList<IModelCapabilityResolver>
+        │                        │ delegates to             │
+        │   ┌────────────────────┼──────────────────────────┼──────────────┐
+        │   │                    │                          │              │
+        │   ▼                    ▼                          ▼              ▼
+   OpenAiCodex            Ollama                  OpenAiCompatible    HuggingFace
+   CapabilityResolver     CapabilityResolver      CapabilityResolver  CapabilityResolver
+   ProviderType="openai"  ProviderType="ollama"   ProviderType=        ProviderType=null
+                                                  "openai-compatible"  (oracle, runs for all)
+                                                  │
+                                                  │ (NEW internal)
+                                                  ▼
+                                          IOpenAiBackendStrategy
+                                          (Matches / Parse)
+                                                  △
+                              ┌───────────────────┼───────────────────┐
+                              ▼                   ▼                   ▼
+                       VllmBackendStrategy  LlamaCppBackend   GenericOpenAi
+                       - max_model_len      Strategy          BackendStrategy
+                       - owned_by:"vllm"    - /props.n_ctx    - last-resort
+                       - leaves modality    - meta.n_ctx_train  identity-only
+                         null                - /props.modalities.vision
+
+                                         shared probe:
+                                  ┌─────────────────────────┐
+                                  │      BackendProbe       │
+                                  │ - modelsJson (string)   │
+                                  │ - propsJson (string?)   │
+                                  │ - modelId (string)      │
+                                  └─────────────────────────┘
+
+
+                       OpenAiCompatibleChatClient
+                       (one chat completion request)
+                                 │
+                                 │ runs each on every response
+                                 ▼
+                          ITimingsExtractor
+                          (Extract(JsonElement, UsageDetails))
+                                 △
+                  ┌──────────────┴──────────────┐
+                  ▼                             ▼
+        LlamaCppTimingsExtractor     VllmTimingsExtractor
+        - timings.cache_n             - usage.prompt_tokens_details
+        - timings.prompt_ms             .cached_tokens
+        - timings.predicted_per_sec
+                  │                             │
+                  └─────────────┬───────────────┘
+                                │ both write into same UsageDetails;
+                                │ non-overlapping field paths
+                                ▼
+                     wall-clock prompt_ms fallback
+                     (sets PromptMs iff still null)
+```
+
+## Appendix B — Execution Flow (vLLM-served Qwen3.6-VL)
+
+```
+SessionActor → ModelCapabilityActor.Ask(
+                  GetModelCapabilities("Qwen/Qwen3.6-VL-30B-FP8"))
+                          │ cache miss
+                          ▼
+              CompositeCapabilityResolver.ResolveAsync(modelId)
+                  │
+                  │ activeProvider = "openai-compatible"   (from ModelReference)
+                  │ initialize merged = (modelId, null, null, null)
+                  │
+                  ├─[1]─► OpenAiCodexCapabilityResolver  (ProviderType="openai")
+                  │         skipped — provider mismatch
+                  │
+                  ├─[2]─► OllamaCapabilityResolver       (ProviderType="ollama")
+                  │         skipped — provider mismatch
+                  │
+                  ├─[3]─► OpenAiCompatibleCapabilityResolver
+                  │         (ProviderType="openai-compatible")  → MATCH
+                  │
+                  │         GET /v1/models → 200 (max_model_len:256000, owned_by:"vllm")
+                  │         GET /props      → 404
+                  │         BackendProbe wraps both
+                  │
+                  │         VllmBackendStrategy.Matches → TRUE
+                  │         VllmBackendStrategy.Parse   → (modelId,null,null,256000)
+                  │
+                  │         merge → (modelId, null, null, 256000)
+                  │
+                  ├─[4]─► OpenRouterOracleResolver       (ProviderType=null, oracle)
+                  │         queries OpenRouter catalog → miss for Qwen3.6-VL
+                  │         returns null → merged unchanged
+                  │
+                  └─[5]─► HuggingFaceCapabilityResolver  (ProviderType=null, oracle)
+                            GET huggingface.co/api/models/Qwen/Qwen3.6-VL-30B-FP8
+                            pipeline_tag = "image-text-to-text"
+                            returns (modelId, Text|Image, Text, null)
+                            merge → (modelId, Text|Image, Text, 256000)   ✓
+                  │
+                  ▼
+              ModelCapabilityResolution.ResolveModelCapabilities(models, detected)
+                  - manual override? no
+                  - context-window override clamp? OK
+                  - apply text-only default? not needed
+                  │
+                  ▼
+                  ModelCapabilities {
+                      ModelId             = "Qwen/Qwen3.6-VL-30B-FP8",
+                      ContextWindowTokens = 256000,
+                      InputModalities     = Text|Image,
+                      OutputModalities    = Text
+                  }
+```
+
+Two key invariants the diagram preserves:
+
+- **Provider-native resolvers skip if `ProviderType` doesn't match the
+  model's active provider.** Oracle resolvers (`ProviderType == null`)
+  always run.
+- **Composite walks the whole eligible chain** and merges first-non-null
+  per field — `OpenAiCompatible` filling `ContextWindowTokens` does not
+  prevent `HuggingFace` from filling modalities.
+
+## Appendix C — Chat-client Timings Flow
+
+```
+OpenAiCompatibleChatClient.GetStreamingResponseAsync(...)
+   │
+   ├── t0 = TimeProvider.GetTimestamp()
+   ├── HttpClient.SendAsync(..., HttpCompletionOption.ResponseHeadersRead)
+   ├── first content byte read from response stream → t1
+   │
+   │   on final response JSON parse:
+   ├── foreach extractor in [LlamaCpp, Vllm]:
+   │      extractor.Extract(root, usageDetails)
+   │      // LlamaCpp reads timings.* (no-op on vLLM)
+   │      // Vllm reads usage.prompt_tokens_details.cached_tokens (no-op on llama.cpp)
+   │
+   └── if usageDetails.PromptMs is null:
+          usageDetails.PromptMs = (t1 - t0).TotalMilliseconds
+          // tagged as client-measured (includes network RTT)
+```

--- a/openspec/changes/vllm-capability-strategy-and-timings/proposal.md
+++ b/openspec/changes/vllm-capability-strategy-and-timings/proposal.md
@@ -1,0 +1,143 @@
+# Proposal: vLLM Capability Strategy & Timings Extraction
+
+## Why
+
+Netclaw is now running against a real vLLM 0.20 instance serving Qwen3.6-VL
+through the `openai-compatible` provider type, and two capability-resolution
+bugs surface as user-visible failures
+([issue #619](https://github.com/netclaw-dev/netclaw/issues/619),
+gaps #1 and #3):
+
+1. **Context window misreported as 32,768** (the default fallback) when the
+   real `max_model_len` is 256,000 — the resolver reads `meta.n_ctx_train`
+   (a llama.cpp extension) and ignores vLLM's top-level `max_model_len`.
+2. **Vision-capable models advertised as text-only** — vLLM has no `/props`
+   endpoint and exposes no modality field on `/v1/models`, so the resolver
+   defaults to `Text`. Slack image-bearing turns are silently dropped because
+   `InputModalities.HasFlag(Image)` is false.
+
+A latent observability regression also lands on cutover: the
+llama.cpp-specific `timings` parser in `OpenAiCompatibleChatClient` silently
+produces zero `cached_tokens` against vLLM, breaking the Multi-Turn Cache
+Evolution eval table. vLLM exposes the equivalent data via
+`usage.prompt_tokens_details.cached_tokens` (OpenAI-standard prefix-cache
+field).
+
+Root architectural cause: `CompositeCapabilityResolver` short-circuits on the
+**first non-null** result. `OpenAiCompatibleCapabilityResolver` returns
+`(modelId, Text, Text, null)` for vLLM — non-null but wrong — so the
+already-registered `HuggingFaceCapabilityResolver` is never consulted to fill
+the modality gap.
+
+## What Changes
+
+- **Composite merging** (BREAKING for resolver authors): change
+  `CompositeCapabilityResolver` from short-circuit-on-first-non-null to
+  field-merge across all resolvers. Each resolver returns a partial answer;
+  the composite walks the chain merging the first non-null value per field.
+- **Provider-aware resolver scoping** (BREAKING for resolver authors):
+  add `string? ProviderType { get; }` to `IModelCapabilityResolver`.
+  Provider-native resolvers tag themselves (`"openai"`, `"ollama"`,
+  `"openai-compatible"`); cross-provider oracles return `null`. The
+  composite filters out resolvers whose `ProviderType` doesn't match the
+  active model's `ModelReference.Provider`, so foreign native resolvers
+  never burn network probes. Necessary once field-merge lands and the
+  testlab cutover plan runs llama.cpp + vLLM in parallel as separate
+  `openai-compatible` providers.
+- **Nullable modalities on `ResolvedModelCapabilities`** (BREAKING for
+  resolver authors): change `InputModalities` / `OutputModalities` from
+  `ModelModality` to `ModelModality?` so resolvers can signal "I don't know"
+  rather than falsely advertising `Text`. The text-only default already
+  lives downstream in `ModelCapabilityResolution.cs` and remains the
+  user-visible default when every resolver returns null.
+- **Backend strategy pattern** inside `OpenAiCompatibleCapabilityResolver`:
+  refactor parsing into `IOpenAiBackendStrategy` with three implementations
+  evaluated in order — `VllmBackendStrategy` (parses `max_model_len` from
+  the top-level model entry), `LlamaCppBackendStrategy` (parses
+  `meta.n_ctx_train` + `/props.modalities.vision`), and
+  `GenericOpenAiBackendStrategy` (last-resort identity). Single probe of
+  `/v1/models` and `/props` is shared across strategies.
+- **Pluggable timings extraction**: split `ParseLlamaCppTimings` into
+  `ITimingsExtractor` with `LlamaCppTimingsExtractor` (existing behaviour
+  against the `timings` object) and `VllmTimingsExtractor` (reads
+  `usage.prompt_tokens_details.cached_tokens`). Both extractors run on every
+  response since the field paths don't conflict.
+- **Wall-clock `prompt_ms`** in `OpenAiCompatibleChatClient`: measure HTTP
+  send → first-byte and populate `UsageDetails.PromptMs` when the server
+  didn't supply its own value. Restores per-request latency telemetry on
+  backends that don't emit it.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ Existing capabilities cover this work — the strategy pattern,
+nullable modalities, and timings split are spec-level refinements of
+already-specified behaviour.
+
+### Modified Capabilities
+
+- `netclaw-model-capabilities`: relaxes "ModelModality default text-only"
+  to apply at the final consumption boundary, not at every resolver. Adds
+  composite-merge semantics. Adds backend-strategy enumeration for the
+  OpenAI-compatible resolver (vLLM, llama.cpp, generic).
+
+## Impact
+
+**Code**
+- `src/Netclaw.Configuration/IModelCapabilityResolver.cs` — nullable
+  modalities on `ResolvedModelCapabilities`.
+- `src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs` —
+  merge-across-resolvers replacing short-circuit. Removes the text-only
+  final fallback (already handled downstream).
+- `src/Netclaw.Providers/SelfHosted/OpenAiCompatibleCapabilityResolver.cs`
+  — strip parse logic; delegate to strategies.
+- NEW `src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs` — holds
+  interface + 3 strategy implementations (single file per CLAUDE.md
+  "group closely related types" rule).
+- `src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs` — call
+  `ITimingsExtractor`s in sequence; capture wall-clock `prompt_ms`.
+- NEW `src/Netclaw.Providers/SelfHosted/TimingsExtractor.cs` — holds
+  interface + 2 timing extractor implementations.
+- Callers of `ResolvedModelCapabilities.InputModalities` /
+  `.OutputModalities` updated for nullable: `OpenAiCodexCapabilityResolver`,
+  `DaemonRuntimeStatusService`, capability log lines in `Program.cs`.
+
+**APIs / Contracts**
+- `IModelCapabilityResolver` contract unchanged in shape; semantic change
+  is that implementations are now expected to return partial answers
+  (null fields allowed) rather than fully-populated records. Downstream
+  consumers already null-coalesce.
+
+**Operational**
+- Live vLLM deployments will start reporting correct context window and
+  vision capability without any config change.
+- Multi-Turn Cache Evolution eval metric starts populating on vLLM
+  backends.
+- Per-request latency telemetry is restored when the backend doesn't emit
+  server-side timings (covers any future OpenAI-compatible backend, not
+  just vLLM).
+
+**Tests**
+- New `VllmBackendStrategyTests`, `LlamaCppBackendStrategyTests`,
+  `CompositeCapabilityResolverMergeTests`, `VllmTimingsExtractorTests`,
+  `LlamaCppTimingsExtractorTests`.
+- Existing `OpenAiCompatibleCapabilityResolverTests` updated to assert
+  partial-result semantics.
+
+**Security**
+- No new auth surface. HuggingFace fallback already exists and runs
+  network requests against `huggingface.co`; this change increases how
+  often it's actually consulted but does not introduce new outbound
+  endpoints.
+
+**Out of scope** (tracked in #619, deferred to follow-up changes):
+- Gap #2 vLLM tool-call parser quirks (`hermes` streaming bug,
+  `qwen3_coder` parser variant).
+- Gap #4 strict `model` field diagnostics.
+- Gaps #5–#7 error shape / stop-sequence / response-extras tolerance.
+
+**PRD reference**: this change has no direct PRD — it's a faithful
+implementation refinement of existing `netclaw-model-capabilities`
+behaviour to handle a second supported backend without regressing the
+first.

--- a/openspec/changes/vllm-capability-strategy-and-timings/specs/netclaw-model-capabilities/spec.md
+++ b/openspec/changes/vllm-capability-strategy-and-timings/specs/netclaw-model-capabilities/spec.md
@@ -1,0 +1,251 @@
+# netclaw-model-capabilities Delta: vLLM Strategy & Timings
+
+## ADDED Requirements
+
+### Requirement: OpenAI-compatible backend strategy selection
+
+The system SHALL identify the concrete backend serving an OpenAI-compatible
+endpoint (llama.cpp, vLLM, or unknown/generic) from a single probe of
+`/v1/models` and `/props`, and dispatch capability parsing to the matching
+backend strategy. Strategies SHALL be evaluated in priority order: vLLM,
+llama.cpp, generic. The first strategy whose match predicate succeeds
+SHALL produce the resolver's result.
+
+#### Scenario: vLLM backend detected via max_model_len
+
+- **GIVEN** an OpenAI-compatible endpoint where `GET /v1/models` returns a
+  model entry containing a top-level `max_model_len` field
+- **AND** `GET /props` returns HTTP 404
+- **WHEN** capabilities are resolved
+- **THEN** the vLLM strategy SHALL match the probe
+- **AND** `ContextWindowTokens` SHALL equal the `max_model_len` value
+- **AND** `InputModalities` and `OutputModalities` SHALL be left null for
+  later resolvers to fill
+
+#### Scenario: vLLM backend detected via owned_by
+
+- **GIVEN** an OpenAI-compatible endpoint where `GET /v1/models` returns a
+  model entry with `owned_by: "vllm"`
+- **WHEN** capabilities are resolved
+- **THEN** the vLLM strategy SHALL match the probe regardless of which
+  numeric fields are present
+
+#### Scenario: llama.cpp backend detected via /props
+
+- **GIVEN** an OpenAI-compatible endpoint where `GET /props` returns
+  HTTP 200 with a `default_generation_settings.params.n_ctx` value
+- **WHEN** capabilities are resolved
+- **THEN** the llama.cpp strategy SHALL match the probe
+- **AND** `ContextWindowTokens` SHALL prefer the `/props` value over
+  `meta.n_ctx_train` from `/v1/models`
+- **AND** `InputModalities` SHALL include `Image` when
+  `/props.modalities.vision` is `true`
+
+#### Scenario: Generic OpenAI-compatible fallback
+
+- **GIVEN** an OpenAI-compatible endpoint that exposes neither vLLM nor
+  llama.cpp signals
+- **WHEN** capabilities are resolved
+- **THEN** the generic strategy SHALL match
+- **AND** the resolver SHALL return `(modelId, null, null, null)` so the
+  downstream chain (HuggingFace, OpenRouter oracle) fills in fields
+
+### Requirement: Provider-aware resolver scoping
+
+Every `IModelCapabilityResolver` SHALL expose a nullable
+`ProviderType` property identifying which provider type the resolver
+speaks for. Provider-native resolvers SHALL return a non-null value
+(e.g., `"openai"`, `"ollama"`, `"openai-compatible"`). Cross-provider
+oracle resolvers (`OpenRouterOracleResolver`,
+`HuggingFaceCapabilityResolver`) SHALL return `null`, indicating they
+apply to all providers.
+
+The composite capability resolver SHALL invoke a resolver only when its
+`ProviderType` is `null` OR when its `ProviderType` matches the active
+model's `ModelReference.Provider`. Filtering SHALL happen before the
+merge walk so foreign provider-native resolvers never issue HTTP probes
+for models they cannot resolve.
+
+#### Scenario: Foreign provider-native resolver skipped
+
+- **GIVEN** a model with `ModelReference.Provider = "openai-compatible"`
+- **AND** an `OllamaCapabilityResolver` (`ProviderType = "ollama"`)
+  registered in the chain
+- **WHEN** capabilities are resolved
+- **THEN** the Ollama resolver SHALL NOT be invoked
+- **AND** no `POST /api/show` request SHALL be issued to the Ollama
+  endpoint
+
+#### Scenario: Matching provider-native resolver runs
+
+- **GIVEN** a model with `ModelReference.Provider = "openai-compatible"`
+- **AND** an `OpenAiCompatibleCapabilityResolver`
+  (`ProviderType = "openai-compatible"`) registered in the chain
+- **WHEN** capabilities are resolved
+- **THEN** the OpenAI-compatible resolver SHALL be invoked
+
+#### Scenario: Oracle resolvers always eligible
+
+- **GIVEN** a model on any provider
+- **AND** `HuggingFaceCapabilityResolver` (`ProviderType = null`)
+  registered in the chain
+- **WHEN** capabilities are resolved
+- **THEN** the HuggingFace resolver SHALL be eligible regardless of the
+  model's provider
+
+#### Scenario: Parallel native backends do not cross-probe
+
+- **GIVEN** both an `OllamaCapabilityResolver` and an
+  `OpenAiCompatibleCapabilityResolver` are registered
+- **AND** the active query targets a model on the OpenAI-compatible
+  provider
+- **WHEN** the composite walks the chain
+- **THEN** only the OpenAI-compatible resolver issues HTTP probes
+- **AND** the Ollama endpoint receives zero traffic for the query
+
+### Requirement: Composite resolver field-merge semantics
+
+The composite capability resolver SHALL combine results across registered
+resolvers by taking the first non-null value per field rather than
+short-circuiting on the first non-null result. A resolver SHALL be
+permitted to populate any subset of `(InputModalities, OutputModalities,
+ContextWindowTokens)`, returning null for fields it cannot determine.
+
+Per-resolver timeout (5 seconds) and exception-to-warning behavior from
+the existing resolver chain SHALL be preserved.
+
+#### Scenario: vLLM context + HuggingFace modality merge
+
+- **GIVEN** the OpenAI-compatible resolver returns `(modelId, null, null, 256000)`
+- **AND** the HuggingFace resolver returns `(modelId, Text|Image, Text, null)`
+- **WHEN** the composite resolver merges these results
+- **THEN** the merged record SHALL be
+  `(modelId, Text|Image, Text, 256000)`
+
+#### Scenario: First non-null wins per field
+
+- **GIVEN** resolver A returns `ContextWindowTokens = 200000`
+- **AND** resolver B (later in the chain) returns `ContextWindowTokens = 256000`
+- **WHEN** the composite resolver merges these results
+- **THEN** the merged record SHALL preserve the value from resolver A
+
+#### Scenario: All resolvers return null fields
+
+- **GIVEN** every registered resolver returns null for `InputModalities`,
+  `OutputModalities`, and `ContextWindowTokens`
+- **WHEN** the composite returns its merged result
+- **THEN** the merged record SHALL carry null values
+- **AND** downstream consumption SHALL apply text-only / default-context
+  defaults at the boundary (existing
+  `ModelCapabilityResolution.ResolveModelCapabilities` behavior)
+
+### Requirement: Per-request timings extraction across backends
+
+The OpenAI-compatible chat client SHALL extract per-request token usage
+and timing telemetry from the response using a chain of
+`ITimingsExtractor` implementations. Extractors SHALL run in sequence on
+every response. Field paths are non-overlapping across supported
+backends so multiple extractors can safely run without conflict.
+
+`UsageDetails.CachedInputTokens` SHALL be populated from whichever
+backend-specific field is present:
+- llama.cpp: `timings.cache_n`
+- vLLM (and any OpenAI-standard prefix-cache backend):
+  `usage.prompt_tokens_details.cached_tokens`
+
+`UsageDetails.PromptMs` SHALL prefer a server-supplied value when
+present (llama.cpp `timings.prompt_ms`). When no server value is
+available, the chat client SHALL populate `PromptMs` from a client-side
+wall-clock measurement between HTTP request send and the first response
+byte received.
+
+#### Scenario: vLLM cached_tokens flow through
+
+- **GIVEN** a vLLM `/v1/chat/completions` response with
+  `usage.prompt_tokens_details.cached_tokens = 1024`
+- **WHEN** the chat client parses usage
+- **THEN** `UsageDetails.CachedInputTokens` SHALL equal `1024`
+
+#### Scenario: llama.cpp timings still extracted
+
+- **GIVEN** a llama.cpp `/v1/chat/completions` response with a top-level
+  `timings` object containing `cache_n = 2048` and `prompt_ms = 450.0`
+- **WHEN** the chat client parses usage
+- **THEN** `UsageDetails.CachedInputTokens` SHALL equal `2048`
+- **AND** `UsageDetails.PromptMs` SHALL equal `450.0`
+
+#### Scenario: Fallback wall-clock prompt_ms
+
+- **GIVEN** a backend response that contains no `timings.prompt_ms` and no
+  other server-provided prompt latency
+- **WHEN** the chat client receives the first response byte 120ms after
+  sending the request
+- **THEN** `UsageDetails.PromptMs` SHALL equal approximately `120.0`
+  (within wall-clock measurement tolerance)
+
+## MODIFIED Requirements
+
+### Requirement: HuggingFace fallback detection
+
+The system SHALL query the HuggingFace Hub API at
+`GET https://huggingface.co/api/models/{id}` to fill capability fields
+that earlier resolvers in the chain left unpopulated, in addition to the
+existing role as a fallback when provider-native and OpenRouter oracle
+lookups produce no result. HuggingFace lookup SHALL be skipped for model
+IDs that do not match the `<org>/<model>` form (existing
+`ModelIdNormalizer.GetCandidates` filter).
+
+#### Scenario: Open-source model resolved via HuggingFace
+
+- **GIVEN** a model is not found in the OpenRouter catalog
+- **AND** the model has a HuggingFace model ID
+- **WHEN** capabilities are resolved for that model
+- **THEN** the system SHALL query the HuggingFace API
+- **AND** map the `pipeline_tag` field to `ModelModality` flags
+- **AND** `"image-text-to-text"` SHALL map to `InputModalities: Text | Image`
+
+#### Scenario: HuggingFace fills modality left null by OpenAI-compatible resolver
+
+- **GIVEN** the OpenAI-compatible resolver returned a non-null
+  `ContextWindowTokens` but null `InputModalities` (vLLM backend)
+- **AND** the served model id has the `<org>/<model>` form
+- **WHEN** the composite continues through the resolver chain
+- **THEN** the HuggingFace resolver SHALL be consulted
+- **AND** its returned `InputModalities` / `OutputModalities` SHALL merge
+  into the final result
+
+#### Scenario: HuggingFace lookup fails
+
+- **GIVEN** the HuggingFace API returns a 404 or is unreachable
+- **WHEN** capabilities are resolved for that model
+- **THEN** the resolver SHALL return null modality fields
+- **AND** downstream defaulting SHALL apply text-only at the consumption
+  boundary
+- **AND** a warning SHALL be logged
+
+### Requirement: Capability lookup failure resilience
+
+The system SHALL NOT block session startup or message processing if
+capability detection fails. Resolvers in the chain MAY return null values
+for any field they cannot determine; the composite SHALL propagate those
+nulls. The final consumption boundary
+(`ModelCapabilityResolution.ResolveModelCapabilities`) SHALL apply
+text-only modality and default-context defaults when no resolver supplies
+a value, and SHALL log a warning identifying the unresolved fields.
+
+#### Scenario: All detection tiers return null modality
+
+- **WHEN** provider-native, OpenRouter oracle, OpenAI-compatible, and
+  HuggingFace resolvers all return null for `InputModalities`
+- **THEN** the consumption boundary SHALL apply
+  `InputModalities: Text, OutputModalities: Text` for that model ID
+- **AND** log a warning with the model ID and the unresolved fields
+- **AND** the session SHALL proceed normally with text-only behavior
+
+#### Scenario: Manual override still wins
+
+- **GIVEN** a `ModelReference` with explicitly configured
+  `InputModalities`
+- **WHEN** capabilities are resolved
+- **THEN** the configured value SHALL be used regardless of what any
+  resolver returned (existing `ModelCapabilityResolution` precedence)

--- a/openspec/changes/vllm-capability-strategy-and-timings/tasks.md
+++ b/openspec/changes/vllm-capability-strategy-and-timings/tasks.md
@@ -1,0 +1,185 @@
+# Tasks: vLLM Capability Strategy & Timings Extraction
+
+## 1. Capability contract — make modalities nullable
+
+- [x] 1.1 Change `ResolvedModelCapabilities.InputModalities` and
+  `OutputModalities` in
+  `src/Netclaw.Configuration/IModelCapabilityResolver.cs` from
+  `ModelModality` to `ModelModality?` (default `null`).
+- [x] 1.2 Update `OpenAiCodexCapabilityResolver` constructor (it builds
+  records from a known catalog — keep non-null).
+- [x] 1.3 Update `DaemonRuntimeStatusService` so it null-coalesces to
+  `ModelModality.Text` before `.ToString()`-ing for display.
+- [x] 1.4 Update the three resolver-success log lines in
+  `Program.cs:1219-1261` so they print `"unknown"` (or similar) when
+  modality fields are null.
+- [x] 1.5 Confirm `ModelCapabilityResolution.ResolveModelCapabilities`
+  (`src/Netclaw.Daemon/Configuration/ModelCapabilityResolution.cs:34-36`)
+  still compiles and behaves correctly under `ModelModality?` inputs
+  — it already null-coalesces.
+
+## 2. Backend strategy seam for OpenAI-compatible
+
+- [x] 2.1 Create
+  `src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs` holding:
+  - `BackendProbe` record (raw `/v1/models` JSON + nullable `/props`
+    JSON + the served model id).
+  - `IOpenAiBackendStrategy` interface
+    (`bool Matches(BackendProbe probe)` /
+    `ResolvedModelCapabilities? Parse(BackendProbe probe, string modelId)`).
+  - `VllmBackendStrategy`: matches on `owned_by == "vllm"` OR
+    `max_model_len` present AND `/props` was 404. Parses
+    `max_model_len`; leaves modalities null.
+  - `LlamaCppBackendStrategy`: matches on `/props` 200 OR
+    `meta.n_ctx_train` present. Reads `/props.n_ctx` preferentially
+    over `meta.n_ctx_train`; reads `/props.modalities.vision` for
+    image input.
+  - `GenericOpenAiBackendStrategy`: always matches as last-resort;
+    returns ModelId only.
+- [x] 2.2 Wire strategies into the existing
+  `OpenAiCompatibleCapabilityResolver`: probe `/v1/models` and `/props`
+  once, build `BackendProbe`, iterate strategies in
+  `[Vllm, LlamaCpp, Generic]` order.
+- [x] 2.3 Add an info-level log line emitting the matched backend
+  strategy name when capabilities are resolved (per Open Question in
+  design doc — diagnostic value, free of cost).
+
+## 2b. Provider-aware resolver scoping
+
+- [x] 2b.1 Add `string? ProviderType { get; }` to
+  `IModelCapabilityResolver` in
+  `src/Netclaw.Configuration/IModelCapabilityResolver.cs`.
+- [x] 2b.2 Set `ProviderType` on each in-tree resolver:
+  - `OpenAiCodexCapabilityResolver` → `"openai"`
+  - `OllamaCapabilityResolver` → `"ollama"`
+  - `OpenAiCompatibleCapabilityResolver` → `"openai-compatible"`
+  - `OpenRouterOracleResolver` → `null` (oracle)
+  - `HuggingFaceCapabilityResolver` → `null` (oracle)
+- [x] 2b.3 Pipe the active model's `ModelReference.Provider` into the
+  composite resolver call. Two options to evaluate during
+  implementation: (a) thread `activeProvider` through
+  `IModelCapabilityResolver.ResolveAsync(modelId, activeProvider, ct)`,
+  or (b) bind `activeProvider` once at composite construction via a
+  factory. (a) is cleaner; verify it doesn't ripple to too many
+  callers.
+- [x] 2b.4 In `CompositeCapabilityResolver`, filter eligible resolvers
+  by `ProviderType is null || ProviderType == activeProvider` **before**
+  the merge walk.
+- [x] 2b.5 Log at debug-level any resolver skipped due to provider
+  mismatch (one line, includes resolver type name + reason). Cheap
+  diagnostic, no info-level noise.
+
+## 3. Composite resolver field-merge
+
+- [x] 3.1 Replace the short-circuit logic in
+  `src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs:34-66`
+  with field-merge across all resolvers (first non-null wins per
+  field).
+- [x] 3.2 Remove the unconditional text-only default at the chain end
+  — return the merged partial; downstream
+  `ModelCapabilityResolution` handles defaulting.
+- [x] 3.3 Preserve per-resolver 5-second timeout + warning-on-exception
+  behavior already in the file.
+
+## 4. Timings extractor split
+
+- [x] 4.1 Create `src/Netclaw.Providers/SelfHosted/TimingsExtractor.cs`
+  holding:
+  - `ITimingsExtractor` interface
+    (`void Extract(JsonElement root, UsageDetails details)`).
+  - `LlamaCppTimingsExtractor`: relocate the body of
+    `ParseLlamaCppTimings` from `OpenAiCompatibleChatClient.cs:699-715`.
+  - `VllmTimingsExtractor`: reads
+    `usage.prompt_tokens_details.cached_tokens` into
+    `UsageDetails.CachedInputTokens`.
+- [x] 4.2 In `OpenAiCompatibleChatClient`, replace the direct
+  `ParseLlamaCppTimings` call at line 675 with a sequence over both
+  extractors. Order: llama.cpp first, vLLM second (idempotent
+  regardless of order; this matches existing test data shape).
+
+## 5. Wall-clock prompt_ms fallback
+
+- [x] 5.1 In `OpenAiCompatibleChatClient.GetResponseAsync` and
+  `.GetStreamingResponseAsync`, capture a timestamp immediately
+  before `_httpClient.SendAsync(...)` and a second timestamp after
+  the first content byte is observed.
+- [x] 5.2 After both timings extractors have run, set
+  `UsageDetails.PromptMs` to the wall-clock value **only** if
+  `details.PromptMs` is still null. Document in code that the
+  wall-clock variant includes network round-trip.
+
+## 6. Tests
+
+- [x] 6.1 Create
+  `src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs`
+  with the real vLLM `/v1/models` shape from the May-13 field repro
+  (`owned_by: "vllm"`, `max_model_len: 256000`). Assert: strategy
+  matches, returns `ContextWindowTokens = 256000`, null modalities.
+- [x] 6.2 Create
+  `src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs`.
+  Migrate existing `ParseModelsResponse`/`ParsePropsResponse` fixtures
+  from `OpenAiCompatibleCapabilityResolverTests`. Cover:
+  `meta.n_ctx_train` only; `/props` only; both
+  (assert `/props.n_ctx` wins); `modalities.vision: true` → `Image`.
+- [x] 6.3 Create
+  `src/Netclaw.Daemon.Tests/Providers/Strategies/GenericOpenAiBackendStrategyTests.cs`.
+  Cover: returns `(modelId, null, null, null)`; matches when other
+  strategies don't.
+- [x] 6.4 Create
+  `src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverMergeTests.cs`.
+  Cover: vLLM-shaped + HF-shaped merge to full record; first
+  non-null per field; all-null inputs propagate as all-null output
+  (no default injected by composite); resolver with mismatched
+  `ProviderType` skipped (no `ResolveAsync` invocation); resolver with
+  `ProviderType == null` runs for any active provider.
+- [x] 6.5 Create
+  `src/Netclaw.Daemon.Tests/Providers/VllmTimingsExtractorTests.cs`.
+  Real vLLM response shape (`usage.prompt_tokens_details.cached_tokens`)
+  → `UsageDetails.CachedInputTokens`.
+- [x] 6.6 Create
+  `src/Netclaw.Daemon.Tests/Providers/LlamaCppTimingsExtractorTests.cs`.
+  Move any existing `ParseLlamaCppTimings` coverage. Verify both
+  `timings.cache_n` and `timings.prompt_ms` round-trip.
+- [x] 6.7 Update
+  `src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs`:
+  delete tests now duplicated in strategy-level test classes; add a
+  high-level test that the resolver delegates to the right strategy
+  given a backend-probe fixture.
+
+## 7. Spec sync + quality gates
+
+- [x] 7.1 `dotnet build` clean from repo root.
+- [x] 7.2 `dotnet test src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj`
+  passes (full suite, not just `Providers` filter — sanity check
+  callers of the changed contract).
+- [x] 7.3 `dotnet slopwatch analyze` reports no new violations.
+- [x] 7.4 `./scripts/Add-FileHeaders.ps1 -Verify` passes on every new
+  `.cs` file.
+- [x] 7.5 Run `openspec validate vllm-capability-strategy-and-timings`
+  and fix any reported issues.
+
+## 8. End-to-end verification against live vLLM
+
+- [ ] 8.1 Run `netclaw models --provider <vllm-local>` and confirm
+  `ContextWindow=256000` and `Input=Text|Image` for the Qwen3.6-VL
+  model.
+- [ ] 8.2 Send a Slack thread image-bearing turn through the vLLM
+  provider and confirm the image is inlined (not stripped).
+- [ ] 8.3 Drive a multi-turn session and confirm
+  `[usage] cached=<non-zero>` lines appear in
+  `HeadlessChannel.cs:271` output on turn 2+.
+- [ ] 8.4 Repoint the same provider at a llama-server endpoint and
+  confirm no regression: existing
+  `meta.n_ctx_train`/`/props`/`timings.cache_n` paths still surface.
+
+## 9. Wrap-up
+
+- [ ] 9.1 Run `/opsx-verify vllm-capability-strategy-and-timings` to
+  ensure code matches spec.
+- [ ] 9.2 Run `/opsx-sync vllm-capability-strategy-and-timings` to merge
+  delta into `openspec/specs/netclaw-model-capabilities/spec.md`.
+- [ ] 9.3 Update `feeds/skills/.system/files/netclaw-operations/SKILL.md`
+  if any operator-visible diagnostic changes (e.g., the new "detected
+  backend = vLLM" log line). Bump skill `metadata.version`.
+- [ ] 9.4 Run `/opsx-archive vllm-capability-strategy-and-timings`
+  after merge.

--- a/src/Netclaw.Configuration/IModelCapabilityResolver.cs
+++ b/src/Netclaw.Configuration/IModelCapabilityResolver.cs
@@ -6,21 +6,33 @@
 namespace Netclaw.Configuration;
 
 /// <summary>
-/// Resolved capability metadata for a model.
+/// Resolved capability metadata for a model. Any field may be null when the
+/// resolver could not determine that field; the composite resolver merges
+/// partial results across the chain by first-non-null-wins.
 /// </summary>
 public sealed record ResolvedModelCapabilities(
     string ModelId,
-    ModelModality InputModalities,
-    ModelModality OutputModalities,
+    ModelModality? InputModalities,
+    ModelModality? OutputModalities,
     int? ContextWindowTokens = null);
 
 /// <summary>
-/// Resolves model capabilities from a specific source (OpenRouter oracle,
-/// HuggingFace, etc.). Returns null when the source cannot determine
-/// capabilities for the given model.
+/// Resolves model capabilities from a specific source (provider-native API,
+/// OpenRouter oracle, HuggingFace, etc.). Returns null when the source cannot
+/// determine any capability for the given model. Returning a record with null
+/// fields is allowed and indicates a partial result that downstream resolvers
+/// can supplement.
 /// </summary>
 public interface IModelCapabilityResolver
 {
+    /// <summary>
+    /// Provider type this resolver speaks for (e.g., "openai", "ollama",
+    /// "openai-compatible"). When null the resolver is treated as a
+    /// cross-provider oracle and is always eligible regardless of the
+    /// active model's provider.
+    /// </summary>
+    string? ProviderType => null;
+
     Task<ResolvedModelCapabilities?> ResolveAsync(
         string modelId,
         CancellationToken ct = default);

--- a/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/CompositeCapabilityResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="CompositeCapabilityResolverTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -13,29 +13,34 @@ namespace Netclaw.Daemon.Tests.Providers;
 public sealed class CompositeCapabilityResolverTests
 {
     [Fact]
-    public async Task FirstResolver_Succeeds_ReturnsResult()
+    public async Task PartialResults_MergeAcrossResolvers()
     {
-        var first = new FakeResolver(new ResolvedModelCapabilities(
-            "test-model", ModelModality.Text | ModelModality.Image, ModelModality.Text));
-        var second = new FakeResolver(null);
+        // Models the vLLM + HuggingFace handoff: first resolver supplies
+        // context window only, second resolver supplies modalities only.
+        var contextOnly = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", null, null, 256_000));
+        var modalityOnly = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", ModelModality.Text | ModelModality.Image, ModelModality.Text, null));
 
         var composite = new CompositeCapabilityResolver(
-            [first, second],
+            [contextOnly, modalityOnly],
             NullLogger<CompositeCapabilityResolver>.Instance);
 
         var result = await composite.ResolveAsync("test-model", TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
-        Assert.False(second.WasCalled);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+        Assert.Equal(256_000, result.ContextWindowTokens);
     }
 
     [Fact]
-    public async Task FirstResolver_ReturnsNull_FallsThrough()
+    public async Task FirstNonNullWinsPerField()
     {
-        var first = new FakeResolver(null);
-        var second = new FakeResolver(new ResolvedModelCapabilities(
-            "test-model", ModelModality.Text | ModelModality.Audio, ModelModality.Text));
+        var first = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", ModelModality.Text, null, 200_000));
+        var second = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", ModelModality.Text | ModelModality.Image, ModelModality.Text, 256_000));
 
         var composite = new CompositeCapabilityResolver(
             [first, second],
@@ -44,13 +49,16 @@ public sealed class CompositeCapabilityResolverTests
         var result = await composite.ResolveAsync("test-model", TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
-        Assert.Equal(ModelModality.Text | ModelModality.Audio, result.InputModalities);
-        Assert.True(second.WasCalled);
+        Assert.Equal(ModelModality.Text, result.InputModalities); // first wins
+        Assert.Equal(ModelModality.Text, result.OutputModalities); // second supplies (first was null)
+        Assert.Equal(200_000, result.ContextWindowTokens); // first wins
     }
 
     [Fact]
-    public async Task AllResolvers_ReturnNull_DefaultsToText()
+    public async Task AllResolvers_ReturnNull_CompositeReturnsNull()
     {
+        // Defaulting now lives at the consumption boundary
+        // (ModelCapabilityResolution), not in the composite.
         var first = new FakeResolver(null);
         var second = new FakeResolver(null);
 
@@ -60,17 +68,15 @@ public sealed class CompositeCapabilityResolverTests
 
         var result = await composite.ResolveAsync("unknown-model", TestContext.Current.CancellationToken);
 
-        Assert.NotNull(result);
-        Assert.Equal(ModelModality.Text, result.InputModalities);
-        Assert.Equal(ModelModality.Text, result.OutputModalities);
+        Assert.Null(result);
     }
 
     [Fact]
-    public async Task FirstResolver_Throws_FallsThrough()
+    public async Task FirstResolver_Throws_ContinuesChain()
     {
         var first = new ThrowingResolver();
-        var second = new FakeResolver(new ResolvedModelCapabilities(
-            "test-model", ModelModality.Text, ModelModality.Text));
+        var second = new FakeResolver(
+            new ResolvedModelCapabilities("test-model", ModelModality.Text, ModelModality.Text, 65_536));
 
         var composite = new CompositeCapabilityResolver(
             [first, second],
@@ -80,14 +86,89 @@ public sealed class CompositeCapabilityResolverTests
 
         Assert.NotNull(result);
         Assert.Equal(ModelModality.Text, result.InputModalities);
+        Assert.Equal(65_536, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task ProviderMismatch_ResolverSkipped()
+    {
+        // Active provider for the model is openai-compatible; the ollama
+        // resolver must not be invoked.
+        var ollama = new FakeResolver(
+            new ResolvedModelCapabilities("model", ModelModality.Text, ModelModality.Text, 32_768),
+            providerType: "ollama");
+        var openAiCompat = new FakeResolver(
+            new ResolvedModelCapabilities("model", null, null, 256_000),
+            providerType: "openai-compatible");
+
+        var composite = new CompositeCapabilityResolver(
+            [ollama, openAiCompat],
+            NullLogger<CompositeCapabilityResolver>.Instance,
+            _ => "openai-compatible");
+
+        var result = await composite.ResolveAsync("model", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.False(ollama.WasCalled);
+        Assert.True(openAiCompat.WasCalled);
+        Assert.Equal(256_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task OracleResolver_RunsRegardlessOfProvider()
+    {
+        var openAiCompat = new FakeResolver(
+            new ResolvedModelCapabilities("model", null, null, 256_000),
+            providerType: "openai-compatible");
+        var oracle = new FakeResolver(
+            new ResolvedModelCapabilities("model", ModelModality.Text | ModelModality.Image, ModelModality.Text, null),
+            providerType: null); // oracle
+
+        var composite = new CompositeCapabilityResolver(
+            [openAiCompat, oracle],
+            NullLogger<CompositeCapabilityResolver>.Instance,
+            _ => "openai-compatible");
+
+        var result = await composite.ResolveAsync("model", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(oracle.WasCalled);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(256_000, result.ContextWindowTokens);
+    }
+
+    [Fact]
+    public async Task NoActiveProviderLookup_AllResolversRun()
+    {
+        // Backward compatibility: when no lookup is provided, the
+        // composite behaves as if every resolver is eligible.
+        var ollama = new FakeResolver(
+            new ResolvedModelCapabilities("model", null, null, 32_768),
+            providerType: "ollama");
+        var openAiCompat = new FakeResolver(null, providerType: "openai-compatible");
+
+        var composite = new CompositeCapabilityResolver(
+            [ollama, openAiCompat],
+            NullLogger<CompositeCapabilityResolver>.Instance);
+
+        var result = await composite.ResolveAsync("model", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(ollama.WasCalled);
+        Assert.True(openAiCompat.WasCalled);
     }
 
     private sealed class FakeResolver : IModelCapabilityResolver
     {
         private readonly ResolvedModelCapabilities? _result;
         public bool WasCalled { get; private set; }
+        public string? ProviderType { get; }
 
-        public FakeResolver(ResolvedModelCapabilities? result) => _result = result;
+        public FakeResolver(ResolvedModelCapabilities? result, string? providerType = null)
+        {
+            _result = result;
+            ProviderType = providerType;
+        }
 
         public Task<ResolvedModelCapabilities?> ResolveAsync(
             string modelId, CancellationToken ct = default)

--- a/src/Netclaw.Daemon.Tests/Providers/LlamaCppTimingsExtractorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/LlamaCppTimingsExtractorTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlamaCppTimingsExtractorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class LlamaCppTimingsExtractorTests
+{
+    [Fact]
+    public void Extracts_CacheN_AndTimings()
+    {
+        const string json = """
+        {
+          "usage": { "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150 },
+          "timings": {
+            "cache_n": 2048,
+            "prompt_ms": 450.5,
+            "prompt_per_second": 200.0,
+            "predicted_ms": 1200.0,
+            "predicted_per_second": 41.67
+          }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new LlamaCppTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Equal(2048, details.CachedInputTokenCount);
+        Assert.NotNull(details.AdditionalCounts);
+        Assert.Equal(450_500L, details.AdditionalCounts[TimingsKeys.PromptUs]);
+        Assert.Equal(20_000L, details.AdditionalCounts[TimingsKeys.PromptTokPerSecX100]);
+        Assert.Equal(1_200_000L, details.AdditionalCounts[TimingsKeys.PredictedUs]);
+        Assert.Equal(4167L, details.AdditionalCounts[TimingsKeys.PredictedTokPerSecX100]);
+    }
+
+    [Fact]
+    public void NoOp_WhenTimingsAbsent()
+    {
+        const string json = """{ "usage": { "prompt_tokens": 100 } }""";
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new LlamaCppTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Null(details.CachedInputTokenCount);
+        Assert.Null(details.AdditionalCounts);
+    }
+
+    [Fact]
+    public void NoOp_WhenTimingsNotObject()
+    {
+        const string json = """{ "timings": "not-an-object" }""";
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new LlamaCppTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Null(details.CachedInputTokenCount);
+    }
+
+    [Fact]
+    public void PartialFields_OK()
+    {
+        // Only cache_n + prompt_ms, missing throughput fields.
+        const string json = """
+        {
+          "timings": { "cache_n": 512, "prompt_ms": 100.0 }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new LlamaCppTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Equal(512, details.CachedInputTokenCount);
+        Assert.Equal(100_000L, details.AdditionalCounts![TimingsKeys.PromptUs]);
+        Assert.False(details.AdditionalCounts.ContainsKey(TimingsKeys.PredictedUs));
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
@@ -284,7 +284,8 @@ public sealed class OpenAiCodexTests
 
             Assert.NotNull(result);
             Assert.Equal(256_000, result.ContextWindowTokens);
-            Assert.True(result.InputModalities.HasFlag(ModelModality.Text | ModelModality.Image));
+            Assert.NotNull(result.InputModalities);
+            Assert.True(result.InputModalities.Value.HasFlag(ModelModality.Text | ModelModality.Image));
             Assert.Equal(ModelModality.Text, result.OutputModalities);
         }
 

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="OpenAiCompatibleCapabilityResolverTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -9,89 +9,88 @@ using Xunit;
 
 namespace Netclaw.Daemon.Tests.Providers;
 
+/// <summary>
+/// High-level dispatch tests for <see cref="OpenAiCompatibleCapabilityResolver"/>.
+/// Per-backend parsing is covered in <c>VllmBackendStrategyTests</c> and
+/// <c>LlamaCppBackendStrategyTests</c>.
+/// </summary>
 public sealed class OpenAiCompatibleCapabilityResolverTests
 {
     [Fact]
-    public void ParseModelsResponse_ExtractsContextWindow()
+    public void ResolveFromProbe_VllmShape_DispatchesToVllmStrategy()
     {
-        const string json = """
+        // vLLM /v1/models exposes max_model_len at the top level of the
+        // model entry and owns "vllm" as the owned_by value. /props 404s.
+        const string modelsJson = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "Qwen/Qwen3.6-VL-30B-FP8",
+              "object": "model",
+              "owned_by": "vllm",
+              "max_model_len": 256000
+            }
+          ]
+        }
+        """;
+        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", modelsJson, PropsJson: null);
+
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(256_000, result.ContextWindowTokens);
+        // vLLM exposes no modality info; HF resolver fills these downstream.
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+    }
+
+    [Fact]
+    public void ResolveFromProbe_LlamaCppShape_DispatchesToLlamaCppStrategy()
+    {
+        // llama.cpp exposes context window in meta.n_ctx_train on /v1/models
+        // and serves /props with modality and runtime n_ctx data.
+        const string modelsJson = """
         {
           "object": "list",
           "data": [
             {
               "id": "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
-              "meta": {
-                "n_ctx_train": 262144
-              }
+              "meta": { "n_ctx_train": 262144 }
             }
           ]
         }
         """;
-
-        var result = OpenAiCompatibleCapabilityResolver.ParseModelsResponse(json, "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf");
-
-        Assert.NotNull(result);
-        Assert.Equal(262_144, result.ContextWindowTokens);
-        Assert.Equal(ModelModality.Text, result.InputModalities);
-    }
-
-    [Fact]
-    public void ParsePropsResponse_VisionEnabled_AddsImageInput()
-    {
-        const string json = """
+        const string propsJson = """
         {
-          "default_generation_settings": {
-            "params": {
-              "n_ctx": 65536
-            }
-          },
-          "modalities": {
-            "vision": true
-          }
+          "default_generation_settings": { "params": { "n_ctx": 65536 } },
+          "modalities": { "vision": true }
         }
         """;
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", modelsJson, propsJson);
 
-        var result = OpenAiCompatibleCapabilityResolver.ParsePropsResponse(json, "Qwen3.5", 32768);
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
 
         Assert.NotNull(result);
+        // /props.n_ctx wins over meta.n_ctx_train when both are present.
+        Assert.Equal(65_536, result.ContextWindowTokens);
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
-        Assert.Equal(65536, result.ContextWindowTokens);
     }
 
     [Fact]
-    public void ParsePropsResponse_VisionDisabled_StaysTextOnly()
+    public void ResolveFromProbe_UnknownShape_FallsThroughToGenericStrategy()
     {
-        const string json = """
-        {
-          "modalities": {
-            "vision": false
-          }
-        }
+        const string modelsJson = """
+        { "object": "list", "data": [ { "id": "mystery-model" } ] }
         """;
+        var probe = new BackendProbe("mystery-model", modelsJson, PropsJson: null);
 
-        var result = OpenAiCompatibleCapabilityResolver.ParsePropsResponse(json, "Qwen3.5", 32768);
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
 
         Assert.NotNull(result);
-        Assert.Equal(ModelModality.Text, result.InputModalities);
-        Assert.Equal(32768, result.ContextWindowTokens);
-    }
-
-    [Fact]
-    public void ParsePropsResponse_UsesModelContextWindowWhenRuntimeValueMissing()
-    {
-        const string json = """
-        {
-          "modalities": {
-            "vision": true
-          }
-        }
-        """;
-
-        var result = OpenAiCompatibleCapabilityResolver.ParsePropsResponse(json, "Qwen3.5", 262144);
-
-        Assert.NotNull(result);
-        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
-        Assert.Equal(262144, result.ContextWindowTokens);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+        Assert.Null(result.ContextWindowTokens);
     }
 }

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleCapabilityResolverTests.cs
@@ -19,8 +19,6 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
     [Fact]
     public void ResolveFromProbe_VllmShape_DispatchesToVllmStrategy()
     {
-        // vLLM /v1/models exposes max_model_len at the top level of the
-        // model entry and owns "vllm" as the owned_by value. /props 404s.
         const string modelsJson = """
         {
           "object": "list",
@@ -34,9 +32,9 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
           ]
         }
         """;
-        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", modelsJson, PropsJson: null);
 
-        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(
+            "Qwen/Qwen3.6-VL-30B-FP8", modelsJson, propsJson: null);
 
         Assert.NotNull(result);
         Assert.Equal(256_000, result.ContextWindowTokens);
@@ -48,8 +46,6 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
     [Fact]
     public void ResolveFromProbe_LlamaCppShape_DispatchesToLlamaCppStrategy()
     {
-        // llama.cpp exposes context window in meta.n_ctx_train on /v1/models
-        // and serves /props with modality and runtime n_ctx data.
         const string modelsJson = """
         {
           "object": "list",
@@ -67,9 +63,9 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
           "modalities": { "vision": true }
         }
         """;
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", modelsJson, propsJson);
 
-        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(
+            "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", modelsJson, propsJson);
 
         Assert.NotNull(result);
         // /props.n_ctx wins over meta.n_ctx_train when both are present.
@@ -84,9 +80,9 @@ public sealed class OpenAiCompatibleCapabilityResolverTests
         const string modelsJson = """
         { "object": "list", "data": [ { "id": "mystery-model" } ] }
         """;
-        var probe = new BackendProbe("mystery-model", modelsJson, PropsJson: null);
 
-        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(probe);
+        var result = OpenAiCompatibleCapabilityResolver.ResolveFromProbe(
+            "mystery-model", modelsJson, propsJson: null);
 
         Assert.NotNull(result);
         Assert.Null(result.InputModalities);

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleChatClientUsageTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCompatibleChatClientUsageTests.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="OpenAiCompatibleChatClientUsageTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class OpenAiCompatibleChatClientUsageTests
+{
+    [Fact]
+    public void ParseUsage_WallClockPromptMs_FillsWhenServerSilent()
+    {
+        // vLLM-shape: no `timings` object, no server-side prompt latency.
+        const string json = """
+        {
+          "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "total_tokens": 125,
+            "prompt_tokens_details": { "cached_tokens": 50 }
+          }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement, wallClockPromptMs: 120.0);
+
+        Assert.NotNull(usage);
+        Assert.Equal(50, usage.CachedInputTokenCount);
+        Assert.NotNull(usage.AdditionalCounts);
+        Assert.Equal(120_000L, usage.AdditionalCounts[TimingsKeys.PromptUs]);
+    }
+
+    [Fact]
+    public void ParseUsage_WallClockPromptMs_DoesNotOverrideServerValue()
+    {
+        // llama.cpp-shape: server supplied prompt_ms via `timings`.
+        // Wall-clock must NOT clobber it.
+        const string json = """
+        {
+          "usage": { "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150 },
+          "timings": { "prompt_ms": 220.0 }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+
+        var usage = OpenAiCompatibleChatClient.ParseUsage(doc.RootElement, wallClockPromptMs: 999.0);
+
+        Assert.NotNull(usage);
+        Assert.Equal(220_000L, usage.AdditionalCounts![TimingsKeys.PromptUs]);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/GenericOpenAiBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/GenericOpenAiBackendStrategyTests.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="GenericOpenAiBackendStrategyTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers.Strategies;
+
+public sealed class GenericOpenAiBackendStrategyTests
+{
+    [Fact]
+    public void Matches_AnyShape()
+    {
+        var probe = new BackendProbe("any", """{}""", PropsJson: null);
+        Assert.True(new GenericOpenAiBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Parse_ReturnsAllFieldsNull()
+    {
+        var probe = new BackendProbe("any-model", """{}""", PropsJson: null);
+        var result = new GenericOpenAiBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal("any-model", result.ModelId);
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+        Assert.Null(result.ContextWindowTokens);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/GenericOpenAiBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/GenericOpenAiBackendStrategyTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Providers.SelfHosted;
 using Xunit;
 
@@ -13,14 +14,16 @@ public sealed class GenericOpenAiBackendStrategyTests
     [Fact]
     public void Matches_AnyShape()
     {
-        var probe = new BackendProbe("any", """{}""", PropsJson: null);
+        using var doc = JsonDocument.Parse("""{}""");
+        var probe = new BackendProbe("any", doc.RootElement, PropsRoot: null);
         Assert.True(new GenericOpenAiBackendStrategy().Matches(probe));
     }
 
     [Fact]
     public void Parse_ReturnsAllFieldsNull()
     {
-        var probe = new BackendProbe("any-model", """{}""", PropsJson: null);
+        using var doc = JsonDocument.Parse("""{}""");
+        var probe = new BackendProbe("any-model", doc.RootElement, PropsRoot: null);
         var result = new GenericOpenAiBackendStrategy().Parse(probe);
 
         Assert.NotNull(result);

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Text.Json;
 using Netclaw.Configuration;
 using Netclaw.Providers.SelfHosted;
 using Xunit;
@@ -26,14 +27,17 @@ public sealed class LlamaCppBackendStrategyTests
     [Fact]
     public void Matches_PropsPresent()
     {
-        var probe = new BackendProbe("any-model", """{"object":"list","data":[]}""", PropsJson: "{}");
+        using var models = JsonDocument.Parse("""{"object":"list","data":[]}""");
+        using var props = JsonDocument.Parse("{}");
+        var probe = new BackendProbe("any-model", models.RootElement, props.RootElement);
         Assert.True(new LlamaCppBackendStrategy().Matches(probe));
     }
 
     [Fact]
     public void Matches_MetaNCtxTrain_PresentEvenWithoutProps()
     {
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, PropsJson: null);
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
         Assert.True(new LlamaCppBackendStrategy().Matches(probe));
     }
 
@@ -46,7 +50,9 @@ public sealed class LlamaCppBackendStrategyTests
           "modalities": { "vision": true }
         }
         """;
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, propsJson);
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        using var props = JsonDocument.Parse(propsJson);
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, props.RootElement);
 
         var result = new LlamaCppBackendStrategy().Parse(probe);
 
@@ -59,7 +65,8 @@ public sealed class LlamaCppBackendStrategyTests
     [Fact]
     public void Parse_FallsBackToMetaNCtxTrain_WhenPropsAbsent()
     {
-        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, PropsJson: null);
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", models.RootElement, PropsRoot: null);
 
         var result = new LlamaCppBackendStrategy().Parse(probe);
 
@@ -71,8 +78,9 @@ public sealed class LlamaCppBackendStrategyTests
     [Fact]
     public void Parse_VisionDisabled_StaysTextOnly()
     {
-        const string propsJson = """{"modalities":{"vision":false}}""";
-        var probe = new BackendProbe("Qwen3.5", ModelsJsonWithMetaCtx, propsJson);
+        using var models = JsonDocument.Parse(ModelsJsonWithMetaCtx);
+        using var props = JsonDocument.Parse("""{"modalities":{"vision":false}}""");
+        var probe = new BackendProbe("Qwen3.5", models.RootElement, props.RootElement);
 
         var result = new LlamaCppBackendStrategy().Parse(probe);
 

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/LlamaCppBackendStrategyTests.cs
@@ -1,0 +1,82 @@
+// -----------------------------------------------------------------------
+// <copyright file="LlamaCppBackendStrategyTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers.Strategies;
+
+public sealed class LlamaCppBackendStrategyTests
+{
+    private const string ModelsJsonWithMetaCtx = """
+    {
+      "object": "list",
+      "data": [
+        {
+          "id": "Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
+          "meta": { "n_ctx_train": 262144 }
+        }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void Matches_PropsPresent()
+    {
+        var probe = new BackendProbe("any-model", """{"object":"list","data":[]}""", PropsJson: "{}");
+        Assert.True(new LlamaCppBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Matches_MetaNCtxTrain_PresentEvenWithoutProps()
+    {
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, PropsJson: null);
+        Assert.True(new LlamaCppBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Parse_PrefersPropsNCtxOverMetaNCtxTrain()
+    {
+        const string propsJson = """
+        {
+          "default_generation_settings": { "params": { "n_ctx": 65536 } },
+          "modalities": { "vision": true }
+        }
+        """;
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, propsJson);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(65_536, result.ContextWindowTokens); // /props overrides
+        Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
+        Assert.Equal(ModelModality.Text, result.OutputModalities);
+    }
+
+    [Fact]
+    public void Parse_FallsBackToMetaNCtxTrain_WhenPropsAbsent()
+    {
+        var probe = new BackendProbe("Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf", ModelsJsonWithMetaCtx, PropsJson: null);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(262_144, result.ContextWindowTokens);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+    }
+
+    [Fact]
+    public void Parse_VisionDisabled_StaysTextOnly()
+    {
+        const string propsJson = """{"modalities":{"vision":false}}""";
+        var probe = new BackendProbe("Qwen3.5", ModelsJsonWithMetaCtx, propsJson);
+
+        var result = new LlamaCppBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal(ModelModality.Text, result.InputModalities);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
@@ -3,7 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using Netclaw.Configuration;
+using System.Text.Json;
 using Netclaw.Providers.SelfHosted;
 using Xunit;
 
@@ -33,7 +33,8 @@ public sealed class VllmBackendStrategyTests
     [Fact]
     public void Matches_OwnedByVllm()
     {
-        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", VllmModelsJson, PropsJson: null);
+        using var doc = JsonDocument.Parse(VllmModelsJson);
+        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", doc.RootElement, PropsRoot: null);
         Assert.True(new VllmBackendStrategy().Matches(probe));
     }
 
@@ -44,7 +45,8 @@ public sealed class VllmBackendStrategyTests
         const string strippedJson = """
         { "object": "list", "data": [ { "id": "model-x", "max_model_len": 131072 } ] }
         """;
-        var probe = new BackendProbe("model-x", strippedJson, PropsJson: null);
+        using var doc = JsonDocument.Parse(strippedJson);
+        var probe = new BackendProbe("model-x", doc.RootElement, PropsRoot: null);
         Assert.True(new VllmBackendStrategy().Matches(probe));
     }
 
@@ -54,14 +56,16 @@ public sealed class VllmBackendStrategyTests
         const string json = """
         { "object": "list", "data": [ { "id": "model-x" } ] }
         """;
-        var probe = new BackendProbe("model-x", json, PropsJson: null);
+        using var doc = JsonDocument.Parse(json);
+        var probe = new BackendProbe("model-x", doc.RootElement, PropsRoot: null);
         Assert.False(new VllmBackendStrategy().Matches(probe));
     }
 
     [Fact]
     public void Parse_ReturnsMaxModelLenAsContext_LeavesModalitiesNull()
     {
-        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", VllmModelsJson, PropsJson: null);
+        using var doc = JsonDocument.Parse(VllmModelsJson);
+        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", doc.RootElement, PropsRoot: null);
         var result = new VllmBackendStrategy().Parse(probe);
 
         Assert.NotNull(result);
@@ -78,7 +82,8 @@ public sealed class VllmBackendStrategyTests
         // Strategy can't say anything useful when the served model is
         // not in the catalog. Returning null lets the composite continue
         // through the rest of the chain.
-        var probe = new BackendProbe("other-model", VllmModelsJson, PropsJson: null);
+        using var doc = JsonDocument.Parse(VllmModelsJson);
+        var probe = new BackendProbe("other-model", doc.RootElement, PropsRoot: null);
         var result = new VllmBackendStrategy().Parse(probe);
 
         Assert.Null(result);

--- a/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/Strategies/VllmBackendStrategyTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="VllmBackendStrategyTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers.Strategies;
+
+public sealed class VllmBackendStrategyTests
+{
+    // Real vLLM 0.20 response shape captured from a live deployment
+    // (see Aaron's 2026-05-13 field-repro comment on issue #619).
+    private const string VllmModelsJson = """
+    {
+      "object": "list",
+      "data": [
+        {
+          "id": "Qwen/Qwen3.6-VL-30B-FP8",
+          "object": "model",
+          "created": 1778684111,
+          "owned_by": "vllm",
+          "root": "/models/xs",
+          "parent": null,
+          "max_model_len": 256000
+        }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void Matches_OwnedByVllm()
+    {
+        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", VllmModelsJson, PropsJson: null);
+        Assert.True(new VllmBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Matches_MaxModelLen_With404Props()
+    {
+        // Strip owned_by to verify the secondary signal works on its own.
+        const string strippedJson = """
+        { "object": "list", "data": [ { "id": "model-x", "max_model_len": 131072 } ] }
+        """;
+        var probe = new BackendProbe("model-x", strippedJson, PropsJson: null);
+        Assert.True(new VllmBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Matches_False_WhenNeitherSignalPresent()
+    {
+        const string json = """
+        { "object": "list", "data": [ { "id": "model-x" } ] }
+        """;
+        var probe = new BackendProbe("model-x", json, PropsJson: null);
+        Assert.False(new VllmBackendStrategy().Matches(probe));
+    }
+
+    [Fact]
+    public void Parse_ReturnsMaxModelLenAsContext_LeavesModalitiesNull()
+    {
+        var probe = new BackendProbe("Qwen/Qwen3.6-VL-30B-FP8", VllmModelsJson, PropsJson: null);
+        var result = new VllmBackendStrategy().Parse(probe);
+
+        Assert.NotNull(result);
+        Assert.Equal("Qwen/Qwen3.6-VL-30B-FP8", result.ModelId);
+        Assert.Equal(256_000, result.ContextWindowTokens);
+        // vLLM exposes no modality info; HF resolver fills these.
+        Assert.Null(result.InputModalities);
+        Assert.Null(result.OutputModalities);
+    }
+
+    [Fact]
+    public void Parse_NoMatchingModelId_ReturnsNull()
+    {
+        // Strategy can't say anything useful when the served model is
+        // not in the catalog. Returning null lets the composite continue
+        // through the rest of the chain.
+        var probe = new BackendProbe("other-model", VllmModelsJson, PropsJson: null);
+        var result = new VllmBackendStrategy().Parse(probe);
+
+        Assert.Null(result);
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Providers/VllmTimingsExtractorTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/VllmTimingsExtractorTests.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------
+// <copyright file="VllmTimingsExtractorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Netclaw.Providers.SelfHosted;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+public sealed class VllmTimingsExtractorTests
+{
+    [Fact]
+    public void Extracts_CachedTokens_FromPromptTokensDetails()
+    {
+        const string json = """
+        {
+          "usage": {
+            "prompt_tokens": 1024,
+            "completion_tokens": 50,
+            "total_tokens": 1074,
+            "prompt_tokens_details": { "cached_tokens": 768 }
+          }
+        }
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new VllmTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Equal(768, details.CachedInputTokenCount);
+    }
+
+    [Fact]
+    public void NoOp_WhenPromptTokensDetailsAbsent()
+    {
+        const string json = """{ "usage": { "prompt_tokens": 100 } }""";
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new VllmTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Null(details.CachedInputTokenCount);
+    }
+
+    [Fact]
+    public void NoOp_WhenUsageAbsent()
+    {
+        const string json = """{ "choices": [] }""";
+        using var doc = JsonDocument.Parse(json);
+        var details = new UsageDetails();
+
+        new VllmTimingsExtractor().Extract(doc.RootElement, details);
+
+        Assert.Null(details.CachedInputTokenCount);
+    }
+}

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -977,11 +977,9 @@ static void ConfigureDaemonServices(
                 openAiCompatibleEndpoint,
                 openAiCompatibleApiKey));
     }
-    // Lookup map: modelId → provider type (e.g. "openai-compatible", "ollama").
-    // Used by CompositeCapabilityResolver to skip provider-native resolvers
-    // whose provider doesn't own the model being queried. Built from the
-    // active ModelSelection at startup so multi-model deployments
-    // (Main on one provider, Compaction on another) get correct scoping.
+    // modelId → provider type lookup for CompositeCapabilityResolver scoping.
+    // Covers Main + optional Compaction independently so multi-provider
+    // deployments resolve each model's capabilities against the right backend.
     var modelProviderLookup = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
     if (!string.IsNullOrWhiteSpace(models.Main.ModelId))
         modelProviderLookup[models.Main.ModelId] = mainProviderType;

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -977,6 +977,18 @@ static void ConfigureDaemonServices(
                 openAiCompatibleEndpoint,
                 openAiCompatibleApiKey));
     }
+    // Lookup map: modelId → provider type (e.g. "openai-compatible", "ollama").
+    // Used by CompositeCapabilityResolver to skip provider-native resolvers
+    // whose provider doesn't own the model being queried. Built from the
+    // active ModelSelection at startup so multi-model deployments
+    // (Main on one provider, Compaction on another) get correct scoping.
+    var modelProviderLookup = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    if (!string.IsNullOrWhiteSpace(models.Main.ModelId))
+        modelProviderLookup[models.Main.ModelId] = mainProviderType;
+    if (models.Compaction is { ModelId: { Length: > 0 } compactionId } &&
+        providers.TryGetValue(models.Compaction.Provider, out var compactionProvider))
+        modelProviderLookup[compactionId] = compactionProvider.Type;
+
     services.AddSingleton<IModelCapabilityResolver>(sp =>
     {
         var resolvers = new List<IModelCapabilityResolver>
@@ -992,7 +1004,8 @@ static void ConfigureDaemonServices(
 
         return new CompositeCapabilityResolver(
             resolvers,
-            sp.GetRequiredService<ILogger<CompositeCapabilityResolver>>());
+            sp.GetRequiredService<ILogger<CompositeCapabilityResolver>>(),
+            modelId => modelProviderLookup.TryGetValue(modelId, out var pt) ? pt : null);
     });
 
     // Composite dependency records for LlmSessionActor DI resolution
@@ -1217,7 +1230,9 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(
             {
                 logger.LogInformation(
                     "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                    modelId, ollamaResult.InputModalities, ollamaResult.OutputModalities,
+                    modelId,
+                    ollamaResult.InputModalities?.ToString() ?? "unknown",
+                    ollamaResult.OutputModalities?.ToString() ?? "unknown",
                     ollamaResult.ContextWindowTokens?.ToString() ?? "unknown");
                 return ollamaResult;
             }
@@ -1238,7 +1253,9 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(
             {
                 logger.LogInformation(
                     "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                    modelId, openAiCompatibleResult.InputModalities, openAiCompatibleResult.OutputModalities,
+                    modelId,
+                    openAiCompatibleResult.InputModalities?.ToString() ?? "unknown",
+                    openAiCompatibleResult.OutputModalities?.ToString() ?? "unknown",
                     openAiCompatibleResult.ContextWindowTokens?.ToString() ?? "unknown");
                 return openAiCompatibleResult;
             }
@@ -1257,7 +1274,9 @@ static ResolvedModelCapabilities? ResolveStartupCapabilities(
         {
             logger.LogInformation(
                 "Auto-detected model capabilities for {ModelId}: input={Input}, output={Output}, context_window={ContextWindow}",
-                modelId, result.InputModalities, result.OutputModalities,
+                modelId,
+                result.InputModalities?.ToString() ?? "unknown",
+                result.OutputModalities?.ToString() ?? "unknown",
                 result.ContextWindowTokens?.ToString() ?? "unknown");
         }
         else

--- a/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
+++ b/src/Netclaw.Daemon/Providers/CompositeCapabilityResolver.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="CompositeCapabilityResolver.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -9,9 +9,13 @@ using Netclaw.Configuration;
 namespace Netclaw.Daemon.Providers;
 
 /// <summary>
-/// Chains multiple <see cref="IModelCapabilityResolver"/> instances in priority
-/// order. Returns the first non-null result, or a text-only default if all
-/// resolvers return null or fail.
+/// Chains multiple <see cref="IModelCapabilityResolver"/> instances and
+/// merges partial results across the chain — first non-null wins per
+/// field. Provider-native resolvers (non-null <see cref="IModelCapabilityResolver.ProviderType"/>)
+/// are skipped when their type does not match the model's active
+/// provider; oracle resolvers (null <c>ProviderType</c>) always run.
+/// Defaulting for unresolved fields lives at the consumption boundary
+/// (<c>ModelCapabilityResolution.ResolveModelCapabilities</c>), not here.
 /// </summary>
 public sealed class CompositeCapabilityResolver : IModelCapabilityResolver
 {
@@ -19,49 +23,97 @@ public sealed class CompositeCapabilityResolver : IModelCapabilityResolver
 
     private readonly IReadOnlyList<IModelCapabilityResolver> _resolvers;
     private readonly ILogger<CompositeCapabilityResolver> _logger;
+    private readonly Func<string, string?> _activeProviderForModel;
 
     public CompositeCapabilityResolver(
         IEnumerable<IModelCapabilityResolver> resolvers,
-        ILogger<CompositeCapabilityResolver> logger)
+        ILogger<CompositeCapabilityResolver> logger,
+        Func<string, string?>? activeProviderForModel = null)
     {
         _resolvers = resolvers.ToList();
         _logger = logger;
+        // Default: no filtering. Production callers wire a real lookup from ModelSelection.
+        _activeProviderForModel = activeProviderForModel ?? (_ => null);
     }
 
     public async Task<ResolvedModelCapabilities?> ResolveAsync(
         string modelId, CancellationToken ct = default)
     {
+        var activeProvider = _activeProviderForModel(modelId);
+
+        // Merge state — each field is filled by the first resolver that
+        // returns a non-null value for it.
+        ModelModality? inputModalities = null;
+        ModelModality? outputModalities = null;
+        int? contextWindowTokens = null;
+        var anyResultProduced = false;
+
         foreach (var resolver in _resolvers)
         {
+            if (!IsEligible(resolver, activeProvider))
+            {
+                _logger.LogDebug(
+                    "Skipping {Resolver} for model {ModelId}: ProviderType={ResolverProvider} does not match active provider {ActiveProvider}",
+                    resolver.GetType().Name, modelId, resolver.ProviderType, activeProvider);
+                continue;
+            }
+
+            ResolvedModelCapabilities? result;
             try
             {
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 timeoutCts.CancelAfter(ResolverTimeout);
 
-                var result = await resolver.ResolveAsync(modelId, timeoutCts.Token);
-                if (result is not null)
-                {
-                    _logger.LogDebug(
-                        "Resolved capabilities for {ModelId} via {Resolver}: input={Input}, output={Output}",
-                        modelId, resolver.GetType().Name, result.InputModalities, result.OutputModalities);
-                    return result;
-                }
+                result = await resolver.ResolveAsync(modelId, timeoutCts.Token);
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                _logger.LogDebug("{Resolver} timed out for model {ModelId}, trying next",
+                _logger.LogDebug("{Resolver} timed out for model {ModelId}, continuing chain",
                     resolver.GetType().Name, modelId);
+                continue;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                _logger.LogDebug(ex, "{Resolver} failed for model {ModelId}, trying next",
+                _logger.LogDebug(ex, "{Resolver} failed for model {ModelId}, continuing chain",
                     resolver.GetType().Name, modelId);
+                continue;
             }
+
+            if (result is null)
+                continue;
+
+            anyResultProduced = true;
+            inputModalities ??= result.InputModalities;
+            outputModalities ??= result.OutputModalities;
+            contextWindowTokens ??= result.ContextWindowTokens;
+
+            _logger.LogDebug(
+                "Resolved partial capabilities for {ModelId} via {Resolver}: input={Input}, output={Output}, ctx={Ctx}",
+                modelId, resolver.GetType().Name,
+                result.InputModalities?.ToString() ?? "null",
+                result.OutputModalities?.ToString() ?? "null",
+                result.ContextWindowTokens?.ToString() ?? "null");
+
+            // Early-out optimization: every field filled, stop walking.
+            if (inputModalities is not null && outputModalities is not null && contextWindowTokens is not null)
+                break;
         }
 
-        // All resolvers failed or returned null — default to text-only
-        _logger.LogWarning(
-            "All capability resolvers failed for model {ModelId}; defaulting to text-only", modelId);
-        return new ResolvedModelCapabilities(modelId, ModelModality.Text, ModelModality.Text);
+        if (!anyResultProduced)
+            return null;
+
+        return new ResolvedModelCapabilities(
+            modelId, inputModalities, outputModalities, contextWindowTokens);
+    }
+
+    private static bool IsEligible(IModelCapabilityResolver resolver, string? activeProvider)
+    {
+        // Oracles (null ProviderType) always run.
+        if (resolver.ProviderType is null)
+            return true;
+        // No active provider known → can't filter → keep current behavior (run all).
+        if (activeProvider is null)
+            return true;
+        return string.Equals(resolver.ProviderType, activeProvider, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Netclaw.Providers/OpenAi/OpenAiCodexCapabilityResolver.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiCodexCapabilityResolver.cs
@@ -23,6 +23,8 @@ public sealed class OpenAiCodexCapabilityResolver : IModelCapabilityResolver
                 m.OutputModalities,
                 m.ContextWindowTokens));
 
+    public string? ProviderType => "openai";
+
     public Task<ResolvedModelCapabilities?> ResolveAsync(
         string modelId, CancellationToken ct = default)
     {

--- a/src/Netclaw.Providers/SelfHosted/OllamaCapabilityResolver.cs
+++ b/src/Netclaw.Providers/SelfHosted/OllamaCapabilityResolver.cs
@@ -32,6 +32,8 @@ public sealed class OllamaCapabilityResolver : IModelCapabilityResolver
         _endpoint = endpoint.TrimEnd('/');
     }
 
+    public string? ProviderType => "ollama";
+
     public async Task<ResolvedModelCapabilities?> ResolveAsync(
         string modelId, CancellationToken ct = default)
     {

--- a/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
@@ -9,11 +9,39 @@ using Netclaw.Configuration;
 namespace Netclaw.Providers.SelfHosted;
 
 /// <summary>
-/// Wraps the raw probe results an OpenAI-compatible capability resolver
-/// shares across strategy implementations. <see cref="PropsJson"/> is null
-/// when the backend has no <c>/props</c> endpoint (e.g. vLLM returns 404).
+/// Pre-parsed probe results shared across strategy implementations. The
+/// resolver owns the underlying <see cref="JsonDocument"/> lifetime, so
+/// <see cref="JsonElement"/> references here are valid only for the
+/// duration of one <c>ResolveAsync</c> call. <see cref="PropsRoot"/> is
+/// null when the backend has no <c>/props</c> endpoint (e.g. vLLM 404).
 /// </summary>
-internal sealed record BackendProbe(string ModelId, string ModelsJson, string? PropsJson);
+internal sealed record BackendProbe(string ModelId, JsonElement ModelsRoot, JsonElement? PropsRoot)
+{
+    /// <summary>
+    /// Locates the <c>/v1/models</c> entry matching <see cref="ModelId"/>
+    /// by case-insensitive <c>id</c> comparison. Returns false when no
+    /// entry matches or the response shape is unexpected.
+    /// </summary>
+    public bool TryFindModelEntry(out JsonElement entry)
+    {
+        entry = default;
+        if (!ModelsRoot.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+            return false;
+
+        foreach (var model in data.EnumerateArray())
+        {
+            if (model.TryGetProperty("id", out var id) &&
+                id.ValueKind == JsonValueKind.String &&
+                string.Equals(id.GetString(), ModelId, StringComparison.OrdinalIgnoreCase))
+            {
+                entry = model;
+                return true;
+            }
+        }
+        return false;
+    }
+}
 
 /// <summary>
 /// Backend-specific parser for an OpenAI-compatible endpoint. The
@@ -44,7 +72,7 @@ internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
 
     public bool Matches(BackendProbe probe)
     {
-        if (!TryFindModelEntry(probe, out var model))
+        if (!probe.TryFindModelEntry(out var model))
             return false;
 
         if (model.TryGetProperty("owned_by", out var ownedBy) &&
@@ -53,14 +81,14 @@ internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
             return true;
 
         // /props 404 + max_model_len present is also a strong vLLM signal.
-        return probe.PropsJson is null &&
+        return probe.PropsRoot is null &&
                model.TryGetProperty("max_model_len", out var mml) &&
                mml.ValueKind == JsonValueKind.Number;
     }
 
     public ResolvedModelCapabilities? Parse(BackendProbe probe)
     {
-        if (!TryFindModelEntry(probe, out var model))
+        if (!probe.TryFindModelEntry(out var model))
             return null;
 
         int? contextWindow = null;
@@ -73,27 +101,6 @@ internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
         // vLLM exposes no modality information; null fields signal that
         // downstream resolvers in the chain (HuggingFace) should fill in.
         return new ResolvedModelCapabilities(probe.ModelId, null, null, contextWindow);
-    }
-
-    private static bool TryFindModelEntry(BackendProbe probe, out JsonElement entry)
-    {
-        entry = default;
-        using var doc = JsonDocument.Parse(probe.ModelsJson);
-        if (!doc.RootElement.TryGetProperty("data", out var data) ||
-            data.ValueKind != JsonValueKind.Array)
-            return false;
-
-        foreach (var model in data.EnumerateArray())
-        {
-            if (model.TryGetProperty("id", out var id) &&
-                id.ValueKind == JsonValueKind.String &&
-                string.Equals(id.GetString(), probe.ModelId, StringComparison.OrdinalIgnoreCase))
-            {
-                entry = model.Clone();
-                return true;
-            }
-        }
-        return false;
     }
 }
 
@@ -110,10 +117,10 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
 
     public bool Matches(BackendProbe probe)
     {
-        if (probe.PropsJson is not null)
+        if (probe.PropsRoot is not null)
             return true;
 
-        if (!TryFindModelEntry(probe, out var model))
+        if (!probe.TryFindModelEntry(out var model))
             return false;
 
         return model.TryGetProperty("meta", out var meta) &&
@@ -126,7 +133,7 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
     {
         // Start with what /v1/models tells us about context window.
         int? contextWindow = null;
-        if (TryFindModelEntry(probe, out var model) &&
+        if (probe.TryFindModelEntry(out var model) &&
             model.TryGetProperty("meta", out var meta) &&
             meta.ValueKind == JsonValueKind.Object &&
             meta.TryGetProperty("n_ctx_train", out var ctx) &&
@@ -137,12 +144,9 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
 
         // /props overrides — runtime-effective n_ctx and vision flag.
         var inputModalities = ModelModality.Text;
-        if (probe.PropsJson is not null)
+        if (probe.PropsRoot is JsonElement props)
         {
-            using var propsDoc = JsonDocument.Parse(probe.PropsJson);
-            var root = propsDoc.RootElement;
-
-            if (root.TryGetProperty("default_generation_settings", out var dgs) &&
+            if (props.TryGetProperty("default_generation_settings", out var dgs) &&
                 dgs.ValueKind == JsonValueKind.Object &&
                 dgs.TryGetProperty("params", out var parameters) &&
                 parameters.ValueKind == JsonValueKind.Object &&
@@ -152,7 +156,7 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
                 contextWindow = nCtx.GetInt32();
             }
 
-            if (root.TryGetProperty("modalities", out var modalities) &&
+            if (props.TryGetProperty("modalities", out var modalities) &&
                 modalities.ValueKind == JsonValueKind.Object &&
                 modalities.TryGetProperty("vision", out var vision) &&
                 vision.ValueKind is JsonValueKind.True or JsonValueKind.False &&
@@ -164,27 +168,6 @@ internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
 
         return new ResolvedModelCapabilities(
             probe.ModelId, inputModalities, ModelModality.Text, contextWindow);
-    }
-
-    private static bool TryFindModelEntry(BackendProbe probe, out JsonElement entry)
-    {
-        entry = default;
-        using var doc = JsonDocument.Parse(probe.ModelsJson);
-        if (!doc.RootElement.TryGetProperty("data", out var data) ||
-            data.ValueKind != JsonValueKind.Array)
-            return false;
-
-        foreach (var model in data.EnumerateArray())
-        {
-            if (model.TryGetProperty("id", out var id) &&
-                id.ValueKind == JsonValueKind.String &&
-                string.Equals(id.GetString(), probe.ModelId, StringComparison.OrdinalIgnoreCase))
-            {
-                entry = model.Clone();
-                return true;
-            }
-        }
-        return false;
     }
 }
 

--- a/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiBackendStrategy.cs
@@ -1,0 +1,205 @@
+// -----------------------------------------------------------------------
+// <copyright file="OpenAiBackendStrategy.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Configuration;
+
+namespace Netclaw.Providers.SelfHosted;
+
+/// <summary>
+/// Wraps the raw probe results an OpenAI-compatible capability resolver
+/// shares across strategy implementations. <see cref="PropsJson"/> is null
+/// when the backend has no <c>/props</c> endpoint (e.g. vLLM returns 404).
+/// </summary>
+internal sealed record BackendProbe(string ModelId, string ModelsJson, string? PropsJson);
+
+/// <summary>
+/// Backend-specific parser for an OpenAI-compatible endpoint. The
+/// resolver enumerates strategies in priority order and uses the first
+/// whose <see cref="Matches"/> predicate is true.
+/// </summary>
+internal interface IOpenAiBackendStrategy
+{
+    /// <summary>Diagnostic name written to logs when a backend is detected.</summary>
+    string Name { get; }
+
+    bool Matches(BackendProbe probe);
+
+    ResolvedModelCapabilities? Parse(BackendProbe probe);
+}
+
+/// <summary>
+/// vLLM-specific strategy. Recognizes vLLM via either <c>owned_by: "vllm"</c>
+/// on a <c>/v1/models</c> entry or the presence of a top-level
+/// <c>max_model_len</c> on the model entry combined with <c>/props</c>
+/// returning non-200. Parses <c>max_model_len</c> as the context window
+/// and leaves modalities null so downstream resolvers (HuggingFace) can
+/// fill them — vLLM exposes no modality field anywhere.
+/// </summary>
+internal sealed class VllmBackendStrategy : IOpenAiBackendStrategy
+{
+    public string Name => "vllm";
+
+    public bool Matches(BackendProbe probe)
+    {
+        if (!TryFindModelEntry(probe, out var model))
+            return false;
+
+        if (model.TryGetProperty("owned_by", out var ownedBy) &&
+            ownedBy.ValueKind == JsonValueKind.String &&
+            string.Equals(ownedBy.GetString(), "vllm", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // /props 404 + max_model_len present is also a strong vLLM signal.
+        return probe.PropsJson is null &&
+               model.TryGetProperty("max_model_len", out var mml) &&
+               mml.ValueKind == JsonValueKind.Number;
+    }
+
+    public ResolvedModelCapabilities? Parse(BackendProbe probe)
+    {
+        if (!TryFindModelEntry(probe, out var model))
+            return null;
+
+        int? contextWindow = null;
+        if (model.TryGetProperty("max_model_len", out var mml) &&
+            mml.ValueKind == JsonValueKind.Number)
+        {
+            contextWindow = mml.GetInt32();
+        }
+
+        // vLLM exposes no modality information; null fields signal that
+        // downstream resolvers in the chain (HuggingFace) should fill in.
+        return new ResolvedModelCapabilities(probe.ModelId, null, null, contextWindow);
+    }
+
+    private static bool TryFindModelEntry(BackendProbe probe, out JsonElement entry)
+    {
+        entry = default;
+        using var doc = JsonDocument.Parse(probe.ModelsJson);
+        if (!doc.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+            return false;
+
+        foreach (var model in data.EnumerateArray())
+        {
+            if (model.TryGetProperty("id", out var id) &&
+                id.ValueKind == JsonValueKind.String &&
+                string.Equals(id.GetString(), probe.ModelId, StringComparison.OrdinalIgnoreCase))
+            {
+                entry = model.Clone();
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// llama.cpp-specific strategy. Recognizes llama.cpp via either a
+/// successful <c>/props</c> response or a <c>meta.n_ctx_train</c> field
+/// on a <c>/v1/models</c> entry. Prefers <c>/props.default_generation_settings.params.n_ctx</c>
+/// for the runtime-effective context window, and reads
+/// <c>/props.modalities.vision</c> for input modality.
+/// </summary>
+internal sealed class LlamaCppBackendStrategy : IOpenAiBackendStrategy
+{
+    public string Name => "llama.cpp";
+
+    public bool Matches(BackendProbe probe)
+    {
+        if (probe.PropsJson is not null)
+            return true;
+
+        if (!TryFindModelEntry(probe, out var model))
+            return false;
+
+        return model.TryGetProperty("meta", out var meta) &&
+               meta.ValueKind == JsonValueKind.Object &&
+               meta.TryGetProperty("n_ctx_train", out var ctx) &&
+               ctx.ValueKind == JsonValueKind.Number;
+    }
+
+    public ResolvedModelCapabilities? Parse(BackendProbe probe)
+    {
+        // Start with what /v1/models tells us about context window.
+        int? contextWindow = null;
+        if (TryFindModelEntry(probe, out var model) &&
+            model.TryGetProperty("meta", out var meta) &&
+            meta.ValueKind == JsonValueKind.Object &&
+            meta.TryGetProperty("n_ctx_train", out var ctx) &&
+            ctx.ValueKind == JsonValueKind.Number)
+        {
+            contextWindow = ctx.GetInt32();
+        }
+
+        // /props overrides — runtime-effective n_ctx and vision flag.
+        var inputModalities = ModelModality.Text;
+        if (probe.PropsJson is not null)
+        {
+            using var propsDoc = JsonDocument.Parse(probe.PropsJson);
+            var root = propsDoc.RootElement;
+
+            if (root.TryGetProperty("default_generation_settings", out var dgs) &&
+                dgs.ValueKind == JsonValueKind.Object &&
+                dgs.TryGetProperty("params", out var parameters) &&
+                parameters.ValueKind == JsonValueKind.Object &&
+                parameters.TryGetProperty("n_ctx", out var nCtx) &&
+                nCtx.ValueKind == JsonValueKind.Number)
+            {
+                contextWindow = nCtx.GetInt32();
+            }
+
+            if (root.TryGetProperty("modalities", out var modalities) &&
+                modalities.ValueKind == JsonValueKind.Object &&
+                modalities.TryGetProperty("vision", out var vision) &&
+                vision.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+                vision.GetBoolean())
+            {
+                inputModalities |= ModelModality.Image;
+            }
+        }
+
+        return new ResolvedModelCapabilities(
+            probe.ModelId, inputModalities, ModelModality.Text, contextWindow);
+    }
+
+    private static bool TryFindModelEntry(BackendProbe probe, out JsonElement entry)
+    {
+        entry = default;
+        using var doc = JsonDocument.Parse(probe.ModelsJson);
+        if (!doc.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+            return false;
+
+        foreach (var model in data.EnumerateArray())
+        {
+            if (model.TryGetProperty("id", out var id) &&
+                id.ValueKind == JsonValueKind.String &&
+                string.Equals(id.GetString(), probe.ModelId, StringComparison.OrdinalIgnoreCase))
+            {
+                entry = model.Clone();
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// Last-resort fallback when neither vLLM nor llama.cpp signals are
+/// present. Returns the model id with null fields so downstream
+/// resolvers (OpenRouter oracle, HuggingFace) have the chance to fill
+/// in. Always matches.
+/// </summary>
+internal sealed class GenericOpenAiBackendStrategy : IOpenAiBackendStrategy
+{
+    public string Name => "generic-openai";
+
+    public bool Matches(BackendProbe probe) => true;
+
+    public ResolvedModelCapabilities? Parse(BackendProbe probe)
+        => new(probe.ModelId, null, null, null);
+}

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleCapabilityResolver.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleCapabilityResolver.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 
@@ -56,8 +57,7 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
             modelsResponse.EnsureSuccessStatusCode();
             var modelsJson = await modelsResponse.Content.ReadAsStringAsync(ct);
 
-            // /props is llama.cpp-specific. vLLM returns 404; treat any
-            // non-success as "no /props" so strategies can react.
+            // /props is llama.cpp-specific. vLLM 404s; treat any non-success as "no /props".
             string? propsJson = null;
             using (var propsRequest = new HttpRequestMessage(HttpMethod.Get, "/props"))
             {
@@ -67,20 +67,10 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
                     propsJson = await propsResponse.Content.ReadAsStringAsync(ct);
             }
 
-            var probe = new BackendProbe(modelId, modelsJson, propsJson);
-
-            foreach (var strategy in Strategies)
-            {
-                if (!strategy.Matches(probe))
-                    continue;
-
-                _logger.LogInformation(
-                    "OpenAI-compatible backend detected as {Backend} for model {ModelId}",
-                    strategy.Name, modelId);
-                return strategy.Parse(probe);
-            }
-
-            return null;
+            using var modelsDoc = JsonDocument.Parse(modelsJson);
+            using var propsDoc = propsJson is null ? null : JsonDocument.Parse(propsJson);
+            var probe = new BackendProbe(modelId, modelsDoc.RootElement, propsDoc?.RootElement);
+            return Dispatch(probe);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -94,8 +84,31 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
     /// without standing up an HTTP server. Production code goes through
     /// <see cref="ResolveAsync"/>.
     /// </summary>
-    internal static ResolvedModelCapabilities? ResolveFromProbe(BackendProbe probe)
+    internal ResolvedModelCapabilities? Dispatch(BackendProbe probe)
     {
+        foreach (var strategy in Strategies)
+        {
+            if (!strategy.Matches(probe))
+                continue;
+
+            _logger.LogInformation(
+                "OpenAI-compatible backend detected as {Backend} for model {ModelId}",
+                strategy.Name, probe.ModelId);
+            return strategy.Parse(probe);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Test helper that parses raw JSON strings into a <see cref="BackendProbe"/>
+    /// and runs the strategy chain. Fixture caller owns the
+    /// <see cref="JsonDocument"/> lifetime via the <c>using</c> blocks.
+    /// </summary>
+    internal static ResolvedModelCapabilities? ResolveFromProbe(string modelId, string modelsJson, string? propsJson)
+    {
+        using var modelsDoc = JsonDocument.Parse(modelsJson);
+        using var propsDoc = propsJson is null ? null : JsonDocument.Parse(propsJson);
+        var probe = new BackendProbe(modelId, modelsDoc.RootElement, propsDoc?.RootElement);
         foreach (var strategy in Strategies)
         {
             if (strategy.Matches(probe))

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleCapabilityResolver.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleCapabilityResolver.cs
@@ -1,17 +1,32 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="OpenAiCompatibleCapabilityResolver.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Net.Http.Headers;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Netclaw.Configuration;
 
 namespace Netclaw.Providers.SelfHosted;
 
+/// <summary>
+/// Resolves model capabilities by probing an OpenAI-compatible
+/// endpoint (<c>/v1/models</c> and the llama.cpp-only <c>/props</c>) and
+/// dispatching to a backend strategy that knows how to parse the
+/// concrete server's response shape. Strategies are evaluated in
+/// priority order — vLLM first, llama.cpp second, generic last.
+/// </summary>
 public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolver
 {
+    // Strategy order is meaningful: vLLM signals are more specific
+    // than llama.cpp's, and the generic fallback matches anything.
+    private static readonly IReadOnlyList<IOpenAiBackendStrategy> Strategies =
+    [
+        new VllmBackendStrategy(),
+        new LlamaCppBackendStrategy(),
+        new GenericOpenAiBackendStrategy(),
+    ];
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<OpenAiCompatibleCapabilityResolver> _logger;
     private readonly OpenAiCompatibleEndpoint _endpoint;
@@ -28,6 +43,8 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
         _httpClient.BaseAddress ??= _endpoint.BaseUri;
     }
 
+    public string? ProviderType => "openai-compatible";
+
     public async Task<ResolvedModelCapabilities?> ResolveAsync(string modelId, CancellationToken ct = default)
     {
         try
@@ -37,27 +54,33 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
 
             using var modelsResponse = await _httpClient.SendAsync(modelsRequest, ct);
             modelsResponse.EnsureSuccessStatusCode();
-
             var modelsJson = await modelsResponse.Content.ReadAsStringAsync(ct);
-            var fromModels = ParseModelsResponse(modelsJson, modelId);
 
-            var inputModalities = fromModels?.InputModalities ?? ModelModality.Text;
-            var outputModalities = fromModels?.OutputModalities ?? ModelModality.Text;
-            var contextWindow = fromModels?.ContextWindowTokens;
-
-            using var propsRequest = new HttpRequestMessage(HttpMethod.Get, "/props");
-            ApplyAuth(propsRequest);
-
-            using var propsResponse = await _httpClient.SendAsync(propsRequest, ct);
-            if (propsResponse.IsSuccessStatusCode)
+            // /props is llama.cpp-specific. vLLM returns 404; treat any
+            // non-success as "no /props" so strategies can react.
+            string? propsJson = null;
+            using (var propsRequest = new HttpRequestMessage(HttpMethod.Get, "/props"))
             {
-                var propsJson = await propsResponse.Content.ReadAsStringAsync(ct);
-                var fromProps = ParsePropsResponse(propsJson, modelId, contextWindow);
-                if (fromProps is not null)
-                    return fromProps with { InputModalities = inputModalities | fromProps.InputModalities };
+                ApplyAuth(propsRequest);
+                using var propsResponse = await _httpClient.SendAsync(propsRequest, ct);
+                if (propsResponse.IsSuccessStatusCode)
+                    propsJson = await propsResponse.Content.ReadAsStringAsync(ct);
             }
 
-            return fromModels;
+            var probe = new BackendProbe(modelId, modelsJson, propsJson);
+
+            foreach (var strategy in Strategies)
+            {
+                if (!strategy.Matches(probe))
+                    continue;
+
+                _logger.LogInformation(
+                    "OpenAI-compatible backend detected as {Backend} for model {ModelId}",
+                    strategy.Name, modelId);
+                return strategy.Parse(probe);
+            }
+
+            return null;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -66,62 +89,19 @@ public sealed class OpenAiCompatibleCapabilityResolver : IModelCapabilityResolve
         }
     }
 
-    internal static ResolvedModelCapabilities? ParseModelsResponse(string json, string modelId)
+    /// <summary>
+    /// Test seam: probe a single backend strategy against fixture JSON
+    /// without standing up an HTTP server. Production code goes through
+    /// <see cref="ResolveAsync"/>.
+    /// </summary>
+    internal static ResolvedModelCapabilities? ResolveFromProbe(BackendProbe probe)
     {
-        using var document = JsonDocument.Parse(json);
-        if (!document.RootElement.TryGetProperty("data", out var data)
-            || data.ValueKind != JsonValueKind.Array)
-            return null;
-
-        foreach (var model in data.EnumerateArray())
+        foreach (var strategy in Strategies)
         {
-            if (!model.TryGetProperty("id", out var id)
-                || id.ValueKind != JsonValueKind.String
-                || !string.Equals(id.GetString(), modelId, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            int? contextWindow = null;
-            if (model.TryGetProperty("meta", out var meta)
-                && meta.ValueKind == JsonValueKind.Object
-                && meta.TryGetProperty("n_ctx_train", out var ctx)
-                && ctx.ValueKind == JsonValueKind.Number)
-            {
-                contextWindow = ctx.GetInt32();
-            }
-
-            return new ResolvedModelCapabilities(modelId, ModelModality.Text, ModelModality.Text, contextWindow);
+            if (strategy.Matches(probe))
+                return strategy.Parse(probe);
         }
-
         return null;
-    }
-
-    internal static ResolvedModelCapabilities? ParsePropsResponse(string json, string modelId, int? contextWindow)
-    {
-        using var document = JsonDocument.Parse(json);
-        var root = document.RootElement;
-
-        int? effectiveContextWindow = contextWindow;
-        if (root.TryGetProperty("default_generation_settings", out var defaultGenerationSettings)
-            && defaultGenerationSettings.ValueKind == JsonValueKind.Object
-            && defaultGenerationSettings.TryGetProperty("params", out var parameters)
-            && parameters.ValueKind == JsonValueKind.Object
-            && parameters.TryGetProperty("n_ctx", out var nCtx)
-            && nCtx.ValueKind == JsonValueKind.Number)
-        {
-            effectiveContextWindow = nCtx.GetInt32();
-        }
-
-        var inputModalities = ModelModality.Text;
-        if (root.TryGetProperty("modalities", out var modalities)
-            && modalities.ValueKind == JsonValueKind.Object
-            && modalities.TryGetProperty("vision", out var vision)
-            && vision.ValueKind is JsonValueKind.True or JsonValueKind.False
-            && vision.GetBoolean())
-        {
-            inputModalities |= ModelModality.Image;
-        }
-
-        return new ResolvedModelCapabilities(modelId, inputModalities, ModelModality.Text, effectiveContextWindow);
     }
 
     private void ApplyAuth(HttpRequestMessage request)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -60,6 +60,14 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
     {
         var payload = BuildPayload(messages, options, stream: true);
         using var request = BuildRequest(payload);
+
+        // Wall-clock measurement for prompt_ms fallback on backends that
+        // don't emit server-side timings (vLLM, generic OpenAI-compat).
+        // Measured request-send → first content delta — includes network
+        // RTT, so flagged as client-measured downstream.
+        var requestSentAt = System.Diagnostics.Stopwatch.GetTimestamp();
+        double? wallClockPromptMs = null;
+
         using var response = await _httpClient.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
@@ -99,7 +107,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                 break;
 
             using var document = JsonDocument.Parse(ssePayload);
-            foreach (var update in ParseStreamingUpdates(document.RootElement, pendingToolCalls))
+            foreach (var update in ParseStreamingUpdates(document.RootElement, pendingToolCalls, wallClockPromptMs))
             {
                 var suppressThisUpdate = false;
                 foreach (var item in update.Contents)
@@ -110,16 +118,24 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                             accumulatedText.Append(tc.Text);
                             textDeltaCount++;
                             textDeltaChars += tc.Text?.Length ?? 0;
+                            // First content delta locks the wall-clock prompt latency.
+                            // Subsequent token deltas don't extend the measurement.
+                            wallClockPromptMs ??=
+                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             if (filter.ShouldSuppress(tc.Text))
                                 suppressThisUpdate = true;
                             break;
                         case TextReasoningContent rc:
                             thinkingDeltaCount++;
                             thinkingDeltaChars += rc.Text?.Length ?? 0;
+                            wallClockPromptMs ??=
+                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             break;
                         case FunctionCallContent:
                             hadStructuredToolCalls = true;
                             toolCallDeltaCount++;
+                            wallClockPromptMs ??=
+                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             break;
                     }
                 }
@@ -515,12 +531,15 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         };
     }
 
-    private static IEnumerable<ChatResponseUpdate> ParseStreamingUpdates(JsonElement root, Dictionary<int, PendingToolCall> pendingToolCalls)
+    private static IEnumerable<ChatResponseUpdate> ParseStreamingUpdates(
+        JsonElement root,
+        Dictionary<int, PendingToolCall> pendingToolCalls,
+        double? wallClockPromptMs = null)
     {
         if (!root.TryGetProperty("choices", out var choices) || choices.GetArrayLength() == 0)
         {
             // The final usage-only chunk has an empty choices array — still parse usage
-            var usageOnly = ParseUsage(root);
+            var usageOnly = ParseUsage(root, wallClockPromptMs);
             if (usageOnly is not null)
                 yield return new ChatResponseUpdate(ChatRole.Assistant, [new UsageContent(usageOnly)]);
             yield break;
@@ -604,7 +623,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
 
         // Usage may appear in the final streaming chunk (when stream_options.include_usage is set)
-        var usage = ParseUsage(root);
+        var usage = ParseUsage(root, wallClockPromptMs);
         if (usage is not null)
             contents.Add(new UsageContent(usage));
 
@@ -639,14 +658,27 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
     }
 
+    // Backend-specific telemetry extractors are applied in sequence on every
+    // response. Field paths don't overlap across supported backends, so order
+    // doesn't matter — whichever shape is present wins.
+    private static readonly IReadOnlyList<ITimingsExtractor> TimingsExtractors =
+    [
+        new LlamaCppTimingsExtractor(),
+        new VllmTimingsExtractor(),
+    ];
+
     /// <summary>
-    /// Parses the <c>usage</c> object from an OpenAI-compatible response or streaming chunk.
-    /// Also reads the llama.cpp <c>timings</c> object when present, mapping <c>cache_n</c>
-    /// to <see cref="UsageDetails.CachedInputTokenCount"/> and storing throughput/latency
-    /// fields in <see cref="UsageDetails.AdditionalCounts"/>.
-    /// Returns null when the usage field is absent or not an object.
+    /// Parses the <c>usage</c> object from an OpenAI-compatible response or
+    /// streaming chunk. Runs every registered <see cref="ITimingsExtractor"/>
+    /// against the root element so backend-specific telemetry (llama.cpp's
+    /// <c>timings</c> object, vLLM's <c>usage.prompt_tokens_details.cached_tokens</c>)
+    /// lands in <see cref="UsageDetails"/>. When the server doesn't supply
+    /// its own prompt latency, <paramref name="wallClockPromptMs"/> fills the
+    /// integer-encoded <c>prompt_us</c> field — typically a streaming-mode
+    /// measurement between request send and first-content-byte. Returns null
+    /// when the usage field is absent or not an object.
     /// </summary>
-    internal static UsageDetails? ParseUsage(JsonElement root)
+    internal static UsageDetails? ParseUsage(JsonElement root, double? wallClockPromptMs = null)
     {
         if (!root.TryGetProperty("usage", out var usage) || usage.ValueKind != JsonValueKind.Object)
             return null;
@@ -668,53 +700,22 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             TotalTokenCount = totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0)
         };
 
-        // llama.cpp includes a sibling `timings` object with cache and throughput data.
-        // This is not part of the OpenAI spec — gracefully skip when absent.
-        if (root.TryGetProperty("timings", out var timings) && timings.ValueKind == JsonValueKind.Object)
+        foreach (var extractor in TimingsExtractors)
+            extractor.Extract(root, details);
+
+        // Wall-clock fallback: only kicks in when no server-side prompt
+        // latency was supplied (vLLM and most generic backends). Includes
+        // network RTT — flagged as client-measured in the metric, not
+        // server-side honest prompt eval time.
+        if (wallClockPromptMs is { } promptMs &&
+            (details.AdditionalCounts is null ||
+             !details.AdditionalCounts.ContainsKey(TimingsKeys.PromptUs)))
         {
-            ParseLlamaCppTimings(timings, details);
+            var additional = details.AdditionalCounts ??= [];
+            additional[TimingsKeys.PromptUs] = (long)(promptMs * 1000);
         }
 
         return details;
-    }
-
-    // llama.cpp's OpenAI-compatible endpoint returns a `timings` object alongside
-    // `usage`. Because M.E.AI's UsageDetails.AdditionalCounts is typed
-    // AdditionalPropertiesDictionary<long>, floating-point timing values are encoded
-    // as integer scale factors: microseconds for latency, ×100 for tokens-per-second.
-    // These keys are the only canonical definition; consumers (LlmSessionActor)
-    // duplicate the strings they read and must stay in sync.
-    internal const string PromptUsKey = "prompt_us";
-    internal const string PromptTokPerSecX100Key = "prompt_tok_per_sec_x100";
-    internal const string PredictedUsKey = "predicted_us";
-    internal const string PredictedTokPerSecX100Key = "predicted_tok_per_sec_x100";
-
-    /// <summary>
-    /// Reads llama.cpp-specific timing fields into <see cref="UsageDetails"/>.
-    /// <c>cache_n</c> maps to <see cref="UsageDetails.CachedInputTokenCount"/>;
-    /// throughput and latency fields go into <see cref="UsageDetails.AdditionalCounts"/>
-    /// via integer-encoded keys (see the PromptUsKey/PredictedTokPerSecX100Key
-    /// constants above). Consumers decode by dividing out the scale factor.
-    /// </summary>
-    internal static void ParseLlamaCppTimings(JsonElement timings, UsageDetails details)
-    {
-        if (TryGetLong(timings, "cache_n", out var cacheN))
-            details.CachedInputTokenCount = cacheN;
-
-        if (TryGetDouble(timings, "prompt_ms", out var promptMs))
-            Additional(details)[PromptUsKey] = (long)(promptMs * 1000);
-
-        if (TryGetDouble(timings, "prompt_per_second", out var promptPerSec))
-            Additional(details)[PromptTokPerSecX100Key] = (long)(promptPerSec * 100);
-
-        if (TryGetDouble(timings, "predicted_ms", out var predictedMs))
-            Additional(details)[PredictedUsKey] = (long)(predictedMs * 1000);
-
-        if (TryGetDouble(timings, "predicted_per_second", out var predictedPerSec))
-            Additional(details)[PredictedTokPerSecX100Key] = (long)(predictedPerSec * 100);
-
-        static AdditionalPropertiesDictionary<long> Additional(UsageDetails d)
-            => d.AdditionalCounts ??= [];
     }
 
     private static bool TryGetLong(JsonElement obj, string name, out long value)

--- a/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
+++ b/src/Netclaw.Providers/SelfHosted/OpenAiCompatibleChatClient.cs
@@ -61,10 +61,9 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         var payload = BuildPayload(messages, options, stream: true);
         using var request = BuildRequest(payload);
 
-        // Wall-clock measurement for prompt_ms fallback on backends that
-        // don't emit server-side timings (vLLM, generic OpenAI-compat).
-        // Measured request-send → first content delta — includes network
-        // RTT, so flagged as client-measured downstream.
+        // Wall-clock prompt_ms fallback for backends that don't emit
+        // server-side timings — locked at first content delta, includes
+        // network RTT.
         var requestSentAt = System.Diagnostics.Stopwatch.GetTimestamp();
         double? wallClockPromptMs = null;
 
@@ -109,6 +108,10 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
             using var document = JsonDocument.Parse(ssePayload);
             foreach (var update in ParseStreamingUpdates(document.RootElement, pendingToolCalls, wallClockPromptMs))
             {
+                if (update.Contents.Count > 0)
+                    wallClockPromptMs ??=
+                        System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
+
                 var suppressThisUpdate = false;
                 foreach (var item in update.Contents)
                 {
@@ -118,24 +121,16 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
                             accumulatedText.Append(tc.Text);
                             textDeltaCount++;
                             textDeltaChars += tc.Text?.Length ?? 0;
-                            // First content delta locks the wall-clock prompt latency.
-                            // Subsequent token deltas don't extend the measurement.
-                            wallClockPromptMs ??=
-                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             if (filter.ShouldSuppress(tc.Text))
                                 suppressThisUpdate = true;
                             break;
                         case TextReasoningContent rc:
                             thinkingDeltaCount++;
                             thinkingDeltaChars += rc.Text?.Length ?? 0;
-                            wallClockPromptMs ??=
-                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             break;
                         case FunctionCallContent:
                             hadStructuredToolCalls = true;
                             toolCallDeltaCount++;
-                            wallClockPromptMs ??=
-                                System.Diagnostics.Stopwatch.GetElapsedTime(requestSentAt).TotalMilliseconds;
                             break;
                     }
                 }
@@ -534,7 +529,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
     private static IEnumerable<ChatResponseUpdate> ParseStreamingUpdates(
         JsonElement root,
         Dictionary<int, PendingToolCall> pendingToolCalls,
-        double? wallClockPromptMs = null)
+        double? wallClockPromptMs)
     {
         if (!root.TryGetProperty("choices", out var choices) || choices.GetArrayLength() == 0)
         {
@@ -658,9 +653,7 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
     }
 
-    // Backend-specific telemetry extractors are applied in sequence on every
-    // response. Field paths don't overlap across supported backends, so order
-    // doesn't matter — whichever shape is present wins.
+    // Field paths don't overlap between backends, so order is irrelevant.
     private static readonly IReadOnlyList<ITimingsExtractor> TimingsExtractors =
     [
         new LlamaCppTimingsExtractor(),
@@ -716,30 +709,6 @@ public sealed class OpenAiCompatibleChatClient : IChatClient
         }
 
         return details;
-    }
-
-    private static bool TryGetLong(JsonElement obj, string name, out long value)
-    {
-        if (obj.TryGetProperty(name, out var prop)
-            && prop.ValueKind == JsonValueKind.Number
-            && prop.TryGetInt64(out value))
-        {
-            return true;
-        }
-        value = 0;
-        return false;
-    }
-
-    private static bool TryGetDouble(JsonElement obj, string name, out double value)
-    {
-        if (obj.TryGetProperty(name, out var prop)
-            && prop.ValueKind == JsonValueKind.Number
-            && prop.TryGetDouble(out value))
-        {
-            return true;
-        }
-        value = 0;
-        return false;
     }
 
     private static ChatFinishReason? ParseFinishReason(JsonElement choice)

--- a/src/Netclaw.Providers/SelfHosted/TimingsExtractor.cs
+++ b/src/Netclaw.Providers/SelfHosted/TimingsExtractor.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="TimingsExtractor.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Providers.SelfHosted;
+
+/// <summary>
+/// Extracts backend-specific per-request timing and cache telemetry from
+/// an OpenAI-compatible chat completion response. Implementations are
+/// applied in sequence on every response — field paths are
+/// non-overlapping across supported backends so multiple extractors can
+/// safely run without conflict.
+/// </summary>
+internal interface ITimingsExtractor
+{
+    /// <summary>
+    /// Reads any backend-specific telemetry from <paramref name="root"/>
+    /// and writes it into <paramref name="details"/>. Implementations
+    /// SHALL be no-ops when their expected field paths are absent.
+    /// </summary>
+    void Extract(JsonElement root, UsageDetails details);
+}
+
+/// <summary>
+/// llama.cpp ships a top-level <c>timings</c> sibling to <c>usage</c>.
+/// <c>cache_n</c> maps to <see cref="UsageDetails.CachedInputTokenCount"/>;
+/// timing/throughput fields are integer-encoded into
+/// <see cref="UsageDetails.AdditionalCounts"/> via the integer-scaled
+/// keys declared in <see cref="TimingsKeys"/> (microseconds for latency,
+/// ×100 for tokens-per-second) to fit the <c>long</c>-typed dictionary.
+/// </summary>
+internal sealed class LlamaCppTimingsExtractor : ITimingsExtractor
+{
+    public void Extract(JsonElement root, UsageDetails details)
+    {
+        if (!root.TryGetProperty("timings", out var timings) ||
+            timings.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (TryGetLong(timings, "cache_n", out var cacheN))
+            details.CachedInputTokenCount = cacheN;
+
+        if (TryGetDouble(timings, "prompt_ms", out var promptMs))
+            Additional(details)[TimingsKeys.PromptUs] = (long)(promptMs * 1000);
+
+        if (TryGetDouble(timings, "prompt_per_second", out var promptPerSec))
+            Additional(details)[TimingsKeys.PromptTokPerSecX100] = (long)(promptPerSec * 100);
+
+        if (TryGetDouble(timings, "predicted_ms", out var predictedMs))
+            Additional(details)[TimingsKeys.PredictedUs] = (long)(predictedMs * 1000);
+
+        if (TryGetDouble(timings, "predicted_per_second", out var predictedPerSec))
+            Additional(details)[TimingsKeys.PredictedTokPerSecX100] = (long)(predictedPerSec * 100);
+    }
+
+    private static AdditionalPropertiesDictionary<long> Additional(UsageDetails d)
+        => d.AdditionalCounts ??= [];
+
+    private static bool TryGetLong(JsonElement obj, string name, out long value)
+    {
+        if (obj.TryGetProperty(name, out var prop)
+            && prop.ValueKind == JsonValueKind.Number
+            && prop.TryGetInt64(out value))
+        {
+            return true;
+        }
+        value = 0;
+        return false;
+    }
+
+    private static bool TryGetDouble(JsonElement obj, string name, out double value)
+    {
+        if (obj.TryGetProperty(name, out var prop)
+            && prop.ValueKind == JsonValueKind.Number
+            && prop.TryGetDouble(out value))
+        {
+            return true;
+        }
+        value = 0;
+        return false;
+    }
+}
+
+/// <summary>
+/// vLLM (and any OpenAI-standard prefix-cache backend) reports cache
+/// hit count inside <c>usage.prompt_tokens_details.cached_tokens</c>.
+/// No per-request timing is exposed by the server — wall-clock
+/// measurement around the HTTP call carries that load (see
+/// <see cref="OpenAiCompatibleChatClient"/>).
+/// </summary>
+internal sealed class VllmTimingsExtractor : ITimingsExtractor
+{
+    public void Extract(JsonElement root, UsageDetails details)
+    {
+        if (!root.TryGetProperty("usage", out var usage) ||
+            usage.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (!usage.TryGetProperty("prompt_tokens_details", out var ptd) ||
+            ptd.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (ptd.TryGetProperty("cached_tokens", out var cached) &&
+            cached.ValueKind == JsonValueKind.Number &&
+            cached.TryGetInt64(out var value))
+        {
+            // Last writer wins — if llama.cpp's timings.cache_n already
+            // populated this, our value would equal it. Both backends
+            // never coexist on the same response.
+            details.CachedInputTokenCount = value;
+        }
+    }
+}
+
+/// <summary>
+/// Integer-encoded telemetry keys shared between the chat client and
+/// the session actor that decodes them. Keep keys in sync.
+/// </summary>
+internal static class TimingsKeys
+{
+    public const string PromptUs = "prompt_us";
+    public const string PromptTokPerSecX100 = "prompt_tok_per_sec_x100";
+    public const string PredictedUs = "predicted_us";
+    public const string PredictedTokPerSecX100 = "predicted_tok_per_sec_x100";
+}


### PR DESCRIPTION
## Summary

Closes #619 gaps **#1 (capability detection)** and **#3 (timings extraction)** against a live vLLM 0.20 deployment serving Qwen3.6-VL.

Before this PR, vLLM was advertised as text-only with a 32k context window — \`OpenAiCompatibleCapabilityResolver\` only knew how to read llama.cpp's \`meta.n_ctx_train\` and \`/props.modalities.vision\`. vLLM exposes \`max_model_len\` at a different path and no modality field anywhere, and \`HuggingFaceCapabilityResolver\` (already in the chain) was being skipped because \`CompositeCapabilityResolver\` short-circuited on the first non-null result.

### What changed

- **\`IOpenAiBackendStrategy\`** (NEW) — \`Vllm\` / \`LlamaCpp\` / \`Generic\` implementations. Single \`/v1/models\` + \`/props\` probe per resolution; first matching strategy wins. vLLM reads \`max_model_len\` and leaves modality null so HF fills it.
- **\`CompositeCapabilityResolver\`** rewritten to field-merge across the chain (first-non-null per field) instead of short-circuiting. Adds provider-aware filtering — resolvers tagged with non-null \`ProviderType\` are skipped when the model's active provider doesn't match. Oracles (\`OpenRouter\`, \`HuggingFace\`) always run. Necessary once llama.cpp + vLLM run in parallel as separate \`openai-compatible\` providers during cutover.
- **\`ResolvedModelCapabilities\`** — \`InputModalities\` / \`OutputModalities\` nullable so resolvers can return partial answers. Text-only defaulting still lives at the consumption boundary in \`ModelCapabilityResolution\`.
- **\`ITimingsExtractor\`** (NEW) — splits the existing \`ParseLlamaCppTimings\` into \`LlamaCppTimingsExtractor\` (existing behavior) and \`VllmTimingsExtractor\` (reads \`usage.prompt_tokens_details.cached_tokens\`). Both run on every response; field paths are non-overlapping.
- **Wall-clock prompt_ms fallback** in \`OpenAiCompatibleChatClient\` — measures HTTP send → first content delta; fills \`UsageDetails.PromptMs\` only when no server-side value is supplied. Restores eval-suite Multi-Turn Cache Evolution telemetry on vLLM.

### OpenSpec

Includes the full \`vllm-capability-strategy-and-timings\` change (proposal, design, specs delta against \`netclaw-model-capabilities\`, tasks).

### Out of scope (deferred to follow-up changes)

- Gap #2 — vLLM \`hermes\` / \`qwen3_coder\` tool-call streaming quirks
- Gap #4 — strict \`model\` field diagnostics
- Gaps #5–#7 — error-shape / stop-sequence / response-extras tolerance

## Test plan

### Automated (run as part of PR)
- [x] \`dotnet test\` — 3,597 tests green (Daemon.Tests Providers filter: 113 passing)
- [x] \`dotnet slopwatch analyze\` — 0 violations
- [x] \`./scripts/Add-FileHeaders.ps1 -Verify\` — clean
- [x] \`openspec validate vllm-capability-strategy-and-timings\` — valid

### Manual against live vLLM (Aaron to run before merge)
- [ ] \`netclaw models --provider <vllm-local>\` reports \`ContextWindow=256000\` and \`Input=Text|Image\` for Qwen3.6-VL (today: \`32768\` + \`Text\`)
- [ ] Image-bearing Slack thread turn flows through with the image inlined (today: stripped by \`SlackThreadHistoryFetcher\`)
- [ ] Multi-turn session shows \`cached=<non-zero>\` in \`[usage]\` output on turn 2+
- [ ] Repoint to a llama-server endpoint — no regression in \`meta.n_ctx_train\` / \`/props\` / \`timings.cache_n\` paths