### PR TITLE
fix(channels): propagate audience on Slack history-fetched ChannelInput

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordThreadHistoryFetcherTests.cs
@@ -402,6 +402,43 @@ public sealed class DiscordThreadHistoryFetcherTests
         Assert.DoesNotContain(result, r => r.Contents.OfType<TextContent>().Any(t => t.Text == "agent's reply turn (in transcript)"));
     }
 
+    [Fact]
+    public async Task Hydrated_channel_input_carries_resolved_historical_audience()
+    {
+        // Locks in the invariant that the Slack twin regressed on: the fetcher
+        // MUST propagate the resolved historical audience to the produced
+        // ChannelInput so hydration-driven backfill doesn't silently fall back
+        // to the channel pipeline's DefaultAudience.
+        var options = new DiscordChannelOptions
+        {
+            AllowDirectMessages = true,
+            ChannelAudiences = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dm"] = "personal"
+            }
+        };
+
+        var fetcher = CreateFetcher(
+            (_, _) => Task.FromResult<IReadOnlyList<DiscordThreadHistoryFetcher.HistoricalMessage>>(
+            [
+                new DiscordThreadHistoryFetcher.HistoricalMessage(
+                    MessageId: "100000000000000010",
+                    SenderId: "user-10",
+                    IsBot: false,
+                    Text: "first DM message",
+                    Timestamp: TimeProvider.System.GetUtcNow(),
+                    Attachments: [])
+            ]),
+            options: options);
+
+        var result = await fetcher.FetchThreadHistoryAsync(
+            new SessionId("100000000000000010/100000000000000010"),
+            TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Equal(TrustAudience.Personal, item.Audience);
+    }
+
     private static DiscordThreadHistoryFetcher CreateFetcher(
         DiscordThreadHistoryFetcher.MessageFetcher? messageFetcher = null,
         HttpMessageHandler? handler = null,

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadHistoryFetcherTests.cs
@@ -64,6 +64,27 @@ public sealed class SlackThreadHistoryFetcherTests
     }
 
     [Fact]
+    public async Task Hydrated_channel_input_carries_resolved_historical_audience()
+    {
+        // Regression: the fetcher previously omitted Audience on the produced
+        // ChannelInput, so hydration-driven backfill on a fresh DM fell back to
+        // the channel pipeline's DefaultAudience (Public) and silently denied
+        // shell_execute with tool_not_allowed_for_audience_profile even when
+        // the operator had `dm: personal` configured.
+        _options.ChannelAudiences["dm"] = "personal";
+
+        _replies.Set("D1", "1000.0", null, new ConversationMessagesResponse
+        {
+            Messages = [new MessageEvent { Ts = "1000.0", User = "U1", Text = "first DM message" }]
+        });
+
+        var result = await CreateFetcher().FetchThreadHistoryAsync(new SessionId("D1/1000.0"), TestContext.Current.CancellationToken);
+
+        var item = Assert.Single(result);
+        Assert.Equal(TrustAudience.Personal, item.Audience);
+    }
+
+    [Fact]
     public async Task Includes_bot_authored_root_for_proactive_post_bootstrap()
     {
         // Proactive-post case: the bot opened the thread. The thread root

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -262,6 +262,7 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
             SenderId = senderId,
             ChannelId = channelId.Value,
             MessageId = $"{channelId.Value}:{message.Ts ?? string.Empty}",
+            Audience = audience,
             Contents = contents,
             ReceivedAt = receivedAt
         };


### PR DESCRIPTION
## Summary

`SlackThreadHistoryFetcher.ConvertMessageAsync` built `ChannelInput` without setting the resolved historical audience. After PR #984 / #45f4c57b made hydration run once per actor lifetime through a Hydrating gate, fresh DM sessions get their backfill from history (the live inbound is dropped as stale by `_pendingCursorTs` advancing inside hydration). With `Audience` null on the produced `ChannelInput`, `MessageSourceFactory.Create` fell back to `SessionPipelineOptions.DefaultAudience = TrustAudience.Public`, silently denying `shell_execute` with `tool_not_allowed_for_audience_profile` — even when the operator had `Slack.ChannelAudiences["dm"] = "personal"` configured.

Discord's twin (`DiscordThreadHistoryFetcher`) already sets `Audience` correctly. Slack regressed at the original introduction (#576) and the recent hydration refactor exposed it on the very first DM message of a fresh session.

Symptom observed in session `D0AC6CKBK5K/1778736039.290249`: a Personal-audience DM saw shell tools blocked.

## Fix

One-line addition in `SlackThreadHistoryFetcher.ConvertMessageAsync`:

```csharp
return new ChannelInput
{
    SenderId = senderId,
    ChannelId = channelId.Value,
    MessageId = $"{channelId.Value}:{message.Ts ?? string.Empty}",
    Audience = audience,   // ← was missing
    Contents = contents,
    ReceivedAt = receivedAt
};
```

The `audience` value is already resolved upstream in `FetchRepliesAsync` via `ResolveHistoricalAudience` and passed down — it just wasn't propagated to the resulting `ChannelInput`.

## Tests

- `SlackThreadHistoryFetcherTests.Hydrated_channel_input_carries_resolved_historical_audience` — regression test that fails on the pre-fix code.
- `DiscordThreadHistoryFetcherTests.Hydrated_channel_input_carries_resolved_historical_audience` — lock-in test for the already-correct Discord twin so it can't regress symmetrically.

## Follow-up

Filed as a separate issue: make `ChannelInput.Audience` a `required` property so future callsites can't omit it and silently fall back. That refactor touches every `new ChannelInput { ... }` callsite plus a handful of tests; out of scope for this hotfix.

## Test plan

- [x] Targeted xUnit runs of both new tests pass.
- [x] `dotnet slopwatch analyze` clean (0 issues).
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` clean.