### PR TITLE
test(smoke): macOS smoke leg + netclaw doctor check (Phase 5)

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -29,7 +29,7 @@ jobs:
             rid: linux-x64
           - os: windows-latest
             rid: win-x64
-          - os: macos-latest
+          - os: macos-26
             rid: osx-arm64
 
     steps:
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26, windows-latest]
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/publish_release_binaries.yml
+++ b/.github/workflows/publish_release_binaries.yml
@@ -85,7 +85,7 @@ jobs:
           - os: windows-latest
             rid: win-x64
             archive_ext: zip
-          - os: macos-latest
+          - os: macos-26
             rid: osx-arm64
             archive_ext: tar.gz
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -27,9 +27,18 @@ permissions:
 
 jobs:
   publish:
-    name: Publish native binaries
-    runs-on: ubuntu-latest
+    name: Publish native binaries (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
 
     steps:
       - name: Checkout
@@ -45,7 +54,7 @@ jobs:
         run: |
           chmod +x scripts/build/publish-binaries.sh
           scripts/build/publish-binaries.sh \
-            --rid linux-x64 --component all --output-dir ./publish
+            --rid ${{ matrix.rid }} --component all --output-dir ./publish
 
       # The mcp-setup scenario registers this as a stdio MCP server. Published
       # self-contained single-file so the SDK-less smoke job can run it.
@@ -53,13 +62,13 @@ jobs:
         shell: bash
         run: >
           dotnet publish tests/Netclaw.SmokeMcpServer
-          -c Release -r linux-x64 --self-contained /p:PublishSingleFile=true
+          -c Release -r ${{ matrix.rid }} --self-contained /p:PublishSingleFile=true
           -o ./publish/mcp-server
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: netclaw-native-binaries-${{ github.run_id }}-${{ github.run_attempt }}
+          name: netclaw-native-binaries-${{ matrix.rid }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             publish/cli/netclaw
             publish/daemon/netclawd
@@ -84,7 +93,7 @@ jobs:
       - name: Download binary artifact
         uses: actions/download-artifact@v7
         with:
-          name: netclaw-native-binaries-${{ github.run_id }}-${{ github.run_attempt }}
+          name: netclaw-native-binaries-linux-x64-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./publish
 
       - name: Mark binaries executable
@@ -105,7 +114,51 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: smoke-native-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          name: smoke-native-logs-linux-${{ github.run_id }}-${{ github.run_attempt }}
+          path: smoke-logs
+          if-no-files-found: warn
+
+  smoke-macos:
+    name: Native Smoke (macOS)
+    needs: publish
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    env:
+      SMOKE_OLLAMA_MODEL: qwen2:0.5b
+      SMOKE_OLLAMA_ALT_MODEL: all-minilm:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: netclaw-native-binaries-osx-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ./publish
+
+      - name: Mark binaries executable
+        run: |
+          chmod +x publish/cli/netclaw publish/daemon/netclawd publish/mcp-server/Netclaw.SmokeMcpServer
+          echo "NETCLAW_SMOKE_CLI=$(pwd)/publish/cli/netclaw" >> "$GITHUB_ENV"
+          echo "NETCLAW_SMOKE_DAEMON=$(pwd)/publish/daemon/netclawd" >> "$GITHUB_ENV"
+          echo "NETCLAW_SMOKE_MCP_SERVER=$(pwd)/publish/mcp-server/Netclaw.SmokeMcpServer" >> "$GITHUB_ENV"
+
+      # Screenshots stay Linux-only (VHS renders identically across OSes); the
+      # macOS leg runs the flow tapes + scenarios, which assert on exit codes.
+      - name: Run native smoke (light)
+        shell: bash
+        run: |
+          mkdir -p smoke-logs
+          set -o pipefail
+          scripts/smoke/run-smoke.sh light 2>&1 | tee smoke-logs/run-smoke.log
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-native-logs-macos-${{ github.run_id }}-${{ github.run_attempt }}
           path: smoke-logs
           if-no-files-found: warn
 
@@ -126,7 +179,7 @@ jobs:
       - name: Download binary artifact
         uses: actions/download-artifact@v7
         with:
-          name: netclaw-native-binaries-${{ github.run_id }}-${{ github.run_attempt }}
+          name: netclaw-native-binaries-linux-x64-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./publish
 
       - name: Mark binaries executable

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - os: ubuntu-latest
             rid: linux-x64
-          - os: macos-latest
+          - os: macos-26
             rid: osx-arm64
 
     steps:
@@ -121,7 +121,7 @@ jobs:
   smoke-macos:
     name: Native Smoke (macOS)
     needs: publish
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 45
 
     env:

--- a/scripts/smoke/install-vhs.sh
+++ b/scripts/smoke/install-vhs.sh
@@ -48,14 +48,16 @@ case "${uname_s}/${uname_m}" in
     if ! have brew; then
       cat >&2 <<'EOF'
 ERROR: vhs is not installed and Homebrew ('brew') is not on PATH.
-GitHub macos-latest runners ship Homebrew; for a local macOS run install it
+GitHub macOS runners ship Homebrew; for a local macOS run install it
 from https://brew.sh first, then re-run. To install vhs manually:
-    brew install vhs ttyd ffmpeg
+    brew install vhs ttyd ffmpeg coreutils
 EOF
       exit 1
     fi
-    echo "Installing vhs + runtime deps (ttyd, ffmpeg) via Homebrew..."
-    brew install vhs ttyd ffmpeg
+    # coreutils provides `gtimeout` — stock macOS has no `timeout`, and
+    # run-native-tape.sh needs one to bound the vhs run.
+    echo "Installing vhs + runtime deps (ttyd, ffmpeg, coreutils) via Homebrew..."
+    brew install vhs ttyd ffmpeg coreutils
     if ! have vhs; then
       echo "ERROR: 'brew install vhs' completed but 'vhs' is still not on PATH." >&2
       exit 1

--- a/scripts/smoke/install-vhs.sh
+++ b/scripts/smoke/install-vhs.sh
@@ -5,6 +5,7 @@
 #   - If `vhs` is already on PATH, do nothing.
 #   - On Linux x86_64: install vhs from the upstream release with SHA256 verification,
 #     and ensure ttyd / ffmpeg are present (apt-get if available).
+#   - On macOS: install vhs / ttyd / ffmpeg via Homebrew.
 #   - Other platforms: print install hints and fail.
 #
 # Pin the VHS version + SHA256 here. Bumping vhs requires updating both.
@@ -39,13 +40,29 @@ case "${uname_s}/${uname_m}" in
     : # supported below
     ;;
   Darwin/*)
-    cat >&2 <<'EOF'
-ERROR: vhs is not installed and automatic install is Linux/x86_64 only.
-On macOS install with Homebrew:
+    # macOS install path. Unlike Linux there is no pinned VHS version + SHA:
+    # the macOS leg does not run the screenshot comparison (Linux is the
+    # canonical screenshot platform), so renderer/font drift across VHS
+    # versions does not affect it. macOS VHS only drives the flow tapes,
+    # which assert on exit codes — not pixels — so `brew`'s latest is fine.
+    if ! have brew; then
+      cat >&2 <<'EOF'
+ERROR: vhs is not installed and Homebrew ('brew') is not on PATH.
+GitHub macos-latest runners ship Homebrew; for a local macOS run install it
+from https://brew.sh first, then re-run. To install vhs manually:
     brew install vhs ttyd ffmpeg
-Then re-run.
 EOF
-    exit 1
+      exit 1
+    fi
+    echo "Installing vhs + runtime deps (ttyd, ffmpeg) via Homebrew..."
+    brew install vhs ttyd ffmpeg
+    if ! have vhs; then
+      echo "ERROR: 'brew install vhs' completed but 'vhs' is still not on PATH." >&2
+      exit 1
+    fi
+    echo "vhs installed at $(command -v vhs)"
+    vhs --version || true
+    exit 0
     ;;
   *)
     cat >&2 <<EOF

--- a/scripts/smoke/lib/ollama.sh
+++ b/scripts/smoke/lib/ollama.sh
@@ -39,10 +39,18 @@ ollama_ensure_installed() {
       echo "Installing ollama via official install script..."
       curl -fsSL https://ollama.com/install.sh | sh
       ;;
+    Darwin)
+      if ! command -v brew >/dev/null 2>&1; then
+        echo "ERROR: ollama is not installed and Homebrew ('brew') is not on PATH." >&2
+        echo "       Install Homebrew from https://brew.sh, then: brew install ollama" >&2
+        return 1
+      fi
+      echo "Installing ollama via Homebrew..."
+      brew install ollama
+      ;;
     *)
-      echo "ERROR: ollama is not installed and automatic install is Linux-only." >&2
-      echo "       On macOS install with: brew install ollama" >&2
-      echo "       See https://ollama.com/download for other platforms." >&2
+      echo "ERROR: ollama is not installed and automatic install is not supported on ${uname_s}." >&2
+      echo "       See https://ollama.com/download for supported platforms." >&2
       return 1
       ;;
   esac

--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -129,7 +129,7 @@ vhs_status=0
 if command -v timeout >/dev/null 2>&1; then
   timeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
 elif command -v gtimeout >/dev/null 2>&1; then
-  gtimeout "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
+  gtimeout --foreground "${TAPE_TIMEOUT_S}" vhs "$combined" || vhs_status=$?
 else
   echo "ERROR: no timeout tool (timeout/gtimeout) found; refusing to run vhs unbounded." >&2
   exit 1

--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -57,6 +57,7 @@ LIGHT_TAPES=(help init-wizard provider-add provider-rename tui-cleanup)
 FULL_TAPES=("${LIGHT_TAPES[@]}")
 
 LIGHT_SCENARIOS=(
+  doctor
   daemon-lifecycle
   provider-model-cli
   context-window

--- a/tests/smoke/scenarios/doctor.sh
+++ b/tests/smoke/scenarios/doctor.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# doctor.sh — goal: `netclaw doctor` runs to completion without crashing.
+#
+# `netclaw doctor` is an offline diagnostic (no daemon). A crash in it was
+# reported on macOS, so this scenario runs it on a fresh config and asserts
+# it exits with a documented code (0 clean / 1 errors / 2 warnings) — never
+# a crash signal (>= 128) or a hang (the run_timed 124).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/smoke/lib/common.sh
+. "${SCRIPT_DIR}/../../../scripts/smoke/lib/common.sh"
+
+log "Running 'netclaw doctor' on a fresh config..."
+doctor_status=0
+run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" doctor || doctor_status=$?
+echo "netclaw doctor exit code: ${doctor_status}"
+
+case "$doctor_status" in
+  0) pass "doctor: exited 0 (all checks passed)" ;;
+  1) pass "doctor: exited 1 (errors reported — expected on a fresh/empty config)" ;;
+  2) pass "doctor: exited 2 (warnings only)" ;;
+  124) die "doctor: timed out (hung) under run_timed" ;;
+  *)
+    if (( doctor_status >= 128 )); then
+      die "doctor: crashed — killed by signal $(( doctor_status - 128 )) (exit ${doctor_status})"
+    fi
+    die "doctor: unexpected exit code ${doctor_status}"
+    ;;
+esac
+
+summarize
+exit $?


### PR DESCRIPTION
## Summary

Phase 5 of the smoke-testing restructure: run the native harness on **macOS** alongside Linux, and add an explicit `netclaw doctor` crash check.

- **`smoke.yml`** — the `publish` job is now a matrix (`ubuntu-latest`/`linux-x64` + `macos-latest`/`osx-arm64`), each leg uploading a per-RID binary artifact. New **`Native Smoke (macOS)`** job runs the harness on `macos-latest`. Screenshot regression stays Linux-only — VHS renders identically across OSes, so one canonical baseline set is the cross-platform guarantee.
- **`install-vhs.sh`** — macOS install path via Homebrew (`vhs`/`ttyd`/`ffmpeg`).
- **`lib/ollama.sh`** — macOS Ollama provisioning via `brew install ollama`.
- **`doctor.sh`** — a new offline scenario: runs `netclaw doctor` on a fresh config and asserts it exits with a documented code (0/1/2) — never a crash signal (≥128) or a hang. This catches the reported macOS `netclaw doctor` crash directly and unambiguously.

This is the leg that makes macOS-specific regressions (like #1036, #1014, and the `doctor` crash) catchable. During the burn-in phase it runs on every PR; a later phase moves it to a nightly schedule.

## Test plan

- [ ] `Native Smoke (macOS)` green — harness provisions Homebrew Ollama/VHS, runs tapes + scenarios on `osx-arm64`
- [ ] `doctor` scenario passes on both Linux and macOS (or surfaces the macOS crash)
- [ ] `Native Smoke (Linux)` + `Screenshot Regression` still green