### PR TITLE
chore: bump Akka.Hosting to 1.5.68

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Nuget package versions -->
-    <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
+    <AkkaHostingVersion>1.5.68</AkkaHostingVersion>
     <AkkaPersistenceSqlHostingVersion>1.5.67</AkkaPersistenceSqlHostingVersion>
     <AkkaRemindersVersion>0.6.0-beta2</AkkaRemindersVersion>
     <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>


### PR DESCRIPTION
Bumps all Akka.Hosting-linked packages (Akka.Hosting, Akka.Cluster.Sharding, Akka.Persistence, Akka.Persistence.Hosting, Akka.Hosting.TestKit) from 1.5.67 → 1.5.68.

Note: Akka.Persistence.Sql.Hosting remains at 1.5.67 — no 1.5.68 release yet for that package.