### PR TITLE
feat(telemetry): configurable service.name and emit service.version

### DIFF
--- a/docs/spec/configuration.md
+++ b/docs/spec/configuration.md
@@ -425,6 +425,7 @@ Optional OpenTelemetry export for logs and metrics.
 {
   "Telemetry": {
     "Enabled": true,
+    "ServiceName": "netclawd",
     "Otlp": {
       "Endpoint": "http://127.0.0.1:4317"
     }
@@ -435,6 +436,7 @@ Optional OpenTelemetry export for logs and metrics.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `Enabled` | bool | `false` | Enables OTLP export pipeline in daemon. |
+| `ServiceName` | string | `OTEL_SERVICE_NAME` env, else `netclawd` | OpenTelemetry `service.name` for this instance. Set it to distinguish multiple netclaw instances (e.g. per-agent) in a shared backend. |
 | `Otlp:Endpoint` | string | `http://127.0.0.1:4317` | OTLP collector endpoint (gRPC). |
 
 ## Secrets

--- a/src/Netclaw.Daemon.Tests/Configuration/TelemetryServiceNameTests.cs
+++ b/src/Netclaw.Daemon.Tests/Configuration/TelemetryServiceNameTests.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="TelemetryServiceNameTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Daemon.Configuration;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Configuration;
+
+public sealed class TelemetryServiceNameTests
+{
+    [Fact]
+    public void ExplicitServiceName_WinsOverEnvironment()
+    {
+        var telemetry = new TelemetryOptions { ServiceName = "netclaw-supervisor" };
+
+        var resolved = TelemetryRegistrationExtensions.ResolveServiceName(
+            telemetry, otelServiceNameEnv: "from-env");
+
+        Assert.Equal("netclaw-supervisor", resolved);
+    }
+
+    [Fact]
+    public void NoConfig_FallsBackToOtelServiceNameEnvironmentVariable()
+    {
+        var telemetry = new TelemetryOptions();
+
+        var resolved = TelemetryRegistrationExtensions.ResolveServiceName(
+            telemetry, otelServiceNameEnv: "netclaw-discord-qa");
+
+        Assert.Equal("netclaw-discord-qa", resolved);
+    }
+
+    [Fact]
+    public void NoConfigAndNoEnvironment_FallsBackToDefault()
+    {
+        var telemetry = new TelemetryOptions();
+
+        var resolved = TelemetryRegistrationExtensions.ResolveServiceName(
+            telemetry, otelServiceNameEnv: null);
+
+        Assert.Equal(TelemetryRegistrationExtensions.DefaultServiceName, resolved);
+    }
+
+    [Fact]
+    public void WhitespaceValues_AreTreatedAsUnset()
+    {
+        var telemetry = new TelemetryOptions { ServiceName = "   " };
+
+        var resolved = TelemetryRegistrationExtensions.ResolveServiceName(
+            telemetry, otelServiceNameEnv: "   ");
+
+        Assert.Equal("netclawd", resolved);
+    }
+}

--- a/src/Netclaw.Daemon/Configuration/TelemetryOptions.cs
+++ b/src/Netclaw.Daemon/Configuration/TelemetryOptions.cs
@@ -11,6 +11,14 @@ public sealed class TelemetryOptions
 
     public bool Enabled { get; init; }
 
+    /// <summary>
+    /// OpenTelemetry <c>service.name</c> reported by this netclaw instance. When
+    /// unset, falls back to the standard <c>OTEL_SERVICE_NAME</c> environment
+    /// variable, then to <c>"netclawd"</c>. Set this to tell otherwise-identical
+    /// netclaw instances apart (e.g. per-agent) in a shared observability backend.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
     public TelemetryOtlpOptions Otlp { get; init; } = new();
 }
 

--- a/src/Netclaw.Daemon/Configuration/TelemetryRegistrationExtensions.cs
+++ b/src/Netclaw.Daemon/Configuration/TelemetryRegistrationExtensions.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="TelemetryRegistrationExtensions.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.Extensions.Options;
 using Netclaw.Channels.Telemetry;
+using Netclaw.Configuration;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -14,6 +15,13 @@ namespace Netclaw.Daemon.Configuration;
 
 public static class TelemetryRegistrationExtensions
 {
+    /// <summary>
+    /// OpenTelemetry <c>service.name</c> used when neither
+    /// <see cref="TelemetryOptions.ServiceName"/> nor the <c>OTEL_SERVICE_NAME</c>
+    /// environment variable is set.
+    /// </summary>
+    internal const string DefaultServiceName = "netclawd";
+
     public static void AddNetclawTelemetry(this WebApplicationBuilder builder)
     {
         builder.Services
@@ -31,22 +39,49 @@ public static class TelemetryRegistrationExtensions
 
         var endpoint = new Uri(telemetry.Otlp.Endpoint);
 
+        // service.name distinguishes netclaw instances in a shared backend;
+        // service.version is the running netclaw build so telemetry is
+        // attributable to a specific release.
+        var serviceName = ResolveServiceName(
+            telemetry,
+            Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME"));
+        var serviceVersion = BuildInfo.Version;
+
         builder.Logging.AddOpenTelemetry(options =>
         {
             options.IncludeFormattedMessage = true;
             options.IncludeScopes = true;
             options.ParseStateValues = true;
-            options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("netclawd"));
+            options.SetResourceBuilder(ResourceBuilder.CreateDefault()
+                .AddService(serviceName, serviceVersion: serviceVersion));
             options.AddOtlpExporter(otlp => otlp.Endpoint = endpoint);
         });
 
         builder.Services.AddOpenTelemetry()
-            .ConfigureResource(resource => resource.AddService("netclawd"))
+            .ConfigureResource(resource =>
+                resource.AddService(serviceName, serviceVersion: serviceVersion))
             .WithMetrics(metrics =>
             {
                 metrics.AddMeter(ChannelTelemetry.MeterName);
                 metrics.AddMeter(SessionTelemetry.MeterName);
                 metrics.AddOtlpExporter(otlp => otlp.Endpoint = endpoint);
             });
+    }
+
+    /// <summary>
+    /// Resolves the OpenTelemetry <c>service.name</c>. Precedence: an explicit
+    /// <see cref="TelemetryOptions.ServiceName"/> wins, then the standard
+    /// <c>OTEL_SERVICE_NAME</c> environment variable, then
+    /// <see cref="DefaultServiceName"/>.
+    /// </summary>
+    internal static string ResolveServiceName(TelemetryOptions telemetry, string? otelServiceNameEnv)
+    {
+        if (!string.IsNullOrWhiteSpace(telemetry.ServiceName))
+            return telemetry.ServiceName;
+
+        if (!string.IsNullOrWhiteSpace(otelServiceNameEnv))
+            return otelServiceNameEnv;
+
+        return DefaultServiceName;
     }
 }


### PR DESCRIPTION
## Problem

`netclawd` hardcodes the OpenTelemetry `service.name` to `"netclawd"` in both
the logging and metrics pipelines (`TelemetryRegistrationExtensions.cs` —
`ResourceBuilder.CreateDefault().AddService("netclawd")` and
`.ConfigureResource(r => r.AddService("netclawd"))`). Every netclaw instance
therefore reports the same `service.name`, so multiple instances cannot be told
apart in a shared observability backend (Seq / Grafana / etc.). The export also
never sets `service.version`.

This blocks running a fleet of netclaw instances (e.g. one per agent) with
per-instance telemetry — the original motivation is the Petabridge testlab,
where two netclaw agents need to be filtered individually in Seq.

## Change

- **`TelemetryOptions.ServiceName`** — new optional field. The service name is
  resolved with this precedence: an explicit `Telemetry:ServiceName` config
  value, then the standard `OTEL_SERVICE_NAME` environment variable, then the
  `"netclawd"` default. Default behaviour is unchanged.
- **`service.version`** — `BuildInfo.Version` is now passed to `AddService(...)`,
  so exported logs and metrics are attributable to a specific netclaw build.
- `docs/spec/configuration.md` — documents the new `ServiceName` field.
- Unit tests for the resolution precedence (`TelemetryServiceNameTests`).

`OTEL_RESOURCE_ATTRIBUTES` continues to flow through `ResourceBuilder.CreateDefault()`'s
standard environment detector.

## Testing

- `dotnet build src/Netclaw.Daemon.Tests/Netclaw.Daemon.Tests.csproj` — succeeds, 0 warnings.
- `dotnet test --filter TelemetryServiceNameTests` — 4/4 pass.
