### PR TITLE
fix(shell): prevent hang when ShellTool.Kill fails with Win32Exception

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -73,17 +73,20 @@ public class ShellToolTests
     }
 
     [Fact]
-    public async Task Caller_cancellation_returns_gracefully()
+    public async Task Caller_cancellation_kills_child_process_tree_and_returns_gracefully()
     {
         // Reproduces the session-pipeline path: ShellTool's own timeout is long,
         // and cancellation instead arrives via the *outer* ct (the pipeline's
         // per-tool deadline). ShellTool must catch that, kill the process, and
         // return a message rather than letting the cancellation escape as an
-        // exception. If the kill failed, draining the pipes would hang and this
-        // test would never complete — so a passing run also proves the process
-        // was terminated.
+        // exception. On Unix the command also spawns a background child that
+        // inherits stdout/stderr; if the tree kill regresses, that child keeps
+        // the pipe write-ends open and the test never completes.
         var tool = new ShellTool(new ToolConfig { ShellTimeoutSeconds = 100 });
-        var args = ToolInput.Create("Command", "sleep 120");
+        var command = OperatingSystem.IsWindows()
+            ? "ping 127.0.0.1 -n 120 > nul"
+            : "sleep 120 & wait";
+        var args = ToolInput.Create("Command", command);
         var context = new ToolExecutionContext("test/thread", Path.GetTempPath())
         {
             Audience = TrustAudience.Personal,

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -134,18 +134,36 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
             }
             catch (OperationCanceledException)
             {
+                var killClosedPipes = true;
+
                 try
                 {
                     process.Kill(entireProcessTree: true);
                 }
-                catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
+                catch (InvalidOperationException ex)
                 {
-                    // Already exited (TOCTOU race), or the OS refused the kill.
+                    // Already exited between cancellation detection and kill.
                     Debug.WriteLine($"shell_execute: process kill skipped — {ex.Message}");
                 }
+                catch (Win32Exception ex)
+                {
+                    // If the OS refuses the kill, the child may keep stdout/stderr
+                    // open forever. Close our read ends so cancellation still
+                    // returns promptly instead of hanging in ReadToEndAsync.
+                    killClosedPipes = false;
+                    Debug.WriteLine($"shell_execute: process kill skipped — {ex.Message}");
+                    process.StandardOutput.Dispose();
+                    process.StandardError.Dispose();
+                }
 
-                // The kill closes the pipes, so the reads now drain to EOF.
-                await Task.WhenAll(stdoutTask, stderrTask);
+                try
+                {
+                    await Task.WhenAll(stdoutTask, stderrTask);
+                }
+                catch (Exception ex) when (!killClosedPipes && ex is IOException or ObjectDisposedException)
+                {
+                    Debug.WriteLine($"shell_execute: pipe drain aborted — {ex.Message}");
+                }
 
                 return timeoutCts.IsCancellationRequested
                     ? $"Error: Command timed out after {effectiveTimeoutSeconds} seconds."


### PR DESCRIPTION
## Summary

PR #1019 fixed the `shell_execute` orphaned-subprocess hang by moving to `WaitForExitAsync` and handling outer cancellation. One gap remains: if `process.Kill(entireProcessTree: true)` throws `Win32Exception` (the OS refuses the kill), the handler logs the error and then immediately `await`s `Task.WhenAll(stdoutTask, stderrTask)`. Since the process may still be alive and holding the pipes open, those `ReadToEndAsync` calls never hit EOF — recreating the exact hung-tool-call failure mode.

## Changes

- **`ShellTool.cs`** — in the `Win32Exception` path, dispose `StandardOutput`/`StandardError` so the pipe reads complete promptly instead of blocking forever; wrap `Task.WhenAll` in a catch for the expected `IOException`/`ObjectDisposedException`.
- **`ShellToolTests.cs`** — tighten the `Caller_cancellation_*` test to spawn a child-process tree (`sleep 120 & wait` on Unix) so it actually exercises the `entireProcessTree` kill path and would hang if the tree-kill regressed.

## Test plan

- [x] `dotnet test ShellTool` — 23/23 pass
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] File header check — all present