### PR TITLE
refactor(providers): extract PipelineRequestBodyEditor + test harness

### DIFF
--- a/src/Netclaw.Daemon.Tests/Providers/OpenRouterReasoningExcludePolicyTests.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/OpenRouterReasoningExcludePolicyTests.cs
@@ -1,11 +1,8 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="OpenRouterReasoningExcludePolicyTests.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Netclaw.Providers.OpenRouter;
 using Xunit;
@@ -24,7 +21,7 @@ public sealed class OpenRouterReasoningExcludePolicyTests
             ["messages"] = new JsonArray(new JsonObject { ["role"] = "user", ["content"] = "hello" })
         };
 
-        var result = ProcessSync(policy, body);
+        var result = PipelinePolicyTestHarness.RunSync(policy, body);
 
         Assert.NotNull(result);
         Assert.True(result!["reasoning"]?["exclude"]?.GetValue<bool>());
@@ -42,7 +39,7 @@ public sealed class OpenRouterReasoningExcludePolicyTests
             ["messages"] = new JsonArray(new JsonObject { ["role"] = "user", ["content"] = "think hard" })
         };
 
-        var result = ProcessSync(policy, body);
+        var result = PipelinePolicyTestHarness.RunSync(policy, body);
 
         Assert.NotNull(result);
         Assert.Equal("deepseek/deepseek-r1", result!["model"]?.GetValue<string>());
@@ -61,7 +58,7 @@ public sealed class OpenRouterReasoningExcludePolicyTests
             ["reasoning"] = new JsonObject { ["effort"] = "high" }
         };
 
-        var result = ProcessSync(policy, body);
+        var result = PipelinePolicyTestHarness.RunSync(policy, body);
 
         Assert.NotNull(result);
         // The policy overwrites any existing reasoning config
@@ -72,78 +69,12 @@ public sealed class OpenRouterReasoningExcludePolicyTests
     public void NoOps_WhenContentIsNull()
     {
         var policy = new OpenRouterReasoningExcludePolicy();
-        // Pipeline wrapper that captures the message without content
-        var pipeline = new CapturePolicy();
-        var message = CreateMessage(content: null);
+        var capture = new PipelinePolicyTestHarness.CapturePolicy();
+        var message = PipelinePolicyTestHarness.CreateMessage(null);
 
-        policy.Process(message, [policy, pipeline], 0);
+        policy.Process(message, [policy, capture], 0);
 
-        // Should pass through without crashing
-        Assert.True(pipeline.WasCalled);
+        Assert.True(capture.WasCalled);
         Assert.Null(message.Request.Content);
-    }
-
-    /// <summary>
-    /// Runs the policy synchronously and returns the modified JSON body.
-    /// </summary>
-    private static JsonObject? ProcessSync(OpenRouterReasoningExcludePolicy policy, JsonObject body)
-    {
-        var pipeline = new CapturePolicy();
-        var message = CreateMessage(body);
-
-        policy.Process(message, [policy, pipeline], 0);
-
-        Assert.True(pipeline.WasCalled, "Policy must call ProcessNext");
-
-        if (message.Request.Content is null)
-            return null;
-
-        using var stream = new MemoryStream();
-        message.Request.Content.WriteTo(stream, default);
-        return JsonSerializer.Deserialize<JsonObject>(stream.ToArray());
-    }
-
-    private static PipelineMessage CreateMessage(JsonObject? body)
-    {
-        var pipeline = ClientPipeline.Create();
-        var message = pipeline.CreateMessage();
-
-        if (body is not null)
-        {
-            var bytes = JsonSerializer.SerializeToUtf8Bytes(body);
-            message.Request.Content = BinaryContent.Create(BinaryData.FromBytes(bytes));
-        }
-
-        return message;
-    }
-
-    private static PipelineMessage CreateMessage(BinaryContent? content)
-    {
-        var pipeline = ClientPipeline.Create();
-        var message = pipeline.CreateMessage();
-        if (content is not null)
-            message.Request.Content = content;
-        return message;
-    }
-
-    /// <summary>
-    /// Terminal policy that records it was reached.
-    /// </summary>
-    private sealed class CapturePolicy : PipelinePolicy
-    {
-        public bool WasCalled { get; private set; }
-
-        public override void Process(
-            PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
-        {
-            WasCalled = true;
-        }
-
-        public override ValueTask ProcessAsync(
-            PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
-        {
-            WasCalled = true;
-            return default;
-        }
     }
 }

--- a/src/Netclaw.Daemon.Tests/Providers/PipelinePolicyTestHarness.cs
+++ b/src/Netclaw.Daemon.Tests/Providers/PipelinePolicyTestHarness.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="PipelinePolicyTestHarness.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Netclaw.Daemon.Tests.Providers;
+
+/// <summary>
+/// Shared test utilities for exercising <see cref="PipelinePolicy"/>
+/// implementations that mutate the outbound JSON request body.
+/// Builds a <see cref="PipelineMessage"/> with the supplied body, runs the
+/// policy synchronously against a single capture policy that records it was
+/// reached, and deserializes the post-mutation body back to <see cref="JsonObject"/>.
+/// </summary>
+internal static class PipelinePolicyTestHarness
+{
+    /// <summary>
+    /// Runs <paramref name="policy"/> against <paramref name="body"/> synchronously
+    /// and returns the modified body, or null if the policy cleared the content.
+    /// Asserts the policy invoked the downstream pipeline (i.e. did not swallow
+    /// the request silently).
+    /// </summary>
+    public static JsonObject? RunSync(PipelinePolicy policy, JsonObject body)
+    {
+        var capture = new CapturePolicy();
+        var message = CreateMessage(body);
+
+        policy.Process(message, [policy, capture], 0);
+
+        Assert.True(capture.WasCalled, "Policy must call ProcessNext");
+
+        if (message.Request.Content is null)
+            return null;
+
+        using var stream = new MemoryStream();
+        message.Request.Content.WriteTo(stream, default);
+        return JsonSerializer.Deserialize<JsonObject>(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Creates a <see cref="PipelineMessage"/> with the supplied JSON body as
+    /// the request content. Pass <c>null</c> to exercise the no-content path
+    /// every body-editing policy should short-circuit on.
+    /// </summary>
+    public static PipelineMessage CreateMessage(JsonObject? body)
+    {
+        var pipeline = ClientPipeline.Create();
+        var message = pipeline.CreateMessage();
+
+        if (body is not null)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(body);
+            message.Request.Content = BinaryContent.Create(BinaryData.FromBytes(bytes));
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Terminal pipeline policy that records whether the upstream policy
+    /// invoked the next step. Use it as the tail of a two-element pipeline.
+    /// </summary>
+    public sealed class CapturePolicy : PipelinePolicy
+    {
+        public bool WasCalled { get; private set; }
+
+        public override void Process(
+            PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            WasCalled = true;
+        }
+
+        public override ValueTask ProcessAsync(
+            PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+            WasCalled = true;
+            return default;
+        }
+    }
+}

--- a/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
+++ b/src/Netclaw.Providers/OpenAi/OpenAiCodexRequestPolicy.cs
@@ -3,9 +3,7 @@
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Netclaw.Providers.OpenAi;
@@ -41,36 +39,23 @@ internal sealed class OpenAiCodexRequestPolicy(string? accountId) : PipelinePoli
 
     private void Modify(PipelineMessage message)
     {
-        var request = message.Request;
-
-        // Inject ChatGPT-Account-Id header (extracted from JWT by JwtAccountIdExtractor)
+        // Inject ChatGPT-Account-Id header (extracted from JWT by JwtAccountIdExtractor).
+        // Set even when the body is empty/non-JSON; the header is always required.
         if (accountId is not null)
-            request.Headers.Set("ChatGPT-Account-Id", accountId);
+            message.Request.Headers.Set("ChatGPT-Account-Id", accountId);
 
-        // Rewrite request body
-        if (request.Content is null)
-            return;
+        PipelineRequestBodyEditor.EditJsonBody(message, obj =>
+        {
+            // Codex backend requires "store": false
+            obj["store"] = false;
 
-        using var stream = new MemoryStream();
-        request.Content.WriteTo(stream, default);
-        var bytes = stream.ToArray();
+            // Move system messages from "input" to "instructions" — the Codex backend
+            // rejects system role messages in the input array.
+            MoveSystemMessagesToInstructions(obj);
 
-        var node = JsonNode.Parse(bytes);
-        if (node is not JsonObject obj)
-            return;
-
-        // Codex backend requires "store": false
-        obj["store"] = false;
-
-        // Move system messages from "input" to "instructions" — the Codex backend
-        // rejects system role messages in the input array.
-        MoveSystemMessagesToInstructions(obj);
-
-        // Strip "strict": null from tool definitions — Codex backend rejects null values
-        StripNullStrict(obj);
-
-        var modified = JsonSerializer.SerializeToUtf8Bytes(obj);
-        request.Content = BinaryContent.Create(BinaryData.FromBytes(modified));
+            // Strip "strict": null from tool definitions — Codex backend rejects null values
+            StripNullStrict(obj);
+        });
     }
 
     /// <summary>

--- a/src/Netclaw.Providers/OpenRouter/OpenRouterReasoningExcludePolicy.cs
+++ b/src/Netclaw.Providers/OpenRouter/OpenRouterReasoningExcludePolicy.cs
@@ -1,11 +1,9 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="OpenRouterReasoningExcludePolicy.cs" company="Petabridge, LLC">
 //      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Netclaw.Providers.OpenRouter;
@@ -21,37 +19,17 @@ internal sealed class OpenRouterReasoningExcludePolicy : PipelinePolicy
     public override void Process(
         PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
     {
-        InjectReasoningExclude(message);
+        PipelineRequestBodyEditor.EditJsonBody(message, InjectReasoningExclude);
         ProcessNext(message, pipeline, currentIndex);
     }
 
     public override async ValueTask ProcessAsync(
         PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
     {
-        InjectReasoningExclude(message);
+        PipelineRequestBodyEditor.EditJsonBody(message, InjectReasoningExclude);
         await ProcessNextAsync(message, pipeline, currentIndex);
     }
 
-    private static void InjectReasoningExclude(PipelineMessage message)
-    {
-        var request = message.Request;
-        if (request.Content is null)
-            return;
-
-        using var stream = new MemoryStream();
-        request.Content.WriteTo(stream, default);
-        var bytes = stream.ToArray();
-
-        var node = JsonNode.Parse(bytes);
-        if (node is not JsonObject obj)
-            return;
-
-        obj["reasoning"] = new JsonObject
-        {
-            ["exclude"] = true
-        };
-
-        var modified = JsonSerializer.SerializeToUtf8Bytes(obj);
-        request.Content = BinaryContent.Create(BinaryData.FromBytes(modified));
-    }
+    private static void InjectReasoningExclude(JsonObject body)
+        => body["reasoning"] = new JsonObject { ["exclude"] = true };
 }

--- a/src/Netclaw.Providers/PipelineRequestBodyEditor.cs
+++ b/src/Netclaw.Providers/PipelineRequestBodyEditor.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="PipelineRequestBodyEditor.cs" company="Petabridge, LLC">
+//      Copyright (C) 2026 - 2026 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Netclaw.Providers;
+
+/// <summary>
+/// Shared helper for <see cref="PipelinePolicy"/> implementations that need to
+/// parse the outbound JSON request body, mutate it, and write it back as
+/// <see cref="BinaryContent"/>. Encapsulates the
+/// <see cref="MemoryStream"/>/<see cref="JsonNode"/>/<see cref="JsonSerializer"/>
+/// dance so per-provider policies can express the mutation as a single
+/// <see cref="Action{JsonObject}"/> lambda.
+/// </summary>
+internal static class PipelineRequestBodyEditor
+{
+    /// <summary>
+    /// Parses <paramref name="message"/>.Request.Content as a JSON object,
+    /// invokes <paramref name="edit"/> on the parsed object, then writes the
+    /// modified JSON back as the request content.
+    /// </summary>
+    /// <remarks>
+    /// No-ops in two cases — both deliberate, both also no-op in the policies
+    /// that previously inlined this pattern: the request has no content (e.g.
+    /// the SDK sent a header-only call), or the content is JSON but not a JSON
+    /// object (e.g. a top-level array). Callers needing array-rooted edits
+    /// should not use this helper.
+    /// </remarks>
+    public static void EditJsonBody(PipelineMessage message, Action<JsonObject> edit)
+    {
+        var request = message.Request;
+        if (request.Content is null)
+            return;
+
+        using var stream = new MemoryStream();
+        request.Content.WriteTo(stream, default);
+        var bytes = stream.ToArray();
+
+        var node = JsonNode.Parse(bytes);
+        if (node is not JsonObject obj)
+            return;
+
+        edit(obj);
+
+        var modified = JsonSerializer.SerializeToUtf8Bytes(obj);
+        request.Content = BinaryContent.Create(BinaryData.FromBytes(modified));
+    }
+}


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Resolves #1137.

Three production `PipelinePolicy` implementations had the same 8-line "stream → parse → mutate `JsonObject` → bail if not an object → serialize back as `BinaryContent`" sequence:

- `OpenRouterReasoningExcludePolicy`
- `OpenAiCodexRequestPolicy`
- `VeniceAiSystemPromptOverridePolicy` (in flight on #1138 — will rebase to consume the helper)

Extracting the boilerplate into `PipelineRequestBodyEditor.EditJsonBody(message, edit)` lets each policy express only its mutation as an `Action<JsonObject>` lambda.

Same treatment for the test side: `CapturePolicy` + `ProcessSync` + `CreateMessage(JsonObject?)` were duplicated between `OpenRouterReasoningExcludePolicyTests` and (in #1138) `VeniceAiSystemPromptOverridePolicyTests`. Hoisted into `PipelinePolicyTestHarness`.

## Per-file delta

| File | Before | After | Δ |
|---|---|---|---|
| `PipelineRequestBodyEditor.cs` (NEW) | 0 | 54 | +54 |
| `PipelinePolicyTestHarness.cs` (NEW) | 0 | 80 | +80 |
| `OpenRouterReasoningExcludePolicy.cs` | 57 | 35 | −22 |
| `OpenAiCodexRequestPolicy.cs` | 150 | 122 | −28 |
| `OpenRouterReasoningExcludePolicyTests.cs` | 149 | 80 | −69 |
| **Net** | | | **+15** |

Roughly line-neutral. The win is having one place that owns the parse/serialize pattern, not raw line reduction.

## Why now

Three real call sites cross the rule-of-three threshold. Two on `dev` today, third arriving with #1138. Landing this PR first means #1138 can use the helper from day one instead of importing the now-duplicated boilerplate and refactoring it later.

## Risk

Low. The mutation logic is unchanged in every site; only the parse/serialize plumbing is consolidated. `OpenAiCodexRequestPolicy` has the most complex mutations (system-message migration, null-strict stripping) and is the highest-risk site — all 20 of its tests pass against the refactored version.

## Validation

- `dotnet build`: 0 warnings, 0 errors
- All `Netclaw.Daemon.Tests` Providers: 134/134 pass
- `OpenAiCodex` tests specifically: 20/20 pass
- `./scripts/Add-FileHeaders.ps1 -Verify`: clean
- `dotnet slopwatch analyze`: 0 issues

## Related

- Resolves: #1137
- Unblocks cleaner version of: #1138 (Venice chat client)

## Test plan

- [x] CI green
- [ ] Manual confirmation against a real OpenRouter call (existing smoke tape `provider-add` / sessions-and-chat scenarios)
- [ ] Manual confirmation against a real Codex call (out of scope of standard smoke tapes; relying on unit test coverage + #1138 rebase end-to-end test)