### PR TITLE
Trigger netclaw.dev rebuild on release publish

### DIFF
--- a/.github/workflows/website-rebuild.yml
+++ b/.github/workflows/website-rebuild.yml
@@ -1,0 +1,30 @@
+# Fires netclaw-website's deploy workflow whenever a release is published
+# here. The receiving workflow rebuilds the site (re-fetching the GitHub
+# Releases API at build time) so /changelog stays in sync.
+#
+# Auth: WEBSITE_DISPATCH_TOKEN repository secret, a fine-grained PAT with
+# Actions: read+write on netclaw-dev/netclaw-website. See
+# ops/auto-rebuild-on-release/README.md in netclaw-website for setup.
+name: Trigger netclaw.dev rebuild
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch netclaw-website deploy workflow
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::WEBSITE_DISPATCH_TOKEN secret is not set on this repository." >&2
+            exit 1
+          fi
+          gh workflow run deploy.yml \
+            --repo netclaw-dev/netclaw-website \
+            --ref dev
+          echo "Dispatched deploy.yml on netclaw-dev/netclaw-website@dev."


### PR DESCRIPTION
## Summary

Adds a tiny workflow that fires `netclaw-dev/netclaw-website`'s `deploy` workflow whenever a release is published here. End result: `/changelog` on netclaw.dev stays in sync with this repo's releases automatically, no manual rebuild needed.

## How it works

```yaml
on:
  release:
    types: [published]   # automatic on every release
  workflow_dispatch:     # manual button for testing
```

## Test plan

After merge:

1. Go to **Actions → Trigger netclaw.dev rebuild → Run workflow** on this repo.
2. Confirm the run logs `Dispatched deploy.yml on netclaw-dev/netclaw-website@dev.`
3. Check `netclaw-dev/netclaw-website` Actions tab — a fresh `deploy` run should appear within a few seconds, attributed to the PAT owner.
4. Once that deploy finishes (~2 min), `/changelog` reflects whatever release state this repo currently has.

The `release: published` path will be exercised naturally the next time a release ships.

## Footprint

One file, 30 lines, no changes to anything else in the repo.
