### PR TITLE
improve(tools): actionable truncation hints and Offset/Limit guidance for file_read

### DIFF
--- a/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
+++ b/src/Netclaw.Actors.Tests/Tools/FileReadToolTests.cs
@@ -72,7 +72,7 @@ public class FileReadToolTests : IDisposable
     }
 
     [Fact]
-    public async Task Large_file_is_truncated()
+    public async Task Large_file_is_truncated_with_continuation_hint()
     {
         var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 100 });
         var filePath = Path.Combine(_dir.Path, "large.txt");
@@ -81,7 +81,23 @@ public class FileReadToolTests : IDisposable
         var args = ToolInput.Create("Path", filePath);
         var result = await tool.ExecuteAsync(args, CreatePersonalContext(), CancellationToken.None);
 
-        Assert.Contains("[output truncated]", result);
+        Assert.Contains("output truncated", result);
+        Assert.Contains("Offset=", result);
+    }
+
+    [Fact]
+    public async Task Paginated_read_truncated_by_char_limit_includes_continuation_hint()
+    {
+        var tool = new FileReadTool(new ToolConfig { MaxOutputChars = 50 });
+        var filePath = Path.Combine(_dir.Path, "paged.txt");
+        var lines = Enumerable.Range(1, 20).Select(i => $"Line {i:D2} content here");
+        await File.WriteAllLinesAsync(filePath, lines, TestContext.Current.CancellationToken);
+
+        var args = ToolInput.Create("Path", filePath, "Offset", 1, "Limit", 20);
+        var result = await tool.ExecuteAsync(args, CreatePersonalContext(), CancellationToken.None);
+
+        Assert.Contains("output truncated", result);
+        Assert.Contains("Offset=", result);
     }
 
     [Fact]

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -18,7 +18,7 @@ namespace Netclaw.Actors.Tools;
 /// Reads file contents as UTF-8 text with optional line offset/limit.
 /// </summary>
 [NetclawTool(ToolName,
-    "Read the contents of a file as text",
+    "Read the contents of a file as text. For large files, use Offset and Limit to read sections to avoid truncation. If output is truncated, the response includes the Offset value to use to continue reading.",
     Grant = "file")]
 public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 {
@@ -33,8 +33,8 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
     public record Params(
         [property: Description("Absolute path to the file to read")] string Path,
-        [property: Description("Line number to start reading from (1-based, optional)")] int? Offset = null,
-        [property: Description("Maximum number of lines to read (optional)")] int? Limit = null);
+        [property: Description("Line number to start reading from (1-based). Use with Limit to read sections of large files and avoid context window truncation.")] int? Offset = null,
+        [property: Description("Maximum number of lines to read. Use with Offset to paginate through large files instead of reading the whole file.")] int? Limit = null);
 
     public FileReadTool(
         ToolConfig config,
@@ -84,7 +84,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
             var content = await File.ReadAllTextAsync(authorizedPath, Encoding.UTF8, ct);
             RecordSkillReadIfApplicable(authorizedPath);
-            return ShellTool.TruncateOutput(content, _config.MaxOutputChars);
+            return TruncateFileOutput(content, _config.MaxOutputChars);
         }
         catch (UnauthorizedAccessException)
         {
@@ -94,6 +94,16 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
         {
             return $"Error reading file: {ex.Message}";
         }
+    }
+
+    private static string TruncateFileOutput(string content, int maxChars)
+    {
+        if (content.Length <= maxChars)
+            return content;
+        var truncated = content[..maxChars];
+        var nextLine = truncated.Count(c => c == '\n') + 1;
+        var totalLines = content.Count(c => c == '\n') + 1;
+        return truncated + $"\n[output truncated at line {nextLine} of {totalLines} — use Offset={nextLine} with Limit to continue reading]";
     }
 
     private static async Task<string> ReadLinesAsync(
@@ -120,7 +130,8 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
 
             if (sb.Length >= maxChars)
             {
-                return ShellTool.TruncateOutput(sb.ToString(), maxChars);
+                var truncated = sb.ToString()[..maxChars];
+                return truncated + $"\n[output truncated — use Offset={lineNumber} with Limit to continue reading]";
             }
         }
 

--- a/src/Netclaw.Actors/Tools/FileReadTool.cs
+++ b/src/Netclaw.Actors/Tools/FileReadTool.cs
@@ -100,10 +100,17 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
     {
         if (content.Length <= maxChars)
             return content;
-        var truncated = content[..maxChars];
-        var nextLine = truncated.Count(c => c == '\n') + 1;
-        var totalLines = content.Count(c => c == '\n') + 1;
-        return truncated + $"\n[output truncated at line {nextLine} of {totalLines} — use Offset={nextLine} with Limit to continue reading]";
+        int newlinesBefore = 0, totalNewlines = 0;
+        for (var i = 0; i < content.Length; i++)
+        {
+            if (content[i] != '\n') continue;
+            totalNewlines++;
+            if (i < maxChars) newlinesBefore++;
+        }
+        var nextLine = newlinesBefore + 1;
+        var totalLines = totalNewlines + 1;
+        return string.Concat(content.AsSpan(0, maxChars),
+            $"\n[output truncated at line {nextLine} of {totalLines} — use Offset={nextLine} with Limit to continue reading]");
     }
 
     private static async Task<string> ReadLinesAsync(
@@ -129,10 +136,7 @@ public sealed partial class FileReadTool : NetclawTool<FileReadTool.Params>
             linesRead++;
 
             if (sb.Length >= maxChars)
-            {
-                var truncated = sb.ToString()[..maxChars];
-                return truncated + $"\n[output truncated — use Offset={lineNumber} with Limit to continue reading]";
-            }
+                return sb.ToString(0, maxChars) + $"\n[output truncated at line {lineNumber} — use Offset={lineNumber} with Limit to continue reading]";
         }
 
         return sb.ToString();


### PR DESCRIPTION
## Summary

- Updates `file_read` tool description and parameter descriptions to explain when and why to use `Offset`/`Limit` for large files
- Replaces generic `[output truncated]` suffix with an actionable message that includes the exact `Offset` to continue reading from; full-file reads also report total line count (already in memory, so free)
- Single-pass newline counting in `TruncateFileOutput` (was two LINQ scans over the full content); uses `string.Concat(AsSpan)` and `StringBuilder.ToString(offset, count)` to avoid extra allocations
- Aligns truncation message phrasing between the full-file and paginated paths

Closes #1096

## Test plan

- [ ] `Large_file_is_truncated_with_continuation_hint` — full-file read truncation includes `output truncated` and `Offset=`
- [ ] `Paginated_read_truncated_by_char_limit_includes_continuation_hint` — paginated read truncation includes same hints
- [ ] All other `FileReadToolTests` continue to pass (18 total)