### PR TITLE
fix(mcp): restore structured JSON args stringified by upstream LLM SDK

### DIFF
--- a/src/Netclaw.Daemon.Tests/Mcp/McpArgumentNormalizerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpArgumentNormalizerTests.cs
@@ -1,0 +1,236 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpArgumentNormalizerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Daemon.Mcp;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+public sealed class McpArgumentNormalizerTests
+{
+    private static JsonElement Schema(string schemaJson)
+        => JsonDocument.Parse(schemaJson).RootElement;
+
+    [Fact]
+    public void Normalize_ArrayOfObjectsAsString_RebuildsAsJsonArrayElement()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"},{\"content\":\"B\"}]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.IsType<JsonElement>(result["tasks"]);
+        var array = (JsonElement)result["tasks"]!;
+        Assert.Equal(JsonValueKind.Array, array.ValueKind);
+        Assert.Equal(2, array.GetArrayLength());
+        Assert.Equal("A", array[0].GetProperty("content").GetString());
+        Assert.Equal("B", array[1].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public void Normalize_ObjectAsString_RebuildsAsJsonObjectElement()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "payload": { "type": "object" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["payload"] = "{\"foo\":42,\"bar\":\"baz\"}"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        var obj = Assert.IsType<JsonElement>(result["payload"]);
+        Assert.Equal(JsonValueKind.Object, obj.ValueKind);
+        Assert.Equal(42, obj.GetProperty("foo").GetInt32());
+        Assert.Equal("baz", obj.GetProperty("bar").GetString());
+    }
+
+    [Fact]
+    public void Normalize_NullableTypeArray_StillRecognisedAsArray()
+    {
+        // Schema with union type — common when JSON Schema generators emit
+        // [ "array", "null" ] to allow optional array values.
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tags": { "type": ["array", "null"], "items": { "type": "string" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tags"] = "[\"a\",\"b\"]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        var array = Assert.IsType<JsonElement>(result["tags"]);
+        Assert.Equal(JsonValueKind.Array, array.ValueKind);
+        Assert.Equal(2, array.GetArrayLength());
+    }
+
+    [Fact]
+    public void Normalize_StringForStringSchema_LeftUnchanged()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "note": { "type": "string" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["note"] = "hello"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("hello", result["note"]);
+    }
+
+    [Fact]
+    public void Normalize_StringForArraySchemaButInvalidJson_LeftUnchanged()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "this is not json"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("this is not json", result["tasks"]);
+    }
+
+    [Fact]
+    public void Normalize_StringWhoseParsedKindDoesNotMatchSchema_LeftUnchanged()
+    {
+        // Schema says array; the string happens to parse as a JSON object —
+        // refuse to coerce (we only restore the structured form when the
+        // parsed kind matches the schema declaration).
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "{\"oops\":\"this should have been an array\"}"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("{\"oops\":\"this should have been an array\"}", result["tasks"]);
+    }
+
+    [Fact]
+    public void Normalize_ExistingJsonElement_NotMolested()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var preExisting = JsonDocument.Parse("[{\"content\":\"A\"}]").RootElement.Clone();
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = preExisting
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal(JsonValueKind.Array, ((JsonElement)result["tasks"]!).ValueKind);
+    }
+
+    [Fact]
+    public void Normalize_SchemaWithoutProperties_ReturnsInputUnchanged()
+    {
+        var schema = Schema("""
+            { "type": "object" }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"}]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+    }
+
+    [Fact]
+    public void Normalize_PreservesOtherUntouchedValues()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } },
+                "dryRun": { "type": "boolean" },
+                "count": { "type": "integer" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"}]",
+            ["dryRun"] = true,
+            ["count"] = 5
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.NotSame(args, result);
+        Assert.Equal(JsonValueKind.Array, ((JsonElement)result["tasks"]!).ValueKind);
+        Assert.Equal(true, result["dryRun"]);
+        Assert.Equal(5, result["count"]);
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpArgumentNormalizer.cs
+++ b/src/Netclaw.Daemon/Mcp/McpArgumentNormalizer.cs
@@ -1,0 +1,153 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpArgumentNormalizer.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Daemon.Mcp;
+
+/// <summary>
+/// Normalises tool-call argument dictionaries before they're handed to an
+/// <see cref="AIFunction"/> for invocation on an MCP server.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some upstream LLM SDK adapters (observed with the Anthropic .NET SDK
+/// surfacing <c>tool_use</c> input) deliver nested JSON arrays and objects
+/// as their <em>JSON-encoded string</em> instead of preserving them as
+/// structured <see cref="JsonElement"/> values. When those arguments then
+/// flow into an MCP <c>tools/call</c> request, the receiving server sees a
+/// <c>string</c> in a slot the schema declares as <c>array</c> or
+/// <c>object</c> and rejects the call with a validation error
+/// (<c>MCP error -32602: Input validation error: expected array</c>).
+/// </para>
+/// <para>
+/// This normalizer inspects the function's declared JSON Schema, and for
+/// any argument whose schema says <c>array</c> or <c>object</c> but whose
+/// value arrived as a <see cref="string"/> that parses as the matching JSON
+/// shape, replaces it with the parsed <see cref="JsonElement"/>. The fix
+/// is defensive: if the schema can't be read, if the value doesn't look
+/// like JSON, or if parsing fails, the original value is preserved.
+/// </para>
+/// </remarks>
+internal static class McpArgumentNormalizer
+{
+    /// <summary>
+    /// Returns an argument dictionary with any stringified array/object
+    /// values reconstituted into their structured form per the function's
+    /// JSON Schema. Returns the input dictionary unchanged when no
+    /// normalisation is needed.
+    /// </summary>
+    public static IDictionary<string, object?> Normalize(
+        AIFunction function,
+        IDictionary<string, object?> arguments)
+        => NormalizeWithSchema(function.JsonSchema, arguments);
+
+    /// <summary>
+    /// Schema-only overload used by tests and any caller that already has
+    /// the raw JSON Schema element handy.
+    /// </summary>
+    internal static IDictionary<string, object?> NormalizeWithSchema(
+        JsonElement schema,
+        IDictionary<string, object?> arguments)
+    {
+        var properties = TryGetSchemaProperties(schema);
+        if (properties.ValueKind != JsonValueKind.Object)
+            return arguments;
+
+        Dictionary<string, object?>? rewritten = null;
+
+        foreach (var (name, value) in arguments)
+        {
+            if (value is not string stringValue || string.IsNullOrEmpty(stringValue))
+                continue;
+
+            var expectedKind = GetExpectedContainerKind(properties, name);
+            if (expectedKind is null)
+                continue;
+
+            if (!TryParseJsonContainer(stringValue, out var parsed) || parsed.ValueKind != expectedKind)
+                continue;
+
+            rewritten ??= new Dictionary<string, object?>(arguments, StringComparer.Ordinal);
+            rewritten[name] = parsed;
+        }
+
+        return rewritten ?? arguments;
+    }
+
+    private static JsonElement TryGetSchemaProperties(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+            return default;
+
+        return schema.TryGetProperty("properties", out var properties)
+            ? properties
+            : default;
+    }
+
+    private static JsonValueKind? GetExpectedContainerKind(JsonElement properties, string parameterName)
+    {
+        if (!properties.TryGetProperty(parameterName, out var parameterSchema))
+            return null;
+
+        if (parameterSchema.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!parameterSchema.TryGetProperty("type", out var typeElement))
+            return null;
+
+        switch (typeElement.ValueKind)
+        {
+            case JsonValueKind.String:
+                return MapTypeName(typeElement.GetString());
+
+            case JsonValueKind.Array:
+                foreach (var entry in typeElement.EnumerateArray())
+                {
+                    if (entry.ValueKind != JsonValueKind.String)
+                        continue;
+
+                    var mapped = MapTypeName(entry.GetString());
+                    if (mapped is not null)
+                        return mapped;
+                }
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    private static JsonValueKind? MapTypeName(string? typeName) => typeName switch
+    {
+        "array" => JsonValueKind.Array,
+        "object" => JsonValueKind.Object,
+        _ => null
+    };
+
+    private static bool TryParseJsonContainer(string value, out JsonElement element)
+    {
+        var trimmed = value.AsSpan().TrimStart();
+        if (trimmed.IsEmpty || (trimmed[0] != '[' && trimmed[0] != '{'))
+        {
+            element = default;
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            element = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            element = default;
+            return false;
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -231,6 +231,9 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         IDictionary<string, object?>? arguments,
         CancellationToken ct)
     {
+        if (arguments is { Count: > 0 })
+            arguments = McpArgumentNormalizer.Normalize(function, arguments);
+
         var aiArgs = arguments is { Count: > 0 }
             ? new AIFunctionArguments(arguments)
             : null;


### PR DESCRIPTION
Closes #1093.

## Problem

When the LLM emits a tool call whose argument schema declares an `array` or `object` parameter, some upstream SDK adapters (observed with the Anthropic .NET SDK surfacing Claude's `tool_use` `input`) deliver the value as a JSON-encoded **string** instead of preserving the structured shape. That string then propagates through `FunctionCallContent.Arguments` into the MCP `tools/call` request, and the receiving MCP server rejects it:

```
MCP error -32602: Input validation error: Invalid arguments for tool add-tasks:
[ { "expected": "array", "code": "invalid_type", ... } ]
```

This blocks any MCP tool whose schema takes an array-of-objects (or nested object) parameter — bulk task creation, batch update, etc. Affected tools include Doist's hosted `add-tasks`, and any equivalent batch endpoint on other MCP servers. The same tools work correctly from other MCP clients (Claude.ai, Claude Desktop), so the bug lives in the path between NetClaw's tool-call ingestion and the MCP transport — not in the MCP server or the LLM.

## Fix

Defensive normalisation at the NetClaw → MCP boundary. New helper `Netclaw.Daemon.Mcp.McpArgumentNormalizer` runs inside `McpClientManager.InvokeFunctionAsync` before arguments are handed to the function's `InvokeAsync`. For each argument:

1. Look at the function's declared JSON Schema (`AIFunction.JsonSchema`) for that parameter.
2. If the schema says `array` or `object` (including union types like `["array","null"]`) and the value is a `string` that starts with `[` or `{` and parses as the matching JSON kind, replace it with the parsed `JsonElement`.
3. In every other case (string for string schema, garbage that doesn't parse, parsed kind that doesn't match the schema, already-structured `JsonElement`, missing schema, etc.) leave the value untouched.

This is intentionally conservative: only restore the structured form when the parsed shape matches what the schema declared. No silent type coercion beyond that.

## Why a boundary fix rather than chasing the SDK

The mis-encoded argument is observable in NetClaw logs by the time `LlmSessionActor` is about to dispatch. Tracing the exact `JsonSerializer` site upstream (Anthropic SDK adapter, `Microsoft.Extensions.AI.AsIChatClient`, etc.) would land the fix outside this repo and outside this maintainer's control. The boundary normaliser solves it deterministically here, with the schema as the source of truth.

If/when the upstream SDK lands a fix, this layer becomes a no-op for properly-shaped values (the `string`-for-`array` branch never fires) and there's no regression cost. Existing-`JsonElement` and other healthy inputs are explicitly tested to be pass-through.

## Tests

`McpArgumentNormalizerTests` — nine xUnit facts under `src/Netclaw.Daemon.Tests/Mcp/`:

- `Normalize_ArrayOfObjectsAsString_RebuildsAsJsonArrayElement` — the primary bug case (Doist `add-tasks` repro shape)
- `Normalize_ObjectAsString_RebuildsAsJsonObjectElement` — analogous object case
- `Normalize_NullableTypeArray_StillRecognisedAsArray` — schemas with `"type": ["array","null"]`
- `Normalize_StringForStringSchema_LeftUnchanged` — no false positives on legitimate strings
- `Normalize_StringForArraySchemaButInvalidJson_LeftUnchanged` — invalid JSON passes through
- `Normalize_StringWhoseParsedKindDoesNotMatchSchema_LeftUnchanged` — parses as object when schema wants array → leave it (don't silently coerce)
- `Normalize_ExistingJsonElement_NotMolested` — already-structured values pass through
- `Normalize_SchemaWithoutProperties_ReturnsInputUnchanged` — degenerate schema is safe
- `Normalize_PreservesOtherUntouchedValues` — other args (bools, ints) pass through unchanged

All nine pass on .NET 10 (`net10.0`, SDK 10.0.300).

## End-to-end verification

Tested against the Doist hosted MCP (`https://ai.todoist.net/mcp`) with the `add-tasks` tool, using the same Claude `claude-sonnet-4-5` model + Anthropic provider that hit the original bug. With this branch, batch task creation succeeds; without it, the MCP server rejects the call exactly as in #1093. Configuration unchanged.

## Out-of-scope

This PR does not investigate or alter the upstream SDK that stringifies the arguments in the first place. It can be removed when the upstream is fixed. The normaliser is opt-out only by virtue of being a no-op on healthy input, not by configuration toggle, to keep the fast path simple.
