### PR TITLE
fix(tests): stabilize DaemonClient reconnect tests with valid SignalR keep-alive

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -177,7 +177,19 @@ public sealed class DaemonClientReconnectIntegrationTests
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseKestrel();
         builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
-        builder.Services.AddSignalR();
+
+        // Both DaemonClients in this file use serverTimeout: 2s so they notice a
+        // dead host fast. SignalR's contract is that the client's ServerTimeout
+        // must be at least 2x the server's KeepAliveInterval — otherwise the
+        // client tears down a perfectly healthy *idle* connection when no server
+        // ping arrives within ServerTimeout. The default KeepAliveInterval is
+        // 15s, so a 2s ServerTimeout would drop every idle connection after 2s.
+        // On a slow CI runner that turns the post-restart reconnect into an
+        // unbounded flap loop that never settles on a stable Connected event.
+        // A 200ms keep-alive keeps the 2s ServerTimeout valid (10x margin) so
+        // reconnected connections stay up.
+        builder.Services.AddSignalR(options =>
+            options.KeepAliveInterval = TimeSpan.FromMilliseconds(200));
         builder.Services.AddSingleton<FakeHubState>();
 
         var app = builder.Build();


### PR DESCRIPTION
## Problem

`DaemonClientReconnectIntegrationTests.EnsureSession_recreates_session_after_server_restart` fails intermittently on Windows CI with `System.TimeoutException : The operation has timed out.` — the test times out after 15s waiting for the client to emit a `Connected` event after the SignalR server is restarted.

Failing run: https://github.com/netclaw-dev/netclaw/actions/runs/26075463729/job/76665455002

## Root cause

Both `DaemonClient`s in this test file are constructed with `serverTimeout: 2s`, but `StartFakeHubAsync` created the fake hub with a bare `AddSignalR()` — leaving the server's `KeepAliveInterval` at SignalR's default **15s**.

SignalR's documented contract is that the client's `ServerTimeout` must be **at least 2× the server's `KeepAliveInterval`**. The client resets its `ServerTimeout` countdown on *any* message from the server, including keep-alive pings. With a 2s `ServerTimeout` and a server that only pings every 15s, the client tears down every healthy **idle** connection after 2s.

On a slow Windows CI runner this turns the post-restart reconnect into an **unbounded flap loop**:

1. The client connects to the replacement hub (`host2`).
2. ~2s later, no server ping has arrived → `ServerTimeout` fires → the connection drops → `Closed`.
3. The `Closed` handler restarts `ReconnectLoopAsync`, which resets its attempt counter to 0.
4. Back to step 1 — the loop never settles on a stable `Connected` emission, and the 15s test budget expires.

The test usually passes because the `Connected` event is emitted *before* the first 2s idle-timeout bites — but when the runner is slow enough to widen the connect→emit gap past 2s, the flap loop takes over and the test times out. That makes it flaky-on-Windows-only.

## Fix

Configure the fake hub's `KeepAliveInterval` to **200ms** in `StartFakeHubAsync`. This makes the test's `serverTimeout: 2s` valid (10× margin) — the server pings ~10×/s, so a healthy idle connection is never torn down, and reconnected connections to `host2` stay up. Both tests in the file share `StartFakeHubAsync`, so both are stabilized (the sibling `EnsureSession_reattaches_same_session_after_transport_disconnect` uses the identical `serverTimeout: 2s` and had the same latent flakiness).

The `serverTimeout: 2s` is kept intentionally — it still bounds how long the client can stay "connected-but-blind" after the original host dies. The fix just makes that short timeout *valid*.

## Production impact

**None.** The daemon (`Netclaw.Daemon/Program.cs`) uses `AddSignalR()`'s default 15s keep-alive, and the production `DaemonClient` is constructed (`DaemonClientFactory`) with **no** `serverTimeout` — it keeps SignalR's default 30s `ServerTimeout`, which satisfies the 2× rule against a 15s keep-alive. The misconfiguration is test-only.

## Verification

- Affected tests run 10× consecutively on Linux: 10/10 pass, ~325ms each (down from a 15s timeout).
- `dotnet slopwatch analyze`: 0 issues.
- `Add-FileHeaders.ps1 -Verify`: all headers present.

## Follow-up (not in this PR)

During analysis, the `dotnet-concurrency-specialist` flagged a separate latent bug in `DaemonClient`: the `_connection.Reconnected` handler awaits `EnsureSessionInternalAsync` *before* emitting `Connected`, so if session re-attach throws, the `Connected` event is silently dropped (the exception is swallowed by SignalR's fire-and-forget event invocation). `ReconnectLoopAsync` retries past this, but the `Reconnected` path does not. This is not the cause of *this* failure and is left for a separate change.