### PR TITLE
fix(daemon): resilient reconnect handling and unambiguous connection states

### DIFF
--- a/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
+++ b/src/Netclaw.Cli.Tests/Cli/DaemonClientReconnectIntegrationTests.cs
@@ -35,17 +35,18 @@ public sealed class DaemonClientReconnectIntegrationTests
         var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reconnectedOutput = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Sync on Reconnecting OR Disconnected: SignalR fires Reconnecting from
+        // Sync on Reconnecting OR TransportClosed: SignalR fires Reconnecting from
         // its state machine as soon as the transport drops, before any retry
-        // attempt. Waiting for Disconnected alone requires WithAutomaticReconnect
+        // attempt. Waiting for TransportClosed alone requires WithAutomaticReconnect
         // to exhaust its retries, which on Windows can exceed the test budget
         // because ConnectEx to a closed loopback port is not immediate (Winsock
         // SYN-retransmit path, exacerbated by WFP/AV filter drivers on hosted
         // runners). Either event is sufficient evidence the client has observed
-        // the drop.
+        // the drop. (Disconnected is now terminal-only — emitted solely when the
+        // supervised reconnect loop exhausts its budget — so it is not a drop signal.)
         using var connectionSub = client.ConnectionEvents.Subscribe(evt =>
         {
-            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.Disconnected)
+            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.TransportClosed)
                 disconnected.TrySetResult();
 
             if (evt.State is DaemonConnectionState.Connected && disconnected.Task.IsCompleted)
@@ -101,9 +102,9 @@ public sealed class DaemonClientReconnectIntegrationTests
         var clientDisconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var reconnectedAfterRestart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Sync on Reconnecting OR Disconnected. SignalR fires Reconnecting from
+        // Sync on Reconnecting OR TransportClosed. SignalR fires Reconnecting from
         // its state machine as soon as the transport drops, before any retry
-        // attempt. Waiting for Disconnected alone requires WithAutomaticReconnect
+        // attempt. Waiting for TransportClosed alone requires WithAutomaticReconnect
         // to exhaust its retries, which on Windows can exceed the test budget:
         // ConnectEx to a closed loopback port is not immediate (Winsock
         // SYN-retransmit path, exacerbated by WFP/AV filter drivers on hosted
@@ -111,12 +112,12 @@ public sealed class DaemonClientReconnectIntegrationTests
         // sub-millisecond ECONNREFUSED seen on Linux.
         //
         // The IsCompleted guard for reconnectedAfterRestart is still safe: at
-        // least one Reconnecting/Disconnected always precedes any subsequent
+        // least one Reconnecting/TransportClosed always precedes any subsequent
         // Connected emission. host1's port release is already synchronous via
         // host1.Dispose(), so it is not gated on the client observing anything.
         using var connectionSub = client.ConnectionEvents.Subscribe(evt =>
         {
-            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.Disconnected)
+            if (evt.State is DaemonConnectionState.Reconnecting or DaemonConnectionState.TransportClosed)
                 clientDisconnected.TrySetResult();
 
             if (evt.State is DaemonConnectionState.Connected && clientDisconnected.Task.IsCompleted)

--- a/src/Netclaw.Cli/Daemon/DaemonClient.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonClient.cs
@@ -45,7 +45,10 @@ public sealed class DaemonClient : IAsyncDisposable
     private string? _sessionId;
     private Actors.Channels.ChannelType? _channelType;
     private bool _hasConnected;
-    private bool _disposed;
+
+    // volatile: read from SignalR callback threads (Reconnected/Closed handlers)
+    // and ReconnectLoopAsync continuations; written by DisposeAsync.
+    private volatile bool _disposed;
     private CancellationTokenSource? _reconnectCts;
 
     public DaemonClient(
@@ -79,8 +82,37 @@ public sealed class DaemonClient : IAsyncDisposable
 
         _connection.Reconnected += async _ =>
         {
+            if (_disposed)
+                return;
+
+            // SignalR's built-in auto-reconnect has restored the transport. Re-attach
+            // the session before announcing Connected so consumers that act on
+            // Connected (the TUI re-runs EnsureSession) observe a live session.
+            //
+            // A re-attach failure must NOT be swallowed: SignalR invokes Reconnected
+            // fire-and-forget, so a thrown exception would vanish and strand consumers
+            // in a stale Reconnecting state on a transport that is actually up. Hand
+            // off to the supervised ReconnectLoopAsync instead — it short-circuits the
+            // already-connected transport and retries EnsureSession past transient
+            // failures, emitting a terminal Disconnected only if it truly exhausts its
+            // budget. This makes the built-in reconnect path as resilient as the
+            // manual Closed-handler path.
             if (_channelType is { } ct)
-                await EnsureSessionInternalAsync(ct, CancellationToken.None);
+            {
+                try
+                {
+                    await EnsureSessionInternalAsync(ct, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _connectionSubject.OnNext(new DaemonConnectionEvent(
+                        DaemonConnectionState.Reconnecting,
+                        _daemonEndpoint,
+                        $"Reconnected to {_daemonEndpoint} but session re-attach failed: {ex.Message}. Retrying..."));
+                    await ReconnectLoopAsync();
+                    return;
+                }
+            }
 
             _connectionSubject.OnNext(new DaemonConnectionEvent(
                 DaemonConnectionState.Connected,
@@ -104,10 +136,14 @@ public sealed class DaemonClient : IAsyncDisposable
                 return;
 
             var reason = ex?.Message ?? "connection closed";
+            // TransportClosed, not Disconnected: SignalR's built-in auto-reconnect
+            // has given up, but ReconnectLoopAsync takes over immediately below. This
+            // is a transient handoff — a Reconnecting follows within microseconds.
+            // Only ReconnectLoopAsync's exhaustion branch emits terminal Disconnected.
             _connectionSubject.OnNext(new DaemonConnectionEvent(
-                DaemonConnectionState.Disconnected,
+                DaemonConnectionState.TransportClosed,
                 _daemonEndpoint,
-                $"Disconnected from daemon at {_daemonEndpoint}: {reason}"));
+                $"Connection to daemon at {_daemonEndpoint} dropped: {reason}"));
 
             if (!string.IsNullOrWhiteSpace(_sessionId))
                 await ReconnectLoopAsync();

--- a/src/Netclaw.Cli/Daemon/DaemonConnectionEvent.cs
+++ b/src/Netclaw.Cli/Daemon/DaemonConnectionEvent.cs
@@ -5,11 +5,37 @@
 // -----------------------------------------------------------------------
 namespace Netclaw.Cli.Daemon;
 
+/// <summary>
+/// Lifecycle states for the daemon SignalR connection, as surfaced by
+/// <see cref="DaemonClient.ConnectionEvents"/>.
+/// </summary>
 public enum DaemonConnectionState
 {
+    /// <summary>An initial connection attempt is in progress.</summary>
     Connecting,
+
+    /// <summary>The transport is connected and the session is attached.</summary>
     Connected,
+
+    /// <summary>
+    /// A reconnect is in progress — either SignalR's built-in auto-reconnect or
+    /// the supervised <c>ReconnectLoopAsync</c>. Transient: a <see cref="Connected"/>
+    /// or a terminal <see cref="Disconnected"/> follows.
+    /// </summary>
     Reconnecting,
+
+    /// <summary>
+    /// The transport dropped and SignalR's built-in auto-reconnect gave up; the
+    /// supervised reconnect loop is taking over. Transient — a <see cref="Reconnecting"/>
+    /// follows within microseconds. Consumers should render this like
+    /// <see cref="Reconnecting"/>, not as a failure.
+    /// </summary>
+    TransportClosed,
+
+    /// <summary>
+    /// Terminal failure: the supervised reconnect loop exhausted its retry budget.
+    /// No further automatic recovery occurs without an explicit reconnect.
+    /// </summary>
     Disconnected
 }
 

--- a/src/Netclaw.Cli/Tui/ChatViewModel.cs
+++ b/src/Netclaw.Cli/Tui/ChatViewModel.cs
@@ -113,7 +113,9 @@ public partial class ChatViewModel : ReactiveViewModel
         _daemonConnectionSubscription = _daemonClient.ConnectionEvents
             .Subscribe(evt =>
             {
-                if (evt.State is DaemonConnectionState.Disconnected or DaemonConnectionState.Reconnecting)
+                if (evt.State is DaemonConnectionState.Disconnected
+                    or DaemonConnectionState.Reconnecting
+                    or DaemonConnectionState.TransportClosed)
                 {
                     _sessionReady = false;
                     IsGenerating.Value = false;


### PR DESCRIPTION
## Summary

Fixes two related flaws in `DaemonClient`'s connection-event model.

### #1089 — `Reconnected` handler drops the `Connected` event on re-attach failure

The SignalR `Reconnected` handler `await`ed session re-attach before publishing `Connected`. Since SignalR invokes `Reconnected` fire-and-forget, a throwing `EnsureSession` suppressed the `Connected` event with no log and no retry — stranding consumers (e.g. the TUI) in a stale `Reconnecting` state on a transport that was actually up.

The handler now catches the failure, surfaces it as a `Reconnecting` event carrying the reason, and hands off to the supervised `ReconnectLoopAsync`, which short-circuits the already-connected transport and retries `EnsureSession` past transient failures. This makes the built-in reconnect path as resilient as the manual `Closed`-handler path — the inconsistency the issue called out.

### #956 — overloaded `Disconnected` state

`DaemonConnectionState.Disconnected` was published from two semantically different sites: the `Closed` handler (a *transient* handoff to `ReconnectLoopAsync`) and `ReconnectLoopAsync` exhaustion (a *terminal* failure). Subscribers couldn't tell them apart.

Added `DaemonConnectionState.TransportClosed` for the transient case, so `Disconnected` now unambiguously means terminal. Every state on the enum is documented with its transient/terminal semantics.

## Consumers

- `ChatViewModel` treats `TransportClosed` like `Reconnecting` (clears `_sessionReady` / `IsGenerating`).
- `HeadlessChannel` only logs `evt.Message` — no change needed.
- The reconnect integration tests sync on `TransportClosed` instead of the now-terminal-only `Disconnected`.

## Validation

- `Netclaw.Cli` builds clean (0 warnings)
- All 35 `DaemonClient` tests pass
- `dotnet slopwatch analyze`: 0 issues
- Copyright headers verified

> **Note:** the native TUI smoke harness was not run locally (it hard-requires an Ollama install needing `sudo`). The `ChatViewModel` change is a single enum value added to a reactive `is`-pattern and touches no Spectre prompt flow; no smoke tape exercises a transport drop. CI should cover it.

Closes #1089
Closes #956