### PR TITLE
build: canonical publish script + osx-arm64 #1036 fix

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -100,29 +100,18 @@ jobs:
       with:
         global-json-file: "./global.json"
 
-    - name: Publish CLI
+    # Publish via the canonical publish script — the single source of truth
+    # for `dotnet publish` flags, shared with the Docker image build and the
+    # smoke-test harness. `shell: bash` runs on the Windows runner too (Git
+    # Bash); `dotnet publish` itself is OS-agnostic.
+    - name: Publish binaries
+      shell: bash
       run: >
-        dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj
-        -c Release
-        -r ${{ matrix.rid }}
-        --self-contained true
-        /p:PublishSingleFile=true
-        /p:EnableCompressionInSingleFile=true
-        /p:IncludeNativeLibrariesForSelfExtract=true
-        /p:Version=${{ github.ref_name }}
-        -o ./publish/cli
-
-    - name: Publish Daemon
-      run: >
-        dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj
-        -c Release
-        -r ${{ matrix.rid }}
-        --self-contained true
-        /p:PublishSingleFile=true
-        /p:EnableCompressionInSingleFile=true
-        /p:IncludeNativeLibrariesForSelfExtract=true
-        /p:Version=${{ github.ref_name }}
-        -o ./publish/daemon
+        bash scripts/build/publish-binaries.sh
+        --rid ${{ matrix.rid }}
+        --component all
+        --output-dir ./publish
+        --version ${{ github.ref_name }}
 
     - name: Smoke-test published binary (macOS)
       if: runner.os == 'macOS'

--- a/scripts/build/publish-binaries.sh
+++ b/scripts/build/publish-binaries.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Canonical publish for Netclaw self-contained single-file binaries.
+#
+# This script is the SINGLE SOURCE OF TRUTH for the `dotnet publish` flags
+# used to produce shipped binaries. The release pipeline
+# (.github/workflows/publish_release_binaries.yml), the Docker image build
+# (scripts/docker/build-image.sh), and the smoke-test harness all call this
+# script — so the binaries they each produce are identical, and a
+# platform-specific publish bug is caught by smoke before it ships.
+#
+# Per-platform publish flags live in the `case "$RID"` block below. Do not
+# add a second copy of these flags anywhere else.
+#
+# Usage:
+#   scripts/build/publish-binaries.sh --rid <rid> [--component cli|daemon|all]
+#                                     [--output-dir <dir>] [--version <ver>]
+#
+#   --rid          required: linux-x64 | linux-arm64 | win-x64 | osx-arm64
+#   --component    cli | daemon | all   (default: all)
+#   --output-dir   base output dir; components land in <dir>/cli and
+#                  <dir>/daemon   (default: ./publish)
+#   --version      assembly version; when omitted, no /p:Version is passed
+#                  and the Directory.Build.props VersionPrefix is used
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+RID=""
+COMPONENT="all"
+OUTPUT_DIR="./publish"
+VERSION=""
+
+usage() {
+  sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rid)        RID="${2:-}"; shift 2 ;;
+    --component)  COMPONENT="${2:-}"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+    --version)    VERSION="${2:-}"; shift 2 ;;
+    -h|--help)    usage 0 ;;
+    *)            echo "ERROR: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$RID" ]]; then
+  echo "ERROR: --rid is required" >&2
+  usage
+fi
+
+case "$COMPONENT" in
+  cli|daemon|all) ;;
+  *) echo "ERROR: --component must be cli, daemon, or all (got '$COMPONENT')" >&2; exit 2 ;;
+esac
+
+# Flags common to every platform.
+COMMON=(
+  -c Release
+  -r "$RID"
+  --self-contained true
+  /p:PublishSingleFile=true
+  /p:IncludeNativeLibrariesForSelfExtract=true
+)
+
+# Per-platform single-file compression. Kept centralized here so the release
+# pipeline and the smoke harness publish with identical flags.
+case "$RID" in
+  osx-arm64)  COMPRESS=true ;;
+  linux-x64|linux-arm64|win-x64) COMPRESS=true ;;
+  *) echo "ERROR: unsupported RID '$RID'" >&2; exit 2 ;;
+esac
+
+EXTRA=(/p:EnableCompressionInSingleFile="$COMPRESS")
+if [[ -n "$VERSION" ]]; then
+  EXTRA+=(/p:Version="$VERSION")
+fi
+
+publish_component() {
+  local name="$1" project="$2"
+  echo "→ Publishing ${name} (${RID})..."
+  dotnet publish "$project" \
+    "${COMMON[@]}" \
+    "${EXTRA[@]}" \
+    -o "${OUTPUT_DIR}/${name}"
+}
+
+if [[ "$COMPONENT" == "cli" || "$COMPONENT" == "all" ]]; then
+  publish_component cli src/Netclaw.Cli/Netclaw.Cli.csproj
+fi
+if [[ "$COMPONENT" == "daemon" || "$COMPONENT" == "all" ]]; then
+  publish_component daemon src/Netclaw.Daemon/Netclaw.Daemon.csproj
+fi
+
+echo "✓ publish-binaries.sh: ${COMPONENT} (${RID}) → ${OUTPUT_DIR}"

--- a/scripts/build/publish-binaries.sh
+++ b/scripts/build/publish-binaries.sh
@@ -69,7 +69,13 @@ COMMON=(
 # Per-platform single-file compression. Kept centralized here so the release
 # pipeline and the smoke harness publish with identical flags.
 case "$RID" in
-  osx-arm64)  COMPRESS=true ;;
+  osx-arm64)
+    # dotnet/runtime #123324: EnableCompressionInSingleFile corrupts memory
+    # via the MAP_JIT RW->RWX transition on Apple Silicon during single-file
+    # self-extract — surfaces as a fatal AccessViolationException (netclaw
+    # #1036). Upstream fix dotnet/runtime #127355 ships in .NET 11; re-converge
+    # this arm with the others when it backports to .NET 10 servicing.
+    COMPRESS=false ;;
   linux-x64|linux-arm64|win-x64) COMPRESS=true ;;
   *) echo "ERROR: unsupported RID '$RID'" >&2; exit 2 ;;
 esac

--- a/scripts/docker/build-image.sh
+++ b/scripts/docker/build-image.sh
@@ -50,26 +50,16 @@ echo "  Tag:              $IMAGE_TAG"
 echo "  RID:              $RID"
 echo "  NO_BUILD:         $NO_BUILD"
 
-publish_args=(
-    -c Release -r "$RID" --self-contained true
-    /p:PublishSingleFile=true
-    /p:EnableCompressionInSingleFile=true
-    /p:IncludeNativeLibrariesForSelfExtract=true
-)
-if [[ -n "$ASSEMBLY_VERSION" ]]; then
-    publish_args+=(/p:Version="$ASSEMBLY_VERSION")
-fi
-
+# Publish via the canonical publish script — the single source of truth for
+# `dotnet publish` flags, shared with the release pipeline and the smoke
+# harness. Docker-specific logic (NO_BUILD, arch-suffixed copy, the RID guard
+# below) stays here; only the publish flags are delegated.
 if [[ "$NO_BUILD" != "1" ]]; then
-    echo "→ Publishing CLI ($RID)..."
-    dotnet publish src/Netclaw.Cli/Netclaw.Cli.csproj \
-        "${publish_args[@]}" \
-        -o ./publish/cli
-
-    echo "→ Publishing Daemon ($RID)..."
-    dotnet publish src/Netclaw.Daemon/Netclaw.Daemon.csproj \
-        "${publish_args[@]}" \
-        -o ./publish/daemon
+    pub_args=(--rid "$RID" --component all --output-dir ./publish)
+    if [[ -n "$ASSEMBLY_VERSION" ]]; then
+        pub_args+=(--version "$ASSEMBLY_VERSION")
+    fi
+    bash "${ROOT_DIR}/scripts/build/publish-binaries.sh" "${pub_args[@]}"
 else
     echo "→ NO_BUILD=1 — skipping dotnet publish"
 fi


### PR DESCRIPTION
## Summary

First phase of the smoke-testing restructure. Two commits:

1. **Extract `scripts/build/publish-binaries.sh`** — the `dotnet publish` flags for the shipped self-contained binaries were duplicated across `publish_release_binaries.yml` and `build-image.sh`. They now live in one script with a per-RID `case` block; both callers delegate. Pure refactor — every RID resolves to the same flags as before, so binaries are byte-identical.
2. **Disable single-file compression for `osx-arm64`** (#1036) — `EnableCompressionInSingleFile` corrupts memory on Apple Silicon via the MAP_JIT RW→RWX transition during single-file self-extract (dotnet/runtime #123324), surfacing as a fatal `AccessViolationException`. `osx-arm64` now publishes uncompressed (larger but correct). Re-converge when dotnet/runtime #127355 backports to .NET 10 servicing.

This is the parity keystone for the broader smoke-testing restructure: smoke tests will build via this same script, so the binaries they exercise are identical to released ones.

## Test plan

- [ ] `validate_docker_image.yml` green — exercises `build-image.sh` delegation
- [ ] `smoke_sandbox.yml` green — exercises the `build-image.sh --publish-only` path
- [ ] Manual: confirm an `osx-arm64` release binary starts without the AVE on macOS 26

Closes #1036