### PR TITLE
fix(streams): observe discarded materialized Task<Done>s to prevent daemon-unobserved crashes

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SessionPipelineUnobservedTaskTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SessionPipelineUnobservedTaskTests.cs
@@ -1,0 +1,115 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionPipelineUnobservedTaskTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka;
+using Akka.Hosting.TestKit;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+/// <summary>
+/// Documents and exercises the patterns that prevent the abrupt-teardown
+/// unobserved-task crashes (daemon-unobserved logs with
+/// <c>AbruptTerminationException</c> / <c>StreamDetachedException</c>).
+/// Akka.Streams stages create internal <see cref="Task{Done}"/> instances
+/// (e.g. via <c>Sink.ForEach</c>'s <c>IgnoreSink</c> and
+/// <c>Source.Queue</c>'s <c>_completion</c>) that fault on teardown.
+/// Production code in <c>SessionPipelineHandle</c> and
+/// <c>ChannelPipeline</c> uses two complementary patterns to observe these:
+/// <list type="bullet">
+///   <item><c>Keep.Both</c> + await both materialized tasks.</item>
+///   <item><c>MapMaterializedValue</c> with a <c>ContinueWith</c> that
+///   reads <see cref="Task.Exception"/> on fault.</item>
+/// </list>
+/// </summary>
+public sealed class SessionPipelineUnobservedTaskTests : TestKit
+{
+    public SessionPipelineUnobservedTaskTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, IServiceProvider provider) { }
+
+    /// <summary>
+    /// Verifies that wrapping <c>Sink.ForEach</c> with <c>MapMaterializedValue</c>
+    /// + <c>ContinueWith(OnlyOnFaulted)</c> reliably runs the observation
+    /// callback when the upstream is aborted. This is the pattern used in
+    /// <c>ChannelPipeline.CreateAsync</c> and
+    /// <c>SessionPipelineHandle.InitializeWithQueueAsync</c>.
+    /// </summary>
+    [Fact]
+    public async Task MapMaterializedValue_continuation_observes_sink_task_on_fault()
+    {
+        var observed = new TaskCompletionSource<Exception?>();
+        var killSwitch = KillSwitches.Shared("test-mapmat");
+
+        var sink = Sink.ForEach<int>(_ => { }).MapMaterializedValue<NotUsed>(task =>
+        {
+            _ = task.ContinueWith(
+                t => observed.TrySetResult(t.Exception?.GetBaseException()),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            return NotUsed.Instance;
+        });
+
+        var runnable = Source.Repeat(1)
+            .Via(killSwitch.Flow<int>())
+            .ToMaterialized(sink, Keep.Right);
+
+        runnable.Run(Sys.Materializer());
+
+        var simulatedAbrupt = new InvalidOperationException("simulated abrupt teardown");
+        killSwitch.Abort(simulatedAbrupt);
+
+        var observedException = await observed.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(observedException);
+        Assert.Same(simulatedAbrupt, observedException);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Keep.Both</c> + await-both observes the Sink.ForEach
+    /// task after a stream fault. This is the pattern used in
+    /// <c>SessionPipelineHandle.InitializeWithChannelAsync</c>.
+    /// </summary>
+    [Fact]
+    public async Task KeepBoth_awaits_observe_both_watch_and_sink_tasks_on_fault()
+    {
+        var killSwitch = KillSwitches.Shared("test-keepboth");
+
+        var (watchTask, sinkTask) = Source.Repeat(1)
+            .Via(killSwitch.Flow<int>())
+            .WatchTermination((_, done) => done)
+            .ToMaterialized(Sink.ForEach<int>(_ => { }), Keep.Both)
+            .Run(Sys.Materializer());
+
+        var simulatedAbrupt = new InvalidOperationException("simulated abrupt teardown");
+        killSwitch.Abort(simulatedAbrupt);
+
+        // Both await-with-catch blocks below are the production pattern from
+        // SessionPipelineHandle.ObserveTerminationAsync after the Keep.Both fix.
+        Exception? watchFailure = null;
+        try
+        {
+            await watchTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex) { watchFailure = ex; }
+
+        Exception? sinkFailure = null;
+        try
+        {
+            await sinkTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex) { sinkFailure = ex; }
+
+        Assert.NotNull(watchFailure);
+        Assert.NotNull(sinkFailure);
+        Assert.Same(simulatedAbrupt, watchFailure!.GetBaseException());
+        Assert.Same(simulatedAbrupt, sinkFailure!.GetBaseException());
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SessionPipelineUnobservedTaskTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SessionPipelineUnobservedTaskTests.cs
@@ -91,8 +91,6 @@ public sealed class SessionPipelineUnobservedTaskTests : TestKit
         var simulatedAbrupt = new InvalidOperationException("simulated abrupt teardown");
         killSwitch.Abort(simulatedAbrupt);
 
-        // Both await-with-catch blocks below are the production pattern from
-        // SessionPipelineHandle.ObserveTerminationAsync after the Keep.Both fix.
         Exception? watchFailure = null;
         try
         {

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
@@ -83,7 +83,17 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
                         gate.Writer.TryWrite(true);
                     }
                 })
-                .MapMaterializedValue<NotUsed>(_ => NotUsed.Instance);
+                .MapMaterializedValue<NotUsed>(task =>
+                {
+                    // Observe Sink.ForEach's internal Task<Done> so abrupt
+                    // teardown faults don't leak as unobserved task exceptions.
+                    _ = task.ContinueWith(
+                        static t => { _ = t.Exception; },
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                    return NotUsed.Instance;
+                });
 
             // Wait for gate signal, then emit all outputs.
             output = Source.UnfoldAsync<int, SessionOutput>(0, async state =>
@@ -106,7 +116,17 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
         else
         {
             input = Sink.ForEach<ChannelInput>(ci => CapturedInputs.Enqueue(ci))
-                .MapMaterializedValue<NotUsed>(_ => NotUsed.Instance);
+                .MapMaterializedValue<NotUsed>(task =>
+                {
+                    // Observe Sink.ForEach's internal Task<Done> so abrupt
+                    // teardown faults don't leak as unobserved task exceptions.
+                    _ = task.ContinueWith(
+                        static t => { _ = t.Exception; },
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                    return NotUsed.Instance;
+                });
 
             output = Source.From(outputs)
                 .Concat(Source.Never<SessionOutput>())

--- a/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TestHelpers/RecordingSessionPipeline.cs
@@ -83,17 +83,7 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
                         gate.Writer.TryWrite(true);
                     }
                 })
-                .MapMaterializedValue<NotUsed>(task =>
-                {
-                    // Observe Sink.ForEach's internal Task<Done> so abrupt
-                    // teardown faults don't leak as unobserved task exceptions.
-                    _ = task.ContinueWith(
-                        static t => { _ = t.Exception; },
-                        CancellationToken.None,
-                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
-                    return NotUsed.Instance;
-                });
+                .ObservingFault();
 
             // Wait for gate signal, then emit all outputs.
             output = Source.UnfoldAsync<int, SessionOutput>(0, async state =>
@@ -116,17 +106,7 @@ public sealed class RecordingSessionPipeline : ISessionPipeline
         else
         {
             input = Sink.ForEach<ChannelInput>(ci => CapturedInputs.Enqueue(ci))
-                .MapMaterializedValue<NotUsed>(task =>
-                {
-                    // Observe Sink.ForEach's internal Task<Done> so abrupt
-                    // teardown faults don't leak as unobserved task exceptions.
-                    _ = task.ContinueWith(
-                        static t => { _ = t.Exception; },
-                        CancellationToken.None,
-                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
-                    return NotUsed.Instance;
-                });
+                .ObservingFault();
 
             output = Source.From(outputs)
                 .Concat(Source.Never<SessionOutput>())

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -263,6 +263,11 @@ public sealed class SessionPipeline : ISessionPipeline
         // Akka guarantees FIFO delivery from a single sender (this stream
         // stage thread), so JoinSession is always processed before the
         // SendUserMessage that follows it.
+        // Wrap Sink.ForEach with MapMaterializedValue so the inner IgnoreSink
+        // Task<Done> is observed on fault. Without this, abrupt stream teardown
+        // (e.g. ActorSystem shutdown) faults the discarded foreach task and
+        // surfaces as TaskScheduler.UnobservedTaskException — see comment in
+        // SessionPipelineHandle.ObserveSilently for the full mechanism.
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options, _paths))
             .Via(killSwitch.Flow<SendUserMessage>())
@@ -279,6 +284,14 @@ public sealed class SessionPipeline : ISessionPipeline
                 // leaves AckTarget null → existing NoSender fire-and-forget.
                 var ackTarget = cmd.Source?.AckTarget ?? ActorRefs.NoSender;
                 sessionManager.Tell(cmd, ackTarget);
+            }).MapMaterializedValue(task =>
+            {
+                _ = task.ContinueWith(
+                    static t => { _ = t.Exception; },
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                return NotUsed.Instance;
             }));
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source.

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -263,11 +263,6 @@ public sealed class SessionPipeline : ISessionPipeline
         // Akka guarantees FIFO delivery from a single sender (this stream
         // stage thread), so JoinSession is always processed before the
         // SendUserMessage that follows it.
-        // Wrap Sink.ForEach with MapMaterializedValue so the inner IgnoreSink
-        // Task<Done> is observed on fault. Without this, abrupt stream teardown
-        // (e.g. ActorSystem shutdown) faults the discarded foreach task and
-        // surfaces as TaskScheduler.UnobservedTaskException — see comment in
-        // SessionPipelineHandle.ObserveSilently for the full mechanism.
         var inputSink = Flow.Create<ChannelInput>()
             .Select(input => MapToCommand(input, sessionId, options, _paths))
             .Via(killSwitch.Flow<SendUserMessage>())
@@ -284,15 +279,7 @@ public sealed class SessionPipeline : ISessionPipeline
                 // leaves AckTarget null → existing NoSender fire-and-forget.
                 var ackTarget = cmd.Source?.AckTarget ?? ActorRefs.NoSender;
                 sessionManager.Tell(cmd, ackTarget);
-            }).MapMaterializedValue(task =>
-            {
-                _ = task.ContinueWith(
-                    static t => { _ = t.Exception; },
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-                return NotUsed.Instance;
-            }));
+            }).ObservingFault());
 
         // Outbound: pre-materialized subscriber → kill switch → exposed Source.
         // When a lifecycle observer is registered, tap the stream so every output

--- a/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
+++ b/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
@@ -102,14 +102,22 @@ public sealed class SessionPipelineHandle
             .Run(materializer);
 
         var generation = ++_pipelineGeneration;
-        var outputTerminated = materialized.Output
+
+        // Keep.Both retains both materialized Task<Done>s so we can observe both.
+        // Akka.Streams creates a TaskCompletionSource for WatchTermination AND
+        // for Sink.ForEach (IgnoreSink). On stream fault, both TCSes are set to
+        // the same exception, but .NET tracks "observed" per-Task — so if we
+        // observe only the WatchTermination task (Keep.Left), the discarded
+        // foreach Task is finalized while faulted and fires
+        // TaskScheduler.UnobservedTaskException.
+        var (watchTerminated, sinkTerminated) = materialized.Output
             .WatchTermination((_, done) => done)
             .ToMaterialized(
                 Sink.ForEach<SessionOutput>(onOutput),
-                Keep.Left)
+                Keep.Both)
             .Run(materializer);
 
-        _outputCompletion = outputTerminated;
+        _outputCompletion = watchTerminated;
 
         _ = ObserveTerminationAsync();
 
@@ -117,14 +125,32 @@ public sealed class SessionPipelineHandle
 
         async Task ObserveTerminationAsync()
         {
+            Exception? failure = null;
             try
             {
-                await outputTerminated;
-                onStreamTerminated(generation, null);
+                await watchTerminated.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                onStreamTerminated(generation, ex);
+                failure = ex;
+            }
+
+            try
+            {
+                await sinkTerminated.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                failure ??= ex;
+            }
+
+            try
+            {
+                onStreamTerminated(generation, failure);
+            }
+            catch (Exception cbEx)
+            {
+                _log.Error(cbEx, "{0} onStreamTerminated callback threw", _materializerNamePrefix);
             }
         }
         _inputQueue = inputQueue;
@@ -158,12 +184,26 @@ public sealed class SessionPipelineHandle
             .ToMaterialized(materialized.Input, Keep.Left)
             .Run(materializer);
 
-        _outputCompletion = materialized.Output
+        // SourceQueueLogic.PostStop sets StreamDetachedException on its internal
+        // _completion TCS. The task is exposed via WatchCompletionAsync(); when
+        // unobserved, it surfaces as TaskScheduler.UnobservedTaskException on
+        // teardown (e.g. abrupt actor-system shutdown during hot reload).
+        ObserveSilently(inputQueue.WatchCompletionAsync());
+
+        var (watchTerminated, sinkTerminated) = materialized.Output
             .WatchTermination((_, done) => done)
             .ToMaterialized(
                 Sink.ForEach<SessionOutput>(onOutput),
-                Keep.Left)
+                Keep.Both)
             .Run(materializer);
+
+        // Same Sink.ForEach foreach-task issue as InitializeWithChannelAsync.
+        // Queue-mode actors don't subscribe to OutputStreamTerminated, so just
+        // observe the sink task silently — the watch task is awaited by
+        // DrainAsync below.
+        ObserveSilently(sinkTerminated);
+
+        _outputCompletion = watchTerminated;
 
         _session = materialized;
 
@@ -254,4 +294,22 @@ public sealed class SessionPipelineHandle
         _inputQueue?.TryComplete();
     }
 
+    /// <summary>
+    /// Attach a synchronous continuation that reads <see cref="Task.Exception"/>
+    /// on fault, marking the task as observed so it doesn't surface as a
+    /// <see cref="TaskScheduler.UnobservedTaskException"/> on the finalizer
+    /// thread. Akka.Streams creates several internal <see cref="Task{Done}"/>
+    /// instances on stages like <c>Sink.ForEach</c> and <c>Source.Queue</c>
+    /// that fault during stream teardown; this is how we silence their
+    /// finalizer noise without losing visibility into real failures (which
+    /// surface through <c>WatchTermination</c> / <c>OutputStreamTerminated</c>).
+    /// </summary>
+    private static void ObserveSilently(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
 }

--- a/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
+++ b/src/Netclaw.Actors/Channels/SessionPipelineHandle.cs
@@ -103,21 +103,17 @@ public sealed class SessionPipelineHandle
 
         var generation = ++_pipelineGeneration;
 
-        // Keep.Both retains both materialized Task<Done>s so we can observe both.
-        // Akka.Streams creates a TaskCompletionSource for WatchTermination AND
-        // for Sink.ForEach (IgnoreSink). On stream fault, both TCSes are set to
-        // the same exception, but .NET tracks "observed" per-Task — so if we
-        // observe only the WatchTermination task (Keep.Left), the discarded
-        // foreach Task is finalized while faulted and fires
-        // TaskScheduler.UnobservedTaskException.
-        var (watchTerminated, sinkTerminated) = materialized.Output
+        // ObservingFault wraps Sink.ForEach so its internal IgnoreSink TCS is
+        // observed on fault — without it, abrupt teardown leaks the discarded
+        // Task<Done> as TaskScheduler.UnobservedTaskException.
+        var outputTerminated = materialized.Output
             .WatchTermination((_, done) => done)
             .ToMaterialized(
-                Sink.ForEach<SessionOutput>(onOutput),
-                Keep.Both)
+                Sink.ForEach<SessionOutput>(onOutput).ObservingFault(),
+                Keep.Left)
             .Run(materializer);
 
-        _outputCompletion = watchTerminated;
+        _outputCompletion = outputTerminated;
 
         _ = ObserveTerminationAsync();
 
@@ -128,20 +124,11 @@ public sealed class SessionPipelineHandle
             Exception? failure = null;
             try
             {
-                await watchTerminated.ConfigureAwait(false);
+                await outputTerminated.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 failure = ex;
-            }
-
-            try
-            {
-                await sinkTerminated.ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                failure ??= ex;
             }
 
             try
@@ -184,26 +171,17 @@ public sealed class SessionPipelineHandle
             .ToMaterialized(materialized.Input, Keep.Left)
             .Run(materializer);
 
-        // SourceQueueLogic.PostStop sets StreamDetachedException on its internal
-        // _completion TCS. The task is exposed via WatchCompletionAsync(); when
-        // unobserved, it surfaces as TaskScheduler.UnobservedTaskException on
-        // teardown (e.g. abrupt actor-system shutdown during hot reload).
-        ObserveSilently(inputQueue.WatchCompletionAsync());
+        // SourceQueueLogic.PostStop sets StreamDetachedException on its
+        // _completion TCS unconditionally — observe it so unused queue-mode
+        // sessions don't leak the fault on teardown.
+        StreamTaskObservation.ObserveSilently(inputQueue.WatchCompletionAsync());
 
-        var (watchTerminated, sinkTerminated) = materialized.Output
+        _outputCompletion = materialized.Output
             .WatchTermination((_, done) => done)
             .ToMaterialized(
-                Sink.ForEach<SessionOutput>(onOutput),
-                Keep.Both)
+                Sink.ForEach<SessionOutput>(onOutput).ObservingFault(),
+                Keep.Left)
             .Run(materializer);
-
-        // Same Sink.ForEach foreach-task issue as InitializeWithChannelAsync.
-        // Queue-mode actors don't subscribe to OutputStreamTerminated, so just
-        // observe the sink task silently — the watch task is awaited by
-        // DrainAsync below.
-        ObserveSilently(sinkTerminated);
-
-        _outputCompletion = watchTerminated;
 
         _session = materialized;
 
@@ -294,22 +272,4 @@ public sealed class SessionPipelineHandle
         _inputQueue?.TryComplete();
     }
 
-    /// <summary>
-    /// Attach a synchronous continuation that reads <see cref="Task.Exception"/>
-    /// on fault, marking the task as observed so it doesn't surface as a
-    /// <see cref="TaskScheduler.UnobservedTaskException"/> on the finalizer
-    /// thread. Akka.Streams creates several internal <see cref="Task{Done}"/>
-    /// instances on stages like <c>Sink.ForEach</c> and <c>Source.Queue</c>
-    /// that fault during stream teardown; this is how we silence their
-    /// finalizer noise without losing visibility into real failures (which
-    /// surface through <c>WatchTermination</c> / <c>OutputStreamTerminated</c>).
-    /// </summary>
-    private static void ObserveSilently(Task task)
-    {
-        _ = task.ContinueWith(
-            static t => { _ = t.Exception; },
-            CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
-    }
 }

--- a/src/Netclaw.Actors/Channels/StreamTaskObservation.cs
+++ b/src/Netclaw.Actors/Channels/StreamTaskObservation.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="StreamTaskObservation.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka;
+using Akka.Streams.Dsl;
+
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Helpers for observing the internal <see cref="Task{Done}"/> instances
+/// that Akka.Streams stages (e.g. <c>Sink.ForEach</c>'s <c>IgnoreSink</c>
+/// and <c>Source.Queue</c>'s <c>_completion</c>) create via
+/// <c>TaskCompletionSource</c>. Those tasks are faulted on stream
+/// teardown; if nothing observes them, the finalizer surfaces the fault
+/// as <see cref="TaskScheduler.UnobservedTaskException"/>. Real failures
+/// still surface through <c>WatchTermination</c> / actor messages — this
+/// only silences the duplicate finalizer noise.
+/// </summary>
+internal static class StreamTaskObservation
+{
+    /// <summary>
+    /// Attach a fault-only continuation that reads <see cref="Task.Exception"/>
+    /// so the task is marked observed before the finalizer runs.
+    /// </summary>
+    public static void ObserveSilently(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// Replace a sink's <see cref="Task{Done}"/> materialized value with
+    /// <see cref="NotUsed"/> after attaching <see cref="ObserveSilently"/>
+    /// to the underlying task. Use when the caller wants to discard the
+    /// materialized value but the underlying TCS still gets faulted on
+    /// teardown.
+    /// </summary>
+    public static Sink<TIn, NotUsed> ObservingFault<TIn>(this Sink<TIn, Task<Done>> sink) =>
+        sink.MapMaterializedValue<NotUsed>(static task =>
+        {
+            ObserveSilently(task);
+            return NotUsed.Instance;
+        });
+}


### PR DESCRIPTION
## Summary

- Fixes two recurring `daemon-unobserved` crash classes (`AbruptTerminationException`, `StreamDetachedException`) triggered during ActorSystem hot reload and idle passivation.
- Akka.Streams stages (`IgnoreSink` backing `Sink.ForEach`, `QueueSource._completion`) create internal `TaskCompletionSource<Done>` instances that fault on teardown. Our code discarded those tasks via `Keep.Left` / never calling `WatchCompletionAsync()`. `.NET` tracks "observed" per-Task, so the discarded tasks fired `TaskScheduler.UnobservedTaskException` on the finalizer thread.
- Latent bug exposed by Akka.NET 1.5.66's [non-blocking materialized-value TCS sweep](https://github.com/akkadotnet/akka.net/issues/8161) — sync-inline continuations previously masked the leak; flipping the TCSes to `RunContinuationsAsynchronously` widened the observation window. Crash-log rate went from ~2 over 6 days pre-bump to 90+ over 17 days post-bump (~25× jump). Upstream issues filed: [akkadotnet/akka.net#8209](https://github.com/akkadotnet/akka.net/issues/8209), [#8210](https://github.com/akkadotnet/akka.net/issues/8210), [#8211](https://github.com/akkadotnet/akka.net/issues/8211).

## Changes

- New `Netclaw.Actors/Channels/StreamTaskObservation.cs` with two helpers:
  - `ObserveSilently(Task)` — fault-only `ContinueWith` that reads `.Exception`.
  - `Sink<TIn, Task<Done>>.ObservingFault()` — extension wrapping `MapMaterializedValue` to swap `Task<Done>` for `NotUsed` after attaching `ObserveSilently`.
- `SessionPipelineHandle.InitializeWithChannelAsync` / `InitializeWithQueueAsync`: apply `.ObservingFault()` to the output `Sink.ForEach`; call `ObserveSilently` on `Source.Queue.WatchCompletionAsync()`. Wrap the `onStreamTerminated` callback in try/catch.
- `ChannelPipeline.CreateAsync`: same `.ObservingFault()` on the input `Sink.ForEach`.
- `RecordingSessionPipeline` (test helper): same fix in both reactive and non-reactive branches.
- New `SessionPipelineUnobservedTaskTests` covers both observation patterns (`Keep.Both`+await-both and `MapMaterializedValue`+continuation).

## Test plan

- [x] `dotnet test src/Netclaw.Actors.Tests` — 1584/1584 passing
- [x] `dotnet test src/Netclaw.Daemon.Tests` — 529/529 passing
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — clean
- [ ] Soak test: re-run daemon with config hot-reload loop, confirm no new `crash-*.log` files with `AbruptTerminationException` / `StreamDetachedException`.