### PR TITLE
test(smoke): native cross-platform smoke harness (Phase 2)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,112 @@
+name: smoke
+
+# Native smoke harness — runs the real netclaw / netclawd binaries
+# natively (no Docker for the binary) against a native Ollama process.
+# Runs in parallel with smoke_sandbox.yml during the bake-in period.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+    # No `labeled` — it caused duplicate cancelled runs on smoke_sandbox.
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: smoke-native-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish native binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          global-json-file: ./global.json
+
+      - name: Publish binaries
+        shell: bash
+        run: |
+          chmod +x scripts/build/publish-binaries.sh
+          scripts/build/publish-binaries.sh \
+            --rid linux-x64 --component all --output-dir ./publish
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: netclaw-native-binaries-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            publish/cli/netclaw
+            publish/daemon/netclawd
+          retention-days: 1
+          if-no-files-found: error
+
+  smoke-linux:
+    name: Native Smoke (Linux)
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      SMOKE_OLLAMA_MODEL: qwen2:0.5b
+      SMOKE_OLLAMA_ALT_MODEL: all-minilm:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: netclaw-native-binaries-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ./publish
+
+      - name: Mark binaries executable
+        run: |
+          chmod +x publish/cli/netclaw publish/daemon/netclawd
+          echo "NETCLAW_SMOKE_CLI=$(pwd)/publish/cli/netclaw" >> "$GITHUB_ENV"
+          echo "NETCLAW_SMOKE_DAEMON=$(pwd)/publish/daemon/netclawd" >> "$GITHUB_ENV"
+
+      - name: Cache Ollama model store
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama/models
+          key: ollama-models-${{ env.SMOKE_OLLAMA_MODEL }}-${{ env.SMOKE_OLLAMA_ALT_MODEL }}
+
+      - name: Run native smoke (light)
+        shell: bash
+        run: |
+          mkdir -p smoke-logs
+          set -o pipefail
+          scripts/smoke/run-smoke.sh light 2>&1 | tee smoke-logs/run-smoke.log
+
+      - name: Collect smoke artifacts
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p smoke-logs
+          scripts/smoke/collect-artifacts.sh smoke-logs || true
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-native-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: smoke-logs
+          if-no-files-found: warn

--- a/scripts/smoke/collect-artifacts.sh
+++ b/scripts/smoke/collect-artifacts.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Collect failure artifacts from the native smoke harness (no Docker).
+#
+# Native successor to scripts/smoke/collect-logs.sh. Copies per-scenario
+# NETCLAW_HOME logs + config, the Ollama serve log, tape GIFs/PNGs, and
+# harness stdout into a destination directory.
+#
+# Usage:
+#   scripts/smoke/collect-artifacts.sh <dest-dir> [run-root]
+#
+#   <dest-dir>   where artifacts are gathered (created if missing)
+#   [run-root]   the run-scoped temp root produced by run-smoke.sh
+#                (default: $RUN_ROOT, then $SMOKE_RUN_ROOT)
+
+set -euo pipefail
+
+DEST_DIR="${1:-${SMOKE_LOG_DIR:-./smoke-logs}}"
+RUN_ROOT="${2:-${RUN_ROOT:-${SMOKE_RUN_ROOT:-}}}"
+
+mkdir -p "$DEST_DIR"
+
+echo "==> Collecting native smoke artifacts to: $DEST_DIR"
+
+# Tape GIFs / PNGs (vhs writes these to /tmp).
+for f in /tmp/tape-*.gif /tmp/tape-*.png; do
+  [[ -e "$f" ]] || continue
+  cp -v "$f" "$DEST_DIR/" 2>/dev/null || true
+done
+
+if [[ -n "$RUN_ROOT" && -d "$RUN_ROOT" ]]; then
+  # Ollama serve log.
+  if [[ -f "$RUN_ROOT/ollama-serve.log" ]]; then
+    cp -v "$RUN_ROOT/ollama-serve.log" "$DEST_DIR/" 2>/dev/null || true
+  fi
+
+  # Harness stdout, if the run captured it.
+  for f in "$RUN_ROOT"/*.log; do
+    [[ -e "$f" ]] || continue
+    cp -v "$f" "$DEST_DIR/" 2>/dev/null || true
+  done
+
+  # Per-scenario / per-tape NETCLAW_HOME directories live under
+  # $RUN_ROOT/home/<name>. Copy each one's logs + config.
+  if [[ -d "$RUN_ROOT/home" ]]; then
+    for home in "$RUN_ROOT"/home/*; do
+      [[ -d "$home" ]] || continue
+      name="$(basename "$home")"
+      out="$DEST_DIR/home-${name}"
+      mkdir -p "$out"
+      if [[ -d "$home/logs" ]]; then
+        cp -r "$home/logs" "$out/logs" 2>/dev/null || true
+      fi
+      if [[ -f "$home/config/netclaw.json" ]]; then
+        cp "$home/config/netclaw.json" "$out/netclaw.json" 2>/dev/null || true
+      fi
+      ls -laR "$home" > "$out/listing.txt" 2>&1 || true
+    done
+  fi
+else
+  echo "    (no run root supplied; skipped NETCLAW_HOME + ollama log collection)" >&2
+fi
+
+echo "==> Artifacts gathered: $(ls "$DEST_DIR" 2>/dev/null | tr '\n' ' ')"

--- a/scripts/smoke/lib/common.sh
+++ b/scripts/smoke/lib/common.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Shared helpers for the native (non-Docker) smoke harness.
+#
+# Source this file; do not execute it. De-Dockerized versions of the
+# helpers that used to live in scripts/smoke/check.sh — the daemon now
+# runs as a native host process bound to loopback 127.0.0.1:5199.
+#
+# Callers must export before sourcing or before calling the helpers:
+#   NETCLAW_SMOKE_CLI     absolute path to the `netclaw` binary
+#   NETCLAW_SMOKE_DAEMON  absolute path to the `netclawd` binary
+#   NETCLAW_DAEMON_PATH   = NETCLAW_SMOKE_DAEMON (CLI daemon resolver)
+#   NETCLAW_HOME          per-scenario config/state directory
+#
+# Environment knobs:
+#   START_TIMEOUT_SECONDS  daemon start/health timeout (default: 180)
+#   STOP_TIMEOUT_SECONDS   daemon stop timeout         (default: 90)
+#   STEP_TIMEOUT_SECONDS   per-command timeout         (default: 120)
+#   DAEMON_HEALTH_URL      health endpoint base        (default loopback:5199)
+
+START_TIMEOUT_SECONDS="${START_TIMEOUT_SECONDS:-180}"
+STOP_TIMEOUT_SECONDS="${STOP_TIMEOUT_SECONDS:-90}"
+STEP_TIMEOUT_SECONDS="${STEP_TIMEOUT_SECONDS:-120}"
+DAEMON_BASE_URL="${DAEMON_BASE_URL:-http://127.0.0.1:5199}"
+
+# ── Output / counters ────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+log()  { echo "[smoke] $*"; }
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+warn() { echo "  [WARN] $1" >&2; }
+
+# Print the running totals and return non-zero if anything failed. Scenario
+# scripts call this at the end and `exit` on its status.
+summarize() {
+  echo
+  echo "[smoke] results: ${PASS} passed, ${FAIL} failed"
+  if (( FAIL > 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+# ── Portable timeout ─────────────────────────────────────────────────────────
+
+# run_timed <seconds> <cmd...>
+# GNU `timeout` (Linux), `gtimeout` (macOS + coreutils), or a perl alarm
+# fallback — stock macOS ships no `timeout`. Kept portable so the future
+# macOS leg needs no change here.
+run_timed() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${secs}s" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${secs}s" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
+# ── Daemon lifecycle ─────────────────────────────────────────────────────────
+
+# start_daemon — launch the native daemon detached and poll until it reports
+# running. Returns non-zero on timeout.
+start_daemon() {
+  : "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set}"
+  log "Starting daemon (detached) ..."
+  # Detach so the CLI's `daemon start` does not hold our stdio.
+  run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon start >/dev/null 2>&1 || true
+
+  local deadline=$((SECONDS + START_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    local status_output
+    status_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon status 2>/dev/null || true)"
+    if [[ "$status_output" == *"Daemon running"* ]]; then
+      log "Daemon running."
+      return 0
+    fi
+    sleep 2
+  done
+
+  log "ERROR: daemon did not report running within ${START_TIMEOUT_SECONDS}s."
+  return 1
+}
+
+# wait_for_health — poll the daemon's readiness endpoint until healthy.
+wait_for_health() {
+  local deadline=$((SECONDS + START_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    local health_output
+    health_output="$(run_timed "$STEP_TIMEOUT_SECONDS" curl -fsS "${DAEMON_BASE_URL}/api/health/ready" 2>/dev/null || true)"
+    if [[ "$health_output" == "healthy" || "$health_output" == '"healthy"' ]]; then
+      log "Health endpoint ready."
+      return 0
+    fi
+    sleep 2
+  done
+
+  log "ERROR: health endpoint not ready within ${START_TIMEOUT_SECONDS}s."
+  return 1
+}
+
+# stop_daemon — best-effort daemon stop. Never fails the caller.
+stop_daemon() {
+  : "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set}"
+  run_timed "$STOP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon stop >/dev/null 2>&1 || true
+}

--- a/scripts/smoke/lib/ollama.sh
+++ b/scripts/smoke/lib/ollama.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Native Ollama provisioning for the native smoke harness.
+#
+# Source this file; do not execute it. It expects RUN_ROOT to be set by
+# the caller (run-smoke.sh) so the serve PID + log land under the run root.
+#
+# Functions:
+#   ollama_ensure_installed   install ollama if it is not on PATH (Linux only)
+#   ollama_serve_start        start `ollama serve` in the background, wait ready
+#   ollama_serve_stop         kill the recorded serve PID if still alive
+#   ollama_pull <model>       pull a model with retries (top flake source)
+#
+# Environment knobs:
+#   SMOKE_OLLAMA_MODEL      primary model       (default: qwen2:0.5b)
+#   SMOKE_OLLAMA_ALT_MODEL  alternate model     (default: all-minilm:latest)
+#   OLLAMA_HOST             host:port to bind   (default: 127.0.0.1:11434)
+#   RUN_ROOT                run-scoped temp dir (set by run-smoke.sh)
+
+SMOKE_OLLAMA_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+SMOKE_OLLAMA_ALT_MODEL="${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}"
+export OLLAMA_HOST="${OLLAMA_HOST:-127.0.0.1:11434}"
+
+# Endpoint derived from OLLAMA_HOST; the smoke API probes always use 127.0.0.1.
+OLLAMA_API_BASE="${OLLAMA_API_BASE:-http://${OLLAMA_HOST}}"
+
+OLLAMA_PID_FILE="${OLLAMA_PID_FILE:-${RUN_ROOT:-/tmp}/ollama.pid}"
+OLLAMA_SERVE_LOG="${OLLAMA_SERVE_LOG:-${RUN_ROOT:-/tmp}/ollama-serve.log}"
+
+ollama_ensure_installed() {
+  if command -v ollama >/dev/null 2>&1; then
+    echo "ollama already installed at $(command -v ollama)"
+    return 0
+  fi
+
+  local uname_s
+  uname_s="$(uname -s)"
+  case "$uname_s" in
+    Linux)
+      echo "Installing ollama via official install script..."
+      curl -fsSL https://ollama.com/install.sh | sh
+      ;;
+    *)
+      echo "ERROR: ollama is not installed and automatic install is Linux-only." >&2
+      echo "       On macOS install with: brew install ollama" >&2
+      echo "       See https://ollama.com/download for other platforms." >&2
+      return 1
+      ;;
+  esac
+
+  if ! command -v ollama >/dev/null 2>&1; then
+    echo "ERROR: ollama install completed but 'ollama' is still not on PATH." >&2
+    return 1
+  fi
+  echo "ollama installed at $(command -v ollama)"
+}
+
+ollama_serve_start() {
+  local ready_timeout="${OLLAMA_READY_TIMEOUT:-120}"
+
+  if curl -fsS "${OLLAMA_API_BASE}/api/tags" >/dev/null 2>&1; then
+    echo "ollama already serving at ${OLLAMA_API_BASE}; not starting a new instance."
+    return 0
+  fi
+
+  echo "Starting 'ollama serve' (OLLAMA_HOST=${OLLAMA_HOST})..."
+  mkdir -p "$(dirname "$OLLAMA_SERVE_LOG")"
+  ollama serve >"$OLLAMA_SERVE_LOG" 2>&1 &
+  local pid=$!
+  echo "$pid" >"$OLLAMA_PID_FILE"
+  echo "ollama serve started (pid=${pid}); log: ${OLLAMA_SERVE_LOG}"
+
+  local deadline=$((SECONDS + ready_timeout))
+  while (( SECONDS < deadline )); do
+    if curl -fsS "${OLLAMA_API_BASE}/api/tags" >/dev/null 2>&1; then
+      echo "ollama API ready at ${OLLAMA_API_BASE}."
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: ollama serve process exited before becoming ready." >&2
+      echo "--- ollama serve log ---" >&2
+      cat "$OLLAMA_SERVE_LOG" >&2 || true
+      return 1
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: ollama API did not become ready within ${ready_timeout}s." >&2
+  echo "--- ollama serve log ---" >&2
+  cat "$OLLAMA_SERVE_LOG" >&2 || true
+  return 1
+}
+
+ollama_serve_stop() {
+  if [[ ! -f "$OLLAMA_PID_FILE" ]]; then
+    return 0
+  fi
+  local pid
+  pid="$(cat "$OLLAMA_PID_FILE" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    echo "Stopping ollama serve (pid=${pid})..."
+    kill "$pid" 2>/dev/null || true
+    # Give it a moment, then hard-kill if still alive.
+    local deadline=$((SECONDS + 10))
+    while (( SECONDS < deadline )); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 1
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  rm -f "$OLLAMA_PID_FILE"
+}
+
+ollama_pull() {
+  local model="$1"
+  local attempts="${OLLAMA_PULL_ATTEMPTS:-3}"
+  local attempt=1
+
+  while (( attempt <= attempts )); do
+    echo "Pulling model '${model}' (attempt ${attempt}/${attempts})..."
+    if ollama pull "$model"; then
+      echo "Model '${model}' pulled."
+      return 0
+    fi
+    echo "WARNING: pull of '${model}' failed (attempt ${attempt}/${attempts})." >&2
+    attempt=$((attempt + 1))
+    if (( attempt <= attempts )); then
+      sleep 5
+    fi
+  done
+
+  echo "ERROR: failed to pull model '${model}' after ${attempts} attempts." >&2
+  return 1
+}

--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Run a single VHS tape against the native netclaw binary (no Docker).
+#
+# Native successor to scripts/smoke/run-tape.sh. The binary runs as a
+# host process; tapes live in tests/smoke/tapes/ and assertions in
+# tests/smoke/assertions/.
+#
+# Usage:
+#   scripts/smoke/run-native-tape.sh <tape-short-name>
+#
+# Steps:
+#   1) Substitute placeholders in preamble.tape and prepend it to the
+#      tape body, producing a combined temp tape.
+#   2) Run `vhs` against the combined tape with a hard timeout.
+#   3) If a per-tape assertion exists at
+#      tests/smoke/assertions/<short-name>.sh, run it.
+#   4) On failure, collect artifacts (tape GIF, NETCLAW_HOME logs +
+#      config) into ${ARTIFACT_DIR} from the host filesystem.
+#
+# Required environment (set by run-smoke.sh):
+#   NETCLAW_SMOKE_CLI     absolute path to the `netclaw` binary
+#   NETCLAW_SMOKE_DAEMON  absolute path to the `netclawd` binary
+#
+# Environment knobs:
+#   NETCLAW_HOME      per-tape home dir; default <tmp>/tape-home-<name>
+#   TAPE_TIMEOUT_S    hard timeout per tape (default: 600)
+#   ARTIFACT_DIR      failure artifact dir (default: smoke-logs/tapes/<name>)
+#   KEEP_TEMP         set to 1 to retain the combined tape for inspection
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <tape-short-name>" >&2
+  exit 2
+fi
+
+TAPE_NAME="$1"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TAPES_DIR="${ROOT_DIR}/tests/smoke/tapes"
+ASSERT_DIR="${ROOT_DIR}/tests/smoke/assertions"
+
+TAPE_TIMEOUT_S="${TAPE_TIMEOUT_S:-600}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/smoke-logs/tapes/${TAPE_NAME}}"
+
+: "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set (run via run-smoke.sh)}"
+: "${NETCLAW_SMOKE_DAEMON:?NETCLAW_SMOKE_DAEMON must be set (run via run-smoke.sh)}"
+
+# The directory containing both binaries is put on PATH inside the tape.
+NETCLAW_BIN_DIR="$(cd "$(dirname "$NETCLAW_SMOKE_CLI")" && pwd)"
+
+# Per-tape NETCLAW_HOME on the host filesystem.
+NETCLAW_HOME="${NETCLAW_HOME:-$(mktemp -d)/tape-home-${TAPE_NAME}}"
+
+preamble="${TAPES_DIR}/preamble.tape"
+body="${TAPES_DIR}/${TAPE_NAME}.tape"
+assertion="${ASSERT_DIR}/${TAPE_NAME}.sh"
+
+if [[ ! -f "$preamble" ]]; then
+  echo "ERROR: preamble not found at $preamble" >&2
+  exit 1
+fi
+
+if [[ ! -f "$body" ]]; then
+  echo "ERROR: tape body not found at $body" >&2
+  exit 1
+fi
+
+if ! command -v vhs >/dev/null 2>&1; then
+  echo "ERROR: vhs not on PATH. Run scripts/smoke/install-vhs.sh first." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+combined="${tmp_dir}/${TAPE_NAME}.tape"
+
+cleanup() {
+  if [[ "${KEEP_TEMP:-0}" == "1" ]]; then
+    echo "KEEP_TEMP=1 — combined tape retained at: $combined"
+  else
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+collect_failure_artifacts() {
+  echo "==> Collecting failure artifacts to ${ARTIFACT_DIR}"
+  set +e
+  mkdir -p "${ARTIFACT_DIR}"
+  cp -v "/tmp/tape-${TAPE_NAME}.gif" "${ARTIFACT_DIR}/" 2>/dev/null
+  cp -v "/tmp/tape-${TAPE_NAME}.png" "${ARTIFACT_DIR}/" 2>/dev/null
+  if [[ -d "${NETCLAW_HOME}/logs" ]]; then
+    cp -r "${NETCLAW_HOME}/logs" "${ARTIFACT_DIR}/netclaw-home-logs" 2>/dev/null
+  fi
+  if [[ -f "${NETCLAW_HOME}/config/netclaw.json" ]]; then
+    cp -v "${NETCLAW_HOME}/config/netclaw.json" "${ARTIFACT_DIR}/netclaw.json" 2>/dev/null
+  fi
+  ls -laR "${NETCLAW_HOME}" > "${ARTIFACT_DIR}/netclaw_home.txt" 2>&1
+  cp -v "$combined" "${ARTIFACT_DIR}/${TAPE_NAME}.combined.tape" 2>/dev/null
+  set -e
+  echo "    artifacts: $(ls "${ARTIFACT_DIR}" 2>/dev/null | tr '\n' ' ')"
+}
+
+# Substitute placeholders in preamble. Sed delimiter is '|' since paths
+# contain '/'. The substituted values are paths set by us, so escaping
+# is minimal.
+sed \
+  -e "s|__NETCLAW_HOME__|${NETCLAW_HOME}|g" \
+  -e "s|__NETCLAW_BIN_DIR__|${NETCLAW_BIN_DIR}|g" \
+  -e "s|__TAPE_NAME__|${TAPE_NAME}|g" \
+  "$preamble" > "$combined"
+
+# Append body. The body declares its own `Output ...`; last-write-wins
+# on Output is fine in vhs.
+cat "$body" >> "$combined"
+
+echo "==> Running native tape: ${TAPE_NAME} (timeout=${TAPE_TIMEOUT_S}s)"
+echo "    NETCLAW_BIN_DIR=${NETCLAW_BIN_DIR}"
+echo "    NETCLAW_HOME=${NETCLAW_HOME}"
+
+vhs_status=0
+if command -v timeout >/dev/null 2>&1; then
+  timeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+elif command -v gtimeout >/dev/null 2>&1; then
+  gtimeout "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+else
+  vhs "$combined" || vhs_status=$?
+fi
+
+if [[ $vhs_status -ne 0 ]]; then
+  echo "FAIL: vhs exited with status ${vhs_status} for tape ${TAPE_NAME}" >&2
+  collect_failure_artifacts
+  exit "$vhs_status"
+fi
+
+# Run per-tape assertion if present.
+if [[ -x "$assertion" ]]; then
+  echo "==> Running post-tape assertion: ${assertion}"
+  assert_status=0
+  NETCLAW_HOME="$NETCLAW_HOME" \
+  NETCLAW_SMOKE_CLI="$NETCLAW_SMOKE_CLI" \
+  NETCLAW_SMOKE_DAEMON="$NETCLAW_SMOKE_DAEMON" \
+  NETCLAW_DAEMON_PATH="$NETCLAW_SMOKE_DAEMON" \
+  TAPE_NAME="$TAPE_NAME" \
+    "$assertion" || assert_status=$?
+  if [[ $assert_status -ne 0 ]]; then
+    echo "FAIL: assertion failed for tape ${TAPE_NAME} (status=${assert_status})" >&2
+    collect_failure_artifacts
+    exit "$assert_status"
+  fi
+elif [[ -f "$assertion" ]]; then
+  echo "WARNING: $assertion exists but is not executable; skipping." >&2
+fi
+
+echo "==> ${TAPE_NAME}: OK"

--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -107,6 +107,7 @@ collect_failure_artifacts() {
 sed \
   -e "s|__NETCLAW_HOME__|${NETCLAW_HOME}|g" \
   -e "s|__NETCLAW_BIN_DIR__|${NETCLAW_BIN_DIR}|g" \
+  -e "s|__NETCLAW_DAEMON__|${NETCLAW_SMOKE_DAEMON}|g" \
   -e "s|__TAPE_NAME__|${TAPE_NAME}|g" \
   "$preamble" > "$combined"
 

--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Unified native smoke harness entrypoint (no Docker for the binary).
+#
+# Runs the real netclaw / netclawd binaries natively against a native
+# Ollama host process. Drives both the interactive VHS tapes and the
+# non-interactive scenario scripts.
+#
+# Usage:
+#   scripts/smoke/run-smoke.sh <profile> [filters...]
+#
+#   <profile>   light | full | <scenario-or-tape-short-name>
+#   [filters]   when <profile> is light/full, restrict to the named
+#               tapes/scenarios (optional)
+#
+# What it does, in order:
+#   1) Resolve the binaries: use NETCLAW_SMOKE_CLI / NETCLAW_SMOKE_DAEMON
+#      if exported, else publish via scripts/build/publish-binaries.sh.
+#   2) Provision native Ollama: install, `ollama serve`, pull models.
+#   3) Ensure vhs is installed.
+#   4) Run interactive tapes (run-native-tape.sh) + non-interactive
+#      scenarios (tests/smoke/scenarios/*.sh). Each gets a fresh
+#      NETCLAW_HOME under a run-scoped temp root.
+#   5) Collect artifacts on failure; tear down.
+#   6) Exit non-zero if anything failed.
+#
+# Environment knobs:
+#   NETCLAW_SMOKE_CLI / NETCLAW_SMOKE_DAEMON  pre-built binary paths
+#   SMOKE_RID                publish RID            (default: linux-x64)
+#   SMOKE_OLLAMA_MODEL       primary model          (default: qwen2:0.5b)
+#   SMOKE_OLLAMA_ALT_MODEL   alternate model        (default: all-minilm:latest)
+#   SMOKE_LOG_DIR            artifact dir           (default: ./smoke-logs)
+#   KEEP_RUN_ROOT            set 1 to keep the temp run root
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_SCRIPTS="${ROOT_DIR}/scripts/smoke"
+TAPES_DIR="${ROOT_DIR}/tests/smoke/tapes"
+SCENARIOS_DIR="${ROOT_DIR}/tests/smoke/scenarios"
+
+SMOKE_RID="${SMOKE_RID:-linux-x64}"
+SMOKE_LOG_DIR="${SMOKE_LOG_DIR:-${ROOT_DIR}/smoke-logs}"
+
+# Cheapest harness checks first so a harness-level break fails fast
+# before paying for the wizard + probe tapes.
+LIGHT_TAPES=(help init-wizard provider-add provider-rename tui-cleanup)
+FULL_TAPES=("${LIGHT_TAPES[@]}")
+
+LIGHT_SCENARIOS=(
+  daemon-lifecycle
+  provider-model-cli
+  context-window
+  sessions-and-chat
+  stats
+  reminders
+  pairing
+)
+FULL_SCENARIOS=("${LIGHT_SCENARIOS[@]}")
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+mode="$1"; shift || true
+filters=("$@")
+
+# ── Resolve which tapes / scenarios to run ───────────────────────────────────
+
+tapes=()
+scenarios=()
+
+case "$mode" in
+  light)
+    tapes=("${LIGHT_TAPES[@]}")
+    scenarios=("${LIGHT_SCENARIOS[@]}")
+    ;;
+  full)
+    tapes=("${FULL_TAPES[@]}")
+    scenarios=("${FULL_SCENARIOS[@]}")
+    ;;
+  *)
+    if [[ -f "${TAPES_DIR}/${mode}.tape" ]]; then
+      tapes=("$mode")
+    elif [[ -f "${SCENARIOS_DIR}/${mode}.sh" ]]; then
+      scenarios=("$mode")
+    else
+      echo "ERROR: '${mode}' is not 'light', 'full', or a known tape/scenario." >&2
+      echo "       Tapes:     ${TAPES_DIR}/<name>.tape" >&2
+      echo "       Scenarios: ${SCENARIOS_DIR}/<name>.sh" >&2
+      exit 2
+    fi
+    ;;
+esac
+
+# Optional filtering when light/full was requested.
+if (( ${#filters[@]} > 0 )) && [[ "$mode" == "light" || "$mode" == "full" ]]; then
+  filtered_tapes=()
+  filtered_scenarios=()
+  for f in "${filters[@]}"; do
+    for t in "${tapes[@]}"; do
+      [[ "$t" == "$f" ]] && filtered_tapes+=("$t")
+    done
+    for s in "${scenarios[@]}"; do
+      [[ "$s" == "$f" ]] && filtered_scenarios+=("$s")
+    done
+  done
+  tapes=("${filtered_tapes[@]:-}")
+  scenarios=("${filtered_scenarios[@]:-}")
+  # Strip the empty placeholder a `[@]:-` expansion can leave behind.
+  [[ "${#tapes[@]}" -eq 1 && -z "${tapes[0]}" ]] && tapes=()
+  [[ "${#scenarios[@]}" -eq 1 && -z "${scenarios[0]}" ]] && scenarios=()
+fi
+
+# ── Run-scoped temp root ─────────────────────────────────────────────────────
+
+RUN_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/netclaw-smoke.XXXXXX")"
+export RUN_ROOT
+mkdir -p "${RUN_ROOT}/home"
+
+teardown_done=0
+teardown() {
+  [[ $teardown_done -eq 1 ]] && return 0
+  teardown_done=1
+  echo "==> Tearing down native smoke harness..."
+  # Stop Ollama if we started it.
+  if declare -f ollama_serve_stop >/dev/null 2>&1; then
+    ollama_serve_stop || true
+  fi
+  # Kill any stray daemon process.
+  pkill -f netclawd >/dev/null 2>&1 || true
+  if [[ "${KEEP_RUN_ROOT:-0}" == "1" ]]; then
+    echo "    KEEP_RUN_ROOT=1 — run root retained at: $RUN_ROOT"
+  else
+    rm -rf "$RUN_ROOT" || true
+  fi
+}
+trap teardown EXIT
+
+# ── 1) Resolve binaries ──────────────────────────────────────────────────────
+
+if [[ -n "${NETCLAW_SMOKE_CLI:-}" && -n "${NETCLAW_SMOKE_DAEMON:-}" ]]; then
+  echo "==> Using pre-built binaries from environment."
+else
+  echo "==> Publishing binaries via publish-binaries.sh (rid=${SMOKE_RID})..."
+  publish_out="${RUN_ROOT}/publish"
+  bash "${ROOT_DIR}/scripts/build/publish-binaries.sh" \
+    --rid "$SMOKE_RID" --component all --output-dir "$publish_out"
+  NETCLAW_SMOKE_CLI="${publish_out}/cli/netclaw"
+  NETCLAW_SMOKE_DAEMON="${publish_out}/daemon/netclawd"
+fi
+
+# Canonicalise to absolute paths.
+NETCLAW_SMOKE_CLI="$(cd "$(dirname "$NETCLAW_SMOKE_CLI")" && pwd)/$(basename "$NETCLAW_SMOKE_CLI")"
+NETCLAW_SMOKE_DAEMON="$(cd "$(dirname "$NETCLAW_SMOKE_DAEMON")" && pwd)/$(basename "$NETCLAW_SMOKE_DAEMON")"
+
+if [[ ! -x "$NETCLAW_SMOKE_CLI" ]]; then
+  echo "ERROR: netclaw CLI binary not found / not executable: $NETCLAW_SMOKE_CLI" >&2
+  exit 1
+fi
+if [[ ! -x "$NETCLAW_SMOKE_DAEMON" ]]; then
+  echo "ERROR: netclawd daemon binary not found / not executable: $NETCLAW_SMOKE_DAEMON" >&2
+  exit 1
+fi
+
+# NETCLAW_DAEMON_PATH makes the CLI's daemon resolver find the daemon binary.
+export NETCLAW_SMOKE_CLI NETCLAW_SMOKE_DAEMON
+export NETCLAW_DAEMON_PATH="$NETCLAW_SMOKE_DAEMON"
+
+echo "    NETCLAW_SMOKE_CLI=${NETCLAW_SMOKE_CLI}"
+echo "    NETCLAW_SMOKE_DAEMON=${NETCLAW_SMOKE_DAEMON}"
+
+# ── 2) Provision native Ollama ───────────────────────────────────────────────
+
+# shellcheck source=lib/ollama.sh
+. "${SMOKE_SCRIPTS}/lib/ollama.sh"
+
+echo "==> Ensuring Ollama is installed..."
+ollama_ensure_installed
+
+echo "==> Starting Ollama serve..."
+ollama_serve_start
+
+echo "==> Pulling smoke models..."
+ollama_pull "$SMOKE_OLLAMA_MODEL"
+ollama_pull "$SMOKE_OLLAMA_ALT_MODEL"
+
+# ── 3) Ensure vhs ────────────────────────────────────────────────────────────
+
+echo "==> Ensuring vhs is installed..."
+bash "${SMOKE_SCRIPTS}/install-vhs.sh"
+
+# ── 4) Run tapes + scenarios ─────────────────────────────────────────────────
+
+failed=()
+
+run_one_tape() {
+  local tape="$1"
+  echo
+  echo "════════════════════════════════════════════════════════"
+  echo "Tape: ${tape}"
+  echo "════════════════════════════════════════════════════════"
+  local home="${RUN_ROOT}/home/tape-${tape}"
+  rm -rf "$home"
+  if ! NETCLAW_HOME="$home" \
+       NETCLAW_SMOKE_CLI="$NETCLAW_SMOKE_CLI" \
+       NETCLAW_SMOKE_DAEMON="$NETCLAW_SMOKE_DAEMON" \
+       ARTIFACT_DIR="${SMOKE_LOG_DIR}/tapes/${tape}" \
+       bash "${SMOKE_SCRIPTS}/run-native-tape.sh" "$tape"; then
+    failed+=("tape:${tape}")
+  fi
+}
+
+run_one_scenario() {
+  local scenario="$1"
+  echo
+  echo "════════════════════════════════════════════════════════"
+  echo "Scenario: ${scenario}"
+  echo "════════════════════════════════════════════════════════"
+  local home="${RUN_ROOT}/home/scenario-${scenario}"
+  rm -rf "$home"
+  mkdir -p "$home"
+  if ! NETCLAW_HOME="$home" \
+       NETCLAW_SMOKE_CLI="$NETCLAW_SMOKE_CLI" \
+       NETCLAW_SMOKE_DAEMON="$NETCLAW_SMOKE_DAEMON" \
+       NETCLAW_DAEMON_PATH="$NETCLAW_SMOKE_DAEMON" \
+       bash "${SCENARIOS_DIR}/${scenario}.sh"; then
+    failed+=("scenario:${scenario}")
+  fi
+}
+
+# Tapes first (harness-level checks fail fast), then scenarios. All are
+# attempted regardless of earlier failures so CI gets a complete artifact set.
+for tape in "${tapes[@]:-}"; do
+  [[ -z "$tape" ]] && continue
+  run_one_tape "$tape"
+done
+
+for scenario in "${scenarios[@]:-}"; do
+  [[ -z "$scenario" ]] && continue
+  run_one_scenario "$scenario"
+done
+
+# ── 5) Collect artifacts on failure ──────────────────────────────────────────
+
+if (( ${#failed[@]} > 0 )); then
+  echo
+  echo "==> Failures detected — collecting artifacts..."
+  bash "${SMOKE_SCRIPTS}/collect-artifacts.sh" "$SMOKE_LOG_DIR" "$RUN_ROOT" || true
+fi
+
+# ── 6) Result ────────────────────────────────────────────────────────────────
+
+if (( ${#failed[@]} > 0 )); then
+  echo
+  echo "FAILURE: ${#failed[@]} item(s) failed: ${failed[*]}" >&2
+  exit 1
+fi
+
+echo
+echo "All smoke checks passed (${#tapes[@]} tape(s), ${#scenarios[@]} scenario(s))."

--- a/tests/smoke/assertions/_lib.sh
+++ b/tests/smoke/assertions/_lib.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared helpers for native tape post-tape assertion scripts. Source this
+# from tests/smoke/assertions/<tape-name>.sh.
+#
+# Sources require these env vars (set by scripts/smoke/run-native-tape.sh):
+#   NETCLAW_HOME        per-tape NETCLAW_HOME on the host filesystem
+#   NETCLAW_SMOKE_CLI   absolute path to the `netclaw` binary
+#
+# Unlike the Docker assertions (tests/smoke-interactive/assertions/_lib.sh),
+# config and SOUL.md are read directly from the host filesystem — there is
+# no container to exec into.
+
+: "${NETCLAW_HOME:?NETCLAW_HOME must be set by run-native-tape.sh}"
+: "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set by run-native-tape.sh}"
+
+CONFIG_PATH="${NETCLAW_HOME}/config/netclaw.json"
+SOUL_PATH="${NETCLAW_HOME}/identity/SOUL.md"
+
+# Cat the produced netclaw.json from the host filesystem to stdout.
+read_config_json() {
+  cat "$CONFIG_PATH" 2>/dev/null
+}
+
+# Assert a jq expression against a JSON blob passed by value.
+#   Usage: assert_field <jq_expr> <expected> "$json_blob"
+# `tostring` so booleans and missing paths produce comparable strings
+# ("true"/"false"/"null") — `// empty` would collapse `false` to "".
+# Sets `assert_fail` on mismatch (caller initialises and inspects).
+assert_field() {
+  local jq_expr="$1"
+  local expected="$2"
+  local json="$3"
+  local actual
+  actual="$(printf '%s' "$json" | jq -r "${jq_expr} | tostring" 2>/dev/null | tr -d '\r')"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: expected %s == %s, got %s\n' "$jq_expr" "$expected" "$actual" >&2
+    assert_fail=1
+    return 1
+  fi
+  printf '  ok  %s == %s\n' "$jq_expr" "$expected"
+}

--- a/tests/smoke/assertions/help.sh
+++ b/tests/smoke/assertions/help.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# help.tape post-tape assertion.
+#
+# help.tape's purpose is to smoke-test the harness itself, not the CLI.
+# vhs exit code (non-zero on any Wait+Screen timeout) is the only signal
+# we need. This script intentionally does nothing.
+
+set -euo pipefail
+echo "help: no post-tape assertion (vhs exit code is the test)"

--- a/tests/smoke/assertions/init-wizard.sh
+++ b/tests/smoke/assertions/init-wizard.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# init-wizard.tape post-tape assertion.
+#
+# Validates that the wizard produced a usable, schema-valid state:
+#   1) config/netclaw.json exists and parses as JSON
+#   2) `netclaw doctor` (which runs ConfigSchemaDoctorCheck) does not
+#      report errors (exit 0 = clean; exit 2 = WARNs only — acceptable
+#      for Personal posture + HostAllowed shell which trips a warn)
+#   3) Provider/model/posture fields in netclaw.json match what the
+#      tape typed
+#   4) Identity/SOUL.md contains the typed user name
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+
+echo "init-wizard: reading produced config..."
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "FAIL: ${CONFIG_PATH} does not exist after wizard run." >&2
+  ls -la "$NETCLAW_HOME" 2>&1 >&2 || true
+  exit 1
+fi
+
+config_json="$(read_config_json)"
+if ! printf '%s' "$config_json" | jq empty >/dev/null 2>&1; then
+  echo "FAIL: ${CONFIG_PATH} is not valid JSON." >&2
+  printf '%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "init-wizard: running 'netclaw doctor'..."
+# DoctorRunner exit codes (src/Netclaw.Cli/Doctor/DoctorRunner.cs):
+#   0 = all PASS, 1 = errors (fail), 2 = WARNs only (acceptable)
+doctor_status=0
+"$NETCLAW_SMOKE_CLI" doctor || doctor_status=$?
+if [[ $doctor_status -eq 1 ]]; then
+  echo "FAIL: netclaw doctor reported errors (exit 1)." >&2
+  exit 1
+fi
+if [[ $doctor_status -ne 0 && $doctor_status -ne 2 ]]; then
+  echo "FAIL: netclaw doctor exited with unexpected status $doctor_status." >&2
+  exit 1
+fi
+
+echo "init-wizard: checking expected fields in netclaw.json..."
+assert_field '.Providers.ollama.Type'       'ollama'                   "$config_json" || :
+assert_field '.Providers.ollama.Endpoint'   'http://localhost:11434'   "$config_json" || :
+assert_field '.Models.Main.Provider'        'ollama'                   "$config_json" || :
+assert_field '.Models.Main.ModelId'         'qwen2:0.5b'               "$config_json" || :
+assert_field '.Security.DeploymentPosture'  'Personal'                 "$config_json" || :
+
+echo "init-wizard: checking identity/SOUL.md for typed user name..."
+if ! grep -q 'Name: SmokeTester' "$SOUL_PATH" 2>/dev/null; then
+  echo "FAIL: identity/SOUL.md does not contain 'Name: SmokeTester'." >&2
+  head -40 "$SOUL_PATH" >&2 2>/dev/null || true
+  assert_fail=1
+else
+  echo "  ok  identity/SOUL.md contains 'Name: SmokeTester'"
+fi
+
+if (( assert_fail )); then
+  printf -- '--- netclaw.json contents ---\n%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "init-wizard: assertions passed."

--- a/tests/smoke/assertions/provider-add.sh
+++ b/tests/smoke/assertions/provider-add.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# provider-add.tape post-tape assertion.
+#
+# Validates that the TUI add flow wrote 'smoke-add-ollama' with the
+# expected Type/Endpoint to netclaw.json, and that `netclaw provider
+# list` shows the new row.
+#
+# Doctor is NOT run here — this tape produces a partial config (no
+# Tools/Security/Models, which come from `netclaw init`). doctor would
+# correctly [FAIL] on the missing sections, but those failures are
+# orthogonal to the surface this tape tests.
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+
+echo "provider-add: reading produced config..."
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "FAIL: ${CONFIG_PATH} does not exist." >&2
+  ls -la "$NETCLAW_HOME" "$NETCLAW_HOME/config" 2>&1 >&2 || true
+  exit 1
+fi
+
+config_json="$(read_config_json)"
+if ! printf '%s' "$config_json" | jq empty >/dev/null 2>&1; then
+  echo "FAIL: ${CONFIG_PATH} is not valid JSON." >&2
+  exit 1
+fi
+
+echo "provider-add: checking 'smoke-add-ollama' in config..."
+assert_field '.Providers["smoke-add-ollama"].Type'     'ollama'                 "$config_json" || :
+assert_field '.Providers["smoke-add-ollama"].Endpoint' 'http://localhost:11434' "$config_json" || :
+
+echo "provider-add: cross-checking 'netclaw provider list'..."
+list_output="$("$NETCLAW_SMOKE_CLI" provider list 2>/dev/null | tr -d '\r')"
+if ! echo "$list_output" | grep -qE '^smoke-add-ollama[[:space:]]+Ollama'; then
+  echo "FAIL: 'smoke-add-ollama' row missing or malformed in 'provider list' output." >&2
+  printf -- '--- provider list ---\n%s\n' "$list_output" >&2
+  assert_fail=1
+else
+  echo "  ok  'smoke-add-ollama' present in provider list"
+fi
+
+if (( assert_fail )); then
+  printf -- '--- netclaw.json contents ---\n%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "provider-add: assertions passed."

--- a/tests/smoke/assertions/provider-rename.sh
+++ b/tests/smoke/assertions/provider-rename.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# provider-rename.tape post-tape assertion.
+#
+# Validates the rename swapped the dictionary key in netclaw.json:
+#   - 'seed-ollama' is gone
+#   - 'renamed-ollama' exists with the original Type/Endpoint
+#   - `netclaw provider list` reflects the rename
+#
+# See provider-add.sh for why doctor is not run here.
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+
+echo "provider-rename: reading produced config..."
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "FAIL: ${CONFIG_PATH} does not exist." >&2
+  exit 1
+fi
+
+config_json="$(read_config_json)"
+
+assert_field '(.Providers | has("seed-ollama"))'      'false'                    "$config_json" || :
+assert_field '(.Providers | has("renamed-ollama"))'   'true'                     "$config_json" || :
+assert_field '.Providers["renamed-ollama"].Type'      'ollama'                   "$config_json" || :
+assert_field '.Providers["renamed-ollama"].Endpoint'  'http://localhost:11434'   "$config_json" || :
+
+echo "provider-rename: cross-checking 'netclaw provider list'..."
+list_output="$("$NETCLAW_SMOKE_CLI" provider list 2>/dev/null | tr -d '\r')"
+if echo "$list_output" | grep -qE '^seed-ollama[[:space:]]'; then
+  echo "FAIL: 'seed-ollama' still shown in provider list." >&2
+  assert_fail=1
+else
+  echo "  ok  'seed-ollama' absent from provider list"
+fi
+if ! echo "$list_output" | grep -qE '^renamed-ollama[[:space:]]+Ollama'; then
+  echo "FAIL: 'renamed-ollama' missing from provider list." >&2
+  printf -- '--- provider list ---\n%s\n' "$list_output" >&2
+  assert_fail=1
+else
+  echo "  ok  'renamed-ollama' present in provider list"
+fi
+
+if (( assert_fail )); then
+  printf -- '--- netclaw.json contents ---\n%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "provider-rename: assertions passed."

--- a/tests/smoke/assertions/tui-cleanup.sh
+++ b/tests/smoke/assertions/tui-cleanup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# tui-cleanup.tape post-tape assertion.
+#
+# The tape's own Wait+Screen anchors are the primary regression
+# detector — if the alt screen corrupts during arrow navigation, the
+# row anchors stop matching and the tape times out. This script
+# confirms the seeded providers survived the TUI round-trip.
+#
+# See provider-add.sh for why doctor is not run here.
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+
+echo "tui-cleanup: checking seeded providers persisted across TUI exit..."
+list_output="$("$NETCLAW_SMOKE_CLI" provider list 2>/dev/null | tr -d '\r')"
+
+for name in seed-a seed-b; do
+  if ! echo "$list_output" | grep -qE "^${name}[[:space:]]+Ollama"; then
+    echo "FAIL: provider '$name' missing from list after TUI exit." >&2
+    assert_fail=1
+  else
+    echo "  ok  '$name' still present"
+  fi
+done
+
+if (( assert_fail )); then
+  printf -- '--- provider list ---\n%s\n' "$list_output" >&2
+  exit 1
+fi
+
+echo "tui-cleanup: assertions passed."

--- a/tests/smoke/scenarios/context-window.sh
+++ b/tests/smoke/scenarios/context-window.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# context-window.sh — context-window auto-detection.
+#
+# Folded from scripts/smoke/check.sh (~lines 240-277). Verifies that
+# `netclaw doctor` and the daemon status API report the provider-detected
+# context window (not the 32k hardcoded default) when no explicit
+# ContextWindow is configured.
+#
+# Self-contained: seeds provider + model config, starts a fresh daemon,
+# asserts, stops it. (In check.sh this config was built up by an earlier
+# section running against the same daemon.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "Seeding provider + model config..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Starting daemon for context window test..."
+if ! start_daemon; then
+  fail "daemon did not start"
+  summarize || exit 1
+  exit 1
+fi
+wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+
+log "Verifying context window auto-detection via status API..."
+ctx_json="$(run_timed "$STEP_TIMEOUT_SECONDS" curl -fsS "${DAEMON_BASE_URL}/api/health/status" 2>/dev/null || true)"
+ctx_window="$(echo "$ctx_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('model',{}).get('contextWindow',0))" 2>/dev/null || echo 0)"
+log "Daemon reports context window: $ctx_window tokens"
+if [[ "${ctx_window:-0}" -le 32768 ]]; then
+  # qwen2:0.5b has a context window > 32k that Ollama reports via /api/show.
+  # If we get exactly 32768 or less, auto-detection failed and we hit the
+  # hardcoded default — which is the bug this test guards against. Treated
+  # as a WARN, not a fail (some models have a native 32k context).
+  warn "Context window is $ctx_window (<= 32768). Auto-detection may not have worked."
+else
+  pass "context window: auto-detected $ctx_window tokens (> 32768)"
+fi
+
+log "Verifying netclaw doctor reports auto-detected context window..."
+doctor_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" doctor 2>&1 || true)"
+echo "$doctor_output"
+if [[ "$doctor_output" == *"Using default 32,768 tokens"* ]]; then
+  fail "doctor: still reports the hardcoded 32k default"
+elif [[ "$doctor_output" == *"Auto-detected"* ]]; then
+  pass "doctor: shows auto-detected context window"
+elif [[ "$doctor_output" == *"Context window explicitly set"* ]]; then
+  pass "doctor: context window explicitly configured (no auto-detection needed)"
+else
+  fail "doctor: unexpected output for context window check"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/daemon-lifecycle.sh
+++ b/tests/smoke/scenarios/daemon-lifecycle.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# daemon-lifecycle.sh — native daemon start / status / health / stop.
+#
+# Folded from scripts/smoke/check.sh (~lines 85-153). De-Dockerized: the
+# daemon runs as a native host process bound to loopback 127.0.0.1:5199.
+#
+# Self-contained: starts a fresh daemon, asserts, stops it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "daemon-lifecycle: starting daemon..."
+if start_daemon; then
+  pass "daemon start: daemon reports running"
+else
+  fail "daemon start: daemon did not report running"
+  summarize || exit 1
+  exit 1
+fi
+
+log "Checking daemon status..."
+status_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon status 2>/dev/null || true)"
+echo "$status_output"
+if [[ "$status_output" == *"Daemon running"* ]]; then
+  pass "daemon status: reports running"
+else
+  fail "daemon status: expected 'Daemon running'"
+fi
+
+log "Waiting for daemon health endpoint..."
+if wait_for_health; then
+  pass "daemon health: /api/health/ready reports healthy"
+else
+  fail "daemon health: endpoint did not become ready"
+fi
+
+log "Stopping daemon..."
+stop_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon stop 2>/dev/null || true)"
+echo "$stop_output"
+
+log "Verifying daemon stopped..."
+stopped_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon status 2>/dev/null || true)"
+echo "$stopped_output"
+if [[ "$stopped_output" == *"Daemon running"* ]]; then
+  fail "daemon stop: daemon still running after stop"
+else
+  pass "daemon stop: daemon is stopped"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/pairing.sh
+++ b/tests/smoke/scenarios/pairing.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# pairing.sh — full device pairing lifecycle.
+#
+# Folded from scripts/smoke/check.sh (~lines 440-505). Exercises the full
+# device pairing flow: generate code, exchange for bearer token, verify
+# device in registry, authenticate with token, revoke, and verify the
+# revoked token is rejected (HTTP 401).
+#
+# Self-contained: seeds provider + model config, starts a fresh daemon,
+# asserts, stops it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "Seeding provider + model config..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Starting daemon for pairing tests..."
+if ! start_daemon; then
+  fail "daemon did not start"
+  summarize || exit 1
+  exit 1
+fi
+wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+
+SMOKE_DEVICE_NAME="smoke-pairing-$$"
+
+log "Generating pairing code via netclaw daemon pair..."
+pair_output="$(nc daemon pair 2>/dev/null || true)"
+echo "$pair_output"
+
+pairing_code="$(echo "$pair_output" | grep 'Pairing code:' | awk '{print $NF}')"
+if [[ -z "$pairing_code" ]]; then
+  fail "daemon pair: expected pairing code in output"
+  summarize || exit 1
+  exit 1
+fi
+pass "daemon pair: extracted pairing code $pairing_code"
+
+log "Exchanging pairing code for bearer token..."
+exchange_response="$(run_timed "$STEP_TIMEOUT_SECONDS" \
+  curl -fsS \
+    -X POST "${DAEMON_BASE_URL}/api/pair/exchange" \
+    -H 'Content-Type: application/json' \
+    -d "{\"code\":\"$pairing_code\",\"deviceName\":\"$SMOKE_DEVICE_NAME\"}" 2>/dev/null || true)"
+echo "$exchange_response"
+
+device_token="$(echo "$exchange_response" | sed 's/.*"token":"\([^"]*\)".*/\1/')"
+if [[ -z "$device_token" || "$device_token" == "$exchange_response" ]]; then
+  fail "pair exchange: expected token field in response"
+  summarize || exit 1
+  exit 1
+fi
+pass "pair exchange: bearer token received"
+
+log "Verifying device appears in daemon devices list..."
+devices_output="$(nc daemon devices 2>/dev/null || true)"
+echo "$devices_output"
+if [[ "$devices_output" == *"$SMOKE_DEVICE_NAME"* ]]; then
+  pass "daemon devices: includes $SMOKE_DEVICE_NAME"
+else
+  fail "daemon devices: expected $SMOKE_DEVICE_NAME"
+fi
+
+log "Verifying bearer token authenticates protected endpoint (/api/pair/devices)..."
+auth_response="$(run_timed "$STEP_TIMEOUT_SECONDS" \
+  curl -fsS \
+    -H "Authorization: Bearer $device_token" \
+    "${DAEMON_BASE_URL}/api/pair/devices" 2>/dev/null || true)"
+echo "$auth_response"
+if [[ "$auth_response" == *"$SMOKE_DEVICE_NAME"* ]]; then
+  pass "auth: bearer token authenticates /api/pair/devices"
+else
+  fail "auth: expected $SMOKE_DEVICE_NAME in authenticated response"
+fi
+
+log "Revoking device $SMOKE_DEVICE_NAME..."
+nc daemon devices revoke "$SMOKE_DEVICE_NAME"
+
+log "Verifying revoked token is rejected (expect HTTP 401)..."
+revoke_status="$(run_timed "$STEP_TIMEOUT_SECONDS" \
+  curl -sS -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $device_token" \
+    "${DAEMON_BASE_URL}/api/pair/devices" 2>/dev/null || true)"
+log "HTTP status after revoke: $revoke_status"
+if [[ "$revoke_status" == "401" ]]; then
+  pass "revoke: revoked token rejected with HTTP 401"
+else
+  fail "revoke: expected 401 for revoked token, got $revoke_status"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/provider-model-cli.sh
+++ b/tests/smoke/scenarios/provider-model-cli.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# provider-model-cli.sh — provider add/list/remove + model set/list/discover/
+# switch/clear against a live native Ollama.
+#
+# Folded from scripts/smoke/check.sh (~lines 155-238). De-Dockerized: the
+# CLI builds up config in a fresh NETCLAW_HOME and the provider endpoint
+# points at the native Ollama on localhost.
+#
+# A daemon is NOT required for these CLI subcommands — they operate on the
+# config files directly. We do not start one.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+ALT_MODEL="${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+log "Testing provider add (local-ollama)..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+
+log "Testing provider list..."
+provider_list="$(nc provider list 2>/dev/null || true)"
+echo "$provider_list"
+if [[ "$provider_list" == *"local-ollama"* ]]; then
+  pass "provider list: includes local-ollama"
+else
+  fail "provider list: expected local-ollama"
+fi
+
+log "Testing model set (main to $SMOKE_MODEL)..."
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Testing model list..."
+model_list="$(nc model list 2>/dev/null || true)"
+echo "$model_list"
+if [[ "$model_list" == *"$SMOKE_MODEL"* ]]; then
+  pass "model list: includes $SMOKE_MODEL"
+else
+  fail "model list: expected $SMOKE_MODEL"
+fi
+
+log "Testing model discover..."
+discover_output="$(nc model discover local-ollama 2>/dev/null || true)"
+echo "$discover_output"
+if [[ "$discover_output" == *"$SMOKE_MODEL"* ]]; then
+  pass "model discover: includes $SMOKE_MODEL"
+else
+  fail "model discover: expected $SMOKE_MODEL"
+fi
+
+log "Testing model switch to alternate model ($ALT_MODEL)..."
+nc model set main local-ollama "$ALT_MODEL"
+switched_list="$(nc model list 2>/dev/null || true)"
+echo "$switched_list"
+if [[ "$switched_list" == *"$ALT_MODEL"* ]]; then
+  pass "model switch: list shows $ALT_MODEL"
+else
+  fail "model switch: expected $ALT_MODEL after switch"
+fi
+
+log "Testing model switch back to original ($SMOKE_MODEL)..."
+nc model set main local-ollama "$SMOKE_MODEL"
+restored_list="$(nc model list 2>/dev/null || true)"
+echo "$restored_list"
+if [[ "$restored_list" == *"$SMOKE_MODEL"* ]]; then
+  pass "model switch back: list shows $SMOKE_MODEL"
+else
+  fail "model switch back: expected $SMOKE_MODEL"
+fi
+
+log "Testing provider add (second provider)..."
+nc provider add test-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+added_list="$(nc provider list 2>/dev/null || true)"
+echo "$added_list"
+if [[ "$added_list" == *"test-ollama"* ]]; then
+  pass "provider add: list includes test-ollama"
+else
+  fail "provider add: expected test-ollama"
+fi
+
+log "Testing provider remove..."
+nc provider remove test-ollama
+removed_list="$(nc provider list 2>/dev/null || true)"
+echo "$removed_list"
+if [[ "$removed_list" == *"test-ollama"* ]]; then
+  fail "provider remove: test-ollama still present"
+else
+  pass "provider remove: test-ollama removed"
+fi
+
+log "Testing model set fallback then clear..."
+nc model set fallback local-ollama "$ALT_MODEL"
+nc model clear fallback
+cleared_list="$(nc model list 2>/dev/null || true)"
+echo "$cleared_list"
+if [[ "$cleared_list" == *"$ALT_MODEL"* ]]; then
+  fail "model clear: $ALT_MODEL still present in fallback"
+else
+  pass "model clear: $ALT_MODEL cleared from fallback"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/reminders.sh
+++ b/tests/smoke/scenarios/reminders.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# reminders.sh — reminder create / list / history / delete lifecycle.
+#
+# Folded from scripts/smoke/check.sh (~lines 384-438). Schedules a
+# one-shot reminder, waits for it to execute and record history, then
+# permanently deletes it and verifies it is fully removed.
+#
+# Self-contained: seeds provider + model config, starts a fresh daemon,
+# asserts, stops it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+REMINDER_WAIT_TIMEOUT="${REMINDER_WAIT_TIMEOUT:-150}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "Seeding provider + model config..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Starting daemon for reminder tests..."
+if ! start_daemon; then
+  fail "daemon did not start"
+  summarize || exit 1
+  exit 1
+fi
+wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+
+REMINDER_ID="smoke-lifecycle-$$"
+
+log "Testing reminder create (one-shot in 1m, id=$REMINDER_ID)..."
+nc reminder create "$REMINDER_ID" once 1m "Say OK in one word"
+
+log "Verifying reminder appears in list..."
+reminder_list="$(nc reminder list 2>/dev/null || true)"
+echo "$reminder_list"
+if [[ "$reminder_list" == *"$REMINDER_ID"* ]]; then
+  pass "reminder list: includes $REMINDER_ID"
+else
+  fail "reminder list: expected $REMINDER_ID"
+fi
+
+log "Waiting up to ${REMINDER_WAIT_TIMEOUT}s for reminder to execute and record history..."
+history_found=false
+deadline=$((SECONDS + REMINDER_WAIT_TIMEOUT))
+while (( SECONDS < deadline )); do
+  history_output="$(run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" reminder history "$REMINDER_ID" --last 5 2>/dev/null || true)"
+  if [[ "$history_output" == *"fired_at"* ]]; then
+    history_found=true
+    log "Reminder executed. History:"
+    echo "$history_output"
+    break
+  fi
+  sleep 5
+done
+
+if [[ "$history_found" == "true" ]]; then
+  pass "reminder history: $REMINDER_ID executed and recorded history"
+else
+  fail "reminder history: timed out waiting for $REMINDER_ID to execute"
+fi
+
+log "Deleting reminder $REMINDER_ID..."
+nc reminder delete "$REMINDER_ID"
+
+log "Verifying reminder is absent from list after delete..."
+after_delete_list="$(nc reminder list 2>/dev/null || true)"
+echo "$after_delete_list"
+if [[ "$after_delete_list" == *"$REMINDER_ID"* ]]; then
+  fail "reminder delete: $REMINDER_ID still in list after delete"
+else
+  pass "reminder delete: $REMINDER_ID absent from list"
+fi
+
+log "Verifying history returns not-found for deleted reminder..."
+history_exit=0
+run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" reminder history "$REMINDER_ID" >/dev/null 2>&1 || history_exit=$?
+if [[ "$history_exit" -eq 0 ]]; then
+  fail "reminder history: expected non-zero exit for deleted reminder $REMINDER_ID"
+else
+  pass "reminder history: returned exit $history_exit for deleted reminder"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/sessions-and-chat.sh
+++ b/tests/smoke/scenarios/sessions-and-chat.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# sessions-and-chat.sh — headless chat, session catalog API, multi-turn
+# resume, and --json output.
+#
+# Folded from scripts/smoke/check.sh (~lines 279-338). De-Dockerized: the
+# daemon is a native host process; curl hits loopback directly.
+#
+# Self-contained: seeds provider + model config, starts a fresh daemon,
+# asserts, stops it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "Seeding provider + model config..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Starting daemon for session/chat tests..."
+if ! start_daemon; then
+  fail "daemon did not start"
+  summarize || exit 1
+  exit 1
+fi
+wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+
+log "Sending a headless prompt to create a session..."
+nc chat -p "Say hello in one word" || true
+
+log "Checking session catalog via REST API..."
+sessions_output="$(run_timed "$STEP_TIMEOUT_SECONDS" curl -fsS "${DAEMON_BASE_URL}/api/sessions" 2>/dev/null || true)"
+echo "$sessions_output"
+if [[ "$sessions_output" == *"persistenceId"* ]]; then
+  pass "/api/sessions: returns at least one session entry"
+else
+  fail "/api/sessions: expected at least one session entry"
+fi
+
+log "Verifying help text includes sessions command..."
+help_output="$(nc --help 2>/dev/null || true)"
+if [[ "$help_output" == *"sessions"* ]]; then
+  pass "--help: includes sessions command"
+else
+  fail "--help: expected sessions command"
+fi
+
+log "Verifying chat --resume help..."
+resume_help="$(nc chat --help 2>/dev/null || true)"
+echo "$resume_help"
+if [[ "$resume_help" == *"--resume"* ]]; then
+  pass "chat --help: includes --resume flag"
+else
+  fail "chat --help: expected --resume flag"
+fi
+if [[ "$resume_help" == *"-p"* ]]; then
+  pass "chat --help: includes -p flag"
+else
+  fail "chat --help: expected -p flag"
+fi
+
+# ── Multi-turn headless resume ──
+MULTI_TURN_SESSION="smoke/multi-turn-$$"
+
+log "Testing multi-turn: Turn 1 (create named session)..."
+nc chat -p --resume "$MULTI_TURN_SESSION" "hello" || true
+
+log "Testing multi-turn: Turn 2 (resume and verify continuity)..."
+turn2_output="$(nc chat -p --resume "$MULTI_TURN_SESSION" "what was my first message?" 2>/dev/null || true)"
+echo "$turn2_output"
+if echo "$turn2_output" | grep -qi "hello"; then
+  pass "multi-turn: response referenced 'hello'"
+else
+  # Model quality issue, not a CLI bug — WARN, not fail (matches check.sh).
+  warn "multi-turn continuity: response did not reference 'hello' (model quality, not CLI bug)"
+fi
+
+log "Testing headless --json output..."
+json_output="$(nc chat -p --json "Say hello in one word" 2>/dev/null || true)"
+echo "$json_output"
+if [[ "$json_output" == *"sessionId"* ]]; then
+  pass "chat --json: output includes sessionId field"
+else
+  fail "chat --json: expected sessionId field"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/scenarios/stats.sh
+++ b/tests/smoke/scenarios/stats.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# stats.sh — `netclaw stats` text / json / --days / skills surfaces.
+#
+# Folded from scripts/smoke/check.sh (~lines 340-382). The stats command
+# reads from the running daemon, which needs at least one completed
+# session to report token counters — so this scenario seeds config,
+# starts a daemon, runs a headless prompt, then exercises stats.
+#
+# Self-contained: seeds provider + model config, starts a fresh daemon,
+# asserts, stops it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+cleanup() { stop_daemon; }
+trap cleanup EXIT
+
+log "Seeding provider + model config..."
+nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+nc model set main local-ollama "$SMOKE_MODEL"
+
+log "Starting daemon for stats tests..."
+if ! start_daemon; then
+  fail "daemon did not start"
+  summarize || exit 1
+  exit 1
+fi
+wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+
+log "Creating a completed session so stats has data..."
+nc chat -p "Say hello in one word" || true
+
+log "Testing netclaw stats (text)..."
+stats_output="$(nc stats 2>/dev/null || true)"
+echo "$stats_output"
+if [[ "$stats_output" == *"tokens:"* ]]; then
+  pass "stats: output includes token counters"
+else
+  fail "stats: expected token counters"
+fi
+
+log "Testing netclaw stats --json..."
+stats_json="$(nc stats --json 2>/dev/null || true)"
+echo "$stats_json"
+if [[ "$stats_json" == *"inputTokensTotal"* ]]; then
+  pass "stats --json: includes inputTokensTotal field"
+else
+  fail "stats --json: expected inputTokensTotal field"
+fi
+
+log "Testing netclaw stats --days 7..."
+stats_days="$(nc stats --days 7 2>/dev/null || true)"
+echo "$stats_days"
+if [[ "$stats_days" == *"date"* ]]; then
+  pass "stats --days 7: includes daily breakdown with date column"
+else
+  fail "stats --days 7: expected daily breakdown with date column"
+fi
+
+log "Testing netclaw stats skills..."
+skill_stats_output="$(nc stats skills 2>/dev/null || true)"
+echo "$skill_stats_output"
+if [[ "$skill_stats_output" == *"by method:"* || "$skill_stats_output" == *"No skill loads recorded."* ]]; then
+  pass "stats skills: method breakdown or empty-state message present"
+else
+  fail "stats skills: expected method breakdown or empty-state message"
+fi
+
+log "Testing netclaw stats skills --json..."
+skill_stats_json="$(nc stats skills --json 2>/dev/null || true)"
+echo "$skill_stats_json"
+if [[ "$skill_stats_json" == *"\"daily\""* ]]; then
+  pass "stats skills --json: includes daily field"
+else
+  fail "stats skills --json: expected daily field"
+fi
+
+summarize
+exit $?

--- a/tests/smoke/tapes/README.md
+++ b/tests/smoke/tapes/README.md
@@ -1,0 +1,99 @@
+# Native Interactive Smoke Tapes
+
+This directory holds VHS tape scripts that drive netclaw's interactive
+CLI surface (Spectre prompts, wizard flows, TUI menus) against the
+**real native binary** — no Docker. They exist to catch regressions
+like the netclaw/knit interactive-wizard bug that the non-interactive
+smoke scenarios (`tests/smoke/scenarios/*.sh`) cannot reach.
+
+These tapes are **end-to-end test scenarios**, not screenshot fodder.
+The pretty-screenshots tapes live in
+`netclaw-website/screenshots/tapes/` and are completely separate.
+
+This is the native successor to `tests/smoke-interactive/tapes/`, which
+runs everything inside a Docker container. The two systems run in
+parallel during a bake-in period; the Docker one is retired in a later
+phase.
+
+## Running locally
+
+```bash
+# Light suite (all tapes + non-interactive scenarios).
+./scripts/smoke/run-smoke.sh light
+
+# Full suite.
+./scripts/smoke/run-smoke.sh full
+
+# Single tape, fast iteration.
+./scripts/smoke/run-smoke.sh init-wizard
+```
+
+`run-smoke.sh` publishes the binary (or uses `NETCLAW_SMOKE_CLI` /
+`NETCLAW_SMOKE_DAEMON` if exported), installs `vhs` if missing, starts a
+native `ollama serve`, and pulls the smoke models automatically.
+
+## Authoring conventions
+
+Tapes here MUST follow these rules. A reviewer should reject anything
+that breaks them.
+
+1. **No literal `Sleep`** for synchronization. Use `Wait+Screen
+   /pattern/` to wait on stable substrings from the wizard's view
+   source (`src/Netclaw.Cli/Tui/Wizard/Steps/*StepView.cs`).
+   Sleep-based synchronization is the single biggest source of CI
+   flakiness. The only acceptable timeout is the outer one inside
+   `run-native-tape.sh`. (The short `Sleep 300ms` Termina-relayout
+   guards in the provider tapes are a known, documented exception.)
+
+2. **Tapes do not reset state.** The wrapper sets a per-tape
+   `NETCLAW_HOME` and clears it before the tape runs. Tape bodies do
+   not `rm -rf`, do not depend on prior tape runs.
+
+3. **Tapes do not produce screenshots.** They MAY emit a debug GIF
+   (`Output /tmp/tape-<name>.gif`) so failures have a visual artifact —
+   but no `Screenshot` directives in the body.
+
+4. **Terminal sizing is in pixels, not columns.** VHS interprets
+   `Set Width` / `Set Height` as pixel dimensions (minimum 120x120).
+   The preamble sets a sensible default (1400x800 at FontSize 14, which
+   gives ~95 cols × 50 rows).
+
+5. **Anchor regexes at every step.** After every `Type` / `Enter` /
+   `Down` / etc. that changes the visible state, immediately
+   `Wait+Screen /…/` for an anchor in the next view.
+
+6. **Pair each non-trivial tape with an assertion.** Place a sibling
+   script at `tests/smoke/assertions/<tape-name>.sh`. The wrapper
+   invokes it with `NETCLAW_HOME` and `NETCLAW_SMOKE_CLI` exported.
+
+## Anatomy
+
+Each tape body is concatenated *after* `preamble.tape`, which sets up a
+plain bash session on the host with a fresh `NETCLAW_HOME` and a
+deterministic prompt (`TAPE$ `). The combined tape is what `vhs` sees;
+the prompt anchor `/TAPE\$/` is the safe "back at shell" wait.
+
+The substitution placeholders the wrapper fills in:
+
+| Placeholder            | Replaced with                                  |
+|------------------------|------------------------------------------------|
+| `__NETCLAW_HOME__`     | per-tape `NETCLAW_HOME` directory (host FS)    |
+| `__NETCLAW_BIN_DIR__`  | directory containing `netclaw` + `netclawd`    |
+| `__TAPE_NAME__`        | tape short name                                |
+
+VHS v0.11 does not support escaped quotes inside `Type "..."`, so the
+binary directory and home paths are burned into the preamble at
+substitution time rather than typed as quoted literals.
+
+## Adding a new tape
+
+1. Identify the interactive flow you're covering.
+2. Read the relevant `*StepView.cs` (or other TUI source) to harvest
+   stable strings for `Wait+Screen` anchors.
+3. Author the tape body following the rules above.
+4. Author a sibling assertion script at
+   `tests/smoke/assertions/<name>.sh`.
+5. Add the tape's short name to `LIGHT_TAPES` / `FULL_TAPES` in
+   `scripts/smoke/run-smoke.sh`.
+6. Run `./scripts/smoke/run-smoke.sh <name>` until it's stable across
+   at least 3 consecutive runs. Treat any flake as a bug.

--- a/tests/smoke/tapes/help.tape
+++ b/tests/smoke/tapes/help.tape
@@ -1,0 +1,14 @@
+# help.tape — smallest possible tape. Validates that the run-native-tape.sh
+# pipeline (install-vhs → preamble → tape body → assertion) works
+# end-to-end against the native binary. No interactive prompts;
+# the only assertion is that vhs reaches the end without timing out.
+
+Output "/tmp/tape-help.gif"
+
+Type "netclaw --help"
+Enter
+Wait+Screen@10s /Usage:/
+Wait+Screen@5s /TAPE\$/
+
+Type "exit"
+Enter

--- a/tests/smoke/tapes/init-wizard.tape
+++ b/tests/smoke/tapes/init-wizard.tape
@@ -1,0 +1,133 @@
+# init-wizard.tape — Personal-posture, Ollama, full wizard walkthrough.
+#
+# This is the regression-catcher: the netclaw/knit interactive-wizard
+# bug lived inside this flow. Every interactive prompt in the wizard
+# is exercised here, and the post-tape assertion validates the
+# produced config against the embedded JSON schema.
+#
+# Synchronization: every step waits on a stable substring from the
+# step's view source (see src/Netclaw.Cli/Tui/Wizard/Steps/*StepView.cs).
+# Do NOT introduce literal `Sleep` — tighten the regex if you hit a
+# false positive.
+#
+# Outputs only a debug GIF; tapes are not authored for screenshots.
+
+Output "/tmp/tape-init-wizard.gif"
+
+# ─── Launch ──────────────────────────────────────────────────────────
+Type "netclaw init"
+Enter
+
+# ─── Step 1: Provider ───────────────────────────────────────────────
+Wait+Screen@10s /Choose your LLM provider:/
+# Provider list ordering is alphabetical by TypeKey:
+#   anthropic, ollama, openai, openai-compatible, openrouter
+# Display order matches: Anthropic (default), then Ollama (one Down).
+Down
+Enter
+
+# Endpoint input (default http://localhost:11434 — native Ollama is at
+# http://localhost:11434, which is also the default).
+Wait+Screen@10s /endpoint:/
+# Clear the default value. VHS has no End/Home — push cursor right past
+# the existing text (Right N is a no-op when already at end), then
+# Backspace enough to clear. Default is "http://localhost:11434" (22 chars).
+Right 32
+Backspace 32
+Type "http://localhost:11434"
+Enter
+
+# Wait for connection probe + model discovery. The "Connected! Found N models"
+# success message auto-advances to the model list quickly enough that vhs
+# can miss it; wait directly for the model selection header instead.
+Wait+Screen@45s /Select a model/
+# Models are alphabetical: all-minilm first, qwen2 second. Move to qwen2:0.5b.
+Down
+Enter
+
+# ─── Step 2: Security Posture ────────────────────────────────────────
+Wait+Screen@10s /Who will interact with this Netclaw instance/
+# Personal is the first / default-highlighted option.
+Enter
+
+# ─── Step 3: Channel Picker ──────────────────────────────────────────
+Wait+Screen@10s /Which channels would you like to connect/
+# 'd' = done without selecting any channels (skip channel setup).
+Type "d"
+
+# ─── Step 4: Web Search ─────────────────────────────────────────────
+Wait+Screen@10s /Choose your web search provider/
+# DuckDuckGo is the first / default option.
+Enter
+
+# ─── Step 5: Browser Automation ──────────────────────────────────────
+Wait+Screen@10s /Enable browser automation/
+# "No" is the first / default option.
+Enter
+
+# ─── Step 6: Identity ───────────────────────────────────────────────
+Wait+Screen@10s /Agent name:/
+Enter
+
+Wait+Screen@10s /Communication style:/
+Enter
+
+Wait+Screen@10s /Your name:/
+Type "SmokeTester"
+Enter
+
+Wait+Screen@10s /Your timezone:/
+Enter
+
+Wait+Screen@10s /Projects directory:/
+Enter
+
+Wait+Screen@10s /Notification webhook URL/
+Enter
+
+# ─── Step 7: External Skills (skipped in smoke) ─────────────────────
+# ExternalSkillsStep.IsApplicable returns false when _detectedSources.Count == 0.
+# The smoke host has no Claude Code etc., so the wizard goes straight
+# from Identity → SkillFeeds with no External Skills prompts. If that ever
+# changes (smoke host starts seeding Claude Code), we'll need to handle
+# the "External skill directories detected" multi-select + custom dir input.
+
+# ─── Step 8: Skill Feeds ────────────────────────────────────────────
+Wait+Screen@10s /Connect to a private skill server/
+# Default is "Yes, connect"; we want "No — skip" (Down + Enter).
+Down
+Enter
+
+# ─── Step 9: Network Exposure ───────────────────────────────────────
+Wait+Screen@10s /How will this Netclaw daemon be accessed/
+# "Local — loopback only" is the first / default option.
+Enter
+
+Wait+Screen@10s /Should this daemon accept inbound webhooks/
+# "No" — second option.
+Down
+Enter
+
+# ─── Step 10: Health Check ──────────────────────────────────────────
+Wait+Screen@10s /Press Enter to run health checks/
+Enter
+
+# Health checks contact ollama, validate config, run doctor probes.
+# On success the wizard auto-navigates to the chat page (the daemon is
+# running by this point and the user lands inside the TUI). Wait for
+# the chat status bar to show the configured model, then quit the TUI
+# with Ctrl+Q to drop back to the shell. The post-tape assertion runs
+# `netclaw doctor` against the config the wizard wrote, which is the
+# real signal — vhs only proves we got this far.
+Wait+Screen@120s /Ready  \|  qwen2:0.5b/
+Ctrl+Q
+
+Wait+Screen@10s /TAPE\$/
+
+# Sanity: re-check at the prompt that init reported success.
+Type "echo INIT_EXIT=$?"
+Enter
+Wait+Screen@5s /INIT_EXIT=0/
+
+Type "exit"
+Enter

--- a/tests/smoke/tapes/preamble.tape
+++ b/tests/smoke/tapes/preamble.tape
@@ -7,8 +7,13 @@
 #
 # The wrapper substitutes:
 #   __NETCLAW_HOME__     — per-tape NETCLAW_HOME directory (host filesystem)
-#   __NETCLAW_BIN_DIR__  — directory containing the `netclaw` + `netclawd` binaries
+#   __NETCLAW_BIN_DIR__  — directory containing the `netclaw` CLI binary (added to PATH)
+#   __NETCLAW_DAEMON__   — absolute path to the `netclawd` daemon binary
 #   __TAPE_NAME__        — short name (e.g. init-wizard)
+#
+# The CLI and daemon publish to separate directories (publish/cli/,
+# publish/daemon/), so NETCLAW_DAEMON_PATH cannot be derived from the CLI
+# directory — it is substituted explicitly.
 #
 # After the preamble runs each tape body can assume:
 #   * It is inside an interactive bash session on the host.
@@ -43,7 +48,7 @@ Type "export PATH=__NETCLAW_BIN_DIR__:$PATH"
 Enter
 Type "export NETCLAW_HOME=__NETCLAW_HOME__"
 Enter
-Type "export NETCLAW_DAEMON_PATH=__NETCLAW_BIN_DIR__/netclawd"
+Type "export NETCLAW_DAEMON_PATH=__NETCLAW_DAEMON__"
 Enter
 Type "export PS1='TAPE$ '"
 Enter

--- a/tests/smoke/tapes/preamble.tape
+++ b/tests/smoke/tapes/preamble.tape
@@ -1,0 +1,54 @@
+# Shared preamble prepended by scripts/smoke/run-native-tape.sh before each
+# tape body.
+#
+# Establishes a plain bash session (no docker) with a per-tape NETCLAW_HOME
+# so each tape gets a clean config directory. The netclaw/netclawd binaries
+# are run from a host directory put on PATH.
+#
+# The wrapper substitutes:
+#   __NETCLAW_HOME__     — per-tape NETCLAW_HOME directory (host filesystem)
+#   __NETCLAW_BIN_DIR__  — directory containing the `netclaw` + `netclawd` binaries
+#   __TAPE_NAME__        — short name (e.g. init-wizard)
+#
+# After the preamble runs each tape body can assume:
+#   * It is inside an interactive bash session on the host.
+#   * `netclaw` / `netclawd` are on PATH.
+#   * NETCLAW_HOME points at an empty per-tape directory.
+#   * NETCLAW_DAEMON_PATH points at the netclawd binary so the CLI's
+#     daemon resolver finds it.
+#   * The shell prompt has been replaced with `TAPE$ ` so screen anchors
+#     like /TAPE\$/ work without depending on PS1.
+#
+# VHS v0.11 does not support escaped quotes inside `Type "..."`, so we
+# avoid them entirely by burning the per-tape directory paths into the
+# preamble at substitution time.
+
+Set Shell "bash"
+# Width/Height are PIXELS in VHS, not character columns. At FontSize 14
+# this gives roughly 95 cols x 50 rows — enough for the wizard's panels
+# without wrapping the typed lines.
+Set Width 1400
+Set Height 800
+Set FontSize 14
+Set Padding 0
+Set TypingSpeed 30ms
+
+Hide
+
+# The host vhs-spawned bash may carry an unhelpful PS1; we set our own
+# below so anchors are deterministic.
+Type "rm -rf __NETCLAW_HOME__ && mkdir -p __NETCLAW_HOME__"
+Enter
+Type "export PATH=__NETCLAW_BIN_DIR__:$PATH"
+Enter
+Type "export NETCLAW_HOME=__NETCLAW_HOME__"
+Enter
+Type "export NETCLAW_DAEMON_PATH=__NETCLAW_BIN_DIR__/netclawd"
+Enter
+Type "export PS1='TAPE$ '"
+Enter
+Type "clear"
+Enter
+Wait+Screen /TAPE\$/
+
+Show

--- a/tests/smoke/tapes/provider-add.tape
+++ b/tests/smoke/tapes/provider-add.tape
@@ -1,0 +1,81 @@
+# provider-add.tape — drive the `netclaw provider` TUI through the
+# add flow introduced in PR #997, including the new "Name your
+# provider" step that lets the user override the generated default
+# (`my-ollama`, `my-anthropic`, …) before any credential entry.
+#
+# Flow shape: when no providers are configured yet, the provider list
+# shows every known provider TYPE as a "(not configured)" row plus
+# the "+ Add new provider..." sentinel at the bottom. Activating a
+# type row goes straight to the AddName step for that type. The
+# sentinel only routes through the explicit AddSelectType step and
+# is only useful when every type is already configured (and we want
+# to add another instance of one).
+#
+# Synchronization: every step waits on a stable substring from
+# src/Netclaw.Cli/Tui/ProviderManagerPage.cs. Each state transition
+# is followed by a brief `Sleep 300ms` — Termina rebuilds the layout
+# (including swapping the focused SelectionList) on every state
+# transition, and vhs's screen anchor matches the rendered text
+# slightly before the new list's input handler is wired up.
+
+Output "/tmp/tape-provider-add.gif"
+
+# ─── Launch ──────────────────────────────────────────────────────────
+Type "netclaw provider"
+Enter
+
+# List view: every type as unconfigured + the sentinel. Anchor on
+# "Ollama" (row 2 — guaranteed to be present in the type list) rather
+# than the sentinel so we know the type rows have rendered.
+Wait+Screen@10s /Ollama/
+Sleep 300ms
+
+# Provider type list (alphabetical by TypeKey): anthropic, ollama,
+# openai, openai-compatible, openrouter. With Anthropic highlighted
+# by default, one Down lands on Ollama.
+Down
+Enter
+
+# ─── Step 1: Name your provider (NEW in #997) ────────────────────────
+Wait+Screen@10s /Name your provider/
+Sleep 300ms
+# Default pre-filled is "my-ollama" (9 chars). Cursor is at end
+# (explicit ConsoleKey.End synth in BuildAddNameView). Backspace
+# clears all 9 chars; 16 backspaces is safely over.
+Backspace 16
+Type "smoke-add-ollama"
+Enter
+
+# ─── Step 2: Endpoint ────────────────────────────────────────────────
+Wait+Screen@10s /Endpoint/
+Sleep 300ms
+# Default is "http://localhost:11434" (22 chars).
+Right 32
+Backspace 32
+Type "http://localhost:11434"
+Enter
+
+# ─── Step 3: Probe + ready-to-save ───────────────────────────────────
+# Probe is async; with qwen2:0.5b + all-minilm baked into native
+# ollama, this resolves in seconds. Wait directly on the "ready to
+# save" success line (skips the transient "Validating..." frame).
+Wait+Screen@45s /ready to save/
+Sleep 300ms
+Enter
+
+# ─── Back at provider list ───────────────────────────────────────────
+# StatusMessage on the list view: "Added provider 'smoke-add-ollama'.
+# Restart daemon for changes to take effect."
+Wait+Screen@10s /Added provider 'smoke-add-ollama'/
+Sleep 300ms
+
+# ─── Exit TUI ────────────────────────────────────────────────────────
+Ctrl+Q
+Wait+Screen@10s /TAPE\$/
+
+Type "echo PROVIDER_ADD_EXIT=$?"
+Enter
+Wait+Screen@5s /PROVIDER_ADD_EXIT=0/
+
+Type "exit"
+Enter

--- a/tests/smoke/tapes/provider-rename.tape
+++ b/tests/smoke/tapes/provider-rename.tape
@@ -1,0 +1,77 @@
+# provider-rename.tape — drive the `netclaw provider` TUI rename
+# action introduced in PR #997 ([N] from the Details view).
+#
+# The tape seeds an existing provider via the non-interactive CLI
+# (`netclaw provider add ...`) before launching the TUI so we are
+# testing the rename flow itself, not the add flow. The expectation
+# is that after the rename:
+#   * the configured key in netclaw.json swaps from the old name to
+#     the new one
+#   * any Models.{Main,Fallback,Compaction}.Provider references are
+#     cascaded (or, if absent, the rename succeeds without warning)
+#
+# See assertions/provider-rename.sh for the post-tape checks.
+
+Output "/tmp/tape-provider-rename.gif"
+
+# ─── Seed an existing provider ───────────────────────────────────────
+# Non-interactive CLI add — bypasses the TUI entirely and writes
+# straight to netclaw.json.
+Type "netclaw provider add seed-ollama ollama --endpoint http://localhost:11434"
+Enter
+Wait+Screen@10s /Added provider 'seed-ollama'|TAPE\$/
+
+# ─── Launch provider TUI ─────────────────────────────────────────────
+Type "netclaw provider"
+Enter
+
+# Wait for the probe to complete. ActivateSelectedProvider() is a no-op
+# while health == Probing, so we must wait for the ✓ checkmark (healthy)
+# before pressing Enter. The list renders seed-ollama immediately with a
+# spinner, but Enter would be silently ignored until the probe settles.
+# 30s covers slow CI; Ollama is pre-loaded so it's typically < 5s.
+Wait+Screen@30s /✓ seed-ollama/
+Sleep 300ms
+
+# The seeded provider is at index 0 and highlighted by default —
+# Enter activates the Details view.
+Enter
+
+# ─── Details view ────────────────────────────────────────────────────
+# Details view shows "Provider: seed-ollama" along with [N] Rename
+# in the key hints. Anchor on the rename hint so we know we landed.
+Wait+Screen@10s /Provider: seed-ollama/
+Sleep 300ms
+
+# Press N to start rename.
+Type "N"
+
+# ─── Rename input ────────────────────────────────────────────────────
+Wait+Screen@10s /Rename 'seed-ollama'/
+Sleep 300ms
+
+# Cursor sits at the end of the pre-filled name (PR #997 moves it
+# there explicitly — see commit 1493ddd1). 'seed-ollama' is 11 chars;
+# 16 backspaces is safely over.
+Backspace 16
+Type "renamed-ollama"
+Enter
+
+# ─── Success status ──────────────────────────────────────────────────
+# StatusMessage on the list view: "Renamed 'seed-ollama' to
+# 'renamed-ollama'. Restart daemon for changes to take effect."
+# The status message and new name both appear on the list view after
+# the rename, so one anchor covering the new name is sufficient.
+Wait+Screen@10s /renamed-ollama/
+Sleep 300ms
+
+# ─── Exit TUI ────────────────────────────────────────────────────────
+Ctrl+Q
+Wait+Screen@10s /TAPE\$/
+
+Type "echo PROVIDER_RENAME_EXIT=$?"
+Enter
+Wait+Screen@5s /PROVIDER_RENAME_EXIT=0/
+
+Type "exit"
+Enter

--- a/tests/smoke/tapes/tui-cleanup.tape
+++ b/tests/smoke/tapes/tui-cleanup.tape
@@ -1,0 +1,90 @@
+# tui-cleanup.tape — regression coverage for the bug class fixed in
+# PR #997, commit 21450c3d "fix(cli): buffer update-available notice;
+# emit after mode handler exits".
+#
+# The underlying bug: any background task that writes to stderr/
+# stdout while a Termina TUI owns the alt screen corrupts the layout
+# (missing panel borders, duplicate rows under arrow navigation).
+# `BackgroundUpdateCheckAsync` was the most visible offender — it
+# fires on every CLI invocation and used to write its "Update
+# available" / "warn: background update check failed" lines straight
+# to stderr.
+#
+# The fix moves those writes into a buffered `_pendingNotice` field
+# emitted by `EmitPendingNoticeIfReady()` AFTER the mode handler
+# returns (TUI torn down). This tape exercises the conditions that
+# used to trigger the corruption:
+#   1) Launch the provider TUI (which Aaron was navigating when he
+#      reproduced the bug on #997).
+#   2) Wait long enough for BackgroundUpdateCheckAsync to plausibly
+#      fire (network probe to the update endpoint).
+#   3) Navigate with arrows; if the background task wrote to stderr
+#      mid-render, the list rendering would drift and our screen
+#      anchors would no longer match.
+#   4) Exit the TUI and verify we land on a clean shell prompt with
+#      no stray output between the TUI tear-down and the prompt.
+#
+# Note: the test cannot force `BackgroundUpdateCheckAsync` to find an
+# update or emit a notice — that depends on the network response from
+# the update endpoint. What it CAN do is keep the TUI up long enough
+# that any background stderr write would manifest as visible
+# corruption. The fix is observable as the absence of that
+# corruption.
+
+Output "/tmp/tape-tui-cleanup.gif"
+
+# Seed a couple of providers so the list has multiple rows to
+# arrow-navigate through — multiple rows is what triggered the
+# "duplicate rows on arrow navigation" symptom in Aaron's report.
+Type "netclaw provider add seed-a ollama --endpoint http://localhost:11434"
+Enter
+Wait+Screen@10s /Added provider 'seed-a'|TAPE\$/
+
+Type "netclaw provider add seed-b ollama --endpoint http://localhost:11434"
+Enter
+Wait+Screen@10s /Added provider 'seed-b'|TAPE\$/
+
+# ─── Launch provider TUI ────────────────────────────────────────────
+Type "netclaw provider"
+Enter
+
+# Both seeded entries present.
+Wait+Screen@10s /seed-a/
+Wait+Screen@10s /seed-b/
+
+# Arrow-navigate up and down through the list. Each step has its own
+# anchor on the row content — if stderr writes corrupted the alt
+# screen, the row text wouldn't reappear unchanged.
+Down
+Wait+Screen@5s /seed-b/
+Down
+Wait+Screen@5s /\+ Add new provider/
+Up
+Wait+Screen@5s /seed-b/
+Up
+Wait+Screen@5s /seed-a/
+
+# ─── Exit and verify clean shell post-TUI ───────────────────────────
+Ctrl+Q
+
+# Anchor on the prompt. If the alt screen wasn't torn down cleanly,
+# the prompt either wouldn't render or would be visually merged with
+# TUI artefacts. The TAPE$ regex must match for this tape to pass.
+Wait+Screen@10s /TAPE\$/
+
+# Run a known echo and verify the output round-trips cleanly. A stray
+# update-notice line emitted at the wrong time would interleave with
+# this output; a buffered notice (the fix) renders BEFORE the prompt
+# and leaves the round-trip uncorrupted.
+Type "echo TUI_EXIT_SENTINEL"
+Enter
+Wait+Screen@5s /TUI_EXIT_SENTINEL/
+
+# Also re-anchor on the prompt to ensure the line was processed and
+# returned us to a working shell — not stuck in some half-state.
+Type "echo POST_SENTINEL_$?"
+Enter
+Wait+Screen@5s /POST_SENTINEL_0/
+
+Type "exit"
+Enter


### PR DESCRIPTION
## Summary

Phase 2 of the smoke-testing restructure. Adds a **native** smoke harness that runs the real `netclaw` / `netclawd` binaries directly on the host — no Docker for the binary — against a native Ollama process. This is the foundation for testing macOS (Phase 5), which the Docker-only `smoke_sandbox.yml` structurally cannot reach.

New harness:
- `scripts/smoke/run-smoke.sh` — unified entrypoint (`light` / `full` / single tape or scenario)
- `scripts/smoke/lib/{common,ollama}.sh` — native daemon lifecycle + Ollama provisioning
- `scripts/smoke/run-native-tape.sh` — de-Dockerized VHS tape runner
- `scripts/smoke/collect-artifacts.sh` — host-filesystem artifact collection
- `tests/smoke/tapes/` — native VHS tapes (5 interactive flows + preamble)
- `tests/smoke/assertions/` — host-filesystem post-tape assertions
- `tests/smoke/scenarios/` — 7 non-interactive scenarios folded from `check.sh` (daemon lifecycle, provider/model CLI, context-window, sessions/chat, stats, reminders, pairing)
- `.github/workflows/smoke.yml` — Linux native smoke, runs on every PR to `dev`

## Additive — nothing removed

The Docker smoke system (`smoke_sandbox.yml`, `docker-compose.smoke.yml`, `check.sh`, `up.sh`, `down.sh`, `ollama-init.sh`, `collect-logs.sh`, `tests/smoke-interactive/`) is **untouched** and keeps gating PRs. Both run in parallel during the bake-in period; the Docker system is removed in Phase 6 once the native harness is proven.

## Test plan

- [ ] New `smoke` workflow (`Publish native binaries` + `Native Smoke (Linux)`) green
- [ ] Existing `smoke_sandbox` + `pr_validation` still green (additive change, should be unaffected)
- [ ] Confirm native harness covers the same surface as `check.sh` (no coverage lost)