### PR TITLE
fix(subagents): route spawn_agent through its streaming override

### DIFF
--- a/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
@@ -21,21 +21,13 @@ using Xunit;
 namespace Netclaw.Actors.Tests.SubAgents;
 
 /// <summary>
-/// Full-chain coverage for the spawn_agent streaming path: a real
-/// <see cref="DispatchingToolExecutor"/> resolves <c>spawn_agent</c>, dispatches
-/// through the <c>INetclawTool</c> interface into <see cref="SpawnAgentTool"/>'s
-/// streaming override, runs a real <see cref="SubAgentActor"/>, and surfaces the
-/// sub-agent's progress as activity items into a real
+/// Regression guard for the default-interface-method dispatch gap that let
+/// <c>spawn_agent</c> bypass its streaming override and run the non-streaming
+/// path — emitting zero activity items, so the parent's per-call watchdog
+/// killed healthy sub-agents at the flat tool timeout. Exercises the full
+/// chain: <see cref="DispatchingToolExecutor"/> → <c>INetclawTool</c> dispatch
+/// → <see cref="SpawnAgentTool"/> → <see cref="SubAgentActor"/> →
 /// <see cref="StreamingToolWatchdog"/>.
-///
-/// Regression guard for the default-interface-method dispatch gap: a plain
-/// <c>public</c> <c>ExecuteStreamAsync</c> on <see cref="SpawnAgentTool"/> was
-/// never reached through the <c>INetclawTool</c> interface (the interface slot
-/// was bound to the DIM default at the <c>NetclawTool&lt;T&gt;</c> base). So
-/// <c>spawn_agent</c> ran the non-streaming path, emitted zero activity items,
-/// and the parent's per-call watchdog killed a healthy sub-agent at the flat
-/// tool timeout. The watchdog's <c>onActivity</c> callback makes the otherwise
-/// ephemeral activity items observable here.
 /// </summary>
 public class SpawnAgentStreamingTests : TestKit
 {
@@ -114,16 +106,14 @@ public class SpawnAgentStreamingTests : TestKit
             onActivity: activity.Add,
             TestContext.Current.CancellationToken);
 
-        // With the DIM dispatch gap, spawn_agent ran the non-streaming path and
-        // produced zero activity items — the watchdog would see only silence and
-        // kill a healthy sub-agent at the flat budget. The streaming override
-        // emits at least one progress item ("calling the model").
+        // The DIM dispatch gap ran spawn_agent on the non-streaming path: zero
+        // activity items, so the watchdog saw only silence and killed healthy
+        // sub-agents at the flat budget. The streaming override emits progress.
         Assert.NotEmpty(activity);
-        Assert.Contains("Response #1", result, StringComparison.Ordinal);
-    }
 
-    private sealed class SingleClientProvider(IChatClient client) : IChatClientProvider
-    {
-        public IChatClient GetClient(ModelRole role) => client;
+        // The terminal result still flows through — a successful sub-agent run,
+        // not a "Subagent '...' failed: ..." message from FormatResult.
+        Assert.NotEmpty(result);
+        Assert.DoesNotContain("failed", result, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
+++ b/src/Netclaw.Actors.Tests/SubAgents/SpawnAgentStreamingTests.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpawnAgentStreamingTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Netclaw.Actors.Sessions.Pipelines;
+using Netclaw.Actors.SubAgents;
+using Netclaw.Actors.Tests.Memory;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Security;
+using Netclaw.Tests.Utilities;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.SubAgents;
+
+/// <summary>
+/// Full-chain coverage for the spawn_agent streaming path: a real
+/// <see cref="DispatchingToolExecutor"/> resolves <c>spawn_agent</c>, dispatches
+/// through the <c>INetclawTool</c> interface into <see cref="SpawnAgentTool"/>'s
+/// streaming override, runs a real <see cref="SubAgentActor"/>, and surfaces the
+/// sub-agent's progress as activity items into a real
+/// <see cref="StreamingToolWatchdog"/>.
+///
+/// Regression guard for the default-interface-method dispatch gap: a plain
+/// <c>public</c> <c>ExecuteStreamAsync</c> on <see cref="SpawnAgentTool"/> was
+/// never reached through the <c>INetclawTool</c> interface (the interface slot
+/// was bound to the DIM default at the <c>NetclawTool&lt;T&gt;</c> base). So
+/// <c>spawn_agent</c> ran the non-streaming path, emitted zero activity items,
+/// and the parent's per-call watchdog killed a healthy sub-agent at the flat
+/// tool timeout. The watchdog's <c>onActivity</c> callback makes the otherwise
+/// ephemeral activity items observable here.
+/// </summary>
+public class SpawnAgentStreamingTests : TestKit
+{
+    public SpawnAgentStreamingTests(ITestOutputHelper output) : base(output: output) { }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // No persistence or hosting needed — SubAgentActor is spawned standalone.
+    }
+
+    [Fact]
+    public async Task Spawn_agent_streams_activity_through_executor_dispatch_to_watchdog()
+    {
+        using var dir = new DisposableTempDir();
+        var paths = new NetclawPaths(dir.Path);
+        paths.EnsureDirectoriesExist();
+
+        var toolAccessPolicy = new ToolAccessPolicy(
+            new ToolConfig(),
+            new EffectivePolicyDefaults(
+                DeploymentPosture.Personal,
+                TrustAudience.Personal,
+                ShellExecutionMode.HostAllowed,
+                UsedStrictFallback: false),
+            new ShellCommandPolicy());
+
+        // The sub-agent resolves "file_read" from this registry; the fake LLM
+        // never calls it — it just has to resolve so the spawn proceeds.
+        var registry = new ToolRegistry();
+        registry.Register(new FakeNetclawTool("file_read", "stub content"));
+
+        var subAgentRegistry = new SubAgentDefinitionRegistry();
+        subAgentRegistry.Register(new SubAgentProfile
+        {
+            Name = "summarizer",
+            Description = "Summarize content",
+            SystemPrompt = "You are a summarizer.",
+            ToolNames = ["file_read"],
+            Visibility = SubAgentVisibility.UserFacing
+        });
+
+        var spawner = new SubAgentSpawner(
+            new SingleClientProvider(new FakeChatClient()),
+            registry,
+            toolAccessPolicy,
+            approvalService: null,
+            new StaticSystemPromptProvider("You are a summarizer."),
+            NullLogger<SubAgentSpawner>.Instance);
+
+        registry.Register(new SpawnAgentTool(subAgentRegistry, spawner, paths));
+
+        var executor = new DispatchingToolExecutor(
+            registry, toolAccessPolicy, approvalService: null, NullLogger<DispatchingToolExecutor>.Instance);
+
+        var ctx = new ToolExecutionContext("console/streaming-test", dir.Path)
+        {
+            Audience = TrustAudience.Personal
+        };
+        ctx.SpawnChildActor = (props, name, _) => Task.FromResult<object>(Sys.ActorOf((Props)props, name));
+
+        var spawnCall = new FunctionCallContent(
+            "call-1",
+            "spawn_agent",
+            new Dictionary<string, object?>
+            {
+                ["agent"] = "summarizer",
+                ["task"] = "Summarize the project."
+            });
+
+        var activity = new List<ToolActivityUpdate>();
+        var result = await StreamingToolWatchdog.ConsumeAsync(
+            executor.ExecuteStreamAsync(spawnCall, ctx, TestContext.Current.CancellationToken),
+            "spawn_agent",
+            ToolWatchdogBudget.Flat(TimeSpan.FromSeconds(30)),
+            TimeProvider.System,
+            onActivity: activity.Add,
+            TestContext.Current.CancellationToken);
+
+        // With the DIM dispatch gap, spawn_agent ran the non-streaming path and
+        // produced zero activity items — the watchdog would see only silence and
+        // kill a healthy sub-agent at the flat budget. The streaming override
+        // emits at least one progress item ("calling the model").
+        Assert.NotEmpty(activity);
+        Assert.Contains("Response #1", result, StringComparison.Ordinal);
+    }
+
+    private sealed class SingleClientProvider(IChatClient client) : IChatClientProvider
+    {
+        public IChatClient GetClient(ModelRole role) => client;
+    }
+}

--- a/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
+++ b/src/Netclaw.Actors/SubAgents/SpawnAgentTool.cs
@@ -70,7 +70,7 @@ public sealed partial class SpawnAgentTool : NetclawTool<SpawnAgentTool.Params>
     /// surfaced as the tool call's stream, so the parent's per-call watchdog
     /// keeps a long-but-healthy delegated run alive.
     /// </summary>
-    public async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamAsync(
+    public override async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamAsync(
         IDictionary<string, object?>? arguments,
         ToolExecutionContext context,
         [EnumeratorCancellation] CancellationToken ct = default)

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -70,15 +70,12 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
     /// they work, which keeps the caller's per-call watchdog alive.
     /// </summary>
     /// <remarks>
-    /// This is a <c>virtual</c> class member rather than just inheriting the
-    /// <see cref="INetclawTool.ExecuteStreamAsync"/> default interface method.
-    /// A default interface method is bound to the interface slot at the class
-    /// that declares <c>: INetclawTool</c> (this base) — a derived tool adding
-    /// a matching public method does NOT re-implement it and would be invisible
-    /// to <c>INetclawTool</c>-typed dispatch. A <c>virtual</c> class member, by
-    /// contrast, is the interface implementation for the whole hierarchy, so a
-    /// derived <c>override</c> is reachable through an <c>INetclawTool</c>
-    /// reference.
+    /// Declared <c>virtual</c> rather than left to the
+    /// <see cref="INetclawTool.ExecuteStreamAsync"/> default interface method:
+    /// a DIM is bound at this interface-declaring base, so a derived tool's
+    /// matching <c>public</c> method does not re-implement it and is unreachable
+    /// through <c>INetclawTool</c> dispatch — only a derived <c>override</c> of
+    /// this <c>virtual</c> is.
     /// </remarks>
     public virtual async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamAsync(
         IDictionary<string, object?>? arguments,

--- a/src/Netclaw.Tools.Abstractions/NetclawTool.cs
+++ b/src/Netclaw.Tools.Abstractions/NetclawTool.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 
@@ -60,6 +61,31 @@ public abstract partial class NetclawTool<TParams> : INetclawTool where TParams 
         return TryParse(arguments, out var error, out var args)
             ? await ExecuteAsync(args, context, ct)
             : error;
+    }
+
+    /// <summary>
+    /// Execute the tool as a stream of <see cref="ToolCallUpdate"/> items. The
+    /// default yields the non-streaming result as a single terminal completion
+    /// item. Long-running tools override this to emit liveness/progress while
+    /// they work, which keeps the caller's per-call watchdog alive.
+    /// </summary>
+    /// <remarks>
+    /// This is a <c>virtual</c> class member rather than just inheriting the
+    /// <see cref="INetclawTool.ExecuteStreamAsync"/> default interface method.
+    /// A default interface method is bound to the interface slot at the class
+    /// that declares <c>: INetclawTool</c> (this base) — a derived tool adding
+    /// a matching public method does NOT re-implement it and would be invisible
+    /// to <c>INetclawTool</c>-typed dispatch. A <c>virtual</c> class member, by
+    /// contrast, is the interface implementation for the whole hierarchy, so a
+    /// derived <c>override</c> is reachable through an <c>INetclawTool</c>
+    /// reference.
+    /// </remarks>
+    public virtual async IAsyncEnumerable<ToolCallUpdate> ExecuteStreamAsync(
+        IDictionary<string, object?>? arguments,
+        ToolExecutionContext context,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ToolCompletedUpdate(await ExecuteAsync(arguments, context, ct));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

A sub-agent spawned via `spawn_agent` was killed at exactly the 90s tool-execution timeout despite actively streaming — the streaming-tool-call work (#1045) meant to prevent mid-run sub-agent timeouts never actually ran for `spawn_agent`.

`SpawnAgentTool.ExecuteStreamAsync` was an orphan method. `INetclawTool.ExecuteStreamAsync` is a C# default interface method, bound to the DIM default at the `NetclawTool<T>` base class — a derived tool adding a matching `public` method does **not** re-implement it, so the override was unreachable through `INetclawTool`-typed dispatch. `DispatchingToolExecutor` always hit the DIM default, collapsing `spawn_agent` to the non-streaming path with no activity sink. Zero `ToolActivityUpdate` items reached the parent's per-call `StreamingToolWatchdog`, which then fired at its flat budget and cancelled a healthy, progressing sub-agent.

- Add a `virtual ExecuteStreamAsync` hook on `NetclawTool<T>` so the override is the interface implementation for the whole tool hierarchy.
- Mark `SpawnAgentTool.ExecuteStreamAsync` as `override` — the wiring is now compiler-enforced, so this class of bug can't recur silently.
- Add a full-chain integration test crossing `DispatchingToolExecutor` → `INetclawTool` dispatch → `SpawnAgentTool` → `SubAgentActor` → `StreamingToolWatchdog`.

## Test plan

- [x] New `SpawnAgentStreamingTests` fails without the fix (verified by reverting the two source changes), passes with it
- [x] `StreamingToolCallTests`, `SubAgentSpawnIntegrationTests`, `SubAgentActorTests`, `SpawnAgentToolTests` still pass (77 tests green)
- [x] Full solution builds with 0 warnings / 0 errors; `slopwatch` reports 0 issues; copyright headers verified