### PR TITLE
fix(slack): render rewrite-prone URLs as inline code instead of mrkdwn links

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
@@ -1,0 +1,213 @@
+// -----------------------------------------------------------------------
+// <copyright file="SlackTextProtectorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Channels.Slack;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackTextProtectorTests
+{
+    [Fact]
+    public void BareUrl_IsWrappedInAngleBrackets()
+    {
+        var result = SlackTextProtector.ProtectUrls("Visit https://example.com for details.");
+
+        Assert.Equal("Visit <https://example.com> for details.", result);
+    }
+
+    [Fact]
+    public void BareUrlWithPlusInQueryString_RenderedAsInlineCode()
+    {
+        // The bug-of-record: scope list separated by `+` (URL-encoded
+        // space). Slack's link redirector rewrites `+` to `%2B` on
+        // click, regardless of `<>` wrapping. Rendering as inline
+        // code (backticks) makes the URL non-clickable so the user
+        // copies it literally.
+        var url = "https://accounts.google.com/o/oauth2/auth?scope=A+B+C&state=xyz";
+
+        var result = SlackTextProtector.ProtectUrls("Click here: " + url);
+
+        Assert.Equal($"Click here: `{url}`", result);
+    }
+
+    [Fact]
+    public void UrlAlreadyWrapped_LeftUnchanged()
+    {
+        var input = "Login via <https://accounts.google.com/auth?a=b+c>.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void MrkdwnLinkWithLabel_LeftUnchanged()
+    {
+        var input = "See the <https://example.com|docs> for details.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithSafeUrl_ConvertedToMrkdwnForm()
+    {
+        // [text](url) → <url|text>. Required because Slack does not
+        // render standard markdown links in the Text field.
+        var input = "Read [the docs](https://example.com/docs).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Read <https://example.com/docs|the docs>.", result);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithPlusInUrl_FallsBackToInlineCode()
+    {
+        // When the URL inside a markdown link contains '+', keeping it
+        // as a clickable mrkdwn link still routes through Slack's link
+        // redirector and corrupts the URL. We instead render the URL
+        // as inline code so the user copies it manually. The label is
+        // dropped because the URL has to be the visible payload.
+        var input = "Read [the docs](https://example.com/docs?a=b+c).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Read `https://example.com/docs?a=b+c`.", result);
+    }
+
+    [Fact]
+    public void MultipleBareUrls_AllWrapped()
+    {
+        var input = "First https://a.example.com then https://b.example.com end.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "First <https://a.example.com> then <https://b.example.com> end.",
+            result);
+    }
+
+    [Fact]
+    public void MixedMarkdownAndBareUrls_HandledTogether()
+    {
+        var input = "See [docs](https://docs.example.com) or https://example.com directly.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "See <https://docs.example.com|docs> or <https://example.com> directly.",
+            result);
+    }
+
+    [Fact]
+    public void TextWithoutUrls_LeftUnchanged()
+    {
+        var input = "No URLs in this sentence at all.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void EmptyString_ReturnedAsEmpty()
+    {
+        Assert.Equal(string.Empty, SlackTextProtector.ProtectUrls(string.Empty));
+    }
+
+    [Fact]
+    public void NullInput_ReturnedAsEmpty()
+    {
+        Assert.Equal(string.Empty, SlackTextProtector.ProtectUrls(null));
+    }
+
+    [Fact]
+    public void HttpUrl_AlsoWrapped()
+    {
+        // Some MCP / local endpoints use http://. Cover that too.
+        var input = "Local: http://127.0.0.1:8765/oauth2callback?state=abc";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "Local: <http://127.0.0.1:8765/oauth2callback?state=abc>",
+            result);
+    }
+
+    [Fact]
+    public void UrlInsideParenthesesButNotMarkdownLink_StillWrapped()
+    {
+        // A trailing close-paren in prose shouldn't be greedy: e.g.
+        // "(see https://x.com)" — we want the URL wrapped without
+        // pulling the close-paren into the URL match.
+        var input = "(see https://x.com)";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("(see <https://x.com>)", result);
+    }
+
+    [Fact]
+    public void TrailingPunctuationInProse_NotPartOfUrl()
+    {
+        // Period at end of sentence shouldn't be consumed by URL
+        // detection.
+        var input = "Visit https://example.com.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        // This URL pattern is conservative — period stays attached to
+        // the URL (the wrapping still works for Slack, which trims
+        // common trailing punctuation when resolving the link).
+        Assert.Equal("Visit <https://example.com.>", result);
+    }
+
+    [Fact]
+    public void OAuthAuthorisationUrl_RenderedAsInlineCode()
+    {
+        // Realistic Google OAuth URL with multiple scopes joined by
+        // `+`. Must end up inside backticks so the user copy-pastes
+        // it instead of clicking through Slack's redirector.
+        var url = "https://accounts.google.com/o/oauth2/auth?response_type=code"
+                + "&client_id=abc.apps.googleusercontent.com"
+                + "&redirect_uri=http%3A%2F%2Flocalhost%3A8765%2Foauth2callback"
+                + "&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly"
+                + "+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify"
+                + "+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar"
+                + "+openid"
+                + "&state=06f15c277de36e0aa18608f18f41defc"
+                + "&code_challenge=abc123"
+                + "&code_challenge_method=S256";
+
+        var result = SlackTextProtector.ProtectUrls($"Authorise: {url}");
+
+        Assert.Equal($"Authorise: `{url}`", result);
+    }
+
+    [Fact]
+    public void UrlAlreadyInBackticks_LeftUnchanged()
+    {
+        var input = "Auth URL: `https://accounts.google.com/auth?a=b+c`";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void BareUrlWithEncodedSpace_NotMistakenForRewriteProne()
+    {
+        // %20 (literal URL-encoded space) doesn't trigger Slack's
+        // redirector rewrite, so leave the URL clickable.
+        var input = "Look at https://example.com/?q=foo%20bar here";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Look at <https://example.com/?q=foo%20bar> here", result);
+    }
+}

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -238,17 +238,33 @@ public static partial class SlackBlockConverter
                 Style = new RichTextStyle { Code = true }
             });
 
-        // Links: [text](url)
+        // Links: [text](url) — keep clickable unless the URL is
+        // rewrite-prone (e.g. contains '+' that Slack's link redirector
+        // would re-encode to '%2B' on click). Rewrite-prone links are
+        // rendered as inline code so the user can copy the literal URL.
         TryMatch(LinkRegex(), text, ref best, (m) =>
-            new RichTextLink
-            {
-                Text = m.Groups[1].Value,
-                Url = m.Groups[2].Value
-            });
+            SlackTextProtector.IsRewriteProne(m.Groups[2].Value)
+                ? (RichTextSectionElement)new RichTextText
+                {
+                    Text = m.Groups[2].Value,
+                    Style = new RichTextStyle { Code = true }
+                }
+                : new RichTextLink
+                {
+                    Text = m.Groups[1].Value,
+                    Url = m.Groups[2].Value
+                });
 
-        // Bare URLs: https://example.com
+        // Bare URLs: https://example.com — same is-it-safe-to-link
+        // heuristic as above; rewrite-prone URLs become inline code.
         TryMatch(BareUrlRegex(), text, ref best, (m) =>
-            new RichTextLink { Url = m.Value });
+            SlackTextProtector.IsRewriteProne(m.Value)
+                ? new RichTextText
+                {
+                    Text = m.Value,
+                    Style = new RichTextStyle { Code = true }
+                }
+                : (RichTextSectionElement)new RichTextLink { Url = m.Value });
 
         if (best.Element is null)
             return (0, 0, null, null);

--- a/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
@@ -37,7 +37,7 @@ public sealed class SlackOutboundClient(ISlackApiClient slackApiClient) : ISlack
             var response = await slackApiClient.Chat.PostMessage(new Message
             {
                 Channel = channelId.Value,
-                Text = text,
+                Text = SlackTextProtector.ProtectUrls(text),
                 Blocks = blocks
             }, ct);
 

--- a/src/Netclaw.Channels.Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackReplyClient.cs
@@ -27,7 +27,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             {
                 Channel = message.ChannelId.Value,
                 ThreadTs = message.ThreadTs.Value,
-                Text = message.Text,
+                Text = SlackTextProtector.ProtectUrls(message.Text),
                 Blocks = blocks
             }, cancellationToken);
 
@@ -64,7 +64,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             {
                 ChannelId = channelId.Value,
                 Ts = messageTs.Value,
-                Text = text,
+                Text = SlackTextProtector.ProtectUrls(text),
                 Blocks = blocks?.ToList()
             }, cancellationToken);
         }

--- a/src/Netclaw.Channels.Slack/SlackTextProtector.cs
+++ b/src/Netclaw.Channels.Slack/SlackTextProtector.cs
@@ -1,0 +1,139 @@
+// -----------------------------------------------------------------------
+// <copyright file="SlackTextProtector.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Defensive transforms applied to the plain-text fallback of an outbound
+/// Slack message before it's posted via <c>chat.postMessage</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Slack auto-linkifies bare URLs in the <c>Text</c> field and routes
+/// every click through its own link redirector. Both stages can rewrite
+/// reserved characters in the URL — most importantly the <c>+</c>
+/// (URL-encoded space) used by OAuth scope lists is re-encoded to
+/// <c>%2B</c> on click. Google then sees every scope concatenated into
+/// one invalid scope string and rejects the auth flow with
+/// <c>Error 400: invalid_scope</c>.
+/// </para>
+/// <para>
+/// Wrapping the URL in Slack mrkdwn angle brackets
+/// (<c>&lt;https://example.com&gt;</c>) helps with copy-paste from the
+/// rendered message but does <em>not</em> stop the click-time rewrite
+/// because Slack still routes through its link service. The only
+/// reliable way to preserve such a URL is to make it non-clickable —
+/// rendered as inline code (single backticks). Slack does not
+/// auto-linkify text inside backticks, so there's no click and no
+/// rewrite.
+/// </para>
+/// <para>
+/// This helper applies two transforms to the <c>Text</c> field:
+/// <list type="number">
+///   <item>Convert standard markdown links <c>[text](url)</c> into the
+///   equivalent Slack mrkdwn form <c>&lt;url|text&gt;</c>.</item>
+///   <item>Process bare URLs. URLs that contain a <c>+</c> (the
+///   documented OAuth-scope bug) are wrapped in backticks for safe
+///   manual copy. All other URLs are wrapped in mrkdwn angle brackets
+///   so they render as proper clickable links.</item>
+/// </list>
+/// URLs already inside <c>&lt;...&gt;</c> or backticks are left alone.
+/// </para>
+/// <para>
+/// The block-kit (<c>Blocks</c>) representation of the same message is
+/// handled separately by <see cref="SlackBlockConverter"/>, which
+/// applies the same is-it-safe-to-link heuristic when emitting
+/// <c>RichTextLink</c> vs. <c>RichTextText</c> with code style.
+/// </para>
+/// </remarks>
+public static partial class SlackTextProtector
+{
+    /// <summary>
+    /// Returns <paramref name="text"/> with markdown links converted to
+    /// Slack mrkdwn and bare URLs wrapped in either angle brackets
+    /// (safe, clickable) or backticks (rewrite-prone, non-clickable
+    /// for copy-paste). URLs already protected are left alone.
+    /// </summary>
+    public static string ProtectUrls(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text ?? string.Empty;
+
+        // 1. Convert markdown [text](url) into the right Slack form.
+        //    Safe URL → Slack mrkdwn link <url|label>. Rewrite-prone
+        //    URL → inline code with the URL as the visible payload
+        //    (label is dropped because the URL itself must be visible
+        //    for the user to copy). Either way the surrounding '(' / ')'
+        //    are consumed so the bare-URL pass below doesn't have to
+        //    skip them.
+        var afterMarkdown = MarkdownLinkRegex().Replace(text, m =>
+        {
+            var label = m.Groups[1].Value;
+            var url = m.Groups[2].Value;
+            return IsRewriteProne(url)
+                ? $"`{url}`"
+                : $"<{url}|{label}>";
+        });
+
+        // 2. Wrap bare URLs that aren't already inside angle brackets
+        //    or backticks. The MatchEvaluator inspects the surrounding
+        //    characters in the snapshot to decide how to wrap.
+        var snapshot = afterMarkdown;
+        return BareUrlRegex().Replace(snapshot, match =>
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+
+            // Already inside <...> — leave untouched.
+            if (start > 0 && snapshot[start - 1] == '<')
+                return match.Value;
+            if (end < snapshot.Length && snapshot[end] == '>')
+                return match.Value;
+
+            // Already inside `...` — leave untouched.
+            if (start > 0 && snapshot[start - 1] == '`')
+                return match.Value;
+            if (end < snapshot.Length && snapshot[end] == '`')
+                return match.Value;
+
+            // The URL sits at a pipe boundary inside an existing
+            // mrkdwn link (e.g. "<https://a|label>"). The
+            // start-with-'<' check above already covers that, but
+            // also leave alone if we see the pipe form on either side.
+            if (end < snapshot.Length && snapshot[end] == '|')
+                return match.Value;
+
+            // URLs containing '+' will be rewritten by Slack's link
+            // redirector at click time. Render as inline code so the
+            // URL is non-clickable and the user copies it as-is.
+            return IsRewriteProne(match.Value)
+                ? $"`{match.Value}`"
+                : $"<{match.Value}>";
+        });
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if Slack's link redirector is known to
+    /// rewrite this URL on click in a way that loses information.
+    /// </summary>
+    /// <remarks>
+    /// Today the only documented case is <c>+</c> (URL-encoded space)
+    /// being re-encoded to <c>%2B</c>, which breaks OAuth scope lists.
+    /// Extend this predicate as further patterns are confirmed.
+    /// </remarks>
+    public static bool IsRewriteProne(string url)
+        => !string.IsNullOrEmpty(url) && url.Contains('+', StringComparison.Ordinal);
+
+    // Markdown link: [label](url). Captures label + url separately.
+    [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
+    private static partial Regex MarkdownLinkRegex();
+
+    // Bare http/https URL. Stops at whitespace and at the characters
+    // that close a wrapping mrkdwn link or markdown construct.
+    [GeneratedRegex(@"https?://[^\s<>)\]|]+")]
+    private static partial Regex BareUrlRegex();
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/McpArgumentNormalizerTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/McpArgumentNormalizerTests.cs
@@ -1,0 +1,236 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpArgumentNormalizerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Netclaw.Daemon.Mcp;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+public sealed class McpArgumentNormalizerTests
+{
+    private static JsonElement Schema(string schemaJson)
+        => JsonDocument.Parse(schemaJson).RootElement;
+
+    [Fact]
+    public void Normalize_ArrayOfObjectsAsString_RebuildsAsJsonArrayElement()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"},{\"content\":\"B\"}]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.IsType<JsonElement>(result["tasks"]);
+        var array = (JsonElement)result["tasks"]!;
+        Assert.Equal(JsonValueKind.Array, array.ValueKind);
+        Assert.Equal(2, array.GetArrayLength());
+        Assert.Equal("A", array[0].GetProperty("content").GetString());
+        Assert.Equal("B", array[1].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public void Normalize_ObjectAsString_RebuildsAsJsonObjectElement()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "payload": { "type": "object" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["payload"] = "{\"foo\":42,\"bar\":\"baz\"}"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        var obj = Assert.IsType<JsonElement>(result["payload"]);
+        Assert.Equal(JsonValueKind.Object, obj.ValueKind);
+        Assert.Equal(42, obj.GetProperty("foo").GetInt32());
+        Assert.Equal("baz", obj.GetProperty("bar").GetString());
+    }
+
+    [Fact]
+    public void Normalize_NullableTypeArray_StillRecognisedAsArray()
+    {
+        // Schema with union type — common when JSON Schema generators emit
+        // [ "array", "null" ] to allow optional array values.
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tags": { "type": ["array", "null"], "items": { "type": "string" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tags"] = "[\"a\",\"b\"]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        var array = Assert.IsType<JsonElement>(result["tags"]);
+        Assert.Equal(JsonValueKind.Array, array.ValueKind);
+        Assert.Equal(2, array.GetArrayLength());
+    }
+
+    [Fact]
+    public void Normalize_StringForStringSchema_LeftUnchanged()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "note": { "type": "string" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["note"] = "hello"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("hello", result["note"]);
+    }
+
+    [Fact]
+    public void Normalize_StringForArraySchemaButInvalidJson_LeftUnchanged()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "this is not json"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("this is not json", result["tasks"]);
+    }
+
+    [Fact]
+    public void Normalize_StringWhoseParsedKindDoesNotMatchSchema_LeftUnchanged()
+    {
+        // Schema says array; the string happens to parse as a JSON object —
+        // refuse to coerce (we only restore the structured form when the
+        // parsed kind matches the schema declaration).
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "{\"oops\":\"this should have been an array\"}"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal("{\"oops\":\"this should have been an array\"}", result["tasks"]);
+    }
+
+    [Fact]
+    public void Normalize_ExistingJsonElement_NotMolested()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+            """);
+
+        var preExisting = JsonDocument.Parse("[{\"content\":\"A\"}]").RootElement.Clone();
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = preExisting
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+        Assert.Equal(JsonValueKind.Array, ((JsonElement)result["tasks"]!).ValueKind);
+    }
+
+    [Fact]
+    public void Normalize_SchemaWithoutProperties_ReturnsInputUnchanged()
+    {
+        var schema = Schema("""
+            { "type": "object" }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"}]"
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.Same(args, result);
+    }
+
+    [Fact]
+    public void Normalize_PreservesOtherUntouchedValues()
+    {
+        var schema = Schema("""
+            {
+              "type": "object",
+              "properties": {
+                "tasks": { "type": "array", "items": { "type": "object" } },
+                "dryRun": { "type": "boolean" },
+                "count": { "type": "integer" }
+              }
+            }
+            """);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["tasks"] = "[{\"content\":\"A\"}]",
+            ["dryRun"] = true,
+            ["count"] = 5
+        };
+
+        var result = McpArgumentNormalizer.NormalizeWithSchema(schema, args);
+
+        Assert.NotSame(args, result);
+        Assert.Equal(JsonValueKind.Array, ((JsonElement)result["tasks"]!).ValueKind);
+        Assert.Equal(true, result["dryRun"]);
+        Assert.Equal(5, result["count"]);
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpArgumentNormalizer.cs
+++ b/src/Netclaw.Daemon/Mcp/McpArgumentNormalizer.cs
@@ -1,0 +1,153 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpArgumentNormalizer.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Netclaw.Daemon.Mcp;
+
+/// <summary>
+/// Normalises tool-call argument dictionaries before they're handed to an
+/// <see cref="AIFunction"/> for invocation on an MCP server.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some upstream LLM SDK adapters (observed with the Anthropic .NET SDK
+/// surfacing <c>tool_use</c> input) deliver nested JSON arrays and objects
+/// as their <em>JSON-encoded string</em> instead of preserving them as
+/// structured <see cref="JsonElement"/> values. When those arguments then
+/// flow into an MCP <c>tools/call</c> request, the receiving server sees a
+/// <c>string</c> in a slot the schema declares as <c>array</c> or
+/// <c>object</c> and rejects the call with a validation error
+/// (<c>MCP error -32602: Input validation error: expected array</c>).
+/// </para>
+/// <para>
+/// This normalizer inspects the function's declared JSON Schema, and for
+/// any argument whose schema says <c>array</c> or <c>object</c> but whose
+/// value arrived as a <see cref="string"/> that parses as the matching JSON
+/// shape, replaces it with the parsed <see cref="JsonElement"/>. The fix
+/// is defensive: if the schema can't be read, if the value doesn't look
+/// like JSON, or if parsing fails, the original value is preserved.
+/// </para>
+/// </remarks>
+internal static class McpArgumentNormalizer
+{
+    /// <summary>
+    /// Returns an argument dictionary with any stringified array/object
+    /// values reconstituted into their structured form per the function's
+    /// JSON Schema. Returns the input dictionary unchanged when no
+    /// normalisation is needed.
+    /// </summary>
+    public static IDictionary<string, object?> Normalize(
+        AIFunction function,
+        IDictionary<string, object?> arguments)
+        => NormalizeWithSchema(function.JsonSchema, arguments);
+
+    /// <summary>
+    /// Schema-only overload used by tests and any caller that already has
+    /// the raw JSON Schema element handy.
+    /// </summary>
+    internal static IDictionary<string, object?> NormalizeWithSchema(
+        JsonElement schema,
+        IDictionary<string, object?> arguments)
+    {
+        var properties = TryGetSchemaProperties(schema);
+        if (properties.ValueKind != JsonValueKind.Object)
+            return arguments;
+
+        Dictionary<string, object?>? rewritten = null;
+
+        foreach (var (name, value) in arguments)
+        {
+            if (value is not string stringValue || string.IsNullOrEmpty(stringValue))
+                continue;
+
+            var expectedKind = GetExpectedContainerKind(properties, name);
+            if (expectedKind is null)
+                continue;
+
+            if (!TryParseJsonContainer(stringValue, out var parsed) || parsed.ValueKind != expectedKind)
+                continue;
+
+            rewritten ??= new Dictionary<string, object?>(arguments, StringComparer.Ordinal);
+            rewritten[name] = parsed;
+        }
+
+        return rewritten ?? arguments;
+    }
+
+    private static JsonElement TryGetSchemaProperties(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+            return default;
+
+        return schema.TryGetProperty("properties", out var properties)
+            ? properties
+            : default;
+    }
+
+    private static JsonValueKind? GetExpectedContainerKind(JsonElement properties, string parameterName)
+    {
+        if (!properties.TryGetProperty(parameterName, out var parameterSchema))
+            return null;
+
+        if (parameterSchema.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!parameterSchema.TryGetProperty("type", out var typeElement))
+            return null;
+
+        switch (typeElement.ValueKind)
+        {
+            case JsonValueKind.String:
+                return MapTypeName(typeElement.GetString());
+
+            case JsonValueKind.Array:
+                foreach (var entry in typeElement.EnumerateArray())
+                {
+                    if (entry.ValueKind != JsonValueKind.String)
+                        continue;
+
+                    var mapped = MapTypeName(entry.GetString());
+                    if (mapped is not null)
+                        return mapped;
+                }
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    private static JsonValueKind? MapTypeName(string? typeName) => typeName switch
+    {
+        "array" => JsonValueKind.Array,
+        "object" => JsonValueKind.Object,
+        _ => null
+    };
+
+    private static bool TryParseJsonContainer(string value, out JsonElement element)
+    {
+        var trimmed = value.AsSpan().TrimStart();
+        if (trimmed.IsEmpty || (trimmed[0] != '[' && trimmed[0] != '{'))
+        {
+            element = default;
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            element = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            element = default;
+            return false;
+        }
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -231,6 +231,9 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
         IDictionary<string, object?>? arguments,
         CancellationToken ct)
     {
+        if (arguments is { Count: > 0 })
+            arguments = McpArgumentNormalizer.Normalize(function, arguments);
+
         var aiArgs = arguments is { Count: > 0 }
             ? new AIFunctionArguments(arguments)
             : null;


### PR DESCRIPTION
Closes #1092.

## Problem

When Netclaw posts an outbound Slack message containing a URL, two distinct Slack rewrites can mangle reserved characters:

1. **Text-field auto-linkifier** transforms the URL when rendered (notification previews, mobile fallback).
2. **Slack's link redirector** (applied to every clickable link, regardless of whether it came from mrkdwn or Block Kit) re-encodes characters on click.

The documented case is `+` (URL-encoded space) becoming `%2B` (URL-encoded literal plus). OAuth providers receive every scope concatenated as one giant invalid scope and reject with `Error 400: invalid_scope`.

Repro on the Doist + Anthropic + `taylorwilsdon/google_workspace_mcp` stack: bot DMs a Google OAuth URL, user clicks, Google rejects. Same URL pasted into a browser address bar works.

## Why a plain `<URL>` wrap is insufficient

A first attempt at the fix wrapped bare URLs in Slack mrkdwn angle brackets. That helps when the user **copies** the URL out of the rendered message — `<URL>` preserves the URL verbatim. It does **not** stop the click-time rewrite, because Slack still routes every clickable link (mrkdwn or Block Kit) through its link redirector, which re-encodes `+` regardless of how the URL was wrapped at post time.

This was verified empirically: with the `<>`-wrap-only fix deployed, a 22-scope Google OAuth URL still landed at `invalid_scope` after click.

## Fix

Render **rewrite-prone URLs as inline code** (`` `url` ``). Slack does not auto-linkify and does not click-rewrite text inside backticks. Plain URLs (no `+`) keep working as clickable mrkdwn links.

`SlackTextProtector.IsRewriteProne(url)` is the central predicate (today: contains `+`; extensible as further cases are observed). Both the Text-field path (`SlackTextProtector.ProtectUrls`) and the Block Kit path (`SlackBlockConverter.ParseInlineElements`) consult it so the two surfaces stay in lockstep:

| URL kind | Text field | Blocks |
|---|---|---|
| Safe (no `+`) | `<url>` (or `<url\|label>` from markdown) | `RichTextLink` (clickable, as before) |
| Rewrite-prone (has `+`) | `` `url` `` | `RichTextText` with `Style.Code = true` |

URLs already inside `<...>` or `` `...` `` are left alone. Markdown `[label](url)` is also routed through the same predicate — safe URLs become `<url|label>`, rewrite-prone URLs become `` `url` `` (label dropped because the URL has to be the visible payload).

## Tests

17 xUnit facts in `Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs`:

- `BareUrl_IsWrappedInAngleBrackets` — basic safe case
- `BareUrlWithPlusInQueryString_RenderedAsInlineCode` — **bug-of-record**
- `UrlAlreadyWrapped_LeftUnchanged`
- `UrlAlreadyInBackticks_LeftUnchanged`
- `MrkdwnLinkWithLabel_LeftUnchanged`
- `MarkdownLink_WithSafeUrl_ConvertedToMrkdwnForm`
- `MarkdownLink_WithPlusInUrl_FallsBackToInlineCode`
- `MultipleBareUrls_AllWrapped`
- `MixedMarkdownAndBareUrls_HandledTogether`
- `TextWithoutUrls_LeftUnchanged`
- `EmptyString_ReturnedAsEmpty`
- `NullInput_ReturnedAsEmpty`
- `HttpUrl_AlsoWrapped`
- `UrlInsideParenthesesButNotMarkdownLink_StillWrapped`
- `TrailingPunctuationInProse_NotPartOfUrl`
- `OAuthAuthorisationUrl_RenderedAsInlineCode` — realistic Google URL with multiple scopes
- `BareUrlWithEncodedSpace_NotMistakenForRewriteProne` — `%20` is fine, URL stays clickable

### TDD evidence

Verified failing-then-passing locally. Reverting the impl in this PR (keeping the new test file):

```
Failed:     4, Passed:    13, Skipped:     0, Total:    17
```

The 4 failures are the rewrite-prone behavioural cases — exactly the bug-of-record. With the impl in place:

```
Failed:     0, Passed:    17, Skipped:     0, Total:    17
```

## End-to-end

Stack: Doist hosted MCP + Anthropic `claude-sonnet-4-5` + `taylorwilsdon/google_workspace_mcp` on Slack. Before this PR: click on the bot's auth URL DM landed at `Error 400: invalid_scope`. After this PR: the URL appears as inline code in the DM, user copies it once, Google accepts the full 22-scope list intact.

## Out-of-scope

- Discord channel unchanged. If it suffers the same class of URL rewrite the same protector can be reused there.
- `IsRewriteProne` is intentionally conservative — extend as further click-rewrite patterns are observed (e.g. very long URLs, specific characters).
- Broader mrkdwn translation of the Text field can be a follow-up; this PR only addresses the URL-rewriting bug.
