### PR TITLE
chore: prepare release 0.18.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.18.1</VersionPrefix>
+    <VersionPrefix>0.18.2</VersionPrefix>
     <PackageReleaseNotes>Netclaw v0.18.1 — macOS binaries, provider renaming, shell subprocess cleanup, and stream stability fixes
 
 **Features**

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,19 @@
+# Netclaw 0.18.2 Release Notes
+
+## Features
+
+- **OpenTelemetry telemetry improvements** — Configurable `service.name` and `service.version` in OTEL resource attributes (#1042)
+
+## Fixes
+
+- **CLI** — Skip startup update checks for interactive flows (#1037)
+- **Build** — Fix slnx load (#1039), mark Netclaw.Tests.Utilities as non-test project (#1041)
+
+## Refactoring
+
+- **Memory** — Pass 7e: type memory/sub-agent enum fields (#1029)
+- **Protocol** — Pass 7d: value objects for ModelId, TurnNumber, et al (#1024)
+
+## Other
+
+- **OpenSpec** — Retire value-object-adoption change (#1040)


### PR DESCRIPTION
## Release 0.18.2

### Features
- **OpenTelemetry telemetry** — Configurable `service.name` and `service.version` in OTEL resource attributes (#1042)

### Fixes
- **CLI** — Skip startup update checks for interactive flows (#1037)
- **Build** — Fix slnx load (#1039), mark Netclaw.Tests.Utilities as non-test project (#1041)

### Refactoring
- **Memory** — Type memory/sub-agent enum fields (#1029)
- **Protocol** — Value objects for ModelId, TurnNumber, etc (#1024)

### Other
- Retire value-object-adoption openspec change (#1040)
