### PR TITLE
fix(shell): start timeout countdown after process spawn

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/ShellToolTests.cs
@@ -60,11 +60,11 @@ public class ShellToolTests
     public async Task Requested_timeout_overrides_default_timeout()
     {
         var tool = new ShellTool(new ToolConfig { ShellTimeoutSeconds = 1 });
-        var args = ToolInput.Create("Command", "sleep 2");
+        var args = ToolInput.Create("Command", "sleep 1");
         var context = new ToolExecutionContext("test/thread", Path.GetTempPath())
         {
             Audience = TrustAudience.Personal,
-            RequestedTimeoutSeconds = 3
+            RequestedTimeoutSeconds = 5
         };
 
         var result = await tool.ExecuteAsync(args, context, CancellationToken.None);

--- a/src/Netclaw.Actors/Tools/ShellTool.cs
+++ b/src/Netclaw.Actors/Tools/ShellTool.cs
@@ -96,7 +96,7 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
             ? context.RequestedTimeoutSeconds.Value
             : _config.ShellTimeoutSeconds;
 
-        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(effectiveTimeoutSeconds));
+        using var timeoutCts = new CancellationTokenSource();
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         Process process;
@@ -108,6 +108,11 @@ public sealed partial class ShellTool : NetclawTool<ShellTool.Params>
         {
             return $"Error starting process: {ex.Message}";
         }
+
+        // Start the timeout countdown only after the shell process exists, so
+        // process-spawn overhead (heavier on Windows: cmd.exe plus the child it
+        // execs) is not charged against the command's execution budget.
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(effectiveTimeoutSeconds));
 
         using (process)
         {


### PR DESCRIPTION
## Summary

- `ShellTool` constructed its timeout `CancellationTokenSource` *before* `Process.Start`, so process-spawn overhead was charged against the command's timeout budget. On Windows this is a double-spawn (`cmd.exe` plus the child it execs), which intermittently consumed enough of the budget to time out commands that should have completed.
- This flaked `ShellToolTests.Requested_timeout_overrides_default_timeout` on Windows CI (e.g. observed on PR #1073, an unrelated Termina version bump).
- Fix: construct the timeout source with no delay and call `CancelAfter` only once the process exists, so `RequestedTimeoutSeconds`/`ShellTimeoutSeconds` bound the command's execution rather than command + shell startup. Also widened the test's margin (`sleep 1` against a 5s requested timeout) so residual spawn jitter cannot reflake it.

This is also a minor production correctness fix: a configured/requested timeout now means "the command gets N seconds," not "N seconds minus shell-spawn overhead."

## Test plan

- [x] `dotnet test` — all 23 `ShellToolTests` pass locally
- [x] `dotnet slopwatch analyze` — 0 issues
- [ ] CI green on `Test-windows-latest`