### PR TITLE
fix(channels): forward stale approval clicks to session

### DIFF
--- a/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
+++ b/src/Netclaw.Actors.Tests/Channels/Contracts/SessionBindingContractTests.cs
@@ -480,6 +480,16 @@ public abstract class SessionBindingContractTests : TestKit
         }, cancellationToken: ct);
     }
 
+    // Regression for the silent-drop class of bugs: the binding observes a
+    // ToolInteractionRequest then a TurnCompleted (which clears its local
+    // _pendingApprovalRequests). A button click arriving afterwards must still
+    // be routed to the session — the session is the authority on whether the
+    // CallId is genuinely stale, and the session emits a user-visible "expired"
+    // notice when it cannot find the CallId. Dropping at the binding leaves the
+    // user staring at a dead button with no feedback. See the LlmSessionActor
+    // pending-interactions invariants (LlmSessionActor.cs:381) — a parked
+    // approval keeps the dictionary populated across idle periods, so a click
+    // that reaches the session is reliably handled.
     [Fact]
     public async Task Cold_text_approval_response_forwards_to_session_when_binding_cold_spawned()
     {
@@ -551,23 +561,25 @@ public abstract class SessionBindingContractTests : TestKit
     }
 
     [Fact]
-    public async Task Approvals_cleared_on_turn_completed()
+    public async Task Approval_response_after_turn_completed_forwards_to_session()
     {
         var ct = TestContext.Current.CancellationToken;
         var detector = new ConfigurablePromptInjectionDetector(PromptInjectionResult.Safe());
-        var sid = new SessionId("session-approval-clear");
+        var sid = new SessionId("session-approval-post-turn");
         var pipeline = new RecordingSessionPipeline(_ =>
         [
             new ToolInteractionRequest
             {
                 SessionId = sid,
                 Kind = "approval",
-                CallId = new Netclaw.Tools.ToolCallId("call-stale"),
+                CallId = new Netclaw.Tools.ToolCallId("call-post-turn"),
                 ToolName = new Netclaw.Tools.ToolName("execute_shell"),
                 DisplayText = "some command",
+                RequesterSenderId = new SenderId("user-1"),
                 Options =
                 [
-                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel)
+                    new ToolInteractionOption(ApprovalOptionKeys.ApproveOnceKey, ApprovalOptionKeys.ApproveOnceLabel),
+                    new ToolInteractionOption(ApprovalOptionKeys.DenyKey, ApprovalOptionKeys.DenyLabel)
                 ]
             },
             new TurnCompleted { SessionId = sid, TurnNumber = new Netclaw.Actors.Protocol.TurnNumber(1) }
@@ -575,27 +587,28 @@ public abstract class SessionBindingContractTests : TestKit
 
         var actor = CreateBindingActor(sid, pipeline, detector);
 
-        // Wait for turn to complete (fallback posted because approval doesn't count as delivered text for empty turn check)
+        // Wait for the approval prompt + turn completion to flush through —
+        // an empty-turn fallback is posted because the approval prompt does not
+        // count as delivered text for the fallback heuristic. Two posts proves
+        // both the prompt and the TurnCompleted have been processed by the
+        // binding, leaving its local pending list cleared.
         await AwaitAssertAsync(() =>
         {
             var texts = GetPostedTexts();
             Assert.True(texts.Count >= 2, $"Expected at least 2 posts, got {texts.Count}");
         }, cancellationToken: ct);
 
-        // Stale approval should NOT produce feedback. Send the approval, then
-        // a PoisonPill to stop the actor. FIFO mailbox ordering guarantees the
-        // actor processes the approval before stopping, so ExpectTerminatedAsync
-        // is a deterministic sync barrier — no time-based waits needed.
-        var probe = CreateTestProbe();
-        probe.Watch(actor);
-        actor.Tell(CreateApprovalResponse("call-stale", ApprovalOptionKeys.ApproveOnce, "user-1"), TestActor);
-        actor.Tell(PoisonPill.Instance, TestActor);
-        await probe.ExpectTerminatedAsync(actor, cancellationToken: ct);
+        actor.Tell(CreateApprovalResponse("call-post-turn", ApprovalOptionKeys.ApproveOnce, "user-1"), TestActor);
 
-        var staleResponses = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>()
-            .Where(f => f.CallId.Value == "call-stale")
-            .ToList();
-        Assert.Empty(staleResponses);
+        await AwaitAssertAsync(() =>
+        {
+            var forwarded = pipeline.RecordedFeedback.OfType<ToolInteractionResponse>()
+                .Where(f => f.CallId.Value == "call-post-turn")
+                .ToList();
+            Assert.Single(forwarded);
+            Assert.Equal(ApprovalOptionKeys.ApproveOnce, forwarded[0].SelectedKey.Value);
+            Assert.Equal("user-1", forwarded[0].SenderId.Value);
+        }, cancellationToken: ct);
     }
 
     // --- Failure Notification ---

--- a/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
+++ b/src/Netclaw.Actors/Sessions/LlmSessionActor.cs
@@ -3215,6 +3215,27 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
         }, OutputFilter.Text);
 
     /// <summary>
+    /// Classifies why a tool-interaction response could not be matched to a
+    /// pending interaction. Intent is operational triage: the same expired
+    /// notice ships to the channel either way, but the log line tells the
+    /// operator whether the click was redundant (already resolved or completed)
+    /// or genuinely unknown (silent-drop suspect).
+    /// </summary>
+    private string ClassifyUnknownApprovalCall(string callId)
+    {
+        if (_resolvedToolApprovals.ContainsKey(callId))
+            return "already_resolved";
+
+        if (ParkedToolBatchHistory.HasToolResult(_state.History, callId))
+            return "already_completed";
+
+        if (ParkedToolBatchHistory.FindRedrivableAssistantMessage(_state.History, callId) is not null)
+            return "orphaned_assistant_tool_use";
+
+        return "unknown";
+    }
+
+    /// <summary>
     /// Shared authorization and grant-persistence for a tool-approval response.
     /// Used by both the live-<c>Processing</c> handler and the idle re-drive
     /// handler so the requester check and grant-scope rules stay in lockstep.
@@ -3424,8 +3445,19 @@ public sealed class LlmSessionActor : ReceivePersistentActor, IWithTimers
             // tail still carries the tool_use block, treat the prompt as
             // expired and fail loud with a channel-visible message rather
             // than silently dropping the click.
+            //
+            // The classification helps triage "where did my click go" reports:
+            // already_resolved means the approval landed but the click is a
+            // duplicate (e.g., user double-clicked, or text + button both
+            // arrived); no_history means the CallId was never observed by this
+            // session — the most common silent-drop scenario when a binding
+            // misroutes; orphaned_history means a tool_use exists with no
+            // pending or resolved record, suggesting the batch was abandoned
+            // (e.g., user sent a new message instead of approving).
+            var classification = ClassifyUnknownApprovalCall(callId);
             _log.Warning(
-                "Tool interaction response for unknown/expired call {CallId}", msg.CallId);
+                "Tool interaction response for unknown/expired call {CallId} ({Classification}); pending={PendingCount} resolved={ResolvedCount}",
+                msg.CallId, classification, _pendingToolInteractions.Count, _resolvedToolApprovals.Count);
             EmitExpiredPromptNotice();
             TryReplyNack("approval_prompt_expired");
             return;

--- a/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Discord/DiscordSessionBindingActor.cs
@@ -46,10 +46,14 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
     private readonly ILoggingAdapter _log;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
-    // Distinguishes "cold-spawned binding that never observed a ToolInteractionRequest"
-    // from "binding that observed at least one, then cleared its list on TurnCompleted."
-    // The former blind-forwards approval responses to the session (#979); the latter
-    // treats unknown callIds as stale and drops them.
+    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
+    // A binding that has never observed any ToolInteractionRequest treats an
+    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
+    // restarted out from under it. Once we've observed at least one prompt,
+    // subsequent ambiguous text from the user is ordinary conversation, not an
+    // approval reply, so the cold path stays off. This does NOT gate button
+    // clicks — those always route to the session, which is the authority on
+    // CallId staleness.
     private bool _hasObservedApprovalRequest;
 
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
@@ -797,16 +801,6 @@ internal sealed class DiscordSessionBindingActor : ReceivePersistentActor, IWith
         if (result is ApprovalLookupResult.WrongRequester)
         {
             await SafeReplyAsync(WrongRequesterWarning);
-            return;
-        }
-
-        // Stale path: this binding has previously observed an approval request and
-        // cleared its list (e.g., on TurnCompleted). Subsequent responses for unknown
-        // callIds are stale — drop at the binding rather than forwarding to the session.
-        if (pending is null && _hasObservedApprovalRequest)
-        {
-            _log.Info("Dropping stale Discord approval response for call {0}; no local pending entry after turn-cleared list", message.CallId);
-            ChannelTelemetry.For(ChannelType.Discord).RecordExtra("interactionErrors", "stale_after_turn");
             return;
         }
 

--- a/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
+++ b/src/Netclaw.Channels.Mattermost/MattermostSessionBindingActor.cs
@@ -46,6 +46,16 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private readonly ILoggingAdapter _log;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
+    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
+    // A binding that has never observed any ToolInteractionRequest treats an
+    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
+    // restarted out from under it. Once we've observed at least one prompt,
+    // subsequent ambiguous text from the user is ordinary conversation, not an
+    // approval reply, so the cold path stays off. This does NOT gate button
+    // clicks — those always route to the session, which is the authority on
+    // CallId staleness.
+    private bool _hasObservedApprovalRequest;
+
     private static readonly TimeSpan PipelineInitTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan ReinitializeDelay = TimeSpan.FromSeconds(2);
     private static readonly object ReinitializeTimerKey = new();
@@ -54,12 +64,6 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
     private TurnNumber _turnNumber;
     private string? _cursorPostId;
     private string? _pendingCursorPostId;
-
-    // Distinguishes a cold-spawned binding that never observed a ToolInteractionRequest
-    // from one whose pending list was cleared after a completed turn. The former
-    // blind-forwards approval responses to the session (#979); the latter drops them
-    // as stale rather than re-routing a response for an already-finished turn.
-    private bool _hasObservedApprovalRequest;
 
     // Set when PerformOneShotHydrationAsync fetched a non-empty thread gap but
     // found no authorized trigger to anchor a turn. This is the proactive-thread
@@ -774,20 +778,6 @@ internal sealed class MattermostSessionBindingActor : ReceivePersistentActor, IW
         {
             await SafeReplyAsync(WrongRequesterWarning);
             ReplyIfExpected(replyTo, CommandNack.For(_sessionId, "approval_wrong_requester"));
-            return;
-        }
-
-        // Stale path: this binding previously observed an approval request and
-        // cleared its pending list (e.g., on TurnCompleted). A later response for
-        // an unknown call is stale — drop it at the binding rather than routing a
-        // response for an already-finished turn.
-        if (pending is null && _hasObservedApprovalRequest)
-        {
-            _log.Info(
-                "Dropping stale Mattermost approval response for call {0}; no local pending entry after turn-cleared list",
-                message.CallId);
-            ChannelTelemetry.For(ChannelType.Mattermost).RecordExtra("interactionErrors", "stale_after_turn");
-            ReplyIfExpected(replyTo, CommandNack.For(_sessionId, "approval_prompt_expired"));
             return;
         }
 

--- a/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
+++ b/src/Netclaw.Channels.Slack/SlackThreadBindingActor.cs
@@ -37,10 +37,14 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
     private PostResult? _lastFailedPost;
     private readonly List<PendingApprovalRequest> _pendingApprovalRequests = [];
 
-    // Distinguishes "cold-spawned binding that never observed a ToolInteractionRequest"
-    // from "binding that observed at least one, then cleared its list on TurnCompleted."
-    // The former blind-forwards approval responses to the session (#979); the latter
-    // treats unknown callIds as stale and drops them.
+    // Gates the text-approval cold path (TryHandleColdTextApprovalResponseAsync).
+    // A binding that has never observed any ToolInteractionRequest treats an
+    // inbound "A"/"B"/"C" as a possible cold approval reply for a session that
+    // restarted out from under it. Once we've observed at least one prompt,
+    // subsequent ambiguous text from the user is ordinary conversation, not an
+    // approval reply, so the cold path stays off. This does NOT gate button
+    // clicks — those always route to the session, which is the authority on
+    // CallId staleness.
     private bool _hasObservedApprovalRequest;
 
     private readonly SessionPipelineHandle _handle;
@@ -1314,18 +1318,6 @@ internal sealed class SlackThreadBindingActor : ReceivePersistentActor, IWithTim
         var pendingIndex = _pendingApprovalRequests.FindIndex(request =>
             request.Request.CallId == message.CallId);
         var pending = pendingIndex >= 0 ? _pendingApprovalRequests[pendingIndex] : null;
-
-        // Stale path: this binding has previously observed an approval request and
-        // cleared its list (e.g., on TurnCompleted). Subsequent responses for unknown
-        // callIds are stale — drop them at the binding rather than forwarding to the
-        // session. This preserves Approvals_cleared_on_turn_completed semantics.
-        if (pending is null && _hasObservedApprovalRequest)
-        {
-            _log.Info(
-                "Dropping stale Slack button approval response for call {CallId}; no local pending entry after turn-cleared list",
-                message.CallId);
-            return;
-        }
 
         // CanApprove fast-path: if the binding still holds the original request we can
         // post the wrong-requester warning locally without round-tripping through the


### PR DESCRIPTION
## Summary

- The Slack, Discord, and Mattermost bindings silently dropped approval button clicks when the binding had previously observed a `ToolInteractionRequest` and then cleared its local pending list (typically on `TurnCompleted`). Users on 0.19.0/0.20.0 saw dead buttons — clicking did nothing, with no channel-visible feedback. Only restarting the netclaw process surfaced an "approval expired" warning, because the cold binding then routed the click through to the session.
- The session side (`LlmSessionActor`) already journals `ToolApprovalRequested` / `ToolApprovalResolved` events, rehydrates `_pendingToolInteractions` on actor recovery, defers passivation while interactions are pending (`LlmSessionActor.cs:381`), and emits a user-visible `EmitExpiredPromptNotice` for unknown CallIds — so a click that *reaches* the session is reliably handled either way.
- Remove the binding-side `pending is null && _hasObservedApprovalRequest` drop guard (and the now-unused field) in all three bindings. The session is the authoritative source for staleness.
- Replace the `Approvals_cleared_on_turn_completed` contract test with `Approval_response_after_turn_completed_forwards_to_session` — same scenario, inverted contract. Asserts the response *is* forwarded.
- Add a `ClassifyUnknownApprovalCall` helper on the session so the expired-prompt log line distinguishes `already_resolved` / `already_completed` / `orphaned_assistant_tool_use` / `unknown` — operational triage signal for future "where did my click go" reports.

## What the worst case looks like now

When a binding forwards a genuinely stale click, the session falls through to `HandleToolInteractionResponseWhenIdle`, the dictionary lookup misses, and the channel-visible "That approval prompt has expired — the session moved on or restarted." notice is emitted. No silent drop. The auth check, the imposter-sender warning, and the wrong-option-key rejection all still run identically when a matching pending entry *is* found.

## Test plan

- [x] `dotnet test src/Netclaw.Actors.Tests` — 1901/1901 passing (incl. 3 new regression test runs across Slack/Discord/Mattermost contract suites and all existing `ApprovalRehydrationTests`)
- [x] `dotnet test src/Netclaw.Daemon.Tests` — 598/598 passing
- [x] `dotnet slopwatch analyze` — 0 issues
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all headers present
- [ ] End-to-end: park a Slack approval, wait through `TurnCompleted` for a subsequent abandoned/heal cycle, click Approve, confirm either the parked batch re-drives or a visible "approval prompt expired" notice posts to the thread (instead of nothing).

## Notes

- Supersedes the binding-side intent of #1130 (which only fixed the *text-reply* cold path; the *button-click* drop guard was left in place).
- No OpenSpec change: `tool-approval-gates` covers gate evaluation, not click routing, and this is a bug fix aligning bindings with the session-side contract that was already enforced.