### PR TITLE
fix(sessions): recover thinking-only LLM responses instead of failing

### DIFF
--- a/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/LlmSessionIntegrationTests.cs
@@ -282,6 +282,10 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
             new FunctionCallContent("call-1", "web_search",
                 new Dictionary<string, object?> { ["query"] = "test" })
         ];
+        // Four post-tool empty responses: the first three are nudged and
+        // retried (MaxPostToolEmptyRetries), the fourth fails the turn.
+        _fakeChatClient.PlannedResponses.Enqueue([]);
+        _fakeChatClient.PlannedResponses.Enqueue([]);
         _fakeChatClient.PlannedResponses.Enqueue([]);
         _fakeChatClient.PlannedResponses.Enqueue([]);
 
@@ -317,7 +321,7 @@ public class LlmSessionIntegrationTests : LlmSessionTestBase
         }, TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         var text = await subscriber.ExpectMsgAsync<TextOutput>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Contains("[fake] Response #4", text.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[fake] Response #6", text.Text, StringComparison.OrdinalIgnoreCase);
         await subscriber.ExpectMsgAsync<TurnCompleted>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
     }
 

--- a/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="TurnStateTrackerTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Netclaw.Actors.Sessions.Handlers;
+using Xunit;
+
+namespace Netclaw.Actors.Tests.Sessions;
+
+/// <summary>
+/// Covers <see cref="TurnStateTracker.EvaluateEmptyResponse"/>: a thinking-only
+/// response (reasoning emitted, no final answer) must get a thinking-specific
+/// nudge, and the post-tool path must tolerate several retries before failing
+/// the turn.
+/// </summary>
+public sealed class TurnStateTrackerTests
+{
+    private const string ThinkingNudgeMarker = "only reasoning";
+
+    [Theory]
+    [InlineData(true, true, true)]     // post-tool, thinking-only → thinking nudge
+    [InlineData(true, false, false)]   // post-tool, empty → generic nudge
+    [InlineData(false, true, true)]    // pre-tool, thinking-only → thinking nudge
+    [InlineData(false, false, false)]  // pre-tool, empty → generic nudge
+    public void EmptyResponse_NudgeMatchesThinkingState(bool afterToolWork, bool hasThinking, bool expectThinkingNudge)
+    {
+        var tracker = new TurnStateTracker();
+        if (afterToolWork)
+            tracker.RecordToolCompletion(resultCount: 1, maxToolCallsPerTurn: 30);
+
+        var action = tracker.EvaluateEmptyResponse(hasThinking);
+
+        var retry = Assert.IsType<EmptyResponseAction.Retry>(action);
+        if (expectThinkingNudge)
+            Assert.Contains(ThinkingNudgeMarker, retry.NudgeText);
+        else
+            Assert.DoesNotContain(ThinkingNudgeMarker, retry.NudgeText);
+    }
+
+    [Fact]
+    public void PostToolThinkingOnly_RetriesSeveralTimesBeforeFailing()
+    {
+        var tracker = new TurnStateTracker();
+        tracker.RecordToolCompletion(resultCount: 1, maxToolCallsPerTurn: 30);
+
+        // The first three consecutive thinking-only responses retry.
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
+
+        // Only the fourth fails the turn.
+        Assert.IsType<EmptyResponseAction.Fail>(tracker.EvaluateEmptyResponse(hasThinking: true));
+    }
+}

--- a/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
+++ b/src/Netclaw.Actors.Tests/Sessions/TurnStateTrackerTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using Netclaw.Actors.Sessions;
 using Netclaw.Actors.Sessions.Handlers;
 using Xunit;
 
@@ -18,21 +19,27 @@ public sealed class TurnStateTrackerTests
 {
     private const string ThinkingNudgeMarker = "only reasoning";
 
+    public enum ToolPhase
+    {
+        BeforeAnyToolUse,
+        AfterToolUse,
+    }
+
     [Theory]
-    [InlineData(true, true, true)]     // post-tool, thinking-only → thinking nudge
-    [InlineData(true, false, false)]   // post-tool, empty → generic nudge
-    [InlineData(false, true, true)]    // pre-tool, thinking-only → thinking nudge
-    [InlineData(false, false, false)]  // pre-tool, empty → generic nudge
-    public void EmptyResponse_NudgeMatchesThinkingState(bool afterToolWork, bool hasThinking, bool expectThinkingNudge)
+    [InlineData(ToolPhase.AfterToolUse, LlmResponseKind.ThinkingOnly)]
+    [InlineData(ToolPhase.AfterToolUse, LlmResponseKind.Empty)]
+    [InlineData(ToolPhase.BeforeAnyToolUse, LlmResponseKind.ThinkingOnly)]
+    [InlineData(ToolPhase.BeforeAnyToolUse, LlmResponseKind.Empty)]
+    public void EmptyResponse_NudgeMatchesResponseKind(ToolPhase phase, LlmResponseKind kind)
     {
         var tracker = new TurnStateTracker();
-        if (afterToolWork)
+        if (phase == ToolPhase.AfterToolUse)
             tracker.RecordToolCompletion(resultCount: 1, maxToolCallsPerTurn: 30);
 
-        var action = tracker.EvaluateEmptyResponse(hasThinking);
+        var action = tracker.EvaluateEmptyResponse(kind);
 
         var retry = Assert.IsType<EmptyResponseAction.Retry>(action);
-        if (expectThinkingNudge)
+        if (kind == LlmResponseKind.ThinkingOnly)
             Assert.Contains(ThinkingNudgeMarker, retry.NudgeText);
         else
             Assert.DoesNotContain(ThinkingNudgeMarker, retry.NudgeText);
@@ -45,11 +52,11 @@ public sealed class TurnStateTrackerTests
         tracker.RecordToolCompletion(resultCount: 1, maxToolCallsPerTurn: 30);
 
         // The first three consecutive thinking-only responses retry.
-        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
-        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
-        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(hasThinking: true));
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(LlmResponseKind.ThinkingOnly));
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(LlmResponseKind.ThinkingOnly));
+        Assert.IsType<EmptyResponseAction.Retry>(tracker.EvaluateEmptyResponse(LlmResponseKind.ThinkingOnly));
 
         // Only the fourth fails the turn.
-        Assert.IsType<EmptyResponseAction.Fail>(tracker.EvaluateEmptyResponse(hasThinking: true));
+        Assert.IsType<EmptyResponseAction.Fail>(tracker.EvaluateEmptyResponse(LlmResponseKind.ThinkingOnly));
     }
 }

--- a/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
@@ -155,12 +155,15 @@ internal sealed class TurnStateTracker
 
     /// <summary>
     /// The LLM produced no reply text and no tool calls. Determine what the
-    /// actor should do. <paramref name="hasThinking"/> is true when the model
-    /// emitted reasoning but no final answer (a thinking-only response) — that
-    /// case gets a nudge telling the model to surface its answer.
+    /// actor should do. Expects <paramref name="kind"/> to be
+    /// <see cref="LlmResponseKind.ThinkingOnly"/> or
+    /// <see cref="LlmResponseKind.Empty"/>; a thinking-only response gets a
+    /// nudge telling the model to surface its answer.
     /// </summary>
-    public EmptyResponseAction EvaluateEmptyResponse(bool hasThinking)
+    public EmptyResponseAction EvaluateEmptyResponse(LlmResponseKind kind)
     {
+        var hasThinking = kind == LlmResponseKind.ThinkingOnly;
+
         // Pre-tool: LLM hasn't done any tool work yet
         if (ToolIterationCount == 0)
         {

--- a/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
+++ b/src/Netclaw.Actors/Sessions/Handlers/TurnStateTracker.cs
@@ -13,8 +13,18 @@ namespace Netclaw.Actors.Sessions.Handlers;
 internal sealed class TurnStateTracker
 {
     private const int MaxPreToolEmptyRetries = 2;
+    private const int MaxPostToolEmptyRetries = 3;
     private const int DuplicateToolThreshold = 3;
     private const double BudgetNudgeRatio = 0.75;
+
+    // Nudge for a thinking-only response: the model emitted reasoning but no
+    // final answer. Generic across providers — no provider-specific payload.
+    private const string ThinkingOnlyNudge =
+        "Your last response contained only reasoning and no reply to the user. "
+        + "Stop thinking and write your answer now as a normal assistant message.";
+
+    private const string EmptyResponseFailureMessage =
+        "I didn't manage to produce a reply. Please try rephrasing or sending your request again.";
 
     private readonly Dictionary<ToolCallFingerprint, int> _toolCallCounts = [];
 
@@ -23,7 +33,7 @@ internal sealed class TurnStateTracker
     public bool ForceNoToolsActive { get; set; }
 
     private bool _budgetNudgeSent;
-    private bool _postToolNudgeSent;
+    private int _postToolEmptyResponseCount;
     private int _preToolEmptyResponseCount;
     private bool _duplicateNudgeSent;
 
@@ -35,7 +45,7 @@ internal sealed class TurnStateTracker
         ToolCallCount = 0;
         ToolIterationCount = 0;
         _budgetNudgeSent = false;
-        _postToolNudgeSent = false;
+        _postToolEmptyResponseCount = 0;
         _preToolEmptyResponseCount = 0;
         ForceNoToolsActive = false;
         _toolCallCounts.Clear();
@@ -61,7 +71,7 @@ internal sealed class TurnStateTracker
     /// </summary>
     public void ResetEmptyResponseGuards()
     {
-        _postToolNudgeSent = false;
+        _postToolEmptyResponseCount = 0;
         _preToolEmptyResponseCount = 0;
         ForceNoToolsActive = false;
     }
@@ -144,9 +154,12 @@ internal sealed class TurnStateTracker
     // ── Empty response decisions ──
 
     /// <summary>
-    /// The LLM produced no text and no tool calls. Determine what the actor should do.
+    /// The LLM produced no reply text and no tool calls. Determine what the
+    /// actor should do. <paramref name="hasThinking"/> is true when the model
+    /// emitted reasoning but no final answer (a thinking-only response) — that
+    /// case gets a nudge telling the model to surface its answer.
     /// </summary>
-    public EmptyResponseAction EvaluateEmptyResponse()
+    public EmptyResponseAction EvaluateEmptyResponse(bool hasThinking)
     {
         // Pre-tool: LLM hasn't done any tool work yet
         if (ToolIterationCount == 0)
@@ -154,28 +167,27 @@ internal sealed class TurnStateTracker
             _preToolEmptyResponseCount++;
             if (_preToolEmptyResponseCount > MaxPreToolEmptyRetries)
                 return new EmptyResponseAction.Fail(
-                    "I didn't manage to produce a reply. Please try rephrasing or sending your request again.",
+                    EmptyResponseFailureMessage,
                     new InvalidOperationException("LLM produced repeated empty responses before any tool execution."));
 
-            return new EmptyResponseAction.Retry(
-                "Your previous response was empty. If you need MCP capabilities, call search_tools(\"servers\") to pick a server "
-                + "(for example browser, memory, or email), then call search_tools(\"<intent>\", server: \"<server_name>\") to load tools. "
-                + "MCP tools are not directly callable until loaded via search_tools.");
+            return new EmptyResponseAction.Retry(hasThinking
+                ? ThinkingOnlyNudge
+                : "Your previous response was empty. If you need MCP capabilities, call search_tools(\"servers\") to pick a server "
+                  + "(for example browser, memory, or email), then call search_tools(\"<intent>\", server: \"<server_name>\") to load tools. "
+                  + "MCP tools are not directly callable until loaded via search_tools.");
         }
 
-        // Post-tool, first empty: nudge to continue
-        if (!_postToolNudgeSent)
-        {
-            _postToolNudgeSent = true;
-            return new EmptyResponseAction.Retry(
-                "You received tool results but did not respond. "
-                + "Continue working or answer the user's question.");
-        }
+        // Post-tool: nudge the model to produce its final reply
+        _postToolEmptyResponseCount++;
+        if (_postToolEmptyResponseCount > MaxPostToolEmptyRetries)
+            return new EmptyResponseAction.Fail(
+                EmptyResponseFailureMessage,
+                new InvalidOperationException("LLM produced repeated empty responses after tool execution."));
 
-        // Post-tool, already nudged: give up
-        return new EmptyResponseAction.Fail(
-            "I didn't manage to produce a reply. Please try rephrasing or sending your request again.",
-            new InvalidOperationException("LLM produced an empty response after tool execution and follow-up nudge."));
+        return new EmptyResponseAction.Retry(hasThinking
+            ? ThinkingOnlyNudge
+            : "You received tool results but did not respond. "
+              + "Continue working or answer the user's question.");
     }
 }
 

--- a/src/Netclaw.Actors/Sessions/LlmResponseClassifier.cs
+++ b/src/Netclaw.Actors/Sessions/LlmResponseClassifier.cs
@@ -35,18 +35,38 @@ internal static class LlmResponseClassifier
             }
         }
 
-        return new LlmResponseAnalysis(
-            toolCalls,
-            hasText,
-            hasThinking,
-            textChars,
-            thinkingChars);
+        var kind =
+            toolCalls.Count > 0 ? LlmResponseKind.ToolCalls
+            : hasText ? LlmResponseKind.Text
+            : hasThinking ? LlmResponseKind.ThinkingOnly
+            : LlmResponseKind.Empty;
+
+        return new LlmResponseAnalysis(toolCalls, kind, textChars, thinkingChars);
     }
+}
+
+/// <summary>
+/// What the model produced on a turn. Tool calls take precedence over reply
+/// text, and reply text over reasoning — so a response carrying both text and
+/// tool calls classifies as <see cref="ToolCalls"/>.
+/// </summary>
+public enum LlmResponseKind
+{
+    /// <summary>Contains reply text — a normal answer to the user.</summary>
+    Text,
+
+    /// <summary>Requested one or more tool calls.</summary>
+    ToolCalls,
+
+    /// <summary>Emitted reasoning but no reply text and no tool calls.</summary>
+    ThinkingOnly,
+
+    /// <summary>No reply text, no reasoning, and no tool calls.</summary>
+    Empty,
 }
 
 internal sealed record LlmResponseAnalysis(
     List<FunctionCallContent> ToolCalls,
-    bool HasText,
-    bool HasThinking,
+    LlmResponseKind Kind,
     int TextChars,
     int ThinkingChars);

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -752,7 +752,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         if (!analysis.HasText && analysis.ToolCalls.Count == 0)
         {
             var label = analysis.HasThinking ? "thinking-only" : "empty";
-            switch (_turnState.EvaluateEmptyResponse())
+            switch (_turnState.EvaluateEmptyResponse(analysis.HasThinking))
             {
                 case EmptyResponseAction.Retry retry:
                     _log.Warning("LLM produced {Label} response ({ThinkingChars} chars) — retrying with nudge",

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -729,7 +729,7 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             analysis.ToolCalls.Count,
             response.FinishReason?.ToString() ?? "null");
 
-        if (analysis.ToolCalls.Count > 0 && _turnState.ForceNoToolsActive)
+        if (analysis.Kind == LlmResponseKind.ToolCalls && _turnState.ForceNoToolsActive)
         {
             TurnLog().Warning(
                 "turn_force_no_tools_violation toolCallCount={ToolCallCount} budgetUsed={BudgetUsed} max={Max}",
@@ -743,25 +743,24 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             return;
         }
 
-        if (analysis.ToolCalls.Count > 0 && _toolExecutor is not null)
+        if (analysis.Kind == LlmResponseKind.ToolCalls && _toolExecutor is not null)
         {
             HandleToolCallResponse(lastMessage, analysis.ToolCalls, response.Usage);
             return;
         }
 
-        if (!analysis.HasText && analysis.ToolCalls.Count == 0)
+        if (analysis.Kind is LlmResponseKind.ThinkingOnly or LlmResponseKind.Empty)
         {
-            var label = analysis.HasThinking ? "thinking-only" : "empty";
-            switch (_turnState.EvaluateEmptyResponse(analysis.HasThinking))
+            switch (_turnState.EvaluateEmptyResponse(analysis.Kind))
             {
                 case EmptyResponseAction.Retry retry:
-                    _log.Warning("LLM produced {Label} response ({ThinkingChars} chars) — retrying with nudge",
-                        label, analysis.ThinkingChars);
+                    _log.Warning("LLM produced {Kind} response ({ThinkingChars} chars) — retrying with nudge",
+                        analysis.Kind, analysis.ThinkingChars);
                     _state = _state.AddSystemNudge(retry.NudgeText);
                     FireLlmCall();
                     return;
                 case EmptyResponseAction.Fail fail:
-                    _log.Warning("LLM produced {Label} response — failing turn", label);
+                    _log.Warning("LLM produced {Kind} response — failing turn", analysis.Kind);
                     FailCurrentTurn(fail.ErrorMessage, fail.Cause, ErrorCategory.ProviderFailure);
                     return;
             }


### PR DESCRIPTION
## Summary

- A reasoning-model response with thinking content but no final text and no tool calls was treated as empty. The post-tool path nudged once, then failed the turn on the second occurrence with _"I didn't manage to produce a reply."_
- `TurnStateTracker.EvaluateEmptyResponse` now takes a `hasThinking` flag — thinking-only responses get a dedicated, provider-generic nudge telling the model to stop reasoning and write its answer as a normal message.
- The post-tool empty-response path now retries up to three times before failing the turn (previously a single retry).
- The duplicated failure-message literal is hoisted to a constant.

Closes #1101.

## Test plan

- [x] `TurnStateTrackerTests` — `[Theory]` covering thinking-vs-empty nudge selection (pre- and post-tool) and a `[Fact]` covering the post-tool retry-then-fail sequence
- [x] `dotnet slopwatch analyze` passes (0 issues)
- [x] copyright headers verified