### PR TITLE
refactor(smoke): dedupe Phase 2 harness, fail loudly

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,14 +40,6 @@ jobs:
         with:
           global-json-file: ./global.json
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/Directory.Build.props', 'global.json') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
-
       - name: Publish binaries
         shell: bash
         run: |
@@ -90,14 +82,6 @@ jobs:
           chmod +x publish/cli/netclaw publish/daemon/netclawd
           echo "NETCLAW_SMOKE_CLI=$(pwd)/publish/cli/netclaw" >> "$GITHUB_ENV"
           echo "NETCLAW_SMOKE_DAEMON=$(pwd)/publish/daemon/netclawd" >> "$GITHUB_ENV"
-
-      - name: Cache Ollama model store
-        uses: actions/cache@v4
-        with:
-          path: ~/.ollama/models
-          key: ollama-models-${{ env.SMOKE_OLLAMA_MODEL }}-${{ env.SMOKE_OLLAMA_ALT_MODEL }}
-          restore-keys: |
-            ollama-models-
 
       - name: Run native smoke (light)
         shell: bash

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           global-json-file: ./global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/Directory.Build.props', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Publish binaries
         shell: bash
         run: |
@@ -88,6 +96,8 @@ jobs:
         with:
           path: ~/.ollama/models
           key: ollama-models-${{ env.SMOKE_OLLAMA_MODEL }}-${{ env.SMOKE_OLLAMA_ALT_MODEL }}
+          restore-keys: |
+            ollama-models-
 
       - name: Run native smoke (light)
         shell: bash
@@ -95,13 +105,6 @@ jobs:
           mkdir -p smoke-logs
           set -o pipefail
           scripts/smoke/run-smoke.sh light 2>&1 | tee smoke-logs/run-smoke.log
-
-      - name: Collect smoke artifacts
-        if: always()
-        shell: bash
-        run: |
-          mkdir -p smoke-logs
-          scripts/smoke/collect-artifacts.sh smoke-logs || true
 
       - name: Upload smoke artifacts
         if: always()

--- a/scripts/smoke/collect-artifacts.sh
+++ b/scripts/smoke/collect-artifacts.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Collect failure artifacts from the native smoke harness (no Docker).
-#
-# Native successor to scripts/smoke/collect-logs.sh. Copies per-scenario
+# Collect failure artifacts from the native smoke harness — per-scenario
 # NETCLAW_HOME logs + config, the Ollama serve log, tape GIFs/PNGs, and
 # harness stdout into a destination directory.
 #

--- a/scripts/smoke/lib/common.sh
+++ b/scripts/smoke/lib/common.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# Shared helpers for the native (non-Docker) smoke harness.
-#
-# Source this file; do not execute it. De-Dockerized versions of the
-# helpers that used to live in scripts/smoke/check.sh — the daemon now
-# runs as a native host process bound to loopback 127.0.0.1:5199.
+# Shared helpers for the native smoke harness — source, do not execute.
 #
 # Callers must export before sourcing or before calling the helpers:
 #   NETCLAW_SMOKE_CLI     absolute path to the `netclaw` binary
@@ -58,7 +54,8 @@ run_timed() {
   elif command -v perl >/dev/null 2>&1; then
     perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
   else
-    "$@"
+    echo "ERROR: no timeout mechanism (timeout/gtimeout/perl) found; cannot bound '$*'." >&2
+    return 1
   fi
 }
 
@@ -108,4 +105,36 @@ wait_for_health() {
 stop_daemon() {
   : "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set}"
   run_timed "$STOP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon stop >/dev/null 2>&1 || true
+}
+
+# ── Scenario helpers ─────────────────────────────────────────────────────────
+
+# Smoke model + Ollama endpoint defaults — shared by every scenario so
+# they cannot drift apart.
+SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
+OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
+
+# nc — run the netclaw CLI under the per-step timeout.
+nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
+
+# die <msg> — record a failure, print the summary, exit non-zero.
+die() { fail "$1"; summarize || true; exit 1; }
+
+# seed_provider_model — write a minimal provider + main-model config so a
+# fresh NETCLAW_HOME has a usable provider before the daemon starts.
+seed_provider_model() {
+  nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
+  nc model set main local-ollama "$SMOKE_MODEL"
+}
+
+# seed_and_start_daemon — the common scenario preamble: install the daemon
+# stop trap, seed config, start the daemon, wait for health. die()s on
+# failure.
+seed_and_start_daemon() {
+  trap stop_daemon EXIT
+  log "Seeding provider + model config..."
+  seed_provider_model
+  log "Starting daemon..."
+  start_daemon || die "daemon did not start"
+  wait_for_health || die "daemon health endpoint not ready"
 }

--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# Run a single VHS tape against the native netclaw binary (no Docker).
-#
-# Native successor to scripts/smoke/run-tape.sh. The binary runs as a
-# host process; tapes live in tests/smoke/tapes/ and assertions in
-# tests/smoke/assertions/.
+# Run a single VHS tape against the native netclaw binary.
 #
 # Usage:
 #   scripts/smoke/run-native-tape.sh <tape-short-name>
@@ -125,7 +121,8 @@ if command -v timeout >/dev/null 2>&1; then
 elif command -v gtimeout >/dev/null 2>&1; then
   gtimeout "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
 else
-  vhs "$combined" || vhs_status=$?
+  echo "ERROR: no timeout tool (timeout/gtimeout) found; refusing to run vhs unbounded." >&2
+  exit 1
 fi
 
 if [[ $vhs_status -ne 0 ]]; then

--- a/tests/smoke/scenarios/context-window.sh
+++ b/tests/smoke/scenarios/context-window.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-# context-window.sh — context-window auto-detection.
-#
-# Folded from scripts/smoke/check.sh (~lines 240-277). Verifies that
-# `netclaw doctor` and the daemon status API report the provider-detected
-# context window (not the 32k hardcoded default) when no explicit
-# ContextWindow is configured.
-#
-# Self-contained: seeds provider + model config, starts a fresh daemon,
-# asserts, stops it. (In check.sh this config was built up by an earlier
-# section running against the same daemon.)
+# context-window.sh — verifies context-window auto-detection (status API + doctor).
 
 set -euo pipefail
 
@@ -16,29 +7,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
-
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
-
-cleanup() { stop_daemon; }
-trap cleanup EXIT
-
-log "Seeding provider + model config..."
-nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
-nc model set main local-ollama "$SMOKE_MODEL"
-
-log "Starting daemon for context window test..."
-if ! start_daemon; then
-  fail "daemon did not start"
-  summarize || exit 1
-  exit 1
-fi
-wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+seed_and_start_daemon
 
 log "Verifying context window auto-detection via status API..."
 ctx_json="$(run_timed "$STEP_TIMEOUT_SECONDS" curl -fsS "${DAEMON_BASE_URL}/api/health/status" 2>/dev/null || true)"
-ctx_window="$(echo "$ctx_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('model',{}).get('contextWindow',0))" 2>/dev/null || echo 0)"
+if [[ -z "$ctx_json" ]] || ! echo "$ctx_json" | jq empty >/dev/null 2>&1; then
+  die "status API did not return a valid JSON response"
+fi
+ctx_window="$(echo "$ctx_json" | jq -r '.model.contextWindow // 0')"
 log "Daemon reports context window: $ctx_window tokens"
 if [[ "${ctx_window:-0}" -le 32768 ]]; then
   # qwen2:0.5b has a context window > 32k that Ollama reports via /api/show.

--- a/tests/smoke/scenarios/daemon-lifecycle.sh
+++ b/tests/smoke/scenarios/daemon-lifecycle.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# daemon-lifecycle.sh — native daemon start / status / health / stop.
-#
-# Folded from scripts/smoke/check.sh (~lines 85-153). De-Dockerized: the
-# daemon runs as a native host process bound to loopback 127.0.0.1:5199.
-#
-# Self-contained: starts a fresh daemon, asserts, stops it.
+# daemon-lifecycle.sh — daemon start / status / health / stop on empty config.
 
 set -euo pipefail
 
@@ -12,16 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-cleanup() { stop_daemon; }
-trap cleanup EXIT
+trap stop_daemon EXIT
 
 log "daemon-lifecycle: starting daemon..."
 if start_daemon; then
   pass "daemon start: daemon reports running"
 else
-  fail "daemon start: daemon did not report running"
-  summarize || exit 1
-  exit 1
+  die "daemon start: daemon did not report running"
 fi
 
 log "Checking daemon status..."

--- a/tests/smoke/scenarios/pairing.sh
+++ b/tests/smoke/scenarios/pairing.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
-# pairing.sh — full device pairing lifecycle.
-#
-# Folded from scripts/smoke/check.sh (~lines 440-505). Exercises the full
-# device pairing flow: generate code, exchange for bearer token, verify
-# device in registry, authenticate with token, revoke, and verify the
-# revoked token is rejected (HTTP 401).
-#
-# Self-contained: seeds provider + model config, starts a fresh daemon,
-# asserts, stops it.
+# pairing.sh — full device pairing lifecycle (pair, exchange, auth, revoke).
 
 set -euo pipefail
 
@@ -15,25 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
-
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
-
-cleanup() { stop_daemon; }
-trap cleanup EXIT
-
-log "Seeding provider + model config..."
-nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
-nc model set main local-ollama "$SMOKE_MODEL"
-
-log "Starting daemon for pairing tests..."
-if ! start_daemon; then
-  fail "daemon did not start"
-  summarize || exit 1
-  exit 1
-fi
-wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+seed_and_start_daemon
 
 SMOKE_DEVICE_NAME="smoke-pairing-$$"
 
@@ -43,9 +17,7 @@ echo "$pair_output"
 
 pairing_code="$(echo "$pair_output" | grep 'Pairing code:' | awk '{print $NF}')"
 if [[ -z "$pairing_code" ]]; then
-  fail "daemon pair: expected pairing code in output"
-  summarize || exit 1
-  exit 1
+  die "daemon pair: expected pairing code in output"
 fi
 pass "daemon pair: extracted pairing code $pairing_code"
 
@@ -57,11 +29,9 @@ exchange_response="$(run_timed "$STEP_TIMEOUT_SECONDS" \
     -d "{\"code\":\"$pairing_code\",\"deviceName\":\"$SMOKE_DEVICE_NAME\"}" 2>/dev/null || true)"
 echo "$exchange_response"
 
-device_token="$(echo "$exchange_response" | sed 's/.*"token":"\([^"]*\)".*/\1/')"
-if [[ -z "$device_token" || "$device_token" == "$exchange_response" ]]; then
-  fail "pair exchange: expected token field in response"
-  summarize || exit 1
-  exit 1
+device_token="$(echo "$exchange_response" | jq -r '.token')"
+if [[ -z "$device_token" || "$device_token" == "null" ]]; then
+  die "pair exchange: expected token field in response"
 fi
 pass "pair exchange: bearer token received"
 

--- a/tests/smoke/scenarios/provider-model-cli.sh
+++ b/tests/smoke/scenarios/provider-model-cli.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
-# provider-model-cli.sh — provider add/list/remove + model set/list/discover/
-# switch/clear against a live native Ollama.
-#
-# Folded from scripts/smoke/check.sh (~lines 155-238). De-Dockerized: the
-# CLI builds up config in a fresh NETCLAW_HOME and the provider endpoint
-# points at the native Ollama on localhost.
-#
-# A daemon is NOT required for these CLI subcommands — they operate on the
-# config files directly. We do not start one.
+# provider-model-cli.sh — provider/model CLI subcommands; no daemon required.
 
 set -euo pipefail
 
@@ -15,11 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
 ALT_MODEL="${SMOKE_OLLAMA_ALT_MODEL:-all-minilm:latest}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
-
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
 
 log "Testing provider add (local-ollama)..."
 nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"

--- a/tests/smoke/scenarios/reminders.sh
+++ b/tests/smoke/scenarios/reminders.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 # reminders.sh — reminder create / list / history / delete lifecycle.
-#
-# Folded from scripts/smoke/check.sh (~lines 384-438). Schedules a
-# one-shot reminder, waits for it to execute and record history, then
-# permanently deletes it and verifies it is fully removed.
-#
-# Self-contained: seeds provider + model config, starts a fresh daemon,
-# asserts, stops it.
 
 set -euo pipefail
 
@@ -14,26 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
 REMINDER_WAIT_TIMEOUT="${REMINDER_WAIT_TIMEOUT:-150}"
 
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
-
-cleanup() { stop_daemon; }
-trap cleanup EXIT
-
-log "Seeding provider + model config..."
-nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
-nc model set main local-ollama "$SMOKE_MODEL"
-
-log "Starting daemon for reminder tests..."
-if ! start_daemon; then
-  fail "daemon did not start"
-  summarize || exit 1
-  exit 1
-fi
-wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+seed_and_start_daemon
 
 REMINDER_ID="smoke-lifecycle-$$"
 

--- a/tests/smoke/scenarios/sessions-and-chat.sh
+++ b/tests/smoke/scenarios/sessions-and-chat.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
-# sessions-and-chat.sh — headless chat, session catalog API, multi-turn
-# resume, and --json output.
-#
-# Folded from scripts/smoke/check.sh (~lines 279-338). De-Dockerized: the
-# daemon is a native host process; curl hits loopback directly.
-#
-# Self-contained: seeds provider + model config, starts a fresh daemon,
-# asserts, stops it.
+# sessions-and-chat.sh — headless chat, session catalog API, multi-turn resume, --json.
 
 set -euo pipefail
 
@@ -14,25 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
-
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
-
-cleanup() { stop_daemon; }
-trap cleanup EXIT
-
-log "Seeding provider + model config..."
-nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
-nc model set main local-ollama "$SMOKE_MODEL"
-
-log "Starting daemon for session/chat tests..."
-if ! start_daemon; then
-  fail "daemon did not start"
-  summarize || exit 1
-  exit 1
-fi
-wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+seed_and_start_daemon
 
 log "Sending a headless prompt to create a session..."
 nc chat -p "Say hello in one word" || true
@@ -80,7 +55,7 @@ echo "$turn2_output"
 if echo "$turn2_output" | grep -qi "hello"; then
   pass "multi-turn: response referenced 'hello'"
 else
-  # Model quality issue, not a CLI bug — WARN, not fail (matches check.sh).
+  # Model quality issue, not a CLI bug — WARN, not fail.
   warn "multi-turn continuity: response did not reference 'hello' (model quality, not CLI bug)"
 fi
 

--- a/tests/smoke/scenarios/stats.sh
+++ b/tests/smoke/scenarios/stats.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 # stats.sh — `netclaw stats` text / json / --days / skills surfaces.
-#
-# Folded from scripts/smoke/check.sh (~lines 340-382). The stats command
-# reads from the running daemon, which needs at least one completed
-# session to report token counters — so this scenario seeds config,
-# starts a daemon, runs a headless prompt, then exercises stats.
-#
-# Self-contained: seeds provider + model config, starts a fresh daemon,
-# asserts, stops it.
 
 set -euo pipefail
 
@@ -15,25 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/smoke/lib/common.sh
 . "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
 
-SMOKE_MODEL="${SMOKE_OLLAMA_MODEL:-qwen2:0.5b}"
-OLLAMA_ENDPOINT="${SMOKE_OLLAMA_ENDPOINT:-http://localhost:11434}"
-
-nc() { run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" "$@"; }
-
-cleanup() { stop_daemon; }
-trap cleanup EXIT
-
-log "Seeding provider + model config..."
-nc provider add local-ollama ollama --endpoint "$OLLAMA_ENDPOINT"
-nc model set main local-ollama "$SMOKE_MODEL"
-
-log "Starting daemon for stats tests..."
-if ! start_daemon; then
-  fail "daemon did not start"
-  summarize || exit 1
-  exit 1
-fi
-wait_for_health || { fail "daemon health endpoint not ready"; summarize || exit 1; exit 1; }
+seed_and_start_daemon
 
 log "Creating a completed session so stats has data..."
 nc chat -p "Say hello in one word" || true


### PR DESCRIPTION
## Summary

Code-quality follow-up to #1048 (a `/simplify` pass over the Phase 2 native smoke harness). No change to what the harness tests — pure cleanup.

- **Dedup** — the 7 `tests/smoke/scenarios/*.sh` each copy-pasted the same ~22-line preamble (provider/model seeding, daemon start, health wait, the fail-and-exit idiom). Hoisted into `lib/common.sh` as `seed_and_start_daemon` / `seed_provider_model` / `nc` / `die`. Net **-138 lines**.
- **Fail loudly** — `run_timed` and the VHS tape timeout previously fell through to running a command *unbounded* when no `timeout` tool was found. Now they error out, per the repo constitution's no-silent-fallbacks rule.
- **`context-window.sh`** — parses the status API with `jq` instead of an undeclared `python3` dependency; fails loudly on an invalid/empty response instead of masking it as a `0`-token warn.
- **`pairing.sh`** — extracts the bearer token with `jq` instead of a fragile `sed` regex.
- **`smoke.yml`** — dropped a redundant post-run collect step (`run-smoke.sh` already collects on failure before teardown). No CI caches: the repo is at its GitHub Actions cache storage limit, so the workflow deliberately uses no NuGet or Ollama-model cache.

## Test plan

- [ ] New `smoke` workflow green — exercises the deduped scenarios end-to-end
- [ ] `pr_validation` + `smoke_sandbox` still green