### PR TITLE
fix(smoke): free port 5199 between native smoke daemons

### DIFF
--- a/scripts/smoke/lib/common.sh
+++ b/scripts/smoke/lib/common.sh
@@ -61,10 +61,42 @@ run_timed() {
 
 # ── Daemon lifecycle ─────────────────────────────────────────────────────────
 
+# ensure_daemon_port_free — block until 127.0.0.1:5199 has no LISTEN socket.
+# Every tape and scenario daemon binds the same fixed port; a daemon orphaned
+# by an earlier NETCLAW_HOME is invisible to `netclaw daemon stop` (which only
+# signals the PID in the current home's PID file) and will squat the port,
+# making every later daemon crash on bind. Hard-kill any such straggler.
+# Returns non-zero if the port is still held after the timeout.
+ensure_daemon_port_free() {
+  local port=5199
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    local holders
+    holders="$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || true)"
+    [[ -z "$holders" ]] && return 0
+    # Allow a graceful exit a moment before resorting to a hard kill.
+    sleep 1
+    holders="$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || true)"
+    [[ -z "$holders" ]] && return 0
+    log "port ${port} still held by PID(s): ${holders} — hard-killing."
+    # shellcheck disable=SC2086 # word-split is intended: holders may be multi-PID
+    kill -9 $holders 2>/dev/null || pkill -9 -f netclawd 2>/dev/null || true
+    sleep 1
+  done
+  log "ERROR: port ${port} never freed."
+  return 1
+}
+
 # start_daemon — launch the native daemon detached and poll until it reports
 # running. Returns non-zero on timeout.
 start_daemon() {
   : "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set}"
+  # Defense in depth: a daemon orphaned by an earlier tape/scenario would still
+  # hold :5199 and make this start crash on bind. Clear it before launching.
+  if ! ensure_daemon_port_free; then
+    log "ERROR: daemon port not free; refusing to start."
+    return 1
+  fi
   log "Starting daemon (detached) ..."
   # Detach so the CLI's `daemon start` does not hold our stdio.
   run_timed "$STEP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon start >/dev/null 2>&1 || true
@@ -105,6 +137,10 @@ wait_for_health() {
 stop_daemon() {
   : "${NETCLAW_SMOKE_CLI:?NETCLAW_SMOKE_CLI must be set}"
   run_timed "$STOP_TIMEOUT_SECONDS" "$NETCLAW_SMOKE_CLI" daemon stop >/dev/null 2>&1 || true
+  # `daemon stop` only signals the PID in this NETCLAW_HOME's PID file; make
+  # sure the listening socket is actually released before the next daemon
+  # tries to bind it.
+  ensure_daemon_port_free || true
 }
 
 # ── Scenario helpers ─────────────────────────────────────────────────────────

--- a/scripts/smoke/run-native-tape.sh
+++ b/scripts/smoke/run-native-tape.sh
@@ -43,6 +43,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TAPES_DIR="${ROOT_DIR}/tests/smoke/tapes"
 ASSERT_DIR="${ROOT_DIR}/tests/smoke/assertions"
 
+# Shared daemon-lifecycle helpers — provides ensure_daemon_port_free / log.
+# shellcheck source=lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
 TAPE_TIMEOUT_S="${TAPE_TIMEOUT_S:-600}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-${ROOT_DIR}/smoke-logs/tapes/${TAPE_NAME}}"
 
@@ -81,6 +85,11 @@ tmp_dir="$(mktemp -d)"
 combined="${tmp_dir}/${TAPE_NAME}.tape"
 
 cleanup() {
+  # A tape (e.g. init-wizard) may leave a daemon running. Stop it and free
+  # the shared port 5199 so it cannot squat into the next tape/scenario —
+  # `daemon stop` is keyed to this tape's NETCLAW_HOME PID file.
+  NETCLAW_HOME="$NETCLAW_HOME" "$NETCLAW_SMOKE_CLI" daemon stop >/dev/null 2>&1 || true
+  ensure_daemon_port_free || true
   if [[ "${KEEP_TEMP:-0}" == "1" ]]; then
     echo "KEEP_TEMP=1 — combined tape retained at: $combined"
   else


### PR DESCRIPTION
## Summary

- The native smoke harness runs every tape and scenario daemon on the fixed loopback port `5199`. After the Docker smoke harness was retired (#1067) nothing provides per-run network isolation anymore.
- `run-native-tape.sh` never stopped a daemon a tape left running, so an orphaned tape daemon (e.g. from `init-wizard`) kept listening on `5199`. It is invisible to every scenario's `daemon stop` — which only signals the PID in its own `NETCLAW_HOME` PID file — so later daemons crash on bind with `address already in use`. A scenario only "passes" when its `daemon status` poll happens to catch its own short-lived doomed daemon, which is the source of the intermittent **Native Smoke (macOS)** failures (observed on #1044).
- Adds `ensure_daemon_port_free` to `scripts/smoke/lib/common.sh`: it hard-kills any straggler still holding `5199`. `start_daemon` calls it as a precondition and `stop_daemon` as a postcondition.
- `scripts/smoke/run-native-tape.sh` now sources `lib/common.sh` and its `cleanup` trap stops the tape's daemon + frees the port, so a tape can no longer orphan a squatter.
- Harness-only change (no product code). The same scripts back both the Linux and macOS native smoke legs, so this fixes the latent flake on both.

## Test plan

- [x] `bash -n` on both modified scripts
- [x] Unit-tested `ensure_daemon_port_free`: returns immediately when `:5199` is free; detects + hard-kills a squatter and leaves the port free
- [ ] CI: `Native Smoke (macOS)` and `Native Smoke (Linux)` pass; re-run a few times to confirm the intermittency is gone
- [ ] No `address already in use` in any collected smoke crash log