### PR TITLE
fix(channels): re-arm deferred hydration for proactive threads

### DIFF
--- a/openspec/changes/restore-proactive-thread-hydration-conformance/.openspec.yaml
+++ b/openspec/changes/restore-proactive-thread-hydration-conformance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/restore-proactive-thread-hydration-conformance/design.md
+++ b/openspec/changes/restore-proactive-thread-hydration-conformance/design.md
@@ -1,0 +1,147 @@
+## Context
+
+Threaded channel adapters hydrate prior thread messages into an adopted-context
+window so an authorized inbound turn carries the conversation that preceded it.
+The `thread-history-backfill` capability specifies that a bot-authored thread
+**root** is hydrated as adopted context for the first authorized reply — the
+scenario that covers a proactively-created thread (a reminder posting via
+`send_slack_message`).
+
+PR #958 implemented this correctly. PR #990 then changed hydration to run
+**once per actor lifetime**, driven by the `RecoveryCompleted` self-tell: the
+binding actor transitions `Initializing → Hydrating → Active`, runs
+`PerformOneShotHydrationAsync` once in `Hydrating`, and thereafter the `Active`
+inbound handler is fetch-free. PR #990 fixed a real bug (in-flight images
+re-downloaded on every inbound) but did not update the spec.
+
+For a **proactively-created** thread the binding actor is created at the moment
+the agent posts the root (`SendSlackMessageTool` → `StartProactiveThread`). Its
+single hydration therefore runs when the thread contains only the bot root.
+`PerformOneShotHydrationAsync` requires an **authorized** gap message to act as
+the turn trigger; the bot root classifies as `Pending` (the bot is not an
+allowed *user*), so `trigger == null`, hydration logs "deferring backfill to
+next live inbound" and returns. The "next live inbound" — the human reply —
+takes the fetch-free `Active` path and never re-hydrates. The bot root is
+silently dropped and the agent answers with no anchor.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore `thread-history-backfill` conformance: a proactively-created thread
+  hydrates its bot root into the adopted-context window of the first authorized
+  inbound, including the quick-reply case (reply arrives within the same actor
+  lifetime, before passivation).
+- Keep the fix channel-agnostic — `SlackThreadBindingActor` and
+  `DiscordSessionBindingActor` received the identical PR #990 change.
+- Preserve PR #990's guarantee: no thread-history fetch on ordinary subsequent
+  inbounds.
+
+**Non-Goals:**
+
+- Surfacing reminder identity/task (vs. the posted message text) into the
+  thread — separate follow-up, requires its own spec delta.
+- Closing the Discord-DM amnesia case — a documented permanent limitation
+  (flat conversation, no thread root).
+- Adding a proactive-posting tool for Discord (issue #953).
+- Any change to ACL, authorized-trigger classification, the history fetchers,
+  or the cursor/watermark persistence model.
+
+## Decisions
+
+### Decision 1: Re-arm hydration when it defers for lack of an authorized trigger
+
+`PerformOneShotHydrationAsync` distinguishes two non-enqueueing outcomes today,
+but treats them identically (hydration consumed):
+
+1. **Complete** — empty thread, or cursor already at head, or an authorized
+   turn was enqueued. Nothing further is owed.
+2. **Deferred** — a non-empty gap was fetched but contained no authorized
+   message to anchor a turn. A turn is still owed once an authorized inbound
+   arrives.
+
+The binding actor will track a `_hydrationPending` flag set only on outcome (2).
+While set, the first **authorized** live inbound performs the deferred
+hydration instead of taking the fetch-free path; the flag is then cleared and
+the actor reverts to normal fetch-free behavior.
+
+This is exactly what the spec already requires — hydration "only when an
+authorized inbound message is about to create an executable turn." The
+once-per-lifetime optimization remains valid; it is simply not counted as spent
+until a hydration has *completed*.
+
+### Decision 2: The live inbound is the authorized trigger; the fetched gap is its adopted context
+
+When `_hydrationPending` and an authorized inbound arrives, the actor fetches
+thread history, computes the gap above the cursor, classifies it, and merges
+the gap as adopted context onto the **live** inbound via the existing
+`AdoptedContextContentBuilder.MergeWithCurrentMessage` — the same merge the
+hydration path already performs. The live inbound keeps its own (live-pipeline)
+representation and remains the executable message; the normal fetch-free
+enqueue for that inbound is skipped so the turn is enqueued exactly once.
+
+**Alternatives considered:**
+
+- *Re-run `PerformOneShotHydrationAsync` standalone and let it synthesize the
+  trigger from history.* Rejected: it would build the trigger from the
+  history-fetched copy of the human reply, diverging from the live inbound's
+  representation, and risks a double enqueue (hydration + live handler).
+- *Carry the deferred gap in actor memory and merge it later without
+  re-fetching.* Rejected: the gap can go stale (more messages may arrive before
+  the reply), and restart-safety still requires a re-fetch — so an in-memory
+  copy adds a divergence risk for no real saving. Re-fetching once yields
+  current truth.
+
+### Decision 3: No new persistent state
+
+`_hydrationPending` is in-memory only. The durable cursor (`_cursorTs` /
+`CursorAdvanced`) advances solely on `TurnCompleted`, so until the proactive
+thread's first authorized turn completes, the bot root remains above the
+cursor. On actor crash/restart, recovery re-queues `PerformHydration`; the
+re-run recomputes the gap from `conversations.replies` and the recovered
+cursor. Restart-safety is therefore already provided by the existing
+watermark + recovery-driven hydration; `_hydrationPending` only optimizes the
+within-lifetime quick-reply path.
+
+### Actor boundaries
+
+The change is contained entirely within the binding actors
+(`SlackThreadBindingActor`, `DiscordSessionBindingActor`). The gateway,
+conversation actor, session pipeline, and history fetchers are untouched. The
+binding actor remains the owner of thread-gap fetch and watermark bookkeeping,
+per the `thread-history-backfill` requirement "Authorized sync watermark and
+gap computation."
+
+## Risks / Trade-offs
+
+- **[Reintroducing the PR #990 image storm]** → The re-armed fetch fires at
+  most once more per actor lifetime, only after a deferral, and never on
+  ordinary inbounds. A proactive thread at deferral time has the cursor at
+  origin and no in-flight turns, so the duplicate-in-flight-media condition
+  PR #990 fixed cannot arise. A regression test asserts no second fetch on a
+  normal second inbound.
+- **[Double enqueue / duplicate adoption]** → The re-armed path enqueues
+  exactly one authorized turn (live inbound as trigger, fetched gap as adopted
+  context) and skips the normal fetch-free enqueue for that inbound.
+- **[Re-armed hydration fetch fails]** → Non-fatal, consistent with today's
+  "hydration threw; continuing without backfill": the turn proceeds without the
+  adopted root. The cursor does not advance, so a later turn can still adopt
+  the gap. `_hydrationPending` stays set so a subsequent authorized inbound
+  retries.
+- **[Non-authorized message arrives while pending]** → No turn is created and
+  `_hydrationPending` stays set, matching the existing "unauthorized inbound
+  does not trigger hydration" rule.
+- **[Discord]** → `DiscordSessionBindingActor` gets the symmetric change.
+  Discord DMs have no thread root, so hydration returns an empty gap, never
+  defers, and never sets `_hydrationPending` — the documented limitation is
+  preserved unchanged.
+
+## Migration Plan
+
+Pure behavior fix. No data, persistence-schema, or API migration. Rollback is a
+straight revert of the change; behavior returns to the once-per-lifetime
+strategy with no residual state to clean up.
+
+## Open Questions
+
+None.

--- a/openspec/changes/restore-proactive-thread-hydration-conformance/proposal.md
+++ b/openspec/changes/restore-proactive-thread-hydration-conformance/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+A proactively-created channel thread (e.g. a reminder posting via
+`send_slack_message`) loses the message that opened the conversation: when the
+user replies, the agent answers with no record of what it posted and
+confabulates an unrelated topic. This is a **regression** — the
+`thread-history-backfill` capability already specifies the correct behavior
+("Bot's own posted message at thread root is hydrated as adopted context"), and
+PR #958 implemented it correctly. PR #990 ("hydrate thread history once per
+actor lifetime") then silently regressed it without touching the spec.
+
+## Source PRDs
+
+- `PRD-009`: Input adapter contract and transport-agnostic session handoff.
+- `PRD-008`: Scheduling and periodic tasks (reminders are the primary producer
+  of proactive threads).
+- `PRD-002`: Gateway security envelope — authorized-trigger classification of
+  hydrated gap messages.
+
+## What Changes
+
+- A one-shot thread-history hydration that **defers for lack of an authorized
+  trigger** SHALL NOT be counted as consumed. The binding actor SHALL re-arm so
+  the next authorized inbound performs the deferred hydration, adopting the gap
+  (including a bot-authored thread root) into that inbound's adopted-context
+  window.
+- This restores conformance for proactively-created threads, where the binding
+  actor's lifetime begins at post time — before any authorized human inbound
+  exists — so the existing "once per actor lifetime at startup" strategy never
+  hydrates the root for a quick reply.
+- PR #990's guarantee is preserved: hydration still does not run on *ordinary*
+  subsequent inbounds; re-arming only applies when the prior hydration produced
+  no authorized turn.
+- Applied symmetrically to the Slack and Discord binding actors (PR #990
+  changed both). Discord cannot exercise the proactive path yet (no proactive
+  posting tool — issue #953), but the fix lands so Discord is correct when that
+  ships. Discord DMs remain a documented out-of-scope limitation.
+- No breaking changes; no API or persistence-schema changes.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `thread-history-backfill`: Add a requirement that a hydration deferred for
+  lack of an authorized trigger is re-armed (not consumed), and a regression
+  scenario covering a proactively-created thread whose authorized reply arrives
+  within the same actor lifetime (before passivation). Clarifies that the
+  "once per actor lifetime" optimization is valid only once a hydration has
+  produced an authorized turn or confirmed an empty thread.
+
+## Impact
+
+- **Code**: `src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs`
+  (`PerformOneShotHydrationAsync`, `Hydrating`/`Active` behaviors);
+  `src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs` (symmetric
+  change). No change expected in the history fetchers.
+- **Tests**: `SlackThreadBackfillIntegrationTests`, `SessionBindingContractTests`,
+  `SlackProactiveThreadTests`.
+- **Behavior**: one additional thread-history fetch on the first authorized
+  inbound of a proactively-created thread; bounded — never repeats on ordinary
+  inbounds.
+- **Security/operational**: no change to ACL or authorized-trigger
+  classification; hydrated gap messages keep their existing
+  authority-at-inclusion semantics. No new failure modes; hydration failure
+  remains non-fatal (logged, turn proceeds).

--- a/openspec/changes/restore-proactive-thread-hydration-conformance/specs/thread-history-backfill/spec.md
+++ b/openspec/changes/restore-proactive-thread-hydration-conformance/specs/thread-history-backfill/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Deferred hydration is re-armed until it completes
+
+A threaded channel adapter SHALL re-arm thread-history hydration whenever a
+hydration pass fetches a non-empty gap but finds no message in that gap with
+`authority-at-inclusion=authorized` to anchor a turn. Such a pass is
+**deferred**: the adapter SHALL NOT count its once-per-actor-lifetime hydration
+as consumed. A pass that confirmed there is nothing to adopt (empty thread, or
+every fetched message at or below the durable watermark) or that enqueued an
+authorized turn is instead **completed**.
+
+While hydration is re-armed, the first subsequent **authorized** inbound SHALL
+perform the deferred hydration: the adapter SHALL fetch the current thread gap,
+classify it, and merge that gap as the adopted-context window preceding the
+authorized inbound, which remains the executable message for the turn. The
+adapter SHALL enqueue exactly one authorized turn for that inbound and SHALL
+then revert to normal fetch-free inbound handling.
+
+Re-arming SHALL be cleared once a re-armed hydration completes (whether or not
+the resulting gap was empty). An adapter whose hydration has completed SHALL
+NOT fetch thread history again on subsequent inbounds; re-arming therefore
+never causes a fetch on an ordinary inbound.
+
+This requirement exists because a proactively-created thread's binding actor
+begins its lifetime when the agent posts the thread root — before any
+authorized human inbound exists. Its startup hydration necessarily defers,
+because the only gap message is the bot-authored root and a bot is not an
+allowed user. Without re-arming, the bot root is never adopted and the first
+human reply executes with no record of the message that opened the thread.
+
+#### Scenario: Proactively-created thread adopts its bot root on the first authorized reply
+
+- **GIVEN** an agent-initiated proactive post created a thread whose root is the
+  bot's own message
+- **AND** the binding actor's startup hydration ran while that bot root was the
+  only message in the thread and deferred for lack of an authorized trigger
+- **WHEN** an authorized user replies in that thread within the same binding
+  actor lifetime
+- **THEN** the adapter performs the deferred hydration
+- **AND** the bot-authored thread root is included in the authorized turn's
+  adopted-context window
+- **AND** the authorized reply is the executable message for that turn
+
+#### Scenario: Ordinary inbound after a completed hydration does not re-fetch history
+
+- **GIVEN** a binding actor whose hydration completed, either by enqueuing an
+  authorized turn or by confirming an empty gap
+- **WHEN** a further authorized inbound arrives
+- **THEN** the adapter does not fetch thread history for that inbound
+- **AND** no adopted-context window is recomputed from server-side history
+
+#### Scenario: Unauthorized inbound while hydration is deferred keeps it re-armed
+
+- **GIVEN** a binding actor whose startup hydration deferred
+- **WHEN** a non-allowed user sends a threaded message before any authorized
+  inbound arrives
+- **THEN** the adapter does not perform the deferred hydration
+- **AND** the adapter does not dispatch a turn
+- **AND** hydration remains re-armed for the next authorized inbound
+
+#### Scenario: Re-armed hydration fetch failure is non-fatal
+
+- **GIVEN** a binding actor whose startup hydration deferred
+- **WHEN** an authorized inbound arrives and the re-armed thread-history fetch
+  fails
+- **THEN** the authorized inbound is still executed as a turn without an
+  adopted-context window
+- **AND** hydration remains re-armed so a later authorized inbound can retry
+
+#### Scenario: Discord DM never defers and never re-arms
+
+- **GIVEN** a Discord DM session, whose flat conversation has no distinct
+  thread root
+- **WHEN** the binding actor's startup hydration runs
+- **THEN** no fetched entry satisfies the thread-root predicate, so no
+  bot-authored entry is hydrated
+- **AND** hydration does not defer on account of a bot root
+- **AND** the adapter does not re-arm hydration

--- a/openspec/changes/restore-proactive-thread-hydration-conformance/tasks.md
+++ b/openspec/changes/restore-proactive-thread-hydration-conformance/tasks.md
@@ -1,0 +1,61 @@
+## 1. Slack binding actor
+
+- [x] 1.1 In `SlackThreadBindingActor`, add an in-memory `_hydrationPending`
+      flag (default false). Make `PerformOneShotHydrationAsync` set it when it
+      returns via the deferral path — a non-empty gap with no authorized
+      trigger (`SlackThreadBindingActor.cs:867-871`) — and leave it false on
+      every completion path (empty thread, cursor at head, fetch failure with
+      no gap, authorized turn enqueued).
+- [x] 1.2 In the `Active` behavior's authorized-inbound handling, when
+      `_hydrationPending` is set: fetch the current thread gap, classify it,
+      and merge it as the adopted-context window onto the live inbound
+      (executable message) using `AdoptedContextContentBuilder.MergeWithCurrentMessage`
+      — reusing the merge already performed by `PerformOneShotHydrationAsync`.
+      Enqueue exactly one authorized turn and skip the normal fetch-free
+      enqueue for that inbound.
+- [x] 1.3 Clear `_hydrationPending` once a re-armed pass completes (gap merged,
+      or empty). On a re-armed fetch failure, keep it set so a later authorized
+      inbound retries; ensure the inbound still executes (non-fatal).
+- [x] 1.4 Confirm an unauthorized inbound arriving while `_hydrationPending` is
+      set does not perform hydration, does not dispatch a turn, and leaves the
+      flag set.
+- [x] 1.5 Verify no behavior change for a normal thread: hydration that
+      completes never sets `_hydrationPending`, so subsequent inbounds stay on
+      the fetch-free path (PR #990 guarantee preserved).
+
+## 2. Discord binding actor
+
+- [x] 2.1 Inspect `DiscordSessionBindingActor` and confirm it has the same
+      `Hydrating`/`Active` structure and a `PerformOneShotHydrationAsync`
+      equivalent with the same deferral path (PR #990 changed both actors).
+- [x] 2.2 Apply the symmetric `_hydrationPending` re-arm change to
+      `DiscordSessionBindingActor`. Confirm Discord DMs (no thread root) yield
+      an empty gap, never defer, and never set the flag.
+
+## 3. Tests
+
+- [x] 3.1 Add a `SlackThreadBackfillIntegrationTests` case: proactively create
+      a thread (bot root only), then deliver an authorized human reply within
+      the same actor lifetime; assert the first authorized turn's
+      adopted-context window contains the bot root and the reply is the
+      executable message. Synchronize with `Ask`/acks — no `Task.Delay`.
+- [x] 3.2 Add a `SessionBindingContractTests` case asserting no thread-history
+      re-fetch on an ordinary second inbound after a completed hydration.
+- [x] 3.3 Add a `SlackProactiveThreadTests` case for the unauthorized-inbound-
+      while-pending scenario (flag stays set, no turn dispatched).
+- [x] 3.4 Add a re-armed fetch-failure case: the authorized inbound still
+      executes without an adopted window and the flag remains set.
+- [x] 3.5 Add the symmetric Discord binding-contract test (proactive path
+      unreachable today, but assert the deferral/re-arm wiring and the
+      Discord-DM empty-gap path).
+
+## 4. Verification and docs
+
+- [x] 4.1 Run the affected test projects (`Netclaw.Actors.Tests`,
+      `Netclaw.Channels.Slack` / Discord test projects); all green.
+- [x] 4.2 Run `dotnet slopwatch analyze` (no new violations) and
+      `./scripts/Add-FileHeaders.ps1 -Verify`.
+- [x] 4.3 Update operational/runbook docs only if behavior described there
+      changes — confirm no `docs/spec` drift; the OpenSpec delta is the spec of
+      record.
+- [x] 4.4 Run `/opsx-verify` for this change; resolve any conformance gaps.

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -232,22 +232,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
 
         await AwaitAssertAsync(() => Assert.Equal(1, fetcher.FetchCount), cancellationToken: ct);
 
-        actor.Tell(new DiscordThreadInbound(
-            SessionId: new SessionId("ignored"),
-            ChannelId: new DiscordChannelId("ch-test"),
-            ReplyChannelId: new DiscordReplyChannelId("reply-test"),
-            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
-            RootMessageId: null,
-            EventId: new DiscordEventId("1000000000000000001"),
-            SenderId: new DiscordUserId("replier-user"),
-            Audience: TrustAudience.Team,
-            Principal: PrincipalClassification.UntrustedExternal,
-            Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
-            {
-                SourceKind = "discord"
-            },
-            Text: "same as yesterday?",
-            ReceivedAt: TimeProvider.System.GetUtcNow()), TestActor);
+        actor.Tell(MakeInbound("1000000000000000001", "replier-user", "same as yesterday?"), TestActor);
 
         await AwaitAssertAsync(() =>
         {

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -172,14 +172,14 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
         SessionId sessionId,
         ISessionPipeline pipeline,
         ConfigurablePromptInjectionDetector detector,
-        IThreadHistoryFetcher? historyFetcher = null)
+        IThreadHistoryFetcher? historyFetcher = null,
+        DiscordChannelOptions? options = null)
     {
-        var options = new DiscordChannelOptions();
         var deps = new DiscordGatewayDependencies(
             Pipeline: pipeline,
             IngressGate: null,
             TimeProvider: TimeProvider.System,
-            Options: options,
+            Options: options ?? new DiscordChannelOptions(),
             DefaultChannelId: null,
             ReplyClient: _replyClient,
             ContentScanner: new NullContentScanner(),
@@ -196,5 +196,203 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             new DiscordThreadOrMessageId("thread-test"),
             rootMessageId: null,
             deps));
+    }
+
+    [Fact]
+    public async Task Deferred_hydration_completes_on_first_authorized_inbound()
+    {
+        // Discord parity for the proactive-thread deferral case: the binding
+        // actor's startup hydration sees only a non-authorized bot root, finds
+        // no authorized trigger, defers, and re-arms. The first authorized
+        // inbound completes the deferred hydration and adopts the bot root.
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-deferred-hydration");
+
+        const string botRootText = "scheduled report: nothing actionable";
+        var botRoot = MakeHistoryItem("bot-account", "900000000000000000", botRootText);
+        var reply = MakeHistoryItem("replier-user", "1000000000000000001", "same as yesterday?");
+
+        // Fetch #1 (startup hydration) sees only the bot root; fetch #2 (the
+        // re-armed hydration) sees the root plus the reply.
+        var fetcher = new CountingHistoryFetcher(call =>
+            call >= 2 ? [botRoot, reply] : [botRoot]);
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+
+        // The bot ("bot-account") is not an allowed user, so the proactively
+        // posted root classifies as pending and startup hydration defers.
+        var actor = CreateActorCore(
+            sid, pipeline, detector, fetcher,
+            new DiscordChannelOptions { AllowedUserIds = ["replier-user"] });
+
+        await AwaitAssertAsync(() => Assert.Equal(1, fetcher.FetchCount), cancellationToken: ct);
+
+        actor.Tell(new DiscordThreadInbound(
+            SessionId: new SessionId("ignored"),
+            ChannelId: new DiscordChannelId("ch-test"),
+            ReplyChannelId: new DiscordReplyChannelId("reply-test"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
+            RootMessageId: null,
+            EventId: new DiscordEventId("1000000000000000001"),
+            SenderId: new DiscordUserId("replier-user"),
+            Audience: TrustAudience.Team,
+            Principal: PrincipalClassification.UntrustedExternal,
+            Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
+            {
+                SourceKind = "discord"
+            },
+            Text: "same as yesterday?",
+            ReceivedAt: TimeProvider.System.GetUtcNow()), TestActor);
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
+            Assert.True(input.HasAdoptedContext);
+            var text = string.Join("\n", input.Contents
+                .OfType<Microsoft.Extensions.AI.TextContent>()
+                .Select(t => t.Text));
+            Assert.Contains("[adopted-context]", text, StringComparison.Ordinal);
+            Assert.Contains(botRootText, text, StringComparison.Ordinal);
+            Assert.Contains("same as yesterday?", text, StringComparison.Ordinal);
+        }, cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Deferred_hydration_stays_armed_for_unauthorized_inbound()
+    {
+        // An inbound from a non-allowed user while hydration is deferred must
+        // not perform the deferred hydration; it stays re-armed for the first
+        // authorized inbound.
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-deferred-unauthorized");
+
+        var botRoot = MakeHistoryItem("bot-account", "900000000000000000", "scheduled report");
+        var reply = MakeHistoryItem("replier-user", "1000000000000000002", "authorized reply");
+        var fetcher = new CountingHistoryFetcher(call =>
+            call >= 2 ? [botRoot, reply] : [botRoot]);
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+        var actor = CreateActorCore(
+            sid, pipeline, detector, fetcher,
+            new DiscordChannelOptions { AllowedUserIds = ["replier-user"] });
+
+        await AwaitAssertAsync(() => Assert.Equal(1, fetcher.FetchCount), cancellationToken: ct);
+
+        // Unauthorized inbound: no deferred hydration, no re-fetch.
+        actor.Tell(MakeInbound("1000000000000000001", "intruder-user", "who are you"), TestActor);
+        await AwaitAssertAsync(
+            () => Assert.True(pipeline.CapturedInputs.Count >= 1), cancellationToken: ct);
+        Assert.Equal(1, fetcher.FetchCount);
+
+        // The first authorized inbound completes the still-armed hydration.
+        actor.Tell(MakeInbound("1000000000000000002", "replier-user", "authorized reply"), TestActor);
+        await AwaitAssertAsync(() => Assert.Equal(2, fetcher.FetchCount), cancellationToken: ct);
+    }
+
+    [Fact]
+    public async Task Deferred_hydration_fetch_failure_executes_turn_and_stays_armed()
+    {
+        // If the re-armed thread-history fetch fails, the authorized inbound
+        // still executes (without an adopted window) and hydration stays
+        // re-armed so a later authorized inbound retries.
+        var ct = TestContext.Current.CancellationToken;
+        var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
+        var sid = new SessionId("session-discord-deferred-fetch-failure");
+
+        var botRoot = MakeHistoryItem("bot-account", "900000000000000000", "scheduled report");
+        var reply = MakeHistoryItem("replier-user", "1000000000000000003", "later reply");
+        var fetcher = new CountingHistoryFetcher(call => call switch
+        {
+            1 => [botRoot],
+            2 => throw new InvalidOperationException("history API down"),
+            _ => [botRoot, reply]
+        });
+
+        var pipeline = new RecordingSessionPipeline(_ =>
+        [
+            new TextOutput { SessionId = sid, Text = "reply" },
+            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+        ]);
+        var actor = CreateActorCore(
+            sid, pipeline, detector, fetcher,
+            new DiscordChannelOptions { AllowedUserIds = ["replier-user"] });
+
+        await AwaitAssertAsync(() => Assert.Equal(1, fetcher.FetchCount), cancellationToken: ct);
+
+        // Re-armed fetch throws: the turn still executes without adopted context.
+        actor.Tell(MakeInbound("1000000000000000001", "replier-user", "first reply"), TestActor);
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(pipeline.CapturedInputs.TryPeek(out var input));
+            Assert.False(input.HasAdoptedContext);
+        }, cancellationToken: ct);
+
+        // Still re-armed: a later authorized inbound retries the fetch.
+        actor.Tell(MakeInbound("1000000000000000003", "replier-user", "later reply"), TestActor);
+        await AwaitAssertAsync(() => Assert.Equal(3, fetcher.FetchCount), cancellationToken: ct);
+    }
+
+    private static ChannelInput MakeHistoryItem(string senderId, string messageId, string text)
+        => new()
+        {
+            SenderId = senderId,
+            ChannelId = "ch-test",
+            MessageId = messageId,
+            Contents = [new Microsoft.Extensions.AI.TextContent(text)],
+            ReceivedAt = TimeProvider.System.GetUtcNow(),
+            Audience = TrustAudience.Team,
+            Boundary = SecurityPolicyDefaults.PublicBoundary,
+            Principal = PrincipalClassification.UntrustedExternal,
+            Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
+        };
+
+    private static DiscordThreadInbound MakeInbound(string eventId, string senderId, string text)
+        => new(
+            SessionId: new SessionId("ignored"),
+            ChannelId: new DiscordChannelId("ch-test"),
+            ReplyChannelId: new DiscordReplyChannelId("reply-test"),
+            ThreadOrMessageId: new DiscordThreadOrMessageId("thread-test"),
+            RootMessageId: null,
+            EventId: new DiscordEventId(eventId),
+            SenderId: new DiscordUserId(senderId),
+            Audience: TrustAudience.Team,
+            Principal: PrincipalClassification.UntrustedExternal,
+            Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
+            {
+                SourceKind = "discord"
+            },
+            Text: text,
+            ReceivedAt: TimeProvider.System.GetUtcNow());
+
+    /// <summary>
+    /// History fetcher that returns a different result per call, keyed on the
+    /// 1-based call index — lets a test stage the proactive deferral (fetch #1)
+    /// separately from the re-armed completion (fetch #2). A <c>byCall</c> that
+    /// throws simulates a transient history-API failure.
+    /// </summary>
+    private sealed class CountingHistoryFetcher(Func<int, IReadOnlyList<ChannelInput>> byCall)
+        : IThreadHistoryFetcher
+    {
+        private int _count;
+
+        public int FetchCount => Volatile.Read(ref _count);
+
+        public async Task<IReadOnlyList<ChannelInput>> FetchThreadHistoryAsync(
+            SessionId sessionId, CancellationToken cancellationToken = default)
+        {
+            var call = Interlocked.Increment(ref _count);
+            await Task.Yield();
+            return byCall(call);
+        }
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackThreadBackfillIntegrationTests.cs
@@ -637,6 +637,137 @@ public sealed class SlackThreadBackfillIntegrationTests : TestKit
     }
 
     [Fact]
+    public async Task Proactively_created_thread_adopts_bot_root_on_first_authorized_reply()
+    {
+        // The true proactive-bootstrap case: the binding actor is created by
+        // StartProactiveThread when the agent posts the thread root — before
+        // any human reply exists. Its one-shot hydration runs against a thread
+        // that contains only the bot-authored root, finds no authorized
+        // trigger, and defers. The first authorized human reply MUST complete
+        // that deferred hydration so the bot root is adopted as context.
+        // Regression: PR #990's once-per-lifetime hydration dropped this, so
+        // the reply landed with no anchor and the agent confabulated an
+        // unrelated topic. Unlike Bot_authored_thread_root_is_hydrated_for_-
+        // proactive_post_bootstrap (which materializes the actor on the user
+        // reply, so hydration already sees both messages), this test creates
+        // the actor at post time via StartProactiveThread.
+        const string botRootText = "scheduled NuGet report: 22,681,480 downloads";
+
+        var pipeline = Host.Services.GetRequiredService<SessionPipeline>();
+        var httpClient = new HttpClient(_httpHandler);
+
+        // Stateful fetcher: the proactive startup hydration (fetch #1) sees
+        // only the bot root; the re-armed hydration after the reply (fetch #2)
+        // sees the root plus the reply. The binding actor serializes the two.
+        var fetchCount = 0;
+        var fetcher = new SlackThreadHistoryFetcher(
+            (channelId, threadTs, limit, cursor, ct) =>
+            {
+                var n = Interlocked.Increment(ref fetchCount);
+                var ts = threadTs.Value;
+                var messages = new List<SlackNet.Events.MessageEvent>
+                {
+                    new() { Ts = ts, User = "UBOT", BotId = "B_NETCLAW", Text = botRootText }
+                };
+                if (n >= 2)
+                {
+                    messages.Add(new SlackNet.Events.MessageEvent
+                    {
+                        Ts = $"{ts[..^1]}1",
+                        User = "U_REPLIER",
+                        Text = "same as yesterday?"
+                    });
+                }
+
+                return Task.FromResult(new SlackNet.WebApi.ConversationMessagesResponse
+                {
+                    Messages = messages
+                });
+            },
+            new SlackChannelOptions { BotToken = new SensitiveString("xoxb-fake") },
+            httpClient,
+            new NullContentScanner(),
+            new NetclawPaths(Path.GetTempPath()),
+            ToolAudienceProfileDefaults.CreateProfiles(),
+            TestSlackGatewayDeps.DefaultVisionCapableModel,
+            NullLogger<SlackThreadHistoryFetcher>.Instance);
+
+        var deps = new SlackGatewayDependencies(
+            Pipeline: pipeline,
+            IngressGate: null,
+            ActorSystem: Sys,
+            TimeProvider: TimeProvider.System,
+            Options: new SlackChannelOptions
+            {
+                Enabled = true,
+                MentionOnly = true,
+                AllowedChannelIds = ["C_REARM"],
+                // The bot ("UBOT") is deliberately NOT an allowed user, so the
+                // proactively-posted root classifies as pending and the
+                // startup hydration defers — the condition this test exercises.
+                AllowedUserIds = ["U_REPLIER"],
+                BotToken = new SensitiveString("xoxb-fake-token")
+            },
+            BotUserId: new SlackUserId("UBOT"),
+            DefaultChannelId: null,
+            ReplyClient: _replyClient,
+            ContentScanner: new NullContentScanner(),
+            HttpClient: httpClient,
+            ThreadHistoryFetcher: fetcher,
+            AudienceProfiles: TestSlackGatewayDeps.DefaultAudienceProfiles,
+            ModelCapabilities: TestSlackGatewayDeps.DefaultVisionCapableModel,
+            Paths: _paths,
+            PromptInjectionDetector: SafePromptInjectionDetector.Instance);
+
+        var gateway = Sys.ActorOf(SlackGatewayActor.CreateProps(deps), "slack-gw-rearm");
+
+        // 1. The agent posts the thread root. The binding actor is created and
+        //    runs its one-shot hydration against the root-only thread (fetch #1).
+        gateway.Tell(new StartProactiveThread(
+            new SlackChannelId("C_REARM"),
+            new SlackThreadTs("8000.0"),
+            new SessionId("C_REARM/8000.0")));
+
+        // The ack is sent from HandleProactiveThreadAsync, which runs in the
+        // Active behavior — i.e. after the Hydrating behavior completed fetch #1.
+        await ExpectMsgAsync<ProactiveThreadAck>(cancellationToken: TestContext.Current.CancellationToken);
+
+        // 2. The human replies in the proactively-created thread.
+        gateway.Tell(new SlackInboundMessage(
+            Kind: SlackInboundKind.Message,
+            EventId: new SlackEventId("C_REARM:8000.1"),
+            ChannelId: new SlackChannelId("C_REARM"),
+            ThreadTs: new SlackThreadTs("8000.0"),
+            EventTs: new SlackEventTs("8000.1"),
+            UserId: new SlackUserId("U_REPLIER"),
+            BotId: null,
+            Text: "same as yesterday?",
+            Subtype: null,
+            Hidden: false,
+            IsDirectMessage: false));
+
+        await AwaitAssertAsync(() =>
+        {
+            Assert.True(_chatClient.CallCount > 0, "Expected at least one LLM call");
+        }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+
+        var messages = _chatClient.LastMessages!;
+        var userMessages = messages.Where(m => m.Role == AiChatRole.User).ToList();
+        Assert.Single(userMessages);
+
+        var mergedText = string.Join("", userMessages[0].Contents.OfType<TextContent>().Select(t => t.Text));
+
+        // The deferred hydration completed on the reply: the bot-authored root
+        // is adopted, so the LLM has the anchor for "same as yesterday?".
+        Assert.Contains("[adopted-context]", mergedText, StringComparison.Ordinal);
+        Assert.Contains(botRootText, mergedText, StringComparison.Ordinal);
+
+        // The reply is the executable message, not part of adopted context.
+        Assert.Contains("same as yesterday?", mergedText, StringComparison.Ordinal);
+        Assert.Contains("[current-authorized-message author=U_REPLIER", mergedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Older_out_of_order_live_event_is_dropped_after_cursor_advances()
     {
         var pipeline = Host.Services.GetRequiredService<SessionPipeline>();

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -62,6 +62,15 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private ulong? _cursorSnowflake;
     private ulong? _pendingCursorSnowflake;
 
+    // Set when PerformOneShotHydrationAsync fetched a non-empty thread gap but
+    // found no authorized trigger to anchor a turn. This is the proactive-thread
+    // case: the binding actor's lifetime began when the agent posted the thread
+    // root, so the one-shot hydration ran before any authorized human inbound
+    // existed. While set, the first authorized inbound performs the deferred
+    // hydration instead of taking the fetch-free path; it is cleared once that
+    // hydration completes.
+    private bool _hydrationPending;
+
     public ITimerScheduler Timers { get; set; } = null!;
 
     public DiscordSessionBindingActor(
@@ -319,10 +328,12 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (liveContents.Count == 0)
             return;
 
-        // Live inbound path is fetch-free. Thread history is hydrated exactly
-        // once per actor lifetime in PerformOneShotHydrationAsync (driven by
-        // the RecoveryCompleted handler), so by the time we get here the
-        // session already has the historical context it needs.
+        // Live inbound path is fetch-free. Thread history is hydrated once per
+        // actor lifetime in PerformOneShotHydrationAsync (driven by the
+        // RecoveryCompleted handler); the only exception is a deferred
+        // hydration, which ApplyDeferredHydrationAsync completes on the first
+        // authorized inbound. By the time we get here the session already has
+        // the historical context it needs.
         var input = new ChannelInput
         {
             SenderId = message.SenderId.Value,
@@ -336,6 +347,9 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             ReceivedAt = message.ReceivedAt,
             ExecutableText = message.Text
         };
+
+        if (_hydrationPending && IsAuthorizedSender(message.SenderId.Value))
+            input = await ApplyDeferredHydrationAsync(input, message.EventId.Value, inboundCts.Token);
 
         try
         {
@@ -424,45 +438,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return;
         }
 
-        var classifications = await Task.WhenAll(
-            candidates.Select(c => ClassifyGapMessageAsync(c, cts.Token)));
-
-        var gap = new List<AdoptedContextMessage>(candidates.Count);
-        var blockedForRisk = 0;
-        var detectorUnavailable = false;
-        for (var i = 0; i < candidates.Count; i++)
-        {
-            switch (classifications[i].Outcome)
-            {
-                case ClassificationOutcome.Allow:
-                    var authority = _dependencies.Options.AllowedUserIds.Length == 0
-                        || _dependencies.Options.AllowedUserIds.Contains(candidates[i].SenderId, StringComparer.Ordinal)
-                        ? AdoptedMessageAuthority.Authorized
-                        : AdoptedMessageAuthority.Pending;
-                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
-                    break;
-
-                case ClassificationOutcome.Block:
-                    blockedForRisk++;
-                    _log.Warning(
-                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
-                        candidates[i].SenderId,
-                        candidates[i].MessageId ?? "none",
-                        classifications[i].Reason ?? "high-risk pattern detected");
-                    break;
-
-                case ClassificationOutcome.DetectorUnavailable:
-                    blockedForRisk++;
-                    detectorUnavailable = true;
-                    break;
-            }
-        }
+        var classified = await ClassifyGapAsync(candidates, cts.Token);
+        var gap = classified.Gap;
 
         _log.Info(
             "Thread history hydration fetched={FetchedCount} gapCount={GapCount} allowed={AllowedCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor} session={Session}",
-            history.Count, candidates.Count, gap.Count, blockedForRisk, cursor?.ToString() ?? "none", _sessionId.Value);
+            history.Count, candidates.Count, gap.Count, classified.BlockedForRisk, cursor?.ToString() ?? "none", _sessionId.Value);
 
-        if (detectorUnavailable)
+        if (classified.DetectorUnavailable)
             await SafeReplyAsync(BackfillDetectorWarning);
 
         if (gap.Count == 0)
@@ -485,7 +468,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         if (trigger is null)
         {
-            _log.Info("Thread history hydration: no authorized message in gap; deferring backfill to next live inbound session={Session}", _sessionId.Value);
+            // Deferred: a non-empty gap with no authorized trigger. The
+            // proactive-thread case — the binding actor's lifetime began when
+            // the agent posted the thread root, so this hydration ran before
+            // any authorized human inbound existed. Re-arm so the first
+            // authorized inbound performs this hydration (adopting the gap,
+            // e.g. the bot-authored root) instead of taking the fetch-free path.
+            _hydrationPending = true;
+            _log.Info("Thread history hydration: no authorized message in gap; re-armed for next authorized inbound session={Session}", _sessionId.Value);
             return;
         }
 
@@ -498,25 +488,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         }
 
         var triggerInput = trigger.Input;
-        var triggerSenderId = triggerInput.SenderId;
         var triggerSnowflake = TryParseSnowflake(triggerInput.MessageId ?? string.Empty);
-
-        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            adoptedContext,
-            triggerInput.Contents,
-            triggerSenderId,
-            triggerInput.ReceivedAt);
-
-        var backfillInput = triggerInput with
-        {
-            Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggerSenderId, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = merged.SpeakerIds,
-            AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor?.ToString(),
-            AdoptedContextUpperBound = triggerInput.MessageId,
-            AdoptedContextEntries = merged.Entries
-        };
+        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
 
         if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
         {
@@ -567,6 +540,166 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
 
         return PromptClassifier.ClassifyAsync(
             _promptInjectionDetector, text, "discord-backfill", _log, cancellationToken);
+    }
+
+    // Discord authorization basis for adopted-context: an empty AllowedUserIds
+    // list means the instance is unrestricted; otherwise the sender must be listed.
+    private bool IsAuthorizedSender(string senderId)
+        => _dependencies.Options.AllowedUserIds.Length == 0
+            || _dependencies.Options.AllowedUserIds.Contains(senderId, StringComparer.Ordinal);
+
+    private readonly record struct GapClassification(
+        List<AdoptedContextMessage> Gap,
+        int BlockedForRisk,
+        bool DetectorUnavailable);
+
+    /// <summary>
+    /// Runs prompt-injection classification over candidate gap messages and
+    /// captures each surviving message's authority-at-inclusion. Blocked
+    /// messages are dropped; detector-unavailable messages are also dropped
+    /// and surface a caller-visible flag.
+    /// </summary>
+    private async Task<GapClassification> ClassifyGapAsync(
+        IReadOnlyList<ChannelInput> candidates,
+        CancellationToken cancellationToken)
+    {
+        var classifications = await Task.WhenAll(
+            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
+
+        var gap = new List<AdoptedContextMessage>(candidates.Count);
+        var blockedForRisk = 0;
+        var detectorUnavailable = false;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            switch (classifications[i].Outcome)
+            {
+                case ClassificationOutcome.Allow:
+                    var authority = IsAuthorizedSender(candidates[i].SenderId)
+                        ? AdoptedMessageAuthority.Authorized
+                        : AdoptedMessageAuthority.Pending;
+                    gap.Add(new AdoptedContextMessage(candidates[i], authority));
+                    break;
+
+                case ClassificationOutcome.Block:
+                    blockedForRisk++;
+                    _log.Warning(
+                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
+                        candidates[i].SenderId,
+                        candidates[i].MessageId ?? "none",
+                        classifications[i].Reason ?? "high-risk pattern detected");
+                    break;
+
+                case ClassificationOutcome.DetectorUnavailable:
+                    blockedForRisk++;
+                    detectorUnavailable = true;
+                    break;
+            }
+        }
+
+        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
+    }
+
+    /// <summary>
+    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
+    /// preceding <paramref name="triggerInput"/> (the executable message) and
+    /// returns the trigger input with adopted-context metadata populated.
+    /// </summary>
+    private static ChannelInput MergeAdoptedContext(
+        ChannelInput triggerInput,
+        List<AdoptedContextMessage> adoptedContext,
+        ulong? cursor)
+    {
+        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
+            adoptedContext,
+            triggerInput.Contents,
+            triggerInput.SenderId,
+            triggerInput.ReceivedAt);
+
+        return triggerInput with
+        {
+            Contents = merged.Contents,
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
+                id => !string.Equals(id, triggerInput.SenderId, StringComparison.Ordinal)),
+            AdoptedSpeakerIds = merged.SpeakerIds,
+            AdoptedContextProjection = merged.Projection,
+            AdoptedContextLowerBound = cursor?.ToString(),
+            AdoptedContextUpperBound = triggerInput.MessageId,
+            AdoptedContextEntries = merged.Entries
+        };
+    }
+
+    /// <summary>
+    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
+    /// deferred for lack of an authorized trigger (<see cref="_hydrationPending"/>).
+    /// This authorized inbound is the executable trigger; the thread gap strictly
+    /// before it — most importantly a proactively-posted bot-authored root — is
+    /// fetched, classified, and merged as its adopted-context window. On fetch
+    /// failure the turn proceeds un-enriched and hydration stays re-armed so a
+    /// later authorized inbound retries.
+    /// </summary>
+    private async Task<ChannelInput> ApplyDeferredHydrationAsync(
+        ChannelInput baseInput,
+        string liveMessageId,
+        CancellationToken cancellationToken)
+    {
+        if (_dependencies.ThreadHistoryFetcher is not { } fetcher)
+            return baseInput;
+
+        // Without the live message's ordering key the gap below it cannot be
+        // bounded; leave hydration re-armed and take the fetch-free path.
+        if (TryParseSnowflake(liveMessageId) is not { } liveSnowflake)
+            return baseInput;
+
+        IReadOnlyList<ChannelInput> history;
+        try
+        {
+            history = await fetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: execute the turn without an adopted window and keep
+            // hydration re-armed so a later authorized inbound retries.
+            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return baseInput;
+        }
+
+        // Hydration has now completed for this actor lifetime.
+        _hydrationPending = false;
+
+        var cursor = _cursorSnowflake;
+        var candidates = new List<ChannelInput>(history.Count);
+        foreach (var item in history)
+        {
+            if (TryParseSnowflake(item.MessageId ?? string.Empty) is not { } itemSnowflake)
+                continue;
+
+            // Strictly above the watermark and strictly below the live inbound:
+            // the live inbound is the executable message, not adopted context.
+            if (cursor is { } c && itemSnowflake <= c)
+                continue;
+            if (itemSnowflake >= liveSnowflake)
+                continue;
+
+            candidates.Add(item);
+        }
+
+        if (candidates.Count == 0)
+            return baseInput;
+
+        var classified = await ClassifyGapAsync(candidates, cancellationToken);
+        if (classified.DetectorUnavailable)
+            await SafeReplyAsync(BackfillDetectorWarning);
+
+        if (classified.Gap.Count == 0)
+            return baseInput;
+
+        _log.Info(
+            "discord_deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId} session={Session}",
+            classified.Gap.Count,
+            baseInput.MessageId,
+            _sessionId.Value);
+
+        return MergeAdoptedContext(baseInput, classified.Gap, cursor);
     }
 
     private async Task<bool> TryHandleTextApprovalResponseAsync(DiscordThreadInbound message, string selectedKey)

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -663,7 +663,8 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             return baseInput;
         }
 
-        // Hydration has now completed for this actor lifetime.
+        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
+        // above) keeps the flag armed — classify/merge outcomes never re-arm.
         _hydrationPending = false;
 
         var cursor = _cursorSnowflake;

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1044,7 +1044,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             return baseResult;
         }
 
-        // Hydration has now completed for this actor lifetime.
+        // Fetch succeeded: hydration is complete. Only a fetch failure (caught
+        // above) keeps the flag armed — classify/merge outcomes never re-arm.
         _hydrationPending = false;
 
         var cursor = _cursorTs;

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -46,6 +46,15 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private readonly SessionPipelineHandle _handle;
     private SlackEventTs? _cursorTs;
     private SlackEventTs? _pendingCursorTs;
+
+    // Set when PerformOneShotHydrationAsync fetched a non-empty thread gap but
+    // found no authorized trigger to anchor a turn. This is the proactive-thread
+    // case: the binding actor's lifetime began when the agent posted the thread
+    // root, so the one-shot hydration ran before any authorized human inbound
+    // existed. While set, the first authorized inbound performs the deferred
+    // hydration instead of taking the fetch-free path; it is cleared once that
+    // hydration completes.
+    private bool _hydrationPending;
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan InboundProcessingTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(10);
@@ -362,7 +371,10 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
                 return;
             }
 
-            var buildResult = BuildInputForInbound(message, contents);
+            var buildResult = _hydrationPending
+                && SlackAclPolicy.IsAllowedUser(new SlackUserId(message.SenderId), _dependencies.Options)
+                ? await BuildInputWithDeferredHydrationAsync(message, contents, currentTs, inboundCts.Token)
+                : BuildInputForInbound(message, contents);
             var input = buildResult.Input;
 
             if (buildResult.BackfillDetectorUnavailable)
@@ -722,13 +734,15 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         SlackThreadInbound triggeringMessage,
         IReadOnlyList<AIContent> liveContents)
     {
-        // Live inbound path is fetch-free. Thread history is hydrated exactly
-        // once per actor lifetime in PerformOneShotHydrationAsync (driven by
-        // the RecoveryCompleted handler), so by the time we get here the
-        // session already has the historical context it needs. Re-fetching
-        // on every inbound was the cause of the duplicate-image bug: in-flight
-        // turns left _cursorTs lagging ingestion (per PR #733), so the gap
-        // window kept re-including in-flight messages and re-emitting their
+        // Live inbound path is fetch-free. Thread history is hydrated once per
+        // actor lifetime in PerformOneShotHydrationAsync (driven by the
+        // RecoveryCompleted handler); the only exception is a deferred
+        // hydration, which BuildInputWithDeferredHydrationAsync completes on
+        // the first authorized inbound. By the time we get here the session
+        // already has the historical context it needs. Re-fetching on every
+        // inbound was the cause of the duplicate-image bug: in-flight turns
+        // left _cursorTs lagging ingestion (per PR #733), so the gap window
+        // kept re-including in-flight messages and re-emitting their
         // DataContent on every inbound.
         var baseInput = new ChannelInput
         {
@@ -805,44 +819,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             return;
         }
 
-        var classifications = await Task.WhenAll(candidates.Select(c => ClassifyGapMessageAsync(c, cts.Token)));
-
-        var gap = new List<AdoptedContextMessage>(candidates.Count);
-        var blockedForRisk = 0;
-        var detectorUnavailable = false;
-        for (var i = 0; i < candidates.Count; i++)
-        {
-            var item = candidates[i];
-            switch (classifications[i].Outcome)
-            {
-                case ClassificationOutcome.Allow:
-                    var authority = SlackAclPolicy.IsAllowedUser(new SlackUserId(item.SenderId), _dependencies.Options)
-                        ? AdoptedMessageAuthority.Authorized
-                        : AdoptedMessageAuthority.Pending;
-                    gap.Add(new AdoptedContextMessage(item, authority));
-                    break;
-
-                case ClassificationOutcome.Block:
-                    blockedForRisk++;
-                    _log.Warning(
-                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
-                        item.SenderId,
-                        item.MessageId ?? "none",
-                        classifications[i].Reason ?? "high-risk pattern detected");
-                    break;
-
-                case ClassificationOutcome.DetectorUnavailable:
-                    blockedForRisk++;
-                    detectorUnavailable = true;
-                    break;
-            }
-        }
+        var classified = await ClassifyGapAsync(candidates, cts.Token);
+        var gap = classified.Gap;
 
         _log.Info(
             "Thread history hydration fetched={FetchedCount} gapCount={GapCount} blockedHighRisk={BlockedHighRiskCount} cursor={Cursor}",
-            history.Count, gap.Count, blockedForRisk, cursor?.Value ?? "none");
+            history.Count, gap.Count, classified.BlockedForRisk, cursor?.Value ?? "none");
 
-        if (detectorUnavailable)
+        if (classified.DetectorUnavailable)
             await SafePostAsync(BackfillDetectorWarning);
 
         if (gap.Count == 0)
@@ -866,7 +850,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         if (trigger is null)
         {
-            _log.Info("Thread history hydration: no authorized message in gap; deferring backfill to next live inbound");
+            // Deferred: a non-empty gap with no authorized trigger. The
+            // proactive-thread case — the binding actor's lifetime began when
+            // the agent posted the thread root, so this hydration ran before
+            // any authorized human inbound existed. Re-arm so the first
+            // authorized inbound performs this hydration (adopting the gap,
+            // e.g. the bot-authored root) instead of taking the fetch-free path.
+            _hydrationPending = true;
+            _log.Info("Thread history hydration: no authorized message in gap; re-armed for next authorized inbound");
             return;
         }
 
@@ -882,25 +873,8 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         // carries its own text+attachment contents (loaded by the history
         // fetcher), so we treat those as the "live" contents for the merge.
         var triggerInput = trigger.Input;
-        var triggerSenderId = triggerInput.SenderId;
         var triggerTs = new SlackEventId(triggerInput.MessageId ?? string.Empty).TryGetEventTs();
-
-        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
-            adoptedContext,
-            triggerInput.Contents,
-            triggerSenderId,
-            triggerInput.ReceivedAt);
-
-        var backfillInput = triggerInput with
-        {
-            Contents = merged.Contents,
-            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(id => !string.Equals(id, triggerSenderId, StringComparison.Ordinal)),
-            AdoptedSpeakerIds = merged.SpeakerIds,
-            AdoptedContextProjection = merged.Projection,
-            AdoptedContextLowerBound = cursor?.Value,
-            AdoptedContextUpperBound = triggerInput.MessageId,
-            AdoptedContextEntries = merged.Entries
-        };
+        var backfillInput = MergeAdoptedContext(triggerInput, adoptedContext, cursor);
 
         if (_dependencies.IngressGate?.ClosedReason is { } ingressClosedReason)
         {
@@ -952,6 +926,158 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
 
         return PromptClassifier.ClassifyAsync(
             _promptInjectionDetector, text, "slack-backfill", _log, cancellationToken);
+    }
+
+    private readonly record struct GapClassification(
+        List<AdoptedContextMessage> Gap,
+        int BlockedForRisk,
+        bool DetectorUnavailable);
+
+    /// <summary>
+    /// Runs prompt-injection classification over candidate gap messages and
+    /// captures each surviving message's authority-at-inclusion. Blocked
+    /// messages are dropped; detector-unavailable messages are also dropped
+    /// and surface a caller-visible flag.
+    /// </summary>
+    private async Task<GapClassification> ClassifyGapAsync(
+        IReadOnlyList<ChannelInput> candidates,
+        CancellationToken cancellationToken)
+    {
+        var classifications = await Task.WhenAll(
+            candidates.Select(c => ClassifyGapMessageAsync(c, cancellationToken)));
+
+        var gap = new List<AdoptedContextMessage>(candidates.Count);
+        var blockedForRisk = 0;
+        var detectorUnavailable = false;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var item = candidates[i];
+            switch (classifications[i].Outcome)
+            {
+                case ClassificationOutcome.Allow:
+                    var authority = SlackAclPolicy.IsAllowedUser(new SlackUserId(item.SenderId), _dependencies.Options)
+                        ? AdoptedMessageAuthority.Authorized
+                        : AdoptedMessageAuthority.Pending;
+                    gap.Add(new AdoptedContextMessage(item, authority));
+                    break;
+
+                case ClassificationOutcome.Block:
+                    blockedForRisk++;
+                    _log.Warning(
+                        "Dropped backfill message due to prompt injection risk sender={SenderId} messageId={MessageId} reason={Reason}",
+                        item.SenderId,
+                        item.MessageId ?? "none",
+                        classifications[i].Reason ?? "high-risk pattern detected");
+                    break;
+
+                case ClassificationOutcome.DetectorUnavailable:
+                    blockedForRisk++;
+                    detectorUnavailable = true;
+                    break;
+            }
+        }
+
+        return new GapClassification(gap, blockedForRisk, detectorUnavailable);
+    }
+
+    /// <summary>
+    /// Merges <paramref name="adoptedContext"/> as the adopted-context window
+    /// preceding <paramref name="triggerInput"/> (the executable message) and
+    /// returns the trigger input with adopted-context metadata populated.
+    /// </summary>
+    private static ChannelInput MergeAdoptedContext(
+        ChannelInput triggerInput,
+        List<AdoptedContextMessage> adoptedContext,
+        SlackEventTs? cursor)
+    {
+        var merged = AdoptedContextContentBuilder.MergeWithCurrentMessage(
+            adoptedContext,
+            triggerInput.Contents,
+            triggerInput.SenderId,
+            triggerInput.ReceivedAt);
+
+        return triggerInput with
+        {
+            Contents = merged.Contents,
+            HasThirdPartyAdoptedContext = merged.SpeakerIds.Any(
+                id => !string.Equals(id, triggerInput.SenderId, StringComparison.Ordinal)),
+            AdoptedSpeakerIds = merged.SpeakerIds,
+            AdoptedContextProjection = merged.Projection,
+            AdoptedContextLowerBound = cursor?.Value,
+            AdoptedContextUpperBound = triggerInput.MessageId,
+            AdoptedContextEntries = merged.Entries
+        };
+    }
+
+    /// <summary>
+    /// Completes a thread-history hydration that <see cref="PerformOneShotHydrationAsync"/>
+    /// deferred for lack of an authorized trigger (<see cref="_hydrationPending"/>).
+    /// This authorized inbound is the executable trigger; the thread gap strictly
+    /// before it — most importantly a proactively-posted bot-authored root —
+    /// is fetched, classified, and merged as its adopted-context window. On
+    /// fetch failure the turn proceeds without an adopted window and hydration
+    /// stays re-armed so a later authorized inbound retries.
+    /// </summary>
+    private async Task<InboundBuildResult> BuildInputWithDeferredHydrationAsync(
+        SlackThreadInbound message,
+        IReadOnlyList<AIContent> liveContents,
+        SlackEventTs? liveTs,
+        CancellationToken cancellationToken)
+    {
+        var baseResult = BuildInputForInbound(message, liveContents);
+
+        // Without the live message's ordering key the gap below it cannot be
+        // bounded; leave hydration re-armed and take the fetch-free path.
+        if (liveTs is not { } liveEventTs)
+            return baseResult;
+
+        IReadOnlyList<ChannelInput> history;
+        try
+        {
+            history = await _dependencies.ThreadHistoryFetcher.FetchThreadHistoryAsync(_sessionId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: execute the turn without an adopted window and keep
+            // hydration re-armed so a later authorized inbound retries.
+            _log.Warning(ex, "Re-armed thread history fetch failed for session {SessionId}", _sessionId.Value);
+            return baseResult;
+        }
+
+        // Hydration has now completed for this actor lifetime.
+        _hydrationPending = false;
+
+        var cursor = _cursorTs;
+        var candidates = new List<ChannelInput>(history.Count);
+        foreach (var item in history)
+        {
+            if (new SlackEventId(item.MessageId ?? string.Empty).TryGetEventTs() is not { } itemTs)
+                continue;
+
+            // Strictly above the watermark and strictly below the live inbound:
+            // the live inbound is the executable message, not adopted context.
+            if (cursor is { } c && itemTs.CompareTo(c) <= 0)
+                continue;
+            if (itemTs.CompareTo(liveEventTs) >= 0)
+                continue;
+
+            candidates.Add(item);
+        }
+
+        if (candidates.Count == 0)
+            return baseResult;
+
+        var classified = await ClassifyGapAsync(candidates, cancellationToken);
+        if (classified.Gap.Count == 0)
+            return new InboundBuildResult(baseResult.Input, classified.DetectorUnavailable);
+
+        var mergedInput = MergeAdoptedContext(baseResult.Input, classified.Gap, cursor);
+        _log.Info(
+            "slack_deferred_hydration_adopted gapCount={GapCount} trigger={TriggerMessageId}",
+            classified.Gap.Count,
+            baseResult.Input.MessageId);
+
+        return new InboundBuildResult(mergedInput, classified.DetectorUnavailable);
     }
 
     private void AdvanceCursor(SlackEventTs candidateTs)


### PR DESCRIPTION
## Summary

A proactively-created channel thread (e.g. a reminder posting via `send_slack_message`) lost the message that opened it. The `SlackThreadBindingActor` materializes at post time and runs its one-shot thread-history hydration when the only message present is the bot-authored root. With no authorized human message to anchor backfill, hydration *deferred* — and PR #990's once-per-actor-lifetime hydration plus the fetch-free live path meant that deferral was never completed. The first human reply landed with no record of what opened the thread, so the agent answered with no anchor. This silently regressed the proactive-bootstrap case PR #958 fixed, without conforming to the `thread-history-backfill` spec.

- A hydration that defers for lack of an authorized trigger is no longer counted as consumed; a `_hydrationPending` flag re-arms it. The first authorized inbound completes the deferred hydration, fetching the gap and merging the bot root as adopted context onto that inbound.
- Ordinary inbounds after a completed hydration still take the fetch-free path — PR #990's guarantee is preserved.
- Applied symmetrically to `SlackThreadBindingActor` and `DiscordSessionBindingActor`.
- Adds the `restore-proactive-thread-hydration-conformance` OpenSpec change (delta on `thread-history-backfill`).

## Test plan

- [ ] `SlackThreadBackfillIntegrationTests.Proactively_created_thread_adopts_bot_root_on_first_authorized_reply` — real binding actor, proactive post then quick reply
- [ ] Discord contract tests: deferred-completes, unauthorized-stays-armed, fetch-failure-non-fatal
- [ ] Existing `Thread_history_fetched_at_most_once_per_actor_lifetime` still green (PR #990 guarantee preserved)
- [ ] Full Channels suite + Discord contract suite green
- [ ] `dotnet slopwatch analyze` clean; copyright headers verified