### PR TITLE
fix(slack): preserve parentheses in markdown link URLs

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackBlockConverterTests.cs
@@ -129,6 +129,23 @@ public class SlackBlockConverterTests
     }
 
     [Fact]
+    public void MarkdownLink_UrlWithParentheses_NotTruncated()
+    {
+        // Regression for #1107: a balanced '(...)' inside the link
+        // destination must stay part of the URL — the destination is
+        // not truncated at the first ')'.
+        var blocks = SlackBlockConverter.Convert(
+            "Read [the article](https://en.wikipedia.org/wiki/Foo_(disambiguation)) now.");
+
+        var rtb = Assert.Single(blocks.OfType<RichTextBlock>());
+        var section = Assert.Single(rtb.Elements.OfType<RichTextSection>());
+
+        var link = Assert.Single(section.Elements.OfType<RichTextLink>());
+        Assert.Equal("https://en.wikipedia.org/wiki/Foo_(disambiguation)", link.Url);
+        Assert.Equal("the article", link.Text);
+    }
+
+    [Fact]
     public void BareUrl_WithRewriteProneUrl_ProducesInlineCode()
     {
         // Bare URL with '+' — block path emits inline code, not a link.

--- a/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/SlackTextProtectorTests.cs
@@ -130,6 +130,43 @@ public sealed class SlackTextProtectorTests
         Assert.Equal("Read `https://example.com/docs?a=b+c`.", result);
     }
 
+    [Fact]
+    public void MarkdownLink_UrlWithParentheses_NotTruncated()
+    {
+        // Regression for #1107: the markdown link destination must not
+        // be cut off at the first ')'. A balanced '(...)' inside the
+        // URL is part of the URL — only an unbalanced ')' closes the link.
+        var input = "Read [the article](https://en.wikipedia.org/wiki/Foo_(disambiguation)) now.";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal(
+            "Read <https://en.wikipedia.org/wiki/Foo_(disambiguation)|the article> now.",
+            result);
+    }
+
+    [Fact]
+    public void MarkdownLink_UrlWithParentheses_FollowedByProseParens_SplitCorrectly()
+    {
+        // The ')' that closes the markdown link must be distinguished
+        // from prose parentheses that follow it.
+        var input = "See [doc](https://e.com/Foo_(bar)) (really).";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("See <https://e.com/Foo_(bar)|doc> (really).", result);
+    }
+
+    [Fact]
+    public void MarkdownLink_UrlWithMultipleParenGroups_NotTruncated()
+    {
+        var input = "[wiki](https://e.com/a_(b)_(c))";
+
+        var result = SlackTextProtector.ProtectUrls(input);
+
+        Assert.Equal("<https://e.com/a_(b)_(c)|wiki>", result);
+    }
+
     // ---- Already-protected URLs --------------------------------------------
 
     [Fact]

--- a/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
+++ b/src/Netclaw.Channels.Slack/SlackBlockConverter.cs
@@ -244,8 +244,9 @@ public static partial class SlackBlockConverter
         // link — addresses #850). Rewrite-prone URLs become inline-
         // code RichTextText so Slack's click redirector can't re-encode
         // them; the label is dropped because the URL has to be the
-        // visible payload for copy.
-        TryMatch(LinkRegex(), text, ref best, (m) =>
+        // visible payload for copy. Uses SlackTextProtector's shared
+        // markdown-link regex so both surfaces tokenize links identically.
+        TryMatch(SlackTextProtector.MarkdownLinkRegex(), text, ref best, (m) =>
         {
             var url = SlackTextProtector.NormaliseScopeList(m.Groups[2].Value);
             return SlackTextProtector.IsRewriteProne(url)
@@ -352,10 +353,6 @@ public static partial class SlackBlockConverter
     // Inline code: `text`
     [GeneratedRegex(@"`([^`]+)`")]
     private static partial Regex InlineCodeRegex();
-
-    // Links: [text](url)
-    [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
-    private static partial Regex LinkRegex();
 
     // Ordered list prefix: 1. or 2. etc.
     [GeneratedRegex(@"^\d+\.\s")]

--- a/src/Netclaw.Channels.Slack/SlackTextProtector.cs
+++ b/src/Netclaw.Channels.Slack/SlackTextProtector.cs
@@ -190,9 +190,18 @@ public static partial class SlackTextProtector
         return string.Concat(url.AsSpan(0, scopeStart), restored, url.AsSpan(scopeEnd));
     }
 
-    // Markdown link: [label](url). Captures label + url separately.
-    [GeneratedRegex(@"\[([^\]]+)\]\(([^)]+)\)")]
-    private static partial Regex MarkdownLinkRegex();
+    // Markdown link: [label](url). Captures label (group 1) + url
+    // (group 2) separately. The url group accepts a parenthesised
+    // segment — e.g. "(disambiguation)" in a Wikipedia-style URL — so
+    // the destination is not truncated at the first ')'. A ')' only
+    // ends the link when it is not part of a balanced pair, matching
+    // CommonMark link-destination semantics. One level of paren
+    // nesting is supported, which covers every URL shape seen in
+    // practice; deeper nesting falls back to first-')' termination.
+    // Shared with SlackBlockConverter so both outbound surfaces
+    // tokenize markdown links identically.
+    [GeneratedRegex(@"\[([^\]]+)\]\(((?:[^()]|\([^()]*\))*)\)")]
+    internal static partial Regex MarkdownLinkRegex();
 
     // Bare http/https URL. Stops at whitespace and at the characters
     // that close a wrapping mrkdwn link or markdown construct. The


### PR DESCRIPTION
## Summary

Follow-up to #1102. Closes #1107 — the markdown-link regex truncated any link destination containing a `)`.

`\[([^\]]+)\]\(([^)]+)\)` cut the URL at the first `)`, so a URL like `https://en.wikipedia.org/wiki/Foo_(disambiguation)` rendered as a link to the truncated `...Foo_(disambiguation` plus a stray `)` of text.

## Changes

- `MarkdownLinkRegex` — the URL group now accepts balanced parenthesised segments: `(?:[^()]|\([^()]*\))*`. A `)` only closes the markdown link when it is not part of a balanced pair (CommonMark link-destination semantics). One level of paren nesting is supported — covers every URL shape seen in practice.
- Consolidated the two duplicated markdown-link regexes: `SlackBlockConverter` now consumes the shared `internal SlackTextProtector.MarkdownLinkRegex`, mirroring the bare-URL regex consolidation from #1102 so both outbound surfaces tokenize links identically.

## Tests

4 regression tests across both outbound surfaces (plain-text `Text` field + Block Kit):

- markdown link URL containing `(...)` is not truncated
- the closing `)` is distinguished from prose parens that follow it
- multiple paren groups in one URL
- Block Kit surface produces a `RichTextLink` with the full URL

Local: 67/67 Slack channel tests pass, `dotnet slopwatch analyze` clean, copyright headers verified.

## Notes

Deeper-than-one-level paren nesting (`(a(b)c)`) falls back to first-`)` termination — documented in the regex comment; such URLs effectively never occur.