### PR TITLE
fix(smoke): scope daemon kills to the smoke binary — closes #1116

### DIFF
--- a/scripts/smoke/lib/common.sh
+++ b/scripts/smoke/lib/common.sh
@@ -61,12 +61,58 @@ run_timed() {
 
 # ── Daemon lifecycle ─────────────────────────────────────────────────────────
 
+# pid_exe_path <pid> — best-effort lookup of a process's executable path.
+# Linux: resolves /proc/<pid>/exe. macOS / restricted-pid fallback: parses
+# `lsof -p`. Prints the resolved path on stdout, or nothing if it cannot be
+# determined positively (pid gone, permission denied, unparseable lsof
+# output, etc.). Callers MUST treat an empty result as "unknown — do not
+# act"; the consequence of misidentifying a foreign pid as ours is silently
+# SIGKILLing a bystander process.
+pid_exe_path() {
+  local pid="$1"
+  local exe=""
+
+  if [[ -L "/proc/${pid}/exe" ]]; then
+    exe="$(readlink -f "/proc/${pid}/exe" 2>/dev/null || true)"
+  fi
+
+  # Fall back to lsof when /proc was unavailable or restricted. Both code
+  # paths can return junk on restricted pids (lsof has been observed to
+  # emit "/proc/<pid>/exe (readlink: Permission denied)" verbatim), so the
+  # validation below applies to both.
+  if [[ -z "$exe" ]] && command -v lsof >/dev/null 2>&1; then
+    exe="$(lsof -p "$pid" -a -d txt -Fn 2>/dev/null \
+      | awk '/^n/{print substr($0,2); exit}')"
+  fi
+
+  # Only emit results that are unambiguous: an absolute path to a regular
+  # file that exists. Anything else is treated as "unknown".
+  if [[ -n "$exe" && "$exe" == /* && -f "$exe" ]]; then
+    printf '%s\n' "$exe"
+  fi
+}
+
+# pid_is_smoke_daemon <pid> — true iff the pid's executable resolves to the
+# binary at NETCLAW_SMOKE_DAEMON. A pid we cannot positively identify is
+# treated as foreign on purpose: the alternative is silently SIGKILLing a
+# bystander netclawd (e.g. the developer's production daemon on the same
+# box), which the constitution's "no silent fallbacks" rule bans outright.
+pid_is_smoke_daemon() {
+  local pid="$1"
+  : "${NETCLAW_SMOKE_DAEMON:?NETCLAW_SMOKE_DAEMON must be set}"
+  local exe
+  exe="$(pid_exe_path "$pid")"
+  [[ -n "$exe" && "$exe" == "$NETCLAW_SMOKE_DAEMON" ]]
+}
+
 # ensure_daemon_port_free — block until 127.0.0.1:5199 has no LISTEN socket.
 # Every tape and scenario daemon binds the same fixed port; a daemon orphaned
 # by an earlier NETCLAW_HOME is invisible to `netclaw daemon stop` (which only
 # signals the PID in the current home's PID file) and will squat the port,
-# making every later daemon crash on bind. Hard-kill any such straggler.
-# Returns non-zero if the port is still held after the timeout.
+# making every later daemon crash on bind. Hard-kill any such straggler — but
+# only if it is in fact one of *our* smoke daemons. Returns non-zero if the
+# port is still held after the timeout OR if it is held by a non-smoke
+# process we refuse to touch.
 ensure_daemon_port_free() {
   local port=5199
   local deadline=$((SECONDS + 30))
@@ -78,13 +124,49 @@ ensure_daemon_port_free() {
     sleep 1
     holders="$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || true)"
     [[ -z "$holders" ]] && return 0
-    log "port ${port} still held by PID(s): ${holders} — hard-killing."
-    # shellcheck disable=SC2086 # word-split is intended: holders may be multi-PID
-    kill -9 $holders 2>/dev/null || pkill -9 -f netclawd 2>/dev/null || true
-    sleep 1
+
+    # Separate smoke-owned holders (safe to hard-kill) from anything else.
+    # Touching a foreign holder — e.g. a developer's `netclaw daemon start`
+    # running against ~/.netclaw on the same box — would silently destroy
+    # unrelated work, so we refuse and exit with a clear diagnostic.
+    local pid killed_any=0
+    local foreign=()
+    for pid in $holders; do
+      if pid_is_smoke_daemon "$pid"; then
+        log "port ${port} held by smoke daemon (pid=${pid}); hard-killing."
+        kill -9 "$pid" 2>/dev/null || true
+        killed_any=1
+      else
+        local exe
+        exe="$(pid_exe_path "$pid")"
+        foreign+=("pid=${pid} exe=${exe:-<unknown>}")
+      fi
+    done
+
+    if (( ${#foreign[@]} > 0 )); then
+      log "ERROR: port ${port} is held by non-smoke process(es): ${foreign[*]}"
+      log "       Refusing to hard-kill — these do not belong to the smoke harness."
+      log "       Stop the offending process manually (e.g. \`netclaw daemon stop\`"
+      log "       against the right NETCLAW_HOME) before re-running smoke tests."
+      return 1
+    fi
+
+    (( killed_any == 1 )) && sleep 1
   done
   log "ERROR: port ${port} never freed."
   return 1
+}
+
+# kill_smoke_daemon_processes — best-effort hard-kill of every still-running
+# smoke daemon. Scoped to NETCLAW_SMOKE_DAEMON's full path so it cannot reach
+# a netclawd installed elsewhere on the box (the run-smoke.sh teardown trap
+# used to call an unscoped `pkill -f netclawd` here; that killed the
+# developer's production daemon — see netclaw-dev/netclaw#1116).
+kill_smoke_daemon_processes() {
+  : "${NETCLAW_SMOKE_DAEMON:?NETCLAW_SMOKE_DAEMON must be set}"
+  # -f matches against the full command line, and the daemon is always
+  # launched by absolute path, so this only catches binaries we own.
+  pkill -f "$NETCLAW_SMOKE_DAEMON" >/dev/null 2>&1 || true
 }
 
 # start_daemon — launch the native daemon detached and poll until it reports

--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -161,8 +161,13 @@ teardown() {
   if declare -f ollama_serve_stop >/dev/null 2>&1; then
     ollama_serve_stop || true
   fi
-  # Kill any stray daemon process.
-  pkill -f netclawd >/dev/null 2>&1 || true
+  # Kill any stray smoke daemon. Scoped to NETCLAW_SMOKE_DAEMON's full path
+  # so a production netclawd on the same box is never targeted — an
+  # unscoped `pkill -f netclawd` used to live here and silently SIGKILLed
+  # the developer's daemon mid-flight (see netclaw-dev/netclaw#1116).
+  if [[ -n "${NETCLAW_SMOKE_DAEMON:-}" ]]; then
+    pkill -f "$NETCLAW_SMOKE_DAEMON" >/dev/null 2>&1 || true
+  fi
   if [[ "${KEEP_RUN_ROOT:-0}" == "1" ]]; then
     echo "    KEEP_RUN_ROOT=1 — run root retained at: $RUN_ROOT"
   else


### PR DESCRIPTION
## Summary

The smoke harness's stray-daemon cleanup ran unfiltered
`pkill -f netclawd`, which on a dev machine with a live `~/.netclaw`
daemon silently SIGKILLs the developer's production daemon mid-session.
See [#1116](https://github.com/netclaw-dev/netclaw/issues/1116) for the
full incident report.

Two cleanup sites were unsafe:

- `scripts/smoke/lib/common.sh:83` (`ensure_daemon_port_free` fallback):
  `kill -9 $holders 2>/dev/null || pkill -9 -f netclawd 2>/dev/null || true`
- `scripts/smoke/run-smoke.sh:165` (teardown trap):
  `pkill -f netclawd >/dev/null 2>&1 || true`

Neither call constrained the match to the smoke run root, smoke
`NETCLAW_HOME`, or the smoke daemon's PID file — so they targeted every
`netclawd` on the box.

## What changed

- New `pid_exe_path` helper resolves a pid's executable via Linux
  `/proc/<pid>/exe` with an `lsof -p` fallback for macOS / restricted
  pids, and validates the result is an absolute path to an existing
  file. Restricted or ambiguous pids return empty on purpose.
- New `pid_is_smoke_daemon` positively identifies a pid by comparing
  its resolved exe against `$NETCLAW_SMOKE_DAEMON`. Pids we cannot
  positively identify are treated as foreign — the cost of a
  misclassification is silently SIGKILLing a bystander.
- `ensure_daemon_port_free` now classifies each port :5199 holder.
  Smoke-owned → hard-kill. Foreign → log `pid=… exe=…` with clear
  remediation guidance and return non-zero. The blanket
  `pkill -9 -f netclawd` fallback is gone.
- `run-smoke.sh` teardown replaces `pkill -f netclawd` with
  `pkill -f "$NETCLAW_SMOKE_DAEMON"`, which matches by absolute path
  and so only catches binaries we launched.

Aligns the harness with the constitution's "no silent fallbacks" rule
on a path that was, in practice, hard SIGKILLing unrelated production
work.

## Test plan

- [x] `bash -n` parses both files clean.
- [x] `shellcheck -x` clean on the new code (remaining warnings are
      pre-existing in `run_one_scenario`).
- [x] Helpers verified live: `pid_exe_path` returns the right path for
      the running shell, returns empty for a root-owned tmux pid we
      can't read, and returns empty for a non-existent pid.
      `pid_is_smoke_daemon` correctly accepts on match, rejects on
      mismatch, and rejects ambiguous/restricted pids.
- [ ] `./scripts/smoke/run-smoke.sh light` end-to-end on a clean box
      (no running production daemon).
- [ ] Manual: start a production daemon (`netclaw daemon start`) and
      then run `./scripts/smoke/run-smoke.sh init-wizard` — expect the
      harness to fail loudly with the foreign-holder diagnostic instead
      of killing the production daemon.

Closes #1116.