### PR TITLE
fix(mcp): decrypt secrets.json Headers and EnvironmentVariables on the daemon side

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(MicrosoftAspNetCoreVersion)" />

--- a/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
+++ b/src/Netclaw.Cli.Tests/Mcp/McpCommandTests.cs
@@ -82,7 +82,7 @@ public sealed class McpCommandTests : IDisposable
 
         // Loader should transparently decrypt encrypted values
         var loaded = McpCommand.LoadMcpServers(_paths);
-        Assert.Equal("secret123", loaded["myserver"].EnvironmentVariables?["API_KEY"]);
+        Assert.Equal("secret123", loaded["myserver"].EnvironmentVariables?["API_KEY"].Value);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public sealed class McpCommandTests : IDisposable
 
         // Loader should transparently decrypt encrypted values
         var loaded = McpCommand.LoadMcpServers(_paths);
-        Assert.Equal("Bearer tok-123", loaded["myapi"].Headers?["Authorization"]);
+        Assert.Equal("Bearer tok-123", loaded["myapi"].Headers?["Authorization"].Value);
     }
 
     // ── Fail-closed defaults for new MCP servers ──

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
@@ -266,7 +266,7 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
 
             var npxCommand = BrowserAutomationRuntimeDetector.GetPreferredNpxCommand();
             var env = BrowserAutomationRuntimeDetector.BuildPlaywrightEnvironmentOverlay(npxCommand)
-                ?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Value, StringComparer.OrdinalIgnoreCase);
+                .ToRawValues(StringComparer.OrdinalIgnoreCase);
             var succeeded = await RunCommandAsync(
                 npxCommand,
                 $"-y playwright@latest install {browser}",

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationBootstrapper.cs
@@ -265,7 +265,8 @@ internal sealed class BrowserAutomationBootstrapper : IBrowserAutomationBootstra
             Directory.CreateDirectory(BrowserAutomationRuntimeDetector.GetPlaywrightBrowsersPath());
 
             var npxCommand = BrowserAutomationRuntimeDetector.GetPreferredNpxCommand();
-            var env = BrowserAutomationRuntimeDetector.BuildPlaywrightEnvironmentOverlay(npxCommand);
+            var env = BrowserAutomationRuntimeDetector.BuildPlaywrightEnvironmentOverlay(npxCommand)
+                ?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Value, StringComparer.OrdinalIgnoreCase);
             var succeeded = await RunCommandAsync(
                 npxCommand,
                 $"-y playwright@latest install {browser}",

--- a/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
+++ b/src/Netclaw.Cli/Mcp/BrowserAutomationRuntimeDetector.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Runtime.InteropServices;
+using Netclaw.Configuration;
 
 namespace Netclaw.Cli.Mcp;
 
@@ -97,7 +98,7 @@ internal static class BrowserAutomationRuntimeDetector
         return ResolveCommandPath("npx") ?? "npx";
     }
 
-    public static Dictionary<string, string>? BuildMcpEnvironmentOverlay(string commandPath)
+    public static Dictionary<string, SensitiveString>? BuildMcpEnvironmentOverlay(string commandPath)
     {
         if (!Path.IsPathRooted(commandPath))
             return null;
@@ -112,17 +113,17 @@ internal static class BrowserAutomationRuntimeDetector
             ? commandDir
             : $"{commandDir}{separator}{existingPath}";
 
-        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        return new Dictionary<string, SensitiveString>(StringComparer.OrdinalIgnoreCase)
         {
-            ["PATH"] = combinedPath
+            ["PATH"] = new SensitiveString(combinedPath)
         };
     }
 
-    public static Dictionary<string, string>? BuildPlaywrightEnvironmentOverlay(string commandPath)
+    public static Dictionary<string, SensitiveString>? BuildPlaywrightEnvironmentOverlay(string commandPath)
     {
         var env = BuildMcpEnvironmentOverlay(commandPath)
-            ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        env["PLAYWRIGHT_BROWSERS_PATH"] = GetPlaywrightBrowsersPath();
+            ?? new Dictionary<string, SensitiveString>(StringComparer.OrdinalIgnoreCase);
+        env["PLAYWRIGHT_BROWSERS_PATH"] = new SensitiveString(GetPlaywrightBrowsersPath());
         return env;
     }
 

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -794,18 +794,11 @@ internal static class McpCommand
 
         if (entry.Transport is "stdio")
         {
-            var envVars = entry.EnvironmentVariables is { Count: > 0 }
-                ? entry.EnvironmentVariables.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => (string?)kvp.Value.Value,
-                    StringComparer.OrdinalIgnoreCase)
-                : null;
-
             transport = new StdioClientTransport(new StdioClientTransportOptions
             {
                 Command = entry.Command!,
                 Arguments = entry.Arguments ?? [],
-                EnvironmentVariables = envVars,
+                EnvironmentVariables = entry.EnvironmentVariables.ToRawNullableValues(StringComparer.OrdinalIgnoreCase),
                 Name = serverName.Value,
                 ShutdownTimeout = TimeSpan.FromSeconds(10),
             });
@@ -816,12 +809,7 @@ internal static class McpCommand
             {
                 Endpoint = new Uri(entry.Url!),
                 Name = serverName.Value,
-                AdditionalHeaders = entry.Headers is { Count: > 0 }
-                    ? entry.Headers.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => kvp.Value.Value,
-                        StringComparer.OrdinalIgnoreCase)
-                    : null,
+                AdditionalHeaders = entry.Headers.ToRawValues(StringComparer.OrdinalIgnoreCase),
                 TransportMode = entry.Transport is "sse"
                     ? HttpTransportMode.Sse : HttpTransportMode.AutoDetect,
             });

--- a/src/Netclaw.Cli/Mcp/McpCommand.cs
+++ b/src/Netclaw.Cli/Mcp/McpCommand.cs
@@ -795,7 +795,10 @@ internal static class McpCommand
         if (entry.Transport is "stdio")
         {
             var envVars = entry.EnvironmentVariables is { Count: > 0 }
-                ? new Dictionary<string, string?>(entry.EnvironmentVariables!)
+                ? entry.EnvironmentVariables.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => (string?)kvp.Value.Value,
+                    StringComparer.OrdinalIgnoreCase)
                 : null;
 
             transport = new StdioClientTransport(new StdioClientTransportOptions
@@ -814,7 +817,11 @@ internal static class McpCommand
                 Endpoint = new Uri(entry.Url!),
                 Name = serverName.Value,
                 AdditionalHeaders = entry.Headers is { Count: > 0 }
-                    ? new Dictionary<string, string>(entry.Headers) : null,
+                    ? entry.Headers.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value.Value,
+                        StringComparer.OrdinalIgnoreCase)
+                    : null,
                 TransportMode = entry.Transport is "sse"
                     ? HttpTransportMode.Sse : HttpTransportMode.AutoDetect,
             });
@@ -879,7 +886,7 @@ internal static class McpCommand
                     foreach (var ev in envVars.EnumerateObject())
                     {
                         var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, ev.Value.GetString());
-                        entry.EnvironmentVariables[ev.Name] = decrypted;
+                        entry.EnvironmentVariables[ev.Name] = new SensitiveString(decrypted);
                     }
                 }
 
@@ -889,7 +896,7 @@ internal static class McpCommand
                     foreach (var h in hdrs.EnumerateObject())
                     {
                         var decrypted = ConfigFileHelper.DecryptIfEncrypted(paths, h.Value.GetString());
-                        entry.Headers[h.Name] = decrypted;
+                        entry.Headers[h.Name] = new SensitiveString(decrypted);
                     }
                 }
             }

--- a/src/Netclaw.Configuration.Tests/McpServerEntryBindingTests.cs
+++ b/src/Netclaw.Configuration.Tests/McpServerEntryBindingTests.cs
@@ -1,0 +1,117 @@
+// -----------------------------------------------------------------------
+// <copyright file="McpServerEntryBindingTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Configuration;
+using Netclaw.Configuration.Secrets;
+using Netclaw.Tests.Utilities;
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+/// <summary>
+/// Pins the daemon-side binding behavior for <see cref="McpServerEntry.Headers"/>
+/// and <see cref="McpServerEntry.EnvironmentVariables"/>. Before SensitiveString
+/// wrapping, the daemon was binding the raw ciphertext (<c>ENC:…</c>) verbatim
+/// into <see cref="Dictionary{TKey,TValue}"/>, then forwarding it as the literal
+/// <c>Authorization</c> header / env value. Any HTTP MCP server that authenticates
+/// from the first byte rejected the resulting garbage with 401 (see issue #1118).
+/// </summary>
+[Collection(SensitiveStringStaticStateCollection.Name)]
+public sealed class McpServerEntryBindingTests : IDisposable
+{
+    private readonly DisposableTempDir _dir = new();
+    private readonly ISecretsProtector? _previousProtector;
+
+    public McpServerEntryBindingTests()
+    {
+        _previousProtector = SensitiveStringTypeConverter.Protector;
+    }
+
+    public void Dispose()
+    {
+        SensitiveStringTypeConverter.Protector = _previousProtector;
+        _dir.Dispose();
+    }
+
+    [Fact]
+    public void Headers_bound_from_configuration_decrypt_ENC_values()
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        var encrypted = protector.Protect("Bearer real-token-abc");
+        Assert.StartsWith("ENC:", encrypted, StringComparison.Ordinal);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["McpServers:atlassian:Transport"] = "http",
+                ["McpServers:atlassian:Url"] = "https://mcp.example.com/v1/mcp",
+                ["McpServers:atlassian:Headers:Authorization"] = encrypted,
+            })
+            .Build();
+
+        var bound = config.GetSection("McpServers")
+            .Get<Dictionary<string, McpServerEntry>>() ?? [];
+
+        var entry = Assert.Contains("atlassian", bound);
+        var header = Assert.Contains("Authorization", entry.Headers!);
+        Assert.Equal("Bearer real-token-abc", header.Value);
+    }
+
+    [Fact]
+    public void EnvironmentVariables_bound_from_configuration_decrypt_ENC_values()
+    {
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        var protector = SecretsProtection.CreateProtector(paths);
+        SensitiveStringTypeConverter.Protector = protector;
+
+        var encrypted = protector.Protect("sk-very-real-key");
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["McpServers:weather:Transport"] = "stdio",
+                ["McpServers:weather:Command"] = "weather-mcp",
+                ["McpServers:weather:EnvironmentVariables:API_KEY"] = encrypted,
+            })
+            .Build();
+
+        var bound = config.GetSection("McpServers")
+            .Get<Dictionary<string, McpServerEntry>>() ?? [];
+
+        var entry = Assert.Contains("weather", bound);
+        var env = Assert.Contains("API_KEY", entry.EnvironmentVariables!);
+        Assert.Equal("sk-very-real-key", env.Value);
+    }
+
+    [Fact]
+    public void Headers_bound_from_plaintext_values_pass_through_unchanged()
+    {
+        // Some test fixtures and migration paths may write plaintext Headers
+        // directly. The SensitiveString converter must treat any value that
+        // lacks the ENC: prefix as already-plaintext and leave it alone.
+        var paths = new NetclawPaths(_dir.Path);
+        paths.EnsureDirectoriesExist();
+        SensitiveStringTypeConverter.Protector = SecretsProtection.CreateProtector(paths);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["McpServers:test:Transport"] = "http",
+                ["McpServers:test:Url"] = "https://example.com/mcp",
+                ["McpServers:test:Headers:Authorization"] = "Bearer plaintext-token",
+            })
+            .Build();
+
+        var bound = config.GetSection("McpServers")
+            .Get<Dictionary<string, McpServerEntry>>() ?? [];
+
+        Assert.Equal("Bearer plaintext-token", bound["test"].Headers!["Authorization"].Value);
+    }
+}

--- a/src/Netclaw.Configuration.Tests/SensitiveStringConverterTests.cs
+++ b/src/Netclaw.Configuration.Tests/SensitiveStringConverterTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Netclaw.Configuration.Tests;
 
+[Collection(SensitiveStringStaticStateCollection.Name)]
 public sealed class SensitiveStringConverterTests : IDisposable
 {
     private readonly DisposableTempDir _dir = new();

--- a/src/Netclaw.Configuration.Tests/SensitiveStringStaticStateCollection.cs
+++ b/src/Netclaw.Configuration.Tests/SensitiveStringStaticStateCollection.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="SensitiveStringStaticStateCollection.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Configuration.Tests;
+
+/// <summary>
+/// xUnit collection used to serialize any test that mutates the static
+/// <see cref="SensitiveStringTypeConverter.Protector"/> hook. The hook is
+/// process-wide because TypeConverters can't be DI-injected; two tests
+/// flipping it concurrently produces flaky cross-class failures
+/// ("Expected: plaintext, Actual: ENC:…").
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SensitiveStringStaticStateCollection
+{
+    public const string Name = "SensitiveString static state";
+}

--- a/src/Netclaw.Configuration/McpServerEntry.cs
+++ b/src/Netclaw.Configuration/McpServerEntry.cs
@@ -23,11 +23,27 @@ public sealed class McpServerEntry
     /// <summary>Endpoint URL for sse/http transport.</summary>
     public string? Url { get; set; }
 
-    /// <summary>Environment variable overlay for the MCP process.</summary>
-    public Dictionary<string, string>? EnvironmentVariables { get; set; }
+    /// <summary>
+    /// Environment variable overlay for the MCP process. Values are wrapped in
+    /// <see cref="SensitiveString"/> so that the <c>ENC:</c>-prefixed ciphertext
+    /// stored in <c>secrets.json</c> is transparently decrypted during
+    /// <see cref="Microsoft.Extensions.Configuration"/> binding and during
+    /// <see cref="System.Text.Json"/> deserialization. Without the wrapper the
+    /// daemon would forward the encrypted blob to the child process verbatim.
+    /// </summary>
+    public Dictionary<string, SensitiveString>? EnvironmentVariables { get; set; }
 
-    /// <summary>Additional HTTP headers (for http/sse transport).</summary>
-    public Dictionary<string, string>? Headers { get; set; }
+    /// <summary>
+    /// Additional HTTP headers (for http/sse transport). Wrapped in
+    /// <see cref="SensitiveString"/> for the same reason as
+    /// <see cref="EnvironmentVariables"/>: <c>secrets.json</c> stores values
+    /// encrypted with the <c>ENC:</c> prefix, and the wrapper drives the
+    /// configuration binder / STJ converter to decrypt on read. A raw
+    /// <c>Dictionary&lt;string, string&gt;</c> would skip decryption and the
+    /// resulting <c>Authorization: ENC:…</c> header would be rejected by every
+    /// server that requires the header to be valid on the first byte.
+    /// </summary>
+    public Dictionary<string, SensitiveString>? Headers { get; set; }
 
     /// <summary>Whether this server is enabled. Disabled servers are skipped at startup.</summary>
     public bool Enabled { get; set; } = true;

--- a/src/Netclaw.Configuration/SensitiveString.cs
+++ b/src/Netclaw.Configuration/SensitiveString.cs
@@ -44,6 +44,39 @@ public static class SensitiveStringExtensions
             throw new InvalidOperationException($"{context} is required but was not configured.");
         return token;
     }
+
+    /// <summary>
+    /// Projects a <see cref="SensitiveString"/>-valued map into raw strings — the form
+    /// the SDK transport layer needs (HTTP <c>AdditionalHeaders</c> and similar).
+    /// Returns <see langword="null"/> for null or empty input so the caller can pass
+    /// the result straight to a transport option without an extra branch. Necessary
+    /// because <see cref="SensitiveString.ToString"/> returns the redacted sentinel,
+    /// so a casual <c>new Dictionary&lt;string,string&gt;(map)</c> would compile but
+    /// silently ship "***REDACTED***" over the wire.
+    /// </summary>
+    public static Dictionary<string, string>? ToRawValues(
+        this IDictionary<string, SensitiveString>? source,
+        StringComparer? comparer = null)
+    {
+        if (source is not { Count: > 0 })
+            return null;
+        return source.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Value, comparer ?? StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Same as <see cref="ToRawValues"/> but with <c>string?</c> values — what
+    /// <see cref="ModelContextProtocol.Client.StdioClientTransportOptions.EnvironmentVariables"/>
+    /// requires. Keep this overload distinct: there is no useful covariance from
+    /// <c>Dictionary&lt;string,string&gt;</c> to a nullable-value dictionary.
+    /// </summary>
+    public static Dictionary<string, string?>? ToRawNullableValues(
+        this IDictionary<string, SensitiveString>? source,
+        StringComparer? comparer = null)
+    {
+        if (source is not { Count: > 0 })
+            return null;
+        return source.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value.Value, comparer ?? StringComparer.Ordinal);
+    }
 }
 
 /// <summary>

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerArgumentCoercionTests.cs
@@ -33,7 +33,7 @@ public sealed class SmokeMcpServerArgumentCoercionTests
         {
             Transport = "stdio",
             Command = "dotnet",
-            Arguments = [LocateSmokeMcpServer()],
+            Arguments = [SmokeMcpServerLocator.LocateDll()],
             Enabled = true,
         };
 
@@ -70,30 +70,4 @@ public sealed class SmokeMcpServerArgumentCoercionTests
         Assert.Contains("reference=00713", result);
     }
 
-    /// <summary>
-    /// Resolves the freshly-built <c>Netclaw.SmokeMcpServer.dll</c>. The server
-    /// is a <c>ReferenceOutputAssembly=false</c> project reference, so it is
-    /// always built; the most recently written copy under its <c>bin/</c> tree
-    /// is the one this test run produced — picking by write time keeps this
-    /// correct regardless of build configuration or RID output subdirectory.
-    /// </summary>
-    private static string LocateSmokeMcpServer()
-    {
-        var repo = new DirectoryInfo(AppContext.BaseDirectory);
-        while (repo is not null && !File.Exists(Path.Combine(repo.FullName, "Netclaw.slnx")))
-            repo = repo.Parent;
-        Assert.NotNull(repo);
-
-        var projectDir = Path.Combine(repo!.FullName, "tests", "Netclaw.SmokeMcpServer");
-        var binMarker = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";
-        var dll = Directory
-            .EnumerateFiles(projectDir, "Netclaw.SmokeMcpServer.dll", SearchOption.AllDirectories)
-            .Where(p => p.Contains(binMarker))
-            .OrderByDescending(File.GetLastWriteTimeUtc)
-            .FirstOrDefault();
-
-        Assert.True(dll is not null,
-            $"Netclaw.SmokeMcpServer.dll not found under {projectDir}/bin — is the project built?");
-        return dll!;
-    }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -1,0 +1,233 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmokeMcpServerHttpHeaderTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Netclaw.Actors.Tools;
+using Netclaw.Configuration;
+using Netclaw.Configuration.Secrets;
+using Netclaw.Tools;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+/// <summary>
+/// End-to-end regression for `netclaw mcp add --header "Authorization: …"`
+/// against an HTTP MCP server. Spawns the smoke server in `--transport http
+/// --capture-auth` mode, points an <see cref="Daemon.Mcp.McpClientManager"/>
+/// at it with a configured Authorization header, and verifies via the
+/// server's `last_auth_header` tool that the header arrived intact.
+///
+/// This pins the bug fixed alongside it: <c>McpServerEntry.Headers</c> being
+/// typed <c>Dictionary&lt;string, string&gt;</c> meant the daemon-side
+/// <see cref="SensitiveStringTypeConverter"/> never decrypted <c>ENC:</c>
+/// ciphertext from <c>secrets.json</c>, so HTTP MCP servers that authenticate
+/// on the first byte (e.g. mcp.atlassian.com) received a garbage Authorization
+/// value and returned 401. The exact same data path is exercised here: a
+/// configured header → <c>HttpClientTransport.AdditionalHeaders</c> → wire →
+/// server-side capture.
+/// </summary>
+public sealed class SmokeMcpServerHttpHeaderTests
+{
+    [Fact]
+    public async Task ConfiguredHeader_IsAttachedToOutboundMcpRequest()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        var ct = cts.Token;
+
+        const string expectedHeader = "Bearer test-creds-from-header-flag";
+
+        await using var server = await SmokeHttpMcpServer.StartAsync(ct);
+
+        var entry = new McpServerEntry
+        {
+            Transport = "http",
+            Url = server.Url,
+            Enabled = true,
+            Headers = new Dictionary<string, SensitiveString>
+            {
+                ["Authorization"] = new SensitiveString(expectedHeader),
+            },
+        };
+
+        var registry = new ToolRegistry();
+        await using var harness = McpSmokeHarness.Create(
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+
+        await harness.Manager.StartAsync(ct);
+
+        var lastAuthHeader = registry.GetAllRegistrations()
+            .Select(r => r.Tool)
+            .OfType<McpToolAdapter>()
+            .SingleOrDefault(t => t.Name == "smoke-http/last_auth_header");
+        Assert.NotNull(lastAuthHeader);
+
+        var observed = await lastAuthHeader!.ExecuteAsync(
+            new Dictionary<string, object?>(), ToolExecutionContext.Empty, ct);
+
+        Assert.Contains(expectedHeader, observed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NoConfiguredHeader_ResultsInNoAuthorizationHeaderOnTheWire()
+    {
+        // Counterpart to the test above: if the operator did not configure
+        // an Authorization header, the SDK MUST NOT invent one. The smoke
+        // server returns "(none)" when it sees no Authorization header.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        var ct = cts.Token;
+
+        await using var server = await SmokeHttpMcpServer.StartAsync(ct);
+
+        var entry = new McpServerEntry
+        {
+            Transport = "http",
+            Url = server.Url,
+            Enabled = true,
+        };
+
+        var registry = new ToolRegistry();
+        await using var harness = McpSmokeHarness.Create(
+            new Dictionary<string, McpServerEntry> { ["smoke-http"] = entry }, registry);
+
+        await harness.Manager.StartAsync(ct);
+
+        var lastAuthHeader = registry.GetAllRegistrations()
+            .Select(r => r.Tool)
+            .OfType<McpToolAdapter>()
+            .SingleOrDefault(t => t.Name == "smoke-http/last_auth_header");
+        Assert.NotNull(lastAuthHeader);
+
+        var observed = await lastAuthHeader!.ExecuteAsync(
+            new Dictionary<string, object?>(), ToolExecutionContext.Empty, ct);
+
+        Assert.Contains("(none)", observed, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Owns the smoke MCP server child process for the duration of a test.
+/// Spawns <c>Netclaw.SmokeMcpServer.dll</c> in HTTP mode with
+/// <c>--port 0</c>, reads the chosen ephemeral port from stderr, and exposes
+/// the resulting <see cref="Url"/>. On <see cref="DisposeAsync"/> the
+/// process is killed and drained so test runs cannot leak orphaned servers.
+/// </summary>
+internal sealed class SmokeHttpMcpServer : IAsyncDisposable
+{
+    private static readonly Regex ListeningPattern = new(
+        @"\[smoke-mcp:listening\]\s+(?<url>https?://[^\s]+)",
+        RegexOptions.Compiled);
+
+    private readonly Process _process;
+    private readonly Task _stderrDrain;
+
+    private SmokeHttpMcpServer(Process process, string url, Task stderrDrain)
+    {
+        _process = process;
+        _stderrDrain = stderrDrain;
+        Url = url;
+    }
+
+    public string Url { get; }
+
+    public static async Task<SmokeHttpMcpServer> StartAsync(CancellationToken ct)
+    {
+        var dll = LocateSmokeMcpServerDll();
+
+        var info = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        info.ArgumentList.Add(dll);
+        info.ArgumentList.Add("--transport");
+        info.ArgumentList.Add("http");
+        info.ArgumentList.Add("--port");
+        info.ArgumentList.Add("0");
+        info.ArgumentList.Add("--capture-auth");
+
+        var process = Process.Start(info)
+            ?? throw new InvalidOperationException("Failed to start smoke MCP server");
+
+        var listeningTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var drain = Task.Run(async () =>
+        {
+            // Drain stderr fully so the child doesn't block on a full pipe
+            // even after the listening line has been seen.
+            string? line;
+            while ((line = await process.StandardError.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
+            {
+                var match = ListeningPattern.Match(line);
+                if (match.Success && !listeningTcs.Task.IsCompleted)
+                    listeningTcs.TrySetResult(match.Groups["url"].Value);
+            }
+            // If we drained to EOF without ever seeing the listening line,
+            // surface that to whoever's awaiting StartAsync.
+            listeningTcs.TrySetException(new InvalidOperationException(
+                "Smoke MCP server exited before publishing a listening URL"));
+        }, ct);
+
+        // Drain stdout in the background too — otherwise Kestrel logs that
+        // make it to stdout could block the process under buffer pressure.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                while (await process.StandardOutput.ReadLineAsync(ct).ConfigureAwait(false) is not null) { }
+            }
+            catch { /* drain best-effort */ }
+        }, ct);
+
+        var startTimeout = Task.Delay(TimeSpan.FromSeconds(30), ct);
+        var completed = await Task.WhenAny(listeningTcs.Task, startTimeout).ConfigureAwait(false);
+        if (completed != listeningTcs.Task)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException("Smoke MCP server did not start within 30s");
+        }
+
+        return new SmokeHttpMcpServer(process, await listeningTcs.Task.ConfigureAwait(false), drain);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_process.HasExited)
+        {
+            try { _process.Kill(entireProcessTree: true); }
+            catch { /* best-effort */ }
+        }
+
+        try { await _process.WaitForExitAsync().ConfigureAwait(false); }
+        catch { /* best-effort */ }
+
+        try { await _stderrDrain.ConfigureAwait(false); }
+        catch { /* drain is best-effort once we're tearing down */ }
+
+        _process.Dispose();
+    }
+
+    private static string LocateSmokeMcpServerDll()
+    {
+        var repo = new DirectoryInfo(AppContext.BaseDirectory);
+        while (repo is not null && !File.Exists(Path.Combine(repo.FullName, "Netclaw.slnx")))
+            repo = repo.Parent;
+        Assert.NotNull(repo);
+
+        var projectDir = Path.Combine(repo!.FullName, "tests", "Netclaw.SmokeMcpServer");
+        var binMarker = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";
+        var dll = Directory
+            .EnumerateFiles(projectDir, "Netclaw.SmokeMcpServer.dll", SearchOption.AllDirectories)
+            .Where(p => p.Contains(binMarker))
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
+
+        Assert.True(dll is not null,
+            $"Netclaw.SmokeMcpServer.dll not found under {projectDir}/bin — is the project built?");
+        return dll!;
+    }
+}

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -122,11 +122,13 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
 
     private readonly Process _process;
     private readonly Task _stderrDrain;
+    private readonly Task _stdoutDrain;
 
-    private SmokeHttpMcpServer(Process process, string url, Task stderrDrain)
+    private SmokeHttpMcpServer(Process process, string url, Task stderrDrain, Task stdoutDrain)
     {
         _process = process;
         _stderrDrain = stderrDrain;
+        _stdoutDrain = stdoutDrain;
         Url = url;
     }
 
@@ -134,8 +136,6 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
 
     public static async Task<SmokeHttpMcpServer> StartAsync(CancellationToken ct)
     {
-        var dll = LocateSmokeMcpServerDll();
-
         var info = new ProcessStartInfo("dotnet")
         {
             RedirectStandardError = true,
@@ -143,7 +143,7 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
             UseShellExecute = false,
             CreateNoWindow = true,
         };
-        info.ArgumentList.Add(dll);
+        info.ArgumentList.Add(SmokeMcpServerLocator.LocateDll());
         info.ArgumentList.Add("--transport");
         info.ArgumentList.Add("http");
         info.ArgumentList.Add("--port");
@@ -155,10 +155,10 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
 
         var listeningTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var drain = Task.Run(async () =>
+        // Drain stderr to completion: scan for the listening line, then keep
+        // reading so a full pipe doesn't deadlock the child.
+        var stderrDrain = Task.Run(async () =>
         {
-            // Drain stderr fully so the child doesn't block on a full pipe
-            // even after the listening line has been seen.
             string? line;
             while ((line = await process.StandardError.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
             {
@@ -166,15 +166,14 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
                 if (match.Success && !listeningTcs.Task.IsCompleted)
                     listeningTcs.TrySetResult(match.Groups["url"].Value);
             }
-            // If we drained to EOF without ever seeing the listening line,
-            // surface that to whoever's awaiting StartAsync.
             listeningTcs.TrySetException(new InvalidOperationException(
                 "Smoke MCP server exited before publishing a listening URL"));
         }, ct);
 
-        // Drain stdout in the background too — otherwise Kestrel logs that
-        // make it to stdout could block the process under buffer pressure.
-        _ = Task.Run(async () =>
+        // Drain stdout too — Kestrel may log there and a full pipe will
+        // wedge the child. Tracked symmetrically with stderr so DisposeAsync
+        // can await it.
+        var stdoutDrain = Task.Run(async () =>
         {
             try
             {
@@ -191,7 +190,8 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
             throw new TimeoutException("Smoke MCP server did not start within 30s");
         }
 
-        return new SmokeHttpMcpServer(process, await listeningTcs.Task.ConfigureAwait(false), drain);
+        return new SmokeHttpMcpServer(
+            process, await listeningTcs.Task.ConfigureAwait(false), stderrDrain, stdoutDrain);
     }
 
     public async ValueTask DisposeAsync()
@@ -205,29 +205,14 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
         try { await _process.WaitForExitAsync().ConfigureAwait(false); }
         catch { /* best-effort */ }
 
+        // Drains terminate when the streams close; await both so teardown
+        // doesn't leave Task.Run continuations executing past the test.
         try { await _stderrDrain.ConfigureAwait(false); }
         catch { /* drain is best-effort once we're tearing down */ }
 
+        try { await _stdoutDrain.ConfigureAwait(false); }
+        catch { /* drain is best-effort once we're tearing down */ }
+
         _process.Dispose();
-    }
-
-    private static string LocateSmokeMcpServerDll()
-    {
-        var repo = new DirectoryInfo(AppContext.BaseDirectory);
-        while (repo is not null && !File.Exists(Path.Combine(repo.FullName, "Netclaw.slnx")))
-            repo = repo.Parent;
-        Assert.NotNull(repo);
-
-        var projectDir = Path.Combine(repo!.FullName, "tests", "Netclaw.SmokeMcpServer");
-        var binMarker = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";
-        var dll = Directory
-            .EnumerateFiles(projectDir, "Netclaw.SmokeMcpServer.dll", SearchOption.AllDirectories)
-            .Where(p => p.Contains(binMarker))
-            .OrderByDescending(File.GetLastWriteTimeUtc)
-            .FirstOrDefault();
-
-        Assert.True(dll is not null,
-            $"Netclaw.SmokeMcpServer.dll not found under {projectDir}/bin — is the project built?");
-        return dll!;
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -179,14 +179,10 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
             {
                 while (await process.StandardOutput.ReadLineAsync(ct).ConfigureAwait(false) is not null) { }
             }
-            catch (OperationCanceledException)
-            {
-                // Drain ends with the test's cancellation token — expected on teardown.
-            }
-            catch (IOException)
-            {
-                // Stream closes when the child is killed in DisposeAsync.
-            }
+            // slopwatch-ignore: SW003 stdout drain ends with the test cancellation token; this is the expected teardown exit, not a swallowed error.
+            catch (OperationCanceledException) { }
+            // slopwatch-ignore: SW003 the child's stdout stream closes when DisposeAsync kills the process; expected teardown race, not a swallowed error.
+            catch (IOException) { }
         }, ct);
 
         // Bounded wait for the child to publish its listening URL on stderr;
@@ -229,10 +225,8 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
         {
             process.Kill(entireProcessTree: true);
         }
-        catch (InvalidOperationException)
-        {
-            // Process exited between HasExited and Kill — nothing to do.
-        }
+        // slopwatch-ignore: SW003 race between HasExited check and Kill — the child exited on its own, nothing to do.
+        catch (InvalidOperationException) { }
     }
 
     private static async Task IgnoreCancellationAsync(Task task)
@@ -241,16 +235,9 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
         {
             await task.ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
-        {
-            // Drains are tied to the test's CancellationToken; cancellation
-            // on teardown is the expected exit, not a failure to report.
-        }
-        catch (InvalidOperationException)
-        {
-            // The stderr drain TCS surfaces this when the child exits before
-            // publishing a listening URL; the caller already saw the
-            // TimeoutException that StartAsync threw.
-        }
+        // slopwatch-ignore: SW003 drains are tied to the test cancellation token; cancellation on teardown is the expected exit, not a failure to surface.
+        catch (OperationCanceledException) { }
+        // slopwatch-ignore: SW003 stderr drain TCS surfaces this when the child exits before publishing a listening URL; the caller already saw the TimeoutException StartAsync threw.
+        catch (InvalidOperationException) { }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerHttpHeaderTests.cs
@@ -179,40 +179,78 @@ internal sealed class SmokeHttpMcpServer : IAsyncDisposable
             {
                 while (await process.StandardOutput.ReadLineAsync(ct).ConfigureAwait(false) is not null) { }
             }
-            catch { /* drain best-effort */ }
+            catch (OperationCanceledException)
+            {
+                // Drain ends with the test's cancellation token — expected on teardown.
+            }
+            catch (IOException)
+            {
+                // Stream closes when the child is killed in DisposeAsync.
+            }
         }, ct);
 
-        var startTimeout = Task.Delay(TimeSpan.FromSeconds(30), ct);
-        var completed = await Task.WhenAny(listeningTcs.Task, startTimeout).ConfigureAwait(false);
-        if (completed != listeningTcs.Task)
+        // Bounded wait for the child to publish its listening URL on stderr;
+        // listeningTcs is the actual sync primitive — the timeout is just a
+        // fail-fast for "child never started" rather than a flake-buffer.
+        string url;
+        try
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
-            throw new TimeoutException("Smoke MCP server did not start within 30s");
+            url = await listeningTcs.Task.WaitAsync(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            TryKill(process);
+            throw new TimeoutException("Smoke MCP server did not publish a listening URL within 30s");
         }
 
-        return new SmokeHttpMcpServer(
-            process, await listeningTcs.Task.ConfigureAwait(false), stderrDrain, stdoutDrain);
+        return new SmokeHttpMcpServer(process, url, stderrDrain, stdoutDrain);
     }
 
     public async ValueTask DisposeAsync()
     {
         if (!_process.HasExited)
-        {
-            try { _process.Kill(entireProcessTree: true); }
-            catch { /* best-effort */ }
-        }
+            TryKill(_process);
 
-        try { await _process.WaitForExitAsync().ConfigureAwait(false); }
-        catch { /* best-effort */ }
+        await _process.WaitForExitAsync().ConfigureAwait(false);
 
-        // Drains terminate when the streams close; await both so teardown
-        // doesn't leave Task.Run continuations executing past the test.
-        try { await _stderrDrain.ConfigureAwait(false); }
-        catch { /* drain is best-effort once we're tearing down */ }
-
-        try { await _stdoutDrain.ConfigureAwait(false); }
-        catch { /* drain is best-effort once we're tearing down */ }
+        // Drains terminate once the streams close; await both so teardown
+        // doesn't leave Task.Run continuations executing past the test. The
+        // drains' own catches handle the cancellation/IO race; surfacing
+        // anything else here would mask a real teardown bug.
+        await IgnoreCancellationAsync(_stderrDrain).ConfigureAwait(false);
+        await IgnoreCancellationAsync(_stdoutDrain).ConfigureAwait(false);
 
         _process.Dispose();
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between HasExited and Kill — nothing to do.
+        }
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Drains are tied to the test's CancellationToken; cancellation
+            // on teardown is the expected exit, not a failure to report.
+        }
+        catch (InvalidOperationException)
+        {
+            // The stderr drain TCS surfaces this when the child exits before
+            // publishing a listening URL; the caller already saw the
+            // TimeoutException that StartAsync threw.
+        }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerLocator.cs
+++ b/src/Netclaw.Daemon.Tests/Mcp/SmokeMcpServerLocator.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmokeMcpServerLocator.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Mcp;
+
+/// <summary>
+/// Resolves the freshly-built <c>Netclaw.SmokeMcpServer.dll</c> for tests
+/// that launch it as a child process. The server is a
+/// <c>ReferenceOutputAssembly=false</c> project reference so it is always
+/// built alongside the test project; the most recently written copy under
+/// the project's <c>bin/</c> tree is the one this test run produced.
+/// Picking by write time keeps this correct regardless of build
+/// configuration or RID output subdirectory.
+/// </summary>
+internal static class SmokeMcpServerLocator
+{
+    public static string LocateDll()
+    {
+        var repo = new DirectoryInfo(AppContext.BaseDirectory);
+        while (repo is not null && !File.Exists(Path.Combine(repo.FullName, "Netclaw.slnx")))
+            repo = repo.Parent;
+        Assert.NotNull(repo);
+
+        var projectDir = Path.Combine(repo!.FullName, "tests", "Netclaw.SmokeMcpServer");
+        var binMarker = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";
+        var dll = Directory
+            .EnumerateFiles(projectDir, "Netclaw.SmokeMcpServer.dll", SearchOption.AllDirectories)
+            .Where(p => p.Contains(binMarker))
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
+
+        Assert.True(dll is not null,
+            $"Netclaw.SmokeMcpServer.dll not found under {projectDir}/bin — is the project built?");
+        return dll!;
+    }
+}

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -548,7 +548,7 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
                 EnvironmentVariables = entry.EnvironmentVariables is { Count: > 0 }
                     ? entry.EnvironmentVariables.ToDictionary(
                         kvp => kvp.Key,
-                        kvp => (string?)kvp.Value,
+                        kvp => (string?)kvp.Value.Value,
                         StringComparer.OrdinalIgnoreCase)
                     : null,
                 Name = serverName.Value,
@@ -556,8 +556,14 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             });
         }
 
+        // Unwrap SensitiveString → raw header value here at the transport
+        // boundary so the SDK sees the actual credential, not the wrapper's
+        // redacted ToString().
         Dictionary<string, string>? headers = entry.Headers is { Count: > 0 }
-            ? new Dictionary<string, string>(entry.Headers)
+            ? entry.Headers.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.Value,
+                StringComparer.OrdinalIgnoreCase)
             : null;
 
         return new HttpClientTransport(new HttpClientTransportOptions

--- a/src/Netclaw.Daemon/Mcp/McpClientManager.cs
+++ b/src/Netclaw.Daemon/Mcp/McpClientManager.cs
@@ -545,26 +545,16 @@ internal sealed class McpClientManager : IHostedService, IDisposable, IMcpToolIn
             {
                 Command = entry.Command!,
                 Arguments = args,
-                EnvironmentVariables = entry.EnvironmentVariables is { Count: > 0 }
-                    ? entry.EnvironmentVariables.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => (string?)kvp.Value.Value,
-                        StringComparer.OrdinalIgnoreCase)
-                    : null,
+                EnvironmentVariables = entry.EnvironmentVariables.ToRawNullableValues(StringComparer.OrdinalIgnoreCase),
                 Name = serverName.Value,
                 ShutdownTimeout = TimeSpan.FromSeconds(10),
             });
         }
 
-        // Unwrap SensitiveString → raw header value here at the transport
-        // boundary so the SDK sees the actual credential, not the wrapper's
-        // redacted ToString().
-        Dictionary<string, string>? headers = entry.Headers is { Count: > 0 }
-            ? entry.Headers.ToDictionary(
-                kvp => kvp.Key,
-                kvp => kvp.Value.Value,
-                StringComparer.OrdinalIgnoreCase)
-            : null;
+        // Unwrap SensitiveString here at the transport boundary so the SDK
+        // sees the actual credential, not SensitiveString.ToString()'s
+        // redacted sentinel.
+        var headers = entry.Headers.ToRawValues(StringComparer.OrdinalIgnoreCase);
 
         return new HttpClientTransport(new HttpClientTransportOptions
         {

--- a/tests/Netclaw.SmokeMcpServer/Netclaw.SmokeMcpServer.csproj
+++ b/tests/Netclaw.SmokeMcpServer/Netclaw.SmokeMcpServer.csproj
@@ -1,10 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <!--
-    Deterministic stdio MCP server used by the native smoke harness
-    (tests/smoke/scenarios/mcp-setup.sh). Exposes three fully-deterministic
-    tools so a scenario can assert on the tool RESULT even though the
-    surrounding LLM prose is non-deterministic. NOT shipped to users.
+    Deterministic test MCP server used by the native smoke harness
+    (tests/smoke/scenarios/mcp-setup.sh) and by xUnit MCP smoke tests.
+
+    Default (stdio) mode exposes three fully-deterministic tools (add, echo,
+    record-tasks) so a scenario can assert on the tool RESULT even when the
+    surrounding LLM prose is non-deterministic.
+
+    HTTP mode adds a `last_auth_header` tool that returns whatever
+    Authorization header the current request arrived with. That is the only
+    reliable way to validate that `netclaw mcp add` correctly attaches the
+    configured header to outbound HTTP MCP traffic — see
+    Netclaw.Configuration.McpServerEntry.Headers and
+    McpClientManager.CreateTransport. NOT shipped to users.
   -->
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -18,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol.Core" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/tests/Netclaw.SmokeMcpServer/Program.cs
+++ b/tests/Netclaw.SmokeMcpServer/Program.cs
@@ -6,38 +6,63 @@
 
 using System.ComponentModel;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
-// Deterministic stdio MCP test server for the native smoke harness.
+// Deterministic MCP test server for the native smoke harness and xUnit tests.
 //
-// Exposes exactly three tools whose output is a pure function of their input:
-//   add(a, b)                -> a + b
-//   echo(text)               -> text
-//   record-tasks(tasks, ref) -> a summary of the structured arguments received
+// Two modes:
+//   stdio (default)
+//     Exposes three fully-deterministic tools whose output is a pure
+//     function of their input:
+//       add(a, b)                -> a + b
+//       echo(text)               -> text
+//       record-tasks(tasks, ref) -> a summary of the structured arguments
 //
-// Determinism is the whole point: add(2, 2) is always 4, so a smoke
-// scenario can hard-assert on the tool RESULT even though the surrounding
-// LLM prose is random. `record-tasks` additionally gives netclaw's
-// schema-driven argument coercion a tool with an array-of-objects parameter
-// to exercise end to end (see SmokeMcpServerArgumentCoercionTests).
+//     Determinism is the whole point: add(2, 2) is always 4, so a smoke
+//     scenario can hard-assert on the tool RESULT even though the
+//     surrounding LLM prose is random. `record-tasks` additionally gives
+//     netclaw's schema-driven argument coercion a tool with an
+//     array-of-objects parameter to exercise end to end (see
+//     SmokeMcpServerArgumentCoercionTests).
 //
-// CRITICAL: stdout is the MCP JSON-RPC protocol channel. Nothing other than
-// protocol frames may be written to stdout. All diagnostics go to stderr.
+//     CRITICAL: stdout is the MCP JSON-RPC protocol channel. Nothing
+//     other than protocol frames may be written to stdout. All
+//     diagnostics go to stderr.
+//
+//   http  (opt-in via `--transport http --port N`)
+//     Adds a `last_auth_header` tool that returns the Authorization
+//     header attached to the *most recent* request the server saw.
+//     `--port 0` asks the kernel for an ephemeral port; the chosen
+//     port is printed to stderr as `[smoke-mcp:listening] http://127.0.0.1:NNNNN/mcp`
+//     so a test can parse it without racing on a fixed port.
+//
+//     The `last_auth_header` tool is the only reliable end-to-end probe
+//     that `netclaw mcp add --header "Authorization: …"` actually
+//     attaches the configured header to outbound HTTP MCP traffic.
+//     Plain string headers used to be silently dropped because
+//     McpServerEntry stored them as Dictionary<string, string> and
+//     SensitiveStringTypeConverter never decrypted the ENC:… ciphertext.
 
 namespace Netclaw.SmokeMcpServer;
 
-internal static class Program
+internal sealed class Program
 {
+    // Class is non-static so WithTools<Program>() can construct it for tool
+    // discovery; tool methods themselves remain static because they have no
+    // per-instance state. Static-only state lives on HttpAuthCapture.
     /// <summary>Deterministic tool: returns the integer sum of two integers.</summary>
+    [McpServerTool(Name = "add")]
     [Description("Add two integers and return their sum.")]
-    private static int Add(
+    public static int Add(
         [Description("The first integer addend.")] int a,
         [Description("The second integer addend.")] int b) => a + b;
 
     /// <summary>Deterministic tool: echoes its input back verbatim.</summary>
+    [McpServerTool(Name = "echo")]
     [Description("Echo the given text back verbatim.")]
-    private static string Echo(
+    public static string Echo(
         [Description("The text to echo back unchanged.")] string text) => text;
 
     /// <summary>
@@ -51,8 +76,9 @@ internal static class Program
     /// zeros). The result echoes the received shape so a test can hard-assert
     /// on it.
     /// </summary>
+    [McpServerTool(Name = "record-tasks")]
     [Description("Record a batch of task objects under a reference code; echoes back the structured arguments received.")]
-    private static string RecordTasks(
+    public static string RecordTasks(
         [Description("The batch of task objects to record.")] object[] tasks,
         [Description("A reference code for the batch.")] string reference)
     {
@@ -60,41 +86,160 @@ internal static class Program
         return $"reference={reference} count={tasks.Length} kinds=[{kinds}]";
     }
 
-    private static async Task<int> Main()
+    /// <summary>
+    /// HTTP-mode-only tool: returns the Authorization header attached to
+    /// the most recent request the server received. Returns the literal
+    /// string "(none)" when no request has carried an Authorization
+    /// header yet. The "(none)" sentinel is deliberate — empty-string vs.
+    /// null vs. missing-header is exactly the distinction we want a
+    /// header-passthrough regression to flag.
+    /// </summary>
+    [McpServerTool(Name = "last_auth_header")]
+    [Description("Returns the Authorization header attached to the most recent incoming request, or '(none)' if no such header has been seen.")]
+    public static string LastAuthHeader() => HttpAuthCapture.LastAuthHeader ?? "(none)";
+
+    private static async Task<int> Main(string[] args)
     {
         try
         {
-            var tools = new McpServerPrimitiveCollection<McpServerTool>
+            var parsed = ParseArgs(args);
+            return parsed.Transport switch
             {
-                McpServerTool.Create(Add, new McpServerToolCreateOptions { Name = "add" }),
-                McpServerTool.Create(Echo, new McpServerToolCreateOptions { Name = "echo" }),
-                McpServerTool.Create(RecordTasks, new McpServerToolCreateOptions { Name = "record-tasks" }),
+                "http" => await RunHttpAsync(parsed),
+                _ => await RunStdioAsync(),
             };
-
-            var options = new McpServerOptions
-            {
-                ServerInfo = new Implementation
-                {
-                    Name = "netclaw-smoke-mcp",
-                    Version = "1.0.0",
-                },
-                ServerInstructions =
-                    "Deterministic test server for the Netclaw smoke harness. " +
-                    "Use 'add' to sum two integers, 'echo' to repeat text, and " +
-                    "'record-tasks' to record a batch of task objects.",
-                ToolCollection = tools,
-            };
-
-            await using var transport = new StdioServerTransport(options);
-            await using var server = McpServer.Create(transport, options);
-            await server.RunAsync();
-            return 0;
         }
         catch (Exception ex)
         {
-            // stderr only — stdout is reserved for the JSON-RPC protocol.
             await Console.Error.WriteLineAsync($"[smoke-mcp:error] {ex}");
             return 1;
         }
     }
+
+    private static async Task<int> RunStdioAsync()
+    {
+        var tools = new McpServerPrimitiveCollection<McpServerTool>
+        {
+            McpServerTool.Create(Add, new McpServerToolCreateOptions { Name = "add" }),
+            McpServerTool.Create(Echo, new McpServerToolCreateOptions { Name = "echo" }),
+            McpServerTool.Create(RecordTasks, new McpServerToolCreateOptions { Name = "record-tasks" }),
+        };
+
+        var options = new McpServerOptions
+        {
+            ServerInfo = new Implementation
+            {
+                Name = "netclaw-smoke-mcp",
+                Version = "1.0.0",
+            },
+            ServerInstructions =
+                "Deterministic test server for the Netclaw smoke harness. " +
+                "Use 'add' to sum two integers, 'echo' to repeat text, and " +
+                "'record-tasks' to record a batch of task objects.",
+            ToolCollection = tools,
+        };
+
+        await using var transport = new StdioServerTransport(options);
+        await using var server = McpServer.Create(transport, options);
+        await server.RunAsync();
+        return 0;
+    }
+
+    private static async Task<int> RunHttpAsync(ParsedArgs args)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+
+        builder.WebHost.ConfigureKestrel(kestrel =>
+        {
+            // Listen on 127.0.0.1 (not localhost) so `--port 0` works.
+            // Kestrel rejects port 0 on the dual-stack ListenLocalhost path.
+            kestrel.Listen(System.Net.IPAddress.Loopback, args.Port);
+        });
+
+        builder.Services
+            .AddMcpServer(opts =>
+            {
+                opts.ServerInfo = new Implementation
+                {
+                    Name = "netclaw-smoke-mcp",
+                    Version = "1.0.0",
+                };
+                opts.ServerInstructions =
+                    "Deterministic HTTP test server for the Netclaw smoke harness. " +
+                    "Includes 'last_auth_header' which echoes the Authorization header " +
+                    "from the most recent request.";
+            })
+            .WithHttpTransport()
+            .WithTools<Program>();
+
+        var app = builder.Build();
+
+        if (args.CaptureAuth)
+        {
+            app.Use(async (ctx, next) =>
+            {
+                HttpAuthCapture.LastAuthHeader = ctx.Request.Headers.TryGetValue("Authorization", out var v)
+                    ? v.ToString()
+                    : null;
+                await next();
+            });
+        }
+
+        app.MapMcp("/mcp");
+
+        await app.StartAsync();
+
+        // Resolve the actual listening port (may differ from args.Port when 0
+        // was requested) and publish it to stderr so the spawning test can
+        // attach without racing on a fixed port.
+        var serverAddresses = app.Services
+            .GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>()
+            .Features
+            .Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>();
+        var address = serverAddresses?.Addresses.FirstOrDefault() ?? $"http://127.0.0.1:{args.Port}";
+        await Console.Error.WriteLineAsync($"[smoke-mcp:listening] {address.TrimEnd('/')}/mcp");
+
+        await app.WaitForShutdownAsync();
+        return 0;
+    }
+
+    private static ParsedArgs ParseArgs(string[] args)
+    {
+        var transport = "stdio";
+        var port = 0;
+        var captureAuth = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--transport" when i + 1 < args.Length:
+                    transport = args[++i];
+                    break;
+                case "--port" when i + 1 < args.Length:
+                    port = int.Parse(args[++i], System.Globalization.CultureInfo.InvariantCulture);
+                    break;
+                case "--capture-auth":
+                    captureAuth = true;
+                    break;
+            }
+        }
+
+        return new ParsedArgs(transport, port, captureAuth);
+    }
+
+    private sealed record ParsedArgs(string Transport, int Port, bool CaptureAuth);
+}
+
+/// <summary>
+/// Holds the Authorization header from the most recently observed inbound
+/// request. Module-static so the <c>[McpServerTool]</c> static method can
+/// read it without dependency injection plumbing — the smoke server is
+/// single-process by construction and the only writer is the capture
+/// middleware in <see cref="Program.RunHttpAsync"/>.
+/// </summary>
+internal static class HttpAuthCapture
+{
+    public static string? LastAuthHeader { get; set; }
 }


### PR DESCRIPTION
Closes #1118.

## Summary

`netclaw mcp add --header "Authorization: …"` writes the header value to `secrets.json` with the `ENC:` ciphertext prefix. The daemon binds MCP servers via `configuration.GetSection("McpServers").Get<Dictionary<string, McpServerEntry>>()`, and `McpServerEntry.Headers` was typed `Dictionary<string, string>` — so `SensitiveStringTypeConverter` was never invoked and the `ENC:` prefix was never stripped. The daemon then sent `Authorization: ENC:CfDJ8…` to the upstream MCP server, which any service that authenticates on the first byte (e.g. `mcp.atlassian.com`) rejected with 401. `EnvironmentVariables` had the same shape and the same bug for stdio servers configured with `--env API_KEY=…`.

The OAuth-probe diagnosis in #1118 is incorrect — see [my comment on the issue](https://github.com/netclaw-dev/netclaw/issues/1118#issuecomment-4503105662) for the trace. Existing HTTP MCP servers (Notion, TextForge, Memorizer) all run through OAuth and therefore route bearers through `McpOAuthTokens` (a separate decrypt-at-load path), so this had been sitting in the wild unnoticed.

## Fix

Retype `Headers` and `EnvironmentVariables` to `Dictionary<string, SensitiveString>` so M.E.Configuration binding and STJ deserialization decrypt through the existing TypeConverter / JsonConverter pair. Unwrap to raw strings at the SDK transport boundary in `McpClientManager.CreateTransport`.

Added `SensitiveStringExtensions.ToRawValues` / `ToRawNullableValues` so the "unwrap at the SDK transport" idiom isn't open-coded at five call sites.

## End-to-end coverage

`Netclaw.SmokeMcpServer` gains an opt-in HTTP mode (Kestrel + `MapMcp("/mcp")`) and a `last_auth_header` tool that returns whatever Authorization header the most recent request arrived with. `--port 0` writes the chosen ephemeral port to stderr as `[smoke-mcp:listening] http://127.0.0.1:NNNNN/mcp` so tests can attach without racing on a fixed port.

`SmokeMcpServerHttpHeaderTests` spawns the smoke server in that mode, points an `McpClientManager` at it with a configured Authorization header, and asserts via the tool that the header arrived intact. A counterpart asserts no Authorization is invented when none is configured.

`McpServerEntryBindingTests` covers the inner ring at the binding-layer in isolation — pure config → `Dictionary<string, McpServerEntry>` decryption — so a regression in the type-converter wiring fails fast without needing a child process.

## Test plan

- [x] `dotnet test src/Netclaw.Configuration.Tests` — 325 passed
- [x] `dotnet test src/Netclaw.Cli.Tests` — 727 passed
- [x] `dotnet test src/Netclaw.Daemon.Tests --filter Mcp` — 53 passed (incl. 2 new HTTP smoke tests + 3 new binding tests)
- [x] `dotnet slopwatch analyze` — clean
- [x] `./scripts/Add-FileHeaders.ps1 -Verify` — clean
- [x] Reproduced the original bug locally against `mcp.atlassian.com` (daemon got 401), confirmed fix works (daemon now gets 200 on initialize with the configured Bearer).

## Notes

- `SensitiveStringStaticStateCollection` serializes any test that mutates the process-wide `SensitiveStringTypeConverter.Protector` hook. `SensitiveStringConverterTests` joins it. Without this the new binding tests race the existing converter tests on the static.
- `Microsoft.NET.Sdk.Web` + `ModelContextProtocol.AspNetCore 1.3.0` added to `Netclaw.SmokeMcpServer` for its HTTP mode. The server is `<IsPackable>false</IsPackable>` and not shipped to users.