### PR TITLE
fix(sessions): fail loud on a tool result with no ToolCallId (#994)

### DIFF
--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -626,16 +626,23 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             {
                 _state = _state with { History = _state.History.Add(result) };
 
+                // A tool result must correlate to a tool call. A null ToolCallId
+                // means the result was assembled wrong; fabricating an empty id
+                // would hand subscribers a non-correlatable id, so fail loud.
+                if (result.ToolCallId is not { } toolCallId)
+                    throw new InvalidOperationException(
+                        $"Tool-result message for tool '{result.Name ?? "unknown"}' has no ToolCallId.");
+
                 var preview = result.Content is { Length: > 200 }
                     ? result.Content[..200] + "..."
                     : result.Content ?? "(null)";
                 _log.Info("Tool [{ToolName}] (call={CallId}) result: {Result}",
-                    result.Name ?? "unknown", result.ToolCallId?.Value ?? "?", preview);
+                    result.Name ?? "unknown", toolCallId.Value, preview);
 
                 EmitOutput(new ToolResultOutput
                 {
                     SessionId = _sessionId,
-                    CallId = result.ToolCallId ?? new ToolCallId(string.Empty),
+                    CallId = toolCallId,
                     ToolName = new ToolName(result.Name ?? "unknown"),
                     Result = result.Content ?? string.Empty
                 }, OutputFilter.ToolCalls);


### PR DESCRIPTION
## Summary

Small issue #994 follow-up. `LlmSessionActor`'s tool-result loop coalesced a missing `ToolCallId` to `new ToolCallId(string.Empty)` and emitted a `ToolResultOutput` carrying that fabricated id:

```csharp
CallId = result.ToolCallId ?? new ToolCallId(string.Empty),
```

An empty tool-call id is **non-correlatable** — every consumer of `ToolResultOutput.CallId` (approval matching, channel result rendering, request/response pairing) needs the genuine id. So the silent fallback handed subscribers a useless value *and* masked whatever assembled a tool-result message without a call id.

A tool-result message reaching this loop without a `ToolCallId` is a programming error, not a normal runtime condition. This change throws instead — consistent with the issue #994 "no silent fallbacks" rule and the fail-loud pattern already applied in Passes 2–4 (`SessionToolExecutionPipeline`, `SubAgentActor`).

The non-null `toolCallId` local is then reused for both the log line and the emitted `CallId`, so the `?? "?"` log fallback also goes away.

## Background

A code-quality bot flagged the nullable dereference at this site. The flag itself was a false positive (the field is nullable by design), but the spot it pointed at had this genuine, separate silent-fallback smell — this PR fixes the real issue.

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean
- [x] `Netclaw.Actors.Tests` green (1,608 tests) — no test depended on the empty-id fallback
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `Add-FileHeaders.ps1 -Verify` — passes