### PR TITLE
fix(channels): hydrate thread history once per actor lifetime; account for media in compaction

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -1279,4 +1279,71 @@ public abstract class SessionBindingContractTests : TestKit
         }, cancellationToken: ct);
     }
 
+    /// <summary>
+    /// Regression test for the daemon-restart duplicate-message bug.
+    /// After a supervised restart where the cursor has advanced to the same ts
+    /// as a message still returned by the thread history fetcher, the second
+    /// hydration must NOT re-emit that message. Otherwise the session ends up
+    /// with the message persisted twice — once from the first lifecycle's
+    /// backfill, and once from the second lifecycle's restart hydration —
+    /// which is the path that reintroduced the duplicate-image overflow
+    /// (D0AC6CKBK5K/1778728886.944599) after the daemon was restarted to
+    /// swap the fallback model.
+    /// </summary>
+    [Fact]
+    public async Task Hydration_after_restart_does_not_re_emit_message_at_cursor_position()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-restart-no-dupe-at-cursor");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        historyFetcher.SetHistory(CreateHistoryItems(1));
+
+        var turnNumber = 0;
+        var pipeline1 = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = $"reply {Interlocked.Increment(ref turnNumber)}" },
+            new TurnCompleted { SessionId = sid, TurnNumber = turnNumber, Outcome = TurnOutcome.Completed }
+        ], reactive: true);
+
+        var actor1 = CreateBindingActorWithHydration(sid, pipeline1, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline1.CapturedOptions), cancellationToken: ct);
+
+        // First lifecycle: hydration treats the single history item as the
+        // trigger, enqueues one backfill input, and the actor's _pendingCursorTs
+        // is set to that item's ts.
+        await AwaitAssertAsync(() => Assert.True(pipeline1.CapturedInputs.Count >= 1),
+            cancellationToken: ct);
+
+        // Wait for TurnCompleted — this advances the cursor to the trigger's ts.
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Contains(GetPostedTexts(), p => p.Contains("reply"));
+        }, cancellationToken: ct);
+
+        ClearPostedTexts();
+        await actor1.GracefulStop(TimeSpan.FromSeconds(5));
+
+        // Simulate daemon restart with the same persistent identity (journal
+        // recovers _cursorTs). The history fetcher still returns the same item
+        // because Slack/Discord don't forget messages between our restarts.
+        historyFetcher.ResetFetchCount();
+        var pipeline2 = new RecordingSessionPipeline(_ => []);
+
+        CreateBindingActorWithHydration(sid, pipeline2, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline2.CapturedOptions), cancellationToken: ct);
+        await AwaitAssertAsync(() => Assert.Equal(1, historyFetcher.FetchCount),
+            cancellationToken: ct);
+
+        // The cursor is exactly at the history item's ts. A correct gap filter
+        // excludes it (it's already in the session's persisted history). A
+        // buggy filter that admits ts == cursor re-emits the message a second
+        // time, doubling its contents (text + any attachments) in the session.
+        // Assert nothing was enqueued.
+        await AwaitAssertAsync(() => Assert.Empty(pipeline2.CapturedInputs),
+            cancellationToken: ct);
+    }
+
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -717,15 +717,23 @@ public abstract class SessionBindingContractTests : TestKit
     }
 
     // --- Thread Hydration ---
+    //
+    // Hydration runs exactly once per actor lifetime, on a self-told
+    // PerformHydration message scheduled from the RecoveryCompleted handler.
+    // The backfill (if any) is enqueued as its own ChannelInput. Live inbound
+    // events after hydration go through a fetch-free path and never carry
+    // historical adopted-context. This prevents the duplicate-image bug where
+    // every inbound during an in-flight turn was re-emitting the same gap
+    // messages and re-loading their attachments.
 
     [Fact]
-    public async Task Thread_history_merged_on_first_inbound()
+    public async Task Hydration_emits_backfill_at_startup_with_adopted_context()
     {
         if (!SupportsThreadHydration) return;
 
         var ct = TestContext.Current.CancellationToken;
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
-        var sid = new SessionId("session-hydration-merge");
+        var sid = new SessionId("session-hydration-startup-backfill");
         var historyFetcher = new RecordingThreadHistoryFetcher();
         historyFetcher.SetHistory(CreateHistoryItems(2));
 
@@ -735,43 +743,40 @@ public abstract class SessionBindingContractTests : TestKit
             new TurnCompleted { SessionId = sid, TurnNumber = 1 }
         ]);
 
-        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
         await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
 
-        actor.Tell(CreateHydrationTriggerInboundMessage("live message", "user-1"), TestActor);
-
+        // No live inbound sent — backfill must be enqueued purely from the
+        // RecoveryCompleted-driven hydration.
         await AwaitAssertAsync(() =>
         {
             Assert.Equal(1, historyFetcher.FetchCount);
             Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
-            Assert.Equal("live message", input.ExecutableText);
             Assert.True(input.HasAdoptedContext);
-            Assert.True(input.HasThirdPartyAdoptedContext);
             var textContent = string.Join("\n", input.Contents
                 .OfType<TextContent>()
                 .Select(t => t.Text));
             Assert.Contains("[adopted-context]", textContent, StringComparison.Ordinal);
             Assert.Contains("[current-authorized-message", textContent, StringComparison.Ordinal);
-            Assert.Contains("live message", textContent);
         }, cancellationToken: ct);
     }
 
     [Fact]
-    public async Task Thread_history_keeps_slash_like_text_out_of_executable_content()
+    public async Task Hydration_backfill_keeps_slash_like_text_in_adopted_projection()
     {
         if (!SupportsThreadHydration) return;
 
         var ct = TestContext.Current.CancellationToken;
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
-        var sid = new SessionId("session-hydration-executable-split");
+        var sid = new SessionId("session-hydration-slash-text");
         var historyFetcher = new RecordingThreadHistoryFetcher();
-        var historyItem = Assert.Single(CreateHistoryItems(1));
+        var items = CreateHistoryItems(2);
+        // Older item carries slash-command-like text. Trigger is the more
+        // recent authorized item (last in the list).
         historyFetcher.SetHistory(
         [
-            historyItem with
-            {
-                Contents = [new TextContent("/opsx-sync")]
-            }
+            items[0] with { Contents = [new TextContent("/opsx-sync")] },
+            items[1]
         ]);
 
         var pipeline = new RecordingSessionPipeline(_ =>
@@ -780,28 +785,27 @@ public abstract class SessionBindingContractTests : TestKit
             new TurnCompleted { SessionId = sid, TurnNumber = 1 }
         ]);
 
-        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
         await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
-
-        actor.Tell(CreateHydrationTriggerInboundMessage("tell me what they said", "user-1"), TestActor);
 
         await AwaitAssertAsync(() =>
         {
             Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
-            Assert.Equal("tell me what they said", input.ExecutableText);
             Assert.True(input.HasAdoptedContext);
-            Assert.True(input.HasThirdPartyAdoptedContext);
 
+            // The slash text from the older gap message lives inside the
+            // adopted-context projection. It must not become the trigger's
+            // ExecutableText, which would risk re-executing it.
+            Assert.NotEqual("/opsx-sync", input.ExecutableText);
             var textContent = string.Join("\n", input.Contents
                 .OfType<TextContent>()
                 .Select(t => t.Text));
             Assert.Contains("/opsx-sync", textContent, StringComparison.Ordinal);
-            Assert.Contains("tell me what they said", textContent, StringComparison.Ordinal);
         }, cancellationToken: ct);
     }
 
     [Fact]
-    public async Task Self_only_thread_history_sets_adopted_context_without_third_party_flag()
+    public async Task Hydration_backfill_marks_self_only_history_without_third_party_flag()
     {
         if (!SupportsThreadHydration) return;
 
@@ -809,13 +813,14 @@ public abstract class SessionBindingContractTests : TestKit
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
         var sid = new SessionId("session-hydration-self-only");
         var historyFetcher = new RecordingThreadHistoryFetcher();
-        var historyItem = Assert.Single(CreateHistoryItems(1));
+        // Two history items, both from the same authorized user. The trigger
+        // (most recent) and the adopted-context entry share a sender, so the
+        // third-party flag must stay false.
+        var items = CreateHistoryItems(2);
         historyFetcher.SetHistory(
         [
-            historyItem with
-            {
-                SenderId = "user-1"
-            }
+            items[0] with { SenderId = "user-1" },
+            items[1] with { SenderId = "user-1" }
         ]);
 
         var pipeline = new RecordingSessionPipeline(_ =>
@@ -824,10 +829,8 @@ public abstract class SessionBindingContractTests : TestKit
             new TurnCompleted { SessionId = sid, TurnNumber = 1 }
         ]);
 
-        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
         await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
-
-        actor.Tell(CreateHydrationTriggerInboundMessage("summarize what I said", "user-1"), TestActor);
 
         await AwaitAssertAsync(() =>
         {
@@ -839,21 +842,194 @@ public abstract class SessionBindingContractTests : TestKit
     }
 
     [Fact]
-    public async Task Thread_history_fetched_for_each_authorized_inbound()
+    public async Task Thread_history_fetched_at_most_once_per_actor_lifetime()
     {
         if (!SupportsThreadHydration) return;
 
         var ct = TestContext.Current.CancellationToken;
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
-        var sid = new SessionId("session-hydration-oneshot");
+        var sid = new SessionId("session-hydration-once-only");
         var historyFetcher = new RecordingThreadHistoryFetcher();
         historyFetcher.SetHistory(CreateHistoryItems(1));
 
         var pipeline = new RecordingSessionPipeline(_ =>
         [
-            new TextOutput { SessionId = sid, Text = "first reply" },
+            new TextOutput { SessionId = sid, Text = "reply" },
             new TurnCompleted { SessionId = sid, TurnNumber = 1 }
         ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        // Hydration runs once at startup.
+        await AwaitAssertAsync(() => Assert.Equal(1, historyFetcher.FetchCount), cancellationToken: ct);
+
+        // Subsequent live inbounds must not re-trigger hydration. This is the
+        // core invariant that prevents the duplicate-image bug: in-flight
+        // turns and concurrent inbounds never re-derive historical content
+        // from the channel's history API.
+        actor.Tell(CreateHydrationTriggerInboundMessage("first live", "user-1"), TestActor);
+        actor.Tell(CreateHydrationTriggerInboundMessage("second live", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() => Assert.True(pipeline.CapturedInputs.Count >= 3),
+            cancellationToken: ct);
+
+        Assert.Equal(1, historyFetcher.FetchCount);
+    }
+
+    [Fact]
+    public async Task Inbounds_arriving_during_hydration_are_stashed_and_unstash_after()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hydration-stash");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        historyFetcher.SetHistory(Array.Empty<ChannelInput>());
+        historyFetcher.InstallGate();
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        // Wait until hydration's fetcher call is in flight (blocked on the
+        // gate). At this point the actor is provably in Hydrating behavior.
+        await historyFetcher.FetchCalledTask.WaitAsync(ct);
+
+        actor.Tell(CreateHydrationTriggerInboundMessage("stashed live", "user-1"), TestActor);
+
+        // No-timing assertion: the actor is in Hydrating and the fetcher is
+        // blocked, so the only way CapturedInputs could be non-empty is if
+        // the inbound was incorrectly processed bypassing the stash. We've
+        // already proved the actor is in Hydrating (fetcher was called),
+        // so a one-shot assertion is sufficient.
+        Assert.Empty(pipeline.CapturedInputs);
+
+        // Release the fetcher gate. Hydration completes (empty history → no
+        // backfill), behavior switches to Active, and the stashed inbound
+        // is unstashed and processed.
+        historyFetcher.ReleaseGate();
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.Single(pipeline.CapturedInputs);
+            Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
+            Assert.Equal("stashed live", input.ExecutableText);
+        }, cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Hydration_re_runs_after_supervised_restart()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hydration-restart");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        historyFetcher.SetHistory(Array.Empty<ChannelInput>());
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.Equal(1, historyFetcher.FetchCount), cancellationToken: ct);
+
+        await actor.GracefulStop(TimeSpan.FromSeconds(5));
+
+        var pipeline2 = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply 2" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 2 }
+        ]);
+        CreateBindingActorWithHydration(sid, pipeline2, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline2.CapturedOptions), cancellationToken: ct);
+
+        // A fresh actor lifecycle must re-run hydration. The fetch counter
+        // is shared across both actor instances on the same RecordingThreadHistoryFetcher.
+        await AwaitAssertAsync(() => Assert.Equal(2, historyFetcher.FetchCount), cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Image_in_history_flows_through_at_most_once_across_multiple_inbounds()
+    {
+        // Direct regression test for the duplicate-image compaction bug.
+        // Under the pre-fix design, every live inbound re-fetched thread
+        // history and re-emitted any in-flight message's DataContent, so the
+        // same image accumulated into history N times — destroying session
+        // compaction budget. The fix: hydration runs once at actor startup,
+        // and live inbounds never re-fetch history. The image flows through
+        // exactly once.
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-image-flows-once");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        var baseItem = Assert.Single(CreateHistoryItems(1));
+        historyFetcher.SetHistory(
+        [
+            baseItem with
+            {
+                Contents = [.. baseItem.Contents, new DataContent(imageBytes, "image/png")]
+            }
+        ]);
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        // Wait for hydration backfill to land.
+        await AwaitAssertAsync(() => Assert.True(pipeline.CapturedInputs.Count >= 1),
+            cancellationToken: ct);
+
+        // Send three live inbounds in quick succession — the kind of scenario
+        // that produced 8 image copies under the pre-fix design.
+        actor.Tell(CreateHydrationTriggerInboundMessage("live 1", "user-1"), TestActor);
+        actor.Tell(CreateHydrationTriggerInboundMessage("live 2", "user-1"), TestActor);
+        actor.Tell(CreateHydrationTriggerInboundMessage("live 3", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() => Assert.True(pipeline.CapturedInputs.Count >= 4),
+            cancellationToken: ct);
+
+        var dataContentCount = pipeline.CapturedInputs
+            .Sum(input => input.Contents.OfType<DataContent>().Count());
+        Assert.Equal(1, dataContentCount);
+    }
+
+    [Fact]
+    public async Task Cursor_does_not_advance_on_non_completed_turn_outcome()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-cursor-not-completed");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        historyFetcher.SetHistory(Array.Empty<ChannelInput>());
+
+        // First lifecycle: live inbound arrives, turn outcome is Failed.
+        // Cursor must NOT advance (PR #733 amnesia fix).
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "partial" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1, Outcome = TurnOutcome.Failed }
+        ], reactive: true);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
         await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
@@ -862,17 +1038,81 @@ public abstract class SessionBindingContractTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.Equal(1, historyFetcher.FetchCount);
             Assert.True(pipeline.CapturedInputs.Count >= 1);
+            Assert.Contains(GetPostedTexts(), t => t.Contains("partial"));
         }, cancellationToken: ct);
 
-        actor.Tell(CreateHydrationTriggerInboundMessage("second live", "user-1"), TestActor);
+        await actor.GracefulStop(TimeSpan.FromSeconds(5));
+
+        // Second lifecycle: history contains TWO items with snowflakes/ts
+        // earlier than the first-live inbound's. If the cursor had advanced
+        // on Failed, the second lifecycle's hydration would skip both items.
+        // Because the cursor stayed put, both stay in the gap and produce
+        // a backfill ChannelInput (older item wrapped as adopted context for
+        // the newer item, which acts as the synthesized trigger).
+        historyFetcher.SetHistory(CreateHistoryItems(2));
+        historyFetcher.ResetFetchCount();
+
+        var pipeline2 = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply 2" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 2, Outcome = TurnOutcome.Completed }
+        ]);
+
+        CreateBindingActorWithHydration(sid, pipeline2, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline2.CapturedOptions), cancellationToken: ct);
 
         await AwaitAssertAsync(() =>
-            Assert.True(pipeline.CapturedInputs.Count >= 2),
+        {
+            Assert.Equal(1, historyFetcher.FetchCount);
+            // The backfill produced from the un-advanced cursor includes the
+            // older history item as adopted context, proving the cursor never
+            // advanced on the failed turn.
+            Assert.True(pipeline2.CapturedInputs.TryPeek(out var input));
+            Assert.True(input.HasAdoptedContext);
+        }, cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Live_inbound_after_hydration_is_plain_without_adopted_context()
+    {
+        if (!SupportsThreadHydration) return;
+
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-hydration-plain-live");
+        var historyFetcher = new RecordingThreadHistoryFetcher();
+        historyFetcher.SetHistory(CreateHistoryItems(1));
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
+        await AwaitAssertAsync(() => Assert.NotNull(pipeline.CapturedOptions), cancellationToken: ct);
+
+        // Wait for hydration backfill to land.
+        await AwaitAssertAsync(() => Assert.True(pipeline.CapturedInputs.Count >= 1),
             cancellationToken: ct);
 
-        Assert.Equal(2, historyFetcher.FetchCount);
+        actor.Tell(CreateHydrationTriggerInboundMessage("live after hydration", "user-1"), TestActor);
+
+        await AwaitAssertAsync(() =>
+        {
+            // Live input lives at index 1 (backfill is index 0).
+            Assert.True(pipeline.CapturedInputs.Count >= 2);
+            var inputs = pipeline.CapturedInputs.ToArray();
+            var live = inputs[^1];
+            Assert.Equal("live after hydration", live.ExecutableText);
+            Assert.False(live.HasAdoptedContext);
+            Assert.False(live.HasThirdPartyAdoptedContext);
+            var liveText = string.Join("\n", live.Contents
+                .OfType<TextContent>()
+                .Select(t => t.Text));
+            Assert.DoesNotContain("[adopted-context]", liveText, StringComparison.Ordinal);
+        }, cancellationToken: ct);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -229,13 +229,15 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
 
         var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-recovery");
 
-        // First mention — triggers backfill
+        // First mention with a TS later than any history item — the actor
+        // materializes, runs one-shot hydration (fetchCount: 0 → 1), enqueues
+        // a backfill, then processes the live inbound on top.
         gateway.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: new SlackEventId("C_RECOVERY:4000.1"),
+            EventId: new SlackEventId("C_RECOVERY:4000.5"),
             ChannelId: new SlackChannelId("C_RECOVERY"),
             ThreadTs: new SlackThreadTs("4000.0"),
-            EventTs: new SlackEventTs("4000.1"),
+            EventTs: new SlackEventTs("4000.5"),
             UserId: new SlackUserId("U_USER"),
             BotId: null,
             Text: "<@UBOT> first message",
@@ -245,18 +247,20 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.True(_chatClient.CallCount >= 1, "Expected first LLM call");
+            Assert.True(_chatClient.CallCount >= 1, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, fetchCount);
 
-        // Second message in the same thread fetches again, but only for the unsynced gap.
+        // Second mention in the same thread MUST NOT re-fetch history — under
+        // the post-fix design, hydration runs once per actor lifecycle, and
+        // live inbounds go through a fetch-free path.
         gateway.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: new SlackEventId("C_RECOVERY:4000.2"),
+            EventId: new SlackEventId("C_RECOVERY:4000.6"),
             ChannelId: new SlackChannelId("C_RECOVERY"),
             ThreadTs: new SlackThreadTs("4000.0"),
-            EventTs: new SlackEventTs("4000.2"),
+            EventTs: new SlackEventTs("4000.6"),
             UserId: new SlackUserId("U_USER"),
             BotId: null,
             Text: "<@UBOT> follow up",
@@ -264,25 +268,28 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Hidden: false,
             IsDirectMessage: false));
 
+        // Verify fetch count holds at 1 even after the second live inbound.
+        // AwaitAssertAsync repeatedly re-asserts; if a stray fetch fires it
+        // will increment the counter and break the assertion.
         await AwaitAssertAsync(() =>
         {
-            Assert.True(_chatClient.CallCount >= 2, "Expected second LLM call");
-        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.Equal(2, fetchCount);
+            Assert.Equal(1, fetchCount);
+        }, duration: TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
 
         Watch(gateway);
         Sys.Stop(gateway);
         await ExpectTerminatedAsync(gateway, cancellationToken: TestContext.Current.CancellationToken);
 
-        // Simulate relaunch/offline recovery: a new gateway runtime should hydrate once again.
+        // Simulate relaunch/offline recovery: a new gateway runtime materializes
+        // a fresh binding actor which must run hydration once on its own
+        // lifecycle (fetchCount: 1 → 2).
         var relaunchedGateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-recovery-relaunched");
         relaunchedGateway.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
-            EventId: new SlackEventId("C_RECOVERY:4000.3"),
+            EventId: new SlackEventId("C_RECOVERY:4000.7"),
             ChannelId: new SlackChannelId("C_RECOVERY"),
             ThreadTs: new SlackThreadTs("4000.0"),
-            EventTs: new SlackEventTs("4000.3"),
+            EventTs: new SlackEventTs("4000.7"),
             UserId: new SlackUserId("U_USER"),
             BotId: null,
             Text: "<@UBOT> after restart",
@@ -292,17 +299,8 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
 
         await AwaitAssertAsync(() =>
         {
-            Assert.True(_chatClient.CallCount >= 3, "Expected third LLM call after relaunch");
+            Assert.Equal(2, fetchCount);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.Equal(3, fetchCount);
-
-        var recoveredMessages = _chatClient.Calls[^1];
-        var recoveredLastUser = recoveredMessages.Last(m => m.Role == AiChatRole.User);
-        var recoveredUserText = string.Join("", recoveredLastUser.Contents.OfType<TextContent>().Select(t => t.Text));
-        Assert.Contains("[adopted-context]", recoveredUserText, StringComparison.Ordinal);
-        Assert.Contains("I think it's the new query", recoveredUserText, StringComparison.Ordinal);
-        Assert.Contains("after restart", recoveredUserText);
     }
 
     [Fact]
@@ -685,10 +683,22 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Hidden: false,
             IsDirectMessage: false));
 
+        // Wait for at least one LLM call (hydration backfill or the live
+        // inbound). The actor materializes, runs one-shot hydration, then
+        // processes the stashed live inbound.
         await AwaitAssertAsync(() =>
         {
-            Assert.Equal(1, _chatClient.CallCount);
+            Assert.True(_chatClient.CallCount >= 1, $"Expected ≥1 LLM call, got {_chatClient.CallCount}");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+
+        // Allow the live inbound to be processed too — pending cursor will
+        // advance past 6000.5, making 6000.4 stale.
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_chatClient.CallCount >= 2, $"Expected backfill + live = ≥2 LLM calls, got {_chatClient.CallCount}");
+        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+
+        var callsBeforeStale = _chatClient.CallCount;
 
         gateway.Tell(new SlackInboundMessage(
             Kind: SlackInboundKind.AppMention,
@@ -703,10 +713,13 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Hidden: false,
             IsDirectMessage: false));
 
+        // The stale event must be dropped — call count must not increase.
+        // AwaitAssertAsync repeatedly re-asserts during the duration; if the
+        // count rises, the assertion fails on retry and the test fails.
         await AwaitAssertAsync(() =>
         {
-            Assert.Equal(1, _chatClient.CallCount);
-        }, duration: TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+            Assert.Equal(callsBeforeStale, _chatClient.CallCount);
+        }, duration: TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -805,9 +818,26 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
             Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
-        var messages = _chatClient.LastMessages!;
-        var user = Assert.Single(messages, m => m.Role == AiChatRole.User);
+        // Locate the hydration backfill call — the one that carries the
+        // adopted-context projection (which is where the historical docx
+        // rejection note lives under the public-channel attachment policy).
+        // Under the post-fix design the backfill is its own LLM call; the
+        // subsequent live inbound is a plain message without adopted context.
+        var backfillCall = _chatClient.Calls
+            .Select((messages, idx) => (messages, idx))
+            .FirstOrDefault(c =>
+            {
+                var lastUser = c.messages.LastOrDefault(m => m.Role == AiChatRole.User);
+                if (lastUser is null) return false;
+                var text = string.Join("", lastUser.Contents.OfType<TextContent>().Select(t => t.Text));
+                return text.Contains("[adopted-context]", StringComparison.Ordinal);
+            }).messages;
 
+        Assert.NotNull(backfillCall);
+        var user = Assert.Single(backfillCall, m => m.Role == AiChatRole.User);
+
+        // The docx must not be forwarded as DataContent — public-channel
+        // attachment policy rejects it.
         Assert.Empty(user.Contents.OfType<DataContent>());
 
         var mergedText = string.Join("", user.Contents.OfType<TextContent>().Select(t => t.Text));

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingThreadHistoryFetcher.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingThreadHistoryFetcher.cs
@@ -13,8 +13,13 @@ internal sealed class RecordingThreadHistoryFetcher : IThreadHistoryFetcher
     private int _fetchCount;
     private IReadOnlyList<ChannelInput> _history = Array.Empty<ChannelInput>();
     private Exception? _throwOnFetch;
+    private TaskCompletionSource? _gate;
+    private readonly TaskCompletionSource _fetchCalled = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public int FetchCount => Volatile.Read(ref _fetchCount);
+
+    /// <summary>Resolves once <see cref="FetchThreadHistoryAsync"/> is first called.</summary>
+    public Task FetchCalledTask => _fetchCalled.Task;
 
     public void ResetFetchCount() => Interlocked.Exchange(ref _fetchCount, 0);
 
@@ -22,13 +27,26 @@ internal sealed class RecordingThreadHistoryFetcher : IThreadHistoryFetcher
 
     public void SetThrowOnFetch(Exception ex) => _throwOnFetch = ex;
 
-    public Task<IReadOnlyList<ChannelInput>> FetchThreadHistoryAsync(
+    /// <summary>
+    /// Installs a TCS gate that blocks <see cref="FetchThreadHistoryAsync"/>
+    /// until <see cref="ReleaseGate"/> is called. Used by stash tests to hold
+    /// the actor in the Hydrating behavior while inbound messages arrive.
+    /// </summary>
+    public void InstallGate() =>
+        _gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public void ReleaseGate() => _gate?.TrySetResult();
+
+    public async Task<IReadOnlyList<ChannelInput>> FetchThreadHistoryAsync(
         SessionId sessionId,
         CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref _fetchCount);
+        _fetchCalled.TrySetResult();
+        if (_gate is { } gate)
+            await gate.Task.WaitAsync(cancellationToken);
         if (_throwOnFetch is not null)
             throw _throwOnFetch;
-        return Task.FromResult(_history);
+        return _history;
     }
 }

--- a/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/ChatMessageConverterTests.cs
@@ -233,6 +233,10 @@ public class ChatMessageConverterTests
         Assert.Equal("image/png", msg.MediaReferences[0].MimeType);
         Assert.Equal((int)MediaModality.Image, msg.MediaReferences[0].Modality);
         Assert.EndsWith(".png", msg.MediaReferences[0].RelativePath);
+        // FileSizeBytes is populated at write time so compaction's token
+        // estimator can account for base64-encoded media payload size without
+        // touching disk.
+        Assert.Equal(imageBytes.Length, msg.MediaReferences[0].FileSizeBytes);
 
         // Verify file was written to disk
         var filePath = Path.Combine(tempDir.Path, "media", msg.MediaReferences[0].RelativePath);

--- a/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionCompactionPipelineTokenEstimationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/Pipelines/SessionCompactionPipelineTokenEstimationTests.cs
@@ -1,0 +1,183 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionCompactionPipelineTokenEstimationTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Protocol;
+using Netclaw.Actors.Sessions.Pipelines;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions.Pipelines;
+
+/// <summary>
+/// Unit tests for <see cref="SessionCompactionPipeline.EstimateTokens"/> with
+/// emphasis on media-reference accounting. The naive char/4 estimator must
+/// include base64-inflated media payload size so the adaptive compaction loop
+/// can react to image-heavy turns. Legacy records (FileSizeBytes = 0) must
+/// produce the same estimate as before this field existed.
+/// </summary>
+public class SessionCompactionPipelineTokenEstimationTests
+{
+    [Fact]
+    public void EstimateTokens_text_only_message_matches_char_quartile()
+    {
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = new string('a', 400)
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([msg], systemPrompt: null);
+
+        Assert.Equal(100, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_legacy_media_reference_without_FileSizeBytes_does_not_inflate()
+    {
+        // Legacy records persisted before the FileSizeBytes field existed
+        // deserialize with FileSizeBytes = 0 (proto3 default). The estimator
+        // must under-count them the same way it did before — no regression.
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = new string('a', 400),
+            MediaReferences =
+            [
+                new SerializableMediaReference
+                {
+                    RelativePath = "img.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image
+                    // FileSizeBytes intentionally omitted → 0
+                }
+            ]
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([msg], systemPrompt: null);
+
+        Assert.Equal(100, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_includes_media_size_inflated_by_base64_ratio()
+    {
+        // A 300KB image base64-encodes to ~400KB chars (4/3 inflation).
+        // At chars/4, that contributes 100,000 tokens above the text content.
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = string.Empty,
+            MediaReferences =
+            [
+                new SerializableMediaReference
+                {
+                    RelativePath = "img.png",
+                    MimeType = "image/png",
+                    Modality = (int)MediaModality.Image,
+                    FileSizeBytes = 300_000
+                }
+            ]
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([msg], systemPrompt: null);
+
+        // 300000 * 4 / 3 / 4 == 100000
+        Assert.Equal(100_000, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_sums_multiple_media_references_on_one_message()
+    {
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.User,
+            Content = string.Empty,
+            MediaReferences =
+            [
+                new SerializableMediaReference { RelativePath = "a.png", MimeType = "image/png", FileSizeBytes = 60_000 },
+                new SerializableMediaReference { RelativePath = "b.png", MimeType = "image/png", FileSizeBytes = 30_000 },
+                new SerializableMediaReference { RelativePath = "c.png", MimeType = "image/png", FileSizeBytes = 30_000 }
+            ]
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([msg], systemPrompt: null);
+
+        // (60_000 + 30_000 + 30_000) * 4 / 3 / 4 == 40_000
+        Assert.Equal(40_000, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_combines_text_tool_call_args_and_media()
+    {
+        var msg = new SerializableChatMessage
+        {
+            Role = ChatRole.Assistant,
+            Content = new string('a', 400), // contributes 100 tokens
+            ToolCalls =
+            [
+                new SerializableToolCall
+                {
+                    CallId = "call-1",
+                    Name = "shell_execute",
+                    ArgumentsJson = new string('b', 200) // contributes 50 tokens
+                }
+            ],
+            MediaReferences =
+            [
+                new SerializableMediaReference { RelativePath = "img.png", MimeType = "image/png", FileSizeBytes = 300_000 } // contributes 100_000 tokens
+            ]
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([msg], systemPrompt: null);
+
+        Assert.Equal(100 + 50 + 100_000, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_includes_system_prompt_media()
+    {
+        var systemPrompt = new SerializableChatMessage
+        {
+            Role = ChatRole.System,
+            Content = new string('s', 800), // contributes 200 tokens
+            MediaReferences =
+            [
+                new SerializableMediaReference { RelativePath = "logo.png", MimeType = "image/png", FileSizeBytes = 150_000 } // contributes 50_000
+            ]
+        };
+
+        var tokens = SessionCompactionPipeline.EstimateTokens([], systemPrompt);
+
+        Assert.Equal(200 + 50_000, tokens);
+    }
+
+    [Fact]
+    public void EstimateTokens_long_accumulator_does_not_overflow_on_multimegabyte_media()
+    {
+        // A 4 MB image base64-encodes to ~5.33 MB chars. With an int accumulator
+        // we'd risk overflow when summing across many messages. The long
+        // accumulator must absorb this and produce a sane token count.
+        var bigImage = new SerializableMediaReference
+        {
+            RelativePath = "huge.png",
+            MimeType = "image/png",
+            FileSizeBytes = 4_000_000
+        };
+        var messages = new List<SerializableChatMessage>();
+        for (var i = 0; i < 5; i++)
+        {
+            messages.Add(new SerializableChatMessage
+            {
+                Role = ChatRole.User,
+                Content = string.Empty,
+                MediaReferences = [bigImage]
+            });
+        }
+
+        var tokens = SessionCompactionPipeline.EstimateTokens(messages, systemPrompt: null);
+
+        // 5 * (4_000_000 * 4 / 3 / 4) == 5 * ~1_333_333 == ~6_666_665
+        Assert.InRange(tokens, 6_000_000, 7_000_000);
+    }
+}

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -359,7 +359,8 @@ public sealed class SessionPipeline : ISessionPipeline
                 {
                     RelativePath = fileName,
                     MimeType = mimeType,
-                    Modality = (int)ChatMessageConverter.MimeToModality(mimeType)
+                    Modality = (int)ChatMessageConverter.MimeToModality(mimeType),
+                    FileSizeBytes = bytes.Length
                 });
             }
         }

--- a/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
+++ b/src/Netclaw.Actors/Protocol/ChatMessageConverter.cs
@@ -184,7 +184,8 @@ public static class ChatMessageConverter
         {
             RelativePath = fileName,
             MimeType = mimeType,
-            Modality = (int)modality
+            Modality = (int)modality,
+            FileSizeBytes = bytes.Length
         };
     }
 

--- a/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
+++ b/src/Netclaw.Actors/Protocol/SerializableChatMessage.cs
@@ -53,6 +53,15 @@ public sealed record SerializableMediaReference : INetclawSerializableMessage
 
     /// <summary>Content modality as integer for wire safety (maps to <see cref="MediaModality"/>).</summary>
     public int Modality { get; init; }
+
+    /// <summary>
+    /// Raw file size in bytes. Used by compaction token estimation to account
+    /// for base64-encoded media payloads at LLM-call time without reading
+    /// files from disk. Zero for records persisted before this field was
+    /// added — proto3 default — which causes legacy records to under-count
+    /// the same way they did before this field existed (no regression).
+    /// </summary>
+    public long FileSizeBytes { get; init; }
 }
 
 /// <summary>

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -56,14 +56,16 @@ internal static class NetclawProtoMapper
     {
         RelativePath = r.RelativePath,
         MimeType = r.MimeType,
-        Modality = r.Modality
+        Modality = r.Modality,
+        FileSizeBytes = r.FileSizeBytes
     };
 
     internal static SerializableMediaReference FromProto(Proto.SerializableMediaReferenceProto proto) => new()
     {
         RelativePath = proto.RelativePath,
         MimeType = proto.MimeType,
-        Modality = proto.Modality
+        Modality = proto.Modality,
+        FileSizeBytes = proto.FileSizeBytes
     };
 
     // ── SerializableToolCall ──

--- a/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
+++ b/src/Netclaw.Actors/Serialization/Protos/netclaw_messages.proto
@@ -55,6 +55,9 @@ message SerializableMediaReferenceProto {
   string relative_path = 1;
   string mime_type = 2;
   int32 modality = 3;
+  // Raw file size in bytes. Zero for records persisted before this field
+  // was added — see SerializableMediaReference.FileSizeBytes.
+  int64 file_size_bytes = 4;
 }
 
 message SerializableToolCallProto {

--- a/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
+++ b/src/Netclaw.Actors/Sessions/Pipelines/SessionCompactionPipeline.cs
@@ -202,22 +202,44 @@ internal static class SessionCompactionPipeline
     }
 
     /// <summary>
-    /// Naive token estimation: total character count / 4.
-    /// Includes the system prompt (if present) plus all compacted messages.
+    /// Naive token estimation: total character count / 4. Includes the system
+    /// prompt (if present), text content, tool-call arguments, and media-payload
+    /// inflation across all messages. Media is estimated as <c>fileSize * 4 / 3</c>
+    /// chars (base64 inflation) and contributes to the token count even though
+    /// the bytes are stored as references on disk — at LLM-call time
+    /// <see cref="ChatMessageConverter.ToAiMessages"/> loads them as
+    /// <c>DataContent</c> and the provider base64-serializes them into the JSON
+    /// payload. The accumulator is <see cref="long"/> to handle multi-megabyte
+    /// images without int overflow.
     /// </summary>
     public static int EstimateTokens(
         List<SerializableChatMessage> messages,
         SerializableChatMessage? systemPrompt)
     {
-        var totalChars = 0;
+        var totalChars = 0L;
         if (systemPrompt is not null)
+        {
             totalChars += systemPrompt.Content?.Length ?? 0;
+            totalChars += EstimateMediaChars(systemPrompt);
+        }
         foreach (var msg in messages)
         {
             totalChars += msg.Content?.Length ?? 0;
             foreach (var tc in msg.ToolCalls)
                 totalChars += tc.ArgumentsJson?.Length ?? 0;
+            totalChars += EstimateMediaChars(msg);
         }
-        return totalChars / 4;
+        return (int)(totalChars / 4);
+    }
+
+    private static long EstimateMediaChars(SerializableChatMessage msg)
+    {
+        var total = 0L;
+        foreach (var media in msg.MediaReferences)
+        {
+            // base64 inflates raw bytes by 4/3
+            total += media.FileSizeBytes * 4 / 3;
+        }
+        return total;
     }
 }

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -83,6 +83,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         _handle = new SessionPipelineHandle(_dependencies.Pipeline, _log, "discord-session");
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
+        // After journal replay completes, queue a one-shot hydration. The
+        // self-tell lands in the mailbox after InitializePipeline (from
+        // PreStart), so the actor finishes pipeline init first, then
+        // transitions into Hydrating and processes PerformHydration.
+        Recover<RecoveryCompleted>(_ => Self.Tell(PerformHydration.Instance));
 
         Initializing();
     }
@@ -139,8 +144,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             try
             {
                 await EnsureInitializedAsync();
-                Become(Active);
-                Stash.UnstashAll();
+                Become(Hydrating);
+                // Do NOT UnstashAll here. PerformHydration is already in the
+                // mailbox (sent from the RecoveryCompleted handler) and will be
+                // processed next by the Hydrating behavior. Stashed live
+                // inbounds stay stashed until Hydrating transitions to Active.
             }
             catch (Exception ex)
             {
@@ -154,6 +162,28 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             if (msg is not InitializePipeline)
                 Stash.Stash();
         });
+    }
+
+    private void Hydrating()
+    {
+        CommandAsync<PerformHydration>(async _ =>
+        {
+            try
+            {
+                await PerformOneShotHydrationAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Thread history hydration threw; continuing without backfill");
+            }
+            finally
+            {
+                Become(Active);
+                Stash.UnstashAll();
+            }
+        });
+
+        CommandAny(_ => Stash.Stash());
     }
 
     private void Active()
@@ -287,11 +317,10 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (liveContents.Count == 0)
             return;
 
-        var (mergedContents, backfillDetectorUnavailable, adoptedSpeakerIds, projection, adoptedEntries) = await BuildInputContentsAsync(message, liveContents, inboundCts.Token);
-
-        if (backfillDetectorUnavailable)
-            await SafeReplyAsync(BackfillDetectorWarning);
-
+        // Live inbound path is fetch-free. Thread history is hydrated exactly
+        // once per actor lifetime in PerformOneShotHydrationAsync (driven by
+        // the RecoveryCompleted handler), so by the time we get here the
+        // session already has the historical context it needs.
         var input = new ChannelInput
         {
             SenderId = message.SenderId.Value,
@@ -301,15 +330,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             Boundary = SecurityPolicyDefaults.TrustedInstanceBoundary,
             Principal = message.Principal,
             Provenance = message.Provenance,
-            Contents = mergedContents,
+            Contents = liveContents,
             ReceivedAt = message.ReceivedAt,
-            ExecutableText = message.Text,
-            HasThirdPartyAdoptedContext = adoptedSpeakerIds.Any(id => !string.Equals(id, message.SenderId.Value, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = adoptedSpeakerIds,
-            AdoptedContextProjection = projection,
-            AdoptedContextLowerBound = _cursorSnowflake?.ToString(),
-            AdoptedContextUpperBound = message.EventId.Value,
-            AdoptedContextEntries = adoptedEntries
+            ExecutableText = message.Text
         };
 
         try
@@ -336,31 +359,42 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
     }
 
-    private async Task<(IReadOnlyList<AIContent> Contents, bool BackfillDetectorUnavailable, IReadOnlyList<string> AdoptedSpeakerIds, string? Projection, IReadOnlyList<ChannelInput.AdoptedContextEntry> AdoptedEntries)> BuildInputContentsAsync(
-        DiscordThreadInbound message,
-        List<AIContent> liveContents,
-        CancellationToken cancellationToken)
+    /// <summary>
+    /// One-shot thread history hydration. Runs once per actor lifetime, in the
+    /// Hydrating behavior immediately after pipeline initialization. Fetches
+    /// thread history, computes the gap relative to the recovered cursor, and
+    /// if there is an authorized message in the gap, synthesizes one backfill
+    /// <see cref="ChannelInput"/> using that message as the trigger and older
+    /// gap messages as adopted context. Hands the synthesized input to the
+    /// session pipeline through the normal input-queue path.
+    /// </summary>
+    private async Task PerformOneShotHydrationAsync()
     {
         if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
-            return (liveContents, false, [], null, []);
+            return;
+
+        using var cts = new CancellationTokenSource(InboundProcessingTimeout);
 
         IReadOnlyList<ChannelInput> history;
         try
         {
-            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
+            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
         }
         catch (Exception ex)
         {
-            _log.Warning(ex, "Thread history fetch failed for session {0}", _sessionId.Value);
-            return (liveContents, false, [], null, []);
+            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return;
         }
 
         if (history.Count == 0)
-            return (liveContents, false, [], null, []);
+        {
+            _log.Info(
+                "Thread history hydration: empty thread, no backfill cursor={Cursor} session={Session}",
+                _cursorSnowflake?.ToString() ?? "none", _sessionId.Value);
+            return;
+        }
 
         var cursor = _cursorSnowflake;
-
-        // Phase 1: filter by cursor bounds (cheap, sync).
         var candidates = new List<ChannelInput>(history.Count);
         foreach (var item in history)
         {
@@ -380,20 +414,17 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (candidates.Count == 0)
         {
             _log.Info(
-                "Thread history hydrated fetched={FetchedCount} gapCount=0 cursor={Cursor} session={Session}",
+                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor} session={Session}",
                 history.Count, cursor?.ToString() ?? "none", _sessionId.Value);
-            return (liveContents, false, [], null, []);
+            return;
         }
 
-        // Phase 2: classify candidates in parallel for prompt injection risk.
         var classifications = await Task.WhenAll(
-            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
+            candidates.Select(c => ClassifyGapMessageAsync(c, cts.Token)));
 
-        // Phase 3: assemble gap preserving chronological order.
-        var safe = new List<AdoptedContextMessage>(candidates.Count);
+        var gap = new List<AdoptedContextMessage>(candidates.Count);
         var blockedForRisk = 0;
         var detectorUnavailable = false;
-
         for (var i = 0; i < candidates.Count; i++)
         {
             switch (classifications[i].Outcome)
@@ -403,7 +434,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
                         || _dependencies.Options.AllowedUserIds.Contains(candidates[i].SenderId, StringComparer.Ordinal)
                         ? AdoptedMessageAuthority.Authorized
                         : AdoptedMessageAuthority.Pending;
-                    safe.Add(new AdoptedContextMessage(candidates[i], authority));
+                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
                     break;
 
                 case ClassificationOutcome.Block:
@@ -423,20 +454,103 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
 
         _log.Info(
-            "Thread history hydrated fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
-            history.Count, candidates.Count, safe.Count, blockedForRisk, cursor?.ToString() ?? "none", _sessionId.Value);
+            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
+            history.Count, candidates.Count, gap.Count, blockedForRisk, cursor?.ToString() ?? "none", _sessionId.Value);
 
-        if (safe.Count == 0)
-            return (liveContents, detectorUnavailable, [], null, []);
+        if (detectorUnavailable)
+            await SafeReplyAsync(BackfillDetectorWarning);
 
-        var merged = MergeHistoryWithLiveContents(safe, liveContents, message);
+        if (gap.Count == 0)
+            return;
 
-        return (
-            merged.Contents,
-            detectorUnavailable,
-            merged.SpeakerIds,
-            merged.Projection,
-            merged.Entries);
+        // Locate the most recent authorized message in the gap — it plays the
+        // role of the "current authorized message" that adopted-context normally
+        // anchors around. Without one we have no authorized trigger to enqueue;
+        // we transition to Active and let the next live authorized inbound be
+        // the trigger.
+        AdoptedContextMessage? trigger = null;
+        for (var i = gap.Count - 1; i >= 0; i--)
+        {
+            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
+            {
+                trigger = gap[i];
+                break;
+            }
+        }
+
+        if (trigger is null)
+        {
+            _log.Info("Thread history hydration: no authorized message in gap; deferring backfill to next live inbound session={Session}", _sessionId.Value);
+            return;
+        }
+
+        var adoptedContext = new List<AdoptedContextMessage>();
+        foreach (var item in gap)
+        {
+            if (ReferenceEquals(item, trigger))
+                break;
+            adoptedContext.Add(item);
+        }
+
+        var triggerInput = trigger.Input;
+        var triggerSenderId = triggerInput.SenderId;
+        var triggerSnowflake = TryParseSnowflake(triggerInput.MessageId ?? string.Empty);
+
+        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
+            adoptedContext,
+            triggerInput.Contents,
+            triggerSenderId,
+            triggerInput.ReceivedAt);
+
+        var backfillInput = triggerInput with
+        {
+            Contents = merged.Contents,
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggerSenderId, StringComparison.Ordinal)),
+            AdoptedSpeakerIds = merged.SpeakerIds,
+            AdoptedContextProjection = merged.Projection,
+            AdoptedContextLowerBound = cursor?.ToString(),
+            AdoptedContextUpperBound = triggerInput.MessageId,
+            AdoptedContextEntries = merged.Entries
+        };
+
+        if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
+        {
+            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
+            return;
+        }
+
+        var writer = _handle.InputQueue;
+        if (writer is null)
+        {
+            _log.Warning("Discord input queue is not initialized; skipping hydration backfill");
+            return;
+        }
+
+        try
+        {
+            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            writeCts.CancelAfter(TimeSpan.FromSeconds(10));
+            await writer.WriteAsync(backfillInput, writeCts.Token);
+
+            if (triggerSnowflake is { } sn)
+            {
+                if (_pendingCursorSnowflake is not { } pending || sn > pending)
+                    _pendingCursorSnowflake = sn;
+            }
+
+            _log.Info(
+                "discord_hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount} session={Session}",
+                triggerInput.MessageId, adoptedContext.Count, _sessionId.Value);
+            ChannelTelemetry.For(ChannelType.Discord).RecordMessageEnqueued();
+        }
+        catch (OperationCanceledException ex)
+        {
+            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
+        catch (ChannelClosedException ex)
+        {
+            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
     }
 
     private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
@@ -449,16 +563,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         return PromptClassifier.ClassifyAsync(
             _promptInjectionDetector, text, "discord-backfill", _log, cancellationToken);
     }
-
-    private static AdoptedContextMergeResult MergeHistoryWithLiveContents(
-        IReadOnlyList<AdoptedContextMessage> history,
-        IReadOnlyList<AIContent> liveContents,
-        DiscordThreadInbound message)
-        => AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            history,
-            liveContents,
-            message.SenderId.Value,
-            message.ReceivedAt);
 
     private async Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message, string selectedKey)
     {
@@ -1171,6 +1275,11 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private sealed record InitializePipeline
     {
         public static readonly InitializePipeline Instance = new();
+    }
+
+    private sealed record PerformHydration
+    {
+        public static readonly PerformHydration Instance = new();
     }
 
     private sealed record OutputReceived(SessionOutput Output);

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -401,11 +401,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             if (TryParseSnowflake(item.MessageId ?? string.Empty) is not { } itemSnowflake)
                 continue;
 
-            // Keep the cursor message itself during fresh-runtime hydration.
-            // If the daemon restarts while a turn is still in-flight, the
-            // session actor may recover with no completed turns even though the
-            // cursor already advanced to the last inbound user message.
-            if (cursor is { } c && itemSnowflake < c)
+            // Strict: only include messages newer than the cursor. PR #733's
+            // "cursor advances only on TurnCompleted" guarantees that
+            // snowflake == cursor means the session already has that message
+            // persisted — re-including it here on a restart hydration would
+            // duplicate it. The in-flight-crash case is handled too: a turn
+            // that didn't complete leaves the cursor un-advanced, so the
+            // message has snowflake > cursor and is correctly included in the gap.
+            if (cursor is { } c && itemSnowflake <= c)
                 continue;
 
             candidates.Add(item);

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -68,6 +68,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             .WithContext("SlackThreadTs", _threadTs);
 
         Recover<CursorAdvanced>(ApplyCursorAdvanced);
+        // After journal replay completes, queue a one-shot hydration. The
+        // self-tell lands in the mailbox after InitializePipeline (from
+        // PreStart), so the actor finishes pipeline init first, then
+        // transitions into Hydrating and processes PerformHydration.
+        Recover<RecoveryCompleted>(_ => Self.Tell(PerformHydration.Instance));
 
         Initializing();
 
@@ -102,8 +107,11 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             try
             {
                 await EnsureInitializedAsync();
-                Become(Active);
-                Stash.UnstashAll();
+                Become(Hydrating);
+                // Do NOT UnstashAll here. PerformHydration is already in the
+                // mailbox (sent from the RecoveryCompleted handler) and will be
+                // processed next by the Hydrating behavior. Stashed live
+                // inbounds stay stashed until Hydrating transitions to Active.
             }
             catch (Exception ex)
             {
@@ -117,6 +125,28 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             if (msg is not InitializePipeline)
                 Stash.Stash();
         });
+    }
+
+    private void Hydrating()
+    {
+        CommandAsync<PerformHydration>(async _ =>
+        {
+            try
+            {
+                await PerformOneShotHydrationAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Thread history hydration threw; continuing without backfill");
+            }
+            finally
+            {
+                Become(Active);
+                Stash.UnstashAll();
+            }
+        });
+
+        CommandAny(_ => Stash.Stash());
     }
 
     private void Active()
@@ -321,7 +351,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 return;
             }
 
-            var buildResult = await BuildInputForInboundAsync(message, contents, currentTs, inboundCts.Token);
+            var buildResult = BuildInputForInbound(message, contents);
             var input = buildResult.Input;
 
             if (buildResult.BackfillDetectorUnavailable)
@@ -686,12 +716,18 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             initCts.Token);
     }
 
-    private async Task<InboundBuildResult> BuildInputForInboundAsync(
+    private InboundBuildResult BuildInputForInbound(
         SlackThreadInbound triggeringMessage,
-        IReadOnlyList<AIContent> liveContents,
-        SlackEventTs? currentTs,
-        CancellationToken cancellationToken)
+        IReadOnlyList<AIContent> liveContents)
     {
+        // Live inbound path is fetch-free. Thread history is hydrated exactly
+        // once per actor lifetime in PerformOneShotHydrationAsync (driven by
+        // the RecoveryCompleted handler), so by the time we get here the
+        // session already has the historical context it needs. Re-fetching
+        // on every inbound was the cause of the duplicate-image bug: in-flight
+        // turns left _cursorTs lagging ingestion (per PR #733), so the gap
+        // window kept re-including in-flight messages and re-emitting their
+        // DataContent on every inbound.
         var baseInput = new ChannelInput
         {
             SenderId = triggeringMessage.SenderId,
@@ -705,23 +741,44 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             ExecutableText = triggeringMessage.Text
         };
 
-        if (currentTs is not { } triggerTs)
-            return new InboundBuildResult(baseInput, false);
+        return new InboundBuildResult(baseInput, false);
+    }
 
-        var history = await _dependencies.ThreadHistoryFetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
+    /// <summary>
+    /// One-shot thread history hydration. Runs once per actor lifetime, in the
+    /// Hydrating behavior immediately after pipeline initialization. Fetches
+    /// thread history, computes the gap relative to the recovered cursor, and
+    /// if there is an authorized message in the gap, synthesizes one backfill
+    /// <see cref="ChannelInput"/> using that message as the trigger and older
+    /// gap messages as adopted context. Hands the synthesized input to the
+    /// session pipeline through the normal input-queue path.
+    /// </summary>
+    private async Task PerformOneShotHydrationAsync()
+    {
+        using var cts = new CancellationTokenSource(InboundProcessingTimeout);
+
+        IReadOnlyList<ChannelInput> history;
+        try
+        {
+            history = await _dependencies.ThreadHistoryFetcher.FetchThreadHistoryAsync(_sessionId, cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return;
+        }
+
         if (history.Count == 0)
-            return new InboundBuildResult(baseInput, false);
+        {
+            _log.Info("Thread history hydration: empty thread, no backfill cursor={Cursor}", _cursorTs?.Value ?? "none");
+            return;
+        }
 
         var cursor = _cursorTs;
-
-        // Phase 1: filter gap candidates by ts bounds (cheap, sync).
-        var candidates = new List<ChannelInput>();
+        var candidates = new List<ChannelInput>(history.Count);
         foreach (var item in history)
         {
             if (new SlackEventId(item.MessageId ?? string.Empty).TryGetEventTs() is not { } itemTs)
-                continue;
-
-            if (itemTs.CompareTo(triggerTs) >= 0)
                 continue;
 
             // Keep the cursor event itself during fresh-runtime hydration.
@@ -739,21 +796,16 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         if (candidates.Count == 0)
         {
             _log.Info(
-                "Thread history hydrated fetched={FetchedCount} gapCount=0 cursor={Cursor}",
-                history.Count,
-                cursor?.Value ?? "none");
-            return new InboundBuildResult(baseInput, false);
+                "Thread history hydration: cursor already at thread head fetched={FetchedCount} cursor={Cursor}",
+                history.Count, cursor?.Value ?? "none");
+            return;
         }
 
-        // Phase 2: classify candidates in parallel — detector calls are the
-        // latency bottleneck on large gaps.
-        var classifications = await Task.WhenAll(candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
+        var classifications = await Task.WhenAll(candidates.Select(c => ClassifyGapMessageAsync(c, cts.Token)));
 
-        // Phase 3: assemble gap preserving chronological order.
         var gap = new List<AdoptedContextMessage>(candidates.Count);
         var blockedForRisk = 0;
         var detectorUnavailable = false;
-
         for (var i = 0; i < candidates.Count; i++)
         {
             var item = candidates[i];
@@ -783,26 +835,108 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
 
         _log.Info(
-            "Thread history hydrated fetched={FetchedCount} gapCount={GapCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor}",
-            history.Count,
-            gap.Count,
-            blockedForRisk,
-            cursor?.Value ?? "none");
+            "Thread history hydration fetched={FetchedCount} gapCount={GapCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor}",
+            history.Count, gap.Count, blockedForRisk, cursor?.Value ?? "none");
+
+        if (detectorUnavailable)
+            await SafePostAsync(BackfillDetectorWarning);
 
         if (gap.Count == 0)
-            return new InboundBuildResult(baseInput, detectorUnavailable);
+            return;
 
-        var merged = MergeGapWithLiveContents(gap, liveContents, triggeringMessage);
-        return new InboundBuildResult(baseInput with
+        // Locate the most recent authorized message in the gap — it plays the
+        // role of the "current authorized message" that adopted-context normally
+        // anchors around. Without one we have no authorized trigger to enqueue;
+        // we transition to Active and let the next live authorized inbound be
+        // the trigger (the cursor stays put, so staleness still drops anything
+        // already seen).
+        AdoptedContextMessage? trigger = null;
+        for (var i = gap.Count - 1; i >= 0; i--)
+        {
+            if (gap[i].AuthorityAtInclusion == AdoptedMessageAuthority.Authorized)
+            {
+                trigger = gap[i];
+                break;
+            }
+        }
+
+        if (trigger is null)
+        {
+            _log.Info("Thread history hydration: no authorized message in gap; deferring backfill to next live inbound");
+            return;
+        }
+
+        var adoptedContext = new List<AdoptedContextMessage>();
+        foreach (var item in gap)
+        {
+            if (ReferenceEquals(item, trigger))
+                break;
+            adoptedContext.Add(item);
+        }
+
+        // Build the synthesized inbound. The trigger's ChannelInput already
+        // carries its own text+attachment contents (loaded by the history
+        // fetcher), so we treat those as the "live" contents for the merge.
+        var triggerInput = trigger.Input;
+        var triggerSenderId = triggerInput.SenderId;
+        var triggerTs = new SlackEventId(triggerInput.MessageId ?? string.Empty).TryGetEventTs();
+
+        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
+            adoptedContext,
+            triggerInput.Contents,
+            triggerSenderId,
+            triggerInput.ReceivedAt);
+
+        var backfillInput = triggerInput with
         {
             Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggeringMessage.SenderId, StringComparison.Ordinal)),
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggerSenderId, StringComparison.Ordinal)),
             AdoptedSpeakerIds = merged.SpeakerIds,
             AdoptedContextProjection = merged.Projection,
             AdoptedContextLowerBound = cursor?.Value,
-            AdoptedContextUpperBound = triggeringMessage.EventId.Value,
+            AdoptedContextUpperBound = triggerInput.MessageId,
             AdoptedContextEntries = merged.Entries
-        }, detectorUnavailable);
+        };
+
+        if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
+        {
+            _log.Info("Skipping hydration backfill enqueue while restart drain is active: {Reason}", ingressClosedReason);
+            return;
+        }
+
+        var writer = _handle.InputQueue;
+        if (writer is null)
+        {
+            _log.Warning("Slack input queue is not initialized; skipping hydration backfill");
+            return;
+        }
+
+        try
+        {
+            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            writeCts.CancelAfter(OperationTimeout);
+            await writer.WriteAsync(backfillInput, writeCts.Token);
+
+            if (triggerTs is { } ts)
+            {
+                if (_pendingCursorTs is not { } pending || ts.CompareTo(pending) > 0)
+                    _pendingCursorTs = ts;
+            }
+
+            _log.Info(
+                "slack_hydration_backfill_enqueued trigger={TriggerMessageId} adoptedCount={AdoptedCount}",
+                triggerInput.MessageId,
+                adoptedContext.Count);
+            ChannelTelemetry.For(ChannelType.Slack).RecordMessageEnqueued();
+        }
+        catch (OperationCanceledException ex)
+        {
+            _log.Warning(ex, "Timed out enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
+        catch (ChannelClosedException ex)
+        {
+            _log.Warning(ex, "Input queue closed while enqueueing hydration backfill for session {SessionId}", _sessionId.Value);
+        }
     }
 
     private Task<Classification> ClassifyGapMessageAsync(ChannelInput input, CancellationToken cancellationToken)
@@ -852,16 +986,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     }
 
     private readonly record struct InboundBuildResult(ChannelInput Input, bool BackfillDetectorUnavailable);
-
-    private static AdoptedContextMergeResult MergeGapWithLiveContents(
-        IReadOnlyList<AdoptedContextMessage> gap,
-        IReadOnlyList<AIContent> liveContents,
-        SlackThreadInbound triggeringMessage)
-        => AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            gap,
-            liveContents,
-            triggeringMessage.SenderId,
-            triggeringMessage.ReceivedAt);
 
     private async Task ReinitializePipelineAsync(string reason)
     {
@@ -1261,5 +1385,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private sealed record InitializePipeline : INoSerializationVerificationNeeded
     {
         public static InitializePipeline Instance { get; } = new();
+    }
+
+    private sealed record PerformHydration : INoSerializationVerificationNeeded
+    {
+        public static PerformHydration Instance { get; } = new();
     }
 }

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -781,13 +781,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             if (new SlackEventId(item.MessageId ?? string.Empty).TryGetEventTs() is not { } itemTs)
                 continue;
 
-            // Keep the cursor event itself during fresh-runtime hydration.
-            // If the daemon restarts while a turn is still in-flight, the
-            // session actor may recover with no completed turns even though the
-            // cursor already advanced to the last inbound user message.
-            // Including ts == cursor prevents that newest pre-restart user turn
-            // from being dropped from rebuilt context.
-            if (cursor is { } c && itemTs.CompareTo(c) < 0)
+            // Strict: only include messages newer than the cursor. PR #733's
+            // "cursor advances only on TurnCompleted" guarantees that
+            // ts == cursor means the session already has that message persisted
+            // — re-including it here on a restart hydration would duplicate it.
+            // The in-flight-crash case is handled too: a turn that didn't
+            // complete leaves the cursor un-advanced, so the message has
+            // ts > cursor and is correctly included in the gap.
+            if (cursor is { } c && itemTs.CompareTo(c) <= 0)
                 continue;
 
             candidates.Add(item);


### PR DESCRIPTION
## Summary

- Slack/Discord binding actors were running `FetchThreadHistoryAsync` on every inbound event. Combined with PR #733's correct cursor-defers-to-`TurnCompleted` crash-safety fix and the post-#986 256K vLLM context window, this caused images from in-flight Slack messages to be re-downloaded and persisted to disk on every concurrent inbound. One 554KB PNG ended up persisted 8 times in a single session, blowing the LLM context window via base64-inflated duplicates in the JSON payload.
- **Layer 1 (structural):** Move hydration to a one-shot `RecoveryCompleted`-driven `Hydrating` behavior, between `Initializing` and `Active`, on both Slack and Discord binding actors. Inbounds during hydration are stashed and unstashed on `Become(Active)`. The live inbound handler is now fetch-free.
- **Layer 2 (defense-in-depth):** `SerializableMediaReference` gains `long FileSizeBytes` (proto3 additive, zero-default = legacy-safe). `SessionCompactionPipeline.EstimateTokens` now accounts for base64-inflated media payload size (`fileSize * 4 / 3`) using a `long` accumulator.
- Cursor (`_cursorTs` / `_cursorSnowflake`) still advances only on `TurnCompleted` — PR #733's amnesia fix is preserved.

## Bug evidence

Affected sessions:
- `D0AC6CKBK5K/1778677292.036639` — 8 copies of one 554KB PNG, ~7M tokens of duplicated context across the session, ended with `Context window exceeded even after compaction` and a failed turn.
- `D0AC6CKBK5K/1778715535.915469` — 7 copies of a 187KB PNG, same overflow pattern.

How it manifests: every new inbound during an in-flight turn re-runs `BuildInputForInboundAsync`, which unconditionally calls `FetchThreadHistoryAsync` and applies a gap filter against the cursor. While the actor is in a long-running turn (tool loops, compactions), the cursor lags ingestion by design (PR #733). The lagging cursor causes the gap window to re-include the in-flight message; its `DataContent` is re-derived and re-written to `media/<new-guid>.png` by `ChannelPipeline.MapToCommand`.

## Fix shape

```
constructor → Recover<RecoveryCompleted>(_ => Self.Tell(PerformHydration.Instance))
              Initializing()

Initializing → on InitializePipeline: await EnsureInitializedAsync(); Become(Hydrating)
               (don't UnstashAll — PerformHydration is already in the mailbox)
               else: Stash

Hydrating    → on PerformHydration: PerformOneShotHydrationAsync(); Become(Active); Stash.UnstashAll()
               else: Stash

Active       → existing inbound handler with the hydration block deleted
```

`PerformOneShotHydrationAsync` fetches thread history, filters by cursor, classifies for prompt injection, finds the most recent authorized message in the gap as a synthesized trigger, builds one backfill `ChannelInput` with older gap messages wrapped as adopted-context, enqueues it, then updates `_pendingCursorTs` so the live inbound staleness check drops any duplicate.

## Tests

New channel-conformance invariants in `SessionBindingContractTests` (inherited by both Slack and Discord concrete suites):

- `Hydration_emits_backfill_at_startup_with_adopted_context`
- `Hydration_backfill_keeps_slash_like_text_in_adopted_projection`
- `Hydration_backfill_marks_self_only_history_without_third_party_flag`
- `Thread_history_fetched_at_most_once_per_actor_lifetime`
- `Live_inbound_after_hydration_is_plain_without_adopted_context`
- `Image_in_history_flows_through_at_most_once_across_multiple_inbounds` — direct regression test for the bug
- `Inbounds_arriving_during_hydration_are_stashed_and_unstash_after` — uses a TCS-based fetcher gate; no `Task.Delay`
- `Hydration_re_runs_after_supervised_restart`
- `Cursor_does_not_advance_on_non_completed_turn_outcome` — regression pin for PR #733

Layer 2 unit tests in `SessionCompactionPipelineTokenEstimationTests`:

- Legacy compatibility (FileSizeBytes = 0 produces same estimate as before this field existed)
- Single media size accounting (`300000 * 4 / 3 / 4 = 100000` tokens)
- Multiple media refs summed
- Text + tool-call args + media combined
- System-prompt media counted
- `long` accumulator absorbs multi-megabyte images without overflow

Three pre-existing `SlackThreadBackfillIntegrationTests` updated to reflect fetch-at-most-once semantics.

## Backward compatibility

- No persistence schema changes in Layer 1; existing channel-binding journals replay unchanged.
- Proto3 `int64 file_size_bytes` is an additive field with zero default — legacy `SerializableMediaReference` records deserialize with `FileSizeBytes = 0`, which causes `EstimateTokens` to under-count them the same way it did before this field existed (no regression).

## Test plan

- [x] `dotnet build` solution-wide
- [x] `dotnet test src/Netclaw.Actors.Tests/` — 1574/1574 passing
- [x] `dotnet test src/Netclaw.Daemon.Tests/` — 529/529 passing
- [x] `dotnet test src/Netclaw.Cli.Tests/` — 640/640 passing
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- [ ] Manual reproduction: send a Slack message with a ≥500KB image; before the turn completes, send three follow-up text messages. Confirm `media/` contains exactly one file and history contains exactly one `SerializableMediaReference` for the image. (Pending local binary swap.)