### PR TITLE
fix(config): align ModelReference modality schema with scalar binding (#988)

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -138,8 +138,8 @@ Named model roles. Each role points to a provider and model ID.
 | `Provider` | string | `"local-ollama"` | Key into the `Providers` dictionary. |
 | `ModelId` | string | `"qwen3:30b"` | Model identifier as used by the provider's API. |
 | `ContextWindow` | int? | `null` | Effective runtime context window in tokens. When set, it clamps the detected provider value. If not set, Netclaw uses the provider-reported value when available, otherwise defaults to 32,768. |
-| `InputModalities` | string[]? | `null` | Manual override for input modalities (`"Text"`, `"Image"`, `"Audio"`, `"Video"`). When set, bypasses automated capability detection. |
-| `OutputModalities` | string[]? | `null` | Manual override for output modalities. Same values as `InputModalities`. |
+| `InputModalities` | string? | `null` | Manual override for input modalities. Comma-separated flags from `Text`, `Image`, `Audio`, `Video` — e.g. `"Text"` or `"Text, Image"`. When set, bypasses automated capability detection. |
+| `OutputModalities` | string? | `null` | Manual override for output modalities. Same form as `InputModalities`. |
 
 ### Session
 

--- a/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
+++ b/src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs
@@ -463,6 +463,64 @@ public sealed class ConfigSchemaDoctorCheckTests
         Assert.Equal(DoctorSeverity.Pass, result.Severity);
     }
 
+    [Fact]
+    public async Task ReturnsPass_WhenInputModalitiesIsValidCommaString()
+    {
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Models": {
+                "Main": {
+                  "Provider": "p",
+                  "ModelId": "m",
+                  "InputModalities": "Text, Image",
+                  "OutputModalities": "Text"
+                }
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Pass, result.Severity);
+    }
+
+    [Fact]
+    public async Task ReturnsError_WhenInputModalitiesIsArray()
+    {
+        // Regression for #988: the legacy array form must now fail schema
+        // validation so operators discover the binding mismatch instead of
+        // silently getting a wrong (no-override) runtime value.
+        var basePath = CreateTempBasePath();
+        var paths = new NetclawPaths(basePath);
+        paths.EnsureDirectoriesExist();
+
+        await File.WriteAllTextAsync(paths.NetclawConfigPath,
+            """
+            {
+              "configVersion": 1,
+              "Models": {
+                "Main": {
+                  "Provider": "p",
+                  "ModelId": "m",
+                  "InputModalities": ["Text", "Image"]
+                }
+              }
+            }
+            """, TestContext.Current.CancellationToken);
+
+        var check = new ConfigSchemaDoctorCheck(paths);
+        var result = await check.RunAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(DoctorSeverity.Error, result.Severity);
+    }
+
     private static string CreateTempBasePath()
     {
         var path = Path.Combine(Path.GetTempPath(), "netclaw-tests", Guid.NewGuid().ToString("N"));

--- a/src/Netclaw.Configuration.Tests/ModelReferenceBindingTests.cs
+++ b/src/Netclaw.Configuration.Tests/ModelReferenceBindingTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="ModelReferenceBindingTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+/// <summary>
+/// Regression coverage for the schema/binding mismatch tracked in issue #988.
+/// <see cref="ModelReference.InputModalities"/> and
+/// <see cref="ModelReference.OutputModalities"/> are scalar nullable flag
+/// enums; the schema is now aligned to a comma-separated string. Verifies
+/// that .NET configuration binding correctly OR-combines flags from the
+/// string form so the operator's manual override actually reaches
+/// <c>ModelCapabilityResolution</c>.
+/// </summary>
+public sealed class ModelReferenceBindingTests
+{
+    [Fact]
+    public void CommaSeparatedString_BindsToCombinedFlags()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Models:Main:Provider"] = "my-vllm",
+                ["Models:Main:ModelId"] = "qwen36-ultimate",
+                ["Models:Main:InputModalities"] = "Text, Image",
+                ["Models:Main:OutputModalities"] = "Text",
+            })
+            .Build();
+
+        var selection = config.GetSection("Models").Get<ModelSelection>()!;
+        var main = selection.Main;
+
+        Assert.Equal("qwen36-ultimate", main.ModelId);
+        Assert.Equal(ModelModality.Text | ModelModality.Image, main.InputModalities);
+        Assert.Equal(ModelModality.Text, main.OutputModalities);
+    }
+
+    [Fact]
+    public void SingleValueString_BindsToSingleFlag()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Models:Main:Provider"] = "p",
+                ["Models:Main:ModelId"] = "m",
+                ["Models:Main:InputModalities"] = "Text",
+            })
+            .Build();
+
+        var selection = config.GetSection("Models").Get<ModelSelection>()!;
+        Assert.Equal(ModelModality.Text, selection.Main.InputModalities);
+    }
+
+    [Fact]
+    public void AbsentField_LeavesNullForDownstreamDefaulting()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Models:Main:Provider"] = "p",
+                ["Models:Main:ModelId"] = "m",
+            })
+            .Build();
+
+        var selection = config.GetSection("Models").Get<ModelSelection>()!;
+        // Null preserves the "no manual override" signal so
+        // ModelCapabilityResolution can fall back to detected/default.
+        Assert.Null(selection.Main.InputModalities);
+        Assert.Null(selection.Main.OutputModalities);
+    }
+
+    [Fact]
+    public void AllFlags_RoundTrip()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Models:Main:Provider"] = "p",
+                ["Models:Main:ModelId"] = "m",
+                ["Models:Main:InputModalities"] = "Text, Image, Audio, Video",
+            })
+            .Build();
+
+        var selection = config.GetSection("Models").Get<ModelSelection>()!;
+        Assert.Equal(
+            ModelModality.Text | ModelModality.Image | ModelModality.Audio | ModelModality.Video,
+            selection.Main.InputModalities);
+    }
+}

--- a/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
+++ b/src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json
@@ -812,14 +812,14 @@
           "description": "Optional model provenance marker (e.g. AutoDetected, Manual)."
         },
         "InputModalities": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/ModelModality" },
-          "description": "Manual override for input modalities. Bypasses automated detection."
+          "type": "string",
+          "description": "Manual override for input modalities. Comma-separated ModelModality flags (e.g. \"Text\", \"Text, Image\"). Bypasses automated detection.",
+          "pattern": "^(Text|Image|Audio|Video)(\\s*,\\s*(Text|Image|Audio|Video))*$"
         },
         "OutputModalities": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/ModelModality" },
-          "description": "Manual override for output modalities. Bypasses automated detection."
+          "type": "string",
+          "description": "Manual override for output modalities. Comma-separated ModelModality flags (e.g. \"Text\"). Bypasses automated detection.",
+          "pattern": "^(Text|Image|Audio|Video)(\\s*,\\s*(Text|Image|Audio|Video))*$"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Closes #988.

## Problem

\`ModelReference.InputModalities\` / \`OutputModalities\` are scalar \`ModelModality?\` properties (single nullable flag enum). The JSON schema declared them as arrays of \`ModelModality\`, so operators writing the documented form silently failed to bind — the field stayed \`null\` and the runtime defaulting produced unexpected results (\`netclaw status\` would report \`input: None\` instead of the intended override).

Discovered while applying the \`InputModalities: [\"Text\", \"Image\"]\` workaround from #987 against a live deployment; the override didn't take effect end-to-end on first try.

## Fix — Option A from #988

Align the schema to the scalar comma-separated string form, which is the canonical .NET representation for \`[Flags]\` enums in \`Microsoft.Extensions.Configuration\`.

\`\`\`json
\"Main\": {
  \"InputModalities\": \"Text, Image\",
  \"OutputModalities\": \"Text\"
}
\`\`\`

This required zero C# changes — the property type was already correct. The schema and docs were the only out-of-sync pieces.

## Changes

- \`src/Netclaw.Configuration/Schemas/netclaw-config.v1.schema.json\` — \`InputModalities\` / \`OutputModalities\` changed from \`array\` of \`ModelModality\` to \`string\` with a regex pattern validating comma-separated flag values.
- \`docs/spec/configuration.md\` — updated row descriptions to match the new form.
- NEW \`src/Netclaw.Configuration.Tests/ModelReferenceBindingTests.cs\` — 4 tests proving the comma-string binds to a flag-OR'd value (single value, multi, all four, absent).
- \`src/Netclaw.Cli.Tests/Doctor/ConfigSchemaDoctorCheckTests.cs\` — 2 added cases: comma-string passes schema validation; legacy array form fails with an error so operators discover the mismatch fast.

## Test plan

- [x] \`dotnet test\` — 3,613 tests green (+6 new, from 3,607 before)
- [x] \`dotnet slopwatch analyze\` — 0 violations
- [x] \`./scripts/Add-FileHeaders.ps1 -Verify\` — clean
- [ ] Manual: live config with \`\"InputModalities\": \"Text, Image\"\` reaches the daemon (already verified during #987 workaround application — \`netclaw status\` showed \`input: Text, Image\` after restart)

## Related

- #987 — vLLM modality detection limitation (documents the operator-facing workaround that this PR makes actually work)
- #986 — vLLM-aware capability resolver (the merge that surfaced this latent bug during live verification)