### PR TITLE
fix(slack): normalise outbound URLs at boundary — closes #1092, partial #850

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -68,8 +68,11 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
-    public void MarkdownLink_ProducesRichTextLink()
+    public void MarkdownLink_WithSafeUrl_ProducesRichTextLink()
     {
+        // Closes #850 at the Block Kit surface: standard markdown
+        // [text](url) is converted into a Slack-native RichTextLink
+        // (with label) so it renders as a clickable link.
         var blocks = SlackBlockConverter.Convert("Visit [Google](https://google.com) for search");
 
         var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
@@ -78,6 +81,70 @@ public class SlackBlockConverterTests
         var link = Assert.Single(section.Elements.OfType<RichTextLink>());
         Assert.Equal("https://google.com", link.Url);
         Assert.Equal("Google", link.Text);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithRewriteProneUrl_ProducesInlineCode()
+    {
+        // Closes #1092 at the Block Kit surface: markdown links with
+        // '+' in the URL would be re-encoded by Slack's link redirector
+        // on click. Render as inline code so the URL is non-clickable
+        // and survives. Label is dropped because the URL has to be the
+        // visible payload.
+        var blocks = SlackBlockConverter.Convert(
+            "Auth at [here](https://accounts.google.com/o/oauth2/auth?scope=A+B+C&state=1).");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        Assert.Empty(section.Elements.OfType<RichTextLink>());
+        var codeElement = Assert.Single(
+            section.Elements.OfType<RichTextText>(),
+            t => t.Style?.Code == true);
+        Assert.Equal(
+            "https://accounts.google.com/o/oauth2/auth?scope=A+B+C&state=1",
+            codeElement.Text);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithMisencodedScopeList_DecodedAndProducesInlineCode()
+    {
+        // Closes #1092 LLM-rewrite shape: bot URL-encoded the literal
+        // '+' between scopes into '%2B' when constructing the markdown
+        // link. The Block path decodes them back to '+' and emits the
+        // URL as inline code.
+        var blocks = SlackBlockConverter.Convert(
+            "Auth at [here](https://x.example.com/auth?scope=A%2BB%2BC&state=1).");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        Assert.Empty(section.Elements.OfType<RichTextLink>());
+        var codeElement = Assert.Single(
+            section.Elements.OfType<RichTextText>(),
+            t => t.Style?.Code == true);
+        Assert.Equal(
+            "https://x.example.com/auth?scope=A+B+C&state=1",
+            codeElement.Text);
+    }
+
+    [Fact]
+    public void BareUrl_WithRewriteProneUrl_ProducesInlineCode()
+    {
+        // Bare URL with '+' — block path emits inline code, not a link.
+        var blocks = SlackBlockConverter.Convert(
+            "Visit https://accounts.google.com/auth?scope=A+B+C for auth");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        Assert.Empty(section.Elements.OfType<RichTextLink>());
+        var codeElement = Assert.Single(
+            section.Elements.OfType<RichTextText>(),
+            t => t.Style?.Code == true);
+        Assert.Equal(
+            "https://accounts.google.com/auth?scope=A+B+C",
+            codeElement.Text);
     }
 
     [Fact]

--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -343,6 +343,23 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
+    public void BareUrl_AtSentenceEnd_ExcludesTrailingPeriodFromLink()
+    {
+        // Shared bare-URL tokenizer (SlackTextProtector.BareUrlRegex):
+        // the sentence's closing period must not be pulled into the
+        // link target — it survives as trailing plain text.
+        var blocks = SlackBlockConverter.Convert("Check https://example.com.");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var link = Assert.Single(section.Elements.OfType<RichTextLink>());
+        Assert.Equal("https://example.com", link.Url);
+
+        Assert.Contains(section.Elements.OfType<RichTextText>(), t => t.Text == ".");
+    }
+
+    [Fact]
     public void BareUrl_InListItem_ProducesRichTextLink()
     {
         var input = "- See https://example.com/docs for more info";

--- a/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
@@ -1,0 +1,273 @@
+// -----------------------------------------------------------------------
+// <copyright file="SlackTextProtectorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Channels.Slack;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Channels;
+
+public sealed class SlackTextProtectorTests
+{
+    // ---- Bare URL handling -------------------------------------------------
+
+    [Fact]
+    public void SafeBareUrl_IsWrappedInAngleBrackets()
+    {
+        var result = SlackTextProtector.ProtectUrls("Visit https://example.com for details.");
+
+        Assert.Equal("Visit <https://example.com> for details.", result);
+    }
+
+    [Fact]
+    public void BareUrlWithLiteralPlus_RenderedAsInlineCode()
+    {
+        // The classic OAuth-scope bug shape: the URL emitted by the
+        // MCP has literal '+' separating scopes. Slack's click
+        // redirector rewrites that to '%2B'. Render as inline code so
+        // the URL is non-clickable and the user copies it intact.
+        var url = "https://accounts.google.com/o/oauth2/auth?scope=A+B+C&state=xyz";
+
+        var result = SlackTextProtector.ProtectUrls("Auth: " + url);
+
+        Assert.Equal($"Auth: `{url}`", result);
+    }
+
+    [Fact]
+    public void BareUrlWithMisencodedScopeList_DecodedAndRenderedAsCode()
+    {
+        // The LLM-introduced corruption shape: '%2B' (URL-encoded '+')
+        // separating scopes inside a 'scope=' parameter. Restore '+'
+        // so the URL is what the IdP expects, then render as inline
+        // code so Slack doesn't re-corrupt on click.
+        var corrupted = "https://accounts.google.com/o/oauth2/auth?scope=A%2BB%2BC&state=xyz";
+        var restored = "https://accounts.google.com/o/oauth2/auth?scope=A+B+C&state=xyz";
+
+        var result = SlackTextProtector.ProtectUrls("Auth: " + corrupted);
+
+        Assert.Equal($"Auth: `{restored}`", result);
+    }
+
+    [Fact]
+    public void BareUrlWithSinglePlusEncoded_LeftAlone()
+    {
+        // A single '%2B' is more likely a legitimate literal '+' in
+        // the URL than a scope-list separator. The decoder must not
+        // touch it. The URL is still flagged as rewrite-prone (so
+        // Slack doesn't make it clickable) — but we don't decode.
+        var url = "https://example.com/path/file%2Bversion?id=42";
+
+        var result = SlackTextProtector.ProtectUrls("Doc: " + url);
+
+        Assert.Equal($"Doc: `{url}`", result);
+    }
+
+    [Fact]
+    public void BareUrlWithEncodedSpace_StaysClickable()
+    {
+        // '%20' is a URL-encoded space — not a rewrite trigger, URL
+        // remains clickable.
+        var input = "Look at https://example.com/?q=foo%20bar here";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Look at <https://example.com/?q=foo%20bar> here", result);
+    }
+
+    // ---- Markdown link handling --------------------------------------------
+
+    [Fact]
+    public void MarkdownLink_WithSafeUrl_ConvertedToMrkdwnLink()
+    {
+        var input = "Read [the docs](https://example.com/docs).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Read <https://example.com/docs|the docs>.", result);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithMisencodedScopeList_DecodedToInlineCode()
+    {
+        // End-to-end bug-of-record: bot wraps URL in markdown link form
+        // and URL-encodes '+' → '%2B' inside. Decode back, drop label,
+        // emit URL as inline code.
+        var corrupted = "https://accounts.google.com/o/oauth2/auth?scope=https%3A%2F%2Fa%2Bhttps%3A%2F%2Fb%2Bhttps%3A%2F%2Fc&state=xyz";
+        var restored = "https://accounts.google.com/o/oauth2/auth?scope=https%3A%2F%2Fa+https%3A%2F%2Fb+https%3A%2F%2Fc&state=xyz";
+        var input = $"Authorise [here]({corrupted}).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal($"Authorise `{restored}`.", result);
+    }
+
+    [Fact]
+    public void MarkdownLink_WithPlusInUrl_DropsLabelAndRendersAsCode()
+    {
+        var input = "Read [the docs](https://example.com/docs?a=b+c).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("Read `https://example.com/docs?a=b+c`.", result);
+    }
+
+    // ---- Already-protected URLs --------------------------------------------
+
+    [Fact]
+    public void UrlAlreadyInAngleBrackets_LeftUntouched()
+    {
+        var input = "Login via <https://accounts.google.com/auth?a=b+c>.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void UrlAlreadyInBackticks_LeftUntouched()
+    {
+        var input = "Auth URL: `https://accounts.google.com/auth?a=b+c`";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void MrkdwnLinkWithLabel_LeftUntouched()
+    {
+        var input = "See the <https://example.com|docs> for details.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(input, result);
+    }
+
+    // ---- Multiplicity and mixed input --------------------------------------
+
+    [Fact]
+    public void MultipleSafeBareUrls_AllWrapped()
+    {
+        var input = "First https://a.example.com then https://b.example.com end.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "First <https://a.example.com> then <https://b.example.com> end.",
+            result);
+    }
+
+    [Fact]
+    public void MixedMarkdownAndBareUrls_HandledTogether()
+    {
+        var input = "See [docs](https://docs.example.com) or https://example.com directly.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "See <https://docs.example.com|docs> or <https://example.com> directly.",
+            result);
+    }
+
+    [Fact]
+    public void TextWithoutUrls_LeftUntouched()
+    {
+        var input = "No URLs in this sentence at all.";
+
+        Assert.Equal(input, SlackTextProtector.ProtectUrls(input));
+    }
+
+    [Fact]
+    public void EmptyString_ReturnedAsEmpty()
+    {
+        Assert.Equal(string.Empty, SlackTextProtector.ProtectUrls(string.Empty));
+    }
+
+    [Fact]
+    public void NullInput_ReturnedAsEmpty()
+    {
+        Assert.Equal(string.Empty, SlackTextProtector.ProtectUrls(null));
+    }
+
+    [Fact]
+    public void HttpUrl_AlsoHandled()
+    {
+        var input = "Local: http://127.0.0.1:8765/oauth2callback?state=abc";
+
+        Assert.Equal(
+            "Local: <http://127.0.0.1:8765/oauth2callback?state=abc>",
+            SlackTextProtector.ProtectUrls(input));
+    }
+
+    [Fact]
+    public void UrlInsideProseParentheses_StillWrapped()
+    {
+        var input = "(see https://x.com)";
+
+        Assert.Equal("(see <https://x.com>)", SlackTextProtector.ProtectUrls(input));
+    }
+
+    // ---- End-to-end realistic OAuth URL ------------------------------------
+
+    [Fact]
+    public void RealisticMisencodedOAuthMarkdownLink_DecodesAllScopesIntact()
+    {
+        var corrupted = "https://accounts.google.com/o/oauth2/auth?response_type=code"
+                      + "&client_id=abc.apps.googleusercontent.com"
+                      + "&redirect_uri=http%3A%2F%2Flocalhost%3A8765%2Foauth2callback"
+                      + "&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly"
+                      + "%2Bhttps%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify"
+                      + "%2Bhttps%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar"
+                      + "%2Bopenid"
+                      + "&state=06f15c277de36e0aa18608f18f41defc";
+        var restored = corrupted.Replace("%2B", "+");
+
+        var result = SlackTextProtector.ProtectUrls($"Authorise [here]({corrupted}).");
+
+        Assert.Equal($"Authorise `{restored}`.", result);
+    }
+
+    // ---- Direct invariants on the helpers ----------------------------------
+
+    [Theory]
+    [InlineData("https://example.com/a+b", true)]
+    [InlineData("https://example.com/a%2Bb", true)]
+    [InlineData("https://example.com/A%2bb", true)]
+    [InlineData("https://example.com/normal", false)]
+    [InlineData("", false)]
+    public void IsRewriteProne_DetectsBothPlusAndPercentTwoB(string url, bool expected)
+    {
+        Assert.Equal(expected, SlackTextProtector.IsRewriteProne(url));
+    }
+
+    [Theory]
+    // Multiple %2B in scope= → decode all of them.
+    [InlineData(
+        "https://x.com/auth?scope=A%2BB%2BC&state=1",
+        "https://x.com/auth?scope=A+B+C&state=1")]
+    // Single %2B in scope= → leave alone (likely literal '+').
+    [InlineData(
+        "https://x.com/auth?scope=A%2BB&state=1",
+        "https://x.com/auth?scope=A%2BB&state=1")]
+    // %2B outside scope= → leave alone.
+    [InlineData(
+        "https://x.com/path%2Bv?id=1&scope=A",
+        "https://x.com/path%2Bv?id=1&scope=A")]
+    // No scope= → leave alone.
+    [InlineData(
+        "https://x.com/?a=b%2Bc%2Bd",
+        "https://x.com/?a=b%2Bc%2Bd")]
+    // Scope= is the last parameter.
+    [InlineData(
+        "https://x.com/auth?state=1&scope=A%2BB%2BC",
+        "https://x.com/auth?state=1&scope=A+B+C")]
+    // Already correct → unchanged.
+    [InlineData(
+        "https://x.com/auth?scope=A+B+C",
+        "https://x.com/auth?scope=A+B+C")]
+    public void NormaliseScopeList_DecodesOnlyOAuthScopePattern(string input, string expected)
+    {
+        Assert.Equal(expected, SlackTextProtector.NormaliseScopeList(input));
+    }
+}

--- a/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
@@ -75,6 +75,24 @@ public sealed class SlackTextProtectorTests
         Assert.Equal("Look at <https://example.com/?q=foo%20bar> here", result);
     }
 
+    [Theory]
+    [InlineData("Visit https://example.com.", "Visit <https://example.com>.")]
+    [InlineData("Excited https://example.com!", "Excited <https://example.com>!")]
+    [InlineData("Right? https://example.com?", "Right? <https://example.com>?")]
+    [InlineData("Done: https://example.com;", "Done: <https://example.com>;")]
+    [InlineData("Two https://example.com, then more", "Two <https://example.com>, then more")]
+    [InlineData("Trailing https://example.com...", "Trailing <https://example.com>...")]
+    [InlineData("Path https://example.com/a.b.c.", "Path <https://example.com/a.b.c>.")]
+    public void BareUrlAtSentenceEnd_DoesNotSwallowTrailingPunctuation(
+        string input, string expected)
+    {
+        // The URL token must stop before sentence punctuation —
+        // otherwise Slack treats e.g. the period as part of the
+        // clickable link target. Punctuation inside the URL path is
+        // still preserved (only the final character is constrained).
+        Assert.Equal(expected, SlackTextProtector.ProtectUrls(input));
+    }
+
     // ---- Markdown link handling --------------------------------------------
 
     [Fact]
@@ -266,6 +284,16 @@ public sealed class SlackTextProtectorTests
     [InlineData(
         "https://x.com/auth?scope=A+B+C",
         "https://x.com/auth?scope=A+B+C")]
+    // 'scope=' embedded in a longer parameter name ('myscope=') is not
+    // an OAuth scope list — must be left alone even with multiple %2B.
+    [InlineData(
+        "https://x.com/auth?myscope=A%2BB%2BC&state=1",
+        "https://x.com/auth?myscope=A%2BB%2BC&state=1")]
+    // A 'myscope=' decoy earlier in the query string must not shadow
+    // the real boundary-anchored 'scope=' parameter.
+    [InlineData(
+        "https://x.com/auth?myscope=keep%2Bme&scope=A%2BB%2BC",
+        "https://x.com/auth?myscope=keep%2Bme&scope=A+B+C")]
     public void NormaliseScopeList_DecodesOnlyOAuthScopePattern(string input, string expected)
     {
         Assert.Equal(expected, SlackTextProtector.NormaliseScopeList(input));

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -262,8 +262,9 @@ public static partial class SlackBlockConverter
         });
 
         // Bare URLs: https://example.com — same is-it-safe-to-link
-        // heuristic.
-        TryMatch(BareUrlRegex(), text, ref best, (m) =>
+        // heuristic. Uses SlackTextProtector's shared bare-URL regex so
+        // the Block Kit and plain-text surfaces tokenize URLs identically.
+        TryMatch(SlackTextProtector.BareUrlRegex(), text, ref best, (m) =>
         {
             var url = SlackTextProtector.NormaliseScopeList(m.Value);
             return SlackTextProtector.IsRewriteProne(url)
@@ -355,10 +356,6 @@ public static partial class SlackBlockConverter
     // Links: [text](url)
     [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
     private static partial Regex LinkRegex();
-
-    // Bare URLs: https://example.com
-    [GeneratedRegex(@"https?://[^\s)\]>]+")]
-    private static partial Regex BareUrlRegex();
 
     // Ordered list prefix: 1. or 2. etc.
     [GeneratedRegex(@"^\d+\.\s")]

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -238,17 +238,42 @@ public static partial class SlackBlockConverter
                 Style = new RichTextStyle { Code = true }
             });
 
-        // Links: [text](url)
+        // Links: [text](url) — normalise the URL (recovers LLM-mangled
+        // OAuth scope lists) then choose the right element. Safe URLs
+        // become Block Kit RichTextLink (proper clickable Slack-native
+        // link — addresses #850). Rewrite-prone URLs become inline-
+        // code RichTextText so Slack's click redirector can't re-encode
+        // them; the label is dropped because the URL has to be the
+        // visible payload for copy.
         TryMatch(LinkRegex(), text, ref best, (m) =>
-            new RichTextLink
-            {
-                Text = m.Groups[1].Value,
-                Url = m.Groups[2].Value
-            });
+        {
+            var url = SlackTextProtector.NormaliseScopeList(m.Groups[2].Value);
+            return SlackTextProtector.IsRewriteProne(url)
+                ? (RichTextSectionElement)new RichTextText
+                {
+                    Text = url,
+                    Style = new RichTextStyle { Code = true }
+                }
+                : new RichTextLink
+                {
+                    Text = m.Groups[1].Value,
+                    Url = url
+                };
+        });
 
-        // Bare URLs: https://example.com
+        // Bare URLs: https://example.com — same is-it-safe-to-link
+        // heuristic.
         TryMatch(BareUrlRegex(), text, ref best, (m) =>
-            new RichTextLink { Url = m.Value });
+        {
+            var url = SlackTextProtector.NormaliseScopeList(m.Value);
+            return SlackTextProtector.IsRewriteProne(url)
+                ? (RichTextSectionElement)new RichTextText
+                {
+                    Text = url,
+                    Style = new RichTextStyle { Code = true }
+                }
+                : new RichTextLink { Url = url };
+        });
 
         if (best.Element is null)
             return (0, 0, null, null);

--- a/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackOutboundClient.cs
@@ -37,7 +37,7 @@ public sealed class SlackOutboundClient(ISlackApiClient slackApiClient) : ISlack
             var response = await slackApiClient.Chat.PostMessage(new Message
             {
                 Channel = channelId.Value,
-                Text = text,
+                Text = SlackTextProtector.ProtectUrls(text),
                 Blocks = blocks
             }, ct);
 

--- a/src/Netclaw.Channels.Slack/SlackReplyClient.cs
+++ b/src/Netclaw.Channels.Slack/SlackReplyClient.cs
@@ -27,7 +27,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             {
                 Channel = message.ChannelId.Value,
                 ThreadTs = message.ThreadTs.Value,
-                Text = message.Text,
+                Text = SlackTextProtector.ProtectUrls(message.Text),
                 Blocks = blocks
             }, cancellationToken);
 
@@ -64,7 +64,7 @@ public sealed class SlackReplyClient(ISlackApiClient slackApiClient) : ISlackRep
             {
                 ChannelId = channelId.Value,
                 Ts = messageTs.Value,
-                Text = text,
+                Text = SlackTextProtector.ProtectUrls(text),
                 Blocks = blocks?.ToList()
             }, cancellationToken);
         }

--- a/src/Netclaw.Channels.Slack/SlackTextProtector.cs
+++ b/src/Netclaw.Channels.Slack/SlackTextProtector.cs
@@ -141,8 +141,27 @@ public static partial class SlackTextProtector
         if (string.IsNullOrEmpty(url))
             return url;
 
-        var scopeMarker = "scope=";
-        var scopeIndex = url.IndexOf(scopeMarker, StringComparison.Ordinal);
+        // Locate a 'scope=' query parameter at a parameter boundary
+        // (preceded by '?' or '&'). A bare IndexOf would also match a
+        // 'scope=' substring embedded in a path segment or inside a
+        // longer parameter name (e.g. 'myscope='), mis-targeting the
+        // decode onto an unrelated value.
+        const string scopeMarker = "scope=";
+        var scopeIndex = -1;
+        var searchFrom = 0;
+        while (true)
+        {
+            var hit = url.IndexOf(scopeMarker, searchFrom, StringComparison.Ordinal);
+            if (hit < 0)
+                break;
+            if (hit > 0 && url[hit - 1] is '?' or '&')
+            {
+                scopeIndex = hit;
+                break;
+            }
+            searchFrom = hit + scopeMarker.Length;
+        }
+
         if (scopeIndex < 0)
             return url;
 
@@ -176,7 +195,14 @@ public static partial class SlackTextProtector
     private static partial Regex MarkdownLinkRegex();
 
     // Bare http/https URL. Stops at whitespace and at the characters
-    // that close a wrapping mrkdwn link or markdown construct.
-    [GeneratedRegex(@"https?://[^\s<>)\]|]+")]
-    private static partial Regex BareUrlRegex();
+    // that close a wrapping mrkdwn link or markdown construct. The
+    // required trailing character additionally excludes sentence
+    // punctuation (.,!?;:) so a URL at the end of a sentence —
+    // "see https://x.com." — does not swallow the period into the
+    // clickable link target. Mid-URL punctuation is preserved because
+    // only the final character is constrained. Shared with
+    // SlackBlockConverter so both outbound surfaces tokenize URLs
+    // identically.
+    [GeneratedRegex(@"https?://[^\s<>)\]|]*[^\s<>)\]|.,!?;:]")]
+    internal static partial Regex BareUrlRegex();
 }

--- a/src/Netclaw.Channels.Slack/SlackTextProtector.cs
+++ b/src/Netclaw.Channels.Slack/SlackTextProtector.cs
@@ -1,0 +1,182 @@
+// -----------------------------------------------------------------------
+// <copyright file="SlackTextProtector.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text.RegularExpressions;
+
+namespace Netclaw.Channels.Slack;
+
+/// <summary>
+/// Defensive URL transforms applied to the plain-text fallback of an
+/// outbound Slack message before it's posted via <c>chat.postMessage</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two distinct breakages can corrupt OAuth-shaped URLs en route from
+/// an MCP tool result to a Slack DM:
+/// </para>
+/// <list type="number">
+///   <item>The LLM rewrites the URL when constructing a markdown link
+///   (<c>[label](url)</c>) — it URL-encodes the literal <c>+</c>
+///   characters that delimit scope-list entries into <c>%2B</c>. The
+///   URL is corrupted before NetClaw ever sees it.</item>
+///   <item>Slack's auto-linkifier and link redirector transform bare
+///   URLs in the <c>Text</c> field on render and on click. The
+///   <c>+</c> → <c>%2B</c> rewrite happens at click time regardless of
+///   how the URL was wrapped.</item>
+/// </list>
+/// <para>
+/// The fix applied here has three pieces:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="NormaliseScopeList"/> — when a URL has a
+///   <c>scope=</c> query parameter whose value contains multiple
+///   <c>%2B</c> separators, decode them back to <c>+</c>. Conservative
+///   enough to leave URLs with a single legitimate <c>%2B</c>
+///   untouched.</item>
+///   <item><see cref="IsRewriteProne"/> — flag URLs that contain
+///   <c>+</c> or <c>%2B</c> as rewrite-prone. Rewrite-prone URLs are
+///   rendered as inline code so Slack never makes them clickable and
+///   the user copies the exact bytes the agent produced.</item>
+///   <item>Markdown links <c>[label](url)</c> are routed through the
+///   same normalisation. Safe URLs become Slack mrkdwn
+///   <c>&lt;url|label&gt;</c>; rewrite-prone URLs lose the label and
+///   become inline-code (the URL is what the user has to be able to
+///   copy).</item>
+/// </list>
+/// <para>
+/// The Block Kit (<c>Blocks</c>) representation of the same message is
+/// handled by <see cref="SlackBlockConverter"/> using the same
+/// <see cref="IsRewriteProne"/> and <see cref="NormaliseScopeList"/>
+/// helpers so the two surfaces stay in lockstep.
+/// </para>
+/// </remarks>
+public static partial class SlackTextProtector
+{
+    /// <summary>
+    /// Returns <paramref name="text"/> with markdown links normalised
+    /// and bare URLs wrapped to survive Slack's auto-linkifier.
+    /// </summary>
+    public static string ProtectUrls(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text ?? string.Empty;
+
+        // 1. Process markdown [label](url) links first.
+        //    Decoding the URL up-front recovers from LLM-introduced
+        //    '+' → '%2B' rewrite before any further routing.
+        var afterMarkdown = MarkdownLinkRegex().Replace(text, m =>
+        {
+            var label = m.Groups[1].Value;
+            var url = NormaliseScopeList(m.Groups[2].Value);
+            return IsRewriteProne(url)
+                ? $"`{url}`"
+                : $"<{url}|{label}>";
+        });
+
+        // 2. Wrap bare URLs that aren't already inside <...> or `...`.
+        var snapshot = afterMarkdown;
+        return BareUrlRegex().Replace(snapshot, match =>
+        {
+            var start = match.Index;
+            var end = match.Index + match.Length;
+
+            // Already inside <...> — leave untouched.
+            if (start > 0 && snapshot[start - 1] == '<')
+                return match.Value;
+            if (end < snapshot.Length && snapshot[end] == '>')
+                return match.Value;
+
+            // Already inside `...` — leave untouched.
+            if (start > 0 && snapshot[start - 1] == '`')
+                return match.Value;
+            if (end < snapshot.Length && snapshot[end] == '`')
+                return match.Value;
+
+            // Pipe boundary (mrkdwn link form already in flight).
+            if (end < snapshot.Length && snapshot[end] == '|')
+                return match.Value;
+
+            var url = NormaliseScopeList(match.Value);
+            return IsRewriteProne(url)
+                ? $"`{url}`"
+                : $"<{url}>";
+        });
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if Slack will rewrite reserved characters in
+    /// this URL on render or on click.
+    /// </summary>
+    /// <remarks>
+    /// Both literal <c>+</c> (URL-encoded space, used in OAuth scope
+    /// lists) and the LLM-introduced <c>%2B</c> variant are treated as
+    /// rewrite-prone — the resulting rendering must be non-clickable
+    /// so the user copies the URL exactly.
+    /// </remarks>
+    public static bool IsRewriteProne(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return false;
+        return url.Contains('+', StringComparison.Ordinal)
+            || url.Contains("%2B", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// If <paramref name="url"/> looks like an OAuth authorisation URL
+    /// whose <c>scope=</c> value has been mis-encoded with <c>%2B</c>
+    /// in place of the literal <c>+</c> scope delimiter, restore the
+    /// original encoding. Returns the URL unchanged in any other case.
+    /// </summary>
+    /// <remarks>
+    /// The heuristic targets the LLM-introduced corruption pattern: a
+    /// URL with a <c>scope=</c> parameter whose value contains two or
+    /// more <c>%2B</c> separators. Two or more is the signal — a single
+    /// <c>%2B</c> in a scope value is more likely a legitimate literal
+    /// plus and is left alone.
+    /// </remarks>
+    public static string NormaliseScopeList(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return url;
+
+        var scopeMarker = "scope=";
+        var scopeIndex = url.IndexOf(scopeMarker, StringComparison.Ordinal);
+        if (scopeIndex < 0)
+            return url;
+
+        var scopeStart = scopeIndex + scopeMarker.Length;
+        var scopeEnd = url.IndexOf('&', scopeStart);
+        if (scopeEnd < 0)
+            scopeEnd = url.Length;
+
+        var scopeValue = url[scopeStart..scopeEnd];
+
+        // Count case-insensitive %2B occurrences in the scope value.
+        var count = 0;
+        for (var i = 0; i + 3 <= scopeValue.Length; i++)
+        {
+            if (scopeValue[i] != '%') continue;
+            if (scopeValue[i + 1] != '2') continue;
+            var c = scopeValue[i + 2];
+            if (c == 'B' || c == 'b')
+                count++;
+        }
+
+        if (count < 2)
+            return url;
+
+        var restored = scopeValue.Replace("%2B", "+", StringComparison.OrdinalIgnoreCase);
+        return string.Concat(url.AsSpan(0, scopeStart), restored, url.AsSpan(scopeEnd));
+    }
+
+    // Markdown link: [label](url). Captures label + url separately.
+    [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
+    private static partial Regex MarkdownLinkRegex();
+
+    // Bare http/https URL. Stops at whitespace and at the characters
+    // that close a wrapping mrkdwn link or markdown construct.
+    [GeneratedRegex(@"https?://[^\s<>)\]|]+")]
+    private static partial Regex BareUrlRegex();
+}


### PR DESCRIPTION
Addresses #1092 in full and **partially** closes #850.

## Two bugs, one outbound-Slack boundary

**#1092 — Slack rewrites OAuth scope delimiters on click.**
The LLM's response sometimes carries the URL inside a markdown link `[label](url)` and URL-encodes the literal `+` (scope-list separator) into `%2B` along the way. Whether the URL reaches Slack as plain text, mrkdwn `<url>`, or Block Kit `RichTextLink`, Slack's click redirector re-encodes `+` to `%2B` on click, so the final URL the IdP sees has every scope concatenated into one invalid string. Repro: Doist + `taylorwilsdon/google_workspace_mcp` + claude-sonnet-4-5 → click → `Error 400: invalid_scope`.

**#850 — Standard markdown links don't render in Slack.**
`[text](url)` shows as raw text in Slack; only Slack-native `<url|text>` renders as a clickable link. Aaron documented the three forms tested in the issue body.

The two bugs share the same outbound boundary (`SlackReplyClient.PostThreadReplyAsync` / `SlackOutboundClient.PostNewThreadAsync` / `SlackReplyClient.UpdateThreadMessageAsync`) so I'm fixing them in one place.

## Fix

A new `SlackTextProtector` runs on the agent's response text before it's posted, plus the same helpers run inside `SlackBlockConverter` so the Block Kit and Text-field paths stay consistent.

| Path | Safe URL (no `+`, no `%2B`) | Rewrite-prone URL |
|---|---|---|
| Bare URL | `<url>` mrkdwn (clickable) | inline code (non-clickable, copy-paste) |
| Markdown link `[label](url)` | `<url|label>` mrkdwn (clickable — **addresses #850**) | label dropped, inline code |
| Block Kit | `RichTextLink` | `RichTextText { Style.Code = true }` |

`NormaliseScopeList(url)` runs first for both paths: if the URL has a `scope=` parameter whose value contains two or more `%2B` separators, decode them back to `+`. Single `%2B` is left alone (likely a legitimate literal `+`).

`IsRewriteProne(url)` is the central is-it-safe-to-link predicate (today: contains `+` or `%2B`; extensible).

## Tests

19 xUnit facts in `Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs`:

- bare URL handling — safe, literal `+`, mis-encoded `%2B`, single-`%2B` negative case, `%20` negative case
- markdown link handling — safe, mis-encoded scope-list, literal `+`
- already-protected URLs — `<...>`, `` `...` ``, `<url|label>` mrkdwn
- multiplicity — multiple URLs, mixed markdown + bare
- prose punctuation — `(see https://...)`
- realistic 22-scope Google OAuth URL — full decode + render as inline code
- direct invariants — `IsRewriteProne` and `NormaliseScopeList` parameterised theories

### TDD evidence

Verified failing-then-passing locally — with `NormaliseScopeList` and `IsRewriteProne` removed (the rest of the test cases kept as-is), the rewrite-prone facts fail with the exact diff the bug shows. With the helpers in place, all 50 facts in `Netclaw.Actors.Tests/Channels/` pass.

## End-to-end verification

Doist hosted MCP + Anthropic `claude-sonnet-4-5` + `taylorwilsdon/google_workspace_mcp` over Slack. Before this PR: bot DM'd an OAuth URL via markdown link; Slack rendered it as raw `[Authorization URL](url-with-%2B)` text and click/paste both produced `invalid_scope`. After this PR: rewrite-prone URL is decoded to original `+` form and rendered as inline code (gray, non-clickable); manual copy out of the code element delivers the URL byte-exact and Google accepts the full 22-scope list.

## Known limitation — why #850 is only partially closed

Rewrite-prone URLs are **intentionally non-clickable** in this PR. Slack's link redirector cannot be told to skip a particular URL, so the only way to preserve a URL containing `+` or `%2B` is to render it as inline code (Slack does not click-rewrite text inside backticks). #850's "must be clickable" requirement is met for safe URLs but is **intentionally not met for rewrite-prone ones** — that's a tradeoff between clickable UX and a URL the IdP can actually accept.

A follow-up could introduce a local HTTP redirector (daemon-side) that hands Slack a short opaque URL which 302s to the real URL. That's the only path I see to clickable + preserved. Out of scope here.

## Out-of-scope

- Discord channel adapter unchanged.
- `IsRewriteProne` is intentionally conservative — extend as further click-rewrite patterns are observed.
- Broader mrkdwn translation of the Text field (bold/italic/code outside URL handling) can be a follow-up.
