### PR TITLE
release: Netclaw 0.18.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,78 +8,37 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.18.0</VersionPrefix>
-    <PackageReleaseNotes>Netclaw v0.18.0 — Directory-scoped approvals, sub-agent reloads, vLLM support, channel reliability, and security hardening
+    <VersionPrefix>0.18.1</VersionPrefix>
+    <PackageReleaseNotes>Netclaw v0.18.1 — macOS binaries, provider renaming, shell subprocess cleanup, and stream stability fixes
 
 **Features**
 
-* **Directory-scoped shell command approval patterns** — approve a shell command rooted at a parent directory and it automatically applies to all subdirectories, eliminating redundant prompts. Approval entries now use a `(verb, directory)` model with proper path hierarchy. ([#896](https://github.com/netclaw-dev/netclaw/pull/896))
+* **macOS (Apple Silicon) support** — Netclaw now ships `osx-arm64` self-contained binaries, and the install script supports macOS installs end-to-end with a Rosetta guard and an explicit Intel-Mac rejection. This is the first release to publish macOS binaries. Path-security checks were also corrected for macOS's `/private` symlink layout. launchd service install and notarization are tracked as follow-ups ([#1015](https://github.com/netclaw-dev/netclaw/issues/1015), [#1016](https://github.com/netclaw-dev/netclaw/issues/1016)). ([#1018](https://github.com/netclaw-dev/netclaw/pull/1018))
 
-* **`netclaw approvals` CLI** — new CLI subcommand for listing, revoking, and managing shell command approvals with a TUI interface. Closes [#921](https://github.com/netclaw-dev/netclaw/issues/921). ([#927](https://github.com/netclaw-dev/netclaw/pull/927))
+* **Editable provider names + rename action** — the provider add flow now opens with a dedicated Name step pre-filled with a suggested default, so multiple self-hosted endpoints (vLLM, llama.cpp) and aggregator accounts are no longer stuck with auto-generated names like `my-vllm-2`. A new `[N] Rename` action and CLI subcommand rename existing providers, cascading the change to `Models.{Main,Fallback,Compaction}.Provider` role references in the same atomic write. ([#997](https://github.com/netclaw-dev/netclaw/pull/997))
 
-* **vLLM-aware capability resolver + timings split** — the provider system now detects vLLM endpoints and resolves capabilities accordingly, with separate prompt/decode timing metrics. ([#619](https://github.com/netclaw-dev/netclaw/pull/619), [#986](https://github.com/netclaw-dev/netclaw/pull/986))
-
-* **File-based sub-agent hot reload** — file-defined sub-agents under `~/.netclaw/agents/` now reload automatically when modified, and spawned sub-agents inherit parent session context (session_dir, project_dir). Invalid edits fail closed. ([#984](https://github.com/netclaw-dev/netclaw/pull/984))
-
-* **Serialization marker interface + test-time verification** — new `ISerializableMessage` marker interface with compile-time and test-time verification to catch unregistered serialization types early. Closes [#961](https://github.com/netclaw-dev/netclaw/issues/961). ([#978](https://github.com/netclaw-dev/netclaw/pull/978))
-
-* **SearXNG backend hardening** — improved SearXNG search with custom User-Agent, 429 retry logic, configurable timeouts, and 403 detection. ([#914](https://github.com/netclaw-dev/netclaw/pull/914))
-
-* **Container/proxy exposure mode relaxation** — daemon no longer rejects `https` exposure mode when bound to loopback, supporting TLS-termination-at-proxy topologies. ([#864](https://github.com/netclaw-dev/netclaw/pull/864))
+* **Approval creation timestamps + gate near-miss diagnostics** — persisted tool approvals now carry an optional `createdAt` timestamp, surfaced as a relative creation time in `netclaw approvals list`, its `--json` output, and the approvals TUI. When a shell pattern is prompted despite a same-verb persisted grant, the daemon now logs why it did not match (directory not under grant, symlink segment, verb-case mismatch). The on-disk schema is unchanged and existing approval files load without migration. ([#1010](https://github.com/netclaw-dev/netclaw/pull/1010))
 
 **Bug Fixes**
 
-* **Button approvals route by SessionId** — approval button clicks now route via the deterministic session actor path instead of the per-thread binding's in-memory lookup, fixing silently-dropped approvals when channel adapters passivate. Closes [#979](https://github.com/netclaw-dev/netclaw/issues/979). ([#982](https://github.com/netclaw-dev/netclaw/pull/982))
+* **`shell_execute` no longer orphans subprocesses** — `shell_execute` could leave a subprocess running indefinitely when the kill branch was skipped on a timeout, and interactive Termina commands launched by a non-interactive caller would hang forever. Process kill is now driven off the linked cancellation token, and a remaining gap where `ShellTool.Kill` throwing `Win32Exception` left pipe reads hung at EOF is also closed. ([#1019](https://github.com/netclaw-dev/netclaw/pull/1019))
 
-* **Thread history hydration** — bot messages from thread history now hydrate only once per actor lifetime, with media properly accounted for in compaction size calculations. ([#990](https://github.com/netclaw-dev/netclaw/pull/990))
+* **Tool results without a ToolCallId now fail loud** — a missing `ToolCallId` is no longer coalesced to an empty value that handed approval matching and channel rendering a non-correlatable id; the session actor throws instead, surfacing the assembly bug. ([#1023](https://github.com/netclaw-dev/netclaw/pull/1023))
 
-* **Passivation race fix** — sessions now use a post-snapshot grace window to close the passivation race condition where messages could be lost during shutdown. ([#985](https://github.com/netclaw-dev/netclaw/pull/985))
+* **Proactive thread hydration re-armed** — a proactively-created channel thread (such as a reminder posting via `send_slack_message`) no longer loses the message that opened it; a deferred hydration is now re-armed so the first authorized inbound completes it. ([#1008](https://github.com/netclaw-dev/netclaw/pull/1008))
 
-* **ModelReference modality schema alignment** — config schema now matches scalar binding for `ModelReference.Modality`. ([#988](https://github.com/netclaw-dev/netclaw/pull/988), [#989](https://github.com/netclaw-dev/netclaw/pull/989))
+* **Cached shell approval matches audited** — cached shell approvals are now evaluated with full approval candidates and record `PreviouslyApproved` audit context.
 
-* **Reminder execution fixes** — removed spurious 5-minute execution timeout that was killing long-running reminders, and prevented duplicate concurrent execution of the same reminder. ([#970](https://github.com/netclaw-dev/netclaw/pull/970))
+* **`netclaw approvals list` fills the terminal** — the approvals list previously showed only 10 of 100+ entries with a scrollbar floating in an empty panel; it now grows with the terminal height. ([#1005](https://github.com/netclaw-dev/netclaw/pull/1005))
 
-* **Config watcher atomic-replace handling** — file system watcher now handles atomic-replace writes (Renamed events) from editors like VS Code. Closes [#959](https://github.com/netclaw-dev/netclaw/issues/959). ([#960](https://github.com/netclaw-dev/netclaw/pull/960))
+* **Daemon no longer crashes on discarded stream tasks** — Akka.Streams stages discarded internal `Task&lt;Done&gt;` instances that surfaced as daemon-unobserved crash logs during hot reload and idle passivation; those tasks are now observed. ([#998](https://github.com/netclaw-dev/netclaw/pull/998))
 
-* **Thread history backfill** — bot messages are now included in thread history backfill, and hydration happens only at thread root. ([#954](https://github.com/netclaw-dev/netclaw/pull/954), [#958](https://github.com/netclaw-dev/netclaw/pull/958))
-
-* **Memory provenance** — adopted-context provenance is now separated from third-party memory policy. ([#952](https://github.com/netclaw-dev/netclaw/pull/952))
-
-* **`netclaw doctor` warning suppression** — no longer warns about explicitly-configured Personal posture and tool profile. ([#950](https://github.com/netclaw-dev/netclaw/pull/950))
-
-* **Systemd PATH fix** — systemd unit now bakes PATH so the shell tool can resolve the `netclaw` CLI. ([#948](https://github.com/netclaw-dev/netclaw/pull/948))
-
-* **Thinking-only retry guard** — three-layer SSE/middleware/actor diagnostics prevent retries on thinking-only responses, plus `RollingFileLogger` Debug-level fix. ([#947](https://github.com/netclaw-dev/netclaw/pull/947))
-
-* **Watchdog two-phase timeout** — watchdog now consumes `prompt_progress` keepalives from llama.cpp and uses a two-phase timeout to prevent false-positive watchdog kills. ([#946](https://github.com/netclaw-dev/netclaw/pull/946))
-
-* **MCP personal mode defaults** — personal mode now defaults all tools to Auto and the toggle grants all tools properly. ([#942](https://github.com/netclaw-dev/netclaw/pull/942), [#943](https://github.com/netclaw-dev/netclaw/pull/943))
-
-* **Approval button label truncation** — button labels are now truncated to fit Slack/Discord character limits. Closes [#931](https://github.com/netclaw-dev/netclaw/issues/931). ([#937](https://github.com/netclaw-dev/netclaw/pull/937))
-
-* **DailyStatsActor SQLite DDL cleanup** — removed SQLite DDL from `PreStart`, and wizard poll-timeout now surfaces crash logs. Closes [#925](https://github.com/netclaw-dev/netclaw/issues/925). ([#938](https://github.com/netclaw-dev/netclaw/pull/938))
-
-* **Session diagnostics logging** — all session diagnostics now route into a single session log file, with sidecar `IChatClient` calls wrapped in `SessionDiagnosticsContext`. ([#916](https://github.com/netclaw-dev/netclaw/pull/916), [#926](https://github.com/netclaw-dev/netclaw/pull/926))
-
-* **TUI context window display** — status bar now uses daemon-reported context window size. ([#906](https://github.com/netclaw-dev/netclaw/pull/906), [#913](https://github.com/netclaw-dev/netclaw/pull/913))
-
-* **Wizard Personal posture fix** — init wizard with Personal posture no longer silently disables all features. ([#907](https://github.com/netclaw-dev/netclaw/pull/907))
-
-**Security**
-
-* **Filesystem root tilde expansion** — `~` and `$HOME` in configured filesystem roots are now properly expanded. ([#975](https://github.com/netclaw-dev/netclaw/pull/975))
-
-* **Skill scanner NoOp for system skills** — swapped skill content scanner to NoOp to unblock system skills from loading. ([#976](https://github.com/netclaw-dev/netclaw/pull/976), [#977](https://github.com/netclaw-dev/netclaw/pull/977))
-
-* **Non-loopback Daemon.Host rejection** — Local exposure mode now rejects non-loopback `Daemon.Host` values. ([#901](https://github.com/netclaw-dev/netclaw/pull/901))
-
-* **Reverted trust-zones** — stayed on the simpler `(verb, directory) ApprovalEntry` model instead of the trust-zone approach. ([#962](https://github.com/netclaw-dev/netclaw/pull/962))
+* **Session log writes deterministic under Windows share-mode races** — `SessionLogFile.AppendLine` now retries transient sharing violations with backoff and uses the canonical `FileShare.ReadWrite|Delete` mask, so concurrent readers no longer cause silently-dropped audit lines on Windows. ([#996](https://github.com/netclaw-dev/netclaw/pull/996))
 
 **Dependencies**
 
-* Bumped `Microsoft.SourceLink.GitHub` from 10.0.203 to 10.0.300. ([#983](https://github.com/netclaw-dev/netclaw/pull/983))
-* Bumped Microsoft platform/AI packages and added Dependabot groups. ([#980](https://github.com/netclaw-dev/netclaw/pull/980))
-* Bumped `Netclaw.SkillClient` from 0.2.1 to 0.3.0. ([#936](https://github.com/netclaw-dev/netclaw/pull/936))</PackageReleaseNotes>
+* Upgraded `ShellSyntaxTree` to 0.1.5 and routed `ExtractPatterns` through `BashParser`. ([#1007](https://github.com/netclaw-dev/netclaw/pull/1007), [#1020](https://github.com/netclaw-dev/netclaw/pull/1020))
+* Bumped `ModelContextProtocol.Core` from 1.2.0 to 1.3.0. ([#992](https://github.com/netclaw-dev/netclaw/pull/992))</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NetCoreTestVersion>net10.0</NetCoreTestVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,36 @@
+#### 0.18.1 May 16 2026 ####
+
+Netclaw v0.18.1 — macOS binaries, provider renaming, shell subprocess cleanup, and stream stability fixes
+
+**Features**
+
+* **macOS (Apple Silicon) support** — Netclaw now ships `osx-arm64` self-contained binaries, and the install script supports macOS installs end-to-end with a Rosetta guard and an explicit Intel-Mac rejection. This is the first release to publish macOS binaries. Path-security checks were also corrected for macOS's `/private` symlink layout. launchd service install and notarization are tracked as follow-ups ([#1015](https://github.com/netclaw-dev/netclaw/issues/1015), [#1016](https://github.com/netclaw-dev/netclaw/issues/1016)). ([#1018](https://github.com/netclaw-dev/netclaw/pull/1018))
+
+* **Editable provider names + rename action** — the provider add flow now opens with a dedicated Name step pre-filled with a suggested default, so multiple self-hosted endpoints (vLLM, llama.cpp) and aggregator accounts are no longer stuck with auto-generated names like `my-vllm-2`. A new `[N] Rename` action and CLI subcommand rename existing providers, cascading the change to `Models.{Main,Fallback,Compaction}.Provider` role references in the same atomic write. ([#997](https://github.com/netclaw-dev/netclaw/pull/997))
+
+* **Approval creation timestamps + gate near-miss diagnostics** — persisted tool approvals now carry an optional `createdAt` timestamp, surfaced as a relative creation time in `netclaw approvals list`, its `--json` output, and the approvals TUI. When a shell pattern is prompted despite a same-verb persisted grant, the daemon now logs why it did not match (directory not under grant, symlink segment, verb-case mismatch). The on-disk schema is unchanged and existing approval files load without migration. ([#1010](https://github.com/netclaw-dev/netclaw/pull/1010))
+
+**Bug Fixes**
+
+* **`shell_execute` no longer orphans subprocesses** — `shell_execute` could leave a subprocess running indefinitely when the kill branch was skipped on a timeout, and interactive Termina commands launched by a non-interactive caller would hang forever. Process kill is now driven off the linked cancellation token, and a remaining gap where `ShellTool.Kill` throwing `Win32Exception` left pipe reads hung at EOF is also closed. ([#1019](https://github.com/netclaw-dev/netclaw/pull/1019))
+
+* **Tool results without a ToolCallId now fail loud** — a missing `ToolCallId` is no longer coalesced to an empty value that handed approval matching and channel rendering a non-correlatable id; the session actor throws instead, surfacing the assembly bug. ([#1023](https://github.com/netclaw-dev/netclaw/pull/1023))
+
+* **Proactive thread hydration re-armed** — a proactively-created channel thread (such as a reminder posting via `send_slack_message`) no longer loses the message that opened it; a deferred hydration is now re-armed so the first authorized inbound completes it. ([#1008](https://github.com/netclaw-dev/netclaw/pull/1008))
+
+* **Cached shell approval matches audited** — cached shell approvals are now evaluated with full approval candidates and record `PreviouslyApproved` audit context.
+
+* **`netclaw approvals list` fills the terminal** — the approvals list previously showed only 10 of 100+ entries with a scrollbar floating in an empty panel; it now grows with the terminal height. ([#1005](https://github.com/netclaw-dev/netclaw/pull/1005))
+
+* **Daemon no longer crashes on discarded stream tasks** — Akka.Streams stages discarded internal `Task<Done>` instances that surfaced as daemon-unobserved crash logs during hot reload and idle passivation; those tasks are now observed. ([#998](https://github.com/netclaw-dev/netclaw/pull/998))
+
+* **Session log writes deterministic under Windows share-mode races** — `SessionLogFile.AppendLine` now retries transient sharing violations with backoff and uses the canonical `FileShare.ReadWrite|Delete` mask, so concurrent readers no longer cause silently-dropped audit lines on Windows. ([#996](https://github.com/netclaw-dev/netclaw/pull/996))
+
+**Dependencies**
+
+* Upgraded `ShellSyntaxTree` to 0.1.5 and routed `ExtractPatterns` through `BashParser`. ([#1007](https://github.com/netclaw-dev/netclaw/pull/1007), [#1020](https://github.com/netclaw-dev/netclaw/pull/1020))
+* Bumped `ModelContextProtocol.Core` from 1.2.0 to 1.3.0. ([#992](https://github.com/netclaw-dev/netclaw/pull/992))
+
 #### 0.18.0 2026-05-14 ####
 
 Netclaw v0.18.0 — Directory-scoped approvals, sub-agent reloads, vLLM support, channel reliability, and security hardening


### PR DESCRIPTION
Release preparation for Netclaw 0.18.1 — a patch release on top of 0.18.0.

## Summary

Updates `RELEASE_NOTES.md` with the 0.18.1 section and bumps `Directory.Build.props` (`<VersionPrefix>` and `<PackageReleaseNotes>`) via `build.ps1`.

## Release highlights

**Features**
- macOS (Apple Silicon) support — first release to publish `osx-arm64` binaries (#1018)
- Editable provider names + rename action (#997)
- Approval creation timestamps + gate near-miss diagnostics (#1010)

**Bug Fixes**
- `shell_execute` no longer orphans subprocesses (#1019)
- Tool results without a ToolCallId now fail loud (#1023)
- Proactive thread hydration re-armed (#1008)
- Cached shell approval matches audited
- `netclaw approvals list` fills the terminal (#1005)
- Daemon no longer crashes on discarded stream tasks (#998)
- Session log writes deterministic under Windows share-mode races (#996)

**Dependencies**
- ShellSyntaxTree upgraded to 0.1.5 (#1007, #1020)
- ModelContextProtocol.Core 1.2.0 -> 1.3.0 (#992)

The `0.18.1` git tag will be created on the merge commit after this PR lands, triggering the release binary publish workflow.