### PR TITLE
ci: fix mislabeled "Upload Linux install script" step (#1031)

### DIFF
--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -446,7 +446,9 @@ jobs:
         --file=./feeds/releases/manifest.pub
         --content-type=text/plain
 
-    - name: Upload Linux install script to R2
+    # install.sh is the unified Unix installer — it handles Linux AND macOS
+    # (uname -s -> darwin -> osx-arm64). There is intentionally one Unix script.
+    - name: Upload Unix (Linux + macOS) install script to R2
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

`scripts/install.sh` is the unified **Unix** installer — it handles both Linux *and* macOS (`uname -s` → `darwin` → `osx-arm64`, including Apple Silicon / Rosetta detection). But the R2-upload step in `publish_release_binaries.yml` was named "Upload **Linux** install script to R2".

During the 0.18.1 release (first to ship `osx-arm64`), that name made it look like the macOS installer hadn't been uploaded and nearly triggered an unnecessary 0.18.2 patch release. The artifact, manifest, and macOS-aware `install.sh` were all published correctly — the only defect was the misleading step name.

Renamed the step to "Upload Unix (Linux + macOS) install script to R2" and added a one-line comment. Purely cosmetic — no artifact or behavior change.

Closes #1031