### PR TITLE
refactor(protocol): Pass 7d value objects — ModelId, TurnNumber, et al (#994)

### DIFF
--- a/openspec/changes/value-object-adoption/tasks.md
+++ b/openspec/changes/value-object-adoption/tasks.md
@@ -95,21 +95,29 @@
 
 ## 6. Pass 7d — Remaining new value objects
 
-- [ ] 6.1 Create `ModelId` (`Netclaw.Configuration`) and replace `string`
+- [x] 6.1 Create `ModelId` (`Netclaw.Configuration`) and replace `string`
   model-id fields on `GetModelCapabilities`, `ModelCapabilitiesResponse`,
   `CapabilityResolved`, `DiscoveredModel`.
-- [ ] 6.2 Create `TurnNumber` and `TurnId` (`Netclaw.Actors.Protocol`); confirm
+- [x] 6.2 Create `TurnNumber` and `TurnId` (`Netclaw.Actors.Protocol`); confirm
   both have real callsites before creating the second, then replace the ordinal
   / correlation fields on `TurnCompleted`, `DeliveryFailed`,
   `SessionSnapshot.EligibleDeliveryTurnNumber`, `SessionOutputDto.TurnNumber`.
-- [ ] 6.3 Create `ApprovalOptionKey`, `ApprovalVerb`, `SkillName`,
-  `WebhookEventType`, `WebhookDeliveryId`, `SourceScope`, `SourceKind` in their
-  domain-owning namespaces and replace the corresponding primitive fields.
-- [ ] 6.4 Update `NetclawProtoMapper` mappings and JSON converters for touched
+  `TurnId` has genuine distinct callsites (`MessageSource.TurnId`,
+  `_activeTurnId`, `MemoryCheckpointRequest.TurnId`, `SlackThreadInbound.TurnId`)
+  and was created.
+- [x] 6.3 Create `ApprovalOptionKey`, `WebhookEventType`, `WebhookDeliveryId`,
+  `SourceScope`, `SourceKind` in their domain-owning namespaces and replace the
+  corresponding primitive fields. `ApprovalVerb` and `SkillName` were SKIPPED:
+  `ApprovalVerb` is a free-form extracted command head on the persisted
+  `tool-approvals.json` schema (audit "leave-as-string"), and no actor/protocol
+  record carries a `SkillName` identity field with type-confusion risk (only the
+  nullable diagnostic label `SkillScanIssue.SkillName` and the config-bound
+  `SkillEntry.Name`).
+- [x] 6.4 Update `NetclawProtoMapper` mappings and JSON converters for touched
   serializer-registered and JSON-persisted types; add byte-equality round-trip
   tests.
-- [ ] 6.5 Fix callsite compiler errors and update affected tests.
-- [ ] 6.6 Verify Pass 7d: build clean, tests green, slopwatch clean, file
+- [x] 6.5 Fix callsite compiler errors and update affected tests.
+- [x] 6.6 Verify Pass 7d: build clean, tests green, slopwatch clean, file
   headers verified.
 
 ## 7. Pass 7e — Memory / sub-agent finding enum unwrap fixes

--- a/src/Netclaw.Actors.Tests/Channels/ChannelPipelineAckTargetTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/ChannelPipelineAckTargetTests.cs
@@ -103,7 +103,7 @@ public sealed class ChannelPipelineAckTargetTests : TestKit
         var source = MessageSourceFactory.Create(
             input,
             new SessionPipelineOptions { ChannelType = ChannelType.Slack },
-            "turn-1");
+            new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         return new SendUserMessage
         {

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/AclPolicyContractTests.cs
@@ -225,6 +225,6 @@ public abstract class AclPolicyContractTests
         };
         var result = EvaluateChannel("ch-1", "user-1", options);
         Assert.True(result.IsAllowed);
-        Assert.Equal(ExpectedSourceKind, result.Provenance.SourceKind);
+        Assert.Equal(ExpectedSourceKind, result.Provenance.SourceKind?.Value);
     }
 }

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/DiscordSessionBindingContractTests.cs
@@ -78,7 +78,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             Principal: PrincipalClassification.UntrustedExternal,
             Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
             {
-                SourceKind = "discord"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("discord")
             },
             Text: text,
             ReceivedAt: TimeProvider.System.GetUtcNow());
@@ -156,7 +156,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             Principal: PrincipalClassification.UntrustedExternal,
             Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
             {
-                SourceKind = "discord"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("discord")
             },
             Text: text,
             ReceivedAt: TimeProvider.System.GetUtcNow());
@@ -221,7 +221,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         // The bot ("bot-account") is not an allowed user, so the proactively
@@ -265,7 +265,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
         var actor = CreateActorCore(
             sid, pipeline, detector, fetcher,
@@ -306,7 +306,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
         var actor = CreateActorCore(
             sid, pipeline, detector, fetcher,
@@ -354,7 +354,7 @@ public sealed class DiscordSessionBindingContractTests(ITestOutputHelper output)
             Principal: PrincipalClassification.UntrustedExternal,
             Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
             {
-                SourceKind = "discord"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("discord")
             },
             Text: text,
             ReceivedAt: TimeProvider.System.GetUtcNow());

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -125,7 +125,7 @@ public abstract class SessionBindingContractTests : TestKit
         var turnCompleted = new TurnCompleted
         {
             SessionId = new SessionId("session-safe"),
-            TurnNumber = 1
+            TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
         };
         var pipeline = new RecordingSessionPipeline(_ => [textOutput, turnCompleted]);
         var sid = new SessionId("session-safe");
@@ -152,7 +152,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("hello from LLM") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActor(sid, pipeline, detector);
@@ -172,7 +172,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new ErrorOutput { SessionId = sid, Message = "something broke" },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActor(sid, pipeline, detector);
@@ -193,7 +193,7 @@ public abstract class SessionBindingContractTests : TestKit
         [
             new TextOutput("file context") { SessionId = sid },
             new FileOutput { SessionId = sid, FilePath = "/tmp/report.pdf", FileName = "report.pdf", MimeType = new Netclaw.Security.MimeType("application/pdf") },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActor(sid, pipeline, detector);
@@ -221,7 +221,7 @@ public abstract class SessionBindingContractTests : TestKit
         var sid = new SessionId("session-empty-turn");
         var pipeline = new RecordingSessionPipeline(_ =>
         [
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActor(sid, pipeline, detector);
@@ -242,7 +242,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("real reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActor(sid, pipeline, detector);
@@ -267,7 +267,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reminder output") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1, SourceReminderId = "reminder-1:123456" }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), SourceReminderId = "reminder-1:123456" }
         ]);
 
         var probe = CreateTestProbe();
@@ -300,8 +300,8 @@ public abstract class SessionBindingContractTests : TestKit
                 DisplayText = "git push origin main",
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -334,8 +334,8 @@ public abstract class SessionBindingContractTests : TestKit
                 RequesterSenderId = new SenderId("user-1"),
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -357,7 +357,7 @@ public abstract class SessionBindingContractTests : TestKit
             var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
             Assert.Single(feedback);
             Assert.Equal("call-2", feedback[0].CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey.Value);
         }, cancellationToken: ct);
     }
 
@@ -387,7 +387,7 @@ public abstract class SessionBindingContractTests : TestKit
             var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
             Assert.Single(feedback);
             Assert.Equal("call-cold", feedback[0].CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey.Value);
             Assert.Equal("user-1", feedback[0].SenderId.Value);
         }, cancellationToken: ct);
     }
@@ -410,8 +410,8 @@ public abstract class SessionBindingContractTests : TestKit
                 RequesterSenderId = new SenderId("user-1"),
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -432,7 +432,7 @@ public abstract class SessionBindingContractTests : TestKit
             var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
             Assert.Single(feedback);
             Assert.Equal("call-3", feedback[0].CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey.Value);
         }, cancellationToken: ct);
     }
 
@@ -453,10 +453,10 @@ public abstract class SessionBindingContractTests : TestKit
                 DisplayText = "some command",
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel)
                 ]
             },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActor(sid, pipeline, detector);
@@ -495,7 +495,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("this will fail to post") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         SetReplyClientThrows(new InvalidOperationException("channel API down"));
@@ -538,7 +538,7 @@ public abstract class SessionBindingContractTests : TestKit
         var sid = new SessionId("session-stash");
         var pipeline = new RecordingSessionPipeline(_ =>
         [
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActor(sid, pipeline, detector);
@@ -580,8 +580,8 @@ public abstract class SessionBindingContractTests : TestKit
                 RequesterPrincipal = PrincipalClassification.VerifiedAutomation,
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -601,7 +601,7 @@ public abstract class SessionBindingContractTests : TestKit
             var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
             Assert.Single(feedback);
             Assert.Equal("call-auto-1", feedback[0].CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, feedback[0].SelectedKey.Value);
             Assert.Equal("random-human-user", feedback[0].SenderId.Value);
         }, cancellationToken: ct);
     }
@@ -626,8 +626,8 @@ public abstract class SessionBindingContractTests : TestKit
                 RequesterSenderId = new SenderId("user-A"),
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -675,8 +675,8 @@ public abstract class SessionBindingContractTests : TestKit
                 RequesterSenderId = new SenderId("user-A"),
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -725,8 +725,8 @@ public abstract class SessionBindingContractTests : TestKit
                 DisplayText = "dangerous command",
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -740,7 +740,7 @@ public abstract class SessionBindingContractTests : TestKit
             var feedback = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>().ToList();
             Assert.Single(feedback);
             Assert.Equal("call-deny-1", feedback[0].CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.Deny, feedback[0].SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.Deny, feedback[0].SelectedKey.Value);
         }, cancellationToken: ct);
 
         ClearReplyClientThrows();
@@ -770,7 +770,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("hydrated reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -812,7 +812,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("hydrated reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -856,7 +856,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("hydrated reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -885,7 +885,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -922,7 +922,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -968,7 +968,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -979,7 +979,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline2 = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply 2") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 2 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(2) }
         ]);
         CreateBindingActorWithHydration(sid, pipeline2, detector, historyFetcher);
         await AwaitAssertAsync(() => Assert.NotNull(pipeline2.CapturedOptions), cancellationToken: ct);
@@ -1018,7 +1018,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1058,7 +1058,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("partial") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1, Outcome = TurnOutcome.Failed }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1), Outcome = TurnOutcome.Failed }
         ], reactive: true);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1086,7 +1086,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline2 = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply 2") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 2, Outcome = TurnOutcome.Completed }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(2), Outcome = TurnOutcome.Completed }
         ]);
 
         CreateBindingActorWithHydration(sid, pipeline2, detector, historyFetcher);
@@ -1117,7 +1117,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1169,7 +1169,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("hydrated reply") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1201,7 +1201,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply without history") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1252,7 +1252,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput($"reply {Interlocked.Increment(ref turnNumber)}") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = turnNumber, Outcome = TurnOutcome.Completed }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(turnNumber), Outcome = TurnOutcome.Completed }
         ], reactive: true);
 
         var actor = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1289,7 +1289,7 @@ public abstract class SessionBindingContractTests : TestKit
         pipeline = new RecordingSessionPipeline(_ =>
         [
             new TextOutput("reply after restart") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = 2, Outcome = TurnOutcome.Completed }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(2), Outcome = TurnOutcome.Completed }
         ], reactive: true);
 
         var actor2 = CreateBindingActorWithHydration(sid, pipeline, detector, historyFetcher);
@@ -1335,7 +1335,7 @@ public abstract class SessionBindingContractTests : TestKit
         var pipeline1 = new RecordingSessionPipeline(_ =>
         [
             new TextOutput($"reply {Interlocked.Increment(ref turnNumber)}") { SessionId = sid },
-            new TurnCompleted { SessionId = sid, TurnNumber = turnNumber, Outcome = TurnOutcome.Completed }
+            new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(turnNumber), Outcome = TurnOutcome.Completed }
         ], reactive: true);
 
         var actor1 = CreateBindingActorWithHydration(sid, pipeline1, detector, historyFetcher);

--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SlackSessionBindingContractTests.cs
@@ -54,13 +54,13 @@ public sealed class SlackSessionBindingContractTests(ITestOutputHelper output)
             ChannelId: new SlackChannelId("C-test"),
             ThreadTs: new SlackThreadTs("1000.1"),
             EventId: new SlackEventId($"evt-{Guid.NewGuid():N}"),
-            TurnId: Guid.NewGuid().ToString("N"),
+            TurnId: new Netclaw.Actors.Protocol.TurnId(Guid.NewGuid().ToString("N")),
             SenderId: new SenderId(senderId),
             Audience: TrustAudience.Team,
             Principal: PrincipalClassification.UntrustedExternal,
             Provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
             {
-                SourceKind = "slack"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("slack")
             },
             Text: text,
             ReceivedAt: TimeProvider.System.GetUtcNow());

--- a/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordApprovalPromptBuilderTests.cs
@@ -23,10 +23,10 @@ public sealed class DiscordApprovalPromptBuilderTests
             DisplayText = "push to origin/main",
             Patterns = ["origin/main"],
             Options = [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 
@@ -55,8 +55,8 @@ public sealed class DiscordApprovalPromptBuilderTests
             DisplayText = "read config.json",
             Patterns = [],
             Options = [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 
@@ -95,9 +95,9 @@ public sealed class DiscordApprovalPromptBuilderTests
             DisplayText = "rm -rf /tmp/test",
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 
@@ -126,7 +126,7 @@ public sealed class DiscordApprovalPromptBuilderTests
             RequesterSenderId = new SenderId("user-123"),
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel)
             ]
         };
 
@@ -163,7 +163,7 @@ public sealed class DiscordApprovalPromptBuilderTests
             RequesterSenderId = null,
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 
@@ -185,7 +185,7 @@ public sealed class DiscordApprovalPromptBuilderTests
             ToolName = new Netclaw.Tools.ToolName("git_push"),
             DisplayText = "push to origin/main",
             Patterns = ["origin/main"],
-            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)]
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel)]
         };
 
         var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
@@ -209,7 +209,7 @@ public sealed class DiscordApprovalPromptBuilderTests
             CallId = new Netclaw.Tools.ToolCallId("call-r2"),
             ToolName = new Netclaw.Tools.ToolName("rm_file"),
             DisplayText = "delete /etc/passwd",
-            Options = [new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)]
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)]
         };
 
         var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
@@ -232,7 +232,7 @@ public sealed class DiscordApprovalPromptBuilderTests
             ToolName = new Netclaw.Tools.ToolName("read_file"),
             DisplayText = "read config.json",
             Patterns = [],
-            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel)]
+            Options = [new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel)]
         };
 
         var text = DiscordApprovalPromptBuilder.BuildResolvedPromptText(
@@ -245,17 +245,17 @@ public sealed class DiscordApprovalPromptBuilderTests
 
     private static IReadOnlyList<ToolInteractionOption> FullButtonRow() =>
     [
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhere, ApprovalOptionKeys.ApproveEverywhereLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveEverywhereLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
     ];
 
     private static IReadOnlyList<ToolInteractionOption> MessyRow() =>
     [
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
     ];
 
     private static ToolInteractionRequest V2Request(

--- a/src/Netclaw.Actors.Tests/Channels/DiscordConversationActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordConversationActorTests.cs
@@ -496,7 +496,7 @@ public sealed class DiscordConversationActorTests(ITestOutputHelper output) : Te
         Principal = PrincipalClassification.TrustedInternal,
         Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted)
         {
-            SourceKind = "reminder"
+            SourceKind = new Netclaw.Actors.Channels.SourceKind("reminder")
         },
         ReminderId = "rem-1"
     };

--- a/src/Netclaw.Actors.Tests/Channels/DiscordGatewayActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/DiscordGatewayActorTests.cs
@@ -248,7 +248,7 @@ public sealed class DiscordGatewayActorTests(ITestOutputHelper output) : TestKit
                 Principal = PrincipalClassification.TrustedInternal,
                 Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted)
                 {
-                    SourceKind = "reminder"
+                    SourceKind = new Netclaw.Actors.Channels.SourceKind("reminder")
                 },
                 ReminderId = "rem-1"
             });
@@ -282,7 +282,7 @@ public sealed class DiscordGatewayActorTests(ITestOutputHelper output) : TestKit
                 Principal = PrincipalClassification.TrustedInternal,
                 Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted)
                 {
-                    SourceKind = "reminder"
+                    SourceKind = new Netclaw.Actors.Channels.SourceKind("reminder")
                 },
                 ReminderId = "rem-1"
             });

--- a/src/Netclaw.Actors.Tests/Channels/ExecutionOutputAccumulatorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/ExecutionOutputAccumulatorTests.cs
@@ -55,7 +55,7 @@ public sealed class ExecutionOutputAccumulatorTests
     {
         var acc = new ExecutionOutputAccumulator(TestNotifyTool);
 
-        var action = acc.ProcessOutput(new TurnCompleted { SessionId = TestSessionId, TurnNumber = 1 });
+        var action = acc.ProcessOutput(new TurnCompleted { SessionId = TestSessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) });
 
         Assert.Equal(OutputAction.TurnCompleted, action);
     }

--- a/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/MessageSourceFactoryTests.cs
@@ -53,11 +53,11 @@ public sealed class MessageSourceFactoryTests : TestKit
             principal: PrincipalClassification.TrustedInternal,
             provenance: new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community)
             {
-                SourceKind = "slack"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("slack")
             });
 
         var result = MessageSourceFactory.Create(
-            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         // The factory is a pure mapper — trust context is whatever the adapter
         // stamped on the ChannelInput, never a pipeline-synthesized default.
@@ -66,14 +66,14 @@ public sealed class MessageSourceFactoryTests : TestKit
         Assert.Equal(PrincipalClassification.TrustedInternal, result.Principal);
         Assert.Equal(TransportAuthenticity.Verified, result.Provenance.TransportAuthenticity);
         Assert.Equal(PayloadTaint.Community, result.Provenance.PayloadTaint);
-        Assert.Equal("slack", result.Provenance.SourceKind);
+        Assert.Equal("slack", result.Provenance.SourceKind?.Value);
     }
 
     [Fact]
     public void Create_propagates_null_ReminderId_and_AckTarget_by_default()
     {
         var result = MessageSourceFactory.Create(
-            BuildInput(), new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+            BuildInput(), new SessionPipelineOptions { ChannelType = ChannelType.Slack }, new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         Assert.Null(result.ReminderId);
         Assert.Null(result.AckTarget);
@@ -89,7 +89,7 @@ public sealed class MessageSourceFactoryTests : TestKit
             ackTarget: probe.Ref);
 
         var result = MessageSourceFactory.Create(
-            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         Assert.Equal("check-pr:1712000000000", result.ReminderId);
         Assert.Same(probe.Ref, result.AckTarget);
@@ -101,7 +101,7 @@ public sealed class MessageSourceFactoryTests : TestKit
         var input = BuildInput(hasThirdParty: false, adoptedSpeakerIds: ["user-1"]);
 
         var result = MessageSourceFactory.Create(
-            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         Assert.True(result.HasAdoptedContext);
         Assert.False(result.HasThirdPartyAdoptedContext);
@@ -114,7 +114,7 @@ public sealed class MessageSourceFactoryTests : TestKit
         var input = BuildInput(hasThirdParty: true, adoptedSpeakerIds: ["user-1", "user-2"]);
 
         var result = MessageSourceFactory.Create(
-            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, "turn-1");
+            input, new SessionPipelineOptions { ChannelType = ChannelType.Slack }, new Netclaw.Actors.Protocol.TurnId("turn-1"));
 
         Assert.True(result.HasAdoptedContext);
         Assert.True(result.HasThirdPartyAdoptedContext);

--- a/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackActorHierarchyTests.cs
@@ -438,7 +438,7 @@ public sealed class SlackActorHierarchyTests(ITestOutputHelper output) : TestKit
         Principal = PrincipalClassification.VerifiedAutomation,
         Provenance = new SourceProvenance(TransportAuthenticity.LocalProcess, PayloadTaint.Trusted)
         {
-            SourceKind = "reminder"
+            SourceKind = new Netclaw.Actors.Channels.SourceKind("reminder")
         },
         ReceivedAt = DateTimeOffset.UtcNow,
         ReminderId = reminderId

--- a/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackApprovalBlockBuilderTests.cs
@@ -15,17 +15,17 @@ public sealed class SlackApprovalBlockBuilderTests
 {
     private static IReadOnlyList<ToolInteractionOption> FullButtonRow() =>
     [
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhere, ApprovalOptionKeys.ApproveEverywhereLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveEverywhereLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
     ];
 
     private static IReadOnlyList<ToolInteractionOption> MessyRow() =>
     [
-        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-        new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+        new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+        new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
     ];
 
     private static ToolInteractionRequest Request(

--- a/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackFileFlowIntegrationTests.cs
@@ -591,7 +591,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             new TurnCompleted
             {
                 SessionId = new SessionId("D7/8000.1"),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             }
         ]);
 
@@ -633,7 +633,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var failure = Assert.IsType<DeliveryFailed>(feedback);
             Assert.Equal(DeliveryFailureKind.UnsupportedContent, failure.FailureKind);
-            Assert.Equal(1, failure.TurnNumber);
+            Assert.Equal(1, failure.TurnNumber.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Watch(actor);
@@ -653,7 +653,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             new TurnCompleted
             {
                 SessionId = new SessionId("D7/9000.1"),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             }
         ]);
 
@@ -692,7 +692,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var failure = Assert.IsType<DeliveryFailed>(feedback);
             Assert.Equal(DeliveryFailureKind.TransportFailure, failure.FailureKind);
-            Assert.Equal(1, failure.TurnNumber);
+            Assert.Equal(1, failure.TurnNumber.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Watch(actor);
@@ -715,10 +715,10 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 Patterns = ["git push"],
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -761,7 +761,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             ChannelId: new SlackChannelId("D7"),
             ThreadTs: new SlackThreadTs("9050.1"),
             EventId: new SlackEventId("D7:approval-reply"),
-            TurnId: "approval-turn",
+            TurnId: new Netclaw.Actors.Protocol.TurnId("approval-turn"),
             SenderId: new SenderId("U123"),
             Audience: TrustAudience.Personal,
             Principal: PrincipalClassification.Operator,
@@ -774,7 +774,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var response = Assert.IsType<ToolInteractionResponse>(feedback);
             Assert.Equal("call-1", response.CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, response.SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, response.SelectedKey.Value);
             Assert.Equal("U123", response.SenderId.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -806,10 +806,10 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 Patterns = ["git push"],
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -878,10 +878,10 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
                 Patterns = ["git push"],
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                    new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             }
         ]);
@@ -931,7 +931,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var response = Assert.IsType<ToolInteractionResponse>(feedback);
             Assert.Equal("call-button", response.CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveSession, response.SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveSession, response.SelectedKey.Value);
             Assert.Equal("U123", response.SenderId.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -998,7 +998,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var response = Assert.IsType<ToolInteractionResponse>(feedback);
             Assert.Equal("call-cold-binding", response.CallId.Value);
-            Assert.Equal(ApprovalOptionKeys.ApproveOnce, response.SelectedKey);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, response.SelectedKey.Value);
             Assert.Equal("U123", response.SenderId.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -1019,7 +1019,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             new TurnCompleted
             {
                 SessionId = new SessionId("D7/9100.1"),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             }
         ]);
 
@@ -1058,7 +1058,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var failure = Assert.IsType<DeliveryFailed>(feedback);
             Assert.Equal(DeliveryFailureKind.Unknown, failure.FailureKind);
-            Assert.Equal(1, failure.TurnNumber);
+            Assert.Equal(1, failure.TurnNumber.Value);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         Watch(actor);
@@ -1078,7 +1078,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             new TurnCompleted
             {
                 SessionId = new SessionId("D7/9200.1"),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             }
         ]);
 
@@ -1120,7 +1120,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var failure = Assert.IsType<DeliveryFailed>(feedback);
             Assert.Equal(DeliveryFailureKind.MessageTooLarge, failure.FailureKind);
-            Assert.Equal(1, failure.TurnNumber);
+            Assert.Equal(1, failure.TurnNumber.Value);
             Assert.Contains("msg_too_long", failure.ErrorMessage);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
@@ -1141,7 +1141,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             new TurnCompleted
             {
                 SessionId = new SessionId("D7/9300.1"),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             }
         ]);
 
@@ -1183,7 +1183,7 @@ public sealed class SlackFileFlowIntegrationTests : TestKit
             var feedback = Assert.Single(feedbackPipeline.Feedback);
             var failure = Assert.IsType<DeliveryFailed>(feedback);
             Assert.Equal(DeliveryFailureKind.ContentRejected, failure.FailureKind);
-            Assert.Equal(1, failure.TurnNumber);
+            Assert.Equal(1, failure.TurnNumber.Value);
             Assert.Contains("invalid_blocks", failure.ErrorMessage);
         }, duration: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 

--- a/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackReplyClientTests.cs
@@ -136,10 +136,10 @@ public sealed class SlackReplyClientTests
             Patterns = ["git status"],
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 

--- a/src/Netclaw.Actors.Tests/Channels/TrustContextDeriverTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/TrustContextDeriverTests.cs
@@ -47,7 +47,7 @@ public sealed class TrustContextDeriverTests
             Principal = PrincipalClassification.TrustedInternal,
             Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
             {
-                SourceKind = "slack"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("slack")
             },
             ReceivedAt = DateTimeOffset.UtcNow
         });
@@ -74,7 +74,7 @@ public sealed class TrustContextDeriverTests
             Principal = PrincipalClassification.Operator,
             Provenance = new SourceProvenance(TransportAuthenticity.LocalProcess, PayloadTaint.Trusted)
             {
-                SourceKind = "signalr"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("signalr")
             },
             ReceivedAt = DateTimeOffset.UtcNow
         }, new WorkingContextOverride(TrustAudience.Team, "sensitive-read"));
@@ -102,7 +102,7 @@ public sealed class TrustContextDeriverTests
             Principal = PrincipalClassification.TrustedInternal,
             Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Community)
             {
-                SourceKind = "slack"
+                SourceKind = new Netclaw.Actors.Channels.SourceKind("slack")
             },
             ReceivedAt = DateTimeOffset.UtcNow
         }, new WorkingContextOverride(TrustAudience.Personal, "broader-than-source"));

--- a/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Jobs/BackgroundJobIntegrationTests.cs
@@ -92,7 +92,7 @@ public class BackgroundJobIntegrationTests : TestKit
         Assert.Equal(TrustAudience.Personal, delivered.Source.Audience);
         Assert.Equal(TrustBoundary.Personal, delivered.Source.Boundary);
         Assert.Equal(PrincipalClassification.VerifiedAutomation, delivered.Source.Principal);
-        Assert.Equal("background-job", delivered.Source.Provenance.SourceKind);
+        Assert.Equal("background-job", delivered.Source.Provenance.SourceKind?.Value);
         Assert.NotNull(delivered.Source.BackgroundJobId);
         Assert.StartsWith("bg-job:", delivered.Source.BackgroundJobId);
 

--- a/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
+++ b/src/Netclaw.Actors.Tests/Protocol/SerializationRoundTripTests.cs
@@ -650,6 +650,54 @@ public sealed class SerializationRoundTripTests : TestKit
     }
 
     [Fact]
+    public void SessionSnapshot_eligible_turn_number_wrap_is_byte_identical_to_raw_primitive_proto()
+    {
+        // Pass 7d wraps SessionSnapshot.EligibleDeliveryTurnNumber in the
+        // TurnNumber value object. The proto field stays a primitive int32, so
+        // the journal bytes must be identical to the pre-wrap representation.
+        var wrapped = new SessionSnapshot
+        {
+            TurnCount = 7,
+            History = [],
+            EligibleDeliveryTurnNumber = new TurnNumber(7)
+        };
+
+        var expected = new Serialization.Proto.SessionSnapshotProto
+        {
+            TurnCount = 7,
+            EligibleDeliveryTurnNumber = 7
+        }.ToByteArray();
+
+        Assert.Equal(expected, Serialize(wrapped));
+
+        var result = RoundTrip(wrapped);
+        Assert.Equal(new TurnNumber(7), result.EligibleDeliveryTurnNumber);
+    }
+
+    [Fact]
+    public void SessionSnapshot_null_eligible_turn_number_omits_proto_field()
+    {
+        // A null EligibleDeliveryTurnNumber must leave the optional proto field
+        // unset — byte-identical to the pre-wrap int? null representation.
+        var wrapped = new SessionSnapshot
+        {
+            TurnCount = 3,
+            History = [],
+            EligibleDeliveryTurnNumber = null
+        };
+
+        var expected = new Serialization.Proto.SessionSnapshotProto
+        {
+            TurnCount = 3
+        }.ToByteArray();
+
+        Assert.Equal(expected, Serialize(wrapped));
+
+        var result = RoundTrip(wrapped);
+        Assert.Null(result.EligibleDeliveryTurnNumber);
+    }
+
+    [Fact]
     public void AdoptedContextRecorded_sender_id_wrap_is_byte_identical_to_raw_primitive_proto()
     {
         // Pass 7c wraps the adopted-context SenderId / AuthorizerSenderId fields

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderExecutionActorTests.cs
@@ -96,7 +96,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                 ToolName = new Netclaw.Tools.ToolName("send_slack_message"),
                 Result = "Error parsing arguments for tool 'send_slack_message': Required parameter 'Message' is missing or empty."
             },
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("notify-fail-test");
@@ -124,7 +124,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                 ToolName = new Netclaw.Tools.ToolName("send_slack_message"),
                 Result = "Message sent to channel C1. Thread: C1/1234567890.000001"
             },
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("notify-success-test");
@@ -146,7 +146,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
             new TextOutput("No new opportunities found.") { SessionId = sessionId },
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("conditional-no-notify") with
@@ -170,7 +170,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
             new TextOutput("Some output.") { SessionId = sessionId },
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         // Default policy is Required — should fail when no notification tool is invoked
@@ -198,7 +198,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
                 ToolName = new Netclaw.Tools.ToolName("send_slack_message"),
                 Result = "Error: channel not found"
             },
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("conditional-notify-error") with
@@ -222,7 +222,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("filter-check") with { DeliveryInstructions = string.Empty };
@@ -338,7 +338,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("audience-override") with
@@ -367,7 +367,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("audience-team-default") with
@@ -391,7 +391,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         var definition = CreateDefinition("boundary-preserved") with
@@ -418,7 +418,7 @@ public class ReminderExecutionActorTests : TestKit, IDisposable
     {
         var pipeline = new ScriptedSessionPipeline(sessionId =>
         [
-            new TurnCompleted { SessionId = sessionId, TurnNumber = 1 }
+            new TurnCompleted { SessionId = sessionId, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
         ]);
 
         // Use Kind = None so success is not gated on send_slack_message

--- a/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Reminders/ReminderManagerActorTests.cs
@@ -500,7 +500,7 @@ public class ReminderManagerActorTests : TestKit
         Assert.NotNull(delivered.Source.ReminderId);
         Assert.StartsWith("mode-b-anchor:", delivered.Source.ReminderId);
         Assert.Equal(PrincipalClassification.VerifiedAutomation, delivered.Source.Principal);
-        Assert.Equal("reminder", delivered.Source.Provenance.SourceKind);
+        Assert.Equal("reminder", delivered.Source.Provenance.SourceKind?.Value);
 
         // Probe receiving the DeliverTrustedSessionTurn is the anchor
         // assertion: it proves the manager branched on OriginChannelType,

--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -128,13 +128,13 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
                 SenderId = new SenderId("webhook:test"),
                 ChannelId = "github-issues",
                 MessageId = "delivery-1",
-                TurnId = "delivery-1",
+                TurnId = new Netclaw.Actors.Protocol.TurnId("delivery-1"),
                 Audience = TrustAudience.Public,
                 Boundary = SecurityPolicyDefaults.ResolveBoundaryFromAudience(TrustAudience.Public),
                 Principal = PrincipalClassification.VerifiedAutomation,
                 Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Public)
                 {
-                    SourceKind = "issues"
+                    SourceKind = new Netclaw.Actors.Channels.SourceKind("issues")
                 },
                 ReceivedAt = _timeProvider.GetUtcNow()
             }
@@ -178,13 +178,13 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
                 SenderId = new SenderId("U123"),
                 ChannelId = "C1234567890",
                 MessageId = "evt-1",
-                TurnId = "turn-1",
+                TurnId = new Netclaw.Actors.Protocol.TurnId("turn-1"),
                 Audience = TrustAudience.Team,
                 Boundary = SecurityPolicyDefaults.ResolveBoundaryFromAudience(TrustAudience.Team),
                 Principal = PrincipalClassification.TrustedInternal,
                 Provenance = new SourceProvenance(TransportAuthenticity.Verified, PayloadTaint.Trusted)
                 {
-                    SourceKind = "slack"
+                    SourceKind = new Netclaw.Actors.Channels.SourceKind("slack")
                 },
                 ReceivedAt = _timeProvider.GetUtcNow()
             }
@@ -228,7 +228,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
 
         var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(sessionId, completed.SessionId);
-        Assert.Equal(1, completed.TurnNumber);
+        Assert.Equal(1, completed.TurnNumber.Value);
     }
 
     [Fact]
@@ -984,7 +984,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         Assert.Contains("fake", text.Text, StringComparison.OrdinalIgnoreCase);
 
         var completed = await recoverSub.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal(3, completed.TurnNumber); // Continues from recovered state
+        Assert.Equal(3, completed.TurnNumber.Value); // Continues from recovered state
     }
 
     [Fact]
@@ -1158,7 +1158,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         sessionManager.Tell(new DeliveryFailed
         {
             SessionId = sessionId,
-            TurnNumber = 999,
+            TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(999),
             ChannelType = ChannelType.Slack,
             FailureKind = DeliveryFailureKind.MessageTooLarge,
             ErrorMessage = "msg_too_long"
@@ -1680,7 +1680,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         Principal = PrincipalClassification.VerifiedAutomation,
         Provenance = new SourceProvenance(TransportAuthenticity.LocalProcess, PayloadTaint.Trusted)
         {
-            SourceKind = "reminder"
+            SourceKind = new Netclaw.Actors.Channels.SourceKind("reminder")
         },
         ReceivedAt = _timeProvider.GetUtcNow(),
         ReminderId = reminderId

--- a/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ModelCapabilityActorTests.cs
@@ -43,7 +43,7 @@ public class ModelCapabilityActorTests : TestKit
 
         var capActor = ActorRegistry.Get<ModelCapabilityActorKey>();
         var result = await capActor.Ask<ModelCapabilitiesResponse>(
-            new GetModelCapabilities("vision-model"), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new GetModelCapabilities(new Netclaw.Configuration.ModelId("vision-model")), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(ModelModality.Text | ModelModality.Image, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);
@@ -61,11 +61,11 @@ public class ModelCapabilityActorTests : TestKit
 
         // First query
         await capActor.Ask<ModelCapabilitiesResponse>(
-            new GetModelCapabilities("cached-model"), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new GetModelCapabilities(new Netclaw.Configuration.ModelId("cached-model")), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Second query — should come from cache
         var result = await capActor.Ask<ModelCapabilitiesResponse>(
-            new GetModelCapabilities("cached-model"), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new GetModelCapabilities(new Netclaw.Configuration.ModelId("cached-model")), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(ModelModality.Text | ModelModality.Audio, result.InputModalities);
         Assert.Equal(1, _resolver.CallCount); // only called once
@@ -78,7 +78,7 @@ public class ModelCapabilityActorTests : TestKit
 
         var capActor = ActorRegistry.Get<ModelCapabilityActorKey>();
         var result = await capActor.Ask<ModelCapabilitiesResponse>(
-            new GetModelCapabilities("failing-model"), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            new GetModelCapabilities(new Netclaw.Configuration.ModelId("failing-model")), TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(ModelModality.Text, result.InputModalities);
         Assert.Equal(ModelModality.Text, result.OutputModalities);

--- a/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ParentSessionApprovalBridgeTests.cs
@@ -51,8 +51,8 @@ public sealed class ParentSessionApprovalBridgeTests
         Assert.Equal(["user-123", "user-456"], emitted.AdoptedSpeakerIds);
         Assert.Equal(["grep timeout logs/app.log | wc -l"], emitted.Patterns);
         Assert.Equal(["grep timeout logs/app.log"], emitted.CandidateVerbs);
-        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, emitted.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession).Label);
-        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, emitted.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, emitted.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, emitted.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways).Label);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/SessionToolExecutionPipelineTests.cs
@@ -203,10 +203,10 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                     CandidateVerbs: ["git push origin dev"],
                     Options:
                     [
-                        new ToolApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                        new ToolApprovalOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                        new ToolApprovalOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                        new ToolApprovalOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                        new ToolApprovalOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                        new ToolApprovalOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                        new ToolApprovalOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                        new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                     ]));
             }
 
@@ -234,9 +234,9 @@ public sealed class SessionToolExecutionPipelineTests(ITestOutputHelper output) 
                     CandidateVerbs: ["ls"],
                     Options:
                     [
-                        new ToolApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                        new ToolApprovalOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                        new ToolApprovalOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                        new ToolApprovalOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                        new ToolApprovalOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                        new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                     ],
                     Cwd: cwd));
             }

--- a/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/ToolExecutionIntegrationTests.cs
@@ -104,7 +104,7 @@ public class ToolExecutionIntegrationTests : LlmSessionTestBase
         Assert.Contains("fake", text.Text, StringComparison.OrdinalIgnoreCase);
 
         var completed = await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal(1, completed.TurnNumber);
+        Assert.Equal(1, completed.TurnNumber.Value);
 
         // Two LLM calls: first returned tool call, second returned text
         Assert.Equal(2, _fakeChatClient.CallCount);

--- a/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ToolApprovalGateTests.cs
@@ -793,8 +793,8 @@ public sealed class ToolApprovalGateTests
 
         Assert.True(decision.NeedsApproval);
         var options = decision.ApprovalContext!.Options;
-        var sessionOption = options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession);
-        var alwaysOption = options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways);
+        var sessionOption = options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession);
+        var alwaysOption = options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways);
         Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, sessionOption.Label);
         Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, alwaysOption.Label);
     }
@@ -809,8 +809,8 @@ public sealed class ToolApprovalGateTests
 
         Assert.True(decision.NeedsApproval);
         var options = decision.ApprovalContext!.Options;
-        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession).Label);
-        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways).Label);
     }
 
     [Fact]
@@ -838,10 +838,10 @@ public sealed class ToolApprovalGateTests
             // button caps make dynamic labels structurally unsafe.
             Assert.Equal(
                 ApprovalOptionKeys.ApproveSessionLabel,
-                decision.ApprovalContext.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession).Label);
+                decision.ApprovalContext.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession).Label);
             Assert.Equal(
                 ApprovalOptionKeys.ApproveAlwaysLabel,
-                decision.ApprovalContext.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways).Label);
+                decision.ApprovalContext.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways).Label);
         }
         finally
         {
@@ -865,8 +865,8 @@ public sealed class ToolApprovalGateTests
         // specific arg shape (`git push origin main *`) rather than the
         // verb family (`git push *`), making them safer by construction.
         Assert.Equal(["git push origin main"], decision.ApprovalContext!.CandidateVerbs);
-        var sessionOption = decision.ApprovalContext.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession);
-        var alwaysOption = decision.ApprovalContext.Options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways);
+        var sessionOption = decision.ApprovalContext.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession);
+        var alwaysOption = decision.ApprovalContext.Options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways);
         Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, sessionOption.Label);
         Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, alwaysOption.Label);
     }
@@ -889,9 +889,9 @@ public sealed class ToolApprovalGateTests
         Assert.All(options, option => Assert.True(
             option.Label.Length <= ApprovalOptionKeys.MaxLabelLength,
             $"Option '{option.Key}' label '{option.Label}' is {option.Label.Length} chars; must stay within {ApprovalOptionKeys.MaxLabelLength}."));
-        Assert.Equal(ApprovalOptionKeys.ApproveOnceLabel, options.Single(o => o.Key == ApprovalOptionKeys.ApproveOnce).Label);
-        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, options.Single(o => o.Key == ApprovalOptionKeys.ApproveSession).Label);
-        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, options.Single(o => o.Key == ApprovalOptionKeys.ApproveAlways).Label);
-        Assert.Equal(ApprovalOptionKeys.DenyLabel, options.Single(o => o.Key == ApprovalOptionKeys.Deny).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveOnceLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveOnce).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveSessionLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveSession).Label);
+        Assert.Equal(ApprovalOptionKeys.ApproveAlwaysLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.ApproveAlways).Label);
+        Assert.Equal(ApprovalOptionKeys.DenyLabel, options.Single(o => o.Key.Value == ApprovalOptionKeys.Deny).Label);
     }
 }

--- a/src/Netclaw.Actors/Channels/ChannelPipeline.cs
+++ b/src/Netclaw.Actors/Channels/ChannelPipeline.cs
@@ -40,7 +40,7 @@ public sealed record SessionPipelineOptions
 
 public static class MessageSourceFactory
 {
-    public static MessageSource Create(ChannelInput input, SessionPipelineOptions options, string turnId)
+    public static MessageSource Create(ChannelInput input, SessionPipelineOptions options, Protocol.TurnId turnId)
     {
         var textContent = string.Join("\n", input.Contents
             .OfType<TextContent>()
@@ -303,9 +303,8 @@ public sealed class SessionPipeline : ISessionPipeline
         SessionPipelineOptions options,
         NetclawPaths paths)
     {
-        var turnId = string.IsNullOrWhiteSpace(input.MessageId)
-            ? IdGen.ShortId()
-            : input.MessageId!;
+        var turnId = new Protocol.TurnId(
+            string.IsNullOrWhiteSpace(input.MessageId) ? IdGen.ShortId() : input.MessageId!);
 
         var textParts = input.Contents.OfType<TextContent>().Select(t => t.Text);
         var content = string.Join("\n", textParts);

--- a/src/Netclaw.Actors/Channels/MessageSource.cs
+++ b/src/Netclaw.Actors/Channels/MessageSource.cs
@@ -48,7 +48,7 @@ public sealed record MessageSource
     /// Correlation identifier for this turn. Propagated across session logs
     /// and actor boundaries for end-to-end traceability.
     /// </summary>
-    public string? TurnId { get; init; }
+    public Protocol.TurnId? TurnId { get; init; }
 
     /// <summary>
     /// Effective source audience attached to the inbound message before any runtime

--- a/src/Netclaw.Actors/Channels/SourceProvenance.cs
+++ b/src/Netclaw.Actors/Channels/SourceProvenance.cs
@@ -19,10 +19,10 @@ public sealed record SourceProvenance(
     /// <summary>
     /// Optional scope identifier such as repository, environment, or tenant.
     /// </summary>
-    public string? SourceScope { get; init; }
+    public SourceScope? SourceScope { get; init; }
 
     /// <summary>
     /// Optional source object identifier such as a webhook event type.
     /// </summary>
-    public string? SourceKind { get; init; }
+    public SourceKind? SourceKind { get; init; }
 }

--- a/src/Netclaw.Actors/Channels/SourceScope.cs
+++ b/src/Netclaw.Actors/Channels/SourceScope.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="SourceScope.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Channels;
+
+/// <summary>
+/// Strongly-typed source scope identifier — the optional provenance marker on
+/// <see cref="SourceProvenance"/> naming the repository, environment, or tenant
+/// a message originated from. Wraps the raw string so a scope identifier cannot
+/// be confused with a <see cref="SourceKind"/> or any other string at a call
+/// boundary.
+/// </summary>
+public readonly record struct SourceScope(string Value)
+{
+    public static explicit operator SourceScope(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Strongly-typed source kind identifier — the optional provenance marker on
+/// <see cref="SourceProvenance"/> naming the source object (such as a webhook
+/// event type) a message originated from. Wraps the raw string so a source-kind
+/// identifier cannot be confused with a <see cref="SourceScope"/> or any other
+/// string at a call boundary.
+/// </summary>
+public readonly record struct SourceKind(string Value)
+{
+    public static explicit operator SourceKind(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Actors/Channels/TrustContextDeriver.cs
+++ b/src/Netclaw.Actors/Channels/TrustContextDeriver.cs
@@ -27,8 +27,8 @@ public sealed record EffectiveTrustContext(
     PrincipalClassification Principal,
     TransportAuthenticity TransportAuthenticity,
     PayloadTaint PayloadTaint,
-    string? SourceScope,
-    string? SourceKind,
+    SourceScope? SourceScope,
+    SourceKind? SourceKind,
     bool UsedStrictFallback,
     bool WasDowngraded,
     string? DowngradeReason);

--- a/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
+++ b/src/Netclaw.Actors/Jobs/BackgroundJobManagerActor.cs
@@ -316,7 +316,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
             ChannelType = originChannelType,
             SenderId = new Protocol.SenderId(SystemSenderId),
             MessageId = jobDeliveryKey,
-            TurnId = jobDeliveryKey,
+            TurnId = new Protocol.TurnId(jobDeliveryKey),
             Audience = def.Audience,
             Boundary = def.Boundary,
             Principal = PrincipalClassification.VerifiedAutomation,
@@ -324,7 +324,7 @@ public sealed class BackgroundJobManagerActor : ReceiveActor
                 TransportAuthenticity.LocalProcess,
                 PayloadTaint.Trusted)
             {
-                SourceKind = SourceKind
+                SourceKind = new SourceKind(BackgroundJobManagerActor.SourceKind)
             },
             ReceivedAt = _timeProvider.GetUtcNow(),
             BackgroundJobId = jobDeliveryKey

--- a/src/Netclaw.Actors/Memory/MemoryCheckpointing.cs
+++ b/src/Netclaw.Actors/Memory/MemoryCheckpointing.cs
@@ -10,7 +10,7 @@ namespace Netclaw.Actors.Memory;
 
 public sealed record MemoryCheckpointRequest(
     SessionId SessionId,
-    string? TurnId,
+    Protocol.TurnId? TurnId,
     CheckpointTriggerType TriggerType,
     int Priority,
     object Payload);
@@ -60,7 +60,7 @@ public sealed class SQLiteMemoryCheckpointSink(
         await store.EnqueueCheckpointAsync(new SQLiteMemoryCheckpoint(
             CheckpointId: checkpointId,
             SessionId: request.SessionId.Value,
-            TurnId: request.TurnId,
+            TurnId: request.TurnId?.Value,
             TriggerType: request.TriggerType.ToWireValue(),
             Priority: request.Priority,
             Status: "pending",

--- a/src/Netclaw.Actors/Protocol/ApprovalButtonValueCodec.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalButtonValueCodec.cs
@@ -17,7 +17,7 @@ public static class ApprovalButtonValueCodec
     public const int MaxEncodedLength = 100;
 
     public static string Encode(ToolInteractionRequest request, ToolInteractionOption option)
-        => Encode(request.CallId.Value, option.Key, request.RequesterSenderId?.Value);
+        => Encode(request.CallId.Value, option.Key.Value, request.RequesterSenderId?.Value);
 
     public static string Encode(string callId, string optionKey, string? requesterSenderId)
     {

--- a/src/Netclaw.Actors/Protocol/ApprovalOptionKey.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalOptionKey.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApprovalOptionKey.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Strongly-typed tool-approval option key — the stable wire discriminator a
+/// channel adapter renders as a button and the user's selection routes back on
+/// <see cref="ToolInteractionResponse.SelectedKey"/>. Wraps the raw key string
+/// so an option key cannot be confused with a session id, tool-call id, or any
+/// other string at a call boundary. The canonical keys are exposed as named
+/// factories on <see cref="ApprovalOptionKeys"/>.
+/// </summary>
+/// <remarks>
+/// Carries a <see cref="JsonConverter"/> attribute because
+/// <see cref="ToolInteractionOption"/> values cross the SignalR JSON boundary
+/// nested inside <c>SessionOutputDto.InteractionOptions</c>; the converter keeps
+/// the wire form a bare string rather than a <c>{ "Value": ... }</c> object.
+/// </remarks>
+[JsonConverter(typeof(ApprovalOptionKeyJsonConverter))]
+public readonly record struct ApprovalOptionKey(string Value)
+{
+    public static explicit operator ApprovalOptionKey(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Serializes <see cref="ApprovalOptionKey"/> as its bare primitive string so
+/// the on-wire JSON form is byte-identical to the pre-value-object
+/// representation (a raw <c>"key"</c> string, never a nested object).
+/// </summary>
+public sealed class ApprovalOptionKeyJsonConverter : JsonConverter<ApprovalOptionKey>
+{
+    public override ApprovalOptionKey Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetString() ?? string.Empty);
+
+    public override void Write(
+        Utf8JsonWriter writer, ApprovalOptionKey value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.Value);
+}

--- a/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
@@ -33,6 +33,14 @@ public static class ApprovalOptionKeys
     public const string ApproveEverywhere = "approve_everywhere";
     public const string Deny = "deny";
 
+    // Typed factories for the canonical keys — used at construction sites so a
+    // raw string literal never has to be cast to ApprovalOptionKey.
+    public static ApprovalOptionKey ApproveOnceKey { get; } = new(ApproveOnce);
+    public static ApprovalOptionKey ApproveSessionKey { get; } = new(ApproveSession);
+    public static ApprovalOptionKey ApproveAlwaysKey { get; } = new(ApproveAlways);
+    public static ApprovalOptionKey ApproveEverywhereKey { get; } = new(ApproveEverywhere);
+    public static ApprovalOptionKey DenyKey { get; } = new(Deny);
+
     public const string ApproveOnceLabel = "Once";
     public const string ApproveSessionLabel = "This chat";
     public const string ApproveAlwaysLabel = "Always here";

--- a/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
+++ b/src/Netclaw.Actors/Protocol/ApprovalOptionKeys.cs
@@ -33,8 +33,6 @@ public static class ApprovalOptionKeys
     public const string ApproveEverywhere = "approve_everywhere";
     public const string Deny = "deny";
 
-    // Typed factories for the canonical keys — used at construction sites so a
-    // raw string literal never has to be cast to ApprovalOptionKey.
     public static ApprovalOptionKey ApproveOnceKey { get; } = new(ApproveOnce);
     public static ApprovalOptionKey ApproveSessionKey { get; } = new(ApproveSession);
     public static ApprovalOptionKey ApproveAlwaysKey { get; } = new(ApproveAlways);

--- a/src/Netclaw.Actors/Protocol/Commands.cs
+++ b/src/Netclaw.Actors/Protocol/Commands.cs
@@ -66,7 +66,7 @@ public sealed record ToolInteractionResponse : IWithSessionId, INoSerializationV
     public required ToolCallId CallId { get; init; }
 
     /// <summary>The selected option key. See <see cref="ApprovalOptionKeys"/>.</summary>
-    public required string SelectedKey { get; init; }
+    public required ApprovalOptionKey SelectedKey { get; init; }
 
     /// <summary>
     /// Identity of the user who selected the option. Used to bind approvals to

--- a/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
+++ b/src/Netclaw.Actors/Protocol/DeliveryFeedback.cs
@@ -33,7 +33,7 @@ public sealed record DeliveryFailed : IWithSessionId, INoSerializationVerificati
     /// Completed turn number whose output failed delivery.
     /// Used to reject stale feedback after a newer user turn has started.
     /// </summary>
-    public required int TurnNumber { get; init; }
+    public required TurnNumber TurnNumber { get; init; }
 
     /// <summary>
     /// Channel adapter identifier.

--- a/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
+++ b/src/Netclaw.Actors/Protocol/ModelCapabilityMessages.cs
@@ -11,13 +11,13 @@ namespace Netclaw.Actors.Protocol;
 /// <summary>
 /// Query the <see cref="ModelCapabilityActor"/> for a model's capabilities.
 /// </summary>
-public sealed record GetModelCapabilities(string ModelId) : INoSerializationVerificationNeeded;
+public sealed record GetModelCapabilities(ModelId ModelId) : INoSerializationVerificationNeeded;
 
 /// <summary>
 /// Response from the capability cache containing resolved modalities.
 /// </summary>
 public sealed record ModelCapabilitiesResponse(
-    string ModelId,
+    ModelId ModelId,
     ModelModality InputModalities,
     ModelModality OutputModalities) : INoSerializationVerificationNeeded;
 
@@ -25,7 +25,7 @@ public sealed record ModelCapabilitiesResponse(
 /// Internal message piped back from async resolution to the actor.
 /// </summary>
 internal sealed record CapabilityResolved(
-    string ModelId,
+    ModelId ModelId,
     ModelModality InputModalities,
     ModelModality OutputModalities,
     bool Success) : INoSerializationVerificationNeeded;

--- a/src/Netclaw.Actors/Protocol/SessionOutput.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutput.cs
@@ -150,7 +150,7 @@ public enum TurnOutcome
 /// </summary>
 public sealed record TurnCompleted : SessionOutput
 {
-    public required int TurnNumber { get; init; }
+    public required TurnNumber TurnNumber { get; init; }
 
     /// <summary>
     /// How the turn ended. Defaults to <see cref="TurnOutcome.Completed"/> for backward compatibility.
@@ -415,4 +415,4 @@ public sealed record ToolInteractionRequest : SessionOutput
 /// <summary>
 /// An option presented to the user in a <see cref="ToolInteractionRequest"/>.
 /// </summary>
-public sealed record ToolInteractionOption(string Key, string Label);
+public sealed record ToolInteractionOption(ApprovalOptionKey Key, string Label);

--- a/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDto.cs
@@ -76,7 +76,8 @@ public sealed record SessionOutputDto
     public double? PredictedPerSecond { get; init; }
 
     // Turn Completed
-    public int? TurnNumber { get; init; }
+    [System.Text.Json.Serialization.JsonConverter(typeof(NullableTurnNumberJsonConverter))]
+    public TurnNumber? TurnNumber { get; init; }
     public string? TurnOutcome { get; init; }
     public string? SourceReminderId { get; init; }
 

--- a/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
+++ b/src/Netclaw.Actors/Protocol/SessionOutputDtoMapper.cs
@@ -252,7 +252,7 @@ public static class SessionOutputDtoMapper
             {
                 SessionId = sessionId,
                 TimestampMs = dto.TimestampMs,
-                TurnNumber = dto.TurnNumber ?? 0,
+                TurnNumber = dto.TurnNumber ?? new TurnNumber(0),
                 Outcome = Enum.TryParse<TurnOutcome>(dto.TurnOutcome, ignoreCase: true, out var outcome)
                     ? outcome
                     : TurnOutcome.Completed,

--- a/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
+++ b/src/Netclaw.Actors/Protocol/SessionSnapshot.cs
@@ -62,7 +62,7 @@ public sealed record SessionSnapshot : INetclawSerializableMessage
     /// <see cref="DeliveryFailed"/> feedback after passivation.
     /// Null when no turn is eligible (initial state or retries exhausted).
     /// </summary>
-    public int? EligibleDeliveryTurnNumber { get; init; }
+    public TurnNumber? EligibleDeliveryTurnNumber { get; init; }
 
     /// <summary>
     /// Durable working-context state (recent files). Null when the session

--- a/src/Netclaw.Actors/Protocol/TurnId.cs
+++ b/src/Netclaw.Actors/Protocol/TurnId.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="TurnId.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Strongly-typed turn correlation id — the unique identifier propagated across
+/// session logs, actor boundaries, and memory checkpoints for end-to-end
+/// traceability of a single turn. Distinct from <see cref="TurnNumber"/>: the
+/// ordinal is a session-scoped counter, this is a globally-unique correlation
+/// string. Wraps the raw id string so a turn id cannot be confused with a
+/// session id, message id, or any other string at a call boundary.
+/// </summary>
+public readonly record struct TurnId(string Value)
+{
+    public static explicit operator TurnId(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Actors/Protocol/TurnNumber.cs
+++ b/src/Netclaw.Actors/Protocol/TurnNumber.cs
@@ -22,22 +22,6 @@ public readonly record struct TurnNumber(int Value)
 }
 
 /// <summary>
-/// Serializes <see cref="TurnNumber"/> as its bare primitive integer so the
-/// on-wire JSON form is byte-identical to the pre-value-object representation
-/// (a raw number, never a nested <c>{ "Value": ... }</c> object).
-/// </summary>
-public sealed class TurnNumberJsonConverter : JsonConverter<TurnNumber>
-{
-    public override TurnNumber Read(
-        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-        new(reader.GetInt32());
-
-    public override void Write(
-        Utf8JsonWriter writer, TurnNumber value, JsonSerializerOptions options) =>
-        writer.WriteNumberValue(value.Value);
-}
-
-/// <summary>
 /// Serializes a nullable <see cref="TurnNumber"/> as a bare primitive integer
 /// or JSON <c>null</c> — used on optional DTO fields so a missing turn ordinal
 /// stays a wire <c>null</c>, never a nested object. Mirrors the pre-value-object

--- a/src/Netclaw.Actors/Protocol/TurnNumber.cs
+++ b/src/Netclaw.Actors/Protocol/TurnNumber.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="TurnNumber.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Netclaw.Actors.Protocol;
+
+/// <summary>
+/// Strongly-typed turn ordinal — the monotonically-increasing turn counter a
+/// session uses to reject stale delivery feedback after a newer user turn has
+/// started. Wraps the raw <see cref="int"/> so a turn number cannot be confused
+/// with a token count, message count, or any other integer at a call boundary.
+/// </summary>
+public readonly record struct TurnNumber(int Value)
+{
+    public static explicit operator TurnNumber(int value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}
+
+/// <summary>
+/// Serializes <see cref="TurnNumber"/> as its bare primitive integer so the
+/// on-wire JSON form is byte-identical to the pre-value-object representation
+/// (a raw number, never a nested <c>{ "Value": ... }</c> object).
+/// </summary>
+public sealed class TurnNumberJsonConverter : JsonConverter<TurnNumber>
+{
+    public override TurnNumber Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetInt32());
+
+    public override void Write(
+        Utf8JsonWriter writer, TurnNumber value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(value.Value);
+}
+
+/// <summary>
+/// Serializes a nullable <see cref="TurnNumber"/> as a bare primitive integer
+/// or JSON <c>null</c> — used on optional DTO fields so a missing turn ordinal
+/// stays a wire <c>null</c>, never a nested object. Mirrors the pre-value-object
+/// <c>int?</c> representation exactly.
+/// </summary>
+public sealed class NullableTurnNumberJsonConverter : JsonConverter<TurnNumber?>
+{
+    public override TurnNumber? Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        reader.TokenType == JsonTokenType.Null ? null : new TurnNumber(reader.GetInt32());
+
+    public override void Write(
+        Utf8JsonWriter writer, TurnNumber? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+            writer.WriteNullValue();
+        else
+            writer.WriteNumberValue(value.Value.Value);
+    }
+}

--- a/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
+++ b/src/Netclaw.Actors/Reminders/ReminderExecutionActor.cs
@@ -147,7 +147,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                     TransportAuthenticity.LocalProcess,
                     PayloadTaint.Trusted)
                 {
-                    SourceKind = "reminder"
+                    SourceKind = new SourceKind("reminder")
                 },
                 Contents = [new TextContent(prompt)],
                 ReceivedAt = _timeProvider.GetUtcNow()
@@ -193,7 +193,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                 ChannelType = originChannelType,
                 SenderId = new Protocol.SenderId("reminder-system"),
                 MessageId = reminderDeliveryKey,
-                TurnId = reminderDeliveryKey,
+                TurnId = new Protocol.TurnId(reminderDeliveryKey),
                 Audience = audience,
                 Boundary = boundary,
                 Principal = PrincipalClassification.VerifiedAutomation,
@@ -201,7 +201,7 @@ internal sealed class ReminderExecutionActor : ReceiveActor
                     TransportAuthenticity.LocalProcess,
                     PayloadTaint.Trusted)
                 {
-                    SourceKind = "reminder"
+                    SourceKind = new SourceKind("reminder")
                 },
                 ReceivedAt = _dispatchedAt,
                 ReminderId = reminderDeliveryKey

--- a/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
+++ b/src/Netclaw.Actors/Serialization/NetclawProtoMapper.cs
@@ -221,7 +221,7 @@ internal static class NetclawProtoMapper
         if (snap.Title is not null)
             proto.Title = snap.Title;
         if (snap.EligibleDeliveryTurnNumber is not null)
-            proto.EligibleDeliveryTurnNumber = snap.EligibleDeliveryTurnNumber.Value;
+            proto.EligibleDeliveryTurnNumber = snap.EligibleDeliveryTurnNumber.Value.Value;
         if (snap.WorkingContext is not null)
             proto.WorkingContext = ToProto(snap.WorkingContext);
         proto.History.AddRange(snap.History.Select(ToProto));
@@ -234,7 +234,9 @@ internal static class NetclawProtoMapper
     {
         TurnCount = proto.TurnCount,
         Title = proto.HasTitle ? proto.Title : null,
-        EligibleDeliveryTurnNumber = proto.HasEligibleDeliveryTurnNumber ? proto.EligibleDeliveryTurnNumber : null,
+        EligibleDeliveryTurnNumber = proto.HasEligibleDeliveryTurnNumber
+            ? new TurnNumber(proto.EligibleDeliveryTurnNumber)
+            : null,
         WorkingContext = proto.WorkingContext is not null ? FromProto(proto.WorkingContext) : null,
         History = proto.History.Select(FromProto).ToArray(),
         ActiveBackgroundJobs = proto.ActiveBackgroundJobs.Select(FromProto).ToArray(),

--- a/src/Netclaw.Actors/Sessions/Handlers/DeliveryRetryHandler.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/DeliveryRetryHandler.cs
@@ -15,11 +15,11 @@ internal sealed class DeliveryRetryHandler
 {
     public const int MaxRetries = 2;
 
-    private int? _eligibleTurnNumber;
+    private TurnNumber? _eligibleTurnNumber;
     private int _retryCount;
     private bool _chainActive;
 
-    public int? EligibleTurnNumber => _eligibleTurnNumber;
+    public TurnNumber? EligibleTurnNumber => _eligibleTurnNumber;
     public int RetryCount => _retryCount;
     public bool ChainActive => _chainActive;
 
@@ -37,7 +37,7 @@ internal sealed class DeliveryRetryHandler
     /// <summary>
     /// Mark the given turn as eligible for delivery retries.
     /// </summary>
-    public void MarkEligible(int turnNumber)
+    public void MarkEligible(TurnNumber turnNumber)
     {
         _eligibleTurnNumber = turnNumber;
         if (!_chainActive)

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -132,7 +132,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     private bool _anyContentStreamed;
 
     // Per-turn diagnostic correlation (ephemeral)
-    private string? _activeTurnId;
+    private Protocol.TurnId? _activeTurnId;
     private string? _activeMessageId;
     private Channels.ChannelType? _activeChannelType;
     private AutomaticRecallResult? _activeRecall;
@@ -820,7 +820,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 return;
             }
 
-            var decision = msg.SelectedKey switch
+            var decision = msg.SelectedKey.Value switch
             {
                 ApprovalOptionKeys.ApproveOnce => ApprovalDecision.ApprovedOnce,
                 ApprovalOptionKeys.ApproveSession => ApprovalDecision.ApprovedSession,
@@ -1804,7 +1804,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                     Title: "turn-completion",
                     UpdateSemantics: "append-document")));
 
-            _deliveryRetry.MarkEligible(_state.TurnCount);
+            _deliveryRetry.MarkEligible(new TurnNumber(_state.TurnCount));
 
             // Check if compaction should trigger
             if (ShouldCompact())
@@ -2585,7 +2585,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
                 EmitOutput(new TurnCompleted
                 {
                     SessionId = _sessionId,
-                    TurnNumber = _state.TurnCount,
+                    TurnNumber = new TurnNumber(_state.TurnCount),
                     Outcome = TurnOutcome.Skipped,
                     SourceReminderId = _currentTurnSource?.ReminderId
                 });
@@ -2611,7 +2611,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         EmitOutput(new TurnCompleted
         {
             SessionId = _sessionId,
-            TurnNumber = _state.TurnCount,
+            TurnNumber = new TurnNumber(_state.TurnCount),
             Outcome = TurnOutcome.Skipped,
             SourceReminderId = _currentTurnSource?.ReminderId
         });
@@ -2638,7 +2638,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -2675,7 +2675,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -2695,7 +2695,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -2712,7 +2712,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -2737,7 +2737,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Skipped,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -2869,7 +2869,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             EmitOutput(new TurnCompleted
             {
                 SessionId = _sessionId,
-                TurnNumber = _state.TurnCount,
+                TurnNumber = new TurnNumber(_state.TurnCount),
                 Outcome = TurnOutcome.Completed,
                 SourceReminderId = _currentTurnSource?.ReminderId
             });
@@ -3022,7 +3022,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         EmitOutput(new TurnCompleted
         {
             SessionId = _sessionId,
-            TurnNumber = _state.TurnCount,
+            TurnNumber = new TurnNumber(_state.TurnCount),
             SourceReminderId = _currentTurnSource?.ReminderId
         });
     }
@@ -3112,7 +3112,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         EmitOutput(new TurnCompleted
         {
             SessionId = _sessionId,
-            TurnNumber = _state.TurnCount,
+            TurnNumber = new TurnNumber(_state.TurnCount),
             Outcome = TurnOutcome.Failed,
             SourceReminderId = _currentTurnSource?.ReminderId
         });
@@ -3378,13 +3378,12 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         var sourceMessageId = source?.MessageId;
         _activeMessageId = sourceMessageId;
         _activeTurnId = source?.TurnId
-            ?? sourceMessageId
-            ?? IdGen.ShortId();
+            ?? new Protocol.TurnId(sourceMessageId ?? IdGen.ShortId());
         _activeChannelType = source?.ChannelType;
 
         CrashContextSnapshot.Update(
             _sessionId.Value,
-            _activeTurnId,
+            _activeTurnId?.Value,
             _activeMessageId,
             _activeChannelType?.ToWireValue(),
             _timeProvider.GetUtcNow());
@@ -3394,8 +3393,8 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
     {
         var log = _log;
 
-        if (!string.IsNullOrWhiteSpace(_activeTurnId))
-            log = log.WithContext("TurnId", _activeTurnId);
+        if (_activeTurnId is { Value: { Length: > 0 } turnIdValue })
+            log = log.WithContext("TurnId", turnIdValue);
 
         if (!string.IsNullOrWhiteSpace(_activeMessageId))
             log = log.WithContext("MessageId", _activeMessageId);

--- a/src/Netclaw.Actors/Sessions/ModelCapabilityActor.cs
+++ b/src/Netclaw.Actors/Sessions/ModelCapabilityActor.cs
@@ -44,22 +44,24 @@ public sealed class ModelCapabilityActor : UntypedActor
 
     private void HandleQuery(GetModelCapabilities query)
     {
+        var modelKey = query.ModelId.Value;
+
         // Cache hit — respond immediately
-        if (_cache.TryGetValue(query.ModelId, out var cached))
+        if (_cache.TryGetValue(modelKey, out var cached))
         {
             Sender.Tell(cached);
             return;
         }
 
         // Already in-flight — add sender to waiting list
-        if (_pending.TryGetValue(query.ModelId, out var waiters))
+        if (_pending.TryGetValue(modelKey, out var waiters))
         {
             waiters.Add(Sender);
             return;
         }
 
         // First query for this model — start resolution
-        _pending[query.ModelId] = [Sender];
+        _pending[modelKey] = [Sender];
         var self = Self;
 
         _ = Task.Run(async () =>
@@ -67,7 +69,7 @@ public sealed class ModelCapabilityActor : UntypedActor
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                var result = await _resolver.ResolveAsync(query.ModelId, cts.Token);
+                var result = await _resolver.ResolveAsync(query.ModelId.Value, cts.Token);
 
                 var input = result?.InputModalities ?? ModelModality.Text;
                 var output = result?.OutputModalities ?? ModelModality.Text;
@@ -86,7 +88,7 @@ public sealed class ModelCapabilityActor : UntypedActor
         var response = new ModelCapabilitiesResponse(
             resolved.ModelId, resolved.InputModalities, resolved.OutputModalities);
 
-        _cache[resolved.ModelId] = response;
+        _cache[resolved.ModelId.Value] = response;
 
         if (!resolved.Success)
         {
@@ -98,7 +100,7 @@ public sealed class ModelCapabilityActor : UntypedActor
                 resolved.ModelId, resolved.InputModalities, resolved.OutputModalities);
         }
 
-        if (_pending.Remove(resolved.ModelId, out var waiters))
+        if (_pending.Remove(resolved.ModelId.Value, out var waiters))
         {
             foreach (var waiter in waiters)
                 waiter.Tell(response);

--- a/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
+++ b/src/Netclaw.Actors/Sessions/ParentSessionApprovalBridge.cs
@@ -76,10 +76,10 @@ internal sealed class ParentSessionApprovalBridge : IParentApprovalBridge
             PersistedAdoptedContext = _hasAdoptedContext,
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         });
 

--- a/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
+++ b/src/Netclaw.Actors/Sessions/SessionMemoryObserverActor.cs
@@ -114,7 +114,7 @@ public sealed class SessionMemoryObserverActor : ReceivePersistentActor
 
             if (msg is TurnCompleted tc && tc.Outcome != TurnOutcome.Skipped)
             {
-                _turnCount = tc.TurnNumber;
+                _turnCount = tc.TurnNumber.Value;
                 _turnsSinceLastDistill++;
 
                 if (_distillTurnInterval > 0 && _hasNewContent && !_draining

--- a/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
+++ b/src/Netclaw.Actors/Tools/ToolAccessPolicy.cs
@@ -429,24 +429,24 @@ public sealed class ToolAccessPolicy
         {
             return
             [
-                new ToolApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolApprovalOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolApprovalOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ];
         }
 
         var options = new List<ToolApprovalOption>(5)
         {
-            new ToolApprovalOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-            new ToolApprovalOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel)
+            new ToolApprovalOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+            new ToolApprovalOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel)
         };
 
         if (!isCwdShallow && !allEffectiveDirsAreSessionScratch)
         {
-            options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel));
+            options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel));
         }
 
-        options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveEverywhere, ApprovalOptionKeys.ApproveEverywhereLabel));
-        options.Add(new ToolApprovalOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel));
+        options.Add(new ToolApprovalOption(ApprovalOptionKeys.ApproveEverywhereKey, ApprovalOptionKeys.ApproveEverywhereLabel));
+        options.Add(new ToolApprovalOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel));
 
         return options;
     }
@@ -647,7 +647,7 @@ public sealed record ToolApprovalContext(
     // actual paths the agent touched.
     IReadOnlyList<ApprovalCandidate>? Candidates = null);
 
-public sealed record ToolApprovalOption(string Key, string Label);
+public sealed record ToolApprovalOption(ApprovalOptionKey Key, string Label);
 
 public sealed class ToolAccessDeniedException : InvalidOperationException
 {

--- a/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
+++ b/src/Netclaw.Channels.Discord/DiscordAclPolicy.cs
@@ -49,8 +49,8 @@ public static class DiscordAclPolicy
                 TransportAuthenticity.Verified,
                 PayloadTaint.Public)
             {
-                SourceKind = "discord",
-                SourceScope = message.ChannelId.Value
+                SourceKind = new SourceKind("discord"),
+                SourceScope = new SourceScope(message.ChannelId.Value)
             });
     }
 

--- a/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
+++ b/src/Netclaw.Channels.Discord/DiscordApprovalPromptBuilder.cs
@@ -55,7 +55,7 @@ internal static class DiscordApprovalPromptBuilder
             .Select(option => new DiscordButtonSpec(
                 CustomId: BuildButtonValue(request, option),
                 Label: option.Label,
-                Style: GetButtonStyle(option.Key)))
+                Style: GetButtonStyle(option.Key.Value)))
             .ToList();
 
         return (sb.ToString().TrimEnd(), buttons);

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -57,7 +57,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private static readonly object ReinitializeTimerKey = new();
     private static readonly TimeSpan IdlePassivationTimeout = TimeSpan.FromHours(1);
     private bool _deliveredThisTurn;
-    private int _turnNumber;
+    private Netclaw.Actors.Protocol.TurnNumber _turnNumber;
     private string? _lastSetThreadName;
     private ulong? _cursorSnowflake;
     private ulong? _pendingCursorSnowflake;
@@ -722,7 +722,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             SessionId = _sessionId,
             CallId = pending!.CallId,
-            SelectedKey = selectedKey,
+            SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(selectedKey),
             SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
         });
 
@@ -754,7 +754,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         {
             SessionId = _sessionId,
             CallId = message.CallId,
-            SelectedKey = message.SelectedKey,
+            SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
             SenderId = new Netclaw.Actors.Protocol.SenderId(message.SenderId.Value)
         });
 
@@ -1098,7 +1098,7 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
             {
                 SessionId = _sessionId,
                 CallId = callId,
-                SelectedKey = ApprovalOptionKeys.Deny,
+                SelectedKey = ApprovalOptionKeys.DenyKey,
                 SenderId = new Netclaw.Actors.Protocol.SenderId("system")
             });
         }

--- a/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Discord/Transport/DiscordThreadHistoryFetcher.cs
@@ -230,8 +230,8 @@ public sealed class DiscordThreadHistoryFetcher : IThreadHistoryFetcher
                 TransportAuthenticity.Verified,
                 PayloadTaint.Public)
             {
-                SourceKind = "discord",
-                SourceScope = threadChannelId.ToString()
+                SourceKind = new SourceKind("discord"),
+                SourceScope = new SourceScope(threadChannelId.ToString())
             },
             Contents = contents,
             ReceivedAt = message.Timestamp

--- a/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
+++ b/src/Netclaw.Channels.Slack/SlackAclPolicy.cs
@@ -55,8 +55,8 @@ public static class SlackAclPolicy
                 TransportAuthenticity.Verified,
                 PayloadTaint.Public)
             {
-                SourceKind = "slack",
-                SourceScope = message.ChannelId.Value
+                SourceKind = new SourceKind("slack"),
+                SourceScope = new SourceScope(message.ChannelId.Value)
             });
     }
 

--- a/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
+++ b/src/Netclaw.Channels.Slack/SlackApprovalBlockBuilder.cs
@@ -97,10 +97,10 @@ internal static class SlackApprovalBlockBuilder
             Elements = [.. request.Options
                 .Select(option => (IActionElement)new Button
                 {
-                    ActionId = BuildActionId(option.Key),
+                    ActionId = BuildActionId(option.Key.Value),
                     Text = new PlainText(option.Label),
                     Value = BuildButtonValue(request, option),
-                    Style = GetButtonStyle(option.Key),
+                    Style = GetButtonStyle(option.Key.Value),
                     AccessibilityLabel = option.Label
                 })]
         });

--- a/src/Netclaw.Channels.Slack/SlackConversationActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackConversationActor.cs
@@ -130,7 +130,7 @@ public sealed class SlackConversationActor : ReceiveActor
                 ChannelId: message.ChannelId,
                 ThreadTs: threadTs,
                 EventId: message.EventId,
-                TurnId: turnId,
+                TurnId: new Netclaw.Actors.Protocol.TurnId(turnId),
                 SenderId: new Netclaw.Actors.Protocol.SenderId(message.UserId?.Value ?? "slack-user"),
                 Audience: aclDecision.Audience,
                 Principal: aclDecision.Principal,

--- a/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
+++ b/src/Netclaw.Channels.Slack/SlackIngressMessages.cs
@@ -45,7 +45,7 @@ public sealed record SlackThreadInbound(
     SlackChannelId ChannelId,
     SlackThreadTs ThreadTs,
     SlackEventId EventId,
-    string TurnId,
+    TurnId TurnId,
     SenderId SenderId,
     TrustAudience Audience,
     PrincipalClassification Principal,

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -1245,7 +1245,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             {
                 SessionId = _sessionId,
                 CallId = pending.Request.CallId,
-                SelectedKey = selectedKey,
+                SelectedKey = new Actors.Protocol.ApprovalOptionKey(selectedKey),
                 SenderId = message.SenderId
             });
 
@@ -1305,7 +1305,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             {
                 SessionId = _sessionId,
                 CallId = message.CallId,
-                SelectedKey = message.SelectedKey,
+                SelectedKey = new Actors.Protocol.ApprovalOptionKey(message.SelectedKey),
                 SenderId = message.SenderId
             });
 
@@ -1373,7 +1373,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         }
     }
 
-    private async Task NotifyDeliveryFailedAsync(int turnNumber, DeliveryFailureKind failureKind, string errorMessage)
+    private async Task NotifyDeliveryFailedAsync(Actors.Protocol.TurnNumber turnNumber, DeliveryFailureKind failureKind, string errorMessage)
     {
         try
         {
@@ -1439,7 +1439,7 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
             {
                 SessionId = _sessionId,
                 CallId = request.CallId,
-                SelectedKey = ApprovalOptionKeys.Deny,
+                SelectedKey = ApprovalOptionKeys.DenyKey,
                 SenderId = request.RequesterSenderId ?? new Netclaw.Actors.Protocol.SenderId(string.Empty)
             });
         }

--- a/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadHistoryFetcher.cs
@@ -269,8 +269,8 @@ public sealed class SlackThreadHistoryFetcher : IThreadHistoryFetcher
                 TransportAuthenticity.Verified,
                 PayloadTaint.Public)
             {
-                SourceKind = "slack",
-                SourceScope = channelId.Value
+                SourceKind = new SourceKind("slack"),
+                SourceScope = new SourceScope(channelId.Value)
             },
             Contents = contents,
             ReceivedAt = receivedAt

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientMappingTests.cs
@@ -272,10 +272,10 @@ public sealed class DaemonClientMappingTests
             CandidateVerbs = ["git push"],
             Options =
             [
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnce, ApprovalOptionKeys.ApproveOnceLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveSession, ApprovalOptionKeys.ApproveSessionLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlways, ApprovalOptionKeys.ApproveAlwaysLabel),
-                new ToolInteractionOption(ApprovalOptionKeys.Deny, ApprovalOptionKeys.DenyLabel)
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveSessionKey, ApprovalOptionKeys.ApproveSessionLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.ApproveAlwaysKey, ApprovalOptionKeys.ApproveAlwaysLabel),
+                new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
             ]
         };
 
@@ -320,5 +320,61 @@ public sealed class DaemonClientMappingTests
         var error = Assert.IsType<ErrorOutput>(output);
         Assert.Equal(ErrorCategory.Unknown, error.Category);
         Assert.NotEqual(Guid.Empty, error.CorrelationId);
+    }
+
+    [Fact]
+    public void SessionOutputDto_turn_number_serializes_as_bare_json_integer()
+    {
+        // Pass 7d wraps SessionOutputDto.TurnNumber in the TurnNumber value
+        // object. The SignalR JSON wire form must stay a bare integer (never a
+        // nested { "Value": N } object) so an old/new daemon and CLI interop.
+        var dto = new SessionOutputDto
+        {
+            Type = SessionOutputTypes.TurnCompleted,
+            SessionId = "signalr/test",
+            TimestampMs = 1,
+            TurnNumber = new TurnNumber(9)
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(dto);
+        Assert.Contains("\"TurnNumber\":9", json);
+        Assert.DoesNotContain("\"Value\"", json);
+
+        var restored = System.Text.Json.JsonSerializer.Deserialize<SessionOutputDto>(json);
+        Assert.Equal(new TurnNumber(9), restored!.TurnNumber);
+    }
+
+    [Fact]
+    public void SessionOutputDto_null_turn_number_serializes_as_json_null()
+    {
+        var dto = new SessionOutputDto
+        {
+            Type = SessionOutputTypes.Text,
+            SessionId = "signalr/test",
+            TimestampMs = 1,
+            TurnNumber = null
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(dto);
+        Assert.Contains("\"TurnNumber\":null", json);
+
+        var restored = System.Text.Json.JsonSerializer.Deserialize<SessionOutputDto>(json);
+        Assert.Null(restored!.TurnNumber);
+    }
+
+    [Fact]
+    public void ToolInteractionOption_key_serializes_as_bare_json_string()
+    {
+        // ToolInteractionOption.Key crosses the SignalR JSON boundary nested in
+        // SessionOutputDto.InteractionOptions. The ApprovalOptionKey converter
+        // must keep it a bare string so channel adapters parse it unchanged.
+        var option = new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, "Once");
+
+        var json = System.Text.Json.JsonSerializer.Serialize(option);
+        Assert.Contains("\"Key\":\"approve_once\"", json);
+        Assert.DoesNotContain("\"Value\"", json);
+
+        var restored = System.Text.Json.JsonSerializer.Deserialize<ToolInteractionOption>(json);
+        Assert.Equal(ApprovalOptionKeys.ApproveOnceKey, restored!.Key);
     }
 }

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -259,7 +259,7 @@ public sealed class DaemonClientReconnectIntegrationTests
                 Type = "turn_completed",
                 SessionId = sessionId,
                 TimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             });
         }
 

--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientSessionTests.cs
@@ -178,7 +178,7 @@ public sealed class DaemonClientSessionTests
                 Type = "turn_completed",
                 SessionId = sessionId,
                 TimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                TurnNumber = 1
+                TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
             });
         }
 

--- a/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
+++ b/src/Netclaw.Cli.Tests/Tui/FakeProviderProbe.cs
@@ -31,8 +31,8 @@ public sealed class FakeProviderProbe : IProviderProbe
     public ProviderProbeResult NextResult { get; set; } = new(
         true, null,
         [
-            new DiscoveredModel { ModelId = "model-a" },
-            new DiscoveredModel { ModelId = "model-b" }
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-a") },
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-b") }
         ]);
 
     /// <summary>

--- a/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/ProviderManagerViewModelTests.cs
@@ -200,7 +200,7 @@ public sealed class ProviderManagerViewModelTests : IDisposable
     public async Task EagerProbe_SetsHealthOnItems()
     {
         _fakeProbe.TypeResults["openrouter"] = new ProviderProbeResult(true, null,
-            [new DiscoveredModel { ModelId = "gpt-4" }]);
+            [new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("gpt-4") }]);
         _fakeProbe.TypeResults["ollama"] = new ProviderProbeResult(false, "Connection refused", []);
 
         WriteConfig(new Dictionary<string, object>
@@ -503,7 +503,7 @@ public sealed class ProviderManagerViewModelTests : IDisposable
 
         // Now the re-probe should succeed — update the per-type result
         _fakeProbe.TypeResults["openrouter"] = new ProviderProbeResult(true, null,
-            [new DiscoveredModel { ModelId = "model-a" }]);
+            [new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("model-a") }]);
 
         vm.FixApiKey = "sk-new-key";
         vm.SubmitFixCredentials();

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ProviderStepViewModelTests.cs
@@ -130,8 +130,8 @@ public sealed class ProviderStepViewModelTests : IDisposable
 
         _fakeProbe.NextResult = new ProviderProbeResult(true, null,
         [
-            new DiscoveredModel { ModelId = "llama3:latest" },
-            new DiscoveredModel { ModelId = "qwen3:30b" }
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("llama3:latest") },
+            new DiscoveredModel { ModelId = new Netclaw.Configuration.ModelId("qwen3:30b") }
         ]);
 
         step.StartProbe();

--- a/src/Netclaw.Cli/Model/ModelCommand.cs
+++ b/src/Netclaw.Cli/Model/ModelCommand.cs
@@ -201,7 +201,7 @@ internal static class ModelCommand
 
         writer.WriteLine();
         writer.WriteLine($"{"Model ID",-40} {"Context Window",-16} {"Cost (in/out per 1M)"}");
-        foreach (var model in result.Models.OrderBy(m => m.ModelId, StringComparer.OrdinalIgnoreCase))
+        foreach (var model in result.Models.OrderBy(m => m.ModelId.Value, StringComparer.OrdinalIgnoreCase))
         {
             var ctx = model.ContextWindowTokens.HasValue
                 ? $"{model.ContextWindowTokens.Value:N0}"

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -239,7 +239,7 @@ public partial class ChatViewModel : ReactiveViewModel
         if (option is null)
             return Task.CompletedTask;
 
-        return SubmitInteractionSelectionAsync(option.Key);
+        return SubmitInteractionSelectionAsync(option.Key.Value);
     }
 
     public string GetApprovalPrompt()

--- a/src/Netclaw.Cli/Tui/ModelManagerPage.cs
+++ b/src/Netclaw.Cli/Tui/ModelManagerPage.cs
@@ -268,7 +268,7 @@ public sealed class ModelManagerPage : ReactivePage<ModelManagerViewModel>
 
         // Build model list with manual entry option
         var items = ViewModel.DiscoveredModels
-            .Select(m => m.ModelId)
+            .Select(m => m.ModelId.Value)
             .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
             .ToList();
         items.Add("Enter model ID manually...");

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ProviderStepView.cs
@@ -255,7 +255,7 @@ public sealed class ProviderStepView : IWizardStepView
 
         var displayCount = Math.Min(models.Count, MaxDisplayedModels);
         for (var i = 0; i < displayCount; i++)
-            items.Add(models[i].ModelId);
+            items.Add(models[i].ModelId.Value);
 
         if (models.Count > MaxDisplayedModels)
             items.Add($"... and {models.Count - MaxDisplayedModels} more (enter manually)");

--- a/src/Netclaw.Configuration/DiscoveredModel.cs
+++ b/src/Netclaw.Configuration/DiscoveredModel.cs
@@ -13,7 +13,7 @@ namespace Netclaw.Configuration;
 public sealed record DiscoveredModel
 {
     /// <summary>Model identifier as used in API calls.</summary>
-    public required string ModelId { get; init; }
+    public required ModelId ModelId { get; init; }
 
     /// <summary>Maximum context window size in tokens, if known.</summary>
     public int? ContextWindowTokens { get; init; }

--- a/src/Netclaw.Configuration/ModelId.cs
+++ b/src/Netclaw.Configuration/ModelId.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="ModelId.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Configuration;
+
+/// <summary>
+/// Strongly-typed model identifier — the provider-facing model name used in
+/// API calls and capability lookups (e.g. <c>claude-opus-4-7</c>). Wraps the
+/// raw id string so a model id cannot be confused with a session id, provider
+/// name, or any other string at a call boundary.
+/// </summary>
+public readonly record struct ModelId
+{
+    /// <summary>
+    /// Constructs a model id from its raw string value. The value is trimmed;
+    /// an empty or whitespace value is rejected.
+    /// </summary>
+    public ModelId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Model id must be a non-empty value.", nameof(value));
+
+        Value = value.Trim();
+    }
+
+    /// <summary>The raw model identifier string.</summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Explicit conversion from the raw model-id string. Routes through the
+    /// validating constructor — there is deliberately no implicit conversion.
+    /// </summary>
+    public static explicit operator ModelId(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
+++ b/src/Netclaw.Daemon.Tests/Gateway/SessionCatalogServiceTests.cs
@@ -376,7 +376,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
         service.OnOutput(new TurnCompleted
         {
             SessionId = sessionId,
-            TurnNumber = 0,
+            TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(0),
             Outcome = TurnOutcome.Skipped
         });
 
@@ -397,7 +397,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
         service.OnOutput(new TurnCompleted
         {
             SessionId = sessionId,
-            TurnNumber = 1,
+            TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1),
             Outcome = TurnOutcome.Failed
         });
 
@@ -418,7 +418,7 @@ public sealed class SessionCatalogServiceTests : IDisposable
         service.OnOutput(new TurnCompleted
         {
             SessionId = sessionId,
-            TurnNumber = 1
+            TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1)
         });
 
         var beforeResume = service.ListRecent().Single().LastActivity;

--- a/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenAiCodexTests.cs
@@ -179,7 +179,7 @@ public sealed class OpenAiCodexTests
             Assert.True(result.Success);
             Assert.Null(result.ErrorMessage);
             Assert.NotEmpty(result.Models);
-            Assert.Contains(result.Models, m => m.ModelId == "o3");
+            Assert.Contains(result.Models, m => m.ModelId.Value == "o3");
 
             // All curated models should have context windows and modalities populated
             Assert.All(result.Models, m =>
@@ -302,7 +302,7 @@ public sealed class OpenAiCodexTests
         {
             foreach (var model in OpenAiDescriptor.CuratedModels)
             {
-                var result = await _resolver.ResolveAsync(model.ModelId, TestContext.Current.CancellationToken);
+                var result = await _resolver.ResolveAsync(model.ModelId.Value, TestContext.Current.CancellationToken);
                 Assert.NotNull(result);
                 Assert.NotNull(result.ContextWindowTokens);
                 Assert.True(result.ContextWindowTokens > 32_768);

--- a/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
+++ b/src/Netclaw.Daemon/Gateway/SessionRegistry.cs
@@ -226,7 +226,7 @@ public sealed class SessionRegistry
                 identity.Transport,
                 PayloadTaint.Trusted)
             {
-                SourceKind = "signalr"
+                SourceKind = new SourceKind("signalr")
             },
             Contents = [new TextContent(text)],
             ReceivedAt = _timeProvider.GetUtcNow()
@@ -263,7 +263,7 @@ public sealed class SessionRegistry
         {
             SessionId = requestedSessionId,
             CallId = new Netclaw.Tools.ToolCallId(callId),
-            SelectedKey = selectedKey,
+            SelectedKey = new Netclaw.Actors.Protocol.ApprovalOptionKey(selectedKey),
             SenderId = identity.SenderId
         });
     }

--- a/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEndpointRouteBuilderExtensions.cs
@@ -125,8 +125,8 @@ public static class WebhookEndpointRouteBuilderExtensions
             var sessionId = new SessionId($"webhook/{registeredRoute.Name}/{SanitizeWebhookId(deliveryKey)}");
             var invocation = new WebhookInvocation(
                 registeredRoute,
-                verification.EventType,
-                verification.DeliveryId,
+                verification.EventType is { } eventType ? new WebhookEventType(eventType) : null,
+                verification.DeliveryId is { } deliveryId ? new WebhookDeliveryId(deliveryId) : null,
                 bodyRead.BodyJson!,
                 sessionId,
                 now);

--- a/src/Netclaw.Daemon/Webhooks/WebhookEventType.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookEventType.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookEventType.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Netclaw.Daemon.Webhooks;
+
+/// <summary>
+/// Strongly-typed webhook event-type discriminator — the provider-supplied
+/// event name (e.g. <c>push</c>, <c>issues.opened</c>) extracted from an
+/// inbound webhook header and used for event-filter matching. Wraps the raw
+/// string so an event type cannot be confused with a <see cref="WebhookDeliveryId"/>
+/// or any other string at a call boundary.
+/// </summary>
+public readonly record struct WebhookEventType(string Value)
+{
+    public static explicit operator WebhookEventType(string value) => new(value);
+
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Strongly-typed webhook delivery correlation id — the provider-supplied
+/// unique delivery identifier extracted from an inbound webhook header and used
+/// for duplicate-delivery suppression. Wraps the raw string so a delivery id
+/// cannot be confused with a <see cref="WebhookEventType"/> or any other string
+/// at a call boundary.
+/// </summary>
+public readonly record struct WebhookDeliveryId(string Value)
+{
+    public static explicit operator WebhookDeliveryId(string value) => new(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Netclaw.Daemon/Webhooks/WebhookExecutionActor.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookExecutionActor.cs
@@ -95,8 +95,9 @@ internal sealed class WebhookExecutionActor : ReceiveActor
                     TransportAuthenticity.Verified,
                     ToPayloadTaint(routeAudience))
                 {
-                    SourceKind = _invocation.EventType ?? _invocation.Route.Name,
-                    SourceScope = _invocation.Route.Name
+                    SourceKind = new SourceKind(
+                        _invocation.EventType?.Value ?? _invocation.Route.Name),
+                    SourceScope = new SourceScope(_invocation.Route.Name)
                 },
                 Contents = [new TextContent(WebhookPayloadFormatter.Format(_invocation))],
                 ReceivedAt = _invocation.ReceivedAt

--- a/src/Netclaw.Daemon/Webhooks/WebhookInvocation.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookInvocation.cs
@@ -9,8 +9,8 @@ namespace Netclaw.Daemon.Webhooks;
 
 public sealed record WebhookInvocation(
     RegisteredWebhookRoute Route,
-    string? EventType,
-    string? DeliveryId,
+    WebhookEventType? EventType,
+    WebhookDeliveryId? DeliveryId,
     string PayloadJson,
     SessionId SessionId,
     DateTimeOffset ReceivedAt);

--- a/src/Netclaw.Daemon/Webhooks/WebhookPayloadFormatter.cs
+++ b/src/Netclaw.Daemon/Webhooks/WebhookPayloadFormatter.cs
@@ -22,11 +22,11 @@ public static class WebhookPayloadFormatter
         builder.AppendLine();
         builder.AppendLine($"Route: {invocation.Route.Name}");
 
-        if (!string.IsNullOrWhiteSpace(invocation.EventType))
-            builder.AppendLine($"Event: {invocation.EventType}");
+        if (invocation.EventType is { Value: { Length: > 0 } eventType })
+            builder.AppendLine($"Event: {eventType}");
 
-        if (!string.IsNullOrWhiteSpace(invocation.DeliveryId))
-            builder.AppendLine($"Delivery ID: {invocation.DeliveryId}");
+        if (invocation.DeliveryId is { Value: { Length: > 0 } deliveryId })
+            builder.AppendLine($"Delivery ID: {deliveryId}");
 
         builder.AppendLine($"Received At (UTC): {invocation.ReceivedAt:u}");
         builder.AppendLine();

--- a/src/Netclaw.Providers/OpenAi/OpenAiCodexCapabilityResolver.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiCodexCapabilityResolver.cs
@@ -16,9 +16,9 @@ public sealed class OpenAiCodexCapabilityResolver : IModelCapabilityResolver
 {
     private static readonly Dictionary<string, ResolvedModelCapabilities> Catalog =
         OpenAiDescriptor.CuratedModels.ToDictionary(
-            m => m.ModelId,
+            m => m.ModelId.Value,
             m => new ResolvedModelCapabilities(
-                m.ModelId,
+                m.ModelId.Value,
                 m.InputModalities,
                 m.OutputModalities,
                 m.ContextWindowTokens));

--- a/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiDescriptor.cs
@@ -75,21 +75,21 @@ public sealed class OpenAiDescriptor : IProviderDescriptor
     internal static readonly DiscoveredModel[] CuratedModels =
     [
         // Frontier — all accept text+image input, produce text output
-        new() { ModelId = "gpt-5.4",      ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-5",        ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-5-mini",   ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-5-nano",   ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-4.1",      ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-4.1-mini", ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-4.1-nano", ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5.4"),      ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5"),        ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5-mini"),   ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5-nano"),   ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-4.1"),      ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-4.1-mini"), ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-4.1-nano"), ContextWindowTokens = 1_047_576, InputModalities = TextImage, OutputModalities = ModelModality.Text },
         // Reasoning — text+image input, text output
-        new() { ModelId = "o3",           ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "o3-mini",      ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "o4-mini",      ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("o3"),           ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("o3-mini"),      ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("o4-mini"),      ContextWindowTokens = 200_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
         // Codex (coding-optimized) — text+image input, text output
-        new() { ModelId = "gpt-5.3-codex", ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-5.2-codex", ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
-        new() { ModelId = "gpt-5-codex",   ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5.3-codex"), ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5.2-codex"), ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
+        new() { ModelId = new("gpt-5-codex"),   ContextWindowTokens = 256_000, InputModalities = TextImage, OutputModalities = ModelModality.Text },
     ];
 
     private const ModelModality TextImage = ModelModality.Text | ModelModality.Image;

--- a/src/Netclaw.Providers/ProbeHelpers.cs
+++ b/src/Netclaw.Providers/ProbeHelpers.cs
@@ -31,7 +31,7 @@ internal static class ProbeHelpers
             {
                 if (model.TryGetProperty("id", out var id))
                 {
-                    models.Add(new DiscoveredModel { ModelId = id.GetString()! });
+                    models.Add(new DiscoveredModel { ModelId = new(id.GetString()!) });
                 }
             }
         }

--- a/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
+++ b/src/Netclaw.Providers/SelfHosted/OllamaDescriptor.cs
@@ -54,7 +54,7 @@ public sealed class OllamaDescriptor : IProviderDescriptor
             {
                 if (model.TryGetProperty("name", out var name))
                 {
-                    models.Add(new DiscoveredModel { ModelId = name.GetString()! });
+                    models.Add(new DiscoveredModel { ModelId = new(name.GetString()!) });
                 }
             }
         }


### PR DESCRIPTION
## Summary

Pass 7d of the issue #994 value-object adoption — the remaining new value objects.

**Created:**
- **`ModelId`** (`Netclaw.Configuration`) — wraps the model-id field on the actor/protocol model-capability messages: `GetModelCapabilities`, `ModelCapabilitiesResponse`, `CapabilityResolved`, `DiscoveredModel`. Config-binding POCOs (`ModelReference`, `ModelCapabilities`) deliberately stay `string` (framework-bound; conversion happens at the boundary).
- **`TurnNumber`** (`Netclaw.Actors.Protocol`) — **`int`-backed**; the monotonic stale-feedback-rejection ordinal on `TurnCompleted`, `DeliveryFailed`, `SessionSnapshot.EligibleDeliveryTurnNumber`, `SessionOutputDto.TurnNumber`.
- **`TurnId`** (`Netclaw.Actors.Protocol`) — turn correlation id (confirmed distinct callsites: `MessageSource.TurnId`, `_activeTurnId`, `MemoryCheckpointRequest.TurnId`, `SlackThreadInbound.TurnId`).
- **`ApprovalOptionKey`** (`Netclaw.Actors.Protocol`) — `ToolInteractionResponse.SelectedKey`, `ToolInteractionOption.Key`, `ToolApprovalOption.Key`, with named factories for the canonical option constants.
- **`WebhookEventType`** / **`WebhookDeliveryId`** (`Netclaw.Daemon.Webhooks`).
- **`SourceScope`** / **`SourceKind`** (`Netclaw.Actors.Channels`) — the `SourceProvenance` / `EffectiveTrustContext` metadata fields.

**Skipped** per the audit's leave-as-string guidance:
- `ApprovalVerb` — `ApprovalEntry.Verb` / `ApprovalCandidate.Verb` are free-form extracted command heads on the persisted `tool-approvals.json` schema; wrapping would ripple through `Netclaw.Security` matchers for no safety gain.
- `SkillName` — no actor/protocol record carries a skill-identity field with type-confusion risk.

## Wire / disk format

Unchanged. `NetclawProtoMapper` maps `TurnNumber` to/from the primitive proto `int32` (`.proto` untouched); `TurnNumberJsonConverter` / `NullableTurnNumberJsonConverter` / `ApprovalOptionKeyJsonConverter` keep the SignalR/DTO surface byte-identical. Byte-equality round-trip tests added for `SessionSnapshot.EligibleDeliveryTurnNumber` and the JSON DTO fields.

## Test plan

- [x] `dotnet build Netclaw.slnx` — clean (0 warnings, 0 errors)
- [x] All 7 test projects green (3,754 tests)
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `Add-FileHeaders.ps1 -Verify` — passes

## Notes

Branched off `dev` (includes #1006/#1009/#1022/#1023). Completes `value-object-adoption` Pass 7d (tasks 6.1–6.6). Remaining: Pass 7e (memory/sub-agent enum unwrap fixes).