### PR TITLE
docs(install): surface `netclaw daemon install` in install.sh get-started hint

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,5 +260,8 @@ fi
 
 echo ""
 echo "Get started:"
-echo "  netclaw init      # First-run setup wizard"
-echo "  netclaw doctor    # Verify configuration"
+echo "  netclaw init             # First-run setup wizard"
+echo "  netclaw doctor           # Verify configuration"
+if [ "$(uname -s)" = "Linux" ]; then
+    echo "  netclaw daemon install   # Enable auto-start on boot (systemd)"
+fi


### PR DESCRIPTION
## Problem

After running `install.sh`, the "Get started" message only mentions
`netclaw init` and `netclaw doctor` — operators never learn about
`netclaw daemon install`, so the daemon doesn't get boot persistence
(systemd user service) set up.

## Change

Adds a `netclaw daemon install` line to the install.sh "Get started"
hint. It is gated to Linux (`uname -s` check) because launchd-based
daemon install on macOS is still tracked separately in #1015.

```
Get started:
  netclaw init             # First-run setup wizard
  netclaw doctor           # Verify configuration
  netclaw daemon install   # Enable auto-start on boot (systemd)   [Linux only]
```

The README/docs portion of the issue was already done; this closes the
remaining install.sh discoverability gap.

## Validation

- `bash -n scripts/install.sh` passes.

Closes #730