### PR TITLE
Update ShellSyntaxTree package version to 0.1.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="SlackNet.Extensions.DependencyInjection" Version="$(SlackNetVersion)" />
     <PackageVersion Include="Cronos" Version="0.12.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.0" />
-    <PackageVersion Include="ShellSyntaxTree" Version="0.1.5-beta" />
+    <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
     <PackageVersion Include="Termina" Version="0.8.0" />
   </ItemGroup>
   <!-- Serialization -->


### PR DESCRIPTION
No changes to the package itself, just a stable release.