### PR TITLE
feat(init): surface reverse-proxy exposure mode in netclaw init

### DIFF
--- a/docs/spec/SPEC-007-guided-onboarding.md
+++ b/docs/spec/SPEC-007-guided-onboarding.md
@@ -40,8 +40,13 @@ Define the guided onboarding flow for first-time Netclaw setup.
 
 ### Step 5: Security Profile
 
-- choose exposure mode (`local`, `tailscale-serve`, `tailscale-funnel`,
-  `cloudflare-tunnel`)
+- choose exposure mode (`local`, `reverse-proxy`, `tailscale-serve`,
+  `tailscale-funnel`, `cloudflare-tunnel`)
+- for `reverse-proxy`: collect `Daemon.Host` (must be non-loopback) and
+  `Daemon.TrustedProxies` (≥1 IP or CIDR entry required to advance — matches
+  the daemon's startup validator so the wizard cannot emit a non-startable
+  config), then show an informational notice with the resulting serving URL
+  (`http://{Host}:{Port}`) before continuing
 - enforce policy prerequisites for selected mode
 
 ### Step 6: Final Validation

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -773,7 +773,8 @@ collect `Daemon.Host` (must be non-loopback) and `Daemon.TrustedProxies` (≥1
 entry required, comma-separated). The wizard refuses to advance past the
 trusted-proxies prompt with an empty list — the same minimum the daemon
 validator enforces at startup — so an operator who does not yet know their
-proxy IP should choose `local` and re-run `netclaw init --resume` later.
+proxy IP should choose `local` and re-run `netclaw init` later — the wizard
+auto-resumes incomplete onboarding by skipping already-completed steps.
 
 Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
 including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -3,7 +3,7 @@ name: netclaw-operations
 description: "REQUIRED when the user asks about scheduling, reminders, cron jobs, timers, background jobs, diagnostics, troubleshooting, MCP tools, daemon health, identity updates, or Netclaw capabilities and self-maintenance."
 metadata:
   author: netclaw
-  version: "2.6.0"
+  version: "2.7.0"
 ---
 
 # Netclaw Operations
@@ -765,6 +765,15 @@ Exposure diagnostics are fail-closed:
   `cloudflare-tunnel`) require their local tunnel process by default.
   `Daemon.SkipTunnelProcessCheck=true` is an explicit opt-in only for sidecar or
   host-managed tunnel topologies; all other exposure requirements still apply.
+
+The `netclaw init` wizard's Network Exposure step offers all five modes —
+`local`, `reverse-proxy`, `tailscale-serve`, `tailscale-funnel`,
+`cloudflare-tunnel`. Selecting `reverse-proxy` adds two follow-up prompts that
+collect `Daemon.Host` (must be non-loopback) and `Daemon.TrustedProxies` (≥1
+entry required, comma-separated). The wizard refuses to advance past the
+trusted-proxies prompt with an empty list — the same minimum the daemon
+validator enforces at startup — so an operator who does not yet know their
+proxy IP should choose `local` and re-run `netclaw init --resume` later.
 
 Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
 including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),

--- a/feeds/skills/.system/files/netclaw-operations/SKILL.md
+++ b/feeds/skills/.system/files/netclaw-operations/SKILL.md
@@ -773,8 +773,9 @@ collect `Daemon.Host` (must be non-loopback) and `Daemon.TrustedProxies` (≥1
 entry required, comma-separated). The wizard refuses to advance past the
 trusted-proxies prompt with an empty list — the same minimum the daemon
 validator enforces at startup — so an operator who does not yet know their
-proxy IP should choose `local` and re-run `netclaw init` later — the wizard
-auto-resumes incomplete onboarding by skipping already-completed steps.
+proxy IP should choose `local` and re-run `netclaw init` later, supplying the
+bind address and trusted proxies on the second pass once the proxy topology
+is known.
 
 Config files: `~/.netclaw/config/netclaw.json` (daemon-owned base config,
 including `Daemon.Host`, `Daemon.Port`, `Daemon.ExposureMode`),

--- a/scripts/smoke/run-smoke.sh
+++ b/scripts/smoke/run-smoke.sh
@@ -53,7 +53,7 @@ SMOKE_LOG_DIR="${SMOKE_LOG_DIR:-${ROOT_DIR}/smoke-logs}"
 
 # Cheapest harness checks first so a harness-level break fails fast
 # before paying for the wizard + probe tapes.
-LIGHT_TAPES=(help init-wizard provider-add provider-rename tui-cleanup)
+LIGHT_TAPES=(help init-wizard init-wizard-reverse-proxy provider-add provider-rename tui-cleanup)
 FULL_TAPES=("${LIGHT_TAPES[@]}")
 
 LIGHT_SCENARIOS=(

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -347,7 +347,7 @@ public sealed class ExposureModeStepViewModelTests : WizardStepTestBase
         var daemon = (Dictionary<string, object>)config["Daemon"];
         Assert.Equal("reverse-proxy", daemon["ExposureMode"]);
         Assert.Equal("10.0.0.5", daemon["Host"]);
-        Assert.Equal(new[] { "10.0.0.0/24", "192.168.1.5" }, (string[])daemon["TrustedProxies"]);
+        Assert.Equal(new[] { "10.0.0.0/24", "192.168.1.5" }, (IEnumerable<string>)daemon["TrustedProxies"]);
     }
 
     [Fact]

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -405,8 +405,10 @@ public sealed class ExposureModeStepViewModelTests : WizardStepTestBase
         Assert.True(step.TryAdvance());
         Assert.Equal(step.ReverseProxyTrustedProxiesSubStep, step.CurrentSubStep);
 
-        // Gate: cannot advance with empty trusted proxies.
-        Assert.False(step.TryAdvance());
+        // Gate: blocked on empty trusted proxies. Returns true ("handled — staying put")
+        // so the orchestrator does NOT interpret it as step-complete and skip ahead.
+        // The sub-step pointer must not move.
+        Assert.True(step.TryAdvance());
         Assert.Equal(step.ReverseProxyTrustedProxiesSubStep, step.CurrentSubStep);
 
         step.TrustedProxies = ["10.0.0.0/24"];

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -477,29 +477,6 @@ public sealed class ExposureModeStepViewModelTests : WizardStepTestBase
     }
 
     [Fact]
-    public void IsReverseProxy_OnlyTrueForReverseProxyMode()
-    {
-        using var step = new ExposureModeStepViewModel();
-
-        foreach (var mode in Enum.GetValues<ExposureMode>())
-        {
-            step.SelectedMode = mode;
-            Assert.Equal(mode == ExposureMode.ReverseProxy, step.IsReverseProxy);
-        }
-    }
-
-    [Fact]
-    public void IsHighRisk_ReverseProxy_IsFalse()
-    {
-        // Reverse proxy is medium-risk (operator-managed perimeter), not high-risk
-        // (public internet without operator-managed perimeter).
-        using var step = new ExposureModeStepViewModel();
-        step.SelectedMode = ExposureMode.ReverseProxy;
-
-        Assert.False(step.IsHighRisk);
-    }
-
-    [Fact]
     public void ContributeSecrets_ReverseProxy_AddsDeviceToken()
     {
         // Reverse proxy is non-local, so the bootstrap device must still be

--- a/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
+++ b/src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs
@@ -274,6 +274,7 @@ public sealed class ExposureModeStepViewModelTests : WizardStepTestBase
 
     [Theory]
     [InlineData(ExposureMode.Local, 2, 1)]
+    [InlineData(ExposureMode.ReverseProxy, 5, 4)]
     [InlineData(ExposureMode.TailscaleServe, 3, 2)]
     [InlineData(ExposureMode.TailscaleFunnel, 3, 2)]
     [InlineData(ExposureMode.CloudflareTunnel, 3, 2)]
@@ -284,6 +285,231 @@ public sealed class ExposureModeStepViewModelTests : WizardStepTestBase
 
         Assert.Equal(expectedSubStepCount, step.SubStepCount);
         Assert.Equal(expectedWebhookSubStep, step.WebhookSubStep);
+    }
+
+    // ── Reverse proxy — config emission ──────────────────────────────────────
+
+    [Fact]
+    public void ContributeConfig_ReverseProxy_WritesHostAndTrustedProxies()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.ReverseProxy;
+        step.Host = "10.0.0.5";
+        step.TrustedProxies = ["10.0.0.0/24", "192.168.1.5"];
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Daemon);
+        Assert.Equal(ExposureMode.ReverseProxy, builder.Daemon.ExposureMode);
+        Assert.Equal("10.0.0.5", builder.Daemon.Host);
+        Assert.Equal(["10.0.0.0/24", "192.168.1.5"], builder.Daemon.TrustedProxies);
+    }
+
+    [Theory]
+    [InlineData(ExposureMode.TailscaleServe)]
+    [InlineData(ExposureMode.TailscaleFunnel)]
+    [InlineData(ExposureMode.CloudflareTunnel)]
+    public void ContributeConfig_NonReverseProxy_DoesNotEmitHostOrTrustedProxies(ExposureMode mode)
+    {
+        // Even if Host / TrustedProxies were collected on a previous reverse-proxy
+        // pass and the operator backed out to switch modes, we must not leak them
+        // into a tailscale/cloudflare Daemon section.
+        using var step = new ExposureModeStepViewModel();
+        step.Host = "10.0.0.5";
+        step.TrustedProxies = ["10.0.0.0/24"];
+        step.SelectedMode = mode;
+
+        var builder = new WizardConfigBuilder(Context.Paths);
+        step.ContributeConfig(builder);
+
+        Assert.NotNull(builder.Daemon);
+        Assert.Null(builder.Daemon.Host);
+        Assert.Empty(builder.Daemon.TrustedProxies);
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_ReverseProxy_WritesHostAndTrustedProxies()
+    {
+        var builder = new WizardConfigBuilder(Context.Paths)
+        {
+            Daemon = new DaemonConfigSection
+            {
+                ExposureMode = ExposureMode.ReverseProxy,
+                Host = "10.0.0.5",
+                TrustedProxies = ["10.0.0.0/24", "192.168.1.5"],
+            }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        Assert.True(config.ContainsKey("Daemon"));
+        var daemon = (Dictionary<string, object>)config["Daemon"];
+        Assert.Equal("reverse-proxy", daemon["ExposureMode"]);
+        Assert.Equal("10.0.0.5", daemon["Host"]);
+        Assert.Equal(new[] { "10.0.0.0/24", "192.168.1.5" }, (string[])daemon["TrustedProxies"]);
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_ReverseProxy_EmptyTrustedProxies_OmitsTrustedProxiesKey()
+    {
+        var builder = new WizardConfigBuilder(Context.Paths)
+        {
+            Daemon = new DaemonConfigSection
+            {
+                ExposureMode = ExposureMode.ReverseProxy,
+                Host = "10.0.0.5",
+                TrustedProxies = [],
+            }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        var daemon = (Dictionary<string, object>)config["Daemon"];
+        Assert.Equal("reverse-proxy", daemon["ExposureMode"]);
+        Assert.Equal("10.0.0.5", daemon["Host"]);
+        Assert.False(daemon.ContainsKey("TrustedProxies"));
+    }
+
+    [Fact]
+    public void BuildConfigDictionary_NonReverseProxy_OmitsHostAndTrustedProxies()
+    {
+        // Defensive: even if a caller populates Host/TrustedProxies on the builder
+        // for a non-reverse-proxy mode, the serializer should still emit them when
+        // explicitly present — guarding against leakage is the ViewModel's job
+        // (see ContributeConfig_NonReverseProxy_DoesNotEmitHostOrTrustedProxies).
+        var builder = new WizardConfigBuilder(Context.Paths)
+        {
+            Daemon = new DaemonConfigSection { ExposureMode = ExposureMode.TailscaleServe }
+        };
+
+        var config = builder.BuildConfigDictionary();
+
+        var daemon = (Dictionary<string, object>)config["Daemon"];
+        Assert.False(daemon.ContainsKey("Host"));
+        Assert.False(daemon.ContainsKey("TrustedProxies"));
+    }
+
+    // ── Reverse proxy — sub-step navigation ──────────────────────────────────
+
+    [Fact]
+    public void TryAdvance_ReverseProxy_WalksMode_Host_TrustedProxies_Notice_Webhook()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.ReverseProxy;
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(step.ReverseProxyHostSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(step.ReverseProxyTrustedProxiesSubStep, step.CurrentSubStep);
+
+        // Gate: cannot advance with empty trusted proxies.
+        Assert.False(step.TryAdvance());
+        Assert.Equal(step.ReverseProxyTrustedProxiesSubStep, step.CurrentSubStep);
+
+        step.TrustedProxies = ["10.0.0.0/24"];
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(step.NoticeSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryAdvance());
+        Assert.Equal(step.WebhookSubStep, step.CurrentSubStep);
+
+        Assert.False(step.TryAdvance()); // step complete
+    }
+
+    [Fact]
+    public void TryGoBack_ReverseProxy_FromWebhook_WalksBackThroughEachSubStep()
+    {
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.ReverseProxy;
+        step.Host = "10.0.0.5";
+        step.TrustedProxies = ["10.0.0.0/24"];
+
+        step.TryAdvance(); // host
+        step.TryAdvance(); // trusted proxies
+        step.TryAdvance(); // notice
+        step.TryAdvance(); // webhook
+        Assert.Equal(step.WebhookSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryGoBack());
+        Assert.Equal(step.NoticeSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryGoBack());
+        Assert.Equal(step.ReverseProxyTrustedProxiesSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryGoBack());
+        Assert.Equal(step.ReverseProxyHostSubStep, step.CurrentSubStep);
+
+        Assert.True(step.TryGoBack());
+        Assert.Equal(0, step.CurrentSubStep);
+
+        Assert.False(step.TryGoBack());
+    }
+
+    [Fact]
+    public void OnEnter_Back_AfterModeDowngrade_ClampsToNewSubStepCount()
+    {
+        // Operator selects reverse-proxy, walks to webhook (sub-step 4),
+        // leaves this wizard step, comes back via Back, switches mode to Local.
+        // The high-water mark from reverse-proxy (4) must NOT restore us past
+        // Local's max sub-step index (SubStepCount - 1 == 1).
+        using var step = new ExposureModeStepViewModel();
+        step.OnEnter(Context, NavigationDirection.Forward);
+        step.SelectedMode = ExposureMode.ReverseProxy;
+        step.TrustedProxies = ["10.0.0.0/24"];
+        step.TryAdvance();
+        step.TryAdvance();
+        step.TryAdvance();
+        step.TryAdvance();
+        Assert.Equal(4, step.CurrentSubStep);
+
+        step.OnLeave();
+        step.SelectedMode = ExposureMode.Local;
+        step.OnEnter(Context, NavigationDirection.Back);
+
+        Assert.InRange(step.CurrentSubStep, 0, step.SubStepCount - 1);
+    }
+
+    [Fact]
+    public void IsReverseProxy_OnlyTrueForReverseProxyMode()
+    {
+        using var step = new ExposureModeStepViewModel();
+
+        foreach (var mode in Enum.GetValues<ExposureMode>())
+        {
+            step.SelectedMode = mode;
+            Assert.Equal(mode == ExposureMode.ReverseProxy, step.IsReverseProxy);
+        }
+    }
+
+    [Fact]
+    public void IsHighRisk_ReverseProxy_IsFalse()
+    {
+        // Reverse proxy is medium-risk (operator-managed perimeter), not high-risk
+        // (public internet without operator-managed perimeter).
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.ReverseProxy;
+
+        Assert.False(step.IsHighRisk);
+    }
+
+    [Fact]
+    public void ContributeSecrets_ReverseProxy_AddsDeviceToken()
+    {
+        // Reverse proxy is non-local, so the bootstrap device must still be
+        // generated to give the operator a way to pair the first remote client.
+        using var step = new ExposureModeStepViewModel();
+        step.SelectedMode = ExposureMode.ReverseProxy;
+
+        var builder = new WizardSecretsBuilder(Context.Paths);
+        step.ContributeSecrets(builder);
+
+        Assert.NotNull(step.BootstrapRawToken);
+        Assert.NotNull(step.BootstrapDevice);
     }
 
     // ── Bootstrap device pairing (#540) ──────────────────────────────────────

--- a/src/Netclaw.Cli/Tui/Wizard/IWizardStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/IWizardStepViewModel.cs
@@ -47,8 +47,11 @@ public interface IWizardStepViewModel : IDisposable
     string GetHelpText();
 
     /// <summary>
-    /// Attempt to advance within the step (next sub-step or validation trigger).
-    /// Returns <c>true</c> if the step handled the advance internally (sub-step change).
+    /// Attempt to advance within the step.
+    /// Returns <c>true</c> if the step handled the advance internally — either by moving
+    /// to the next sub-step OR by staying on the current sub-step because an in-step
+    /// validation gate blocked the advance. In both cases the orchestrator should NOT
+    /// move to the next wizard step.
     /// Returns <c>false</c> when the step is complete and the orchestrator should move forward.
     /// </summary>
     bool TryAdvance();

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
@@ -22,9 +22,6 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 /// </summary>
 public sealed class ExposureModeStepView : IWizardStepView
 {
-    /// <summary>Default daemon port when the operator does not override it via netclaw.json.</summary>
-    private const int DefaultDaemonPort = 5199;
-
     private IDisposable? _modeList;
     private SelectionListNode<string>? _confirmList;
     private IDisposable? _webhookList;
@@ -54,7 +51,6 @@ public sealed class ExposureModeStepView : IWizardStepView
         if (vm.CurrentSubStep == vm.WebhookSubStep)
             return BuildWebhookToggle(vm, callbacks);
 
-        // Sub-step 1 confirmation (non-reverse-proxy non-Local modes only)
         return BuildConfirmation(vm, callbacks);
     }
 
@@ -343,7 +339,7 @@ public sealed class ExposureModeStepView : IWizardStepView
         var displayHost = host;
         if (host.Contains(':') && !host.StartsWith('['))
             displayHost = $"[{host}]";
-        return $"http://{displayHost}:{DefaultDaemonPort}";
+        return $"http://{displayHost}:{DaemonConfig.DefaultPort}";
     }
 
     public bool HandleKeyPress(KeyPressed key)

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="ExposureModeStepView.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
@@ -14,18 +14,24 @@ using Termina.Terminal;
 namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
-/// Termina view for the ExposureMode wizard step.
-/// Sub-step 0: mode selection list (four modes, local pre-selected).
-/// Sub-step 1 (non-local only): informational notice (tailscale-serve) or high-risk warning
-///             with explicit confirmation (tailscale-funnel, cloudflare-tunnel).
-/// Last sub-step: inbound webhook enable/disable toggle.
+/// Termina view for the ExposureMode wizard step. Sub-step layout depends on the
+/// selected mode — see <see cref="ExposureModeStepViewModel"/> summary.
+///
+/// Reverse-proxy adds three sub-steps: bind-address input, trusted-proxies input,
+/// and an informational notice that echoes the resulting serving URL.
 /// </summary>
 public sealed class ExposureModeStepView : IWizardStepView
 {
+    /// <summary>Default daemon port when the operator does not override it via netclaw.json.</summary>
+    private const int DefaultDaemonPort = 5199;
+
     private IDisposable? _modeList;
     private SelectionListNode<string>? _confirmList;
     private IDisposable? _webhookList;
+    private TextInputNode? _hostInput;
+    private TextInputNode? _trustedProxiesInput;
     private IFocusable? _lastFocusedList;
+    private TextInputNode? _lastFocusedInput;
 
     public string StepId => WizardStepIds.ExposureMode;
 
@@ -36,10 +42,19 @@ public sealed class ExposureModeStepView : IWizardStepView
         if (vm.CurrentSubStep == 0)
             return BuildModeSelection(vm, callbacks);
 
+        if (vm.IsReverseProxy && vm.CurrentSubStep == vm.ReverseProxyHostSubStep)
+            return BuildReverseProxyHost(vm, callbacks);
+
+        if (vm.IsReverseProxy && vm.CurrentSubStep == vm.ReverseProxyTrustedProxiesSubStep)
+            return BuildReverseProxyTrustedProxies(vm, callbacks);
+
+        if (vm.IsReverseProxy && vm.CurrentSubStep == vm.NoticeSubStep)
+            return BuildReverseProxyNotice(vm, callbacks);
+
         if (vm.CurrentSubStep == vm.WebhookSubStep)
             return BuildWebhookToggle(vm, callbacks);
 
-        // Sub-step 1 confirmation (non-Local modes only)
+        // Sub-step 1 confirmation (non-reverse-proxy non-Local modes only)
         return BuildConfirmation(vm, callbacks);
     }
 
@@ -47,6 +62,8 @@ public sealed class ExposureModeStepView : IWizardStepView
     {
         var localOption = new SelectionOption<ExposureMode>(ExposureMode.Local,
             "Local — loopback only, safest (recommended)");
+        var reverseProxyOption = new SelectionOption<ExposureMode>(ExposureMode.ReverseProxy,
+            "Reverse Proxy — behind nginx, Caddy, Traefik, IIS, ALB, etc.");
         var serveOption = new SelectionOption<ExposureMode>(ExposureMode.TailscaleServe,
             "Tailscale Serve — accessible within your tailnet");
         var funnelOption = new SelectionOption<ExposureMode>(ExposureMode.TailscaleFunnel,
@@ -55,15 +72,19 @@ public sealed class ExposureModeStepView : IWizardStepView
             "Cloudflare Tunnel — public internet ⚠");
 
         var modeList = Layouts.SelectionList<SelectionOption<ExposureMode>>(
-                [localOption, serveOption, funnelOption, cloudflareOption], static o => o.ToString())
+                [localOption, reverseProxyOption, serveOption, funnelOption, cloudflareOption],
+                static o => o.ToString())
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
 
         _modeList = modeList;
         modeList.OnFocused();
         _lastFocusedList = modeList;
+        _lastFocusedInput = null;
         _confirmList = null;
         _webhookList = null;
+        _hostInput = null;
+        _trustedProxiesInput = null;
 
         modeList.SelectionConfirmed
             .Subscribe(selected =>
@@ -85,10 +106,133 @@ public sealed class ExposureModeStepView : IWizardStepView
                 .WithForeground(Color.BrightBlack));
     }
 
+    private ILayoutNode BuildReverseProxyHost(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _modeList = null;
+        _confirmList = null;
+        _webhookList = null;
+        _trustedProxiesInput = null;
+
+        _hostInput = new TextInputNode().WithPlaceholder(ExposureModeStepViewModel.DefaultReverseProxyHost);
+        _hostInput.Text = vm.Host;
+        _hostInput.OnFocused();
+        _lastFocusedInput = _hostInput;
+        _lastFocusedList = null;
+
+        _hostInput.Submitted
+            .Subscribe(text =>
+            {
+                vm.Host = string.IsNullOrWhiteSpace(text)
+                    ? ExposureModeStepViewModel.DefaultReverseProxyHost
+                    : text.Trim();
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Reverse proxy: bind address").WithForeground(Color.White))
+            .WithChild(new TextNode("  Daemon will listen on this address. Loopback (127.0.0.1, ::1) is not allowed —")
+                .WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("  loopback auto-auth cannot be inherited through a proxy.")
+                .WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(WizardStepHelpers.BuildTextInputPanel(_hostInput, "Bind address"));
+    }
+
+    private ILayoutNode BuildReverseProxyTrustedProxies(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _modeList = null;
+        _confirmList = null;
+        _webhookList = null;
+        _hostInput = null;
+
+        _trustedProxiesInput = new TextInputNode().WithPlaceholder("10.0.0.0/24, 192.168.1.5");
+        _trustedProxiesInput.Text = string.Join(", ", vm.TrustedProxies);
+        _trustedProxiesInput.OnFocused();
+        _lastFocusedInput = _trustedProxiesInput;
+        _lastFocusedList = null;
+
+        _trustedProxiesInput.Submitted
+            .Subscribe(text =>
+            {
+                var parsed = WizardStepHelpers.ParseUserIds(text);
+                vm.TrustedProxies = parsed;
+
+                // The ViewModel gate also blocks advance on empty input, but we redraw here
+                // so the help line below the input reflects the latest state immediately.
+                if (parsed.Count == 0)
+                {
+                    callbacks.InvalidateAndRedraw();
+                    return;
+                }
+                callbacks.AdvanceStep();
+            })
+            .DisposeWith(callbacks.Subscriptions);
+
+        var helpLine = vm.TrustedProxies.Count == 0
+            ? new TextNode("  At least one IP or CIDR is required — the daemon will not start without it.")
+                .WithForeground(Color.Yellow)
+            : new TextNode($"  {vm.TrustedProxies.Count} trusted proxy entr{(vm.TrustedProxies.Count == 1 ? "y" : "ies")} captured. Press Enter again to continue.")
+                .WithForeground(Color.BrightBlack);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Reverse proxy: trusted proxies").WithForeground(Color.White))
+            .WithChild(new TextNode("  Comma-separated IP addresses or CIDR ranges. Forwarded headers from any")
+                .WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("  other source will be ignored.")
+                .WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(WizardStepHelpers.BuildTextInputPanel(_trustedProxiesInput, "Trusted proxies"))
+            .WithChild(helpLine);
+    }
+
+    private ILayoutNode BuildReverseProxyNotice(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
+    {
+        _modeList = null;
+        _webhookList = null;
+        _hostInput = null;
+        _trustedProxiesInput = null;
+
+        _confirmList = Layouts.SelectionList("Got it — continue")
+            .WithMode(SelectionMode.Single)
+            .WithHighlightColors(Color.Black, Color.Cyan);
+
+        _confirmList.OnFocused();
+        _lastFocusedList = _confirmList;
+        _lastFocusedInput = null;
+
+        _confirmList.SelectionConfirmed
+            .Subscribe(_ => callbacks.AdvanceStep())
+            .DisposeWith(callbacks.Subscriptions);
+
+        var servingUrl = FormatServingUrl(vm.Host);
+        var proxiesLabel = vm.TrustedProxies.Count == 0
+            ? "(none)"
+            : string.Join(", ", vm.TrustedProxies);
+
+        return Layouts.Vertical()
+            .WithChild(new TextNode("  Reverse proxy configured").WithForeground(Color.Cyan))
+            .WithSpacing(1)
+            .WithChild(new TextNode($"  Daemon will listen on:    {servingUrl}").WithForeground(Color.White))
+            .WithChild(new TextNode($"  Trusted proxies:          {proxiesLabel}").WithForeground(Color.White))
+            .WithSpacing(1)
+            .WithChild(new TextNode($"  Point your reverse proxy at {servingUrl} and terminate TLS at").WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("  the proxy. Forwarded headers from any other source IP will be ignored.").WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(new TextNode("  You are responsible for:").WithForeground(Color.White))
+            .WithChild(new TextNode("    • Terminating TLS at the proxy").WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("    • Restricting inbound access at the proxy / firewall").WithForeground(Color.BrightBlack))
+            .WithChild(new TextNode("    • Setting X-Forwarded-For and X-Forwarded-Proto correctly").WithForeground(Color.BrightBlack))
+            .WithSpacing(1)
+            .WithChild(_confirmList);
+    }
+
     private ILayoutNode BuildConfirmation(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
     {
         _modeList = null;
         _webhookList = null;
+        _hostInput = null;
+        _trustedProxiesInput = null;
 
         if (vm.IsHighRisk)
             return BuildHighRiskWarning(vm, callbacks);
@@ -108,6 +252,7 @@ public sealed class ExposureModeStepView : IWizardStepView
 
         _confirmList.OnFocused();
         _lastFocusedList = _confirmList;
+        _lastFocusedInput = null;
 
         _confirmList.SelectionConfirmed
             .Subscribe(_ => callbacks.AdvanceStep())
@@ -133,6 +278,7 @@ public sealed class ExposureModeStepView : IWizardStepView
 
         _confirmList.OnFocused();
         _lastFocusedList = _confirmList;
+        _lastFocusedInput = null;
 
         _confirmList.SelectionConfirmed
             .Subscribe(_ => callbacks.AdvanceStep())
@@ -157,6 +303,8 @@ public sealed class ExposureModeStepView : IWizardStepView
 
         _modeList = null;
         _confirmList = null;
+        _hostInput = null;
+        _trustedProxiesInput = null;
 
         var webhookList = Layouts.SelectionList<SelectionOption<bool>>(
                 [disableOption, enableOption], static o => o.ToString())
@@ -166,6 +314,7 @@ public sealed class ExposureModeStepView : IWizardStepView
         _webhookList = webhookList;
         webhookList.OnFocused();
         _lastFocusedList = webhookList;
+        _lastFocusedInput = null;
 
         webhookList.SelectionConfirmed
             .Subscribe(selected =>
@@ -189,6 +338,14 @@ public sealed class ExposureModeStepView : IWizardStepView
                 .WithForeground(Color.BrightBlack));
     }
 
+    private static string FormatServingUrl(string host)
+    {
+        var displayHost = host;
+        if (host.Contains(':') && !host.StartsWith('['))
+            displayHost = $"[{host}]";
+        return $"http://{displayHost}:{DefaultDaemonPort}";
+    }
+
     public bool HandleKeyPress(KeyPressed key)
     {
         if (_lastFocusedList is not null)
@@ -196,19 +353,27 @@ public sealed class ExposureModeStepView : IWizardStepView
             _lastFocusedList.HandleInput(key.KeyInfo);
             return true;
         }
+        if (_lastFocusedInput is not null)
+        {
+            _lastFocusedInput.HandleInput(key.KeyInfo);
+            return true;
+        }
         return false;
     }
 
     public void HandlePaste(PasteEvent paste)
     {
-        // No text inputs in this step
+        _lastFocusedInput?.HandlePaste(paste);
     }
 
     public void ClearFocusState()
     {
         _lastFocusedList = null;
+        _lastFocusedInput = null;
         _modeList = null;
         _confirmList = null;
         _webhookList = null;
+        _hostInput = null;
+        _trustedProxiesInput = null;
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Net;
+using System.Net.Sockets;
 using Netclaw.Configuration;
 using R3;
 using Termina.Extensions;
@@ -29,6 +31,12 @@ public sealed class ExposureModeStepView : IWizardStepView
     private TextInputNode? _trustedProxiesInput;
     private IFocusable? _lastFocusedList;
     private TextInputNode? _lastFocusedInput;
+
+    // Transient validation error messages, set by submit handlers and rendered
+    // above the corresponding input on the next layout build. Cleared on every
+    // ClearFocusState (i.e. when navigating away from this wizard step).
+    private string? _hostInputError;
+    private string? _trustedProxiesInputError;
 
     public string StepId => WizardStepIds.ExposureMode;
 
@@ -104,11 +112,6 @@ public sealed class ExposureModeStepView : IWizardStepView
 
     private ILayoutNode BuildReverseProxyHost(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _modeList = null;
-        _confirmList = null;
-        _webhookList = null;
-        _trustedProxiesInput = null;
-
         _hostInput = new TextInputNode().WithPlaceholder(ExposureModeStepViewModel.DefaultReverseProxyHost);
         _hostInput.Text = vm.Host;
         _hostInput.OnFocused();
@@ -118,30 +121,42 @@ public sealed class ExposureModeStepView : IWizardStepView
         _hostInput.Submitted
             .Subscribe(text =>
             {
-                vm.Host = string.IsNullOrWhiteSpace(text)
+                var candidate = string.IsNullOrWhiteSpace(text)
                     ? ExposureModeStepViewModel.DefaultReverseProxyHost
                     : text.Trim();
+
+                // Mirror DaemonExposureValidator.IsLoopbackHost — reject inline so the
+                // operator sees the error in the wizard instead of at daemon startup.
+                if (DaemonExposureValidator.IsLoopbackHost(candidate))
+                {
+                    _hostInputError = $"'{candidate}' is loopback — not allowed for reverse-proxy mode. Use a non-loopback bind address (e.g. 0.0.0.0 or this host's internal IP).";
+                    callbacks.InvalidateAndRedraw();
+                    return;
+                }
+
+                _hostInputError = null;
+                vm.Host = candidate;
                 callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
 
-        return Layouts.Vertical()
+        var layout = Layouts.Vertical()
             .WithChild(new TextNode("  Reverse proxy: bind address").WithForeground(Color.White))
-            .WithChild(new TextNode("  Daemon will listen on this address. Loopback (127.0.0.1, ::1) is not allowed —")
+            .WithChild(new TextNode("  Daemon will listen on this address. Loopback (127.0.0.1, ::1, localhost)")
                 .WithForeground(Color.BrightBlack))
-            .WithChild(new TextNode("  loopback auto-auth cannot be inherited through a proxy.")
+            .WithChild(new TextNode("  is not allowed — loopback auto-auth cannot be inherited through a proxy.")
                 .WithForeground(Color.BrightBlack))
             .WithSpacing(1)
             .WithChild(WizardStepHelpers.BuildTextInputPanel(_hostInput, "Bind address"));
+
+        if (_hostInputError is not null)
+            layout = layout.WithChild(new TextNode($"  ✗ {_hostInputError}").WithForeground(Color.Red));
+
+        return layout;
     }
 
     private ILayoutNode BuildReverseProxyTrustedProxies(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _modeList = null;
-        _confirmList = null;
-        _webhookList = null;
-        _hostInput = null;
-
         _trustedProxiesInput = new TextInputNode().WithPlaceholder("10.0.0.0/24, 192.168.1.5");
         _trustedProxiesInput.Text = string.Join(", ", vm.TrustedProxies);
         _trustedProxiesInput.OnFocused();
@@ -152,15 +167,40 @@ public sealed class ExposureModeStepView : IWizardStepView
             .Subscribe(text =>
             {
                 var parsed = WizardStepHelpers.ParseUserIds(text);
-                vm.TrustedProxies = parsed;
 
-                // The ViewModel gate also blocks advance on empty input, but we redraw here
-                // so the help line below the input reflects the latest state immediately.
+                // Empty submit: do NOT overwrite previously captured entries. The yellow
+                // help-line below the input already tells the operator what's required;
+                // we add an inline error indicator so a no-op Enter is visibly distinct
+                // from a successful submit.
                 if (parsed.Count == 0)
                 {
+                    _trustedProxiesInputError = vm.TrustedProxies.Count > 0
+                        ? "Empty input ignored — your previous entries are kept. Enter to continue, or type new values to replace them."
+                        : "Empty input rejected — enter at least one IP or CIDR.";
                     callbacks.InvalidateAndRedraw();
                     return;
                 }
+
+                // Per-entry IP/CIDR validation — same canonical helper the daemon uses
+                // at startup (DaemonExposureValidator.TryParseTrustedProxy). The wizard's
+                // job is to produce a config the daemon will actually start with; let
+                // the operator fix typos here, not after the wizard exits.
+                var errors = new List<string>();
+                foreach (var entry in parsed)
+                {
+                    if (!DaemonExposureValidator.TryParseTrustedProxy(entry, out _, out var error))
+                        errors.Add(error ?? $"'{entry}' is not a valid IP or CIDR.");
+                }
+
+                if (errors.Count > 0)
+                {
+                    _trustedProxiesInputError = string.Join("  ", errors);
+                    callbacks.InvalidateAndRedraw();
+                    return;
+                }
+
+                _trustedProxiesInputError = null;
+                vm.TrustedProxies = parsed;
                 callbacks.AdvanceStep();
             })
             .DisposeWith(callbacks.Subscriptions);
@@ -168,10 +208,10 @@ public sealed class ExposureModeStepView : IWizardStepView
         var helpLine = vm.TrustedProxies.Count == 0
             ? new TextNode("  At least one IP or CIDR is required — the daemon will not start without it.")
                 .WithForeground(Color.Yellow)
-            : new TextNode($"  {vm.TrustedProxies.Count} trusted proxy entr{(vm.TrustedProxies.Count == 1 ? "y" : "ies")} captured. Press Enter again to continue.")
+            : new TextNode($"  {vm.TrustedProxies.Count} trusted proxy entr{(vm.TrustedProxies.Count == 1 ? "y" : "ies")} captured. Press Enter to continue.")
                 .WithForeground(Color.BrightBlack);
 
-        return Layouts.Vertical()
+        var layout = Layouts.Vertical()
             .WithChild(new TextNode("  Reverse proxy: trusted proxies").WithForeground(Color.White))
             .WithChild(new TextNode("  Comma-separated IP addresses or CIDR ranges. Forwarded headers from any")
                 .WithForeground(Color.BrightBlack))
@@ -180,15 +220,15 @@ public sealed class ExposureModeStepView : IWizardStepView
             .WithSpacing(1)
             .WithChild(WizardStepHelpers.BuildTextInputPanel(_trustedProxiesInput, "Trusted proxies"))
             .WithChild(helpLine);
+
+        if (_trustedProxiesInputError is not null)
+            layout = layout.WithChild(new TextNode($"  ✗ {_trustedProxiesInputError}").WithForeground(Color.Red));
+
+        return layout;
     }
 
     private ILayoutNode BuildReverseProxyNotice(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _modeList = null;
-        _webhookList = null;
-        _hostInput = null;
-        _trustedProxiesInput = null;
-
         _confirmList = Layouts.SelectionList("Got it — continue")
             .WithMode(SelectionMode.Single)
             .WithHighlightColors(Color.Black, Color.Cyan);
@@ -197,23 +237,38 @@ public sealed class ExposureModeStepView : IWizardStepView
         _lastFocusedList = _confirmList;
         _lastFocusedInput = null;
 
-        _confirmList.SelectionConfirmed
-            .Subscribe(_ => callbacks.AdvanceStep())
-            .DisposeWith(callbacks.Subscriptions);
-
         var servingUrl = FormatServingUrl(vm.Host);
+        var bindsToAllInterfaces = vm.Host == "0.0.0.0" || vm.Host == "::";
         var proxiesLabel = vm.TrustedProxies.Count == 0
             ? "(none)"
             : string.Join(", ", vm.TrustedProxies);
 
-        return Layouts.Vertical()
+        _confirmList.SelectionConfirmed
+            .Subscribe(_ => callbacks.AdvanceStep())
+            .DisposeWith(callbacks.Subscriptions);
+
+        var layout = Layouts.Vertical()
             .WithChild(new TextNode("  Reverse proxy configured").WithForeground(Color.Cyan))
             .WithSpacing(1)
-            .WithChild(new TextNode($"  Daemon will listen on:    {servingUrl}").WithForeground(Color.White))
+            .WithChild(new TextNode($"  Daemon listen address:    {servingUrl}").WithForeground(Color.White))
             .WithChild(new TextNode($"  Trusted proxies:          {proxiesLabel}").WithForeground(Color.White))
-            .WithSpacing(1)
-            .WithChild(new TextNode($"  Point your reverse proxy at {servingUrl} and terminate TLS at").WithForeground(Color.BrightBlack))
-            .WithChild(new TextNode("  the proxy. Forwarded headers from any other source IP will be ignored.").WithForeground(Color.BrightBlack))
+            .WithSpacing(1);
+
+        if (bindsToAllInterfaces)
+        {
+            layout = layout
+                .WithChild(new TextNode($"  {vm.Host} binds all interfaces. In your reverse proxy's upstream config,").WithForeground(Color.BrightBlack))
+                .WithChild(new TextNode($"  use a reachable address: this host's loopback if the proxy runs on the").WithForeground(Color.BrightBlack))
+                .WithChild(new TextNode($"  same machine, or this host's LAN/internal IP if the proxy is remote.").WithForeground(Color.BrightBlack));
+        }
+        else
+        {
+            layout = layout
+                .WithChild(new TextNode($"  Point your reverse proxy at {servingUrl} and terminate TLS at").WithForeground(Color.BrightBlack))
+                .WithChild(new TextNode("  the proxy. Forwarded headers from any other source IP will be ignored.").WithForeground(Color.BrightBlack));
+        }
+
+        return layout
             .WithSpacing(1)
             .WithChild(new TextNode("  You are responsible for:").WithForeground(Color.White))
             .WithChild(new TextNode("    • Terminating TLS at the proxy").WithForeground(Color.BrightBlack))
@@ -225,11 +280,6 @@ public sealed class ExposureModeStepView : IWizardStepView
 
     private ILayoutNode BuildConfirmation(ExposureModeStepViewModel vm, StepViewCallbacks callbacks)
     {
-        _modeList = null;
-        _webhookList = null;
-        _hostInput = null;
-        _trustedProxiesInput = null;
-
         if (vm.IsHighRisk)
             return BuildHighRiskWarning(vm, callbacks);
 
@@ -297,11 +347,6 @@ public sealed class ExposureModeStepView : IWizardStepView
         var disableOption = new SelectionOption<bool>(false, "No — do not accept inbound webhooks (default)");
         var enableOption = new SelectionOption<bool>(true, "Yes — accept inbound webhook requests");
 
-        _modeList = null;
-        _confirmList = null;
-        _hostInput = null;
-        _trustedProxiesInput = null;
-
         var webhookList = Layouts.SelectionList<SelectionOption<bool>>(
                 [disableOption, enableOption], static o => o.ToString())
             .WithMode(SelectionMode.Single)
@@ -336,9 +381,15 @@ public sealed class ExposureModeStepView : IWizardStepView
 
     private static string FormatServingUrl(string host)
     {
+        // Bracket-wrap raw IPv6 addresses for URL syntax. Use IPAddress.TryParse rather
+        // than a colon-substring check so a typo like 'hostname:port' isn't treated as IPv6.
         var displayHost = host;
-        if (host.Contains(':') && !host.StartsWith('['))
+        if (!host.StartsWith('[')
+            && IPAddress.TryParse(host, out var parsed)
+            && parsed.AddressFamily == AddressFamily.InterNetworkV6)
+        {
             displayHost = $"[{host}]";
+        }
         return $"http://{displayHost}:{DaemonConfig.DefaultPort}";
     }
 
@@ -371,5 +422,7 @@ public sealed class ExposureModeStepView : IWizardStepView
         _webhookList = null;
         _hostInput = null;
         _trustedProxiesInput = null;
+        _hostInputError = null;
+        _trustedProxiesInputError = null;
     }
 }

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
@@ -119,12 +119,15 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
     {
         // Gate: cannot leave the trusted-proxies sub-step until ≥1 entry is present.
         // Mirrors DaemonExposureValidator's startup contract so the wizard never emits
-        // a config the daemon would refuse.
+        // a config the daemon would refuse. Return true (not false): per IWizardStepViewModel,
+        // true means "handled internally — stay in this step." Returning false here would
+        // tell the orchestrator the step is complete and to advance to the next wizard step,
+        // which would skip the notice + webhook sub-steps entirely.
         if (IsReverseProxy
             && _currentSubStep == ReverseProxyTrustedProxiesSubStep
             && TrustedProxies.Count == 0)
         {
-            return false;
+            return true;
         }
 
         var next = _currentSubStep + 1;

--- a/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs
@@ -15,10 +15,18 @@ namespace Netclaw.Cli.Tui.Wizard.Steps;
 
 /// <summary>
 /// Wizard step for selecting the daemon network exposure mode and inbound webhook enablement.
-/// Sub-steps: mode selection → optional confirmation/notice → webhook toggle.
+/// Sub-step plan by mode:
+///   Local:        mode → webhook (2 sub-steps)
+///   ReverseProxy: mode → bind address → trusted proxies → notice → webhook (5 sub-steps)
+///   Tailscale*/Cloudflare: mode → notice → webhook (3 sub-steps)
+/// One <c>TextInputNode</c> per sub-step matches the established wizard pattern
+/// (see SlackStepView, IdentityStepView).
 /// </summary>
 public sealed class ExposureModeStepViewModel : IWizardStepViewModel
 {
+    /// <summary>Default bind address suggested in the reverse-proxy config sub-step.</summary>
+    public const string DefaultReverseProxyHost = "0.0.0.0";
+
     private static readonly JsonSerializerOptions DevicesJsonOptions = new()
     {
         WriteIndented = true,
@@ -41,24 +49,48 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
     /// <summary>Whether inbound webhook ingestion is enabled.</summary>
     public bool WebhooksEnabled { get; set; }
 
+    /// <summary>
+    /// Bind address collected on the reverse-proxy config sub-step. Loopback / format
+    /// validation is left to <c>DaemonExposureValidator</c> and the doctor check —
+    /// the wizard does not duplicate that logic.
+    /// </summary>
+    public string Host { get; set; } = DefaultReverseProxyHost;
+
+    /// <summary>
+    /// Trusted reverse-proxy IPs / CIDR ranges collected on the reverse-proxy config sub-step.
+    /// At least one entry is required to advance past that sub-step (matches the runtime contract
+    /// in <c>DaemonExposureValidator.Validate</c>).
+    /// </summary>
+    public IReadOnlyList<string> TrustedProxies { get; set; } = [];
+
     public bool IsApplicable(WizardContext context) => true;
 
     public int CurrentSubStep => _currentSubStep;
 
-    /// <summary>
-    /// Sub-steps: mode selection + optional confirmation/notice + webhook toggle.
-    /// </summary>
-    public int SubStepCount => NeedsConfirmation ? 3 : 2;
+    /// <summary>Sub-step count varies by mode — see class summary.</summary>
+    public int SubStepCount => IsReverseProxy ? 5 : (NeedsConfirmation ? 3 : 2);
 
     /// <summary>True when the selected mode requires a confirmation or notice screen.</summary>
     internal bool NeedsConfirmation => SelectedMode != ExposureMode.Local;
+
+    /// <summary>True when the selected mode is reverse proxy.</summary>
+    internal bool IsReverseProxy => SelectedMode == ExposureMode.ReverseProxy;
 
     /// <summary>True for modes that expose the daemon to the public internet.</summary>
     public bool IsHighRisk =>
         SelectedMode is ExposureMode.TailscaleFunnel or ExposureMode.CloudflareTunnel;
 
-    /// <summary>The sub-step index for the inbound webhook toggle (always last).</summary>
-    internal int WebhookSubStep => NeedsConfirmation ? 2 : 1;
+    /// <summary>Sub-step index of the reverse-proxy bind-address input. Only valid when <see cref="IsReverseProxy"/>.</summary>
+    internal int ReverseProxyHostSubStep => 1;
+
+    /// <summary>Sub-step index of the reverse-proxy trusted-proxies input. Only valid when <see cref="IsReverseProxy"/>.</summary>
+    internal int ReverseProxyTrustedProxiesSubStep => 2;
+
+    /// <summary>The sub-step index for the confirmation/notice screen. Only valid when <see cref="NeedsConfirmation"/>.</summary>
+    internal int NoticeSubStep => IsReverseProxy ? 3 : 1;
+
+    /// <summary>The sub-step index for the inbound webhook toggle (always last in the plan).</summary>
+    internal int WebhookSubStep => SubStepCount - 1;
 
     public string GetHelpText()
     {
@@ -68,7 +100,16 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
         if (_currentSubStep == WebhookSubStep)
             return "  Inbound webhooks let external services trigger autonomous runs via HTTP POST.";
 
-        // Sub-step 1 confirmation (non-Local modes only)
+        if (IsReverseProxy && _currentSubStep == ReverseProxyHostSubStep)
+            return "  Bind to a non-loopback address. Loopback auto-auth cannot be inherited through a proxy.";
+
+        if (IsReverseProxy && _currentSubStep == ReverseProxyTrustedProxiesSubStep)
+            return "  Comma-separated IPs / CIDRs. At least one is required — the daemon refuses to start without it.";
+
+        if (IsReverseProxy && _currentSubStep == NoticeSubStep)
+            return "  Point your reverse proxy at the serving URL shown above. Press Enter to continue.";
+
+        // Notice sub-step for non-reverse-proxy modes.
         return IsHighRisk
             ? "  This mode exposes your daemon beyond your tailnet. Ensure hub authentication is configured."
             : "  Tailscale Serve limits access to your tailnet only. Press Enter to confirm.";
@@ -76,21 +117,24 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
 
     public bool TryAdvance()
     {
-        if (_currentSubStep == 0 && NeedsConfirmation)
+        // Gate: cannot leave the trusted-proxies sub-step until ≥1 entry is present.
+        // Mirrors DaemonExposureValidator's startup contract so the wizard never emits
+        // a config the daemon would refuse.
+        if (IsReverseProxy
+            && _currentSubStep == ReverseProxyTrustedProxiesSubStep
+            && TrustedProxies.Count == 0)
         {
-            _currentSubStep = 1;
-            _highWaterSubStep = 1;
-            return true; // mode selection → confirmation
+            return false;
         }
 
-        if (_currentSubStep < WebhookSubStep)
-        {
-            _currentSubStep = WebhookSubStep;
-            _highWaterSubStep = WebhookSubStep;
-            return true; // → webhook toggle
-        }
+        var next = _currentSubStep + 1;
+        if (next >= SubStepCount)
+            return false; // step complete; orchestrator advances the wizard
 
-        return false; // step complete, orchestrator advances
+        _currentSubStep = next;
+        if (_currentSubStep > _highWaterSubStep)
+            _highWaterSubStep = _currentSubStep;
+        return true;
     }
 
     public bool TryGoBack()
@@ -106,15 +150,24 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
     public void OnEnter(WizardContext context, NavigationDirection direction)
     {
         if (direction == NavigationDirection.Back)
-            _currentSubStep = _highWaterSubStep;
+        {
+            // SubStepCount depends on SelectedMode, which the operator can change
+            // at sub-step 0. Clamp so we don't restore a high-water mark from a
+            // mode with more sub-steps than the currently selected one.
+            _currentSubStep = Math.Min(_highWaterSubStep, SubStepCount - 1);
+        }
         else
+        {
             _currentSubStep = 0;
+        }
     }
 
     public void OnLeave() { }
 
     /// <summary>
     /// Writes the Daemon section (non-local modes) and Webhooks section (when enabled).
+    /// For reverse-proxy mode the section also carries the operator-supplied bind address
+    /// and trusted-proxy list — required by <c>DaemonExposureValidator</c> at startup.
     /// </summary>
     public void ContributeConfig(WizardConfigBuilder builder)
     {
@@ -122,7 +175,9 @@ public sealed class ExposureModeStepViewModel : IWizardStepViewModel
         {
             builder.Daemon = new DaemonConfigSection
             {
-                ExposureMode = SelectedMode
+                ExposureMode = SelectedMode,
+                Host = IsReverseProxy ? Host : null,
+                TrustedProxies = IsReverseProxy ? TrustedProxies : [],
             };
         }
 

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -317,7 +317,7 @@ public sealed class WizardConfigBuilder
                 daemonSection["Host"] = Daemon.Host;
 
             if (Daemon.TrustedProxies.Count > 0)
-                daemonSection["TrustedProxies"] = Daemon.TrustedProxies.ToArray();
+                daemonSection["TrustedProxies"] = Daemon.TrustedProxies;
 
             config["Daemon"] = daemonSection;
         }

--- a/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
+++ b/src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs
@@ -308,10 +308,18 @@ public sealed class WizardConfigBuilder
         // Daemon section — only written for non-default exposure modes (local = omit)
         if (Daemon is not null && Daemon.ExposureMode != ExposureMode.Local)
         {
-            config["Daemon"] = new Dictionary<string, object>
+            var daemonSection = new Dictionary<string, object>
             {
                 ["ExposureMode"] = Daemon.ExposureMode.ToWireValue()
             };
+
+            if (!string.IsNullOrWhiteSpace(Daemon.Host))
+                daemonSection["Host"] = Daemon.Host;
+
+            if (Daemon.TrustedProxies.Count > 0)
+                daemonSection["TrustedProxies"] = Daemon.TrustedProxies.ToArray();
+
+            config["Daemon"] = daemonSection;
         }
 
         // Webhooks section — only written when enabled (disabled = default, omit)
@@ -511,6 +519,20 @@ public sealed class IdentityConfigSection
 public sealed class DaemonConfigSection
 {
     public ExposureMode ExposureMode { get; init; } = ExposureMode.Local;
+
+    /// <summary>
+    /// Bind address for the daemon. Only emitted when set; the daemon defaults to
+    /// <c>127.0.0.1</c> when absent. Required (non-loopback) for
+    /// <see cref="ExposureMode.ReverseProxy"/>.
+    /// </summary>
+    public string? Host { get; init; }
+
+    /// <summary>
+    /// Trusted reverse-proxy source IPs / CIDR ranges. Only meaningful for
+    /// <see cref="ExposureMode.ReverseProxy"/>, where at least one entry is required
+    /// for the daemon to start. Emitted only when non-empty.
+    /// </summary>
+    public IReadOnlyList<string> TrustedProxies { get; init; } = [];
 }
 
 public sealed class WebhooksConfigSection

--- a/src/Netclaw.Configuration/DaemonConfig.cs
+++ b/src/Netclaw.Configuration/DaemonConfig.cs
@@ -15,14 +15,20 @@ namespace Netclaw.Configuration;
 public sealed record DaemonConfig
 {
     /// <summary>
+    /// Default TCP port the daemon listens on when <c>Daemon.Port</c> is not set
+    /// in <c>netclaw.json</c>. Single source of truth for the port literal.
+    /// </summary>
+    public const int DefaultPort = 5199;
+
+    /// <summary>
     /// IP address the daemon binds to. Defaults to loopback (<c>127.0.0.1</c>).
     /// </summary>
     public string Host { get; init; } = "127.0.0.1";
 
     /// <summary>
-    /// TCP port the daemon listens on. Defaults to <c>5199</c>.
+    /// TCP port the daemon listens on. Defaults to <see cref="DefaultPort"/>.
     /// </summary>
-    public int Port { get; init; } = 5199;
+    public int Port { get; init; } = DefaultPort;
 
     /// <summary>
     /// Declares which tunnel infrastructure (if any) is in front of the daemon.
@@ -62,7 +68,7 @@ public sealed record DaemonConfig
             return new DaemonConfig();
 
         var host = section["Host"] ?? "127.0.0.1";
-        var port = section.GetValue<int?>("Port") ?? 5199;
+        var port = section.GetValue<int?>("Port") ?? DefaultPort;
         var modeStr = section["ExposureMode"];
         var mode = ParseExposureMode(modeStr);
         var disableSelfUpdate = section.GetValue<bool?>("DisableSelfUpdate") ?? false;

--- a/src/Netclaw.Configuration/DaemonControlPlaneEndpointResolver.cs
+++ b/src/Netclaw.Configuration/DaemonControlPlaneEndpointResolver.cs
@@ -11,7 +11,7 @@ namespace Netclaw.Configuration;
 /// </summary>
 public static class DaemonControlPlaneEndpointResolver
 {
-    public const string DefaultEndpoint = "http://127.0.0.1:5199";
+    public static readonly string DefaultEndpoint = $"http://127.0.0.1:{DaemonConfig.DefaultPort}";
 
     public static string ResolveFallbackEndpoint(DaemonConfig daemonConfig)
     {

--- a/tests/smoke/assertions/init-wizard-reverse-proxy.sh
+++ b/tests/smoke/assertions/init-wizard-reverse-proxy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# init-wizard-reverse-proxy.tape post-tape assertion.
+#
+# Validates that the wizard surfaced reverse-proxy as an exposure mode and
+# produced a startable config:
+#   1) config/netclaw.json exists and parses as JSON
+#   2) `netclaw doctor` does not report errors (exit 0 = clean, exit 2 = WARN ok)
+#   3) Daemon section contains ExposureMode=reverse-proxy, Host=0.0.0.0,
+#      and TrustedProxies[0]=10.0.0.0/24 — what the tape typed.
+#   4) Bootstrap device file exists (reverse-proxy is non-local so the
+#      wizard must seed at least one paired device).
+
+set -euo pipefail
+
+. "$(dirname "$0")/_lib.sh"
+
+assert_fail=0
+
+echo "init-wizard-reverse-proxy: reading produced config..."
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "FAIL: ${CONFIG_PATH} does not exist after wizard run." >&2
+  ls -la "$NETCLAW_HOME" 2>&1 >&2 || true
+  exit 1
+fi
+
+config_json="$(read_config_json)"
+if ! printf '%s' "$config_json" | jq empty >/dev/null 2>&1; then
+  echo "FAIL: ${CONFIG_PATH} is not valid JSON." >&2
+  printf '%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "init-wizard-reverse-proxy: running 'netclaw doctor'..."
+doctor_status=0
+"$NETCLAW_SMOKE_CLI" doctor || doctor_status=$?
+if [[ $doctor_status -eq 1 ]]; then
+  echo "FAIL: netclaw doctor reported errors (exit 1)." >&2
+  exit 1
+fi
+if [[ $doctor_status -ne 0 && $doctor_status -ne 2 ]]; then
+  echo "FAIL: netclaw doctor exited with unexpected status $doctor_status." >&2
+  exit 1
+fi
+
+echo "init-wizard-reverse-proxy: checking Daemon section..."
+assert_field '.Daemon.ExposureMode'      'reverse-proxy' "$config_json" || :
+assert_field '.Daemon.Host'              '0.0.0.0'       "$config_json" || :
+assert_field '.Daemon.TrustedProxies[0]' '10.0.0.0/24'   "$config_json" || :
+
+echo "init-wizard-reverse-proxy: confirming bootstrap device was seeded..."
+devices_path="${NETCLAW_HOME}/config/devices.json"
+if [[ ! -f "$devices_path" ]]; then
+  echo "FAIL: ${devices_path} not written — bootstrap device missing." >&2
+  assert_fail=1
+else
+  device_count="$(jq 'length' "$devices_path" 2>/dev/null || echo 0)"
+  if [[ "$device_count" -lt 1 ]]; then
+    echo "FAIL: ${devices_path} contains no paired devices." >&2
+    assert_fail=1
+  else
+    echo "  ok  ${devices_path} has $device_count device(s)"
+  fi
+fi
+
+if (( assert_fail )); then
+  printf -- '--- netclaw.json contents ---\n%s\n' "$config_json" >&2
+  exit 1
+fi
+
+echo "init-wizard-reverse-proxy: assertions passed."

--- a/tests/smoke/tapes/init-wizard-reverse-proxy.tape
+++ b/tests/smoke/tapes/init-wizard-reverse-proxy.tape
@@ -117,22 +117,22 @@ Enter
 Wait+Screen@10s /Press Enter to run health checks/
 Enter
 
-# Reverse-proxy mode binds to a non-loopback address; the daemon will refuse
-# to start cleanly inside the smoke env (it tries to listen on 0.0.0.0:5199
-# which may not be reachable / may already be bound). That's fine — the
-# tape's job is to drive the wizard through the new sub-steps and produce
-# a netclaw.json; the post-tape assertion is the real signal.
+# Daemon starts on 0.0.0.0:5199 but in reverse-proxy mode the CLI cannot
+# auto-auth back to it via loopback (loopback auto-auth is intentionally
+# disabled for reverse-proxy to prevent a forwarded-header from inheriting
+# operator privileges). The wizard's chat-page handshake therefore gets 401
+# and the wizard exits to the shell instead of opening the TUI — that's
+# correct behavior, not a bug.
 #
-# The wizard may either:
-#   (a) reach the chat page after the daemon starts (if 0.0.0.0:5199 is
-#       bindable in the smoke env), or
-#   (b) hang on the health-check screen if daemon startup fails.
-#
-# Wait for whichever marker appears first within a generous window, then quit.
-Wait+Screen@120s /(Ready  \|  qwen2:0\.5b|Health checks)/
+# Wait for either terminal state:
+#   (a) chat-page ready bar (if a future change ever wires post-init differently)
+#   (b) the shell prompt re-appearing post-wizard-exit, with `netclaw init`
+#       still visible as the last-typed command
+Wait+Screen@180s /(Ready  \|  qwen2:0\.5b|TAPE\$ netclaw init)/
+# No-op if we're already at the shell; quits the TUI if (a) above.
 Ctrl+Q
 
-Wait+Screen@10s /TAPE\$/
+Wait+Screen@15s /TAPE\$ /
 
 # Sanity: re-check at the prompt that init reported success.
 Type "echo INIT_EXIT=$?"

--- a/tests/smoke/tapes/init-wizard-reverse-proxy.tape
+++ b/tests/smoke/tapes/init-wizard-reverse-proxy.tape
@@ -108,7 +108,12 @@ Wait+Screen@10s /Reverse proxy configured/
 Wait+Screen@5s /http:\/\/0\.0\.0\.0:5199/
 Enter
 
-# Sub-step 4: webhook toggle. "No" = second option.
+# Sub-step 4: webhook toggle.
+# Option order is [No (default), Yes]. Down+Enter selects "Yes — accept inbound
+# webhook requests" so the produced netclaw.json gets a Webhooks section.
+# (The assertion script does not validate the webhook choice; both branches
+# work for the smoke run. We deliberately exercise the non-default branch to
+# prove the toggle plumbing.)
 Wait+Screen@10s /Should this daemon accept inbound webhooks/
 Down
 Enter

--- a/tests/smoke/tapes/init-wizard-reverse-proxy.tape
+++ b/tests/smoke/tapes/init-wizard-reverse-proxy.tape
@@ -22,8 +22,10 @@ Enter
 
 # ─── Step 1: Provider ───────────────────────────────────────────────
 Wait+Screen@10s /Choose your LLM provider:/
-# Anthropic (default), Ollama is one Down.
-Down
+# Provider list ordering is alphabetical by TypeKey:
+#   anthropic, github-copilot, ollama, openai, openai-compatible, openrouter
+# Two Downs from the Anthropic default land on Ollama.
+Down 2
 Enter
 
 Wait+Screen@10s /endpoint:/

--- a/tests/smoke/tapes/init-wizard-reverse-proxy.tape
+++ b/tests/smoke/tapes/init-wizard-reverse-proxy.tape
@@ -1,0 +1,141 @@
+# init-wizard-reverse-proxy.tape — Personal posture, Ollama, ReverseProxy exposure.
+#
+# Variant of init-wizard.tape that exercises the reverse-proxy branch of the
+# Network Exposure step. Covers:
+#   - selecting "Reverse Proxy" from the exposure mode list (second option)
+#   - the bind-address text input (kept at the 0.0.0.0 default)
+#   - the trusted-proxies text input (one CIDR entered)
+#   - the medium-risk notice screen that shows the serving URL
+#
+# The post-tape assertion (init-wizard-reverse-proxy.sh) jq-checks the produced
+# Daemon section and runs `netclaw doctor`.
+#
+# Synchronization rule (per tapes/README.md): no literal Sleep for step
+# synchronization; every step has a Wait+Screen anchor pulled from the
+# matching *StepView.cs.
+
+Output "/tmp/tape-init-wizard-reverse-proxy.gif"
+
+# ─── Launch ──────────────────────────────────────────────────────────
+Type "netclaw init"
+Enter
+
+# ─── Step 1: Provider ───────────────────────────────────────────────
+Wait+Screen@10s /Choose your LLM provider:/
+# Anthropic (default), Ollama is one Down.
+Down
+Enter
+
+Wait+Screen@10s /endpoint:/
+Right 32
+Backspace 32
+Type "http://localhost:11434"
+Enter
+
+Wait+Screen@45s /Select a model/
+# Termina list-key-handler wiring beat — see init-wizard.tape:46
+Sleep 1s
+Down
+Enter
+
+# ─── Step 2: Security Posture ────────────────────────────────────────
+Wait+Screen@10s /Who will interact with this Netclaw instance/
+Enter
+
+# ─── Step 3: Channel Picker ──────────────────────────────────────────
+Wait+Screen@10s /Which channels would you like to connect/
+Type "d"
+
+# ─── Step 4: Web Search ─────────────────────────────────────────────
+Wait+Screen@10s /Choose your web search provider/
+Enter
+
+# ─── Step 5: Browser Automation ──────────────────────────────────────
+Wait+Screen@10s /Enable browser automation/
+Enter
+
+# ─── Step 6: Identity ───────────────────────────────────────────────
+Wait+Screen@10s /Agent name:/
+Enter
+
+Wait+Screen@10s /Communication style:/
+Enter
+
+Wait+Screen@10s /Your name:/
+Type "SmokeTester"
+Enter
+
+Wait+Screen@10s /Your timezone:/
+Enter
+
+Wait+Screen@10s /Projects directory:/
+Enter
+
+Wait+Screen@10s /Notification webhook URL/
+Enter
+
+# ─── Step 8: Skill Feeds ────────────────────────────────────────────
+Wait+Screen@10s /Connect to a private skill server/
+Down
+Enter
+
+# ─── Step 9: Network Exposure (reverse proxy branch) ────────────────
+Wait+Screen@10s /How will this Netclaw daemon be accessed/
+# Mode list (ExposureModeStepView.BuildModeSelection):
+#   0: Local — loopback only, safest (recommended)        ← default
+#   1: Reverse Proxy — behind nginx, Caddy, Traefik, ...  ← target
+#   2: Tailscale Serve
+#   3: Tailscale Funnel
+#   4: Cloudflare Tunnel
+Down
+Enter
+
+# Sub-step 1: bind address. Default placeholder is 0.0.0.0; accept it.
+Wait+Screen@10s /Reverse proxy: bind address/
+Enter
+
+# Sub-step 2: trusted proxies. Empty list is rejected by the ViewModel gate;
+# enter one CIDR so the wizard can advance.
+Wait+Screen@10s /Reverse proxy: trusted proxies/
+Type "10.0.0.0/24"
+Enter
+
+# Sub-step 3: notice with serving URL.
+Wait+Screen@10s /Reverse proxy configured/
+# Serving URL line is rendered as "Daemon will listen on:    http://0.0.0.0:5199"
+Wait+Screen@5s /http:\/\/0\.0\.0\.0:5199/
+Enter
+
+# Sub-step 4: webhook toggle. "No" = second option.
+Wait+Screen@10s /Should this daemon accept inbound webhooks/
+Down
+Enter
+
+# ─── Step 10: Health Check ──────────────────────────────────────────
+Wait+Screen@10s /Press Enter to run health checks/
+Enter
+
+# Reverse-proxy mode binds to a non-loopback address; the daemon will refuse
+# to start cleanly inside the smoke env (it tries to listen on 0.0.0.0:5199
+# which may not be reachable / may already be bound). That's fine — the
+# tape's job is to drive the wizard through the new sub-steps and produce
+# a netclaw.json; the post-tape assertion is the real signal.
+#
+# The wizard may either:
+#   (a) reach the chat page after the daemon starts (if 0.0.0.0:5199 is
+#       bindable in the smoke env), or
+#   (b) hang on the health-check screen if daemon startup fails.
+#
+# Wait for whichever marker appears first within a generous window, then quit.
+Wait+Screen@120s /(Ready  \|  qwen2:0\.5b|Health checks)/
+Ctrl+Q
+
+Wait+Screen@10s /TAPE\$/
+
+# Sanity: re-check at the prompt that init reported success.
+Type "echo INIT_EXIT=$?"
+Enter
+Wait+Screen@5s /INIT_EXIT=/
+
+Type "exit"
+Enter


### PR DESCRIPTION
Closes #1114.

## Summary

Reverse proxy has been a fully-supported `ExposureMode` in the config schema, daemon runtime, `ForwardedHeaders` middleware, validator, and doctor check — but `netclaw init` only offered four of the five modes (Local, Tailscale Serve / Funnel, Cloudflare Tunnel). Operators deploying behind nginx / Caddy / Traefik / IIS / ALB had to hand-edit `netclaw.json` after init or pick a mode they didn't want.

This PR is a **UI-only** gap fix:

- Adds **Reverse Proxy** as the second option in the Network Exposure step (ordered by deployment friction: Local → Reverse Proxy → Tailscale → Cloudflare).
- Three new sub-steps when Reverse Proxy is selected:
  1. **Bind address** input — defaults to `0.0.0.0`; loopback rejected at daemon startup (existing validator).
  2. **Trusted proxies** input — comma-separated IPs/CIDRs. **Advance blocked until ≥1 entry is present**, mirroring `DaemonExposureValidator.Validate`'s startup contract so the wizard cannot emit a non-startable config.
  3. **Informational notice** echoing the serving URL `http://{Host}:5199` and listing operator responsibilities (TLS termination, firewalling, X-Forwarded-* setup).

No deferrable "configure later" path — if an operator doesn't yet know their proxy IP, they pick Local and re-run `netclaw init --resume`. This was an explicit design decision (the daemon refuses to start without trusted proxies; a wizard that "succeeded" on an empty list would silently break the user).

## What did NOT change

- `DaemonExposureValidator`, `ExposureModeDoctorCheck`, the JSON schema, the daemon's `ForwardedHeaders` wiring — already correct.
- No port input in the wizard; port stays at the `Daemon.Port` default. (This PR promotes `5199` → `DaemonConfig.DefaultPort` as a follow-up so the literal lives in one place.)

## Files

- `src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepView.cs` — option + 3 new render methods
- `src/Netclaw.Cli/Tui/Wizard/Steps/ExposureModeStepViewModel.cs` — `Host` + `TrustedProxies` fields, 5-sub-step plan, advance gate, mode-downgrade high-water clamp
- `src/Netclaw.Cli/Tui/Wizard/WizardConfigBuilder.cs` — `DaemonConfigSection.Host?` + `TrustedProxies`; serializer emits them only when non-default
- `src/Netclaw.Configuration/DaemonConfig.cs` — promote port literal to `public const int DefaultPort = 5199`
- `src/Netclaw.Cli.Tests/Tui/Wizard/ExposureModeStepViewModelTests.cs` — +9 reverse-proxy tests (config emission, sub-step walk, gate, mode-downgrade clamp, bootstrap device, leakage prevention)
- `tests/smoke/tapes/init-wizard-reverse-proxy.tape` + `tests/smoke/assertions/init-wizard-reverse-proxy.sh` — new smoke tape (registered in `LIGHT_TAPES`); jq-asserts `Daemon.ExposureMode` / `Host` / `TrustedProxies[0]` and runs `netclaw doctor`
- `feeds/skills/.system/files/netclaw-operations/SKILL.md` — documents the wizard support; `metadata.version` 2.4.0 → 2.5.0
- `docs/spec/SPEC-007-guided-onboarding.md` — reverse proxy added to the wizard exposure-mode list with the trusted-proxies-required rule

## Test plan

- [x] `dotnet test src/Netclaw.Cli.Tests` — 713/713 pass
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — all headers present
- [x] `dotnet build src/Netclaw.Daemon` — clean (sanity check for the `DefaultPort` constant promotion)
- [ ] `./scripts/smoke/run-smoke.sh init-wizard-reverse-proxy` in CI (the tape mirrors the proven `init-wizard.tape` pattern; both fail locally on machines with `~/.claude/skills` because of an unrelated External Skills step issue that pre-dates this PR)
- [ ] Manual: `netclaw init`, pick Reverse Proxy, leave bind default, enter `10.0.0.0/24`, confirm notice, disable webhooks → verify `~/.netclaw/netclaw.json` has the expected `Daemon` section and `netclaw doctor` is clean.