### PR TITLE
Update Termina package version to 0.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Cronos" Version="0.12.0" />
     <PackageVersion Include="Netclaw.SkillClient" Version="0.3.0" />
     <PackageVersion Include="ShellSyntaxTree" Version="0.1.5" />
-    <PackageVersion Include="Termina" Version="0.8.0" />
+    <PackageVersion Include="Termina" Version="0.9.0" />
   </ItemGroup>
   <!-- Serialization -->
   <ItemGroup>


### PR DESCRIPTION
close #1069

Also opens the door for addressing https://github.com/netclaw-dev/netclaw/issues/765