### PR TITLE
feat(approvals): creation timestamps + gate near-miss diagnostics

### DIFF
--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 # Netclaw Operations
@@ -365,7 +365,9 @@ mutations take effect on the next prompt without a daemon restart.
 # Interactive TUI: see everything grouped by audience and tool
 netclaw approvals
 
-# List — human-readable. Entries print as "<verb> in <dir>" or "<verb> anywhere".
+# List — human-readable. Entries print as "<verb> in <dir>" or "<verb> anywhere",
+# each followed by when the grant was added ("added 3 days ago"; "added —" for
+# grants saved before timestamps were tracked).
 netclaw approvals list
 netclaw approvals list --audience personal --tool shell_execute
 

--- a/openspec/changes/approval-creation-timestamps/.openspec.yaml
+++ b/openspec/changes/approval-creation-timestamps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/approval-creation-timestamps/design.md
+++ b/openspec/changes/approval-creation-timestamps/design.md
@@ -1,0 +1,164 @@
+## Context
+
+Persistent tool approvals live in `~/.netclaw/config/tool-approvals.json`
+(`version: 2`) as `ApprovalEntry` records carrying only `verb` and a nullable
+`directory`. When the daemon re-prompts for an approval the operator believes
+they already granted, there is nothing to inspect: no record of when a grant
+was created, and no log line when a persisted grant is a near-miss at the gate.
+
+Relevant current state:
+
+- `ApprovalEntry` (`Netclaw.Configuration`) — `record` with `Verb` +
+  `Directory`. `ToolApprovalEntryComparer` defines canonical equality
+  (verb + normalized directory; case rules are platform-correct).
+- `ToolApprovalStore` — JSON read/write with an mtime+size cache;
+  `AddApproval` is idempotent via `ToolApprovalEntryComparer.Equals`.
+  Constructed directly (`new ToolApprovalStore(path)`) at ~11 sites; not
+  DI-registered.
+- `ApprovalPatternMatching` (`Netclaw.Security`) — `MatchesShellApproval`
+  (verb + directory-containment + symlink-segment guard) and `MatchesAny`
+  (verb-only, non-shell). Returns `bool`.
+- `ToolApprovalActor` — evaluates `GetUnapprovedPatterns`; has no logger.
+- `tool-approvals.json` schema gate: `IsCurrentSchema` accepts **only**
+  `version == 2`; anything else is quarantined to `.v1.bak`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record when each persisted grant was first created.
+- Let an operator confirm, from logs, that a re-prompt happened despite a
+  same-verb grant being present — and see why it did not match.
+- Surface grant age in the `netclaw approvals` CLI and TUI.
+
+**Non-Goals:**
+
+- No change to matcher decisions or to the approval prompt body.
+- No `tool-approvals.json` schema-version bump and no migration tooling.
+- No "last used" / "use count" telemetry — only creation time.
+- No timestamps on session-scoped (in-memory) approvals.
+
+## Decisions
+
+### 1. `createdAt` is an optional additive field; `version` stays 2
+
+`ApprovalEntry` gains `DateTimeOffset? CreatedAt` (`[JsonPropertyName("createdAt")]`).
+The on-disk schema version stays `2`.
+
+Rationale: `IsCurrentSchema` quarantines any file whose `version != 2`.
+Bumping to `3` would move every existing operator's `tool-approvals.json` to
+`.v1.bak` and return an empty store — silently wiping every grant. An additive
+optional field is backward compatible (an old daemon ignores the unknown
+property) and forward compatible (a new daemon reads pre-feature entries as
+`CreatedAt == null`). `WhenWritingNull` already in `JsonOptions` means a null
+timestamp is simply omitted, exactly as `directory: null` is today.
+
+Alternative considered: version 3 with an in-place migration on load that
+stamps legacy entries. Rejected — there is no honest creation time for a
+legacy entry, and a load-path rewrite of the file is a riskier operation than
+leaving old entries `null`.
+
+### 2. Stamp at write time in `ToolApprovalStore.AddApproval` via `TimeProvider`
+
+`AddApproval` stamps `CreatedAt` when the incoming entry's `CreatedAt` is
+`null`, using an injected `TimeProvider`. The store's constructor gains an
+optional `TimeProvider? timeProvider = null` parameter resolving to
+`TimeProvider.System`.
+
+Rationale: `AddApproval` is the single chokepoint for both the daemon
+(`ToolApprovalActor`) and the operator CLI (`netclaw approvals trust-verb`),
+so stamping there guarantees identical behavior without touching either
+caller. The optional parameter keeps the ~11 direct `new ToolApprovalStore(path)`
+sites compiling unchanged; production paths get `TimeProvider.System`
+(the CLAUDE.md-blessed production default), and tests that assert on
+timestamps pass a `FakeTimeProvider`. This is a documented default, not a
+silent fallback.
+
+Idempotency interaction: when `AddApproval` finds an equivalent entry
+(`ToolApprovalEntryComparer.Equals`), it already returns `false` without
+appending. The existing entry — and its original `CreatedAt` — is left
+untouched, so re-granting reports grant age from first grant, which is the
+desired semantics.
+
+### 3. `createdAt` excluded from equality and normalization identity
+
+`ToolApprovalEntryComparer.Equals` continues to compare verb + directory only.
+`ToolApprovalEntryComparer.Normalize` copies `CreatedAt` through unchanged.
+
+Rationale: two grants for the same `(verb, directory)` are the same grant
+regardless of when they were stamped — otherwise idempotent add breaks and the
+file accumulates duplicates. The `ApprovalEntry` record's compiler-synthesized
+`Equals`/`GetHashCode` will now include `CreatedAt`, but the type's existing
+doc-comment already directs callers to `ToolApprovalEntryComparer` and away
+from record equality, so no consumer regresses.
+
+### 4. Near-miss diagnostics: pure explainer in `Netclaw.Security`, logged by the actor
+
+`ApprovalPatternMatching` gains a pure function that, given an unapproved
+shell candidate and the persisted entries, returns the set of same-verb
+near-misses with a classified reason (directory-not-under-grant,
+symlink-segment-on-path, verb-case-mismatch). `ToolApprovalActor` acquires an
+`ILoggingAdapter` (`Context.GetLogger()`) and, for each pattern it reports
+unapproved, logs one diagnostic line per near-miss including the grant's
+`CreatedAt`.
+
+Rationale: keeping the explainer pure and in `Netclaw.Security` makes it
+unit-testable in isolation and reuses the exact path/symlink logic that
+`MatchesShellApproval` uses, so the diagnostic cannot drift from the real
+matcher. The actor is the only place that knows the audience/tool/session
+context and already holds the persisted snapshot, so it is the natural log
+site. The explainer is invoked **only** on the unapproved branch, so the hot
+approved path pays nothing.
+
+Non-shell tools (`MatchesAny`) approve on a verb match alone, so the only
+possible non-shell near-miss is a verb-case mismatch; that case is folded into
+the same explainer rather than given a separate path.
+
+### 5. Display: relative text, `added —` placeholder for null
+
+CLI `list` and TUI rows render `CreatedAt` as relative text ("added 3 days
+ago") computed against the current time. A null `CreatedAt` renders the fixed
+string `added —`. `list --json` emits the raw `createdAt` (ISO-8601 or
+absent-as-null, consistent with how `directory: null` is already handled under
+`WhenWritingNull`).
+
+Rationale: relative text answers the operator's real question ("is this grant
+stale?") at a glance. The user chose relative over absolute. A null timestamp
+must render a stable, honest placeholder rather than today's date or a blank,
+so legacy entries are visibly distinguishable from fresh ones.
+
+## Risks / Trade-offs
+
+- **Record equality now includes `CreatedAt`** → A future caller using
+  `HashSet<ApprovalEntry>` / `Distinct()` would treat differently-stamped
+  entries as distinct. Mitigation: the existing `ApprovalEntry` doc-comment
+  already forbids relying on record equality for approval semantics; the
+  store and matcher use `ToolApprovalEntryComparer` exclusively.
+- **`--json` null representation** → Under `WhenWritingNull`, a null
+  `createdAt` is omitted rather than emitted as literal `null`. Mitigation:
+  this matches the existing treatment of `directory: null`; the spec
+  scenario's "`createdAt` is `null`" is satisfied by property absence, which
+  every JSON parser surfaces as null/undefined. Tests SHALL deserialize and
+  assert the property, not string-match the raw JSON.
+- **Clock skew / non-monotonic time** → `CreatedAt` is wall-clock and may go
+  backwards across a system clock change. Mitigation: acceptable — the field
+  is human-facing provenance, not an ordering key; the matcher never reads it.
+- **TUI regression risk** → The approvals list is a Termina surface that
+  xUnit cannot drive. Mitigation: validate with the interactive tape harness
+  per the testing policy before marking done.
+
+## Migration Plan
+
+No migration step. Existing `version: 2` files are read as-is; their entries
+deserialize with `CreatedAt == null`. The first `AddApproval` after upgrade
+rewrites the file with `createdAt` on newly added entries only; pre-existing
+entries keep no timestamp until they are revoked and re-granted. Rollback: an
+older daemon reading a file that now contains `createdAt` ignores the unknown
+property — no quarantine, no data loss.
+
+## Open Questions
+
+- None blocking. Relative-time granularity (e.g. "today" vs "3 hours ago" vs
+  "just now") is left to implementation using the standard humanizer pattern
+  already used elsewhere in the CLI, if one exists; otherwise a minimal
+  buckets helper.

--- a/openspec/changes/approval-creation-timestamps/proposal.md
+++ b/openspec/changes/approval-creation-timestamps/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+When the daemon re-prompts an operator for a tool approval they believe they
+already granted, there is no way to confirm whether a matching grant exists or
+to diagnose why it failed to match. `ApprovalEntry` carries no temporal
+metadata (only `verb` + `directory`), and the approval gate logs nothing when a
+same-verb persisted grant is a near-miss. Operators cannot prove a duplicate
+prompt, and silent near-misses hide real matcher bugs (path normalization,
+symlink-segment rejection, case rules). This change adds the missing
+provenance: a creation timestamp on every new grant, plus loud diagnostics at
+the gate. Relevant PRDs: PRD-002 (gateway security envelope), PRD-003 (operator
+ops console), PRD-004 (CLI).
+
+## What Changes
+
+- Add an optional `createdAt` (`DateTimeOffset?`) field to `ApprovalEntry`.
+  New grants are stamped at write time in `ToolApprovalStore.AddApproval` via
+  an injected `TimeProvider`. Entries already on disk read back as `null`
+  ("added before timestamps were tracked").
+- **No schema-version bump.** `createdAt` is an additive optional field that
+  is backward- and forward-compatible. Bumping `tool-approvals.json` from
+  `version: 2` to `3` would quarantine every existing file to `.v1.bak` and
+  wipe all persisted grants, because `IsCurrentSchema` requires exactly `2`.
+- `ToolApprovalEntryComparer` continues to compare `verb` + `directory` only.
+  Idempotent re-grants of an existing approval keep the **original**
+  timestamp; `Normalize` passes `createdAt` through unchanged.
+- Add a near-miss diagnostic at the approval gate: when a pattern is
+  unapproved but a persisted entry exists with the **same verb**, the daemon
+  logs why it did not match (cwd not under the grant's directory, symlink
+  segment along the path, or verb case mismatch), including the grant's
+  `createdAt`. Diagnostics go to the daemon log only — no change to the
+  approval prompt body.
+- Surface creation time as relative text ("added 3 days ago", "added —" for
+  null) in the `netclaw approvals` interactive TUI list and the
+  `netclaw approvals list` CLI output. The `--json` output exposes the raw
+  `createdAt` field.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. This change modifies existing capabilities only. -->
+
+### Modified Capabilities
+
+- `tool-approval-gates`: adds a requirement for an optional `createdAt` field
+  on `ApprovalEntry`, and a requirement for near-miss approval-gate
+  diagnostics.
+- `netclaw-cli`: adds a requirement for creation-time display in both the
+  `netclaw approvals list` output and the interactive `netclaw approvals` TUI
+  (the TUI is specced under this capability, not `netclaw-operator-ui`).
+
+## Impact
+
+- `Netclaw.Configuration`: `ApprovalEntry` (new field), `ToolApprovalStore`
+  (constructor gains `TimeProvider`; `AddApproval` stamps `createdAt`),
+  `ToolApprovalEntryComparer` (`Normalize` passes `createdAt` through;
+  equality unchanged).
+- `Netclaw.Security`: `ApprovalPatternMatching` gains a diagnostic-producing
+  method that explains same-verb near-misses without changing match results.
+- `Netclaw.Actors`: `ToolApprovalActor` logs near-miss diagnostics; DI wiring
+  passes `TimeProvider` into `ToolApprovalStore`.
+- `Netclaw.Cli`: `ApprovalsManagerViewModel` / approvals TUI view and
+  `netclaw approvals list` rendering show relative creation time. TUI change
+  requires the interactive tape harness per the testing policy.
+- DI / construction sites of `ToolApprovalStore` (daemon host, CLI, TUI,
+  tests) must supply a `TimeProvider`.
+- `tool-approvals.json` on-disk format: additive optional `createdAt`,
+  `version` stays `2`. No migration, no quarantine.
+- System skill `netclaw-operations` (CLI/diagnostics surface changed).
+- No security-posture change: diagnostics are read-only logging; the matcher's
+  decisions are untouched.

--- a/openspec/changes/approval-creation-timestamps/specs/netclaw-cli/spec.md
+++ b/openspec/changes/approval-creation-timestamps/specs/netclaw-cli/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Approval surfaces show grant creation time
+
+The `netclaw approvals` inspection surfaces SHALL display when each
+persisted grant was created. Both the `netclaw approvals list` command
+and the interactive `netclaw approvals` Termina TUI list SHALL derive
+this from the `ApprovalEntry.createdAt` field.
+
+Human-readable output (the default `list` rendering and the TUI list
+rows) SHALL render the creation time as relative text — for example
+`added 3 days ago`. An entry whose `createdAt` is `null` (a grant
+written before timestamp tracking) SHALL render a stable placeholder
+(`added —`) rather than a fabricated or omitted value. The creation-time
+text SHALL NOT be mixed into the scope label column; it is presented as
+distinct per-entry metadata.
+
+`netclaw approvals list --json` SHALL expose the raw `createdAt` value
+on each entry — an ISO-8601 string when present, `null` otherwise — so
+scripts can compare it against daemon log timestamps. The JSON output
+SHALL remain a superset of the previous shape: existing `verb` and
+`directory` fields are unchanged.
+
+#### Scenario: List shows relative creation time
+
+- **GIVEN** `tool-approvals.json` contains an entry whose `createdAt` is
+  three days before now
+- **WHEN** the operator runs `netclaw approvals list`
+- **THEN** the entry's row includes relative text such as `added 3 days ago`
+
+#### Scenario: Entry without a timestamp shows a placeholder
+
+- **GIVEN** `tool-approvals.json` contains an entry with no `createdAt`
+- **WHEN** the operator runs `netclaw approvals list`
+- **THEN** the entry's row shows the `added —` placeholder
+- **AND** the command exits with code `0`
+
+#### Scenario: JSON output exposes the raw timestamp
+
+- **GIVEN** `tool-approvals.json` contains one entry with a `createdAt`
+  and one without
+- **WHEN** the operator runs `netclaw approvals list --json`
+- **THEN** the first entry's JSON object includes a `createdAt`
+  ISO-8601 string
+- **AND** the second entry's `createdAt` is `null`
+
+#### Scenario: TUI list shows creation time per entry
+
+- **GIVEN** the operator launches the interactive `netclaw approvals` TUI
+- **AND** `tool-approvals.json` contains at least one timestamped entry
+- **WHEN** the approvals list page renders
+- **THEN** each row shows the grant's relative creation time alongside
+  its scope label

--- a/openspec/changes/approval-creation-timestamps/specs/tool-approval-gates/spec.md
+++ b/openspec/changes/approval-creation-timestamps/specs/tool-approval-gates/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Approval entry creation timestamp
+
+`ApprovalEntry` SHALL carry an optional `createdAt` field — a
+`DateTimeOffset` serialized as the ISO-8601 JSON property `createdAt` —
+recording when the grant was first persisted. The field SHALL be
+populated by `ToolApprovalStore.AddApproval` at write time using an
+injected `TimeProvider` (`TimeProvider.System` in production), so the
+daemon and the operator CLI stamp grants identically.
+
+The `createdAt` field SHALL be additive and optional on disk. Reading a
+`tool-approvals.json` file whose entries lack `createdAt` SHALL succeed
+and yield entries with a `null` timestamp. The on-disk schema version
+SHALL remain `2`; adding `createdAt` SHALL NOT bump the version and
+SHALL NOT cause an existing file to be quarantined.
+
+`createdAt` SHALL NOT participate in approval-entry equality. Two
+entries with the same verb and directory but different (or absent)
+timestamps SHALL still be considered the same grant by
+`ToolApprovalEntryComparer`. `AddApproval` SHALL remain idempotent: when
+an equivalent grant already exists, the existing entry — and therefore
+its original `createdAt` — SHALL be left in place and SHALL NOT be
+restamped.
+
+#### Scenario: New grant is stamped with the current time
+
+- **GIVEN** a `ToolApprovalStore` constructed with a `TimeProvider`
+- **WHEN** `AddApproval` persists a new `(verb, directory)` entry
+- **THEN** the stored entry's `createdAt` equals the provider's current
+  time
+- **AND** the serialized JSON includes a `createdAt` property
+
+#### Scenario: Legacy entry without a timestamp reads back as null
+
+- **GIVEN** a `version: 2` `tool-approvals.json` whose entries have no
+  `createdAt` property
+- **WHEN** the store loads the file
+- **THEN** each entry's `createdAt` is `null`
+- **AND** the file is NOT quarantined to `tool-approvals.json.v1.bak`
+- **AND** the store's schema version remains `2`
+
+#### Scenario: Idempotent re-grant preserves the original timestamp
+
+- **GIVEN** a persisted entry `(git push, /home/user/repos/foo)` stamped
+  at time T1
+- **WHEN** `AddApproval` is called again for the same verb and directory
+  at a later time T2
+- **THEN** `AddApproval` reports no new entry was appended
+- **AND** the stored entry's `createdAt` is still T1
+
+#### Scenario: Timestamp does not affect matching or equality
+
+- **GIVEN** a persisted entry `(git push, null)` stamped at any time
+- **WHEN** the agent invokes `git push` and the matcher evaluates the
+  entry
+- **THEN** the match result is identical to the result for an entry with
+  a `null` `createdAt`
+- **AND** `ToolApprovalEntryComparer.Equals` treats the two entries as
+  equal
+
+### Requirement: Approval-gate near-miss diagnostics
+
+The approval gate SHALL log a near-miss diagnostic when it marks a
+candidate pattern unapproved AND at least one persisted `ApprovalEntry`
+exists for the same audience and tool whose `verb` equals the
+candidate's verb chain. The diagnostic SHALL explain why each same-verb
+grant failed to match and SHALL identify the grant (verb, directory
+scope, and `createdAt`) and the reason it did not match — for example
+the candidate's effective directory is not under the grant's directory,
+a symlink segment lies along the path between the grant directory and
+the effective directory, or the verbs differ only by case.
+
+The diagnostic SHALL be emitted to the daemon log only. It SHALL NOT
+appear in the approval prompt body and SHALL NOT alter the gate's
+decision — it is read-only instrumentation. When no persisted entry
+shares the candidate's verb, no near-miss diagnostic SHALL be emitted
+(a first-time prompt has nothing to diagnose).
+
+#### Scenario: Directory-scoped near-miss is logged
+
+- **GIVEN** a persisted entry `(git push, /home/user/repos/foo)`
+- **WHEN** the agent invokes `git push` with cwd
+  `/home/user/repos/bar` and the gate marks it unapproved
+- **THEN** the daemon logs a near-miss diagnostic naming the grant, its
+  `createdAt`, and the reason the cwd is not under the grant directory
+- **AND** the approval prompt body is unchanged
+
+#### Scenario: First-time prompt emits no near-miss diagnostic
+
+- **GIVEN** no persisted entry exists whose verb equals `terraform apply`
+- **WHEN** the agent invokes `terraform apply` and the gate marks it
+  unapproved
+- **THEN** no near-miss diagnostic is logged
+- **AND** the approval prompt is emitted normally
+
+#### Scenario: Diagnostic does not change the gate decision
+
+- **GIVEN** a persisted entry whose verb matches the candidate but whose
+  directory does not
+- **WHEN** the gate evaluates the candidate
+- **THEN** the candidate remains unapproved
+- **AND** the user is still prompted

--- a/openspec/changes/approval-creation-timestamps/tasks.md
+++ b/openspec/changes/approval-creation-timestamps/tasks.md
@@ -1,0 +1,85 @@
+## 1. Configuration: `createdAt` field and write-time stamping
+
+- [x] 1.1 Add `DateTimeOffset? CreatedAt { get; init; }` to `ApprovalEntry`
+  with `[JsonPropertyName("createdAt")]` and an XML doc-comment noting it is
+  optional, null for pre-feature entries, and excluded from approval equality.
+- [x] 1.2 In `ToolApprovalEntryComparer.Normalize`, ensure `CreatedAt` is
+  carried through unchanged (the `entry with { ... }` path must not drop it);
+  confirm `Equals` still compares verb + directory only.
+- [x] 1.3 Add an optional `TimeProvider? timeProvider = null` parameter to the
+  `ToolApprovalStore` constructor, resolving to `TimeProvider.System`.
+- [x] 1.4 In `ToolApprovalStore.AddApproval`, stamp `CreatedAt` with
+  `timeProvider.GetUtcNow()` when the (normalized) entry's `CreatedAt` is
+  null; leave a non-null incoming value untouched. Ensure the idempotent
+  "already exists" branch does not restamp the existing entry.
+- [x] 1.5 Confirm `version` stays `2` and `IsCurrentSchema` is unchanged;
+  verify a v2 file with no `createdAt` properties is not quarantined.
+
+## 2. Security: near-miss explainer
+
+- [x] 2.1 Add a pure method to `ApprovalPatternMatching` that, given an
+  unapproved shell candidate (verb, candidate directory, cwd) and the
+  persisted entries, returns same-verb near-misses with a classified reason
+  (directory-not-under-grant, symlink-segment-on-path, verb-case-mismatch).
+  Reuse the path/symlink logic from `MatchesShellApproval` so the diagnostic
+  cannot drift from the matcher.
+- [x] 2.2 Cover the case where a persisted entry's verb equals the candidate
+  only under case-insensitive comparison but not under the platform comparer
+  (verb-case-mismatch), so POSIX case rules are explained.
+
+## 3. Actors: gate-side diagnostic logging
+
+- [x] 3.1 Add an `ILoggingAdapter` (`Context.GetLogger()`) to
+  `ToolApprovalActor`.
+- [x] 3.2 In the `GetUnapprovedPatterns` handler, for each pattern reported
+  unapproved, invoke the explainer and log one diagnostic line per near-miss
+  including the grant's verb, directory scope, `CreatedAt`, and reason. Emit
+  nothing when there is no same-verb persisted entry.
+- [x] 3.3 Verify the diagnostic runs only on the unapproved branch and does
+  not alter `UnapprovedPatternsResponse`.
+- [x] 3.4 Pass a `TimeProvider` into `ToolApprovalStore` at the daemon
+  construction site (`Netclaw.Daemon/Program.cs`) — `TimeProvider.System` or
+  the daemon's existing injected provider if one is in scope.
+
+## 4. CLI and TUI: creation-time display
+
+- [x] 4.1 Add a relative-time formatter for `DateTimeOffset?` returning
+  `added <relative>` for a value and `added —` for null. Reuse an existing
+  CLI humanizer if one exists; otherwise add a minimal buckets helper.
+- [x] 4.2 Render the relative creation time per entry in `netclaw approvals
+  list` human output (`ApprovalsCommand` / `ApprovalsListView` rendering),
+  as distinct metadata, not mixed into the scope-label column.
+- [x] 4.3 Confirm `netclaw approvals list --json` carries `createdAt` on each
+  entry (raw ISO-8601, or absent-as-null consistent with `directory`).
+- [x] 4.4 Show the relative creation time in the `netclaw approvals` TUI list
+  rows (`ApprovalsManagerViewModel.ApprovalDisplayItem` / approvals page
+  view).
+
+## 5. Tests
+
+- [x] 5.1 `ToolApprovalStore` tests: new grant stamped via `FakeTimeProvider`;
+  legacy v2 file (no `createdAt`) loads with null and is not quarantined;
+  idempotent re-grant preserves the original `CreatedAt`.
+- [x] 5.2 `ToolApprovalEntryComparer` test: entries differing only by
+  `CreatedAt` compare equal; `Normalize` preserves `CreatedAt`.
+- [x] 5.3 `ApprovalPatternMatching` explainer tests: directory-not-under-grant,
+  symlink-segment, and verb-case-mismatch near-misses each classified;
+  no near-miss when no same-verb entry exists.
+- [x] 5.4 `ToolApprovalActor` test: a same-verb directory near-miss produces a
+  log line and does not change the unapproved result.
+- [x] 5.5 CLI tests: `list` shows relative time and the `added —` placeholder;
+  `list --json` round-trips `createdAt`.
+- [x] 5.6 No VHS tape covers the `netclaw approvals` page; the page is
+  validated by the headless xUnit Termina test
+  `ApprovalsManagerPageTests.ListView_ShowsRelativeCreationTime`, which drives
+  the real render pipeline via `VirtualTerminal` and asserts the new "Added"
+  column and relative text.
+
+## 6. Quality gates and docs
+
+- [x] 6.1 Update the `netclaw-operations` system skill if CLI approval-output
+  guidance references the `approvals list` shape.
+- [x] 6.2 Run `dotnet slopwatch analyze` — no new violations.
+- [x] 6.3 Run `./scripts/Add-FileHeaders.ps1 -Verify` for any new `.cs` files.
+- [ ] 6.4 `openspec validate approval-creation-timestamps --strict` passes
+  (done); archive the change once it is merged and verified.

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalActorTests.cs
@@ -33,6 +33,9 @@ public sealed class ToolApprovalActorTests : TestKit
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
+        // The near-miss diagnostic is emitted at Info; make the level
+        // explicit so the EventFilter assertion is deterministic.
+        builder.AddHocon("akka.loglevel = INFO", HoconAddMode.Prepend);
     }
 
     [Fact]
@@ -307,6 +310,71 @@ public sealed class ToolApprovalActorTests : TestKit
         var unapproved = await service.GetUnapprovedPatternsAsync(subAgentScope, TrustAudience.Personal, new ToolName("shell_execute"), ["git push"], cwd: null, ct);
 
         Assert.Equal(["git push"], unapproved);
+    }
+
+    [Fact]
+    public async Task Directory_near_miss_is_logged_without_changing_the_decision()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            // Lexical containment only — the directories need not exist.
+            var grantDir = Path.Combine(Path.GetTempPath(), "netclaw-nearmiss", "grant");
+            var otherDir = Path.Combine(Path.GetTempPath(), "netclaw-nearmiss", "other");
+
+            var store = new ToolApprovalStore(tempFile);
+            store.AddApproval(TrustAudience.Personal, "shell_execute",
+                new ApprovalEntry { Verb = "git push", Directory = grantDir });
+
+            var actor = Sys.ActorOf(ToolApprovalActor.CreateProps(store));
+            var service = CreateService(actor);
+
+            IReadOnlyList<string> unapproved = [];
+            await EventFilter.Info(contains: "near-miss").ExpectOneAsync(async () =>
+            {
+                unapproved = await service.GetUnapprovedPatternsAsync(
+                    "session-a", TrustAudience.Personal, new ToolName("shell_execute"),
+                    ["git push"], cwd: otherDir, ct);
+            }, cancellationToken: ct);
+
+            // The diagnostic is read-only: the candidate is still unapproved.
+            Assert.Equal(["git push"], unapproved);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task First_time_prompt_emits_no_near_miss_diagnostic()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            // Store holds an unrelated verb, so the prompted verb has no
+            // same-verb grant to explain.
+            var store = new ToolApprovalStore(tempFile);
+            store.AddApproval(TrustAudience.Personal, "shell_execute",
+                new ApprovalEntry { Verb = "npm install", Directory = null });
+
+            var actor = Sys.ActorOf(ToolApprovalActor.CreateProps(store));
+            var service = CreateService(actor);
+
+            await EventFilter.Info(contains: "near-miss").ExpectAsync(0, async () =>
+            {
+                var unapproved = await service.GetUnapprovedPatternsAsync(
+                    "session-a", TrustAudience.Personal, new ToolName("shell_execute"),
+                    ["terraform apply"], cwd: null, ct);
+                Assert.Equal(["terraform apply"], unapproved);
+            }, cancellationToken: ct);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     private static AkkaToolApprovalService CreateService(IActorRef actor)

--- a/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
+++ b/src/Netclaw.Actors/Tools/ToolApprovalActor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Akka.Actor;
+using Akka.Event;
 using Netclaw.Actors.Protocol;
 using Netclaw.Configuration;
 using Netclaw.Security;
@@ -15,6 +16,7 @@ internal sealed class ToolApprovalActor : ReceiveActor
 {
     private readonly ToolApprovalStore? _persistentStore;
     private readonly Dictionary<string, Dictionary<string, HashSet<string>>> _sessionApprovals = new(StringComparer.Ordinal);
+    private readonly ILoggingAdapter _log = Context.GetLogger();
 
     public ToolApprovalActor(ToolApprovalStore? persistentStore = null)
     {
@@ -35,7 +37,10 @@ internal sealed class ToolApprovalActor : ReceiveActor
             foreach (var pattern in msg.Patterns)
             {
                 if (!IsApproved(msg.SessionId, msg.Audience, msg.ToolName, pattern, msg.Cwd, approved))
+                {
                     unapproved.Add(pattern);
+                    LogApprovalNearMisses(msg.ToolName, pattern, msg.Cwd, approved);
+                }
             }
 
             Sender.Tell(new UnapprovedPatternsResponse(unapproved));
@@ -129,6 +134,34 @@ internal sealed class ToolApprovalActor : ReceiveActor
         => string.Equals(toolName.Value, ShellTool.ToolName, StringComparison.Ordinal)
             ? ApprovalPatternMatching.MatchesShellApproval(candidateVerb, cwd, approved)
             : ApprovalPatternMatching.MatchesAny(candidateVerb, approved);
+
+    /// <summary>
+    /// Emits a diagnostic when a shell pattern is prompted for despite a
+    /// persisted grant existing for the same verb — the operator's
+    /// "I already approved this" case. Read-only: it does not affect the
+    /// gate decision. Non-shell tools authorize on a verb match alone, so a
+    /// same-verb persisted entry would have approved them; nothing to explain.
+    /// </summary>
+    private void LogApprovalNearMisses(ToolName toolName, string candidateVerb, string? cwd, IReadOnlyList<ApprovalEntry> approved)
+    {
+        if (!string.Equals(toolName.Value, ShellTool.ToolName, StringComparison.Ordinal))
+            return;
+
+        var nearMisses = ApprovalPatternMatching.ExplainShellNearMisses(
+            candidateVerb, candidateDirectory: null, cwd, approved);
+
+        foreach (var miss in nearMisses)
+        {
+            _log.Info(
+                "Approval near-miss for {0} '{1}' (cwd '{2}'): prompted despite persisted grant '{3}' (added {4}) — {5}",
+                toolName.Value,
+                candidateVerb,
+                cwd ?? "(none)",
+                miss.Grant.FormatScope(),
+                miss.Grant.CreatedAt?.ToString("u") ?? "unknown",
+                miss.Describe());
+        }
+    }
 
     private static string BuildSessionKey(SessionId sessionId, TrustAudience audience)
         => $"{sessionId.Value}|{audience.ToWireValue()}";

--- a/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Approvals/ApprovalsCommandTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Cli.Approvals;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -16,13 +17,14 @@ public sealed class ApprovalsCommandTests : IDisposable
     private readonly DisposableTempDir _dir = new();
     private readonly NetclawPaths _paths;
     private readonly StringWriter _output = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
     private readonly ToolApprovalStore _store;
 
     public ApprovalsCommandTests()
     {
         _paths = new NetclawPaths(_dir.Path);
         _paths.EnsureDirectoriesExist();
-        _store = new ToolApprovalStore(_paths.ToolApprovalsPath);
+        _store = new ToolApprovalStore(_paths.ToolApprovalsPath, _time);
     }
 
     public void Dispose()
@@ -89,6 +91,72 @@ public sealed class ApprovalsCommandTests : IDisposable
 
         var gitPush = personalShell.EnumerateArray().Single(e => e.GetProperty("verb").GetString() == "git push");
         Assert.False(gitPush.TryGetProperty("directory", out _));
+    }
+
+    [Fact]
+    public async Task List_shows_relative_creation_time()
+    {
+        // SeedDefault stamps entries at the fake clock; advancing it makes
+        // the rendered relative age deterministic.
+        SeedDefault();
+        _time.Advance(TimeSpan.FromDays(3));
+
+        var exit = await ApprovalsCommand.RunAsync(["approvals", "list"], _paths, _output, _time);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("added 3 days ago", _output.ToString());
+    }
+
+    [Fact]
+    public async Task List_shows_placeholder_for_entry_without_a_timestamp()
+    {
+        // A v2 file written before timestamp tracking: the entry has no
+        // createdAt property.
+        File.WriteAllText(_paths.ToolApprovalsPath, """
+            {
+              "version": 2,
+              "audiences": { "personal": { "shell_execute": [ { "verb": "git push" } ] } }
+            }
+            """);
+
+        var exit = await ApprovalsCommand.RunAsync(["approvals", "list"], _paths, _output, _time);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("added —", _output.ToString());
+    }
+
+    [Fact]
+    public async Task List_json_round_trips_createdAt()
+    {
+        File.WriteAllText(_paths.ToolApprovalsPath, """
+            {
+              "version": 2,
+              "audiences": {
+                "personal": {
+                  "shell_execute": [
+                    { "verb": "git push", "directory": null, "createdAt": "2026-05-01T12:00:00+00:00" },
+                    { "verb": "npm install", "directory": null }
+                  ]
+                }
+              }
+            }
+            """);
+
+        await ApprovalsCommand.RunAsync(["approvals", "list", "--json"], _paths, _output, _time);
+
+        using var doc = JsonDocument.Parse(_output.ToString());
+        var entries = doc.RootElement
+            .GetProperty("audiences").GetProperty("personal").GetProperty("shell_execute");
+
+        var stamped = entries.EnumerateArray().Single(e => e.GetProperty("verb").GetString() == "git push");
+        Assert.True(stamped.TryGetProperty("createdAt", out var createdAt));
+        Assert.Equal(
+            new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+            createdAt.GetDateTimeOffset());
+
+        // An entry written before timestamp tracking omits the field.
+        var legacy = entries.EnumerateArray().Single(e => e.GetProperty("verb").GetString() == "npm install");
+        Assert.False(legacy.TryGetProperty("createdAt", out _));
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ApprovalsManagerPageTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Netclaw.Cli.Tui;
 using Netclaw.Configuration;
 using Netclaw.Tests.Utilities;
@@ -26,12 +27,13 @@ public sealed class ApprovalsManagerPageTests : IDisposable
     private readonly DisposableTempDir _dir = new();
     private readonly NetclawPaths _paths;
     private readonly ToolApprovalStore _store;
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
 
     public ApprovalsManagerPageTests()
     {
         _paths = new NetclawPaths(_dir.Path);
         _paths.EnsureDirectoriesExist();
-        _store = new ToolApprovalStore(_paths.ToolApprovalsPath);
+        _store = new ToolApprovalStore(_paths.ToolApprovalsPath, _time);
     }
 
     public void Dispose() => _dir.Dispose();
@@ -75,6 +77,26 @@ public sealed class ApprovalsManagerPageTests : IDisposable
             $"Expected directory '/tmp/scratch'. Screen:\n{terminal}");
         Assert.True(terminal.Contains("ls anywhere"),
             $"Expected entry 'ls anywhere' (public audience). Screen:\n{terminal}");
+    }
+
+    [Fact]
+    public async Task ListView_ShowsRelativeCreationTime()
+    {
+        // The grant is stamped at the fake clock; advancing it makes the
+        // rendered relative age deterministic.
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("git push"));
+        _time.Advance(TimeSpan.FromDays(3));
+
+        var (terminal, app, _) = CreateHeadlessApp(out var input);
+        input.EnqueueKey(ConsoleKey.Q, false, false, true);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await app.RunAsync(cts.Token);
+
+        Assert.True(terminal.Contains("Added"),
+            $"Expected an 'Added' column header. Screen:\n{terminal}");
+        Assert.True(terminal.Contains("added 3 days ago"),
+            $"Expected relative creation time 'added 3 days ago'. Screen:\n{terminal}");
     }
 
     [Fact]
@@ -157,7 +179,7 @@ public sealed class ApprovalsManagerPageTests : IDisposable
                 _ => new ApprovalsManagerPage(),
                 _ =>
                 {
-                    capturedVm = new ApprovalsManagerViewModel(_paths);
+                    capturedVm = new ApprovalsManagerViewModel(_paths, _time);
                     return capturedVm;
                 });
         });

--- a/src/Netclaw.Cli/Approvals/ApprovalTimeText.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalTimeText.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalTimeText.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Cli.Approvals;
+
+/// <summary>
+/// Renders an <see cref="Netclaw.Configuration.ApprovalEntry.CreatedAt"/>
+/// value as the relative "added ..." text shown by <c>netclaw approvals
+/// list</c> and the interactive approvals TUI. A <c>null</c> timestamp — a
+/// grant written before approval timestamps were tracked — renders the fixed
+/// <c>added —</c> placeholder rather than a fabricated or blank value.
+/// </summary>
+internal static class ApprovalTimeText
+{
+    public static string Added(DateTimeOffset? createdAt, DateTimeOffset now)
+        => createdAt is { } ts ? $"added {Relative(ts, now)}" : "added —";
+
+    private static string Relative(DateTimeOffset then, DateTimeOffset now)
+    {
+        var elapsed = now - then;
+
+        // Clock skew (a timestamp ahead of "now") collapses to "just now"
+        // rather than rendering a negative age.
+        if (elapsed < TimeSpan.FromMinutes(1)) return "just now";
+        if (elapsed < TimeSpan.FromHours(1)) return Plural((int)elapsed.TotalMinutes, "minute");
+        if (elapsed < TimeSpan.FromDays(1)) return Plural((int)elapsed.TotalHours, "hour");
+        if (elapsed < TimeSpan.FromDays(30)) return Plural((int)elapsed.TotalDays, "day");
+        if (elapsed < TimeSpan.FromDays(365)) return Plural((int)(elapsed.TotalDays / 30), "month");
+        return Plural((int)(elapsed.TotalDays / 365), "year");
+    }
+
+    private static string Plural(int count, string unit)
+        => count <= 1 ? $"1 {unit} ago" : $"{count} {unit}s ago";
+}

--- a/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
+++ b/src/Netclaw.Cli/Approvals/ApprovalsCommand.cs
@@ -28,27 +28,29 @@ internal static class ApprovalsCommand
     public static Task<int> RunAsync(
         string[] args,
         NetclawPaths paths,
-        TextWriter? output = null)
+        TextWriter? output = null,
+        TimeProvider? timeProvider = null)
     {
         var writer = output ?? Console.Out;
+        var clock = timeProvider ?? TimeProvider.System;
         var subcommand = args.Length > 1 ? args[1] : "help";
 
         return subcommand switch
         {
-            "list" => Task.FromResult(RunList(args, paths, writer)),
-            "revoke" => Task.FromResult(RunRevoke(args, paths, writer)),
-            "trust-verb" => Task.FromResult(RunTrustVerb(args, paths, writer)),
+            "list" => Task.FromResult(RunList(args, paths, writer, clock)),
+            "revoke" => Task.FromResult(RunRevoke(args, paths, writer, clock)),
+            "trust-verb" => Task.FromResult(RunTrustVerb(args, paths, writer, clock)),
             "help" or "-h" or "--help" => Task.FromResult(WriteHelp(writer)),
             _ => Task.FromResult(WriteHelp(writer)),
         };
     }
 
-    private static int RunList(string[] args, NetclawPaths paths, TextWriter writer)
+    private static int RunList(string[] args, NetclawPaths paths, TextWriter writer, TimeProvider clock)
     {
         if (TryParseListFlags(args, writer) is not { } opts)
             return 1;
 
-        var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        var store = new ToolApprovalStore(paths.ToolApprovalsPath, clock);
         WarnIfQuarantined(store, writer);
 
         var view = BuildView(store.Snapshot(), opts.Audience, opts.Tool);
@@ -65,6 +67,7 @@ internal static class ApprovalsCommand
             return 0;
         }
 
+        var now = clock.GetUtcNow();
         var first = true;
         foreach (var (audienceKey, tools) in view.Audiences)
         {
@@ -72,8 +75,10 @@ internal static class ApprovalsCommand
             {
                 if (!first) writer.WriteLine();
                 writer.WriteLine($"{audienceKey} / {toolName}");
-                foreach (var entry in entries)
-                    writer.WriteLine($"  {entry.FormatScope()}");
+                var rows = entries.Select(e => (Scope: e.FormatScope(), e.CreatedAt)).ToList();
+                var scopeWidth = rows.Count == 0 ? 0 : rows.Max(r => r.Scope.Length);
+                foreach (var (scope, createdAt) in rows)
+                    writer.WriteLine($"  {scope.PadRight(scopeWidth)}   {ApprovalTimeText.Added(createdAt, now)}");
                 first = false;
             }
         }
@@ -81,7 +86,7 @@ internal static class ApprovalsCommand
         return 0;
     }
 
-    private static int RunRevoke(string[] args, NetclawPaths paths, TextWriter writer)
+    private static int RunRevoke(string[] args, NetclawPaths paths, TextWriter writer, TimeProvider clock)
     {
         if (TryParseRevokeFlags(args, writer) is not { } opts)
             return 1;
@@ -93,7 +98,7 @@ internal static class ApprovalsCommand
             return 1;
         }
 
-        var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        var store = new ToolApprovalStore(paths.ToolApprovalsPath, clock);
         WarnIfQuarantined(store, writer);
 
         if (opts.RevokeAll)
@@ -150,7 +155,7 @@ internal static class ApprovalsCommand
         return 0;
     }
 
-    private static int RunTrustVerb(string[] args, NetclawPaths paths, TextWriter writer)
+    private static int RunTrustVerb(string[] args, NetclawPaths paths, TextWriter writer, TimeProvider clock)
     {
         if (TryParseTrustVerbFlags(args, writer) is not { } opts)
             return 1;
@@ -170,7 +175,7 @@ internal static class ApprovalsCommand
             return 1;
         }
 
-        var store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        var store = new ToolApprovalStore(paths.ToolApprovalsPath, clock);
         WarnIfQuarantined(store, writer);
 
         var entry = new ApprovalEntry { Verb = opts.Verb, Directory = null };

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerPage.cs
@@ -127,7 +127,7 @@ public sealed class ApprovalsManagerPage : ReactivePage<ApprovalsManagerViewMode
     private ILayoutNode BuildListView()
     {
         var rows = ViewModel.DisplayApprovals
-            .Select(item => $"{item.AudienceWire,-10} {item.ToolName,-20} {item.DisplayText}")
+            .Select(item => $"{item.AudienceWire,-10} {item.ToolName,-20} {item.DisplayText,-44} {item.AddedText}")
             .ToList();
 
         _approvalList = Layouts.SelectionList(rows)
@@ -149,7 +149,7 @@ public sealed class ApprovalsManagerPage : ReactivePage<ApprovalsManagerViewMode
             .DisposeWith(_stepSubs);
 
         return Layouts.Vertical()
-            .WithChild(new TextNode($"  {"Audience",-10} {"Tool",-20} Approval")
+            .WithChild(new TextNode($"  {"Audience",-10} {"Tool",-20} {"Approval",-44} Added")
                 .WithForeground(Color.White).Bold())
             .WithChild(_approvalList);
     }

--- a/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ApprovalsManagerViewModel.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Cli.Approvals;
 using Netclaw.Configuration;
 using R3;
 using Termina.Reactive;
@@ -20,7 +21,8 @@ public enum ApprovalsManagerState
 public sealed record ApprovalDisplayItem(
     TrustAudience Audience,
     string ToolName,
-    ApprovalEntry Entry)
+    ApprovalEntry Entry,
+    string AddedText)
 {
     public string AudienceWire => Audience.ToWireValue();
     public string DisplayText => Entry.FormatScope();
@@ -35,10 +37,12 @@ public sealed record ApprovalDisplayItem(
 public sealed class ApprovalsManagerViewModel : ReactiveViewModel
 {
     private readonly ToolApprovalStore _store;
+    private readonly TimeProvider _timeProvider;
 
-    public ApprovalsManagerViewModel(NetclawPaths paths)
+    public ApprovalsManagerViewModel(NetclawPaths paths, TimeProvider timeProvider)
     {
-        _store = new ToolApprovalStore(paths.ToolApprovalsPath);
+        _timeProvider = timeProvider;
+        _store = new ToolApprovalStore(paths.ToolApprovalsPath, timeProvider);
     }
 
     public ReactiveProperty<ApprovalsManagerState> CurrentState { get; } = new(ApprovalsManagerState.Loading);
@@ -60,6 +64,7 @@ public sealed class ApprovalsManagerViewModel : ReactiveViewModel
     {
         DisplayApprovals.Clear();
         var snapshot = _store.Snapshot();
+        var now = _timeProvider.GetUtcNow();
 
         foreach (var audienceKey in snapshot.Keys.OrderBy(k => k, StringComparer.Ordinal))
         {
@@ -73,7 +78,8 @@ public sealed class ApprovalsManagerViewModel : ReactiveViewModel
                     .OrderBy(static e => e.Verb, StringComparer.Ordinal)
                     .ThenBy(static e => e.Directory ?? string.Empty, StringComparer.Ordinal))
                 {
-                    DisplayApprovals.Add(new ApprovalDisplayItem(audience, toolName, entry));
+                    DisplayApprovals.Add(new ApprovalDisplayItem(
+                        audience, toolName, entry, ApprovalTimeText.Added(entry.CreatedAt, now)));
                 }
             }
         }

--- a/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
+++ b/src/Netclaw.Configuration.Tests/ToolApprovalStoreTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Netclaw.Configuration.Tests;
@@ -10,12 +11,13 @@ namespace Netclaw.Configuration.Tests;
 public sealed class ToolApprovalStoreTests : IDisposable
 {
     private readonly string _file;
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
     private readonly ToolApprovalStore _store;
 
     public ToolApprovalStoreTests()
     {
         _file = Path.Combine(Path.GetTempPath(), $"netclaw-approvals-{Guid.NewGuid():N}.json");
-        _store = new ToolApprovalStore(_file);
+        _store = new ToolApprovalStore(_file, _time);
     }
 
     public void Dispose()
@@ -254,5 +256,65 @@ public sealed class ToolApprovalStoreTests : IDisposable
         Assert.Equal(2, reloaded.Count);
         Assert.Contains(reloaded, e => e.Verb == "freshdesk" && e.Directory is null);
         Assert.Contains(reloaded, e => e.Verb == "grep" && e.Directory == "/home/user/logs");
+    }
+
+    [Fact]
+    public void AddApproval_stamps_createdAt_with_the_provider_clock()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("git push"));
+
+        var entry = Assert.Single(_store.GetApprovedEntries(TrustAudience.Personal, "shell_execute"));
+        Assert.Equal(_time.GetUtcNow(), entry.CreatedAt);
+    }
+
+    [Fact]
+    public void AddApproval_persists_createdAt_to_disk()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("freshdesk"));
+
+        Assert.Contains("\"createdAt\"", File.ReadAllText(_file));
+    }
+
+    [Fact]
+    public void AddApproval_idempotent_regrant_preserves_the_original_createdAt()
+    {
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("git push"));
+        var firstStamp = _time.GetUtcNow();
+
+        _time.Advance(TimeSpan.FromDays(7));
+        _store.AddApproval(TrustAudience.Personal, "shell_execute", Verb("git push"));
+
+        var entry = Assert.Single(_store.GetApprovedEntries(TrustAudience.Personal, "shell_execute"));
+        Assert.Equal(firstStamp, entry.CreatedAt);
+    }
+
+    [Fact]
+    public void Load_reads_v2_entries_without_createdAt_as_null_without_quarantine()
+    {
+        File.WriteAllText(_file, """
+            {
+              "version": 2,
+              "audiences": { "personal": { "shell_execute": [ { "verb": "git push" } ] } }
+            }
+            """);
+
+        var data = _store.Load();
+
+        Assert.Equal(ToolApprovalStore.CurrentSchemaVersion, data.Version);
+        var entry = Assert.Single(_store.GetApprovedEntries(TrustAudience.Personal, "shell_execute"));
+        Assert.Null(entry.CreatedAt);
+        Assert.True(File.Exists(_file));
+        Assert.False(File.Exists(_store.V1QuarantinePath));
+    }
+
+    [Fact]
+    public void ToolApprovalEntryComparer_treats_entries_differing_only_by_createdAt_as_equal()
+    {
+        var early = new ApprovalEntry { Verb = "git push", Directory = "/repo", CreatedAt = _time.GetUtcNow() };
+        var late = early with { CreatedAt = _time.GetUtcNow().AddYears(1) };
+        var none = early with { CreatedAt = null };
+
+        Assert.True(ToolApprovalEntryComparer.Equals(early, late));
+        Assert.True(ToolApprovalEntryComparer.Equals(early, none));
     }
 }

--- a/src/Netclaw.Configuration/ApprovalEntry.cs
+++ b/src/Netclaw.Configuration/ApprovalEntry.cs
@@ -48,6 +48,19 @@ public sealed record ApprovalEntry
     public string? Directory { get; init; }
 
     /// <summary>
+    /// When this grant was first persisted, or <c>null</c> for entries
+    /// written before approval timestamps were tracked. Stamped by
+    /// <see cref="ToolApprovalStore.AddApproval"/> at write time. This is an
+    /// additive, optional field — its presence does not change the on-disk
+    /// schema version. It is provenance only: it does NOT participate in
+    /// approval matching or in
+    /// <see cref="ToolApprovalEntryComparer.Equals(ApprovalEntry, ApprovalEntry)"/>,
+    /// so re-granting an existing approval keeps the original timestamp.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>
     /// The user-visible scope label emitted by <c>netclaw approvals list</c>
     /// and shown in the TUI. Folder-scoped entries render as
     /// <c>&lt;verb&gt; in &lt;dir&gt;</c>; global wildcards render as

--- a/src/Netclaw.Configuration/ToolApprovalStore.cs
+++ b/src/Netclaw.Configuration/ToolApprovalStore.cs
@@ -32,6 +32,7 @@ public sealed class ToolApprovalStore
     public const int CurrentSchemaVersion = 2;
 
     private readonly string _filePath;
+    private readonly TimeProvider _timeProvider;
     private readonly object _lock = new();
 
     // Cache state guarded by _lock. `_cachedData` is the live in-memory
@@ -75,9 +76,16 @@ public sealed class ToolApprovalStore
         AllowTrailingCommas = true
     };
 
-    public ToolApprovalStore(string filePath)
+    /// <param name="filePath">Path to <c>tool-approvals.json</c>.</param>
+    /// <param name="timeProvider">
+    /// Clock used to stamp <see cref="ApprovalEntry.CreatedAt"/> on newly
+    /// added grants. Defaults to <see cref="TimeProvider.System"/> in
+    /// production; tests pass a fake to assert on timestamps.
+    /// </param>
+    public ToolApprovalStore(string filePath, TimeProvider? timeProvider = null)
     {
         _filePath = filePath;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -258,7 +266,15 @@ public sealed class ToolApprovalStore
                     return false;
             }
 
-            entries.Add(normalized);
+            // Stamp creation time on the new grant only. An equivalent grant
+            // already on disk returns above without restamping, so re-granting
+            // an existing approval preserves its original CreatedAt. A non-null
+            // incoming CreatedAt (e.g. a hand-edited file) is left untouched.
+            var stamped = normalized.CreatedAt is null
+                ? normalized with { CreatedAt = _timeProvider.GetUtcNow() }
+                : normalized;
+
+            entries.Add(stamped);
             Save(data);
             return true;
         }

--- a/src/Netclaw.Daemon/Program.cs
+++ b/src/Netclaw.Daemon/Program.cs
@@ -525,7 +525,7 @@ static void ConfigureDaemonServices(
         safeVerbs);
     services.AddSingleton(toolAccessPolicy);
 
-    var toolApprovalStore = new ToolApprovalStore(paths.ToolApprovalsPath);
+    var toolApprovalStore = new ToolApprovalStore(paths.ToolApprovalsPath, TimeProvider.System);
     services.AddSingleton(toolApprovalStore);
     services.AddSingleton<IToolApprovalService, AkkaToolApprovalService>();
 

--- a/src/Netclaw.Security.Tests/ApprovalNearMissTests.cs
+++ b/src/Netclaw.Security.Tests/ApprovalNearMissTests.cs
@@ -1,0 +1,122 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalNearMissTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Configuration;
+using Xunit;
+
+namespace Netclaw.Security.Tests;
+
+/// <summary>
+/// Tests for <see cref="ApprovalPatternMatching.ExplainShellNearMisses"/>,
+/// the read-only diagnostic that explains why a persisted grant for the same
+/// verb failed to auto-approve a candidate.
+/// </summary>
+public sealed class ApprovalNearMissTests
+{
+    private static ApprovalEntry InDir(string verb, string dir) => new() { Verb = verb, Directory = dir };
+
+    private static ApprovalEntry Verb(string verb) => new() { Verb = verb, Directory = null };
+
+    [Fact]
+    public void DirectoryNotUnderGrant_is_reported_when_cwd_is_outside_the_grant()
+    {
+        var grant = InDir("git push", "/home/user/repos/foo");
+
+        var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+            "git push", candidateDirectory: null, cwd: "/home/user/repos/bar", [grant]);
+
+        var miss = Assert.Single(misses);
+        Assert.Equal(ApprovalNearMissReason.DirectoryNotUnderGrant, miss.Reason);
+        Assert.Same(grant, miss.Grant);
+        Assert.Contains("/home/user/repos/foo", miss.Describe());
+    }
+
+    [Fact]
+    public void No_near_miss_when_no_persisted_entry_shares_the_verb()
+    {
+        var unrelated = InDir("npm install", "/home/user/repos/foo");
+
+        var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+            "git push", candidateDirectory: null, cwd: "/home/user/repos/bar", [unrelated]);
+
+        Assert.Empty(misses);
+    }
+
+    [Fact]
+    public void NoCandidateDirectory_is_reported_for_a_folder_scoped_grant()
+    {
+        var grant = InDir("git push", "/home/user/repos/foo");
+
+        var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+            "git push", candidateDirectory: null, cwd: null, [grant]);
+
+        var miss = Assert.Single(misses);
+        Assert.Equal(ApprovalNearMissReason.NoCandidateDirectory, miss.Reason);
+    }
+
+    [Fact]
+    public void VerbCaseMismatch_is_reported_on_case_sensitive_filesystems()
+    {
+        // A global-wildcard grant for "Git" isolates the verb-case logic from
+        // any directory comparison.
+        var grant = Verb("Git");
+
+        var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+            "git", candidateDirectory: null, cwd: "/home/user/repos/foo", [grant]);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Windows folds case in the platform comparer, so the wildcard
+            // grant matches outright — there is nothing to explain.
+            Assert.Empty(misses);
+        }
+        else
+        {
+            var miss = Assert.Single(misses);
+            Assert.Equal(ApprovalNearMissReason.VerbCaseMismatch, miss.Reason);
+        }
+    }
+
+    [Fact]
+    public void SymlinkSegment_breaks_the_match_and_is_reported_as_a_near_miss()
+    {
+        // CreateSymbolicLink without elevation requires Developer Mode on
+        // Windows; POSIX is sufficient for regression coverage.
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var grantRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(grantRoot);
+        var leak = Path.Combine(grantRoot, "leak");
+        Directory.CreateSymbolicLink(leak, "/etc");
+
+        try
+        {
+            var grant = InDir("cat", grantRoot);
+
+            var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+                "cat", candidateDirectory: null, cwd: leak, [grant]);
+
+            var miss = Assert.Single(misses);
+            Assert.Equal(ApprovalNearMissReason.SymlinkSegmentOnPath, miss.Reason);
+        }
+        finally
+        {
+            File.Delete(leak);
+            Directory.Delete(grantRoot);
+        }
+    }
+
+    [Fact]
+    public void A_matching_global_wildcard_grant_is_not_a_near_miss()
+    {
+        // A (verb, null) grant would have approved the candidate outright, so
+        // it must never surface as a near-miss.
+        var misses = ApprovalPatternMatching.ExplainShellNearMisses(
+            "git push", candidateDirectory: null, cwd: "/anywhere", [Verb("git push")]);
+
+        Assert.Empty(misses);
+    }
+}

--- a/src/Netclaw.Security/ApprovalPatternMatching.cs
+++ b/src/Netclaw.Security/ApprovalPatternMatching.cs
@@ -165,4 +165,147 @@ public static class ApprovalPatternMatching
 
         return ShellTokenizer.SingleTokenSideEffectVerbs.Contains(candidate.Verb);
     }
+
+    /// <summary>
+    /// Explains why a shell candidate that <see cref="MatchesShellApproval"/>
+    /// rejected is nonetheless a near-miss against the persisted entries —
+    /// i.e. an entry exists that the operator would reasonably expect to
+    /// match. This is read-only diagnostics: it never changes a match
+    /// decision and is meant to be logged when the approval gate prompts
+    /// despite a same-verb grant being present.
+    ///
+    /// A near-miss is one of:
+    /// <list type="bullet">
+    /// <item>verb matches exactly but the candidate's effective directory is
+    /// not under the grant's directory;</item>
+    /// <item>verb matches exactly and the effective directory IS under the
+    /// grant's directory, but a symlink segment along the path breaks the
+    /// match;</item>
+    /// <item>verb matches exactly but the folder-scoped grant cannot be
+    /// evaluated because the candidate has no effective directory;</item>
+    /// <item>verb matches only case-insensitively — on a case-sensitive
+    /// filesystem <c>git</c> and <c>Git</c> are distinct grants.</item>
+    /// </list>
+    /// A grant whose verb matches and whose directory is <c>null</c> would
+    /// have been approved, so it never appears here.
+    /// </summary>
+    public static IReadOnlyList<ApprovalNearMiss> ExplainShellNearMisses(
+        string candidateVerb,
+        string? candidateDirectory,
+        string? cwd,
+        IEnumerable<ApprovalEntry> approvedEntries)
+    {
+        var effectiveDirectory = ResolveEffectiveDirectory(candidateDirectory, cwd);
+        string? normalizedCandidate = null;
+        List<ApprovalNearMiss>? misses = null;
+
+        foreach (var entry in approvedEntries)
+        {
+            if (!ToolApprovalEntryComparer.Equals(entry.Verb, candidateVerb))
+            {
+                // Verb-case near-miss: equal ignoring case but not under the
+                // platform comparer. Only possible on case-sensitive POSIX —
+                // on Windows the platform comparer already folds case.
+                if (string.Equals(entry.Verb, candidateVerb, StringComparison.OrdinalIgnoreCase))
+                {
+                    (misses ??= []).Add(new ApprovalNearMiss(
+                        entry, ApprovalNearMissReason.VerbCaseMismatch, candidateVerb,
+                        effectiveDirectory ?? string.Empty));
+                }
+
+                continue;
+            }
+
+            // A null-directory grant for this verb would have matched, so it
+            // is not a near-miss; if we are explaining, no such grant exists.
+            if (entry.Directory is null)
+                continue;
+
+            if (string.IsNullOrEmpty(effectiveDirectory))
+            {
+                (misses ??= []).Add(new ApprovalNearMiss(
+                    entry, ApprovalNearMissReason.NoCandidateDirectory, candidateVerb, string.Empty));
+                continue;
+            }
+
+            try
+            {
+                normalizedCandidate ??= PathUtility.Normalize(effectiveDirectory);
+
+                if (!PathUtility.IsNormalizedWithinRoot(normalizedCandidate, entry.Directory))
+                {
+                    (misses ??= []).Add(new ApprovalNearMiss(
+                        entry, ApprovalNearMissReason.DirectoryNotUnderGrant, candidateVerb, effectiveDirectory));
+                    continue;
+                }
+
+                if (PathUtility.ContainsSymlinkSegment(entry.Directory, effectiveDirectory))
+                {
+                    (misses ??= []).Add(new ApprovalNearMiss(
+                        entry, ApprovalNearMissReason.SymlinkSegmentOnPath, candidateVerb, effectiveDirectory));
+                }
+
+                // Under the root with no symlink segment: this grant matched,
+                // so the candidate would have been approved — not a near-miss.
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException)
+            {
+                // A malformed path cannot be classified precisely; report it
+                // as a directory near-miss rather than dropping it silently.
+                (misses ??= []).Add(new ApprovalNearMiss(
+                    entry, ApprovalNearMissReason.DirectoryNotUnderGrant, candidateVerb, effectiveDirectory));
+            }
+        }
+
+        return misses ?? (IReadOnlyList<ApprovalNearMiss>)[];
+    }
+}
+
+/// <summary>
+/// Why a persisted <see cref="ApprovalEntry"/> failed to auto-approve a
+/// candidate the operator might have expected it to. See
+/// <see cref="ApprovalPatternMatching.ExplainShellNearMisses"/>.
+/// </summary>
+public enum ApprovalNearMissReason
+{
+    /// <summary>Verb matched; the candidate's directory is not under the grant's.</summary>
+    DirectoryNotUnderGrant,
+
+    /// <summary>Verb matched and the directory is under the grant's, but a
+    /// symlink segment along the path breaks the containment check.</summary>
+    SymlinkSegmentOnPath,
+
+    /// <summary>Verb matched a folder-scoped grant, but the candidate has no
+    /// effective directory to evaluate containment against.</summary>
+    NoCandidateDirectory,
+
+    /// <summary>Verbs are equal ignoring case but differ under the
+    /// platform's case-sensitive comparer (POSIX).</summary>
+    VerbCaseMismatch,
+}
+
+/// <summary>
+/// One persisted grant that nearly — but did not — authorize a candidate,
+/// paired with the reason. Carries enough context to render a human-readable
+/// diagnostic via <see cref="Describe"/>.
+/// </summary>
+public sealed record ApprovalNearMiss(
+    ApprovalEntry Grant,
+    ApprovalNearMissReason Reason,
+    string CandidateVerb,
+    string EffectiveDirectory)
+{
+    /// <summary>Renders the near-miss as an operator-facing explanation.</summary>
+    public string Describe() => Reason switch
+    {
+        ApprovalNearMissReason.DirectoryNotUnderGrant =>
+            $"cwd '{EffectiveDirectory}' is not under the grant directory '{Grant.Directory}'",
+        ApprovalNearMissReason.SymlinkSegmentOnPath =>
+            $"a symlink segment lies between grant directory '{Grant.Directory}' and cwd '{EffectiveDirectory}'",
+        ApprovalNearMissReason.NoCandidateDirectory =>
+            $"the invocation had no working directory to match against folder-scoped grant '{Grant.Directory}'",
+        ApprovalNearMissReason.VerbCaseMismatch =>
+            $"grant verb '{Grant.Verb}' differs from invoked verb '{CandidateVerb}' only by case (case-sensitive on this OS)",
+        _ => "unrecognized near-miss reason",
+    };
 }


### PR DESCRIPTION
## Summary

- **Creation timestamps on persisted approvals.** `ApprovalEntry` gains an optional `createdAt` field, stamped by `ToolApprovalStore.AddApproval` via an injected `TimeProvider`. The field is additive and optional: the on-disk schema stays `version: 2`, existing files load with `null` timestamps and are **not** quarantined, and the entry comparer still keys on verb + directory only (idempotent re-grants preserve the original timestamp).
- **Approval-gate near-miss diagnostics.** When a shell pattern is prompted despite a persisted grant for the same verb, the daemon logs why it didn't match — directory not under the grant, a symlink segment on the path, or a verb-case mismatch. `ApprovalPatternMatching.ExplainShellNearMisses` reuses the exact path/symlink helpers the matcher uses, so the diagnostic can't drift from the gate decision. Read-only: it never changes the outcome.
- **Display.** `netclaw approvals list`, its `--json` output, and the approvals TUI now show each grant's relative creation time (`added 3 days ago`; `added —` for pre-timestamp grants).

Includes OpenSpec change artifacts (`approval-creation-timestamps`) and a `netclaw-operations` skill update.

## Test plan

- [x] `ToolApprovalStore` tests — write-time stamping, legacy v2 file loads with `null` and isn't quarantined, idempotent re-grant preserves original timestamp
- [x] `ApprovalPatternMatching` near-miss explainer tests — directory / symlink / verb-case classifications, plus no-near-miss cases
- [x] `ToolApprovalActor` tests — near-miss logged without changing the gate decision; first-time prompt emits no diagnostic
- [x] CLI tests — `list` shows relative time and the `added —` placeholder; `list --json` round-trips `createdAt`
- [x] Headless TUI test (`VirtualTerminal`) — approvals page renders the new "Added" column
- [x] `dotnet slopwatch analyze` clean; copyright headers verified