### PR TITLE
fix(build): use -p: MSBuild args so win-x64 release publish survives Git Bash

### DIFF
--- a/scripts/build/publish-binaries.sh
+++ b/scripts/build/publish-binaries.sh
@@ -19,7 +19,7 @@
 #   --component    cli | daemon | all   (default: all)
 #   --output-dir   base output dir; components land in <dir>/cli and
 #                  <dir>/daemon   (default: ./publish)
-#   --version      assembly version; when omitted, no /p:Version is passed
+#   --version      assembly version; when omitted, no -p:Version is passed
 #                  and the Directory.Build.props VersionPrefix is used
 set -euo pipefail
 
@@ -58,12 +58,19 @@ case "$COMPONENT" in
 esac
 
 # Flags common to every platform.
+#
+# MSBuild properties MUST use the `-p:` form, not `/p:`. On the Windows
+# release runner this script executes under Git Bash, whose MSYS argument
+# conversion strips the leading `/` from `/p:Name=value` — MSBuild then
+# receives a bare `p:Name=value` token and aborts with MSB1008 ("Only one
+# project can be specified"). `-p:` is immune to that conversion and is
+# accepted identically by `dotnet` on every shell and platform.
 COMMON=(
   -c Release
   -r "$RID"
   --self-contained true
-  /p:PublishSingleFile=true
-  /p:IncludeNativeLibrariesForSelfExtract=true
+  -p:PublishSingleFile=true
+  -p:IncludeNativeLibrariesForSelfExtract=true
 )
 
 # Per-platform single-file compression. Kept centralized here so the release
@@ -80,9 +87,9 @@ case "$RID" in
   *) echo "ERROR: unsupported RID '$RID'" >&2; exit 2 ;;
 esac
 
-EXTRA=(/p:EnableCompressionInSingleFile="$COMPRESS")
+EXTRA=(-p:EnableCompressionInSingleFile="$COMPRESS")
 if [[ -n "$VERSION" ]]; then
-  EXTRA+=(/p:Version="$VERSION")
+  EXTRA+=(-p:Version="$VERSION")
 fi
 
 publish_component() {


### PR DESCRIPTION
## Problem

The 0.19.0 release pipeline failed on the **Build win-x64** leg:

```
MSBUILD : error MSB1008: Only one project can be specified.
... src/Netclaw.Cli/Netclaw.Cli.csproj p:PublishSingleFile=true p:IncludeNativeLibrariesForSelfExtract=true ...
```

`scripts/build/publish-binaries.sh` passed MSBuild properties as `/p:Name=value`. The release pipeline runs this script under **Git Bash** on the Windows runner; MSYS argument conversion strips the leading `/`, so MSBuild received bare `p:Name=value` tokens and treated them as extra project arguments.

The Linux/macOS smoke harness exercises this script, but only the release pipeline builds **win-x64** through it — so the bug surfaced for the first time at release time.

## Fix

Switch the four MSBuild properties from `/p:` to `-p:`. The `-p:` form is immune to MSYS path conversion and is accepted identically by `dotnet` on every shell/platform. No behavior change on Linux/macOS.

## Test plan

- [ ] PR CI green (smoke.yml `publish` job runs this script for linux-x64 + osx-arm64)
- [ ] win-x64 leg validated by re-running the 0.19.0 release pipeline after merge